### PR TITLE
fix: improve social media link previews

### DIFF
--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -124,10 +124,10 @@ import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
 
 	<!-- Open Graph / Facebook -->
 	<meta property="og:type" content="music.song" />
-	<meta property="og:title" content="{data.track.title} by {data.track.artist}" />
+	<meta property="og:title" content="{data.track.title}" />
 	<meta
 		property="og:description"
-		content={`listen to ${data.track.title} by ${data.track.artist} on ${APP_NAME}`}
+		content="{data.track.artist}{data.track.album ? ` • ${data.track.album}` : ''}"
 	/>
 	<meta
 		property="og:url"
@@ -140,6 +140,8 @@ import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
 	{/if}
 	{#if data.track.image_url}
 		<meta property="og:image" content="{data.track.image_url}" />
+		<meta property="og:image:width" content="1200" />
+		<meta property="og:image:height" content="1200" />
 	{/if}
 	{#if data.track.r2_url}
 		<meta property="og:audio" content="{data.track.r2_url}" />
@@ -147,11 +149,11 @@ import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
 	{/if}
 
 	<!-- Twitter -->
-	<meta name="twitter:card" content="summary" />
-	<meta name="twitter:title" content="{data.track.title} by {data.track.artist}" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content="{data.track.title}" />
 	<meta
 		name="twitter:description"
-		content={`listen to ${data.track.title} by ${data.track.artist} on ${APP_NAME}`}
+		content="{data.track.artist}{data.track.album ? ` • ${data.track.album}` : ''}"
 	/>
 	{#if data.track.image_url}
 		<meta name="twitter:image" content="{data.track.image_url}" />

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -167,10 +167,10 @@
 
 		<!-- Open Graph / Facebook -->
 		<meta property="og:type" content="profile" />
-		<meta property="og:title" content="{data.artist.display_name} (@{data.artist.handle})" />
+		<meta property="og:title" content="{data.artist.display_name}" />
 		<meta
 			property="og:description"
-			content={`listen to audio by ${data.artist.display_name} on ${APP_NAME}`}
+			content="@{data.artist.handle} on {APP_NAME}"
 		/>
 		<meta
 			property="og:url"
@@ -180,14 +180,16 @@
 		<meta property="profile:username" content="{data.artist.handle}" />
 		{#if data.artist.avatar_url}
 			<meta property="og:image" content="{data.artist.avatar_url}" />
+			<meta property="og:image:width" content="400" />
+			<meta property="og:image:height" content="400" />
 		{/if}
 
 		<!-- Twitter -->
 		<meta name="twitter:card" content="summary" />
-		<meta name="twitter:title" content="{data.artist.display_name} (@{data.artist.handle})" />
+		<meta name="twitter:title" content="{data.artist.display_name}" />
 		<meta
 			name="twitter:description"
-			content={`listen to audio by ${data.artist.display_name} on ${APP_NAME}`}
+			content="@{data.artist.handle} on {APP_NAME}"
 		/>
 		{#if data.artist.avatar_url}
 			<meta name="twitter:image" content="{data.artist.avatar_url}" />


### PR DESCRIPTION
## summary

fixes the split image issue and makes link previews more informative.

## changes

**track previews:**
- title: just the track name (e.g., "floating")
- description: artist + album (e.g., "nate • covid ableton sessions")
- use `summary_large_image` card for better presentation
- add image dimensions (1200x1200) for proper rendering

**artist previews:**
- title: just the display name (e.g., "nate")
- description: handle on platform (e.g., "@zzstoatzz.io on plyr.fm")
- add image dimensions (400x400) for avatar

## before
- showing half logo, half image (split down middle)
- description just said "music streaming on atproto"
- didn't indicate what track/artist was being shared

## after
- full image displayed properly
- clear track/artist information
- better card formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)