### PR TITLE
fix: position queue feedback above button, not overlaying icon

### DIFF
--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -314,33 +314,27 @@
 
 	.queue-feedback {
 		position: absolute;
-		top: 50%;
+		top: -8px;
 		left: 50%;
-		transform: translate(-50%, -50%);
+		transform: translateX(-50%);
 		color: var(--accent);
-		font-size: 1.2rem;
+		font-size: 0.9rem;
 		pointer-events: none;
-		animation: check-pulse 1s ease-out forwards;
+		animation: check-float 1s ease-out forwards;
 	}
 
-	@keyframes check-pulse {
+	@keyframes check-float {
 		0% {
 			opacity: 0;
-			transform: translate(-50%, -50%) scale(0.8);
+			transform: translateX(-50%) translateY(0);
 		}
-		15% {
+		20% {
 			opacity: 1;
-			transform: translate(-50%, -50%) scale(1.1);
-		}
-		30% {
-			transform: translate(-50%, -50%) scale(1);
-		}
-		85% {
-			opacity: 1;
+			transform: translateX(-50%) translateY(-4px);
 		}
 		100% {
 			opacity: 0;
-			transform: translate(-50%, -50%) scale(0.9);
+			transform: translateX(-50%) translateY(-16px);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes the broken queue feedback animation that was overlaying the button's existing plus icon.

## The Problem

The previous implementation positioned the checkmark centered over the button (`top: 50%; left: 50%`), which made it appear directly on top of the existing plus-queue icon. This made both icons invisible/confusing.

## The Fix

Now the checkmark:
- Appears just **above** the button (`top: -8px`)
- Floats upward while fading out
- Is clearly separate from the button's icon
- Provides unambiguous feedback without obscuring anything

## Why This Happened

I didn't think through where the feedback would actually appear relative to the existing button icon. Should have positioned it outside the button area from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)