### PR TITLE
fix: display album title instead of [object Object] in portal

### DIFF
--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -663,7 +663,7 @@
 										{/if}
 										{#if track.album}
 											<span class="separator">•</span>
-											<span class="album">{track.album}</span>
+											<span class="album">{track.album.title}</span>
 										{/if}
 									</div>
 									{#if track.created_at}
@@ -685,7 +685,12 @@
 										onclick={() => deleteTrack(track.id, track.title)}
 										title="delete track"
 									>
-										×
+										<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+											<polyline points="3 6 5 6 21 6"></polyline>
+											<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+											<line x1="10" y1="11" x2="10" y2="17"></line>
+											<line x1="14" y1="11" x2="14" y2="17"></line>
+										</svg>
 									</button>
 								</div>
 							{/if}


### PR DESCRIPTION
## summary

fixes the bug where album names show as  in the portal's track list

## changes

- **portal track list**: use  instead of  (which is an object)
- **delete button**: changed from × to trash bin icon for better UX

## before/after

**before**:   
**after**: proper album title (e.g., "my album name")

the issue was that  is an  object with properties like , so trying to render it directly showed .