### PR TITLE
fix: sync queue state when playing tracks on liked page

### DIFF
--- a/frontend/src/routes/liked/+page.svelte
+++ b/frontend/src/routes/liked/+page.svelte
@@ -64,7 +64,7 @@
 	}
 
 	function playTrack(track: Track) {
-		player.playTrack(track);
+		queue.playNow(track);
 	}
 
 	function queueAll() {


### PR DESCRIPTION
## summary
fixes queue/player state desync on the liked tracks page

## problem
when clicking tracks on the liked page:
- player would play the track
- queue state wouldn't update
- queue UI would show wrong "now playing" track
- subsequent clicks would behave unpredictably

## solution
changed liked page to use `queue.playNow()` instead of `player.playTrack()`, matching the home page behavior and ensuring both player and queue state stay in sync.

## testing
manually verified that:
- clicking tracks on liked page now properly updates queue
- "now playing" indicator is correct
- behavior matches home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)