### PR TITLE
feat: configure api.plyr.fm as production backend domain

### DIFF
--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -11,7 +11,7 @@ This command helps a new agent/contributor quickly understand where the project 
 1. **Read STATUS.md** at the root of the repository
    - Understand the long-term, medium-term, and short-term vision
    - Review the current technical state
-   - Note what's working, what's in progress, and known issues
+   - Note what's working, what's in progress, and known issues (via gh cli)
 
 2. **Review Key Files**
    - `README.md` - project overview and quick start

--- a/fly.toml
+++ b/fly.toml
@@ -36,6 +36,6 @@ primary_region = 'iad'
 # - DATABASE_URL
 # - AWS_ACCESS_KEY_ID
 # - AWS_SECRET_ACCESS_KEY
-# - ATPROTO_CLIENT_ID (will be https://relay-api.fly.dev/client-metadata.json after deployment)
-# - ATPROTO_REDIRECT_URI (will be https://relay-api.fly.dev/auth/callback after deployment)
+# - ATPROTO_CLIENT_ID (will be https://api.plyr.fm/client-metadata.json after deployment)
+# - ATPROTO_REDIRECT_URI (will be https://api.plyr.fm/auth/callback after deployment)
 # - OAUTH_ENCRYPTION_KEY (44-character base64 Fernet key, generate with: python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -202,7 +202,7 @@ class AtprotoSettings(RelaySettingsSection):
         description="OAuth redirect URI",
     )
     app_namespace: str = Field(
-        default="app.plyr",
+        default="fm.plyr",
         validation_alias="ATPROTO_APP_NAMESPACE",
         description="ATProto app namespace used for record collections",
     )

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -122,7 +122,7 @@ async def client_metadata() -> dict:
 
     return {
         "client_id": settings.atproto.client_id,
-        "client_name": "relay",
+        "client_name": settings.app.name,
         "client_uri": client_uri,
         "redirect_uris": [settings.atproto.redirect_uri],
         "scope": settings.atproto.resolved_scope,


### PR DESCRIPTION
## summary
- configured api.plyr.fm as custom domain for production backend
- dns records added and certificate provisioned
- updated namespace to fm.plyr (reverse domain notation)
- client metadata now uses settings.app.name

## changes
- fly.toml: updated comments to reference api.plyr.fm
- config.py: changed default namespace from app.plyr to fm.plyr
- main.py: use settings.app.name instead of hardcoded "relay"

## deployment steps
after merge, update fly secrets:
```bash
flyctl secrets set \
  ATPROTO_CLIENT_ID=https://api.plyr.fm/client-metadata.json \
  ATPROTO_REDIRECT_URI=https://api.plyr.fm/auth/callback \
  ATPROTO_APP_NAMESPACE=fm.plyr \
  ATPROTO_OLD_APP_NAMESPACE=app.relay \
  --app relay-api
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)