### PR TITLE
ui: improve mobile responsiveness and add navigation features

### DIFF
--- a/frontend/src/lib/branding.ts
+++ b/frontend/src/lib/branding.ts
@@ -1,5 +1,5 @@
 const DEFAULT_APP_NAME = 'plyr.fm';
-const DEFAULT_TAGLINE = 'music streaming on atproto';
+const DEFAULT_TAGLINE = 'music on atproto';
 const DEFAULT_CANONICAL_HOST = 'plyr.fm';
 const DEFAULT_BROADCAST_PREFIX = 'plyr';
 

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -15,25 +15,7 @@
 
 <header>
 	<div class="header-content">
-		<a href="/" class="brand">
-			<h1>{APP_NAME}</h1>
-			<p>{APP_TAGLINE}</p>
-		</a>
-
-		<nav>
-			{#if isAuthenticated}
-				<a href="/liked" class="nav-link" class:active={$page.url.pathname === '/liked'}>
-					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-						<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
-					</svg>
-					<span>liked</span>
-				</a>
-				<a href="/portal" class="user-handle">@{user?.handle}</a>
-				<SettingsMenu />
-				<button onclick={onLogout} class="btn-logout">logout</button>
-			{:else}
-				<a href="/login" class="btn-primary">login</a>
-			{/if}
+		<div class="left-section">
 			<a
 				href="https://bsky.app/profile/plyr.fm"
 				target="_blank"
@@ -53,6 +35,37 @@
 					/>
 				</svg>
 			</a>
+			<a
+				href="https://status.zzstoatzz.io/@plyr.fm"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="status-link"
+				title="View status page"
+			>
+				<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+					<polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+				</svg>
+			</a>
+			<a href="/" class="brand">
+				<h1>{APP_NAME}</h1>
+				<p>{APP_TAGLINE}</p>
+			</a>
+		</div>
+
+		<nav>
+			{#if isAuthenticated}
+				<a href="/liked" class="nav-link" class:active={$page.url.pathname === '/liked'}>
+					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+					</svg>
+					<span>liked</span>
+				</a>
+				<a href="/portal" class="user-handle">@{user?.handle}</a>
+				<SettingsMenu />
+				<button onclick={onLogout} class="btn-logout">logout</button>
+			{:else}
+				<a href="/login" class="btn-primary">login</a>
+			{/if}
 		</nav>
 	</div>
 </header>
@@ -73,6 +86,12 @@
 		gap: 1rem;
 	}
 
+	.left-section {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
 	.brand {
 		text-decoration: none;
 		color: inherit;
@@ -80,23 +99,30 @@
 		flex-direction: column;
 		gap: 0.25rem;
 		flex-shrink: 0;
+		margin-left: 1.5rem;
 	}
 
 	.brand:hover h1 {
 		color: var(--accent);
 	}
 
-	.bluesky-link {
+	.bluesky-link,
+	.status-link {
 		display: flex;
 		align-items: center;
 		justify-content: center;
 		color: var(--text-secondary);
 		transition: color 0.2s;
 		text-decoration: none;
+		flex-shrink: 0;
 	}
 
 	.bluesky-link:hover {
 		color: #1185fe;
+	}
+
+	.status-link:hover {
+		color: var(--accent);
 	}
 
 	h1 {
@@ -207,36 +233,54 @@
 
 	@media (max-width: 640px) {
 		.header-content {
-			padding: 1rem;
+			padding: 0.75rem 0.75rem;
+			gap: 0.75rem;
+		}
+
+		.left-section {
 			gap: 0.5rem;
+		}
+
+		.brand {
+			margin-left: 0;
 		}
 
 		.brand h1 {
-			font-size: 1.25rem;
+			font-size: 1.15rem;
 		}
 
 		.brand p {
-			font-size: 0.75rem;
+			font-size: 0.7rem;
 		}
 
-		.bluesky-link {
-			order: -1;
-		}
-
-		.bluesky-link svg {
-			width: 18px;
-			height: 18px;
+		.bluesky-link svg,
+		.status-link svg {
+			width: 16px;
+			height: 16px;
 		}
 
 		nav {
-			gap: 0.5rem;
+			gap: 0.4rem;
 		}
 
-		.nav-link,
-		.user-handle,
-		.btn-logout {
-			font-size: 0.85rem;
-			padding: 0.35rem 0.6rem;
+		.nav-link {
+			padding: 0.3rem 0.5rem;
+			font-size: 0.8rem;
+		}
+
+		.nav-link span {
+			display: none;
+		}
+
+		.user-handle {
+			font-size: 0.8rem;
+			padding: 0.3rem 0.5rem;
+		}
+
+		.btn-logout,
+		.btn-primary {
+			font-size: 0.8rem;
+			padding: 0.3rem 0.65rem;
 		}
 	}
 </style>

--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -342,7 +342,7 @@
 
 	@media (max-width: 768px) {
 		.track-container {
-			padding: 0.75rem;
+			padding: 0.65rem 0.75rem;
 			gap: 0.5rem;
 		}
 
@@ -350,32 +350,77 @@
 			gap: 0.5rem;
 		}
 
+		.track-image,
+		.track-image-placeholder,
 		.track-avatar {
-			width: 44px;
-			height: 44px;
+			width: 40px;
+			height: 40px;
 		}
 
 		.track-title {
-			font-size: 0.95rem;
+			font-size: 0.9rem;
 		}
 
 		.track-metadata {
-			font-size: 0.85rem;
-			gap: 0.4rem;
+			font-size: 0.8rem;
+			gap: 0.35rem;
 		}
 
 		.track-meta {
-			font-size: 0.75rem;
+			font-size: 0.7rem;
+		}
+
+		.track-actions {
+			gap: 0.35rem;
 		}
 
 		.action-button {
-			width: 28px;
-			height: 28px;
+			width: 32px;
+			height: 32px;
 		}
 
 		.action-button svg {
 			width: 14px;
 			height: 14px;
+		}
+	}
+
+	@media (max-width: 480px) {
+		.track-container {
+			padding: 0.5rem 0.65rem;
+		}
+
+		.track-image,
+		.track-image-placeholder,
+		.track-avatar {
+			width: 36px;
+			height: 36px;
+		}
+
+		.track-title {
+			font-size: 0.85rem;
+		}
+
+		.track-metadata {
+			font-size: 0.75rem;
+		}
+
+		.metadata-separator {
+			font-size: 0.6rem;
+		}
+
+		.track-meta {
+			display: none;
+		}
+
+		.action-button {
+			width: 30px;
+			height: 30px;
+		}
+
+		.action-button svg {
+			width: 13px;
+			height: 13px;
 		}
 	}
 </style>

--- a/frontend/src/routes/liked/+page.svelte
+++ b/frontend/src/routes/liked/+page.svelte
@@ -6,6 +6,7 @@
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
 	import { fetchLikedTracks } from '$lib/tracks.svelte';
 	import { player } from '$lib/player.svelte';
+	import { queue } from '$lib/queue.svelte';
 	import type { Track, User } from '$lib/types';
 
 	let tracks = $state<Track[]>([]);
@@ -65,6 +66,11 @@
 	function playTrack(track: Track) {
 		player.playTrack(track);
 	}
+
+	function queueAll() {
+		if (tracks.length === 0) return;
+		queue.addTracks(tracks);
+	}
 </script>
 
 <svelte:head>
@@ -75,10 +81,27 @@
 
 <div class="page">
 	<header class="page-header">
-		<h1>liked tracks</h1>
-		{#if !loading && tracks.length > 0}
-			<p class="subtitle">{tracks.length} {tracks.length === 1 ? 'track' : 'tracks'}</p>
-		{/if}
+		<div class="header-top">
+			<div>
+				<h1>liked tracks</h1>
+				{#if !loading && tracks.length > 0}
+					<p class="subtitle">{tracks.length} {tracks.length === 1 ? 'track' : 'tracks'}</p>
+				{/if}
+			</div>
+			{#if !loading && tracks.length > 0}
+				<button class="btn-queue-all" onclick={queueAll} title="queue all liked tracks">
+					<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<line x1="8" y1="6" x2="21" y2="6"></line>
+						<line x1="8" y1="12" x2="21" y2="12"></line>
+						<line x1="8" y1="18" x2="21" y2="18"></line>
+						<line x1="3" y1="6" x2="3.01" y2="6"></line>
+						<line x1="3" y1="12" x2="3.01" y2="12"></line>
+						<line x1="3" y1="18" x2="3.01" y2="18"></line>
+					</svg>
+					<span>queue all</span>
+				</button>
+			{/if}
+		</div>
 	</header>
 
 	{#if loading}
@@ -122,6 +145,14 @@
 		margin-bottom: 2rem;
 	}
 
+	.header-top {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 1rem;
+		flex-wrap: wrap;
+	}
+
 	.page-header h1 {
 		font-size: 2rem;
 		font-weight: 700;
@@ -133,6 +164,31 @@
 		font-size: 0.95rem;
 		color: #888;
 		margin: 0;
+	}
+
+	.btn-queue-all {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.6rem 1rem;
+		background: transparent;
+		border: 1px solid var(--accent);
+		color: var(--accent);
+		border-radius: 6px;
+		font-size: 0.9rem;
+		font-family: inherit;
+		cursor: pointer;
+		transition: all 0.2s;
+		white-space: nowrap;
+	}
+
+	.btn-queue-all:hover {
+		background: var(--accent);
+		color: var(--bg-primary);
+	}
+
+	.btn-queue-all svg {
+		flex-shrink: 0;
 	}
 
 	.loading-container {
@@ -179,11 +235,11 @@
 
 	@media (max-width: 768px) {
 		.page {
-			padding: 1.5rem 1rem;
+			padding: 1.25rem 0.75rem;
 		}
 
 		.page-header h1 {
-			font-size: 1.5rem;
+			font-size: 1.35rem;
 		}
 
 		.empty-state {
@@ -192,6 +248,49 @@
 
 		.empty-state h2 {
 			font-size: 1.25rem;
+		}
+
+		.btn-queue-all {
+			padding: 0.5rem 0.75rem;
+			font-size: 0.85rem;
+		}
+
+		.btn-queue-all svg {
+			width: 18px;
+			height: 18px;
+		}
+	}
+
+	@media (max-width: 480px) {
+		.page {
+			padding: 1rem 0.65rem;
+		}
+
+		.page-header {
+			margin-bottom: 1.5rem;
+		}
+
+		.header-top {
+			gap: 0.75rem;
+		}
+
+		.page-header h1 {
+			font-size: 1.2rem;
+			margin: 0 0 0.35rem 0;
+		}
+
+		.subtitle {
+			font-size: 0.85rem;
+		}
+
+		.btn-queue-all {
+			padding: 0.45rem 0.65rem;
+			font-size: 0.8rem;
+		}
+
+		.btn-queue-all svg {
+			width: 16px;
+			height: 16px;
 		}
 	}
 </style>


### PR DESCRIPTION
## Summary

- Change tagline from "music streaming on atproto" to "music on atproto"
- Add "Queue All" button to liked tracks page with list icon
- Reorganize header: move Bluesky and status links to left of brand name
- Add status page link (https://status.zzstoatzz.io/@plyr.fm)
- Significantly improve responsive design for mobile/narrow screens

## Mobile Improvements

**Header:**
- More compact layout with tighter padding
- Hidden "liked" text label on mobile (just shows heart icon)
- Smaller icons (16px on mobile)
- Remove left margin on brand name for mobile

**Track Items:**
- Progressive sizing: 48px → 40px → 36px for avatars/images
- Hidden play counts on very narrow screens (≤480px)
- Compact action buttons (32px → 30px)
- Reduced padding throughout

**Desktop:**
- Added 1.5rem spacing between icons and brand name for better visual separation

## Screenshots

Before: Empty wasted space, elements too large on narrow screens
After: Efficient use of space, graceful adaptation

🤖 Generated with [Claude Code](https://claude.com/claude-code)