### PR TITLE
fix: initialize image_format to avoid UnboundLocalError

### DIFF
--- a/src/backend/api/tracks.py
+++ b/src/backend/api/tracks.py
@@ -561,6 +561,7 @@ async def update_track_metadata(
 
     # handle image update
     image_url = None
+    image_format = None
     if image and image.filename:
         image_format = ImageFormat.from_filename(image.filename)
         if not image_format:


### PR DESCRIPTION
fixes UnboundLocalError when uploading images from mobile

## issue
when uploading an image, users saw error: "cannot access local variable 'image_format' where it is not associated with a value"

## root cause
`image_format` was only assigned inside `if image and image.filename:` block. if an exception occurred during error handling, Python would treat it as an unbound local variable

## fix
initialize `image_format = None` before the if block