### PR TITLE
fix: update login help link to handle spec

### DIFF
--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -24,11 +24,11 @@
 				<div class="label-row">
 					<label for="handle">atproto handle</label>
 					<a
-						href="https://atproto.com/specs/account"
+						href="https://atproto.com/specs/handle"
 						target="_blank"
 						rel="noopener noreferrer"
 						class="help-link"
-						title="learn about ATProto handles and identity"
+						title="learn about ATProto handles"
 					>
 						what's this?
 					</a>


### PR DESCRIPTION
## summary

updates the "what's this?" help link on the login page to point to the handle spec instead of the account spec, which is more directly relevant to understanding ATProto handles.

## changes

- changed link from `https://atproto.com/specs/account` to `https://atproto.com/specs/handle`
- updated tooltip text from "learn about ATProto handles and identity" to "learn about ATProto handles"

## motivation

the handle spec is more focused and directly explains what users need to know when entering their ATProto handle on the login page. the account spec is broader and covers more than just handles.