### PR TITLE
fix: include auto_advance in queue state updates

### DIFF
--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -278,7 +278,8 @@ class Queue {
 				current_index: this.currentIndex,
 				current_track_id: this.currentTrack?.file_id ?? null,
 				shuffle: this.shuffle,
-				original_order_ids: this.originalOrder.map((t) => t.file_id)
+				original_order_ids: this.originalOrder.map((t) => t.file_id),
+				auto_advance: this.autoAdvance
 			};
 
 			const headers: HeadersInit = {


### PR DESCRIPTION
## problem

the frontend was not including `auto_advance` in queue state updates sent to the server. while the backend adds this field when reading from the database (by fetching from `user_preferences`), the client-side state was missing it during pushes.

this could cause issues during conflict resolution or with stale caches in production where multiple fly.io instances might serve different data.

## solution

include `auto_advance: this.autoAdvance` in the queue state object when pushing to the server (queue.svelte.ts:282).

## testing

- tested locally that auto-advance works as expected
- track automatically advances to next when enabled
- track stops when disabled

## notes

production 409 conflicts observed in logfire suggest possible cache synchronization issues across fly.io instances. this fix ensures auto_advance is always persisted regardless of cache state, but the underlying multi-instance cache sync via LISTEN/NOTIFY may need further investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)