### PR TITLE
fix: use separate fly.io API tokens for staging and prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -27,4 +27,4 @@ jobs:
           fi
           flyctl deploy --config fly.toml --remote-only -a relay-api
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -38,4 +38,4 @@ jobs:
           fi
           flyctl deploy --config fly.staging.toml --remote-only -a relay-api-staging
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_STAGING }}


### PR DESCRIPTION
Separates fly.io API tokens into environment-specific secrets to fix deployment failures.

**Changes:**
- Staging workflow now uses `FLY_API_TOKEN_STAGING` 
- Production workflow now uses `FLY_API_TOKEN_PROD`

**Action required:**
You need to create two new GitHub secrets:
1. `FLY_API_TOKEN_STAGING` - token with access to `relay-api-staging` app
2. `FLY_API_TOKEN_PROD` - token with access to `relay-api` app

To create app-specific tokens:
```bash
# for staging
flyctl tokens create deploy -a relay-api-staging

# for production  
flyctl tokens create deploy -a relay-api
```

Then add these tokens to GitHub secrets at: https://github.com/zzstoatzz/plyr.fm/settings/secrets/actions