### PR TITLE
fix: resolve mobile layout overflow

### DIFF
--- a/frontend/src/lib/components/Player.svelte
+++ b/frontend/src/lib/components/Player.svelte
@@ -568,23 +568,19 @@
 			width: 100%;
 			flex-wrap: wrap;
 			justify-content: center;
-			gap: 1rem;
-		}
-
-		/* keep playback buttons horizontal */
-		.control-btn {
-			flex-shrink: 0;
+			gap: 0.75rem 1rem;
 		}
 
 		.playback-options {
-			order: 3;
-			width: 100%;
-			justify-content: center;
+			order: 1;
+			display: flex;
+			width: auto;
 		}
 
 		.time-control {
 			width: 100%;
 			order: 2;
+			flex: 1 1 100%;
 		}
 
 		/* hide volume control on mobile - use device volume */

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -147,10 +147,14 @@
 	.app-layout {
 		display: flex;
 		min-height: 100vh;
+		width: 100%;
+		overflow-x: hidden;
 	}
 
 	.main-content {
 		flex: 1;
+		min-width: 0;
+		width: 100%;
 		transition: margin-right 0.3s ease;
 	}
 
@@ -162,7 +166,7 @@
 		position: fixed;
 		top: 0;
 		right: 0;
-		width: 360px;
+		width: min(360px, 100%);
 		height: 100vh;
 		background: var(--bg-primary);
 		border-left: 1px solid var(--border-subtle);


### PR DESCRIPTION
## problem

- the track list and player shell were wider than the mobile viewport, clipping the action buttons.
- shuffle dropped to its own row on phones, wasting vertical space and looking broken.

## solution

- constrain the top-level layout to the viewport width and let the main content shrink (`min-width: 0`) so track cards stay flush.
- cap the queue sidebar at `min(360px, 100%)` so it never forces horizontal scrolling.
- adjust the mobile player controls to keep shuffle alongside the transport buttons while the seek bar fills the second row.

## testing

- `bun run check`
- local manual test on iPhone (Safari) via LAN host; confirmed no horizontal overflow and playback controls stay on one row.