### PR TITLE
fix: prevent layout metadata from overriding page-specific metadata

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -16,8 +16,12 @@
 	let { children } = $props();
 	let showQueue = $state(false);
 
-	// only show default meta tags when not on a track page
-	let isTrackPage = $derived($page.url.pathname.startsWith('/track/'));
+	// only show default meta tags on pages without their own specific metadata
+	let hasPageMetadata = $derived(
+		$page.url.pathname === '/' || // homepage has its own metadata
+		$page.url.pathname.startsWith('/track/') || // track pages have specific metadata
+		$page.url.pathname.match(/^\/u\/[^/]+\/album\/[^/]+/) // album pages have specific metadata
+	);
 
 	// initialize auth on mount
 	if (browser) {
@@ -89,8 +93,8 @@
 <svelte:head>
 	<link rel="icon" href={logo} />
 
-	{#if !isTrackPage}
-		<!-- default meta tags for link previews (not on track pages) -->
+	{#if !hasPageMetadata}
+		<!-- default meta tags for pages without specific metadata -->
 		<title>{APP_NAME} - {APP_TAGLINE}</title>
 		<meta
 			name="description"


### PR DESCRIPTION
## Problem

After adding rich Open Graph metadata to album pages and homepage in #230, the link previews still weren't working. Investigation showed that the root layout was rendering **duplicate** metadata tags - both the generic layout defaults AND the page-specific metadata.

When social media scrapers encounter duplicate OG tags, they use the **first** one they find, which was the generic layout metadata. This meant our rich album-specific metadata was being ignored.

Example from production HTML:
```html
<!-- Layout metadata (generic) -->
<meta property="og:type" content="website"/>
<meta property="og:title" content="plyr.fm - music on atproto"/>
<!-- Later... page metadata (specific, but ignored) -->
<meta property="og:type" content="music.album"/>
<meta property="og:title" content="Album Name by Artist"/>
```

## Solution

Updated the root layout to exclude pages that have their own `<svelte:head>` metadata:
- Homepage (`/`)  
- Track pages (`/track/*`)
- Album pages (`/u/*/album/*`)

Now only one set of metadata renders per page - the most specific and relevant one.

## Changes

- Renamed `isTrackPage` → `hasPageMetadata` for clarity
- Added homepage and album page patterns to exclusion logic
- Updated comment to reflect broader purpose

## Testing

After deploy, verify with:
```bash
curl -s https://plyr.fm/u/nate.n8n.wtf/album/field-recordings-of-life-around-ny-parables-from-tigray-ignant-hype-shit | grep 'og:type'
```

Should now show `music.album` instead of `website`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)