### PR TITLE
fix: analytics dashboard not showing on user's own profile

### DIFF
--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -121,19 +121,14 @@
 	}
 
 	async function loadAnalytics() {
-		const sessionId = localStorage.getItem('session_id');
-		if (!sessionId) return;
+		if (!artist?.did) return;
 
 		analyticsLoading = true;
 		const startTime = Date.now();
 		const minDisplayTime = 300; // minimum 300ms to avoid flicker
 
 		try {
-			const response = await fetch(`${API_URL}/artists/me/analytics`, {
-				headers: {
-					'Authorization': `Bearer ${sessionId}`
-				}
-			});
+			const response = await fetch(`${API_URL}/artists/${artist.did}/analytics`);
 			if (response.ok) {
 				analytics = await response.json();
 			}
@@ -227,46 +222,44 @@
 			</div>
 		</section>
 
-		{#if isOwnProfile}
-			<section class="analytics">
-				<h2>analytics</h2>
-				<div class="analytics-grid">
-					{#key analyticsLoading}
-						{#if analyticsLoading}
-							<div class="stat-card skeleton" transition:fade={{ duration: 200 }}>
-								<div class="skeleton-bar large"></div>
-								<div class="skeleton-bar small"></div>
+		<section class="analytics">
+			<h2>analytics</h2>
+			<div class="analytics-grid">
+				{#key analyticsLoading}
+					{#if analyticsLoading}
+						<div class="stat-card skeleton" transition:fade={{ duration: 200 }}>
+							<div class="skeleton-bar large"></div>
+							<div class="skeleton-bar small"></div>
+						</div>
+						<div class="stat-card skeleton" transition:fade={{ duration: 200 }}>
+							<div class="skeleton-bar large"></div>
+							<div class="skeleton-bar small"></div>
+						</div>
+						<div class="stat-card skeleton" transition:fade={{ duration: 200 }}>
+							<div class="skeleton-bar small"></div>
+							<div class="skeleton-bar medium"></div>
+							<div class="skeleton-bar small"></div>
+						</div>
+					{:else if analytics}
+						<div class="stat-card" transition:fade={{ duration: 200 }}>
+							<div class="stat-value">{analytics.total_plays.toLocaleString()}</div>
+							<div class="stat-label">total plays</div>
+						</div>
+						<div class="stat-card" transition:fade={{ duration: 200 }}>
+							<div class="stat-value">{analytics.total_items}</div>
+							<div class="stat-label">total tracks</div>
+						</div>
+						{#if analytics.top_item}
+							<div class="stat-card top-item" transition:fade={{ duration: 200 }}>
+								<div class="stat-label">most played</div>
+								<div class="top-item-title">{analytics.top_item.title}</div>
+								<div class="top-item-plays">{analytics.top_item.play_count.toLocaleString()} plays</div>
 							</div>
-							<div class="stat-card skeleton" transition:fade={{ duration: 200 }}>
-								<div class="skeleton-bar large"></div>
-								<div class="skeleton-bar small"></div>
-							</div>
-							<div class="stat-card skeleton" transition:fade={{ duration: 200 }}>
-								<div class="skeleton-bar small"></div>
-								<div class="skeleton-bar medium"></div>
-								<div class="skeleton-bar small"></div>
-							</div>
-						{:else if analytics}
-							<div class="stat-card" transition:fade={{ duration: 200 }}>
-								<div class="stat-value">{analytics.total_plays.toLocaleString()}</div>
-								<div class="stat-label">total plays</div>
-							</div>
-							<div class="stat-card" transition:fade={{ duration: 200 }}>
-								<div class="stat-value">{analytics.total_items}</div>
-								<div class="stat-label">total tracks</div>
-							</div>
-							{#if analytics.top_item}
-								<div class="stat-card top-item" transition:fade={{ duration: 200 }}>
-									<div class="stat-label">most played</div>
-									<div class="top-item-title">{analytics.top_item.title}</div>
-									<div class="top-item-plays">{analytics.top_item.play_count.toLocaleString()} plays</div>
-								</div>
-							{/if}
 						{/if}
-					{/key}
-				</div>
-			</section>
-		{/if}
+					{/if}
+				{/key}
+			</div>
+		</section>
 
 		<section class="tracks">
 			<h2>tracks</h2>


### PR DESCRIPTION
## Problem
Analytics dashboard was only showing up when viewing your own profile, but it should be public for everyone to see.

## Solution
Made analytics completely public:
- Created new public endpoint `GET /artists/{artist_did}/analytics` (no authentication required)
- Removed `isOwnProfile` check from UI - analytics now display on all profiles
- Changed frontend to fetch from public endpoint using artist's DID
- Kept `/artists/me/analytics` for authenticated convenience (delegates to public endpoint)

## Changes
**Backend** (`src/backend/api/artists.py`):
- Added public `get_artist_analytics(artist_did)` endpoint
- Refactored `get_my_analytics()` to call public endpoint with auth user's DID

**Frontend** (`frontend/src/routes/u/[handle]/+page.svelte`):
- Removed session/auth checks from `loadAnalytics()`
- Changed to fetch from `/artists/{did}/analytics` instead of `/artists/me/analytics`
- Removed `{#if isOwnProfile}` wrapper - analytics section now always visible

## Testing
- [x] Analytics show on any profile without login
- [x] Analytics show correct data for each artist
- [x] No authentication required
- [x] Skeleton loading states work correctly

Future work can add private analytics for artists, but starting simple with public stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)