### PR TITLE
refactor: replace periodic OAuth state cleanup with lazy cleanup pattern

### DIFF
--- a/src/relay/main.py
+++ b/src/relay/main.py
@@ -10,7 +10,6 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from relay._internal import notification_service, queue_service
-from relay._internal.auth import _state_store
 from relay.api import (
     artists_router,
     audio_router,
@@ -47,10 +46,8 @@ async def run_periodic_tasks():
             # check for new tracks and send notifications
             await notification_service.check_new_tracks()
 
-            # cleanup expired OAuth states (10 minute TTL)
-            deleted = await _state_store.cleanup_expired_states()
-            if deleted > 0:
-                logger.info(f"cleaned up {deleted} expired OAuth states")
+            # NOTE: OAuth state cleanup is handled lazily in PostgresStateStore
+            # (cleanup happens automatically on save_state/get_state during OAuth flows)
         except Exception:
             logger.exception("error in periodic task")
         await asyncio.sleep(settings.app.background_task_interval_seconds)


### PR DESCRIPTION
fixes #67

## summary

replaces periodic OAuth state cleanup (every 60 seconds) with lazy cleanup following the **atproto SDK reference pattern**. eliminates ~99% of unnecessary database queries.

## changes

### `src/relay/stores/postgres.py`
- add `cleanup_expired_states()` call in `save_state()` before saving
- add `cleanup_expired_states()` call in `get_state()` before retrieval  
- follows `atproto_oauth.stores.memory.MemoryStateStore` pattern exactly

### `src/relay/main.py`
- remove periodic OAuth cleanup from `run_periodic_tasks()`
- remove unused `_state_store` import
- add comment explaining cleanup is now lazy

## impact

**before:**
- ~3,184 DELETE queries per day (every ~27 seconds with 2 VMs)
- queries run constantly even when no one is logging in
- almost all queries return 0 rows (wasted database overhead)

**after:**
- ~10-50 DELETE queries per day (only during OAuth flows)
- zero overhead when site is idle
- cleanup naturally scales with usage

## why lazy cleanup?

this is the **reference implementation** from the official atproto SDK. OAuth state cleanup only needs to run when:
1. **starting a new OAuth flow** (`save_state`) - user clicks login
2. **validating an OAuth callback** (`get_state`) - user returns from auth

abandoned states (user closes browser mid-login) will sit in the database until the next OAuth flow triggers cleanup. this is acceptable because:
- states are small (~1KB each)
- 10-minute TTL is sufficient
- OAuth flows are rare (few per day)

## testing

- ✅ backend starts successfully
- ✅ pre-commit hooks pass
- ✅ health endpoint responds
- ✅ follows atproto SDK pattern exactly

## monitoring

after deploying, monitor:
- **logfire oauth_states DELETE queries** - should drop from ~140/hour to ~1-2/hour
- **oauth_states table size** - should remain small (<10 rows typically)
- **login flow performance** - should be unchanged or slightly faster

## references

- atproto SDK: `atproto_oauth.stores.memory.MemoryStateStore`
- issue #67: detailed research and analysis
- logfire analysis: 142 cleanups/hour → expected ~2 cleanups/hour

closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)