### PR TITLE
fix: clean up repository hygiene and documentation links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ python_modules/
 # OS
 .DS_Store
 Thumbs.db
+
+# Frontend
+frontend/node_modules/
+frontend/.svelte-kit/
+frontend/build/

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ just deploy-backend   # deploy backend to fly.io
 just deploy-frontend  # deploy frontend to cloudflare pages
 ```
 
-see [docs/cloudflare-deployment.md](docs/cloudflare-deployment.md) for details.
+see [docs/deployment/overview.md](docs/deployment/overview.md) for details.
 
 </details>
 
@@ -155,6 +155,6 @@ relay/
 
 ## documentation
 
-- [deployment guide](docs/cloudflare-deployment.md)
+- [deployment guide](docs/deployment/overview.md)
 - [latest status](sandbox/2025-10-31-status-update.md)
 - [archived docs](sandbox/archive/)


### PR DESCRIPTION
fixes #9

## changes
- added frontend `node_modules/`, `.svelte-kit/`, and `build/` to root `.gitignore` for better repository hygiene
- fixed README deployment guide links to point to `docs/deployment/overview.md` instead of the non-existent `docs/cloudflare-deployment.md`

## testing
- verified links now resolve correctly
- confirmed `.gitignore` patterns work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)