### PR TITLE
fix: simplify navigation

### DIFF
--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -22,10 +22,7 @@
 
 		<nav>
 			{#if isAuthenticated}
-				{#if $page.url.pathname !== '/portal'}
-					<a href="/portal" class="nav-link">portal</a>
-				{/if}
-				<a href="/u/{user?.handle}" class="user-handle">@{user?.handle}</a>
+				<a href="/portal" class="user-handle">@{user?.handle}</a>
 				<SettingsMenu />
 				<button onclick={onLogout} class="btn-logout">logout</button>
 			{:else}

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -340,7 +340,10 @@
 		</div>
 
 		<section class="profile-section">
-			<h2>profile settings</h2>
+			<div class="section-header">
+				<h2>profile settings</h2>
+				<a href="/u/{user.handle}" class="view-profile-link">view public profile</a>
+			</div>
 
 			{#if profileSuccess}
 				<div class="message success">{profileSuccess}</div>
@@ -652,6 +655,35 @@
 	.upload-section h2 {
 		font-size: 1.5rem;
 		margin-bottom: 1.5rem;
+	}
+
+	.section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 1.5rem;
+	}
+
+	.section-header h2 {
+		margin-bottom: 0;
+	}
+
+	.view-profile-link {
+		color: var(--text-secondary);
+		text-decoration: none;
+		font-size: 0.9rem;
+		padding: 0.4rem 0.75rem;
+		background: #1a1a1a;
+		border-radius: 6px;
+		border: 1px solid #333;
+		transition: all 0.2s;
+		white-space: nowrap;
+	}
+
+	.view-profile-link:hover {
+		border-color: var(--accent);
+		color: var(--accent);
+		background: #222;
 	}
 
 	form {


### PR DESCRIPTION
removes redundant portal link and simplifies navigation flow.

## changes
- remove "portal" link from header navigation
- @{handle} button now goes to /portal (your editing space)
- add "view public profile" link inside portal page
- users can preview their public profile from within portal

## navigation flow
- click @{handle} → /portal (private editing space)
- inside portal, click "view public profile" → /u/{handle} (public view)