### PR TITLE
fix: improve liked page UX

### DIFF
--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -62,17 +62,19 @@
 
 		<nav>
 			{#if isAuthenticated}
-				<a href="/liked" class="nav-link" class:active={$page.url.pathname === '/liked'}>
-					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-						<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
-					</svg>
-					<span>liked</span>
-				</a>
+				{#if $page.url.pathname !== '/liked'}
+					<a href="/liked" class="nav-link">
+						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+						</svg>
+						<span>liked</span>
+					</a>
+				{/if}
 				<a href="/portal" class="user-handle">@{user?.handle}</a>
 				<SettingsMenu />
 				<button onclick={onLogout} class="btn-logout">logout</button>
 			{:else}
-				<a href="/login" class="btn-primary">login</a>
+				<a href="/login" class="btn-primary">log in</a>
 			{/if}
 		</nav>
 	</div>

--- a/frontend/src/routes/liked/+page.svelte
+++ b/frontend/src/routes/liked/+page.svelte
@@ -117,8 +117,13 @@
 			<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
 				<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
 			</svg>
-			<h2>no liked tracks yet</h2>
-			<p>tracks you like will appear here</p>
+			{#if !isAuthenticated}
+				<h2>log in to like tracks</h2>
+				<p>you need to be logged in to like tracks</p>
+			{:else}
+				<h2>no liked tracks yet</h2>
+				<p>tracks you like will appear here</p>
+			{/if}
 		</div>
 	{:else}
 		<div class="tracks-list">


### PR DESCRIPTION
## summary

improves the UX on the liked tracks page for both authenticated and unauthenticated users by hiding redundant navigation and providing clearer messaging.

## changes

**header navigation:**
- hide the "liked" nav button when already on `/liked` page
- prevents confusing clickable button that does nothing

**empty state messaging:**
- split empty state based on authentication status
- **unauthenticated**: "log in to like tracks" with clear explanation
  - no redundant login button (already in header)
- **authenticated**: "no liked tracks yet" with helpful message
  - tells user tracks they like will appear here

**consistency:**
- standardized "log in" as two words everywhere (was inconsistent)
- removed misleading "tracks you like" message for logged-out users

## motivation

the previous implementation had several UX issues:
1. "liked" button shown on `/liked` page did nothing when clicked
2. empty state told logged-out users "tracks you like will appear here" - misleading since they can't like tracks
3. inconsistent "login" vs "log in" wording
4. redundant login button in empty state when header already has one

## testing

- visit `/liked` while logged out - should see "log in to like tracks" message
- visit `/liked` while logged in with no likes - should see "no liked tracks yet"
- navigate to `/liked` page - "liked" button should disappear from header
- verify "log in" is two words everywhere