### PR TITLE
fix: use reactive effect for auto-playing shared tracks

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -39,10 +39,12 @@
 
 		// fetch tracks from cache (will use cached data if recent)
 		await tracksCache.fetch();
+	});
 
-		// check for track query param and auto-play
+	// reactive effect to auto-play track from URL query param
+	$effect(() => {
 		const trackId = $page.url.searchParams.get('track');
-		if (trackId) {
+		if (trackId && tracks.length > 0) {
 			const track = tracks.find(t => t.id === parseInt(trackId));
 			if (track) {
 				queue.playNow(track);


### PR DESCRIPTION
fixes auto-play when following shared track links

## issue
when visiting `/?track=20` (after redirect from `/track/20`), the track wasn't auto-playing because tracks hadn't loaded yet when `onMount` ran

## fix
moved track query param handling from `onMount` to `$effect` so it:
- waits for tracks to load
- reacts to URL changes
- reacts to tracks becoming available