### PR TITLE
fix: initialize image_format in R2 storage

### DIFF
--- a/src/backend/storage/r2.py
+++ b/src/backend/storage/r2.py
@@ -57,6 +57,7 @@ class R2Storage:
         ext = Path(filename).suffix.lower()
 
         # try audio format first
+        image_format = None  # initialize to prevent UnboundLocalError
         audio_format = AudioFormat.from_extension(ext)
         if audio_format:
             key = f"audio/{file_id}{ext}"


### PR DESCRIPTION
## problem

the actual bug causing upload failures was in the R2 storage backend at line 82.

when uploading an audio file:
1. code goes through `if audio_format:` path
2. `image_format` is never assigned
3. line 82 references `image_format` to determine bucket
4. UnboundLocalError

this is why uploads were broken even after PR #129 and #133.

## fix

initialize `image_format = None` before the conditional blocks.

## why wasn't this caught?

- ruff doesn't detect this pattern
- mypy doesn't run by default (and may not catch it either)
- this suggests we need better static analysis in CI

## next steps

this is the third place we've had to add this same fix. we should refactor to centralize the image format handling logic.