### PR TITLE
fix: update frontend branding defaults to plyr.fm

### DIFF
--- a/frontend/src/lib/branding.ts
+++ b/frontend/src/lib/branding.ts
@@ -1,7 +1,7 @@
-const DEFAULT_APP_NAME = 'relay';
+const DEFAULT_APP_NAME = 'plyr.fm';
 const DEFAULT_TAGLINE = 'music streaming on atproto';
-const DEFAULT_CANONICAL_HOST = 'relay.zzstoatzz.io';
-const DEFAULT_BROADCAST_PREFIX = 'relay';
+const DEFAULT_CANONICAL_HOST = 'plyr.fm';
+const DEFAULT_BROADCAST_PREFIX = 'plyr';
 
 const APP_NAME = import.meta.env.VITE_APP_NAME ?? DEFAULT_APP_NAME;
 const APP_TAGLINE = import.meta.env.VITE_APP_TAGLINE ?? DEFAULT_TAGLINE;


### PR DESCRIPTION
updates default app name, canonical host, and broadcast prefix from 'relay' to 'plyr.fm'/'plyr' in frontend branding configuration.

this fixes the issue where the deployed frontend was still showing 'relay' because cloudflare pages environment variables weren't set and the code was falling back to hardcoded defaults.