### PR TITLE
fix: allow multiple tracks to reference same audio file

### DIFF
--- a/alembic/versions/ba46ea4ba64e_remove_unique_constraint_from_tracks_.py
+++ b/alembic/versions/ba46ea4ba64e_remove_unique_constraint_from_tracks_.py
@@ -1,0 +1,35 @@
+"""remove unique constraint from tracks file_id
+
+Revision ID: ba46ea4ba64e
+Revises: 008ffaa79bea
+Create Date: 2025-11-09 02:23:52.593507
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "ba46ea4ba64e"
+down_revision: str | Sequence[str] | None = "008ffaa79bea"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # drop unique constraint on file_id
+    op.drop_constraint("tracks_file_id_key", "tracks", type_="unique")
+
+    # add non-unique index for query performance
+    op.create_index("ix_tracks_file_id", "tracks", ["file_id"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # remove index
+    op.drop_index("ix_tracks_file_id", "tracks")
+
+    # re-add unique constraint
+    op.create_unique_constraint("tracks_file_id_key", "tracks", ["file_id"])

--- a/src/backend/api/tracks.py
+++ b/src/backend/api/tracks.py
@@ -193,11 +193,8 @@ async def _process_upload_background(
 
             except IntegrityError as e:
                 await db.rollback()
-                error_msg = "this file has already been uploaded"
-                if "tracks_file_id_key" in str(e):
-                    error_msg = (
-                        "duplicate file: this audio file already exists in the database"
-                    )
+                # integrity errors now only occur for foreign key violations or other constraints
+                error_msg = f"database constraint violation: {e!s}"
                 upload_tracker.update_status(
                     upload_id, UploadStatus.FAILED, "upload failed", error=error_msg
                 )

--- a/src/backend/models/track.py
+++ b/src/backend/models/track.py
@@ -25,7 +25,7 @@ class Track(Base):
     # essential fields
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     title: Mapped[str] = mapped_column(String, nullable=False)
-    file_id: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    file_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
     file_type: Mapped[str] = mapped_column(String, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),


### PR DESCRIPTION
## Problem

Users were blocked from uploading the same audio file with different metadata:

![error screenshot](https://github.com/user-attachments/assets/...)
> duplicate file: this audio file already exists in the database

This happened because:
- `file_id` is generated by hashing file content (`hash_file_chunked(file)[:16]`)
- `file_id` had a **unique constraint** in database
- Same audio bytes → same hash → duplicate error

## Solution

Remove unique constraint on `file_id`, allowing multiple track records to reference the same audio file.

### Changes

**Track model** (`src/backend/models/track.py:28`):
```python
- file_id: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+ file_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
```

**Migration** (`alembic/versions/ba46ea4ba64e_*.py`):
- Drops constraint: `tracks_file_id_key`
- Adds non-unique index: `ix_tracks_file_id` (for query performance)
- Fully reversible via `downgrade()`

**Error handling** (`src/backend/api/tracks.py:194-203`):
- Updated IntegrityError handler (no longer checks for `tracks_file_id_key`)

### Why This is Safe

1. **Storage already supports it**: R2 backend handles multiple track records pointing to same file
2. **Deduplication works**: Same audio bytes = same file_id = same R2 object (saves storage)
3. **Legitimate use case**: Users can have different metadata for same audio
   - Different title
   - Different album
   - Different featured artists

### Testing

Ran `uv run ruff check` - all checks passed ✓

### Deployment

On merge to main:
- ✅ Staging backend deploys automatically via GitHub Actions
- ✅ Migration runs via `release_command` in `fly.staging.toml`
- ⏸️ Production release requires `just release` (manual trigger)

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)