### PR TITLE
feat: redirect pages.dev to plyr.fm with password bypass

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -14,6 +14,25 @@
 	let showQueue = $state(false);
 
 	onMount(() => {
+		// redirect pages.dev domains to plyr.fm unless bypass password is provided
+		if (window.location.hostname.endsWith('.pages.dev')) {
+			const bypassPassword = sessionStorage.getItem('pages_dev_bypass');
+			const BYPASS_SECRET = 'plyr-staging-2024'; // change this to your preferred password
+
+			if (bypassPassword !== BYPASS_SECRET) {
+				const password = prompt('This is a staging environment. Enter password to continue, or click Cancel to go to production:');
+
+				if (password === BYPASS_SECRET) {
+					sessionStorage.setItem('pages_dev_bypass', password);
+				} else {
+					// redirect to production
+					const currentPath = window.location.pathname + window.location.search + window.location.hash;
+					window.location.href = `https://plyr.fm${currentPath}`;
+					return;
+				}
+			}
+		}
+
 		// apply saved accent color from localStorage
 		const savedAccent = localStorage.getItem('accentColor');
 		if (savedAccent) {


### PR DESCRIPTION
## Problem
Users with old `relay-4i6.pages.dev` links access staging environment and experience namespace migration errors.

## Solution
Simple client-side redirect:
1. Detect if on `*.pages.dev` domain
2. Show browser password prompt
3. Correct password → store in sessionStorage, allow access
4. Wrong/cancel → redirect to `plyr.fm` with same path

## How It Works

**When visiting `relay-4i6.pages.dev/whatever`:**
- Prompt appears: "This is a staging environment. Enter password to continue, or click Cancel to go to production:"
- Enter correct password → staging loads normally, password saved for session
- Click Cancel or wrong password → redirects to `https://plyr.fm/whatever`

**Password:** `plyr-staging-2024` (hardcoded in `+layout.svelte` line 20)

**Session persistence:** Password stored in `sessionStorage`, lasts until tab closes

## Benefits
✅ Simple - no Cloudflare config needed  
✅ Works immediately on deploy  
✅ Mom gets redirected to production automatically  
✅ You can access staging by entering password  
✅ Password persists for browser session  

## Testing
- [ ] Visit `relay-4i6.pages.dev` → see prompt
- [ ] Click Cancel → redirects to `plyr.fm`
- [ ] Visit again, enter `plyr-staging-2024` → staging loads
- [ ] Refresh page → no prompt (session persists)
- [ ] Close tab, reopen → prompt appears again

🤖 Generated with [Claude Code](https://claude.com/claude-code)