### PR TITLE
feat: improve mobile UX with compact action menus

### DIFF
--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/stores';
 	import type { User } from '$lib/types';
 	import SettingsMenu from './SettingsMenu.svelte';
+	import LinksMenu from './LinksMenu.svelte';
 	import { APP_NAME, APP_TAGLINE } from '$lib/branding';
 
 	interface Props {
@@ -16,11 +17,12 @@
 <header>
 	<div class="header-content">
 		<div class="left-section">
+			<!-- desktop: show icons inline -->
 			<a
 				href="https://bsky.app/profile/plyr.fm"
 				target="_blank"
 				rel="noopener noreferrer"
-				class="bluesky-link"
+				class="bluesky-link desktop-only"
 				title="Follow @plyr.fm on Bluesky"
 			>
 				<svg
@@ -39,13 +41,19 @@
 				href="https://status.zzstoatzz.io/@plyr.fm"
 				target="_blank"
 				rel="noopener noreferrer"
-				class="status-link"
+				class="status-link desktop-only"
 				title="View status page"
 			>
 				<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 					<polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
 				</svg>
 			</a>
+
+			<!-- mobile: show menu button -->
+			<div class="mobile-only">
+				<LinksMenu />
+			</div>
+
 			<a href="/" class="brand">
 				<h1>{APP_NAME}</h1>
 				<p>{APP_TAGLINE}</p>
@@ -104,6 +112,14 @@
 
 	.brand:hover h1 {
 		color: var(--accent);
+	}
+
+	.desktop-only {
+		display: flex;
+	}
+
+	.mobile-only {
+		display: none;
 	}
 
 	.bluesky-link,
@@ -231,7 +247,15 @@
 		color: var(--accent);
 	}
 
