### PR TITLE
fix: allow queue to work locally for unauthenticated users

### DIFF
--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -106,7 +106,10 @@ class Queue {
 			}
 		};
 
-		await this.fetchQueue();
+		// only fetch from server if authenticated
+		if (this.isAuthenticated()) {
+			await this.fetchQueue();
+		}
 
 		document.addEventListener('visibilitychange', this.handleVisibilityChange);
 		window.addEventListener('beforeunload', this.handleBeforeUnload);
@@ -136,8 +139,14 @@ class Queue {
 		}
 	}
 
+	private isAuthenticated(): boolean {
+		if (!browser) return false;
+		return !!localStorage.getItem('session_id');
+	}
+
 	async fetchQueue(force = false) {
 		if (!browser) return;
+		if (!this.isAuthenticated()) return; // skip if not authenticated
 
 		// while we have unsent or in-flight local changes, skip non-forced fetches
 		if (
@@ -289,6 +298,7 @@ class Queue {
 
 	async pushQueue(): Promise<boolean> {
 		if (!browser) return false;
+		if (!this.isAuthenticated()) return false; // skip if not authenticated
 
 		if (this.syncInProgress) {
 			this.pendingSync = true;


### PR DESCRIPTION
## Problem
Sporadic 401 errors appearing in console when visiting the site without being logged in:

```
:8001/queue/:1  Failed to load resource: the server responded with a status of 401 (Unauthorized)
queue.svelte.ts:186 failed to fetch queue: Error: failed to fetch queue: Unauthorized
queue.svelte.ts:369 failed to push queue: Error: failed to push queue: Unauthorized
```

## Root Cause
Queue system was attempting to sync with the server even when not authenticated. The queue would initialize on page load and try to fetch from the `/queue/` endpoint, which requires authentication, causing 401 errors for unauthenticated users.

## Solution

### Keep queue functional for everyone
The queue now works locally for all users, regardless of authentication status. The key insight is that server sync operations (fetchQueue/pushQueue) are separate from local queue functionality.

### Guard server sync operations only
- Added `isAuthenticated()` helper method to check for session_id
- `initialize()` conditionally fetches from server only if authenticated  
- `fetchQueue()` returns early if not authenticated (no request)
- `pushQueue()` returns false if not authenticated (no request)
- All local queue operations (addTracks, playNow, next, previous, etc.) work independently

## Changes

**queue.svelte.ts:**
```typescript
async initialize() {
  if (!browser || this.initialized) return;
  this.initialized = true;

  // ... setup tabId, autoAdvance, broadcast channel ...

  // only fetch from server if authenticated
  if (this.isAuthenticated()) {
    await this.fetchQueue();
  }

  // ... event listeners ...
}

private isAuthenticated(): boolean {
  if (!browser) return false;
  return !!localStorage.getItem('session_id');
}

async fetchQueue(force = false) {
  if (!browser) return;
  if (!this.isAuthenticated()) return; // skip if not authenticated

  // ... fetch from server, apply snapshot
}

async pushQueue(): Promise<boolean> {
  if (!browser) return false;
  if (!this.isAuthenticated()) return false; // skip if not authenticated

  // ... send to server
}
```

## Benefits
✅ No 401 errors in console when not logged in  
✅ No unnecessary requests to authenticated endpoints  
✅ Queue works locally for everyone (add tracks, play, reorder)  
✅ Server sync when authenticated (persisted state)  
✅ Clean console on anonymous visits  
✅ Better UX - queue is functional without requiring login

## How It Works
- **Unauthenticated users**: Queue works entirely in memory. Add tracks, play music, reorder - all operations work. State is lost on page refresh.
- **Authenticated users**: Same local functionality + server persistence. Queue state syncs to backend and persists across sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)