### PR TITLE
feat: add frosted glass backdrop to toast notifications

### DIFF
--- a/frontend/src/lib/components/Toast.svelte
+++ b/frontend/src/lib/components/Toast.svelte
@@ -45,13 +45,16 @@
 		display: inline-flex;
 		align-items: flex-start;
 		gap: 0.5rem;
-		padding: 0.4rem 0.9rem;
-		background: transparent;
-		border: none;
-		border-radius: 4px;
+		padding: 0.5rem 1rem;
+		background: rgba(10, 10, 10, 0.6);
+		backdrop-filter: blur(12px);
+		-webkit-backdrop-filter: blur(12px);
+		border: 1px solid rgba(255, 255, 255, 0.06);
+		border-radius: 8px;
 		pointer-events: none;
 		font-size: 0.85rem;
 		max-width: 450px;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 	}
 
 	.toast-icon {


### PR DESCRIPTION
## Summary

Adds a subtle liquid glass effect to toast notifications, giving the text a surface to exist on while maintaining the elegant aesthetic.

## Changes

- **Background**: `rgba(10, 10, 10, 0.6)` - semi-transparent dark surface
- **Backdrop filter**: `blur(12px)` - frosted glass blur effect
- **Border**: `1px solid rgba(255, 255, 255, 0.06)` - subtle edge definition
- **Border radius**: increased to `8px` for softer corners
- **Shadow**: `0 4px 12px rgba(0, 0, 0, 0.4)` - depth and separation from background
- **Padding**: `0.5rem 1rem` - slightly more breathing room

## Visual Effect

The toast now has a gentle, glassy surface that makes the differentiated text (icon, "queued", track name) pop against any background without being heavy-handed. The frosted glass effect creates separation while maintaining transparency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)