### PR TITLE
fixes

### DIFF
--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -19,7 +19,7 @@
 
 		try {
 			// fetch artist info (handle already has @ stripped by SvelteKit)
-			const artistResponse = await fetch(`${API_URL}/artists/${handle}`);
+			const artistResponse = await fetch(`${API_URL}/artists/by-handle/${handle}`);
 			if (!artistResponse.ok) {
 				if (artistResponse.status === 404) {
 					// check if handle is valid via AT Protocol identity resolution

--- a/src/relay/api/artists.py
+++ b/src/relay/api/artists.py
@@ -140,18 +140,25 @@ async def update_my_artist_profile(
         db.close()
 
 
-@router.get("/{handle_or_did}", response_model=ArtistResponse)
-async def get_artist_profile(handle_or_did: str):
-    """get artist profile by handle or DID (public endpoint)."""
+@router.get("/by-handle/{handle}", response_model=ArtistResponse)
+async def get_artist_profile_by_handle(handle: str):
+    """get artist profile by handle (public endpoint)."""
     db = next(get_db())
     try:
-        # try to find by handle first (more common in URLs)
-        artist = db.query(Artist).filter(Artist.handle == handle_or_did).first()
-
-        # if not found, try DID
+        artist = db.query(Artist).filter(Artist.handle == handle).first()
         if not artist:
-            artist = db.query(Artist).filter(Artist.did == handle_or_did).first()
+            raise HTTPException(status_code=404, detail="artist not found")
+        return artist
+    finally:
+        db.close()
 
+
+@router.get("/{did}", response_model=ArtistResponse)
+async def get_artist_profile_by_did(did: str):
+    """get artist profile by DID (public endpoint)."""
+    db = next(get_db())
+    try:
+        artist = db.query(Artist).filter(Artist.did == did).first()
         if not artist:
             raise HTTPException(status_code=404, detail="artist not found")
         return artist

--- a/src/relay/models/artist.py
+++ b/src/relay/models/artist.py
@@ -1,11 +1,15 @@
 """artist model for storing artist profile data."""
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from relay.models.database import Base
+
+if TYPE_CHECKING:
+    from relay.models.track import Track
 
 
 class Artist(Base):

--- a/src/relay/models/track.py
+++ b/src/relay/models/track.py
@@ -1,12 +1,16 @@
 """track model for storing music metadata."""
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime, ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from relay.models.database import Base
+
+if TYPE_CHECKING:
+    from relay.models.artist import Artist
 
 
 class Track(Base):
@@ -39,7 +43,9 @@ class Track(Base):
     artist: Mapped["Artist"] = relationship("Artist", back_populates="tracks")
 
     # flexible extra fields (album, duration, genre, etc.)
-    extra: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict, server_default="{}")
+    extra: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default="{}"
+    )
 
     # featured artists (list of {did, handle, display_name})
     features: Mapped[list[dict]] = mapped_column(
@@ -55,7 +61,9 @@ class Track(Base):
     atproto_record_cid: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # engagement metrics
-    play_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    play_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
 
     @property
     def album(self) -> str | None:


### PR DESCRIPTION
- **add artist pages with global player state**
  implements public artist pages at /@handle with:
  - artist profile header (avatar, name, handle, bio)
  - track listings for each artist
  - global player state that persists across route navigation
  - mobile-optimized player with time scrubber (volume hidden on mobile)
  - scrolling text animation for long track titles
  
  backend enhancements:
  - artist lookup by handle or DID
  - track filtering by artist DID
  - proper ATProto record URL resolution per artist
  
  frontend improvements:
  - new global Player component in layout
  - player state managed via svelte 5 runes
  - volume preference saved to localStorage
  - play count tracking with 30s threshold
  - seamless navigation between artist pages without interrupting playback
  
  🤖 Generated with [Claude Code](https://claude.com/claude-code)
  
  Co-Authored-By: Claude <noreply@anthropic.com>
  

- **add artist pages with persistent global player**
  - implement artist pages at /u/[handle] route
  - create global player state using svelte 5 class with $state fields
  - fix client-side navigation by removing stopPropagation from artist links
  - add reactive effects to sync audio loading and playback
  - prevent effect contention with isLoadingTrack flag for clean first-click playback
  - update all artist links from /@handle to /u/handle format
  - add mobile-responsive player with scrolling text for long titles
  - remove debug logging for production readiness
  
  🤖 Generated with [Claude Code](https://claude.com/claude-code)
  
  Co-Authored-By: Claude <noreply@anthropic.com>
  

- **commit .claude**
  

- **fix artist page resolution**
  