### PR TITLE
feat: use production branch for production deployments

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -3,7 +3,7 @@ name: deploy prod
 on:
   push:
     branches:
-      - prd-frontend
+      - production
     paths:
       - "src/**"
       - "pyproject.toml"

--- a/scripts/release
+++ b/scripts/release
@@ -46,18 +46,18 @@ def main() -> int:
     version = datetime.now(UTC).strftime("%Y.%m%d.%H%M%S")
 
     print(f"🚀 creating release {version}")
-    print("📝 tagging main and pushing to prd-frontend branch")
+    print("📝 tagging main and pushing to production branch")
 
     # create tag on main
     subprocess.run(["git", "tag", version], check=True)
     subprocess.run(["git", "push", "origin", version], check=True)
 
-    # update prd-frontend branch to match main
+    # update production branch to match main
     subprocess.run(["git", "fetch", "origin"], check=True)
-    subprocess.run(["git", "push", "origin", "main:prd-frontend", "--force"], check=True)
+    subprocess.run(["git", "push", "origin", "main:production", "--force"], check=True)
 
     print(f"✅ release {version} tagged")
-    print("🚢 production deployment starting automatically via prd-frontend branch...")
+    print("🚢 production deployment starting automatically via production branch...")
 
     return 0
 


### PR DESCRIPTION
## changes

- created `production` branch as copy of main for production deployments
- updated release script to push main to production instead of creating GitHub releases
- updated deploy-prod workflow to trigger on production branch pushes

## workflow

- **main branch** → staging (stg.plyr.fm frontend + relay-api-staging backend)
- **production branch** → production (plyr.fm frontend + relay-api backend)

when running `just release`:
1. creates timestamp tag on main
2. pushes tag to origin
3. force-pushes main to production branch
4. triggers production deployment via GitHub Actions

## next steps

after merge, you'll need to:
1. configure `stg.plyr.fm` as custom domain for **main** branch in Cloudflare Pages
2. configure `plyr.fm` as custom domain for **production** branch in Cloudflare Pages