### PR TITLE
fix: show likers inline instead of tooltip

### DIFF
--- a/frontend/src/lib/components/LikersTooltip.svelte
+++ b/frontend/src/lib/components/LikersTooltip.svelte
@@ -17,7 +17,7 @@
 	let { trackId, likeCount }: Props = $props();
 
 	let likers = $state<Liker[]>([]);
-	let loading = $state(true); // start as loading
+	let loading = $state(true);
 	let error = $state<string | null>(null);
 
 	$effect(() => {
@@ -26,22 +26,16 @@
 			return;
 		}
 
-		console.log('fetching likers for track', trackId);
-
 		const fetchLikers = async () => {
 			try {
 				const url = `${API_URL}/tracks/${trackId}/likes`;
-				console.log('fetching from:', url);
 				const response = await fetch(url);
 
 				if (!response.ok) {
-					const text = await response.text();
-					console.error('failed to fetch likers:', response.status, text);
 					throw new Error(`failed to fetch likers: ${response.status}`);
 				}
 
 				const data = await response.json();
-				console.log('received likers data:', data);
 				likers = data.users || [];
 			} catch (err) {
 				error = 'failed to load';
@@ -53,185 +47,46 @@
 
 		fetchLikers();
 	});
-
-	// format relative time
-	function formatTime(isoString: string): string {
-		const date = new Date(isoString);
-		const now = new Date();
-		const seconds = Math.floor((now.getTime() - date.getTime()) / 1000);
-
-		if (seconds < 60) return 'just now';
-		if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
-		if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
-		if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`;
-		return `${Math.floor(seconds / 604800)}w ago`;
-	}
 </script>
 
-<div
-	class="likers-tooltip"
-	role="tooltip"
->
+<span class="likers-inline">
 	{#if loading}
-		<div class="loading">loading...</div>
+		<span class="likes-text">loading likes...</span>
 	{:else if error}
-		<div class="error">{error}</div>
+		<span class="likes-text">{likeCount} {likeCount === 1 ? 'like' : 'likes'}</span>
 	{:else if likers.length > 0}
-		<div class="likers-list">
-			{#each likers.slice(0, 10) as liker}
-				<a
-					href="/u/{liker.handle}"
-					class="liker"
-				>
-					{#if liker.avatar_url}
-						<img src={liker.avatar_url} alt={liker.display_name} class="avatar" />
-					{:else}
-						<div class="avatar-placeholder">
-							{liker.display_name.charAt(0).toUpperCase()}
-						</div>
-					{/if}
-					<div class="liker-info">
-						<div class="display-name">{liker.display_name}</div>
-						<div class="handle">@{liker.handle}</div>
-					</div>
-					<div class="liked-time">{formatTime(liker.liked_at)}</div>
-				</a>
-			{/each}
-			{#if likers.length > 10}
-				<div class="more">+{likers.length - 10} more</div>
+		<span class="likes-text">
+			{likeCount} {likeCount === 1 ? 'like' : 'likes'} from
+			{#each likers.slice(0, 3) as liker, i}
+				{#if i > 0}{i === likers.length - 1 && likers.length <= 3 ? ' and ' : ', '}{/if}<a href="/u/{liker.handle}" class="liker-link">{liker.display_name}</a>
+			{/each}{#if likers.length > 3}
+				and {likers.length - 3} {likers.length - 3 === 1 ? 'other' : 'others'}
 			{/if}
-		</div>
+		</span>
+	{:else}
+		<span class="likes-text">{likeCount} {likeCount === 1 ? 'like' : 'likes'}</span>
 	{/if}
-</div>
+</span>
 
 <style>
-	.likers-tooltip {
-		position: absolute;
-		bottom: 100%;
-		left: 50%;
-		transform: translateX(-50%);
-		margin-bottom: 0.5rem;
-		background: #1a1a1a;
-		border: 1px solid #333;
-		border-radius: 8px;
-		padding: 0.75rem;
-		min-width: 240px;
-		max-width: 320px;
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
-		z-index: 1000;
-		pointer-events: auto;
-	}
-
-	.loading,
-	.error,
-	.empty {
-		color: #888;
-		font-size: 0.85rem;
-		text-align: center;
-		padding: 0.5rem;
-	}
-
-	.error {
-		color: #e74c3c;
-	}
-
-	.likers-list {
-		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
-		max-height: 300px;
-		overflow-y: auto;
-	}
-
-	.liker {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		padding: 0.5rem;
-		border-radius: 6px;
-		text-decoration: none;
-		transition: background 0.2s;
-	}
-
-	.liker:hover {
-		background: #252525;
-	}
-
-	.avatar,
-	.avatar-placeholder {
-		width: 32px;
-		height: 32px;
-		border-radius: 50%;
-		flex-shrink: 0;
-	}
-
-	.avatar {
-		object-fit: cover;
-		border: 1px solid #333;
-	}
-
-	.avatar-placeholder {
-		background: #333;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		color: #888;
-		font-weight: 600;
-		font-size: 0.9rem;
-	}
-
-	.liker-info {
-		flex: 1;
-		min-width: 0;
-	}
-
-	.display-name {
-		color: #e8e8e8;
-		font-weight: 500;
-		font-size: 0.9rem;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
-	}
-
-	.handle {
-		color: #888;
+	.likers-inline {
+		color: #999;
+		font-family: inherit;
 		font-size: 0.8rem;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
 	}
 
-	.liked-time {
-		color: #666;
-		font-size: 0.75rem;
-		flex-shrink: 0;
+	.likes-text {
+		color: #999;
 	}
 
-	.more {
-		color: #888;
-		font-size: 0.85rem;
-		text-align: center;
-		padding: 0.5rem;
-		border-top: 1px solid #282828;
-		margin-top: 0.25rem;
+	.liker-link {
+		color: var(--accent);
+		text-decoration: none;
+		transition: opacity 0.2s;
 	}
 
-	/* custom scrollbar */
-	.likers-list::-webkit-scrollbar {
-		width: 6px;
-	}
-
-	.likers-list::-webkit-scrollbar-track {
-		background: #1a1a1a;
-	}
-
-	.likers-list::-webkit-scrollbar-thumb {
-		background: #333;
-		border-radius: 3px;
-	}
-
-	.likers-list::-webkit-scrollbar-thumb:hover {
-		background: #444;
+	.liker-link:hover {
+		opacity: 0.8;
+		text-decoration: underline;
 	}
 </style>

--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -17,7 +17,6 @@
 
 	let { track, isPlaying = false, onPlay, isAuthenticated = false, hideAlbum = false }: Props = $props();
 
-	let showLikersTooltip = $state(false);
 	let likeCount = $state(track.like_count || 0);
 
 	// sync likeCount when track changes
@@ -40,15 +39,6 @@
 	function handleQueue() {
 		queue.addTracks([track]);
 		toast.success(`queued ${track.title}`, 1800);
-	}
-
-	function handleLikesMouseEnter() {
-		// show tooltip immediately, fetch will handle its own delay
-		showLikersTooltip = true;
-	}
-
-	function handleLikesMouseLeave() {
-		showLikersTooltip = false;
 	}
 
 	function handleLikeChange(liked: boolean) {
@@ -126,16 +116,7 @@
 				<span class="plays">{track.play_count} {track.play_count === 1 ? 'play' : 'plays'}</span>
 				{#if likeCount > 0}
 					<span class="meta-separator">•</span>
-					<span
-						class="likes"
-						onmouseenter={handleLikesMouseEnter}
-						onmouseleave={handleLikesMouseLeave}
-					>
-						{likeCount} {likeCount === 1 ? 'like' : 'likes'}
-						{#if showLikersTooltip}
-							<LikersTooltip trackId={track.id} likeCount={likeCount} />
-						{/if}
-					</span>
+					<LikersTooltip trackId={track.id} likeCount={likeCount} />
 				{/if}
 			</div>
 		</div>


### PR DESCRIPTION
## summary

fixes the scrolling UX issue with the hover tooltip - now shows likers inline in the track metadata

## the problem

the hover tooltip prevented scrolling because:
1. you had to keep your mouse over the like count to see the tooltip  
2. moving your mouse away (to scroll) hid the tooltip
3. this made it impossible to scroll when viewing tracks with many likers

## the solution

show likers inline directly in the metadata, like:
- `3 likes from alice, bob and charlie`
- `5 likes from alice, bob, carol and 2 others`

## changes

- removed hover/tooltip behavior from `TrackItem`
- simplified `LikersTooltip` to render inline text
- shows first 3 likers by name, then aggregates the rest

much cleaner UX and solves the scrolling problem!