### PR TITLE
feat: add track cover art to link previews

### DIFF
--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -138,6 +138,9 @@ import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
 	{#if data.track.album}
 		<meta property="music:album" content="{data.track.album}" />
 	{/if}
+	{#if data.track.image_url}
+		<meta property="og:image" content="{data.track.image_url}" />
+	{/if}
 	{#if data.track.r2_url}
 		<meta property="og:audio" content="{data.track.r2_url}" />
 		<meta property="og:audio:type" content="audio/{data.track.file_type}" />
@@ -150,6 +153,9 @@ import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
 		name="twitter:description"
 		content={`listen to ${data.track.title} by ${data.track.artist} on ${APP_NAME}`}
 	/>
+	{#if data.track.image_url}
+		<meta name="twitter:image" content="{data.track.image_url}" />
+	{/if}
 </svelte:head>
 
 {#if loading}


### PR DESCRIPTION
## summary

adds track cover art to social media link previews (Open Graph and Twitter cards).

## changes

- added `og:image` meta tag for tracks with images
- added `twitter:image` meta tag for tracks with images
- supports all image formats including GIFs
- artist pages already had avatar support

## testing

when sharing a track link (e.g., `https://plyr.fm/track/20`) that has cover art, the preview will now show the track's image instead of just the logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)