### PR TITLE
Fix track detail page play button to update queue state

### DIFF
--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -89,7 +89,11 @@
 	}
 
 	function handlePlay() {
-		player.playTrack(track);
+		if (isCurrentlyPlaying) {
+			player.togglePlayPause();
+		} else {
+			queue.playNow(track);
+		}
 	}
 
 	function addToQueue() {


### PR DESCRIPTION
Fixes a bug where clicking play on a track detail page would not correctly update the queue state, causing the player to revert to the previously playing track.

## Problem
The track detail page was calling `player.playTrack()` directly without updating the queue. This caused the queue sync effect in `Player.svelte` to immediately override the player's current track with the queue's stale state (the previously playing track).

## Solution
Changed the track detail page to use `queue.playNow(track)` like all other entry points (home feed, artist page, etc.), ensuring the queue state stays in sync with the player.

## Testing
- Click play on a track detail page after closing/reopening the browser with a previous track in the queue
- The clicked track should now play correctly instead of reverting to the old track