### PR TITLE
fix: force player to stick to bottom on Chrome iOS

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/frontend/src/lib/components/Player.svelte
+++ b/frontend/src/lib/components/Player.svelte
@@ -303,13 +303,17 @@
 <style>
 	.player {
 		position: fixed;
-		bottom: env(safe-area-inset-bottom, 0);
+		bottom: 0;
 		left: 0;
 		right: 0;
 		background: #1a1a1a;
 		border-top: 1px solid #333;
-		padding: 0.75rem 2rem 0.75rem 2rem;
+		padding: 0.75rem 2rem;
+		padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
 		z-index: 100;
+		/* force player to stick to visual viewport bottom on iOS Chrome */
+		transform: translateZ(0);
+		-webkit-transform: translateZ(0);
 	}
 
 	.player-content {
@@ -596,6 +600,7 @@
 	@media (max-width: 768px) {
 		.player {
 			padding: 1rem;
+			padding-bottom: max(1rem, env(safe-area-inset-bottom));
 		}
 
 		.player-content {


### PR DESCRIPTION
## summary

Second attempt at fixing the gap between player and bottom of screen on Chrome iOS.

## changes

1. Added `viewport-fit=cover` to the viewport meta tag in app.html - this allows the page to extend into safe areas
2. Added hardware acceleration to player with `transform: translateZ(0)` - forces GPU rendering and fixes positioning issues with iOS Chrome's dynamic viewport
3. Restored `bottom: 0` positioning with proper safe-area-inset handling in padding

## technical details

Chrome on iOS has a "minimal UI" mode where the address bar slides in/out dynamically. This changes the viewport height, causing `position: fixed` elements to not stick properly. The combination of:
- `viewport-fit=cover` ensures content can extend to screen edges
- `translateZ(0)` forces hardware acceleration which fixes the fixed positioning behavior
- Safe area insets handled via padding instead of bottom property

🤖 Generated with [Claude Code](https://claude.com/claude-code)