### PR TITLE
feat: add workflow_dispatch trigger to staging deploy

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -13,6 +13,7 @@ on:
       - "alembic/**"
       - "alembic.ini"
       - ".github/workflows/deploy-backend.yml"
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
allows manual triggering of staging backend deployment from github actions ui when automatic triggers don't fire (e.g. when only secrets change)