### PR TITLE
add reminder to always create PRs before merging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@ decentralized music streaming platform on ATProto.
 
 ## critical reminders
 
+- **pull requests**: always create a PR for review before merging to main - we will have users soon
 - **testing**: empirical first - run code and prove it works before writing tests
 - **auth**: OAuth 2.1 implementation from fork (`git+https://github.com/zzstoatzz/atproto@main`)
 - **storage**: Cloudflare R2 for audio files


### PR DESCRIPTION
adds a critical reminder at the top of CLAUDE.md to always create PRs for review before merging to main.

this follows the spirit of the reminder itself by being submitted as a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)