### PR TITLE
fix: show liked state on artist page tracks

### DIFF
--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -106,8 +106,14 @@
 			}
 			artist = await artistResponse.json();
 
-			// fetch artist's tracks
-			const tracksResponse = await fetch(`${API_URL}/tracks/?artist_did=${artist?.did}`);
+			// fetch artist's tracks with auth header to get like status
+			const headers: Record<string, string> = {};
+			const sessionId = localStorage.getItem('session_id');
+			if (sessionId) {
+				headers['Authorization'] = `Bearer ${sessionId}`;
+			}
+
+			const tracksResponse = await fetch(`${API_URL}/tracks/?artist_did=${artist?.did}`, { headers });
 			if (tracksResponse.ok) {
 				const data = await tracksResponse.json();
 			tracks = data.tracks;


### PR DESCRIPTION
## problem

tracks on artist pages weren't showing as liked even when the user had liked them. the heart icon would be filled on the homepage and liked page, but empty on artist pages.

## root cause

the artist page was fetching tracks without the Authorization header:

```typescript
const tracksResponse = await fetch(`${API_URL}/tracks/?artist_did=${artist?.did}`);
```

without the header, the backend couldn't determine which tracks were liked by the current user, so `is_liked` was always false.

## the fix

added Authorization header to the tracks fetch on artist page:

```typescript
const headers: Record<string, string> = {};
const sessionId = localStorage.getItem('session_id');
if (sessionId) {
  headers['Authorization'] = `Bearer ${sessionId}`;
}

const tracksResponse = await fetch(`${API_URL}/tracks/?artist_did=${artist?.did}`, { headers });
```

this matches the pattern used on the homepage and liked page.

## backend support

the backend `/tracks/` endpoint already supports this - it checks for the Authorization header and passes `liked_track_ids` to `TrackResponse.from_track()` when present.

## changes

- `frontend/src/routes/u/[handle]/+page.svelte`: added Authorization header to tracks fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)