### PR TITLE
feat: implement namespace migration (app.relay → fm.plyr)

### DIFF
--- a/frontend/src/lib/components/MigrationBanner.svelte
+++ b/frontend/src/lib/components/MigrationBanner.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+	import { API_URL } from '$lib/config';
+
+	let needsMigration = $state(false);
+	let oldRecordCount = $state(0);
+	let migrating = $state(false);
+	let migrated = $state(false);
+	let error = $state('');
+	let dismissed = $state(false);
+
+	// check if migration is needed
+	export async function checkMigrationStatus(): Promise<void> {
+		const sessionId = localStorage.getItem('session_id');
+		if (!sessionId) return;
+
+		// check if user already dismissed this
+		const dismissedKey = `migration_dismissed_${sessionId}`;
+		if (localStorage.getItem(dismissedKey) === 'true') {
+			dismissed = true;
+			return;
+		}
+
+		try {
+			const response = await fetch(`${API_URL}/migration/check`, {
+				headers: {
+					'Authorization': `Bearer ${sessionId}`
+				}
+			});
+
+			if (response.ok) {
+				const data = await response.json();
+				needsMigration = data.needs_migration;
+				oldRecordCount = data.old_record_count;
+			}
+		} catch (e) {
+			console.error('failed to check migration status:', e);
+		}
+	}
+
+	async function migrateRecords(): Promise<void> {
+		migrating = true;
+		error = '';
+
+		const sessionId = localStorage.getItem('session_id');
+		if (!sessionId) {
+			error = 'not authenticated';
+			migrating = false;
+			return;
+		}
+
+		try {
+			const response = await fetch(`${API_URL}/migration/migrate`, {
+				method: 'POST',
+				headers: {
+					'Authorization': `Bearer ${sessionId}`
+				}
+			});
+
+			if (response.ok) {
+				const data = await response.json();
+				if (data.migrated_count > 0) {
+					migrated = true;
+					setTimeout(() => {
+						needsMigration = false;
+					}, 3000); // hide banner after 3s
+				} else if (data.failed_count > 0) {
+					error = `migration failed for ${data.failed_count} tracks`;
+				}
+			} else {
+				const errorData = await response.json();
+				error = errorData.detail || 'migration failed';
+			}
+		} catch (e) {
+			console.error('migration error:', e);
+			error = 'network error during migration';
+		} finally {
+			migrating = false;
+		}
+	}
+
+	function dismiss(): void {
+		dismissed = true;
+		needsMigration = false;
+
+		// remember dismissal
+		const sessionId = localStorage.getItem('session_id');
+		if (sessionId) {
+			localStorage.setItem(`migration_dismissed_${sessionId}`, 'true');
+		}
+	}
+</script>
+
+{#if needsMigration && !dismissed}
+	<div class="migration-banner">
+		<div class="migration-content">
+			<div class="migration-message">
+				<strong>namespace update</strong>
+				<p>
+					we've updated our record namespace to follow atproto conventions.
+					{#if oldRecordCount > 0}
+						you have {oldRecordCount} {oldRecordCount === 1 ? 'track' : 'tracks'} that need to be migrated.
+					{/if}
+				</p>
+				{#if error}
+					<p class="error">{error}</p>
+				{/if}
+				{#if migrated}
+					<p class="success">✓ migration complete! your tracks are now on the new namespace.</p>
+				{/if}
+			</div>
+
+			{#if !migrated}
+				<div class="migration-actions">
+					<button
+						class="migrate-button"
+						onclick={migrateRecords}
+						disabled={migrating}
+					>
+						{migrating ? 'migrating...' : 'migrate now'}
+					</button>
+					<button
+						class="dismiss-button"
+						onclick={dismiss}
+						disabled={migrating}
+					>
+						remind me later
+					</button>
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}
+
+<style>
+	.migration-banner {
+		background: var(--background-alt, #1a1a1a);
+		border: 1px solid var(--border-color, #333);
+		border-radius: 8px;
+		padding: 1rem;
+		margin-bottom: 1.5rem;
+	}
+
+	.migration-content {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.migration-message {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.migration-message strong {
+		font-size: 1.1em;
+		color: var(--text-primary, #fff);
+	}
+
+	.migration-message p {
+		margin: 0;
+		color: var(--text-secondary, #aaa);
+		font-size: 0.9em;
+	}
+
+	.error {
+		color: var(--error-color, #ff6b6b);
+	}
+
+	.success {
+		color: var(--success-color, #51cf66);
+	}
+
+	.migration-actions {
+		display: flex;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	.migrate-button,
+	.dismiss-button {
+		padding: 0.5rem 1rem;
+		border-radius: 4px;
+		font-size: 0.9em;
+		cursor: pointer;
+		border: none;
+		transition: opacity 0.2s;
+	}
+
+	.migrate-button {
+		background: var(--primary-color, #007bff);
+		color: white;
+	}
+
+	.migrate-button:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	.dismiss-button {
+		background: transparent;
+		color: var(--text-secondary, #aaa);
+		border: 1px solid var(--border-color, #333);
+	}
+
+	.dismiss-button:hover:not(:disabled) {
+		background: var(--background-hover, #222);
+	}
+
+	button:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	@media (min-width: 640px) {
+		.migration-content {
+			flex-direction: row;
+			align-items: center;
+			justify-content: space-between;
+		}
+
+		.migration-actions {
+			flex-shrink: 0;
+		}
+	}
+</style>

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -3,9 +3,12 @@
 	import Header from '$lib/components/Header.svelte';
 	import HandleSearch from '$lib/components/HandleSearch.svelte';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
+	import MigrationBanner from '$lib/components/MigrationBanner.svelte';
 	import type { User, Track, FeaturedArtist } from '$lib/types';
 	import { API_URL } from '$lib/config';
 	import { uploader } from '$lib/uploader.svelte';
+
+	let migrationBanner: MigrationBanner;
 
 	const ACCEPTED_AUDIO_EXTENSIONS = ['.mp3', '.wav', '.m4a', '.aif', '.aiff'];
 	const ACCEPTED_AUDIO_MIME_TYPES = ['audio/*', 'audio/mpeg', 'audio/wav', 'audio/mp4', 'audio/aiff'];
@@ -83,6 +86,8 @@
 			if (response.ok) {
 				user = await response.json();
 				await loadMyTracks();
+				// check if migration is needed (non-blocking)
+				migrationBanner?.checkMigrationStatus();
 			} else if (response.status === 401) {
 				// only clear session on explicit 401 (unauthorized)
 				localStorage.removeItem('session_id');
@@ -257,6 +262,8 @@
 {:else if user}
 	<Header {user} isAuthenticated={!!user} onLogout={logout} />
 	<main>
+		<MigrationBanner bind:this={migrationBanner} />
+
 		<div class="portal-header">
 			<h2>artist portal</h2>
 		</div>

--- a/src/backend/api/migration.py
+++ b/src/backend/api/migration.py
@@ -1,0 +1,269 @@
+"""API endpoints for namespace migration."""
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend._internal import Session as AuthSession
+from backend._internal import oauth_client, require_auth
+from backend.atproto.records import _reconstruct_oauth_session, _refresh_session_tokens
+from backend.config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/migration", tags=["migration"])
+
+
+@router.get("/check")
+async def check_migration_needed(
+    session: AuthSession = Depends(require_auth),
+) -> dict[str, Any]:
+    """check if user has records in old namespace that need migration.
+
+    returns:
+        {
+            "needs_migration": bool,
+            "old_record_count": int,
+            "old_collection": str | None
+        }
+    """
+    # only check if old namespace is configured
+    if not settings.atproto.old_app_namespace:
+        return {
+            "needs_migration": False,
+            "old_record_count": 0,
+            "old_collection": None,
+        }
+
+    old_collection = settings.atproto.old_track_collection
+    if not old_collection:
+        return {
+            "needs_migration": False,
+            "old_record_count": 0,
+            "old_collection": None,
+        }
+
+    try:
+        # reconstruct OAuth session
+        oauth_data = session.oauth_session
+        if not oauth_data or "access_token" not in oauth_data:
+            raise HTTPException(status_code=401, detail="invalid session")
+
+        oauth_session = _reconstruct_oauth_session(oauth_data)
+
+        # list records from old collection
+        url = f"{oauth_data['pds_url']}/xrpc/com.atproto.repo.listRecords"
+        params = {
+            "repo": session.did,
+            "collection": old_collection,
+            "limit": 100,  # max we can get in one request
+        }
+
+        # try request, refresh token if expired
+        for attempt in range(2):
+            response = await oauth_client.make_authenticated_request(
+                session=oauth_session,
+                method="GET",
+                url=url,
+                params=params,
+            )
+
+            if response.status_code == 200:
+                result = response.json()
+                records = result.get("records", [])
+                return {
+                    "needs_migration": len(records) > 0,
+                    "old_record_count": len(records),
+                    "old_collection": old_collection,
+                }
+
+            # token expired - refresh and retry
+            if response.status_code == 401 and attempt == 0:
+                try:
+                    error_data = response.json()
+                    if "exp" in error_data.get("message", ""):
+                        logger.info(
+                            f"access token expired for {session.did}, refreshing"
+                        )
+                        oauth_session = await _refresh_session_tokens(
+                            session, oauth_session
+                        )
+                        continue
+                except Exception:
+                    pass
+
+            # error
+            logger.error(
+                f"failed to list old records for {session.did}: {response.status_code} {response.text}"
+            )
+            raise HTTPException(
+                status_code=response.status_code,
+                detail=f"failed to check old records: {response.text}",
+            )
+
+        raise HTTPException(status_code=500, detail="failed to check migration status")
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"error checking migration for {session.did}: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/migrate")
+async def migrate_records(
+    session: AuthSession = Depends(require_auth),
+) -> dict[str, Any]:
+    """migrate user's records from old namespace to new namespace.
+
+    this will:
+    1. list all records from old collection
+    2. create copies in new collection
+    3. optionally delete old records (not implemented yet for safety)
+
+    returns:
+        {
+            "migrated_count": int,
+            "failed_count": int,
+            "errors": list[str]
+        }
+    """
+    # only migrate if old namespace is configured
+    if not settings.atproto.old_app_namespace:
+        raise HTTPException(status_code=400, detail="migration not available")
+
+    old_collection = settings.atproto.old_track_collection
+    if not old_collection:
+        raise HTTPException(status_code=400, detail="migration not available")
+
+    try:
+        # reconstruct OAuth session
+        oauth_data = session.oauth_session
+        if not oauth_data or "access_token" not in oauth_data:
+            raise HTTPException(status_code=401, detail="invalid session")
+
+        oauth_session = _reconstruct_oauth_session(oauth_data)
+
+        # list all records from old collection
+        url = f"{oauth_data['pds_url']}/xrpc/com.atproto.repo.listRecords"
+        params = {
+            "repo": session.did,
+            "collection": old_collection,
+            "limit": 100,
+        }
+
+        # fetch old records (with token refresh if needed)
+        for attempt in range(2):
+            response = await oauth_client.make_authenticated_request(
+                session=oauth_session,
+                method="GET",
+                url=url,
+                params=params,
+            )
+
+            if response.status_code == 200:
+                break
+
+            if response.status_code == 401 and attempt == 0:
+                try:
+                    error_data = response.json()
+                    if "exp" in error_data.get("message", ""):
+                        oauth_session = await _refresh_session_tokens(
+                            session, oauth_session
+                        )
+                        continue
+                except Exception:
+                    pass
+
+            raise HTTPException(
+                status_code=response.status_code,
+                detail=f"failed to list old records: {response.text}",
+            )
+
+        result = response.json()
+        old_records = result.get("records", [])
+
+        if not old_records:
+            return {
+                "migrated_count": 0,
+                "failed_count": 0,
+                "errors": [],
+            }
+
+        # migrate each record to new collection
+        migrated_count = 0
+        failed_count = 0
+        errors: list[str] = []
+
+        create_url = f"{oauth_data['pds_url']}/xrpc/com.atproto.repo.createRecord"
+
+        for old_record in old_records:
+            try:
+                # extract record value
+                record_value = old_record.get("value", {})
+
+                # create record in new collection
+                payload = {
+                    "repo": session.did,
+                    "collection": settings.atproto.track_collection,
+                    "record": {
+                        "$type": settings.atproto.track_collection,
+                        "title": record_value.get("title", ""),
+                        "artist": record_value.get("artist", ""),
+                        "audioUrl": record_value.get("audioUrl", ""),
+                        "fileType": record_value.get("fileType", ""),
+                        "createdAt": record_value.get("createdAt", ""),
+                        **(
+                            {("album"): record_value["album"]}
+                            if "album" in record_value
+                            else {}
+                        ),
+                        **(
+                            {("duration"): record_value["duration"]}
+                            if "duration" in record_value
+                            else {}
+                        ),
+                        **(
+                            {("features"): record_value["features"]}
+                            if "features" in record_value
+                            else {}
+                        ),
+                    },
+                }
+
+                create_response = await oauth_client.make_authenticated_request(
+                    session=oauth_session,
+                    method="POST",
+                    url=create_url,
+                    json=payload,
+                )
+
+                if create_response.status_code in (200, 201):
+                    migrated_count += 1
+                    logger.info(
+                        f"migrated record {old_record.get('uri')} for {session.did}"
+                    )
+                else:
+                    failed_count += 1
+                    error_msg = f"failed to create record: {create_response.status_code} {create_response.text}"
+                    errors.append(error_msg)
+                    logger.error(error_msg)
+
+            except Exception as e:
+                failed_count += 1
+                error_msg = f"error migrating record {old_record.get('uri')}: {e}"
+                errors.append(error_msg)
+                logger.error(error_msg, exc_info=True)
+
+        return {
+            "migrated_count": migrated_count,
+            "failed_count": failed_count,
+            "errors": errors,
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"error during migration for {session.did}: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -19,6 +19,7 @@ from backend.api import (
     search_router,
     tracks_router,
 )
+from backend.api.migration import router as migration_router
 from backend.config import settings
 from backend.models import init_db
 
@@ -106,6 +107,7 @@ app.include_router(audio_router)
 app.include_router(search_router)
 app.include_router(preferences_router)
 app.include_router(queue_router)
+app.include_router(migration_router)
 
 
 @app.get("/health")


### PR DESCRIPTION
## summary
implements migration flow for users to move their records from old namespace (`app.relay.track`) to new namespace (`fm.plyr.track`)

## backend changes
- `POST /migration/check` - detect if user has old records
- `POST /migration/migrate` - copy records to new namespace
- handles token refresh automatically during migration
- non-destructive: copies records without deleting originals

## frontend changes
- `MigrationBanner` component shows when old records detected
- two actions: "migrate now" or "remind me later"
- dismissal remembered per session in localStorage
- shows migration progress and success states
- checks migration status on portal load (non-blocking)

## how it works
1. when `ATPROTO_OLD_APP_NAMESPACE=app.relay` is set, OAuth requests both scopes
2. on portal load, frontend calls `/migration/check`
3. if old records found, banner appears
4. user clicks "migrate now" → calls `/migration/migrate`
5. backend copies all records from `app.relay.track` to `fm.plyr.track`
6. success message shown, banner dismisses after 3s

## testing
- set `ATPROTO_OLD_APP_NAMESPACE=app.relay` in production (already done)
- users with existing tracks will see migration banner
- after migration, their tracks appear in both collections

## future cleanup
once all users have migrated:
- remove `ATPROTO_OLD_APP_NAMESPACE` secret
- remove migration endpoints and banner component
- update OAuth scope to only request `fm.plyr.track`

🤖 Generated with [Claude Code](https://claude.com/claude-code)