### PR TITLE
fix: use dynamic player height for page bottom padding

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -86,7 +86,7 @@ import { queue } from '$lib/queue.svelte';
 	main {
 		max-width: 800px;
 		margin: 0 auto;
-		padding: 0 1rem 120px;
+		padding: 0 1rem calc(var(--player-height, 120px) + env(safe-area-inset-bottom, 0px));
 	}
 
 	.tracks h2 {

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -263,7 +263,7 @@ import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
 	main {
 		max-width: 800px;
 		margin: 0 auto;
-		padding: 0 1rem 120px;
+		padding: 0 1rem calc(var(--player-height, 120px) + env(safe-area-inset-bottom, 0px));
 	}
 
 	.not-found {

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -495,7 +495,7 @@
 	@media (max-width: 768px) {
 		main {
 			padding: 1rem;
-			padding-bottom: 10rem;
+			padding-bottom: calc(var(--player-height, 10rem) + env(safe-area-inset-bottom, 0px));
 		}
 
 		.artist-header {


### PR DESCRIPTION
## Problem

Two related mobile issues visible in the screenshot:

1. **Gap at bottom**: White/gray bar appearing between player bottom and screen bottom
2. **Content cut off**: Can't scroll far enough to see last track - it's hidden behind/below the player

![mobile-scroll-issue](https://github.com/user-attachments/assets/...)

## Root Cause

Pages used hardcoded bottom padding that didn't match the actual dynamic player height:

**frontend/src/routes/+page.svelte:**
```css
main {
    padding: 0 1rem 120px;  /* hardcoded, doesn't match player */
}
```

**Player.svelte:**
```css
.player {
    position: fixed;
    bottom: 0;
    padding-bottom: max(1rem, env(safe-area-inset-bottom));
    /* height varies by content + safe areas */
}
```

The mismatch meant:
- Player sits at `bottom: 0` (flush with screen) ✓
- But page padding doesn't account for player's dynamic height ✗
- On mobile with safe area insets, player is taller than expected ✗
- Gap appears, last track gets cut off ✗

## Solution

Use the `--player-height` CSS variable (already set by Player component in PR #101) combined with `env(safe-area-inset-bottom)`:

```css
main {
    padding: 0 1rem calc(var(--player-height, 120px) + env(safe-area-inset-bottom, 0px));
}
```

This ensures:
- Bottom padding exactly matches player height
- Safe area insets accounted for  
- No gap at bottom
- All content scrollable

## Changes

**Updated bottom padding on 3 pages:**
- Homepage (`+page.svelte`): `120px` → `calc(var(--player-height, 120px) + env(safe-area-inset-bottom, 0px))`
- Track page (`track/[id]/+page.svelte`): same
- User profile mobile (`u/[handle]/+page.svelte`): `10rem` → `calc(var(--player-height, 10rem) + env(safe-area-inset-bottom, 0px))`

## Testing

Test on mobile (especially iPhone with safe areas):
- [ ] No gap between player and screen bottom
- [ ] Can scroll to see last track completely
- [ ] Player stays firmly at bottom when scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)