### PR TITLE
revert: restore layout og:image for iMessage compatibility

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -14,13 +14,6 @@
 	let { children } = $props();
 	let showQueue = $state(false);
 
-	// only show default meta tags when not on a content page (track/artist/etc)
-	// content pages provide their own specific meta tags
-	let isContentPage = $derived(
-		$page.url.pathname.startsWith('/track/') ||
-		$page.url.pathname.startsWith('/u/')
-	);
-
 	onMount(() => {
 		// redirect pages.dev domains to plyr.fm unless bypass password is provided
 		if (window.location.hostname.endsWith('.pages.dev')) {
@@ -72,34 +65,32 @@
 <svelte:head>
 	<link rel="icon" href={logo} />
 
-	{#if !isContentPage}
-		<!-- default meta tags for link previews (not on content pages) -->
-		<title>{APP_NAME} - {APP_TAGLINE}</title>
-		<meta
-			name="description"
-			content={`discover and stream audio on the AT Protocol with ${APP_NAME}`}
-		/>
+	<!-- default meta tags for link previews -->
+	<title>{APP_NAME} - {APP_TAGLINE}</title>
+	<meta
+		name="description"
+		content={`discover and stream audio on the AT Protocol with ${APP_NAME}`}
+	/>
 
-		<!-- Open Graph / Facebook -->
-		<meta property="og:type" content="website" />
-		<meta property="og:title" content="{APP_NAME} - {APP_TAGLINE}" />
-		<meta
-			property="og:description"
-			content={`discover and stream audio on the AT Protocol with ${APP_NAME}`}
-		/>
-		<meta property="og:site_name" content={APP_NAME} />
-		<meta property="og:url" content={APP_CANONICAL_URL} />
-		<meta property="og:image" content={logo} />
+	<!-- Open Graph / Facebook -->
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content="{APP_NAME} - {APP_TAGLINE}" />
+	<meta
+		property="og:description"
+		content={`discover and stream audio on the AT Protocol with ${APP_NAME}`}
+	/>
+	<meta property="og:site_name" content={APP_NAME} />
+	<meta property="og:url" content={APP_CANONICAL_URL} />
+	<meta property="og:image" content={logo} />
 
-		<!-- Twitter -->
-		<meta name="twitter:card" content="summary" />
-		<meta name="twitter:title" content="{APP_NAME} - {APP_TAGLINE}" />
-		<meta
-			name="twitter:description"
-			content={`discover and stream audio on the AT Protocol with ${APP_NAME}`}
-		/>
-		<meta name="twitter:image" content={logo} />
-	{/if}
+	<!-- Twitter -->
+	<meta name="twitter:card" content="summary" />
+	<meta name="twitter:title" content="{APP_NAME} - {APP_TAGLINE}" />
+	<meta
+		name="twitter:description"
+		content={`discover and stream audio on the AT Protocol with ${APP_NAME}`}
+	/>
+	<meta name="twitter:image" content={logo} />
 
 	<script>
 		// prevent flash by applying saved settings immediately


### PR DESCRIPTION
## problem
After PR #137 conditionally removed layout's og:image for content pages, iMessage link previews stopped showing ANY image for tracks/artists.

## investigation
looked at git history to compare working vs broken states:

**when it was working (showing split-screen):**
- layout: had og:image pointing to favicon (unconditionally)  
- track page: had og:image pointing to cover art (conditionally)
- result: iMessage showed BOTH images in split-screen

**after PR #137 (broken - no image):**
- layout: NO og:image on content pages (conditionally excluded)
- track page: had og:image pointing to cover art (with og:image:secure_url added)
- result: iMessage shows NO image at all

## hypothesis
iMessage may have a quirk where it:
- works when it finds MULTIPLE og:image tags (shows both)
- fails when it finds only ONE og:image tag (shows none)

OR there's something else about having the layout og:image that makes it work.

## solution
revert to having BOTH og:image tags (layout + content page) like the working state.

## trade-offs
- iMessage will show split-screen again (favicon + cover art) instead of just cover art
- but this is better than showing NO image at all
- other platforms (Twitter, Discord, Bluesky) correctly show only the cover art

## test plan
- [ ] share track link in iMessage - should show split-screen with favicon + cover art
- [ ] verify Twitter/Discord/Bluesky still show cover art only (not split-screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)