### PR TITLE
fix: track link preview meta tags

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -9,9 +9,13 @@
 	import Toast from '$lib/components/Toast.svelte';
 	import Queue from '$lib/components/Queue.svelte';
 	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
 
 	let { children } = $props();
 	let showQueue = $state(false);
+
+	// only show default meta tags when not on a track page
+	let isTrackPage = $derived($page.url.pathname.startsWith('/track/'));
 
 	onMount(() => {
 		// redirect pages.dev domains to plyr.fm unless bypass password is provided
@@ -64,32 +68,34 @@
 <svelte:head>
 	<link rel="icon" href={logo} />
 
-	<!-- default meta tags for link previews -->
-	<title>{APP_NAME} - {APP_TAGLINE}</title>
-	<meta
-		name="description"
-		content={`discover and stream audio on the AT Protocol with ${APP_NAME}`}
-	/>
+	{#if !isTrackPage}
+		<!-- default meta tags for link previews (not on track pages) -->
+		<title>{APP_NAME} - {APP_TAGLINE}</title>
+		<meta
+			name="description"
+			content={`discover and stream audio on the AT Protocol with ${APP_NAME}`}
+		/>
 
-	<!-- Open Graph / Facebook -->
-	<meta property="og:type" content="website" />
-	<meta property="og:title" content="{APP_NAME} - {APP_TAGLINE}" />
-	<meta
-		property="og:description"
-		content={`discover and stream audio on the AT Protocol with ${APP_NAME}`}
-	/>
-	<meta property="og:site_name" content={APP_NAME} />
-	<meta property="og:url" content={APP_CANONICAL_URL} />
-	<meta property="og:image" content={logo} />
+		<!-- Open Graph / Facebook -->
+		<meta property="og:type" content="website" />
+		<meta property="og:title" content="{APP_NAME} - {APP_TAGLINE}" />
+		<meta
+			property="og:description"
+			content={`discover and stream audio on the AT Protocol with ${APP_NAME}`}
+		/>
+		<meta property="og:site_name" content={APP_NAME} />
+		<meta property="og:url" content={APP_CANONICAL_URL} />
+		<meta property="og:image" content={logo} />
 
-	<!-- Twitter -->
-	<meta name="twitter:card" content="summary" />
-	<meta name="twitter:title" content="{APP_NAME} - {APP_TAGLINE}" />
-	<meta
-		name="twitter:description"
-		content={`discover and stream audio on the AT Protocol with ${APP_NAME}`}
-	/>
-	<meta name="twitter:image" content={logo} />
+		<!-- Twitter -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="{APP_NAME} - {APP_TAGLINE}" />
+		<meta
+			name="twitter:description"
+			content={`discover and stream audio on the AT Protocol with ${APP_NAME}`}
+		/>
+		<meta name="twitter:image" content={logo} />
+	{/if}
 
 	<script>
 		// prevent flash by applying saved settings immediately


### PR DESCRIPTION
## problem

track link previews were showing 'plyr.fm - music streaming on atproto' instead of the actual track name and artist.

## root cause

the layout's `<svelte:head>` renders default meta tags before the page's meta tags. social media crawlers use the FIRST occurrence of each meta tag, so they were picking up the generic layout tags instead of the track-specific ones.

## fix

made layout meta tags conditional - they only render when NOT on a track page (`/track/*`).

now track pages correctly show:
- **title**: "Track Name - Artist"
- **description**: "Artist • Album" 
- **image**: track artwork
- **audio**: track audio file

## testing

build succeeds and track pages will now have proper meta tags for link previews.