### PR TITLE
fix: prevent unnecessary backend releases and enforce just usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ music streaming platform on ATProto.
 - **issues**: GitHub, not Linear
 - **PRs**: always create for review before merging to main
 - **deployment**: automated via GitHub Actions on merge - NEVER deploy locally
+- **releases**: ALWAYS use `just release` (never `./scripts/release` directly)
 - **migrations**: automated via fly.io release_command
 - **logs**: `flyctl logs` is BLOCKING - use `run_in_background=true`
 - **type hints**: required everywhere

--- a/scripts/release
+++ b/scripts/release
@@ -43,6 +43,30 @@ def main() -> int:
         print("❌ working directory has uncommitted changes")
         return 1
 
+    # check if there are backend changes since last release
+    result = subprocess.run(
+        ["gh", "release", "list", "--limit", "1"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    if result.stdout.strip():
+        last_release = result.stdout.split()[0]
+
+        # check for backend changes since last release
+        result = subprocess.run(
+            ["git", "log", f"{last_release}..HEAD", "--oneline", "--", "src/backend/"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        if not result.stdout.strip():
+            print("❌ no backend changes since last release")
+            print(f"   last release: {last_release}")
+            print("   only frontend/docs changes do not require a backend release")
+            return 1
+
     version = datetime.now(UTC).strftime("%Y.%m%d.%H%M%S")
 
     # print banner using figlet


### PR DESCRIPTION
## Problem
Created unnecessary release `2025.1107.174612` even though there were no backend changes since the last release - only frontend and docs changes were merged.

Two issues:
1. Release script doesn't validate that backend changes exist before creating a release
2. No documentation requiring use of `just release` instead of calling `./scripts/release` directly

## Solution

### Prevent releases without backend changes
Added validation to check for backend changes since last release:
- Uses `gh release list --limit 1` to get most recent release
- Runs `git log <last_release>..HEAD -- src/backend/` to check for backend changes
- Exits with error if no backend changes found

### Document just usage
Updated CLAUDE.md to specify that releases should always use `just release`, not `./scripts/release` directly.

## Changes

**scripts/release:**
```python
# check if there are backend changes since last release
result = subprocess.run(
    ["gh", "release", "list", "--limit", "1"],
    capture_output=True,
    text=True,
    check=True,
)
if result.stdout.strip():
    last_release = result.stdout.split()[0]

    # check for backend changes since last release
    result = subprocess.run(
        ["git", "log", f"{last_release}..HEAD", "--oneline", "--", "src/backend/"],
        capture_output=True,
        text=True,
        check=True,
    )

    if not result.stdout.strip():
        print("❌ no backend changes since last release")
        print(f"   last release: {last_release}")
        print("   only frontend/docs changes do not require a backend release")
        return 1
```

**CLAUDE.md:**
```markdown
- **releases**: ALWAYS use `just release` (never `./scripts/release` directly)
```

## Testing
Running the release script on current main (no backend changes):
```
❌ no backend changes since last release
   last release: 2025.1107.174612
   only frontend/docs changes do not require a backend release
```

## Benefits
✅ Prevents unnecessary backend deployments  
✅ Enforces use of justfile for consistency  
✅ Clear error message when trying to release without backend changes  
✅ Validates release is needed before creating it

🤖 Generated with [Claude Code](https://claude.com/claude-code)