### PR TITLE
fix: use alembic stamp instead of upgrade for staging

### DIFF
--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -9,7 +9,7 @@ primary_region = 'iad'
 [build]
 
 [deploy]
-  release_command = 'uv run alembic upgrade head'
+  release_command = 'uv run alembic stamp head'
 
 [env]
   ATPROTO_PDS_URL = 'https://pds.zzstoatzz.io'


### PR DESCRIPTION
staging database tables are created by init_database() in the fastapi lifespan, so migrations that try to ALTER tables will fail if the base tables don't exist. using stamp instead marks the database as being at the latest migration without running migrations.