### PR TITLE
fix: player and queue toggle positioning issues

### DIFF
--- a/frontend/src/lib/components/Player.svelte
+++ b/frontend/src/lib/components/Player.svelte
@@ -39,6 +39,30 @@
 		if (savedVolume) {
 			player.volume = parseFloat(savedVolume);
 		}
+
+		// update player height css variable for dynamic positioning
+		function updatePlayerHeight() {
+			const playerEl = document.querySelector('.player') as HTMLElement | null;
+			if (playerEl) {
+				const height = playerEl.offsetHeight;
+				document.documentElement.style.setProperty('--player-height', `${height}px`);
+			} else {
+				document.documentElement.style.setProperty('--player-height', '0px');
+			}
+		}
+
+		// update on mount and resize
+		updatePlayerHeight();
+		window.addEventListener('resize', updatePlayerHeight);
+
+		// also update when player visibility changes
+		const observer = new MutationObserver(updatePlayerHeight);
+		observer.observe(document.body, { childList: true, subtree: true });
+
+		return () => {
+			window.removeEventListener('resize', updatePlayerHeight);
+			observer.disconnect();
+		};
 	});
 
 	// save volume to localStorage when it changes
@@ -285,6 +309,7 @@
 		background: #1a1a1a;
 		border-top: 1px solid #333;
 		padding: 1rem 2rem;
+		padding-bottom: max(1rem, env(safe-area-inset-bottom));
 		z-index: 100;
 	}
 
@@ -561,6 +586,7 @@
 	@media (max-width: 768px) {
 		.player {
 			padding: 1rem;
+			padding-bottom: max(1rem, env(safe-area-inset-bottom));
 		}
 
 		.player-content {

--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -141,7 +141,7 @@
 		display: flex;
 		flex-direction: column;
 		height: 100%;
-		padding: 1.5rem 1.25rem 140px;
+		padding: 1.5rem 1.25rem calc(var(--player-height, 0px) + 40px + env(safe-area-inset-bottom, 0px));
 		background: var(--bg-primary);
 		border-left: 1px solid var(--border-subtle);
 		gap: 1rem;

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -190,7 +190,7 @@
 
 	.queue-toggle {
 		position: fixed;
-		bottom: 120px;
+		bottom: calc(var(--player-height, 0px) + 20px + env(safe-area-inset-bottom, 0px));
 		right: 20px;
 		width: 48px;
 		height: 48px;
@@ -224,7 +224,7 @@
 		}
 
 		.queue-toggle {
-			bottom: 200px;
+			bottom: calc(var(--player-height, 0px) + 20px + env(safe-area-inset-bottom, 0px));
 		}
 	}
 </style>


### PR DESCRIPTION
## Problem
Two related positioning bugs on mobile:
1. **Player not firmly stuck to bottom**: Gap visible between player and bottom of screen on some mobile browsers
2. **Queue toggle incorrectly positioned**: Button stays 120px from bottom even when player isn't visible (no track loaded)

## Root Cause
Hardcoded positioning values that don't account for:
- Dynamic player presence/absence
- Mobile browser UI bars (address bar, bottom toolbar)
- Device safe areas (notches, home indicators)
- Actual player height variations (desktop vs mobile)

## Solution
Implemented dynamic positioning using CSS custom properties and safe area insets:

### Player.svelte
- Added `--player-height` CSS variable tracking via MutationObserver
- Updates on mount, resize, and visibility changes
- Uses `env(safe-area-inset-bottom)` for device safe areas
- Height = 0px when player not visible

### +layout.svelte
- Queue toggle: `bottom: calc(var(--player-height) + 20px + env(safe-area-inset-bottom))`
- Removed hardcoded `bottom: 120px` (desktop) and `bottom: 200px` (mobile)
- Button now positioned relative to actual player height

### Queue.svelte
- Padding: `calc(var(--player-height) + 40px + env(safe-area-inset-bottom))`
- Removed hardcoded `140px` padding
- Adjusts dynamically to player presence/absence

## Benefits
✅ Player always flush with screen bottom (no gaps)
✅ Queue toggle correctly positioned when no track loaded (near bottom)
✅ Queue toggle correctly positioned when player visible (above player)  
✅ Accounts for mobile browser UI and device notches
✅ Single source of truth for player height

## Testing
- [x] Desktop: queue toggle moves when player appears/disappears
- [x] Mobile: player sits above safe area, no gaps
- [x] Resize: positions update correctly
- [x] Type safety: TypeScript checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)