### PR TITLE
feat: make storage operations fully async to prevent event loop blocking

### DIFF
--- a/src/backend/api/tracks.py
+++ b/src/backend/api/tracks.py
@@ -113,7 +113,7 @@ async def _process_upload_background(
         )
         try:
             file_obj = BytesIO(file_data)
-            file_id = storage.save(file_obj, filename)
+            file_id = await storage.save(file_obj, filename)
         except ValueError as e:
             upload_tracker.update_status(
                 upload_id, UploadStatus.FAILED, "upload failed", error=str(e)
@@ -140,7 +140,7 @@ async def _process_upload_background(
                 try:
                     image_obj = BytesIO(image_data)
                     # save with images/ prefix to namespace it
-                    image_id = storage.save(image_obj, f"images/{image_filename}")
+                    image_id = await storage.save(image_obj, f"images/{image_filename}")
                     # get R2 URL for image if using R2 storage
                     if settings.storage.backend == "r2" and isinstance(
                         storage, R2Storage
@@ -265,7 +265,7 @@ async def _process_upload_background(
                 )
                 # cleanup: delete uploaded file
                 with contextlib.suppress(Exception):
-                    storage.delete(file_id)
+                    await storage.delete(file_id)
 
     except Exception as e:
         logger.exception(f"upload {upload_id} failed with unexpected error")
@@ -498,7 +498,7 @@ async def delete_track(
 
     # delete audio file from storage
     try:
-        storage.delete(track.file_id)
+        await storage.delete(track.file_id)
     except Exception as e:
         # log but don't fail - maybe file was already deleted
         logger.warning(f"failed to delete file {track.file_id}: {e}", exc_info=True)
@@ -613,7 +613,7 @@ async def update_track_metadata(
         # read and save image
         image_data = await image.read()
         image_obj = BytesIO(image_data)
-        image_id = storage.save(image_obj, f"images/{image.filename}")
+        image_id = await storage.save(image_obj, f"images/{image.filename}")
 
         # get R2 URL for image if using R2 storage
         if settings.storage.backend == "r2" and isinstance(storage, R2Storage):
@@ -622,7 +622,7 @@ async def update_track_metadata(
         # delete old image if exists
         if track.image_id:
             with contextlib.suppress(Exception):
-                storage.delete(track.image_id)
+                await storage.delete(track.image_id)
 
         track.image_id = image_id
 

--- a/tests/storage/test_r2_upload.py
+++ b/tests/storage/test_r2_upload.py
@@ -25,7 +25,7 @@ async def test_r2_upload():
 
     # upload file
     with open(test_file, "rb") as f:
-        file_id = storage.save(f, "test_audio.m4a")
+        file_id = await storage.save(f, "test_audio.m4a")
 
     print(f"✓ uploaded file with id: {file_id}")
 


### PR DESCRIPTION
Addresses the blocking I/O issues identified in the I/O review by making all storage operations (save/delete) async for both R2 and filesystem backends.

## Changes

**R2 storage** (src/backend/storage/r2.py)
- Made `save()` async using `aioboto3.upload_fileobj()`
- Made `delete()` async using `aioboto3.delete_object()`
- Both operations now use async context manager for S3 client

**Filesystem storage** (src/backend/storage/filesystem.py)
- Made `save()` async using `anyio.open_file()` with chunked writes (64KB chunks)
- Made `delete()` async using `anyio.Path` for async file operations
- Maintains constant memory usage during large file uploads
- True async I/O without thread pool offloading

**Call sites** (src/backend/api/tracks.py)
- Updated all `storage.save()` calls to await (lines 116, 143, 616)
- Updated all `storage.delete()` calls to await (lines 268, 501, 625)
- These include: upload background task, delete endpoint, image replacement

**Tests**
- Made all storage tests async to match new signatures
- All 84 tests pass
- Type checking passes

## Impact

**Before:** Synchronous boto3/filesystem operations blocked the event loop thread during uploads/deletes, monopolizing the worker and stalling concurrent requests/tasks

**After:** All storage I/O is non-blocking
- R2: uses aioboto3 for true async S3 operations
- Filesystem: uses anyio for async file I/O with chunked writes
- Background tasks no longer starve the event loop during large uploads
- Delete endpoint responses are no longer blocked by R2 HTTP calls
- Constant memory usage maintained via chunked writes (64KB)

## Testing

Verified with staging upload showing:
- POST /tracks/ endpoint: 300ms response time
- Background task completes async work without blocking
- No event loop starvation during multi-MB uploads

## Related

Follows up on #149 (async R2 reads) and #150 (concurrent PDS resolution) to eliminate remaining blocking I/O in storage layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)