### PR TITLE
fix: add color to album-link after restructuring

### DIFF
--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -410,6 +410,7 @@
 	}
 
 	.album-link {
+		color: #909090;
 		text-decoration: none;
 		transition: color 0.2s;
 		display: inline-block;


### PR DESCRIPTION
Fixes missing color on album links after #255 restructured the markup.

## Issue
After moving the album icon outside the link in #255, the album link no longer inherits color from the parent `.album` wrapper.

## Fix
Add explicit `color: #909090` declaration to `.album-link` to match the intended gray color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)