### PR TITLE
feat: enhance link preview metadata for albums and homepage

### DIFF
--- a/frontend/src/lib/components/Player.svelte
+++ b/frontend/src/lib/components/Player.svelte
@@ -585,30 +585,6 @@
 		flex-shrink: 0;
 	}
 
-	.player-album {
-		color: #808080;
-		white-space: nowrap;
-		overflow: hidden;
-		position: relative;
-		min-width: 0;
-	}
-
-	.player-album.scrolling {
-		overflow: hidden;
-		mask-image: linear-gradient(to right, black 0%, black calc(100% - 15px), transparent 100%);
-		-webkit-mask-image: linear-gradient(to right, black 0%, black calc(100% - 15px), transparent 100%);
-	}
-
-	.player-album span {
-		display: inline-block;
-		white-space: nowrap;
-	}
-
-	.player-album.scrolling span {
-		padding-right: 1.5rem;
-		animation: scroll-text 8s linear infinite;
-	}
-
 	.player-album-link {
 		color: #808080;
 		text-decoration: none;
@@ -897,7 +873,6 @@
 		}
 
 		.player-artist-link,
-		.player-album,
 		.player-album-link {
 			overflow: hidden;
 			min-width: 0;

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -7,6 +7,7 @@
 	import { queue } from '$lib/queue.svelte';
 	import { tracksCache } from '$lib/tracks.svelte';
 	import { auth } from '$lib/auth.svelte';
+	import { APP_NAME, APP_TAGLINE, APP_CANONICAL_URL } from '$lib/branding';
 
 	// use cached tracks
 	let tracks = $derived(tracksCache.tracks);
@@ -41,6 +42,23 @@
 		window.location.href = '/';
 	}
 </script>
+
+<svelte:head>
+	<title>{APP_NAME} - {APP_TAGLINE}</title>
+	<meta name="description" content="discover and stream music on the atproto network" />
+
+	<!-- Open Graph / Facebook -->
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content={APP_NAME} />
+	<meta property="og:description" content={APP_TAGLINE} />
+	<meta property="og:url" content={APP_CANONICAL_URL} />
+	<meta property="og:site_name" content={APP_NAME} />
+
+	<!-- Twitter -->
+	<meta name="twitter:card" content="summary" />
+	<meta name="twitter:title" content={APP_NAME} />
+	<meta name="twitter:description" content={APP_TAGLINE} />
+</svelte:head>
 
 <Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={logout} />
 

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -63,7 +63,7 @@ onMount(async () => {
 	}
 });
 
-let shareUrl = '';
+let shareUrl = $state('');
 
 $effect(() => {
 	if (typeof window !== 'undefined') {

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -308,10 +308,6 @@
 		min-height: 120px;
 	}
 
-	.discography {
-		margin: 3rem 0;
-	}
-
 	.section-header {
 		display: flex;
 		align-items: baseline;

--- a/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
@@ -6,6 +6,7 @@
 	import { queue } from '$lib/queue.svelte';
 	import { toast } from '$lib/toast.svelte';
 	import { auth } from '$lib/auth.svelte';
+	import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
@@ -35,14 +36,21 @@
 
 <svelte:head>
 	<title>{album.metadata.title} by {album.metadata.artist} - plyr.fm</title>
-	<meta name="description" content="{album.metadata.track_count} tracks by {album.metadata.artist}" />
+	<meta name="description" content="{album.metadata.title} by {album.metadata.artist} - {album.metadata.track_count} tracks on plyr.fm" />
 
 	<!-- Open Graph / Facebook -->
 	<meta property="og:type" content="music.album" />
 	<meta property="og:title" content="{album.metadata.title} by {album.metadata.artist}" />
 	<meta property="og:description" content="{album.metadata.track_count} tracks • {album.metadata.total_plays} plays" />
+	<meta property="og:url" content="{APP_CANONICAL_URL}/u/{album.metadata.artist_handle}/album/{album.metadata.slug}" />
+	<meta property="og:site_name" content={APP_NAME} />
+	<meta property="music:musician" content="{album.metadata.artist_handle}" />
 	{#if album.metadata.image_url}
-		<meta property="og:image" content={album.metadata.image_url} />
+		<meta property="og:image" content="{album.metadata.image_url}" />
+		<meta property="og:image:secure_url" content="{album.metadata.image_url}" />
+		<meta property="og:image:width" content="1200" />
+		<meta property="og:image:height" content="1200" />
+		<meta property="og:image:alt" content="{album.metadata.title} by {album.metadata.artist}" />
 	{/if}
 
 	<!-- Twitter -->
@@ -50,7 +58,7 @@
 	<meta name="twitter:title" content="{album.metadata.title} by {album.metadata.artist}" />
 	<meta name="twitter:description" content="{album.metadata.track_count} tracks • {album.metadata.total_plays} plays" />
 	{#if album.metadata.image_url}
-		<meta name="twitter:image" content={album.metadata.image_url} />
+		<meta name="twitter:image" content="{album.metadata.image_url}" />
 	{/if}
 </svelte:head>
 


### PR DESCRIPTION
## Summary

Improves Open Graph and Twitter Card metadata to make link previews consistent across all pages and match the quality of track page previews.

## Changes

### Album Page
Following the track page as a reference, added:
- `og:url` with canonical URL
- `og:site_name` property
- `music:musician` property with artist handle
- Complete image metadata (width, height, alt text, secure_url)
- Improved meta description

### Homepage
Added comprehensive metadata:
- Open Graph metadata (type, title, description, url, site_name)
- Twitter card metadata
- Uses `APP_NAME` and `APP_TAGLINE` from branding

### Cleanup
Fixed svelte-check warnings:
- Removed unused `.player-album` CSS selectors from Player component
- Removed unused `.discography` CSS selector from artist page  
- Fixed `shareUrl` reactivity warning in track page by using `$state()`

## Testing

All svelte-check warnings resolved. Link previews should now be consistent across:
- Homepage
- Artist pages
- Album pages
- Track pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)