### PR TITLE
ui: use accent color for liked tracks

### DIFF
--- a/frontend/src/lib/components/LikeButton.svelte
+++ b/frontend/src/lib/components/LikeButton.svelte
@@ -91,14 +91,13 @@
 	}
 
 	.like-button.liked {
-		color: #ff6b9d;
-		border-color: #ff6b9d;
+		color: var(--accent);
+		border-color: var(--accent);
 	}
 
 	.like-button.liked:hover {
-		color: #ff4d7d;
-		border-color: #ff4d7d;
-		background: rgba(255, 107, 157, 0.1);
+		color: var(--accent-hover);
+		border-color: var(--accent-hover);
 	}
 
 	.like-button:disabled {


### PR DESCRIPTION
## Summary

Use the user's configured accent color for liked tracks instead of hardcoded pink (`#ff6b9d`).

## Changes

- **Liked state**: Uses `var(--accent)` instead of `#ff6b9d`
- **Liked hover**: Uses `var(--accent-hover)` instead of `#ff4d7d`
- Removed hardcoded pink rgba background on hover

## Benefits

- Consistent with user's color preferences
- Prepares for future multi-color palette support
- Like button now matches the rest of the UI theming

🤖 Generated with [Claude Code](https://claude.com/claude-code)