### PR TITLE
reject AIFF/AIF uploads due to browser compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ python_modules/
 Thumbs.db
 
 # Frontend
+node_modules/
 frontend/node_modules/
 frontend/.svelte-kit/
 frontend/build/

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -8,17 +8,16 @@
 	import { API_URL } from '$lib/config';
 	import { uploader } from '$lib/uploader.svelte';
 
-	const ACCEPTED_AUDIO_EXTENSIONS = ['.mp3', '.wav', '.m4a', '.aif', '.aiff'];
-	const ACCEPTED_AUDIO_MIME_TYPES = ['audio/mpeg', 'audio/wav', 'audio/mp4', 'audio/aiff', 'audio/x-aiff'];
+	// browser-compatible audio formats only
+	// note: aiff/aif not supported in most browsers (safari only)
+	const ACCEPTED_AUDIO_EXTENSIONS = ['.mp3', '.wav', '.m4a'];
+	const ACCEPTED_AUDIO_MIME_TYPES = ['audio/mpeg', 'audio/wav', 'audio/mp4'];
 	const FILE_INPUT_ACCEPT = [...ACCEPTED_AUDIO_EXTENSIONS, ...ACCEPTED_AUDIO_MIME_TYPES].join(',');
 
 	function isSupportedAudioFile(name: string): boolean {
 		const dotIndex = name.lastIndexOf('.');
 		if (dotIndex === -1) return false;
 		const ext = name.slice(dotIndex).toLowerCase();
-		if (ext === '.aif') {
-			return true;
-		}
 		return ACCEPTED_AUDIO_EXTENSIONS.includes(ext);
 	}
 
@@ -443,6 +442,7 @@
 						onchange={handleFileChange}
 						required
 					/>
+					<p class="format-hint">supported: mp3, wav, m4a</p>
 					{#if file}
 						<p class="file-info">{file.name} ({(file.size / 1024 / 1024).toFixed(2)} MB)</p>
 					{/if}
@@ -459,6 +459,7 @@
 							imageFile = target.files?.[0] ?? null;
 						}}
 					/>
+					<p class="format-hint">supported: jpg, png, webp, gif</p>
 					{#if imageFile}
 						<p class="file-info">{imageFile.name} ({(imageFile.size / 1024 / 1024).toFixed(2)} MB)</p>
 					{/if}
@@ -802,6 +803,12 @@
 	input[type='file']:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
+	}
+
+	.format-hint {
+		margin-top: 0.25rem;
+		font-size: 0.8rem;
+		color: #888;
 	}
 
 	.file-info {

--- a/src/backend/models/audio.py
+++ b/src/backend/models/audio.py
@@ -9,8 +9,6 @@ class AudioFormat(str, Enum):
     MP3 = "mp3"
     WAV = "wav"
     M4A = "m4a"
-    AIFF = "aiff"
-    AIF = "aif"
 
     @property
     def extension(self) -> str:
@@ -24,8 +22,6 @@ class AudioFormat(str, Enum):
             AudioFormat.MP3: "audio/mpeg",
             AudioFormat.WAV: "audio/wav",
             AudioFormat.M4A: "audio/mp4",
-            AudioFormat.AIFF: "audio/aiff",
-            AudioFormat.AIF: "audio/aiff",
         }
         return media_types[self]
 

--- a/tests/test_audio_formats.py
+++ b/tests/test_audio_formats.py
@@ -23,14 +23,6 @@ class TestAudioFormat:
             (".m4a", AudioFormat.M4A),
             ("m4a", AudioFormat.M4A),
             (".M4A", AudioFormat.M4A),
-            # aiff
-            (".aiff", AudioFormat.AIFF),
-            ("aiff", AudioFormat.AIFF),
-            (".AIFF", AudioFormat.AIFF),
-            # aif (alias for aiff)
-            (".aif", AudioFormat.AIFF),
-            ("aif", AudioFormat.AIFF),
-            (".AIF", AudioFormat.AIFF),
         ],
     )
     def test_from_extension_supported(
@@ -46,6 +38,8 @@ class TestAudioFormat:
             ".ogg",
             ".aac",
             ".wma",
+            ".aiff",
+            ".aif",
             "",
             "invalid",
         ],
@@ -59,14 +53,12 @@ class TestAudioFormat:
         assert AudioFormat.MP3.media_type == "audio/mpeg"
         assert AudioFormat.WAV.media_type == "audio/wav"
         assert AudioFormat.M4A.media_type == "audio/mp4"
-        assert AudioFormat.AIFF.media_type == "audio/aiff"
 
     def test_extensions_with_dots(self):
         """test extension property includes dots."""
         assert AudioFormat.MP3.extension == ".mp3"
         assert AudioFormat.WAV.extension == ".wav"
         assert AudioFormat.M4A.extension == ".m4a"
-        assert AudioFormat.AIFF.extension == ".aiff"
 
     def test_all_extensions(self):
         """test all_extensions returns complete list."""
@@ -74,8 +66,9 @@ class TestAudioFormat:
         assert ".mp3" in extensions
         assert ".wav" in extensions
         assert ".m4a" in extensions
-        assert ".aiff" in extensions
-        assert len(extensions) == 4
+        assert ".aiff" not in extensions
+        assert ".aif" not in extensions
+        assert len(extensions) == 3
 
     def test_supported_extensions_str(self):
         """test formatted string of supported extensions."""


### PR DESCRIPTION
## problem

AIFF/AIF audio files have limited browser support:
- only Safari supports AIFF natively
- Chrome/Firefox throw `MediaError code 4: MEDIA_ERR_SRC_NOT_SUPPORTED`
- users could upload AIFF files but they wouldn't play in most browsers

## solution

reject AIFF/AIF uploads and clearly communicate supported formats:

**backend**:
- removed AIFF/AIF from `AudioFormat` enum (only MP3, WAV, M4A remain)
- backend validation now rejects AIFF uploads with clear error message

**frontend**:
- updated file input to only accept `.mp3, .wav, .m4a`
- added format hints under audio upload: "supported: mp3, wav, m4a"
- added format hints under artwork upload: "supported: jpg, png, webp, gif"
- client-side validation rejects unsupported formats before upload

**observability**:
- added logfire instrumentation to upload background tasks
- added logfire spans to R2 storage operations
- documented logfire querying patterns in `docs/logfire-querying.md`

## future work

created #153 to track transcoding pipeline implementation (ffmpeg-based queue worker to convert AIFF→MP3)

## testing

- [x] verified AIFF files are rejected at upload with helpful error
- [x] verified format hints display correctly
- [x] cleaned up dev database and R2 buckets
- [x] confirmed MP3/WAV/M4A files still upload and play correctly

closes #147