### PR TITLE
feat: add password protection for pages.dev domains

### DIFF
--- a/frontend/functions/_middleware.ts
+++ b/frontend/functions/_middleware.ts
@@ -1,0 +1,42 @@
+import { CFP_ALLOWED_PATHS } from './constants';
+import { getCookieKeyValue } from './utils';
+import { getTemplate } from './template';
+
+export async function onRequest(context: {
+  request: Request;
+  next: () => Promise<Response>;
+  env: { CFP_PASSWORD?: string };
+}): Promise<Response> {
+  const { request, next, env } = context;
+  const url = new URL(request.url);
+  const { pathname, searchParams, hostname } = url;
+  const { error } = Object.fromEntries(searchParams);
+
+  // Only apply password protection to *.pages.dev domains
+  if (!hostname.endsWith('.pages.dev')) {
+    return await next();
+  }
+
+  const cookie = request.headers.get('cookie') || '';
+  const cookieKeyValue = await getCookieKeyValue(env.CFP_PASSWORD);
+
+  if (
+    cookie.includes(cookieKeyValue) ||
+    // allow the request to cfp_login only if it is a POST request
+    (request.method == "POST" && pathname === '/cfp_login') ||
+    CFP_ALLOWED_PATHS.includes(pathname) ||
+    !env.CFP_PASSWORD
+  ) {
+    // Correct hash in cookie, allowed path, or no password set.
+    // Continue to next middleware.
+    return await next();
+  } else {
+    // No cookie or incorrect hash in cookie. Redirect to login.
+    return new Response(getTemplate({ redirectPath: pathname, withError: error === '1' }), {
+      headers: {
+        'content-type': 'text/html',
+        'cache-control': 'no-cache'
+      }
+    });
+  }
+}

--- a/frontend/functions/cfp_login.ts
+++ b/frontend/functions/cfp_login.ts
@@ -1,0 +1,37 @@
+import { CFP_COOKIE_MAX_AGE } from './constants';
+import { sha256, getCookieKeyValue } from './utils';
+
+export async function onRequestPost(context: {
+  request: Request;
+  env: { CFP_PASSWORD?: string };
+}): Promise<Response> {
+  const { request, env } = context;
+  const body = await request.formData();
+  const { password, redirect } = Object.fromEntries(body);
+  const hashedPassword = await sha256(password.toString());
+  const hashedCfpPassword = await sha256(env.CFP_PASSWORD);
+  const redirectPath = redirect.toString() || '/';
+
+  if (hashedPassword === hashedCfpPassword) {
+    // Valid password. Redirect to home page and set cookie with auth hash.
+    const cookieKeyValue = await getCookieKeyValue(env.CFP_PASSWORD);
+
+    return new Response('', {
+      status: 302,
+      headers: {
+        'Set-Cookie': `${cookieKeyValue}; Max-Age=${CFP_COOKIE_MAX_AGE}; Path=/; HttpOnly; Secure`,
+        'Cache-Control': 'no-cache',
+        Location: redirectPath
+      }
+    });
+  } else {
+    // Invalid password. Redirect to login page with error.
+    return new Response('', {
+      status: 302,
+      headers: {
+        'Cache-Control': 'no-cache',
+        Location: `${redirectPath}?error=1`
+      }
+    });
+  }
+}

--- a/frontend/functions/constants.ts
+++ b/frontend/functions/constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Key for the auth cookie.
+ */
+export const CFP_COOKIE_KEY = 'CFP-Auth-Key';
+
+/**
+ * Max age of the auth cookie in seconds.
+ * Default: 1 week.
+ */
+export const CFP_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+
+/**
+ * Paths that don't require authentication.
+ */
+export const CFP_ALLOWED_PATHS = [];

