### PR TITLE
chore: remove unused scale import from toast component

### DIFF
--- a/frontend/src/lib/components/Toast.svelte
+++ b/frontend/src/lib/components/Toast.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { toast } from '$lib/toast.svelte';
-	import { fade, scale } from 'svelte/transition';
+	import { fade } from 'svelte/transition';
 
 	// icons for different toast types
 	const icons: Record<string, string> = {


### PR DESCRIPTION
tiny cleanup - removes unused `scale` import from toast component.

the component only uses `fade` transition, so `scale` was dead code.