### PR TITLE
feat: secure browser auth with HttpOnly cookies

### DIFF
--- a/frontend/src/lib/auth.svelte.ts
+++ b/frontend/src/lib/auth.svelte.ts
@@ -20,17 +20,9 @@ class AuthManager {
 			return;
 		}
 
-		const sessionId = this.getSessionId();
-		if (!sessionId) {
-			this.loading = false;
-			return;
-		}
-
 		try {
 			const response = await fetch(`${API_URL}/auth/me`, {
-				headers: {
-					'Authorization': `Bearer ${sessionId}`
-				}
+				credentials: 'include'
 			});
 
 			if (response.ok) {
@@ -47,47 +39,25 @@ class AuthManager {
 		}
 	}
 
-	getSessionId(): string | null {
-		if (!browser) return null;
-		return localStorage.getItem('session_id');
-	}
-
-	setSessionId(sessionId: string): void {
-		if (!browser) return;
-		localStorage.setItem('session_id', sessionId);
-	}
-
 	clearSession(): void {
 		if (!browser) return;
-		localStorage.removeItem('session_id');
-		localStorage.removeItem('exchange_token');
 		this.user = null;
 		this.isAuthenticated = false;
 	}
 
 	async logout(): Promise<void> {
-		const sessionId = this.getSessionId();
-		if (sessionId) {
-			try {
-				await fetch(`${API_URL}/auth/logout`, {
-					method: 'POST',
-					headers: {
-						'Authorization': `Bearer ${sessionId}`
-					}
-				});
-			} catch (e) {
-				console.error('logout failed:', e);
-			}
+		try {
+			await fetch(`${API_URL}/auth/logout`, {
+				method: 'POST',
+				credentials: 'include'
+			});
+		} catch (e) {
+			console.error('logout failed:', e);
 		}
 		this.clearSession();
 	}
 
-	// helper to get auth headers
 	getAuthHeaders(): Record<string, string> {
-		const sessionId = this.getSessionId();
-		if (sessionId) {
-			return { 'Authorization': `Bearer ${sessionId}` };
-		}
 		return {};
 	}
 }

--- a/frontend/src/lib/components/BrokenTracks.svelte
+++ b/frontend/src/lib/components/BrokenTracks.svelte
@@ -16,12 +16,9 @@
 
 	async function loadBrokenTracks() {
 		loading = true;
-		const sessionId = localStorage.getItem('session_id');
 		try {
 			const response = await fetch(`${API_URL}/tracks/me/broken`, {
-				headers: {
-					'Authorization': `Bearer ${sessionId}`
-				}
+				credentials: 'include'
 			});
 			if (response.ok) {
 				const data = await response.json();
@@ -42,14 +39,11 @@
 		}
 
 		restoringTrackId = trackId;
-		const sessionId = localStorage.getItem('session_id');
 
 		try {
 			const response = await fetch(`${API_URL}/tracks/${trackId}/restore-record`, {
 				method: 'POST',
-				headers: {
-					'Authorization': `Bearer ${sessionId}`
-				}
+				credentials: 'include'
 			});
 
 			if (response.ok) {
@@ -86,7 +80,6 @@
 		}
 
 		restoringAll = true;
-		const sessionId = localStorage.getItem('session_id');
 		const trackCount = brokenTracks.length;
 
 		try {
@@ -94,9 +87,7 @@
 				brokenTracks.map(track =>
 					fetch(`${API_URL}/tracks/${track.id}/restore-record`, {
 						method: 'POST',
-						headers: {
-							'Authorization': `Bearer ${sessionId}`
-						}
+						credentials: 'include'
 					}).then(async response => {
 						if (!response.ok) {
 							let errorMsg = `failed to restore ${track.title}`;

--- a/frontend/src/lib/components/ColorSettings.svelte
+++ b/frontend/src/lib/components/ColorSettings.svelte
@@ -17,11 +17,8 @@
 	onMount(async () => {
 		// try to fetch from backend if authenticated
 		try {
-			const sessionId = localStorage.getItem('session_id');
 			const response = await fetch(`${API_URL}/preferences/`, {
-				headers: {
-					'Authorization': `Bearer ${sessionId}`
-				}
+				credentials: 'include'
 			});
 			if (response.ok) {
 				const data = await response.json();
@@ -61,13 +58,12 @@
 
 		// save to backend if authenticated
 		try {
-			const sessionId = localStorage.getItem('session_id');
 			await fetch(`${API_URL}/preferences/`, {
 				method: 'POST',
 				headers: {
-					'Content-Type': 'application/json',
-					'Authorization': `Bearer ${sessionId}`
+					'Content-Type': 'application/json'
 				},
+				credentials: 'include',
 				body: JSON.stringify({ accent_color: color })
 			});
 		} catch (e) {

--- a/frontend/src/lib/components/MigrationBanner.svelte
+++ b/frontend/src/lib/components/MigrationBanner.svelte
@@ -19,11 +19,8 @@
 
 	// check if migration is needed
 	export async function checkMigrationStatus(): Promise<void> {
-		const sessionId = localStorage.getItem('session_id');
-		if (!sessionId) return;
-
-		// check if user already dismissed this
-		const dismissedKey = `migration_dismissed_${sessionId}`;
+		// check if user already dismissed this (using a generic key since we don't have session_id)
+		const dismissedKey = 'migration_dismissed';
 		if (localStorage.getItem(dismissedKey) === 'true') {
 			dismissed = true;
 			return;
@@ -31,9 +28,7 @@
 
 		try {
 			const response = await fetch(`${API_URL}/migration/check`, {
-				headers: {
-					'Authorization': `Bearer ${sessionId}`
-				}
+				credentials: 'include'
 			});
 
 			if (response.ok) {
@@ -53,19 +48,10 @@
 		migrating = true;
 		error = '';
 
-		const sessionId = localStorage.getItem('session_id');
-		if (!sessionId) {
-			error = 'not authenticated';
-			migrating = false;
-			return;
-		}
-
 		try {
 			const response = await fetch(`${API_URL}/migration/migrate`, {
 				method: 'POST',
-				headers: {
-					'Authorization': `Bearer ${sessionId}`
-				}
+				credentials: 'include'
 			});
 
 			if (response.ok) {
@@ -95,10 +81,7 @@
 		needsMigration = false;
 
 		// remember dismissal
-		const sessionId = localStorage.getItem('session_id');
-		if (sessionId) {
-			localStorage.setItem(`migration_dismissed_${sessionId}`, 'true');
-		}
+		localStorage.setItem('migration_dismissed', 'true');
 	}
 </script>
 

--- a/frontend/src/lib/components/SettingsMenu.svelte
+++ b/frontend/src/lib/components/SettingsMenu.svelte
@@ -28,13 +28,8 @@
 		queue.setAutoAdvance(autoAdvance);
 
 		try {
-			const sessionId = localStorage.getItem('session_id');
-			if (!sessionId) return;
-
 			const response = await fetch(`${API_URL}/preferences/`, {
-				headers: {
-					Authorization: `Bearer ${sessionId}`
-				}
+				credentials: 'include'
 			});
 
 			if (!response.ok) return;
@@ -70,15 +65,12 @@
 
 	async function savePreferences(update: Record<string, unknown>) {
 		try {
-			const sessionId = localStorage.getItem('session_id');
-			if (!sessionId) return;
-
 			await fetch(`${API_URL}/preferences/`, {
 				method: 'POST',
 				headers: {
-					'Content-Type': 'application/json',
-					Authorization: `Bearer ${sessionId}`
+					'Content-Type': 'application/json'
 				},
+				credentials: 'include',
 				body: JSON.stringify(update)
 			});
 		} catch (error) {

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -159,18 +159,16 @@ class Queue {
 		try {
 			this.hydrating = true;
 
-			const sessionId = localStorage.getItem('session_id');
 			const headers: HeadersInit = {};
-
-			if (sessionId) {
-				headers['Authorization'] = `Bearer ${sessionId}`;
-			}
 
 			if (this.etag && !force) {
 				headers['If-None-Match'] = this.etag;
 			}
 
-			const response = await fetch(`${API_URL}/queue/`, { headers });
+			const response = await fetch(`${API_URL}/queue/`, {
+				headers,
+				credentials: 'include'
+			});
 
 			if (response.status === 304) {
 				return;
@@ -314,7 +312,6 @@ class Queue {
 		this.pendingSync = false;
 
 		try {
-			const sessionId = localStorage.getItem('session_id');
 			const state: QueueState = {
 				track_ids: this.tracks.map((t) => t.file_id),
 				current_index: this.currentIndex,
@@ -328,23 +325,19 @@ class Queue {
 				'Content-Type': 'application/json'
 			};
 
-			if (sessionId) {
-				headers['Authorization'] = `Bearer ${sessionId}`;
-			}
-
 			if (this.revision !== null) {
 				headers['If-Match'] = `"${this.revision}"`;
 			}
 
 			const response = await fetch(`${API_URL}/queue/`, {
+				credentials: 'include',
 				method: 'PUT',
 				headers,
 				body: JSON.stringify({ state })
 			});
 
 			if (response.status === 401) {
-				// session expired or invalid, clear it and stop trying to sync
-				localStorage.removeItem('session_id');
+				// session expired or invalid, stop trying to sync
 				return false;
 			}
 

--- a/frontend/src/lib/tracks.svelte.ts
+++ b/frontend/src/lib/tracks.svelte.ts
@@ -35,14 +35,9 @@ class TracksCache {
 
 		this.loading = true;
 		try {
-			// include auth header if available to get like status
-			const headers: Record<string, string> = {};
-			const sessionId = localStorage.getItem('session_id');
-			if (sessionId) {
-				headers['Authorization'] = `Bearer ${sessionId}`;
-			}
-
-			const response = await fetch(`${API_URL}/tracks/`, { headers });
+			const response = await fetch(`${API_URL}/tracks/`, {
+				credentials: 'include'
+			});
 			const data = await response.json();
 			this.tracks = data.tracks;
 
@@ -76,12 +71,9 @@ export const tracksCache = new TracksCache();
 // like/unlike track functions
 export async function likeTrack(trackId: number): Promise<boolean> {
 	try {
-		const sessionId = localStorage.getItem('session_id');
 		const response = await fetch(`${API_URL}/tracks/${trackId}/like`, {
 			method: 'POST',
-			headers: {
-				'Authorization': `Bearer ${sessionId}`
-			}
+			credentials: 'include'
 		});
 
 		if (!response.ok) {
@@ -100,12 +92,9 @@ export async function likeTrack(trackId: number): Promise<boolean> {
 
 export async function unlikeTrack(trackId: number): Promise<boolean> {
 	try {
-		const sessionId = localStorage.getItem('session_id');
 		const response = await fetch(`${API_URL}/tracks/${trackId}/like`, {
 			method: 'DELETE',
-			headers: {
-				'Authorization': `Bearer ${sessionId}`
-			}
+			credentials: 'include'
 		});
 
 		if (!response.ok) {
@@ -124,11 +113,8 @@ export async function unlikeTrack(trackId: number): Promise<boolean> {
 
 export async function fetchLikedTracks(): Promise<Track[]> {
 	try {
-		const sessionId = localStorage.getItem('session_id');
 		const response = await fetch(`${API_URL}/tracks/liked`, {
-			headers: {
-				'Authorization': `Bearer ${sessionId}`
-			}
+			credentials: 'include'
 		});
 
 		if (!response.ok) {

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -43,7 +43,6 @@ class UploaderState {
 		const toastId = toast.info(uploadMessage, 30000);
 
 		if (!browser) return;
-		const sessionId = localStorage.getItem('session_id');
 		const formData = new FormData();
 		formData.append('file', file);
 		formData.append('title', title);
@@ -58,7 +57,7 @@ class UploaderState {
 
 		const xhr = new XMLHttpRequest();
 		xhr.open('POST', `${API_URL}/tracks/`);
-		xhr.setRequestHeader('Authorization', `Bearer ${sessionId}`);
+		xhr.withCredentials = true;
 
 		let uploadComplete = false;
 

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -16,19 +16,9 @@ export async function load({ fetch }: LoadEvent): Promise<LayoutData> {
 		};
 	}
 
-	const sessionId = localStorage.getItem('session_id');
-	if (!sessionId) {
-		return {
-			user: null,
-			isAuthenticated: false
-		};
-	}
-
 	try {
 		const response = await fetch(`${API_URL}/auth/me`, {
-			headers: {
-				'Authorization': `Bearer ${sessionId}`
-			}
+			credentials: 'include'
 		});
 
 		if (response.ok) {

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -65,17 +65,16 @@
 		const exchangeToken = params.get('exchange_token');
 
 		if (exchangeToken) {
-			// exchange token for session_id
+			// exchange token for session_id (cookie is set automatically by backend)
 			try {
 				const exchangeResponse = await fetch(`${API_URL}/auth/exchange`, {
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },
+					credentials: 'include',
 					body: JSON.stringify({ exchange_token: exchangeToken })
 				});
 
 				if (exchangeResponse.ok) {
-					const data = await exchangeResponse.json();
-					auth.setSessionId(data.session_id);
 					await auth.initialize();
 				}
 			} catch (e) {
@@ -107,7 +106,7 @@
 		loadingTracks = true;
 		try {
 			const response = await fetch(`${API_URL}/tracks/me`, {
-				headers: auth.getAuthHeaders()
+				credentials: 'include'
 			});
 			if (response.ok) {
 				const data = await response.json();
@@ -123,7 +122,7 @@
 	async function loadArtistProfile() {
 		try {
 			const response = await fetch(`${API_URL}/artists/me`, {
-				headers: auth.getAuthHeaders()
+				credentials: 'include'
 			});
 			if (response.ok) {
 				const artist = await response.json();
@@ -164,7 +163,7 @@
 		try {
 			const response = await fetch(`${API_URL}/albums/${albumId}/cover`, {
 				method: 'POST',
-				headers: auth.getAuthHeaders(),
+				credentials: 'include',
 				body: formData
 			});
 
@@ -203,9 +202,9 @@
 			const response = await fetch(`${API_URL}/artists/me`, {
 				method: 'PUT',
 				headers: {
-					'Content-Type': 'application/json',
-					...auth.getAuthHeaders()
+					'Content-Type': 'application/json'
 				},
+				credentials: 'include',
 				body: JSON.stringify({
 					display_name: displayName,
 					bio: bio || null,
@@ -280,7 +279,7 @@
 		try {
 			const response = await fetch(`${API_URL}/tracks/${trackId}`, {
 				method: 'DELETE',
-				headers: auth.getAuthHeaders()
+				credentials: 'include'
 			});
 
 			if (response.ok) {
@@ -329,7 +328,7 @@
 			const response = await fetch(`${API_URL}/tracks/${trackId}`, {
 				method: 'PATCH',
 				body: formData,
-				headers: auth.getAuthHeaders()
+				credentials: 'include'
 			});
 
 			if (response.ok) {

--- a/frontend/src/routes/profile/setup/+page.svelte
+++ b/frontend/src/routes/profile/setup/+page.svelte
@@ -22,17 +22,16 @@
 		const exchangeToken = params.get('exchange_token');
 
 		if (exchangeToken) {
-			// exchange token for session_id
+			// exchange token for session_id (cookie is set automatically by backend)
 			try {
 				const exchangeResponse = await fetch(`${API_URL}/auth/exchange`, {
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },
+					credentials: 'include',
 					body: JSON.stringify({ exchange_token: exchangeToken })
 				});
 
 				if (exchangeResponse.ok) {
-					const data = await exchangeResponse.json();
-					auth.setSessionId(data.session_id);
 					await auth.initialize();
 				}
 			} catch (e) {
@@ -70,7 +69,7 @@
 		try {
 			// call our backend which will use the Bluesky API
 			const response = await fetch(`${API_URL}/artists/${auth.user.did}`, {
-				headers: auth.getAuthHeaders()
+				credentials: 'include'
 			});
 
 			// if artist profile already exists, redirect to portal
@@ -96,9 +95,9 @@
 			const response = await fetch(`${API_URL}/artists/`, {
 				method: 'POST',
 				headers: {
-					'Content-Type': 'application/json',
-					...auth.getAuthHeaders()
+					'Content-Type': 'application/json'
 				},
+				credentials: 'include',
 				body: JSON.stringify({
 					display_name: displayName,
 					bio: bio || null,

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -22,14 +22,9 @@
 	);
 
 	async function loadLikedState() {
-		const sessionId = auth.getSessionId();
-		if (!sessionId) return;
-
 		try {
 			const response = await fetch(`${API_URL}/tracks/${track.id}`, {
-				headers: {
-					'Authorization': `Bearer ${sessionId}`
-				}
+				credentials: 'include'
 			});
 
 			if (response.ok) {

--- a/frontend/src/routes/u/[handle]/album/[slug]/+page.ts
+++ b/frontend/src/routes/u/[handle]/album/[slug]/+page.ts
@@ -1,12 +1,10 @@
 import type { PageLoad } from './$types';
 import type { AlbumResponse } from '$lib/types';
 import { API_URL } from '$lib/config';
-import { auth } from '$lib/auth.svelte';
 
 export const load: PageLoad = async ({ params, fetch }) => {
 	const response = await fetch(`${API_URL}/albums/${params.handle}/${params.slug}`, {
-		credentials: 'include',
-		headers: auth.getAuthHeaders()
+		credentials: 'include'
 	});
 
 	if (!response.ok) {

--- a/src/backend/api/auth.py
+++ b/src/backend/api/auth.py
@@ -1,10 +1,13 @@
 """authentication api endpoints."""
 
 from typing import Annotated
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from pydantic import BaseModel
+from starlette.requests import Request
+from starlette.responses import Response
 
 from backend._internal import (
     Session,
@@ -78,11 +81,18 @@ class ExchangeTokenResponse(BaseModel):
 
 
 @router.post("/exchange")
-async def exchange_token(request: ExchangeTokenRequest) -> ExchangeTokenResponse:
+async def exchange_token(
+    request: ExchangeTokenRequest,
+    http_request: Request,
+    response: Response,
+) -> ExchangeTokenResponse:
     """exchange one-time token for session_id.
 
     frontend calls this immediately after OAuth callback to securely
     exchange the short-lived token for the actual session_id.
+
+    for browser requests: sets HttpOnly cookie and still returns session_id in response
+    for SDK/CLI clients: only returns session_id in response (no cookie)
     """
     session_id = await consume_exchange_token(request.exchange_token)
 
@@ -92,14 +102,62 @@ async def exchange_token(request: ExchangeTokenRequest) -> ExchangeTokenResponse
             detail="invalid, expired, or already used exchange token",
         )
 
+    user_agent = http_request.headers.get("user-agent", "").lower()
+    is_browser = any(
+        browser in user_agent
+        for browser in ["mozilla", "chrome", "safari", "firefox", "edge", "opera"]
+    )
+
+    if is_browser:
+        cookie_domain = None
+        use_cookies = False
+
+        frontend_url = settings.frontend.url
+        if frontend_url and not frontend_url.startswith("http://localhost"):
+            parsed = urlparse(frontend_url)
+            frontend_host = parsed.netloc.split(":")[0]
+
+            if frontend_host.endswith(".plyr.fm") or frontend_host == "plyr.fm":
+                cookie_domain = ".plyr.fm"
+                use_cookies = True
+
+        if use_cookies:
+            response.set_cookie(
+                key="session_id",
+                value=session_id,
+                httponly=True,
+                secure=True,
+                samesite="none",
+                domain=cookie_domain,
+                max_age=14 * 24 * 60 * 60,
+            )
+
     return ExchangeTokenResponse(session_id=session_id)
 
 
 @router.post("/logout")
-async def logout(session: Session = Depends(require_auth)) -> dict:
+async def logout(
+    session: Session = Depends(require_auth),
+) -> JSONResponse:
     """logout current user."""
     await delete_session(session.session_id)
-    return {"message": "logged out successfully"}
+    response = JSONResponse(content={"message": "logged out successfully"})
+
+    frontend_url = settings.frontend.url
+    if frontend_url and not frontend_url.startswith("http://localhost"):
+        parsed = urlparse(frontend_url)
+        frontend_host = parsed.netloc.split(":")[0]
+
+        if frontend_host.endswith(".plyr.fm") or frontend_host == "plyr.fm":
+            response.delete_cookie(
+                key="session_id",
+                httponly=True,
+                secure=True,
+                samesite="none",
+                domain=".plyr.fm",
+            )
+
+    return response
 
 
 @router.get("/me")


### PR DESCRIPTION
## Summary

Implements cookie-based authentication for browser requests while maintaining bearer token support for SDK/CLI clients. This addresses the security issue (#39, #237) where localStorage-based sessions were vulnerable to XSS attacks.

## Changes

### Backend
- `/auth/exchange` endpoint now sets HttpOnly cookies for browser requests (detected via User-Agent)
- `require_auth` dependency checks cookies first, then falls back to Authorization header
- Cookies only set when frontend URL is on `.plyr.fm` domain (production/staging)
- `/auth/logout` properly deletes cookies

### Frontend
- Removed all `localStorage` usage for `session_id`
- Updated all fetch calls to use `credentials: 'include` instead of Authorization headers
- Exchange token flow no longer stores session_id in localStorage
- XMLHttpRequest uploader uses `withCredentials = true`

## Security Benefits

- HttpOnly cookies prevent JavaScript access (XSS protection)
- Secure flag ensures HTTPS-only transmission
- SameSite=None allows cross-subdomain sharing (plyr.fm ↔ api.plyr.fm)
- 14-day expiration matches session TTL

## Backward Compatibility

- SDK/CLI clients can still use bearer tokens via Authorization header
- Staging environment (relay-4i6.pages.dev) falls back to bearer tokens until custom domains are configured
- Local development uses bearer tokens

## Testing

- [ ] Test login flow in production (plyr.fm)
- [ ] Verify cookies are set and sent correctly
- [ ] Test logout clears cookies
- [ ] Verify bearer tokens still work for API clients
- [ ] Test staging after domain setup

---

<details>
<summary>Staging Domain Setup Instructions</summary>

To enable cookie-based auth in staging, follow these steps:

### 1. Fly.io Backend - Add `api-staging.plyr.fm`

```bash
# Add the certificate (Fly.io will provision it automatically)
flyctl certs add api-staging.plyr.fm -a relay-api-staging

# Verify it's issued (wait a minute, then check)
flyctl certs show api-staging.plyr.fm -a relay-api-staging
```

### 2. Cloudflare DNS - Add CNAME for Backend

In Cloudflare DNS for `plyr.fm`:
- Type: `CNAME`
- Name: `api-staging`
- Target: `relay-api-staging.fly.dev`
- Proxy status: Proxied (orange cloud)

### 3. Cloudflare Pages - Add Custom Domain for Frontend

In Cloudflare Pages for your project:
- Go to Custom domains
- Add `staging.plyr.fm`
- Cloudflare will auto-configure DNS

### 4. Update Cloudflare Pages Environment Variables

In Cloudflare Pages → Settings → Environment variables:
- Preview environment: change `PUBLIC_API_URL` from `https://relay-api-staging.fly.dev` to `https://api-staging.plyr.fm`

### 5. Update Fly.io Staging Secrets

```bash
# Set frontend URL so cookies work
flyctl secrets set FRONTEND_URL=https://staging.plyr.fm -a relay-api-staging

# Update OAuth client ID (you'll need to register a new one at oauthclientregistry.bsky.app)
flyctl secrets set ATPROTO_CLIENT_ID=https://api-staging.plyr.fm/client-metadata.json -a relay-api-staging

# Update OAuth redirect URI
flyctl secrets set ATPROTO_REDIRECT_URI=https://api-staging.plyr.fm/auth/callback -a relay-api-staging
```

### 6. Register New OAuth Client for Staging

Go to https://oauthclientregistry.bsky.app/ and register:
- Client ID: `https://api-staging.plyr.fm/client-metadata.json`
- Redirect URI: `https://api-staging.plyr.fm/auth/callback`

### 7. Update Docs (Optional)

After it's working, update `docs/deployment/environments.md` to reflect the new staging URLs.

</details>