### PR TITLE
perf: optimize image loading to improve LCP

### DIFF
--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -13,9 +13,14 @@
 		onPlay: (_track: Track) => void;
 		isAuthenticated?: boolean;
 		hideAlbum?: boolean;
+		index?: number;
 	}
 
-	let { track, isPlaying = false, onPlay, isAuthenticated = false, hideAlbum = false }: Props = $props();
+	let { track, isPlaying = false, onPlay, isAuthenticated = false, hideAlbum = false, index = 0 }: Props = $props();
+
+	// optimize image loading: eager for first 3, lazy for rest
+	const imageLoading = index < 3 ? 'eager' : 'lazy';
+	const imageFetchPriority = index < 2 ? 'high' : undefined;
 
 	let showLikersTooltip = $state(false);
 	let likeCount = $state(track.like_count || 0);
@@ -72,14 +77,28 @@
 	>
 		{#if track.image_url}
 			<div class="track-image">
-				<img src={track.image_url} alt="{track.title} artwork" />
+				<img
+					src={track.image_url}
+					alt="{track.title} artwork"
+					width="48"
+					height="48"
+					loading={imageLoading}
+					fetchpriority={imageFetchPriority}
+				/>
 			</div>
 		{:else if track.artist_avatar_url}
 			<a
 				href="/u/{track.artist_handle}"
 				class="track-avatar"
 			>
-				<img src={track.artist_avatar_url} alt={track.artist} />
+				<img
+					src={track.artist_avatar_url}
+					alt={track.artist}
+					width="48"
+					height="48"
+					loading={imageLoading}
+					fetchpriority={imageFetchPriority}
+				/>
 			</a>
 		{:else}
 			<div class="track-image-placeholder">

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -71,9 +71,10 @@
 			<p class="empty">no tracks yet</p>
 		{:else}
 			<div class="track-list">
-				{#each tracks as track}
+				{#each tracks as track, i}
 					<TrackItem
 						{track}
+						index={i}
 						isPlaying={player.currentTrack?.id === track.id}
 						onPlay={(t) => queue.playNow(t)}
 						isAuthenticated={auth.isAuthenticated}

--- a/frontend/src/routes/liked/+page.svelte
+++ b/frontend/src/routes/liked/+page.svelte
@@ -72,9 +72,10 @@
 		</div>
 	{:else}
 		<div class="tracks-list">
-			{#each data.tracks as track (track.id)}
+			{#each data.tracks as track, i (track.id)}
 				<TrackItem
 					{track}
+					index={i}
 					isPlaying={player.currentTrack?.id === track.id && !player.paused}
 					onPlay={playTrack}
 					isAuthenticated={auth.isAuthenticated}

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -176,9 +176,10 @@
 				<p class="empty">no tracks yet</p>
 			{:else}
 				<div class="track-list">
-					{#each tracks as track}
+					{#each tracks as track, i}
 						<TrackItem
 							{track}
+							index={i}
 							isPlaying={player.currentTrack?.id === track.id}
 							onPlay={(t) => queue.playNow(t)}
 							isAuthenticated={auth.isAuthenticated}

--- a/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
@@ -113,9 +113,10 @@
 		<div class="tracks-section">
 			<h2 class="section-heading">tracks</h2>
 			<div class="tracks-list">
-				{#each album.tracks as track}
+				{#each album.tracks as track, i}
 					<TrackItem
 						{track}
+						index={i}
 						isPlaying={player.currentTrack?.id === track.id}
 						onPlay={playTrack}
 						{isAuthenticated}


### PR DESCRIPTION
## summary

optimizes image loading in TrackItem components to improve Largest Contentful Paint (LCP) and reduce Cumulative Layout Shift (CLS).

## changes

- **lazy loading**: images below fold (index >= 3) use `loading="lazy"`
- **priority hints**: first 2 images use `fetchpriority="high"` for faster LCP
- **explicit dimensions**: all images have `width="48" height="48"` to prevent layout shift
- **conditional loading**: TrackItem accepts `index` prop to determine loading strategy

## expected impact

- **faster LCP**: priority loading for above-the-fold images
- **reduced CLS**: explicit dimensions prevent layout shifts
- **better bandwidth**: lazy loading saves data for below-fold images

## testing

test with Chrome DevTools Lighthouse:
1. open homepage in Chrome
2. DevTools → Lighthouse tab
3. select "Performance" category
4. click "Analyze page load"

should see improved LCP score (target: <2.5s) and CLS score (target: <0.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)