### PR TITLE
feat: isolate ATProto namespaces per environment

### DIFF
--- a/docs/deployment/environments.md
+++ b/docs/deployment/environments.md
@@ -81,6 +81,7 @@ or via github UI: releases → draft new release → create tag → publish
 - `DATABASE_URL` → neon staging connection string
 - `ATPROTO_CLIENT_ID` → `https://relay-api-staging.fly.dev/client-metadata.json`
 - `ATPROTO_REDIRECT_URI` → `https://relay-api-staging.fly.dev/auth/callback`
+- `ATPROTO_APP_NAMESPACE` → `app.relay-staging` (isolated ATProto collection)
 - `OAUTH_ENCRYPTION_KEY` → unique key for staging
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` → same as production (shared R2)
 - `LOGFIRE_WRITE_TOKEN` → logfire token
@@ -88,6 +89,10 @@ or via github UI: releases → draft new release → create tag → publish
 
 **production secrets** (already configured):
 - same structure but with production URLs and database
+- `ATPROTO_APP_NAMESPACE` → not set (uses default `app.relay`)
+
+**local dev (.env)**:
+- `ATPROTO_APP_NAMESPACE` → `app.relay-dev` (throwaway collection for testing)
 
 ## database migrations
 
@@ -110,13 +115,12 @@ if a migration fails:
 
 ## cloudflare pages
 
-**current configuration**:
-- production branch: `main` (currently)
-- all deployments use production backend
-
-**TODO** (requires manual cloudflare configuration):
-- set preview deployments to use staging backend URL
-- configure environment variable: `PUBLIC_API_URL=https://relay-api-staging.fly.dev`
+**configuration**:
+- production branch: `production`
+- staging branch: `staging` → staging.relay-4i6.pages.dev
+- environment variables (set via cloudflare UI):
+  - preview: `PUBLIC_API_URL=https://relay-api-staging.fly.dev`
+  - production: `PUBLIC_API_URL=https://relay-api.fly.dev`
 
 ## monitoring
 
@@ -149,11 +153,13 @@ if a migration fails:
 - **team validation**: team can test changes before user-facing deployment
 - **clear release process**: explicit versioning via github releases
 
-## next steps
+## deployment history
 
-1. run `scripts/setup-staging-secrets.sh` to configure staging secrets
-2. merge environment separation PR
-3. push to main → automatic staging deploy
-4. validate staging deployment
-5. create first production release
-6. configure cloudflare pages preview deployments (manual step via UI)
+environment separation implemented in PR #72 (2025-11-05):
+- created staging fly.io app (relay-api-staging)
+- created separate neon databases (relay-dev, relay-staging, relay)
+- created separate r2 buckets (relay-dev, relay-stg, relay)
+- configured staging secrets
+- set up cloudflare pages branch deployments
+- staging backend: https://relay-api-staging.fly.dev
+- staging frontend: https://staging.relay-4i6.pages.dev


### PR DESCRIPTION
## summary

Prevents staging and dev environments from writing ATProto records to the same collection as production.

## changes

- staging uses `app.relay-staging` collection (set via `ATPROTO_APP_NAMESPACE` secret)
- production uses `app.relay` collection (default, no override needed)
- local dev uses `app.relay-dev` collection (set in .env)

## why

Currently both staging and production write to `app.relay.track` on users' PDSs. This means:
- Testing in staging writes real records to production collection
- No way to safely test destructive changes
- Test data pollutes real user profiles

With isolated namespaces:
- Staging writes to `app.relay-staging.track`
- Production writes to `app.relay.track`
- Complete isolation between environments

## testing

- [x] Set `ATPROTO_APP_NAMESPACE=app.relay-staging` on relay-api-staging
- [x] Verified staging backend healthy after update
- [x] Updated documentation