### PR TITLE
fix: revert to SvelteKit's $env/static/public for API_URL

### DIFF
--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,4 +1,6 @@
-export const API_URL = import.meta.env.PUBLIC_API_URL || 'http://localhost:8001';
+import { PUBLIC_API_URL } from '$env/static/public';
+
+export const API_URL = PUBLIC_API_URL || 'http://localhost:8001';
 
 interface ServerConfig {
 	max_upload_size_mb: number;


### PR DESCRIPTION
## problem

PR #247 (PWA) changed `frontend/src/lib/config.ts` from:
```typescript
import { PUBLIC_API_URL } from '$env/static/public';
```

to:
```typescript
import.meta.env.PUBLIC_API_URL
```

this broke staging deployment - the frontend tries to hit `localhost:8001` instead of `https://api-stg.plyr.fm`.

## cause

`import.meta.env` doesn't pick up Cloudflare Pages environment variables correctly at build time, so `PUBLIC_API_URL` is undefined and falls back to localhost.

## fix

revert to `$env/static/public`, which is the correct SvelteKit way to access environment variables during static builds.

## testing

staging should correctly hit `https://api-stg.plyr.fm` after deployment instead of `localhost:8001`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)