-	@media (max-width: 640px) {
+	@media (max-width: 768px) {
+		.desktop-only {
+			display: none !important;
+		}
+
+		.mobile-only {
+			display: flex;
+		}
+
 		.header-content {
 			padding: 0.75rem 0.75rem;
 			gap: 0.75rem;

--- a/frontend/src/lib/components/LinksMenu.svelte
+++ b/frontend/src/lib/components/LinksMenu.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+	let showMenu = $state(false);
+
+	function toggleMenu() {
+		showMenu = !showMenu;
+	}
+
+	function closeMenu() {
+		showMenu = false;
+	}
+</script>
+
+<div class="links-menu">
+	<button class="menu-button" onclick={toggleMenu} title="view links">
+		<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+			<circle cx="12" cy="12" r="10"></circle>
+			<line x1="12" y1="16" x2="12" y2="12"></line>
+			<line x1="12" y1="8" x2="12.01" y2="8"></line>
+		</svg>
+	</button>
+
+	{#if showMenu}
+		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div class="menu-backdrop" onclick={closeMenu}></div>
+		<div class="menu-popover">
+			<div class="menu-header">
+				<span>links</span>
+				<button class="close-button" onclick={closeMenu} aria-label="close">
+					<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<line x1="18" y1="6" x2="6" y2="18"></line>
+						<line x1="6" y1="6" x2="18" y2="18"></line>
+					</svg>
+				</button>
+			</div>
+			<nav class="menu-links">
+				<a href="https://bsky.app/profile/plyr.fm" target="_blank" rel="noopener noreferrer" class="menu-link">
+					<svg width="24" height="24" viewBox="0 0 600 530" fill="currentColor">
+						<path d="m135.72 44.03c66.496 49.921 138.02 151.14 164.28 205.46 26.262-54.316 97.782-155.54 164.28-205.46 47.98-36.021 125.72-63.892 125.72 24.795 0 17.712-10.155 148.79-16.111 170.07-20.703 73.984-96.144 92.854-163.25 81.433 117.3 19.964 147.14 86.092 82.697 152.22-122.39 125.59-175.91-31.511-189.63-71.766-2.514-7.3797-3.6904-10.832-3.7077-7.8964-0.0174-2.9357-1.1937 0.51669-3.7077 7.8964-13.714 40.255-67.233 197.36-189.63 71.766-64.444-66.128-34.605-132.26 82.697-152.22-67.108 11.421-142.55-7.4491-163.25-81.433-5.9562-21.282-16.111-152.36-16.111-170.07 0-88.687 77.742-60.816 125.72-24.795z"/>
+					</svg>
+					<div class="link-info">
+						<span class="link-title">bluesky profile</span>
+						<span class="link-subtitle">@plyr.fm</span>
+					</div>
+				</a>
+				<a href="https://status.zzstoatzz.io/@plyr.fm" target="_blank" rel="noopener noreferrer" class="menu-link">
+					<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+					</svg>
+					<div class="link-info">
+						<span class="link-title">status page</span>
+						<span class="link-subtitle">system health</span>
+					</div>
+				</a>
+			</nav>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.links-menu {
+		position: relative;
+	}
+
+	.menu-button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		background: transparent;
+		border: 1px solid #333;
+		border-radius: 6px;
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: all 0.2s;
+	}
+
+	.menu-button:hover {
+		background: #1a1a1a;
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+
+	.menu-backdrop {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background: rgba(0, 0, 0, 0.5);
+		z-index: 100;
+		animation: fadeIn 0.15s ease-out;
+	}
+
+	.menu-popover {
+		position: fixed;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		width: min(320px, calc(100vw - 2rem));
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-default);
+		border-radius: 12px;
+		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+		z-index: 101;
+		animation: slideIn 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+	}
+
+	.menu-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 1rem 1.25rem;
+		border-bottom: 1px solid var(--border-subtle);
+	}
+
+	.menu-header span {
+		font-size: 0.9rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.close-button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 28px;
+		height: 28px;
+		background: transparent;
+		border: none;
+		border-radius: 4px;
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: all 0.2s;
+	}
+
+	.close-button:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.menu-links {
+		display: flex;
+		flex-direction: column;
+		padding: 0.5rem;
+	}
+
+	.menu-link {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		padding: 1rem;
+		background: transparent;
+		border-radius: 8px;
+		text-decoration: none;
+		color: var(--text-primary);
+		transition: all 0.2s;
+	}
+
+	.menu-link:hover {
+		background: var(--bg-hover);
+	}
+
+	.menu-link svg {
+		flex-shrink: 0;
+		color: var(--text-secondary);
+		transition: color 0.2s;
+	}
+
+	.menu-link:hover svg {
+		color: var(--accent);
+	}
+
+	.link-info {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		min-width: 0;
+	}
+
+	.link-title {
+		font-size: 0.95rem;
+		font-weight: 500;
+		color: var(--text-primary);
+	}
+
+	.link-subtitle {
+		font-size: 0.8rem;
+		color: var(--text-tertiary);
+	}
+
+	@keyframes fadeIn {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+
+	@keyframes slideIn {
+		from {
+			opacity: 0;
+			transform: translate(-50%, -48%) scale(0.96);
+		}
+		to {
+			opacity: 1;
+			transform: translate(-50%, -50%) scale(1);
+		}
+	}
+</style>

--- a/frontend/src/lib/components/TrackActionsMenu.svelte
+++ b/frontend/src/lib/components/TrackActionsMenu.svelte
@@ -1,0 +1,239 @@
+<script lang="ts">
+	import { likeTrack, unlikeTrack } from '$lib/tracks.svelte';
+	import { toast } from '$lib/toast.svelte';
+
+	interface Props {
+		trackId: number;
+		trackTitle: string;
+		initialLiked: boolean;
+		shareUrl: string;
+		onQueue: () => void;
+		isAuthenticated: boolean;
+	}
+
+	let { trackId, trackTitle, initialLiked, shareUrl, onQueue, isAuthenticated }: Props = $props();
+
+	let showMenu = $state(false);
+	let liked = $state(initialLiked);
+	let loading = $state(false);
+
+	// update liked state when initialLiked changes
+	$effect(() => {
+		liked = initialLiked;
+	});
+
+	function toggleMenu(e: Event) {
+		e.stopPropagation();
+		showMenu = !showMenu;
+	}
+
+	function closeMenu() {
+		showMenu = false;
+	}
+
+	function handleQueue(e: Event) {
+		e.stopPropagation();
+		onQueue();
+		closeMenu();
+	}
+
+	async function handleShare(e: Event) {
+		e.stopPropagation();
+		try {
+			await navigator.clipboard.writeText(shareUrl);
+			console.log('copied to clipboard:', shareUrl);
+			toast.success('link copied');
+			closeMenu();
+		} catch (err) {
+			console.error('failed to copy:', err);
+			toast.error('failed to copy link');
+		}
+	}
+
+	async function handleLike(e: Event) {
+		e.stopPropagation();
+
+		if (loading) return;
+
+		loading = true;
+		const previousState = liked;
+
+		// optimistic update
+		liked = !liked;
+
+		try {
+			const success = liked
+				? await likeTrack(trackId)
+				: await unlikeTrack(trackId);
+
+			if (!success) {
+				// revert on failure
+				liked = previousState;
+				toast.error('failed to update like');
+			} else {
+				// show success feedback
+				if (liked) {
+					toast.success(`liked ${trackTitle}`);
+				} else {
+					toast.info(`unliked ${trackTitle}`);
+				}
+			}
+			closeMenu();
+		} catch (e) {
+			// revert on error
+			liked = previousState;
+			toast.error('failed to update like');
+		} finally {
+			loading = false;
+		}
+	}
+</script>
+
+<div class="actions-menu">
+	<button class="menu-button" onclick={toggleMenu} title="actions">
+		<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+			<circle cx="12" cy="5" r="1"></circle>
+			<circle cx="12" cy="12" r="1"></circle>
+			<circle cx="12" cy="19" r="1"></circle>
+		</svg>
+	</button>
+
+	{#if showMenu}
+		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div class="menu-backdrop" onclick={closeMenu}></div>
+		<div class="menu-panel">
+			{#if isAuthenticated}
+				<button class="menu-item" onclick={handleLike} disabled={loading}>
+					<svg width="18" height="18" viewBox="0 0 24 24" fill={liked ? 'currentColor' : 'none'} stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+					</svg>
+					<span>{liked ? 'unlike' : 'like'}</span>
+				</button>
+			{/if}
+			<button class="menu-item" onclick={handleQueue}>
+				<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+					<line x1="5" y1="15" x2="5" y2="21"></line>
+					<line x1="2" y1="18" x2="8" y2="18"></line>
+					<line x1="9" y1="6" x2="21" y2="6"></line>
+					<line x1="9" y1="12" x2="21" y2="12"></line>
+					<line x1="9" y1="18" x2="21" y2="18"></line>
+				</svg>
+				<span>add to queue</span>
+			</button>
+			<button class="menu-item" onclick={handleShare}>
+				<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+					<circle cx="18" cy="5" r="3"></circle>
+					<circle cx="6" cy="12" r="3"></circle>
+					<circle cx="18" cy="19" r="3"></circle>
+					<line x1="8.59" y1="13.51" x2="15.42" y2="17.49"></line>
+					<line x1="15.41" y1="6.51" x2="8.59" y2="10.49"></line>
+				</svg>
+				<span>share</span>
+			</button>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.actions-menu {
+		position: relative;
+	}
+
+	.menu-button {
+		width: 32px;
+		height: 32px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: transparent;
+		border: 1px solid #333;
+		border-radius: 4px;
+		color: #888;
+		cursor: pointer;
+		transition: all 0.2s;
+	}
+
+	.menu-button:hover {
+		background: #1a1a1a;
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+
+	.menu-backdrop {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		z-index: 100;
+	}
+
+	.menu-panel {
+		position: absolute;
+		right: 100%;
+		top: 50%;
+		transform: translateY(-50%);
+		margin-right: 0.5rem;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-default);
+		border-radius: 8px;
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+		z-index: 101;
+		animation: slideIn 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+		min-width: 140px;
+	}
+
+	.menu-item {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		background: transparent;
+		border: none;
+		color: var(--text-secondary);
+		cursor: pointer;
+		padding: 0.75rem 1rem;
+		transition: all 0.2s;
+		font-family: inherit;
+		width: 100%;
+		text-align: left;
+		border-bottom: 1px solid var(--border-subtle);
+	}
+
+	.menu-item:last-child {
+		border-bottom: none;
+	}
+
+	.menu-item:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.menu-item span {
+		font-size: 0.9rem;
+		font-weight: 400;
+		flex: 1;
+	}
+
+	.menu-item svg {
+		width: 18px;
+		height: 18px;
+		flex-shrink: 0;
+	}
+
+	.menu-item:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	@keyframes slideIn {
+		from {
+			opacity: 0;
+			transform: translateY(-50%) scale(0.95);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(-50%) scale(1);
+		}
+	}
+</style>

--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ShareButton from './ShareButton.svelte';
 	import LikeButton from './LikeButton.svelte';
+	import TrackActionsMenu from './TrackActionsMenu.svelte';
 	import type { Track } from '$lib/types';
 	import { queue } from '$lib/queue.svelte';
 	import { toast } from '$lib/toast.svelte';
@@ -22,6 +23,11 @@
 
 	function addToQueue(e: Event) {
 		e.stopPropagation();
+		queue.addTracks([track]);
+		toast.success(`queued ${track.title}`, 1800);
+	}
+
+	function handleQueue() {
 		queue.addTracks([track]);
 		toast.success(`queued ${track.title}`, 1800);
 	}
@@ -96,25 +102,40 @@
 		</div>
 	</button>
 	<div class="track-actions" role="presentation" onclick={(e) => e.stopPropagation()}>
-		{#if isAuthenticated}
-			<LikeButton trackId={track.id} trackTitle={track.title} initialLiked={track.is_liked || false} />
-		{/if}
-		<button
-			class="action-button"
-			onclick={addToQueue}
-			title="add to queue"
-		>
-			<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-				<!-- plus sign -->
-				<line x1="5" y1="15" x2="5" y2="21"></line>
-				<line x1="2" y1="18" x2="8" y2="18"></line>
-				<!-- list lines -->
-				<line x1="9" y1="6" x2="21" y2="6"></line>
-				<line x1="9" y1="12" x2="21" y2="12"></line>
-				<line x1="9" y1="18" x2="21" y2="18"></line>
-			</svg>
-		</button>
-		<ShareButton url={shareUrl} />
+		<!-- desktop: show individual buttons -->
+		<div class="desktop-actions">
+			{#if isAuthenticated}
+				<LikeButton trackId={track.id} trackTitle={track.title} initialLiked={track.is_liked || false} />
+			{/if}
+			<button
+				class="action-button"
+				onclick={addToQueue}
+				title="add to queue"
+			>
+				<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+					<!-- plus sign -->
+					<line x1="5" y1="15" x2="5" y2="21"></line>
+					<line x1="2" y1="18" x2="8" y2="18"></line>
+					<!-- list lines -->
+					<line x1="9" y1="6" x2="21" y2="6"></line>
+					<line x1="9" y1="12" x2="21" y2="12"></line>
+					<line x1="9" y1="18" x2="21" y2="18"></line>
+				</svg>
+			</button>
+			<ShareButton url={shareUrl} />
+		</div>
+
+		<!-- mobile: show three-dot menu -->
+		<div class="mobile-actions">
+			<TrackActionsMenu
+				trackId={track.id}
+				trackTitle={track.title}
+				initialLiked={track.is_liked || false}
+				shareUrl={shareUrl}
+				onQueue={handleQueue}
+				isAuthenticated={isAuthenticated}
+			/>
+		</div>
 	</div>
 </div>
 
@@ -221,6 +242,16 @@
 		gap: 0.5rem;
 		flex-shrink: 0;
 		align-items: center;
+	}
+
+	.desktop-actions {
+		display: flex;
+		gap: 0.5rem;
+		align-items: center;
+	}
+
+	.mobile-actions {
+		display: none;
 	}
 
 	.track-title {
@@ -341,6 +372,14 @@
 	}
 
 	@media (max-width: 768px) {
+		.desktop-actions {
+			display: none;
+		}
+
+		.mobile-actions {
+			display: flex;
+		}
+
 		.track-container {
 			padding: 0.65rem 0.75rem;
 			gap: 0.5rem;

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -342,6 +342,12 @@ class Queue {
 				body: JSON.stringify({ state })
 			});
 
+			if (response.status === 401) {
+				// session expired or invalid, clear it and stop trying to sync
+				localStorage.removeItem('session_id');
+				return false;
+			}
+
 			if (response.status === 409) {
 				console.warn('queue conflict detected, fetching latest state');
 				await this.fetchQueue(true);

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { replaceState } from '$app/navigation';
 	import Header from '$lib/components/Header.svelte';
 	import HandleSearch from '$lib/components/HandleSearch.svelte';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
@@ -73,7 +74,7 @@
 			}
 
 			// remove exchange_token from URL
-			window.history.replaceState({}, '', '/portal');
+			replaceState('/portal', {});
 		}
 
 		// get session_id from localStorage

--- a/frontend/src/routes/profile/setup/+page.svelte
+++ b/frontend/src/routes/profile/setup/+page.svelte
@@ -2,6 +2,7 @@
 <script lang="ts">
 	import { APP_NAME } from '$lib/branding';
 	import { onMount } from 'svelte';
+	import { replaceState } from '$app/navigation';
 	import { API_URL } from '$lib/config';
 	import type { User } from '$lib/types';
 
@@ -40,7 +41,7 @@
 			}
 
 			// remove exchange_token from URL
-			window.history.replaceState({}, '', '/profile/setup');
+			replaceState('/profile/setup', {});
 		}
 
 		// get session_id from localStorage

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ run-backend:
 
 # run frontend dev server
 run-frontend:
-    cd frontend && bun run dev
+    cd frontend && bun run dev --host 0.0.0.0
 
 # run tests with docker-compose
 test *ARGS='tests/':


### PR DESCRIPTION
## summary

improves mobile UX by collapsing UI elements into compact menus at narrow screen widths (≤768px).

## changes

### mobile improvements
- **header navigation**: bluesky and status links collapse into an info icon modal on mobile
- **track actions**: like, queue, and share buttons collapse into a three-dot menu that opens vertically to the left
- **consistent breakpoint**: both header and track items switch to mobile layout at 768px
- **authentication aware**: like option only shows in menu when user is authenticated

### fixes
- handle 401 responses in queue sync by clearing invalid session instead of logging errors
- replace `window.history.replaceState` with sveltekit's `replaceState` API
- bind frontend dev server to 0.0.0.0 for mobile device testing

### new components
- `LinksMenu.svelte`: modal for header links on mobile
- `TrackActionsMenu.svelte`: three-dot menu with direct action implementations

## testing
tested on mobile device by connecting to dev server via local network

## screenshots
mobile menu behavior working correctly with smooth animations and proper click handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)