### PR TITLE
fix: ensure migration banner displays collection names correctly

### DIFF
--- a/frontend/src/lib/components/MigrationBanner.svelte
+++ b/frontend/src/lib/components/MigrationBanner.svelte
@@ -107,10 +107,16 @@
 		<div class="migration-content">
 			<div class="migration-message">
 				<strong>collection migration available</strong>
-				<p>
-					your tracks are currently stored in the <code class="collection-name">{oldCollection}</code> collection.
-					we've migrated to <code class="collection-name">{newCollection}</code> to follow atproto reverse-DNS conventions.
-				</p>
+				{#if oldCollection && newCollection}
+					<p>
+						your tracks are currently stored in the <code class="collection-name">{oldCollection}</code> collection.
+						we've migrated to <code class="collection-name">{newCollection}</code> to follow atproto reverse-DNS conventions.
+					</p>
+				{:else}
+					<p>
+						we've updated our record namespace to follow atproto reverse-DNS conventions.
+					</p>
+				{/if}
 				{#if oldRecordCount > 0}
 					<p>
 						you have {oldRecordCount} {oldRecordCount === 1 ? 'track' : 'tracks'} to migrate.

--- a/src/backend/api/migration.py
+++ b/src/backend/api/migration.py
@@ -37,6 +37,8 @@ async def check_migration_needed(
             "needs_migration": False,
             "old_record_count": 0,
             "old_collection": None,
+            "new_collection": settings.atproto.track_collection,
+            "did": session.did,
         }
 
     old_collection = settings.atproto.old_track_collection
@@ -46,6 +48,8 @@ async def check_migration_needed(
             "needs_migration": False,
             "old_record_count": 0,
             "old_collection": None,
+            "new_collection": settings.atproto.track_collection,
+            "did": session.did,
         }
 
     logger.debug(f"checking for records in old collection: {old_collection}")


### PR DESCRIPTION
## summary

fixes the migration banner displaying "to to" instead of showing the new collection name.

## problem

the migration banner message was rendering:
```
your tracks are currently stored in the app.relay.track collection.
we've migrated to to follow atproto reverse-DNS conventions.
```

the `{newCollection}` variable wasn't rendering because the backend `/migration/check` endpoint wasn't returning `new_collection` and `did` in all response code paths (specifically the early return cases when no migration is needed).

## changes

**frontend (MigrationBanner.svelte)**
- added conditional rendering for collection name message
- fallback to generic message when collection data isn't available

**backend (migration.py)**
- ensure all response paths from `/migration/check` include `new_collection` and `did`
- fixes early return cases to include these fields

## testing

- [x] banner now displays collection names correctly
- [x] links to pdsls.dev work properly with DID and collection names
- [x] pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)