### PR TITLE
fix: serialize TrackResponse to dict in album endpoint

### DIFF
--- a/src/backend/api/albums.py
+++ b/src/backend/api/albums.py
@@ -44,7 +44,7 @@ class AlbumResponse(BaseModel):
     """album detail response with tracks."""
 
     metadata: AlbumMetadata
-    tracks: list[dict]  # TrackResponse is a dict subclass, not a Pydantic model
+    tracks: list[dict]
 
 
 class AlbumListItem(BaseModel):
@@ -309,7 +309,10 @@ async def get_album(
     total_plays = sum(t.play_count for t in tracks)
     metadata = await _album_metadata(album, artist, len(tracks), total_plays)
 
-    return AlbumResponse(metadata=metadata, tracks=track_responses)
+    return AlbumResponse(
+        metadata=metadata,
+        tracks=[t.model_dump(mode="json") for t in track_responses],
+    )
 
 
 @router.post("/{album_id}/cover")

--- a/tests/api/test_albums.py
+++ b/tests/api/test_albums.py
@@ -1,13 +1,43 @@
 """tests for album API helpers."""
 
-import pytest
+from collections.abc import Generator
 
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import Session
 from backend.api.albums import list_artist_albums
+from backend.main import app
 from backend.models import Album, Artist, Track
 
 
-@pytest.mark.asyncio
-async def test_list_artist_albums_groups_tracks(db_session):
+class MockSession(Session):
+    """mock session for auth bypass in tests."""
+
+    def __init__(self, did: str = "did:test:user123"):
+        self.did = did
+        self.access_token = "test_token"
+        self.refresh_token = "test_refresh"
+
+
+@pytest.fixture
+def test_app(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
+    """create test app with mocked auth."""
+    from backend._internal import require_auth
+
+    async def mock_require_auth() -> Session:
+        return MockSession()
+
+    app.dependency_overrides[require_auth] = mock_require_auth
+
+    yield app
+
+    app.dependency_overrides.clear()
+
+
+async def test_list_artist_albums_groups_tracks(db_session: AsyncSession):
     """albums listing groups tracks per slug and aggregates counts."""
     artist = Artist(
         did="did:plc:testartist",
@@ -81,3 +111,79 @@ async def test_list_artist_albums_groups_tracks(db_session):
     second = next(album for album in albums if album.slug == "album-b")
     assert second.track_count == 1
     assert second.total_plays == 2
+
+
+async def test_get_album_serializes_tracks_correctly(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    """test that get_album properly serializes tracks with album data."""
+    # create artist
+    artist = Artist(
+        did="did:test:user123",
+        handle="test.artist",
+        display_name="Test Artist",
+    )
+    db_session.add(artist)
+    await db_session.flush()
+
+    # create album
+    album = Album(
+        artist_did=artist.did,
+        slug="test-album",
+        title="Test Album",
+        image_url="https://example.com/album.jpg",
+    )
+    db_session.add(album)
+    await db_session.flush()
+
+    # create tracks linked to album
+    track1 = Track(
+        title="Track 1",
+        file_id="test-file-1",
+        file_type="audio/mpeg",
+        artist_did=artist.did,
+        album_id=album.id,
+        play_count=5,
+    )
+    track2 = Track(
+        title="Track 2",
+        file_id="test-file-2",
+        file_type="audio/mpeg",
+        artist_did=artist.did,
+        album_id=album.id,
+        play_count=3,
+    )
+    db_session.add_all([track1, track2])
+    await db_session.commit()
+
+    # fetch album via API
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get(f"/albums/{artist.handle}/{album.slug}")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # verify album metadata
+    assert data["metadata"]["id"] == album.id
+    assert data["metadata"]["title"] == "Test Album"
+    assert data["metadata"]["slug"] == "test-album"
+    assert data["metadata"]["artist"] == "Test Artist"
+    assert data["metadata"]["artist_handle"] == "test.artist"
+    assert data["metadata"]["track_count"] == 2
+    assert data["metadata"]["total_plays"] == 8
+
+    # verify tracks are properly serialized as dicts
+    assert len(data["tracks"]) == 2
+    assert isinstance(data["tracks"][0], dict)
+    assert data["tracks"][0]["title"] == "Track 1"
+    assert data["tracks"][0]["artist"] == "Test Artist"
+    assert data["tracks"][0]["file_id"] == "test-file-1"
+    assert data["tracks"][0]["play_count"] == 5
+
+    # verify album data is included in tracks
+    assert data["tracks"][0]["album"] is not None
+    assert data["tracks"][0]["album"]["id"] == album.id
+    assert data["tracks"][0]["album"]["slug"] == "test-album"
+    assert data["tracks"][0]["album"]["title"] == "Test Album"


### PR DESCRIPTION
## problem

the album detail endpoint (`GET /albums/{handle}/{slug}`) was returning 500 errors on staging. logfire traces showed a Pydantic validation error:

```
Input should be a valid dictionary [type=dict_type, input_value=TrackResponse(...), input_type=TrackResponse]
```

## root cause

regression from #259 where we changed `TrackResponse` from a dict subclass to a proper Pydantic `BaseModel`. the album endpoint was passing `TrackResponse` objects directly to `AlbumResponse`, but `AlbumResponse` expects `tracks: list[dict]`.

## fix

- serialize `track_responses` using `model_dump(mode="json")` before passing to `AlbumResponse`
- remove outdated comment about `TrackResponse` being a dict subclass
- add regression test `test_get_album_serializes_tracks_correctly` that verifies proper serialization

## testing

- all album tests pass locally
- test verifies tracks are serialized as dicts with nested album data

🤖 Generated with [Claude Code](https://claude.com/claude-code)