--- a/frontend/functions/template.ts
+++ b/frontend/functions/template.ts
@@ -1,0 +1,62 @@
+export function getTemplate({
+  redirectPath,
+  withError
+}: {
+  redirectPath: string;
+  withError: boolean;
+}): string {
+  return `
+  <!doctype html>
+  <html lang="en" data-theme="dark">
+
+    <head>
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <title>Password Protected Site</title>
+      <meta name="description" content="This site is password protected.">
+      <link rel="shortcut icon" href="https://picocss.com/favicon.ico">
+
+      <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css">
+
+      <style>
+        body > main {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          min-height: calc(100vh - 7rem);
+          padding: 1rem 0;
+          max-width: 600px;
+          margin: 0 auto;
+        }
+
+        .error {
+          background: white;
+          border-radius: 10px;
+          color: var(--del-color);
+          padding: 0.5em 1em;
+        }
+
+        h2 { color: var(--color-h2); }
+      </style>
+    </head>
+
+    <body>
+      <main>
+        <article>
+          <hgroup>
+            <h1>Password</h1>
+            <h2>Please enter your password for this site.</h2>
+          </hgroup>
+          ${withError ? `<p class="error">Incorrect password, please try again.</p>` : ''}
+          <form method="post" action="/cfp_login">
+            <input type="hidden" name="redirect" value="${redirectPath}" />
+            <input type="password" name="password" placeholder="Password" aria-label="Password" autocomplete="current-password" required autofocus>
+            <button type="submit" class="contrast">Login</button>
+          </form>
+        </article>
+      </main>
+    </body>
+
+  </html>
+  `;
+}

--- a/frontend/functions/utils.ts
+++ b/frontend/functions/utils.ts
@@ -1,0 +1,13 @@
+import { CFP_COOKIE_KEY } from './constants';
+
+export async function sha256(str: string): Promise<string> {
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(str));
+  return Array.prototype.map
+    .call(new Uint8Array(buf), (x) => ('00' + x.toString(16)).slice(-2))
+    .join('');
+}
+
+export async function getCookieKeyValue(password?: string): Promise<string> {
+  const hash = await sha256(password);
+  return `${CFP_COOKIE_KEY}=${hash}`;
+}


### PR DESCRIPTION
## Problem

Users (like my mom) have old links to `relay-4i6.pages.dev` which now points to the staging backend. When they try to use the app:
- Staging backend uses old namespace (`app.relay`)
- Their production data uses new namespace (`fm.plyr`)
- Migrations fail with namespace mismatch errors
- Confusing UX - they think the production site is broken

Need to block public access to `*.pages.dev` URLs (both `relay-4i6.pages.dev` and preview deployments) to prevent this.

## Solution

Password-protect all `*.pages.dev` domains using Cloudflare Functions middleware. This is the standard Cloudflare Pages approach for protecting preview/staging environments.

**Implementation based on:** https://github.com/Charca/cloudflare-pages-auth

**How it works:**
1. Middleware intercepts all requests to `*.pages.dev` domains
2. Checks for valid authentication cookie
3. No cookie → shows login page
4. Correct password → sets HttpOnly/Secure cookie (1 week expiry)
5. Production domain (`plyr.fm`) unaffected - no password required

## Setup Required

After merging, set the `CFP_PASSWORD` environment variable in Cloudflare Pages dashboard:

1. Go to Workers & Pages → plyr.fm project
2. Settings → Environment Variables
3. Add `CFP_PASSWORD` with your chosen password
4. Deploy to apply

## Changes

**New files in `frontend/functions/`:**
- `_middleware.ts`: Request interceptor, only applies to `*.pages.dev` hostnames
- `cfp_login.ts`: POST handler for login form submission
- `constants.ts`: Cookie configuration (name, max age, allowed paths)
- `template.ts`: HTML login page template
- `utils.ts`: SHA-256 hashing and cookie utilities

## Security

- Password hashed with SHA-256 before comparison
- Cookie is HttpOnly and Secure
- 1 week expiration on auth cookie
- Only affects `*.pages.dev` domains - production (`plyr.fm`) requires no password

## Testing

After deployment with `CFP_PASSWORD` set:
- [ ] Visiting `relay-4i6.pages.dev` shows login page
- [ ] Entering correct password grants access
- [ ] Cookie persists across page refreshes
- [ ] Visiting `plyr.fm` requires no password

🤖 Generated with [Claude Code](https://claude.com/claude-code)