### PR TITLE
feat: make analytics cards clickable links to track detail pages

### DIFF
--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -260,18 +260,18 @@
 							<div class="stat-label">total tracks</div>
 						</div>
 						{#if analytics.top_item}
-							<div class="stat-card top-item" transition:fade={{ duration: 200 }}>
+							<a href="/track/{analytics.top_item.id}" class="stat-card top-item" transition:fade={{ duration: 200 }}>
 								<div class="stat-label">most played</div>
 								<div class="top-item-title">{analytics.top_item.title}</div>
 								<div class="top-item-plays">{analytics.top_item.play_count.toLocaleString()} plays</div>
-							</div>
+							</a>
 						{/if}
 						{#if analytics.top_liked}
-							<div class="stat-card top-item" transition:fade={{ duration: 200 }}>
+							<a href="/track/{analytics.top_liked.id}" class="stat-card top-item" transition:fade={{ duration: 200 }}>
 								<div class="stat-label">most liked</div>
 								<div class="top-item-title">{analytics.top_liked.title}</div>
 								<div class="top-item-plays">{analytics.top_liked.play_count.toLocaleString()} {analytics.top_liked.play_count === 1 ? 'like' : 'likes'}</div>
-							</div>
+							</a>
 						{/if}
 					{/if}
 				{/key}
@@ -416,6 +416,15 @@
 
 	.stat-card.top-item {
 		grid-column: span 1;
+		text-decoration: none;
+		display: block;
+		cursor: pointer;
+	}
+
+	.stat-card.top-item:hover {
+		border-color: var(--accent);
+		transform: translateY(-2px);
+		box-shadow: 0 4px 12px rgba(138, 179, 255, 0.2);
 	}
 
 	.top-item-title {


### PR DESCRIPTION
## summary

makes the "most played" and "most liked" analytics cards on artist profile pages clickable links that navigate to the track detail page. this improves navigation UX and allows testing that the global player state is maintained across page navigation.

## changes

- converted `stat-card` divs to anchor tags with `href="/track/{id}"`
- added CSS styling to maintain card appearance:
  - removed default link underline
  - block display for proper card behavior
  - pointer cursor on hover
- enhanced hover effects:
  - border changes to accent color
  - subtle upward translation (2px)
  - soft glow effect

## motivation

users should be able to easily navigate from an artist's analytics to individual track pages. the entire card being clickable (not just the track title) provides a larger click target and better UX. this also serves as a test case to verify that the global player state is preserved during SPA navigation.

## testing

- visually inspect analytics cards on artist profile pages
- click on "most played" and "most liked" cards
- verify navigation to track detail page works
- confirm player state (if playing) is maintained during navigation
- check hover effects work as expected

## screenshots

analytics cards now have enhanced hover state and full card clickability:
- hover shows accent border, lift effect, and glow
- entire card area is clickable
- maintains original card design aesthetic