### PR TITLE
fix: restore authentication state on artist page and unify button sizing

### DIFF
--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -136,7 +136,7 @@
 		background: transparent;
 		border: 1px solid #444;
 		color: #b0b0b0;
-		padding: 0.4rem 0.75rem;
+		padding: 0.5rem 1rem;
 		border-radius: 6px;
 		font-size: 0.9rem;
 		cursor: pointer;


### PR DESCRIPTION
fixes two UI bugs:

## bug 1: artist page shows logged-out state when user is authenticated

**issue**: when navigating to an artist page (`/u/:handle`) while logged in, the header incorrectly shows "login" button instead of the user's handle and logout button.

**root cause**: the artist page component was hardcoded with:
```svelte
<Header user={null} isAuthenticated={false} onLogout={async () => {}} />
```

**fix**: added `checkAuth()` function that:
- checks localStorage for `session_id`
- calls `/auth/me` to verify the session
- sets `user` and `isAuthenticated` state accordingly
- passes real auth state to Header component

## bug 2: inconsistent button sizing

**issue**: login and logout buttons have different padding, causing layout shift when auth state changes.

**before**:
- login button (`.btn-primary`): `padding: 0.5rem 1rem`
- logout button (`.btn-logout`): `padding: 0.4rem 0.75rem`

**after**: standardized both to `padding: 0.5rem 1rem`

## testing

tested locally by:
- logging in
- navigating to artist page via track item avatar/name
- verifying header shows authenticated state
- verifying buttons are same size

🤖 Generated with [Claude Code](https://claude.com/claude-code)