### PR TITLE
fix: show all likers in tooltip without scrolling

### DIFF
--- a/frontend/src/lib/components/LikersTooltip.svelte
+++ b/frontend/src/lib/components/LikersTooltip.svelte
@@ -78,7 +78,7 @@
 		<div class="error">{error}</div>
 	{:else if likers.length > 0}
 		<div class="likers-list">
-			{#each likers.slice(0, 10) as liker}
+			{#each likers as liker}
 				<a
 					href="/u/{liker.handle}"
 					class="liker"
@@ -97,9 +97,6 @@
 					<div class="liked-time">{formatTime(liker.liked_at)}</div>
 				</a>
 			{/each}
-			{#if likers.length > 10}
-				<div class="more">+{likers.length - 10} more</div>
-			{/if}
 		</div>
 	{/if}
 </div>
@@ -139,8 +136,6 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;
-		max-height: 300px;
-		overflow-y: auto;
 	}
 
 	.liker {


### PR DESCRIPTION
## summary

removes the 10-liker limit and scrolling from the hover tooltip - now shows ALL likers

## changes

- removed `.slice(0, 10)` - now shows all likers, not just first 10
- removed `max-height: 300px` and `overflow-y: auto` from `.likers-list`
- removed "+ N more" message since we show everyone

the tooltip now expands vertically to show all likers. if this ever becomes an issue with many likers, we can address it then, but for now this gives the best UX.