### PR TITLE
fix: update release script to deploy production frontend

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -103,7 +103,17 @@ def main() -> int:
     )
 
     print(f"\n✓ release {version} created")
-    print("✓ production deployment starting...")
+    print("✓ production backend deployment starting...")
+
+    # merge main -> production-fe to trigger frontend deployment
+    print("\n🔄 updating production-fe branch...")
+    subprocess.run(["git", "fetch", "origin"], check=True)
+    subprocess.run(["git", "checkout", "production-fe"], check=True)
+    subprocess.run(["git", "merge", "main", "--ff-only"], check=True)
+    subprocess.run(["git", "push", "origin", "production-fe"], check=True)
+    subprocess.run(["git", "checkout", "main"], check=True)
+
+    print("✓ production frontend deployment starting...")
 
     return 0
 


### PR DESCRIPTION
## problem

currently when running `just release`:
- creates github tag → deploys production backend ✅
- but cloudflare pages production is now pointing at `production-fe` branch
- result: frontend and backend can be out of sync after release

## solution

update release script to merge `main` → `production-fe` after creating the tag:
1. create github release (triggers prod backend deploy)
2. merge main → production-fe with fast-forward only
3. push production-fe (triggers cloudflare pages prod deploy)

## workflow

**before merge to main:**
- staging backend deploys
- preview frontend builds on main

**after `just release`:**
- production backend deploys (from tag)
- production frontend deploys (from production-fe branch update)

follows the nebula pattern suggested by @theguidry