### PR TITLE
fix: use explicit ArtistResponse serialization in artist endpoints

### DIFF
--- a/src/relay/api/artists.py
+++ b/src/relay/api/artists.py
@@ -52,7 +52,7 @@ class ArtistResponse(BaseModel):
 async def create_artist(
     request: CreateArtistRequest,
     auth_session: Session = Depends(require_auth),
-) -> Artist:
+) -> ArtistResponse:
     """create artist profile for authenticated user.
 
     this should be called on first login if artist profile doesn't exist.
@@ -84,7 +84,7 @@ async def create_artist(
         logger.info(
             f"created artist profile for {auth_session.did} (@{auth_session.handle})"
         )
-        return artist
+        return ArtistResponse.model_validate(artist)
 
     finally:
         db.close()
@@ -93,7 +93,7 @@ async def create_artist(
 @router.get("/me")
 async def get_my_artist_profile(
     auth_session: Session = Depends(require_auth),
-) -> Artist:
+) -> ArtistResponse:
     """get authenticated user's artist profile."""
     db = next(get_db())
     try:
@@ -103,7 +103,7 @@ async def get_my_artist_profile(
                 status_code=404,
                 detail="artist profile not found - please create one first",
             )
-        return artist
+        return ArtistResponse.model_validate(artist)
     finally:
         db.close()
 
@@ -112,7 +112,7 @@ async def get_my_artist_profile(
 async def update_my_artist_profile(
     request: UpdateArtistRequest,
     auth_session: Session = Depends(require_auth),
-) -> Artist:
+) -> ArtistResponse:
     """update authenticated user's artist profile."""
     db = next(get_db())
     try:
@@ -136,33 +136,33 @@ async def update_my_artist_profile(
         db.refresh(artist)
 
         logger.info(f"updated artist profile for {auth_session.did}")
-        return artist
+        return ArtistResponse.model_validate(artist)
 
     finally:
         db.close()
 
 
 @router.get("/by-handle/{handle}")
-async def get_artist_profile_by_handle(handle: str) -> Artist:
+async def get_artist_profile_by_handle(handle: str) -> ArtistResponse:
     """get artist profile by handle (public endpoint)."""
     db = next(get_db())
     try:
         artist = db.query(Artist).filter(Artist.handle == handle).first()
         if not artist:
             raise HTTPException(status_code=404, detail="artist not found")
-        return artist
+        return ArtistResponse.model_validate(artist)
     finally:
         db.close()
 
 
 @router.get("/{did}")
-async def get_artist_profile_by_did(did: str) -> Artist:
+async def get_artist_profile_by_did(did: str) -> ArtistResponse:
     """get artist profile by DID (public endpoint)."""
     db = next(get_db())
     try:
         artist = db.query(Artist).filter(Artist.did == did).first()
         if not artist:
             raise HTTPException(status_code=404, detail="artist not found")
-        return artist
+        return ArtistResponse.model_validate(artist)
     finally:
         db.close()


### PR DESCRIPTION
## production outage fix

fixes FastAPI crash: `FastAPIError: Invalid args for response field!`

### root cause
- artist endpoints were returning SQLAlchemy `Artist` ORM models directly
- FastAPI requires Pydantic models for response serialization
- relying on implicit conversion was failing in production

### changes
- changed all artist endpoint return types from `Artist` to `ArtistResponse`
- explicitly convert ORM models using `ArtistResponse.model_validate(artist)`
- no more implicit Pydantic conversion - serialization is now explicit

### testing
- added `test_artist_endpoints.py` to verify all public endpoints work
- tested locally - all endpoints return proper JSON with correct structure
- pre-commit hooks pass (ruff, ty, prettier)

### affected endpoints
- `POST /artists/` (create artist)
- `GET /artists/me` (get my profile)
- `PUT /artists/me` (update my profile)
- `GET /artists/by-handle/{handle}` (public)
- `GET /artists/{did}` (public)

🤖 Generated with [Claude Code](https://claude.com/claude-code)