### PR TITLE
chore: trigger redeploy with CFP_PASSWORD

### DIFF
--- a/frontend/functions/constants.ts
+++ b/frontend/functions/constants.ts
@@ -12,4 +12,4 @@ export const CFP_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 /**
  * Paths that don't require authentication.
  */
-export const CFP_ALLOWED_PATHS = [];
+export const CFP_ALLOWED_PATHS: string[] = [];


### PR DESCRIPTION
Trivial change to trigger a new deployment now that CFP_PASSWORD is set in environment variables.