### PR TITLE
fix: add explicit app name to staging deploy command

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -36,6 +36,6 @@ jobs:
           if [ "${{ steps.changes.outputs.migrations }}" == "true" ]; then
             echo "🔄 migrations detected - will run via release_command before deployment"
           fi
-          flyctl deploy --config fly.staging.toml --remote-only
+          flyctl deploy --config fly.staging.toml --remote-only -a relay-api-staging
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
The staging deployment workflow was failing with "Could not find App relay-api-staging" because the flyctl deploy command was missing the explicit `-a relay-api-staging` flag.

This brings the staging workflow in line with the production workflow which already has the `-a relay-api` flag.

fixes the recurring CI/CD authentication issue.