### PR TITLE
remove redundant 'decentralized' from tagline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # relay
 
-decentralized music streaming platform on ATProto.
+music streaming platform on ATProto.
 
 ## critical reminders
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # relay
 
-decentralized music streaming on ATProto
+music streaming on ATProto
 
 ## what is relay?
 
 relay is a music streaming platform built on the AT Protocol (ATProto), the same protocol that powers Bluesky. it combines:
 
-- **OAuth 2.1 authentication** via ATProto for secure, decentralized identity
+- **OAuth 2.1 authentication** via ATProto for secure identity
 - **artist profiles** synced with ATProto user profiles (avatar, display name, handle)
 - **track metadata** published as ATProto records (shareable across the network)
 - **audio storage** on cloudflare R2 for fast, scalable streaming

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -27,18 +27,18 @@
 	<link rel="icon" href={favicon} />
 
 	<!-- default meta tags for link previews -->
-	<title>relay - decentralized music streaming</title>
+	<title>relay - music streaming on atproto</title>
 	<meta name="description" content="discover and stream music on the atproto network" />
 
 	<!-- Open Graph / Facebook -->
 	<meta property="og:type" content="website" />
-	<meta property="og:title" content="relay - decentralized music streaming" />
+	<meta property="og:title" content="relay - music streaming on atproto" />
 	<meta property="og:description" content="discover and stream music on the atproto network" />
 	<meta property="og:site_name" content="relay" />
 
 	<!-- Twitter -->
 	<meta name="twitter:card" content="summary" />
-	<meta name="twitter:title" content="relay - decentralized music streaming" />
+	<meta name="twitter:title" content="relay - music streaming on atproto" />
 	<meta name="twitter:description" content="discover and stream music on the atproto network" />
 
 	<script>

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -16,7 +16,7 @@
 <div class="container">
 	<div class="login-card">
 		<h1>relay</h1>
-		<p>decentralized music streaming</p>
+		<p>music streaming on atproto</p>
 
 		<form onsubmit={startOAuth}>
 			<div class="input-group">


### PR DESCRIPTION
update all instances of 'decentralized music streaming on ATProto' to 'music streaming on ATProto' since ATProto is inherently decentralized.

## changes
- README.md: tagline and OAuth description  
- CLAUDE.md: tagline
- frontend/src/routes/+layout.svelte: page title and meta tags (link previews)
- frontend/src/routes/login/+page.svelte: tagline

this affects the page title, link previews (Open Graph/Twitter cards), and all user-facing copy.