### PR TITLE
perf: resolve PDS URLs concurrently instead of serially

### DIFF
--- a/.claude/commands/consider-review.md
+++ b/.claude/commands/consider-review.md
@@ -1,0 +1,1 @@
+Check the current PR for comments, reviews, and inline review comments via the gh cli.


### PR DESCRIPTION
## summary

fixes homepage loading slowly (2-6 seconds) by resolving all artist PDS URLs concurrently instead of serially.

## root cause analysis

the `GET /tracks/` endpoint was doing serial PDS URL resolution:

```python
for track in tracks:
    if artist not cached:
        await resolver.resolve_atproto_data(track.artist_did)  # BLOCKS
```

with 8 unique artists on the homepage, this meant:
- 8 artists × 200-300ms each = **1.6-2.4 seconds** of blocking network calls

### evidence from logfire

**slow trace** (`019a7067dd848d3978e95f73218c3a94`):
- total duration: 1.92 seconds
- database queries: 15ms
- **missing 1.9 seconds**: untraced PDS resolution calls

**fast trace** (`019a70610ca27f57b2f0982b1b9d8170`) - when PDS URLs were cached:
- total duration: 155ms
- database queries: 93ms
- endpoint logic: ~60ms

## fix

changed from serial to concurrent resolution:

1. collect all artists needing PDS resolution (no cached `pds_url`)
2. resolve all concurrently using `asyncio.gather()`
3. update cache and database after all resolutions complete

## expected improvement

- homepage load time: **2-6 seconds → 200-400ms**
- first load (cold cache): ~300-400ms for all PDS resolutions
- subsequent loads: instant (cached in database)

## testing

- ✅ type checking passes
- ✅ no database migration required
- ready for local testing