### PR TITLE
include alembic files in docker image for migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ RUN uv sync --frozen --no-dev --no-install-project
 # copy application code
 COPY src ./src
 
+# copy alembic migration files
+COPY alembic.ini ./
+COPY alembic ./alembic
+
 # install the project itself
 RUN uv sync --frozen --no-dev
 


### PR DESCRIPTION
## summary

fixes the inability to run database migrations in production by including alembic files in the docker image.

## changes

- added `COPY alembic.ini ./` to dockerfile
- added `COPY alembic ./alembic` to dockerfile

## context

when attempting to run the timezone migration on production:
```bash
flyctl ssh console -a relay-api -C "uv run alembic upgrade head"
```

got error: `FAILED: No 'script_location' key found in configuration.`

this was because the dockerfile wasn't copying `alembic.ini` or the `alembic/` directory to the image.

## testing

after this merges and deploys, can run migration #31e69ba0c570 (timezone support) on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)