### PR TITLE
fix: prevent double loading state on homepage

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -15,6 +15,8 @@ import { queue } from '$lib/queue.svelte';
 	let tracks = $derived(tracksCache.tracks);
 	let loadingTracks = $derived(tracksCache.loading);
 	let hasTracks = $derived(tracks.length > 0);
+	// only show loading if we don't have cached data
+	let showLoading = $derived(loadingTracks && !hasTracks);
 
 	onMount(async () => {
 		// check authentication (non-blocking)
@@ -56,7 +58,7 @@ import { queue } from '$lib/queue.svelte';
 <main>
 	<section class="tracks">
 		<h2>latest tracks</h2>
-		{#if loadingTracks}
+		{#if showLoading}
 			<p class="loading-text">loading tracks...</p>
 		{:else if !hasTracks}
 			<p class="empty">no tracks yet</p>


### PR DESCRIPTION
## Problem
Homepage shows flickering loading state on hard refresh:
1. Cached tracks appear immediately ✓
2. "loading tracks..." message appears briefly ✗
3. Tracks appear again ✗

This creates a jarring visual flash where content appears, disappears, then reappears.

## Root Cause

**frontend/src/lib/tracks.svelte.ts:**
```typescript
class TracksCache {
    tracks = $state<Track[]>(loadCachedTracks());  // loads from localStorage on init
    loading = $state(false);  // starts false

    async fetch() {
        this.loading = true;  // <-- triggers loading UI even though we have cached data
        // ... fetch from server
        this.loading = false;
    }
}
```

**Render sequence:**
1. Initial: `tracks` has cached data, `loading = false` → shows tracks
2. `fetch()` called: `loading = true` → shows "loading tracks..."
3. Complete: `loading = false`, tracks updated → shows tracks again

## Solution

Only show loading state when we don't have cached data:

```typescript
// only show loading if we don't have cached data
let showLoading = $derived(loadingTracks && !hasTracks);

{#if showLoading}
    <p class="loading-text">loading tracks...</p>
{:else if !hasTracks}
    <p class="empty">no tracks yet</p>
{:else}
    <!-- show tracks -->
{/if}
```

## Behavior

**With cached data:**
- Shows cached tracks immediately
- Fetches updates in background (no loading UI)
- Updates tracks seamlessly when fetch completes
- No flicker

**Without cached data:**
- Shows "loading tracks..." 
- Shows tracks when fetch completes
- Normal loading experience

## Changes

**frontend/src/routes/+page.svelte:**
- Added `showLoading` derived state: `loadingTracks && !hasTracks`
- Changed template condition from `loadingTracks` to `showLoading`

🤖 Generated with [Claude Code](https://claude.com/claude-code)