### PR TITLE
fix: prevent layout meta tags from overriding content page previews

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -14,8 +14,12 @@
 	let { children } = $props();
 	let showQueue = $state(false);
 
-	// only show default meta tags when not on a track page
-	let isTrackPage = $derived($page.url.pathname.startsWith('/track/'));
+	// only show default meta tags when not on a content page (track/artist/etc)
+	// content pages provide their own specific meta tags
+	let isContentPage = $derived(
+		$page.url.pathname.startsWith('/track/') ||
+		$page.url.pathname.startsWith('/u/')
+	);
 
 	onMount(() => {
 		// redirect pages.dev domains to plyr.fm unless bypass password is provided
@@ -68,8 +72,8 @@
 <svelte:head>
 	<link rel="icon" href={logo} />
 
-	{#if !isTrackPage}
-		<!-- default meta tags for link previews (not on track pages) -->
+	{#if !isContentPage}
+		<!-- default meta tags for link previews (not on content pages) -->
 		<title>{APP_NAME} - {APP_TAGLINE}</title>
 		<meta
 			name="description"


### PR DESCRIPTION
## summary
- fixes link previews for tracks and artists showing generic "music streaming on atproto" instead of proper track/artist information
- prevents layout's generic meta tags from overriding page-specific ones

## technical details
social media crawlers use the FIRST occurrence of meta tags in HTML. in SvelteKit, layout's `<svelte:head>` renders before page's `<svelte:head>`, so layout meta tags were winning.

## changes
- added `isContentPage` derived state to detect track (`/track/*`) and artist (`/u/*`) pages
- conditionally render layout meta tags only on non-content pages
- content pages now properly show their own images (cover art, avatar) instead of favicon

## test plan
- [ ] verify track link preview shows track title, artist, and cover art
- [ ] verify artist link preview shows artist name, handle, and avatar
- [ ] verify home page and other non-content pages still show generic meta tags with favicon
- [ ] test on Twitter, Discord, Slack, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)