### PR TITLE
feat: add origin validation for image URLs

### DIFF
--- a/src/backend/atproto/records.py
+++ b/src/backend/atproto/records.py
@@ -144,6 +144,8 @@ def build_track_record(
             for f in features
         ]
     if image_url:
+        # validate image URL comes from allowed origin
+        settings.storage.validate_image_url(image_url)
         record["imageUrl"] = image_url
 
     return record

--- a/tests/test_origin_validation.py
+++ b/tests/test_origin_validation.py
@@ -1,0 +1,74 @@
+import pytest
+
+from backend.config import StorageSettings
+
+
+@pytest.fixture
+def storage_settings(monkeypatch: pytest.MonkeyPatch) -> StorageSettings:
+    """fixture for storage settings with R2 image bucket configured."""
+    monkeypatch.setenv(
+        "R2_PUBLIC_IMAGE_BUCKET_URL", "https://images.example.com/bucket"
+    )
+    return StorageSettings()
+
+
+def test_validate_image_url_allows_none(storage_settings: StorageSettings) -> None:
+    """validate that None/empty imageUrl is allowed."""
+    assert storage_settings.validate_image_url(None) is True
+    assert storage_settings.validate_image_url("") is True
+
+
+def test_validate_image_url_allows_trusted_origin(
+    storage_settings: StorageSettings,
+) -> None:
+    """validate that imageUrl from allowed origin passes."""
+    url = "https://images.example.com/bucket/track123.jpg"
+    assert storage_settings.validate_image_url(url) is True
+
+
+def test_validate_image_url_rejects_external_origin(
+    storage_settings: StorageSettings,
+) -> None:
+    """validate that imageUrl from external origin is rejected."""
+    url = "https://malicious.com/bad-image.jpg"
+
+    with pytest.raises(ValueError, match="image must be hosted on allowed origins"):
+        storage_settings.validate_image_url(url)
+
+
+def test_validate_image_url_rejects_subdomain_mismatch(
+    storage_settings: StorageSettings,
+) -> None:
+    """validate that subdomains are not automatically trusted."""
+    url = "https://evil.images.example.com/fake.jpg"
+
+    with pytest.raises(ValueError, match="image must be hosted on allowed origins"):
+        storage_settings.validate_image_url(url)
+
+
+def test_validate_image_url_respects_scheme(storage_settings: StorageSettings) -> None:
+    """validate that scheme (http vs https) is enforced."""
+    url = "http://images.example.com/bucket/track123.jpg"
+
+    with pytest.raises(ValueError, match="image must be hosted on allowed origins"):
+        storage_settings.validate_image_url(url)
+
+
+def test_allowed_image_origins_empty_when_no_bucket_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """validate that allowed_image_origins is empty without R2 config."""
+    monkeypatch.setenv("R2_PUBLIC_IMAGE_BUCKET_URL", "")
+    settings = StorageSettings()
+    assert settings.allowed_image_origins == set()
+
+
+def test_allowed_image_origins_extracts_origin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """validate that allowed_image_origins correctly extracts scheme+netloc."""
+    monkeypatch.setenv(
+        "R2_PUBLIC_IMAGE_BUCKET_URL", "https://cdn.example.com/my-bucket/path"
+    )
+    settings = StorageSettings()
+    assert settings.allowed_image_origins == {"https://cdn.example.com"}


### PR DESCRIPTION
## summary

implement origin validation for `imageUrl` fields in track records to prevent malicious external URLs.

## changes

- add `allowed_image_origins` computed field to `StorageSettings` that extracts allowed origins from R2 bucket config
- add `validate_image_url()` method that validates URLs against allowed origins
- integrate validation into `build_track_record()` in `src/backend/atproto/records.py:148`
- add comprehensive unit tests in `tests/test_origin_validation.py`

## security impact

protects against attack vector where users modify ATProto records to point `imageUrl` to harmful content. now only R2 bucket URLs are accepted.

## related

addresses phase 1 (immediate implementation) of #166