### PR TITLE
docs: fix queue design link

### DIFF
--- a/docs/frontend/state-management.md
+++ b/docs/frontend/state-management.md
@@ -31,7 +31,7 @@ plyr.fm uses global state managers following the Svelte 5 runes pattern for cros
 - optimistic updates with 250ms debounce
 - handles shuffle and repeat modes
 - conflict resolution for multi-device scenarios
-- see [`docs/queue-design.md`](../queue-design.md) for details
+- see [`queue.md`](./queue.md) for details
 
 ### liked tracks (`frontend/src/lib/tracks.svelte.ts`)
 - like/unlike functions exported from tracks module


### PR DESCRIPTION
## Summary
- correct the broken reference in docs/frontend/state-management.md to point to the existing queue.md

No behavioral changes; doc-only fix.

## Testing
- n/a