### PR TITLE
docs: remove fake OAuth registry references

### DIFF
--- a/docs/backend/configuration.md
+++ b/docs/backend/configuration.md
@@ -69,7 +69,7 @@ all settings can be configured via environment variables. the variable names mat
 # database
 DATABASE_URL=postgresql+psycopg://user:pass@host/db
 
-# oauth (register at https://oauthclientregistry.bsky.app/)
+# oauth (uses client metadata discovery - no registration required)
 ATPROTO_CLIENT_ID=https://your-domain.com/client-metadata.json
 ATPROTO_CLIENT_SECRET=<optional-client-secret>
 ATPROTO_REDIRECT_URI=https://your-domain.com/auth/callback

--- a/docs/local-development/setup.md
+++ b/docs/local-development/setup.md
@@ -44,7 +44,7 @@ create a `.env` file in the project root:
 DATABASE_URL=postgresql+asyncpg://localhost/plyr  # local
 # DATABASE_URL=<neon-dev-connection-string>        # neon dev
 
-# oauth (register at https://oauthclientregistry.bsky.app/)
+# oauth (uses client metadata discovery - no registration required)
 ATPROTO_CLIENT_ID=http://localhost:8001/client-metadata.json
 ATPROTO_CLIENT_SECRET=<your-client-secret>
 ATPROTO_REDIRECT_URI=http://localhost:5173/auth/callback
@@ -303,10 +303,8 @@ bun --version
 # verify ATPROTO_REDIRECT_URI matches frontend URL
 # should be: http://localhost:5173/auth/callback
 
-# check ATPROTO_CLIENT_ID is accessible
+# check ATPROTO_CLIENT_ID is accessible (should return client metadata JSON)
 curl http://localhost:8001/client-metadata.json
-
-# verify oauth registration at oauthclientregistry.bsky.app
 ```
 
 ### r2 upload failures


### PR DESCRIPTION
## problem

documentation incorrectly referenced `oauthclientregistry.bsky.app` as a place to "register" OAuth clients. this registry **does not exist** and is not how ATProto OAuth works.

## how ATProto OAuth actually works

ATProto uses **client metadata discovery**:
1. `ATPROTO_CLIENT_ID` is a URL (e.g., `https://api.plyr.fm/client-metadata.json`)
2. the backend serves client metadata JSON at that URL
3. when users authenticate, their PDS automatically fetches metadata from the client ID URL
4. **no registration required** - it's purely discovery-based

see `docs/backend/atproto-identity.md` for the correct explanation.

## changes

removed fake registry references from:
- `docs/local-development/setup.md` (2 occurrences)
- `docs/backend/configuration.md` (1 occurrence)

replaced with: `# oauth (uses client metadata discovery - no registration required)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)