### PR TITLE
fix(deploy): explicitly specify app name in production deployment

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -25,6 +25,6 @@ jobs:
           if [ "${{ steps.changes.outputs.migrations }}" == "true" ]; then
             echo "🔄 migrations detected - will run via release_command before deployment"
           fi
-          flyctl deploy --config fly.toml --remote-only
+          flyctl deploy --config fly.toml --remote-only -a relay-api
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
Fixes the production deployment workflow by adding the explicit `-a relay-api` flag to the flyctl deploy command.

This resolves the "Could not find App 'relay-api'" error that occurred during the first release attempt. The staging workflow works fine with the same token, so explicitly specifying the app name should resolve the lookup issue.