### PR TITLE
fix: prevent lazy loading issues in Track.artist relationship

### DIFF
--- a/src/relay/api/tracks.py
+++ b/src/relay/api/tracks.py
@@ -241,6 +241,7 @@ async def list_my_tracks(
     stmt = (
         select(Track)
         .join(Artist)
+        .options(selectinload(Track.artist))
         .where(Track.artist_did == auth_session.did)
         .order_by(Track.created_at.desc())
     )
@@ -315,7 +316,12 @@ async def update_track_metadata(
 
     features: optional JSON array of ATProto handles, e.g., ["user1.bsky.social", "user2.bsky.social"]
     """
-    result = await db.execute(select(Track).join(Artist).where(Track.id == track_id))
+    result = await db.execute(
+        select(Track)
+        .join(Artist)
+        .options(selectinload(Track.artist))
+        .where(Track.id == track_id)
+    )
     track = result.scalar_one_or_none()
 
     if not track:
@@ -409,7 +415,12 @@ async def get_track(
     track_id: int, db: Annotated[AsyncSession, Depends(get_db)]
 ) -> dict:
     """get a specific track."""
-    result = await db.execute(select(Track).join(Artist).where(Track.id == track_id))
+    result = await db.execute(
+        select(Track)
+        .join(Artist)
+        .options(selectinload(Track.artist))
+        .where(Track.id == track_id)
+    )
     track = result.scalar_one_or_none()
 
     if not track:

--- a/src/relay/models/track.py
+++ b/src/relay/models/track.py
@@ -40,7 +40,9 @@ class Track(Base):
         nullable=False,
         index=True,
     )
-    artist: Mapped["Artist"] = relationship("Artist", back_populates="tracks")
+    artist: Mapped["Artist"] = relationship(
+        "Artist", back_populates="tracks", lazy="raise"
+    )
 
     # flexible extra fields (album, duration, genre, etc.)
     extra: Mapped[dict] = mapped_column(


### PR DESCRIPTION
## problem

GET /tracks/me and other track endpoints were failing with 500 errors after the async SQLAlchemy migration.

**error from Logfire** (trace: `019a47807b28c7f2ca504d7d671f807e`):
```
greenlet_spawn has not been called; can't call await_only() here
```

The issue: accessing `track.artist.display_name` triggered lazy loading in async context, causing MissingGreenlet errors.

## why did we miss this initially?

We fixed GET /tracks/ but missed GET /tracks/me, PATCH /tracks/{track_id}, and GET /tracks/{track_id}. This is a systemic issue - we were playing whack-a-mole fixing individual endpoints instead of preventing the problem at the source.

## solution: two-pronged fix

### 1. root cause prevention (following Nebula pattern)

added `lazy="raise"` to the `Track.artist` relationship in `src/relay/models/track.py`:

```python
artist: Mapped["Artist"] = relationship(
    "Artist", back_populates="tracks", lazy="raise"
)
```

**why this matters**: now if someone forgets to add eager loading, SQLAlchemy will raise an explicit error in development instead of silently failing. no more discovering these bugs in production.

### 2. immediate fixes

added `selectinload(Track.artist)` to all endpoints that access `track.artist`:

- `list_my_tracks` (GET /tracks/me) - line 244
- `update_track_metadata` (PATCH /tracks/{track_id}) - line 322  
- `get_track` (GET /tracks/{track_id}) - line 421

note: GET /tracks/ already had this fix from the initial migration.

## testing

verified fix locally - all endpoints now work correctly. the `lazy="raise"` config will catch any future lazy loading attempts during development.

## files changed

- `src/relay/models/track.py` - add `lazy="raise"` to artist relationship
- `src/relay/api/tracks.py` - add `selectinload(Track.artist)` to 3 endpoints

## related

discovered via user report after async SQLAlchemy migration (PR #23).