### PR TITLE
fix: eliminate gap between player and screen bottom on Chrome iOS

### DIFF
--- a/frontend/src/lib/components/Player.svelte
+++ b/frontend/src/lib/components/Player.svelte
@@ -303,13 +303,12 @@
 <style>
 	.player {
 		position: fixed;
-		bottom: 0;
+		bottom: env(safe-area-inset-bottom, 0);
 		left: 0;
 		right: 0;
 		background: #1a1a1a;
 		border-top: 1px solid #333;
-		padding: 0.75rem 2rem;
-		padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+		padding: 0.75rem 2rem 0.75rem 2rem;
 		z-index: 100;
 	}
 
@@ -597,7 +596,6 @@
 	@media (max-width: 768px) {
 		.player {
 			padding: 1rem;
-			padding-bottom: max(1rem, env(safe-area-inset-bottom));
 		}
 
 		.player-content {


### PR DESCRIPTION
## summary

Fixes the gap between the player and the bottom of the screen that appears specifically on Chrome iOS.

## changes

- Changed `.player` positioning to use `bottom: env(safe-area-inset-bottom, 0)` instead of `bottom: 0`
- Simplified padding by removing `max()` calculations since safe area inset is now handled by the `bottom` property
- Applied same fix to mobile media query

## technical details

Chrome on iOS has a known issue where `position: fixed` elements with `bottom: 0` don't actually stick to the visual viewport bottom when the browser chrome (address bar/toolbar) is showing/hiding. By using `env(safe-area-inset-bottom, 0)` directly on the `bottom` property, the player now correctly positions itself relative to the safe area, eliminating the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)