### PR TITLE
fix: album tracks respect sticky player

### DIFF
--- a/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
@@ -154,6 +154,10 @@
 		padding: 0 1rem calc(var(--player-height, 120px) + 2rem + env(safe-area-inset-bottom, 0px)) 1rem;
 	}
 
+	.tracks-section {
+		padding-bottom: calc(var(--player-height, 120px) + env(safe-area-inset-bottom, 0px));
+	}
+
 	main {
 		margin-top: 2rem;
 	}


### PR DESCRIPTION
## Summary
- add bottom padding to the album detail tracks section so the sticky player no longer covers the last track on mobile
- verified other track lists (homepage, liked page, artist detail, track detail) already include equivalent padding, so no additional changes were needed

## Testing
- svelte check
- eslint