### PR TITLE
fix: restore CORS origin regex for production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,14 +4,22 @@
 DEBUG=false
 PORT=8001
 FRONTEND_URL=http://localhost:5173
-FRONTEND_CORS_ORIGINS=["http://localhost:5173"]
+# FRONTEND_CORS_ORIGIN_REGEX=  # optional regex pattern for CORS (defaults to relay-4i6.pages.dev + localhost)
 
 # branding (optional)
+# backend branding settings
 # APP_NAME=relay
 # APP_TAGLINE=music streaming on atproto
 # CANONICAL_HOST=relay.zzstoatzz.io
 # CANONICAL_URL_OVERRIDE=
 # BROADCAST_CHANNEL_PREFIX=relay
+
+# frontend branding (requires VITE_ prefix for SvelteKit)
+# VITE_APP_NAME=relay
+# VITE_APP_TAGLINE=music streaming on atproto
+# VITE_APP_CANONICAL_HOST=relay.zzstoatzz.io
+# VITE_APP_CANONICAL_URL=
+# VITE_APP_BROADCAST_PREFIX=relay
 
 # database
 DATABASE_URL=postgresql+asyncpg://localhost/relay

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,8 @@ settings.app.canonical_url                     # computed: https://relay.zzstoat
 
 # frontend settings
 settings.frontend.url                          # from FRONTEND_URL
-settings.frontend.cors_origins                 # from FRONTEND_CORS_ORIGINS
+settings.frontend.cors_origin_regex            # from FRONTEND_CORS_ORIGIN_REGEX (optional)
+settings.frontend.resolved_cors_origin_regex   # computed: defaults to relay-4i6.pages.dev pattern
 
 # database settings
 settings.database.url                          # from DATABASE_URL
@@ -109,6 +110,16 @@ automatically determines the protocol based on host:
 - anything else → `https://`
 
 can be overridden with `canonical_url_override` if needed.
+
+### `settings.frontend.resolved_cors_origin_regex`
+
+constructs the CORS origin regex pattern:
+```python
+# default: allows localhost + relay-4i6.pages.dev (including preview deployments)
+r"^(https://([a-z0-9]+\.)?relay-4i6\.pages\.dev|http://localhost:5173)$"
+```
+
+can be overridden with `FRONTEND_CORS_ORIGIN_REGEX` if needed.
 
 ### `settings.atproto.track_collection`
 

--- a/src/relay/config.py
+++ b/src/relay/config.py
@@ -116,11 +116,21 @@ class FrontendSettings(RelaySettingsSection):
         validation_alias="FRONTEND_URL",
         description="Frontend URL for redirects",
     )
-    cors_origins: list[str] = Field(
-        default_factory=lambda: ["http://localhost:5173"],
-        validation_alias="FRONTEND_CORS_ORIGINS",
-        description="CORS allowed origins",
+    cors_origin_regex: str | None = Field(
+        default=None,
+        validation_alias="FRONTEND_CORS_ORIGIN_REGEX",
+        description="CORS origin regex pattern (if not set, uses default for relay-4i6.pages.dev)",
     )
+
+    @computed_field
+    @property
+    def resolved_cors_origin_regex(self) -> str:
+        """Resolved CORS origin regex pattern."""
+        if self.cors_origin_regex is not None:
+            return self.cors_origin_regex
+
+        # default: allow localhost for dev + cloudflare pages (including preview deployments)
+        return r"^(https://([a-z0-9]+\.)?relay-4i6\.pages\.dev|http://localhost:5173)$"
 
 
 class DatabaseSettings(RelaySettingsSection):

--- a/src/relay/main.py
+++ b/src/relay/main.py
@@ -89,7 +89,7 @@ if logfire:
 # configure CORS - allow localhost for dev and cloudflare pages for production
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.frontend.cors_origins,
+    allow_origin_regex=settings.frontend.resolved_cors_origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
fixes production CORS errors from PR #58 by restoring regex-based CORS matching.

## problem

PR #58's settings refactor changed CORS from regex to list-based matching, which only allowed localhost and broke production.

## solution

- restore `allow_origin_regex` approach
- add `FrontendSettings.resolved_cors_origin_regex` computed field
- default pattern: `^(https://([a-z0-9]+\.)?relay-4i6\.pages\.dev|http://localhost:5173)$`
- handles cloudflare preview deployments automatically
- configurable via `FRONTEND_CORS_ORIGIN_REGEX` env var

## changes

- replace `cors_origins` list with `cors_origin_regex` field
- update `main.py` to use `allow_origin_regex`
- update `.env.example` with CORS config and VITE_ prefixed vars
- update `docs/configuration.md` to document CORS settings

## testing

- tests pass
- CORS regex resolves correctly

this PR builds on top of the merged PR #58 state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)