### PR TITLE
refactor: global scroll padding for sticky player

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -241,6 +241,7 @@
 		min-width: 0;
 		width: 100%;
 		transition: margin-right 0.3s ease;
+		padding-bottom: calc(var(--player-height, 0px) + 2rem + env(safe-area-inset-bottom, 0px));
 	}
 
 	.main-content.with-queue {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -95,7 +95,7 @@
 	main {
 		max-width: 800px;
 		margin: 0 auto;
-		padding: 0 1rem calc(var(--player-height, 120px) + env(safe-area-inset-bottom, 0px));
+		padding: 0 1rem 2rem;
 	}
 
 	.tracks h2 {

--- a/frontend/src/routes/liked/+page.svelte
+++ b/frontend/src/routes/liked/+page.svelte
@@ -89,7 +89,7 @@
 	.page {
 		max-width: 800px;
 		margin: 0 auto;
-		padding: 0 1rem calc(var(--player-height, 0px) + 2rem + env(safe-area-inset-bottom, 0px));
+		padding: 0 1rem 2rem;
 		min-height: 100vh;
 	}
 

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -481,7 +481,6 @@ $effect(() => {
 	@media (max-width: 768px) {
 		main {
 			padding: 0.75rem;
-			padding-bottom: calc(var(--player-height, 10rem) + env(safe-area-inset-bottom, 0px));
 			align-items: flex-start;
 			justify-content: flex-start;
 		}

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -546,7 +546,6 @@
 	@media (max-width: 768px) {
 		main {
 			padding: 1rem;
-			padding-bottom: calc(var(--player-height, 10rem) + env(safe-area-inset-bottom, 0px));
 		}
 
 		.artist-header {

--- a/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
@@ -154,9 +154,6 @@
 		padding: 0 1rem calc(var(--player-height, 120px) + 2rem + env(safe-area-inset-bottom, 0px)) 1rem;
 	}
 
-	.tracks-section {
-		padding-bottom: calc(var(--player-height, 120px) + env(safe-area-inset-bottom, 0px));
-	}
 
 	main {
 		margin-top: 2rem;


### PR DESCRIPTION
## Summary\n- add a single  rule to  in  so any route rendered inside it automatically reserves space for the sticky player\n- remove individual  rules from the homepage, liked page, artist page, track page, and album page\n- this keeps scroll behavior consistent and avoids future regressions when new routes are added\n\n## Testing\n- svelte check\n- eslint