### PR TITLE
fix: restore mobile bottom padding to 1.25rem

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -244,6 +244,12 @@
 		padding-bottom: calc(var(--player-height, 0px) + 2rem + env(safe-area-inset-bottom, 0px));
 	}
 
+	@media (max-width: 768px) {
+		.main-content {
+			padding-bottom: calc(var(--player-height, 0px) + 1.25rem + env(safe-area-inset-bottom, 0px));
+		}
+	}
+
 	.main-content.with-queue {
 		margin-right: 360px;
 	}


### PR DESCRIPTION
## problem

PR #266 centralized sticky player padding but unintentionally increased mobile padding:
- **before #266**: mobile had 1.25rem bottom padding
- **after #266**: mobile inherited desktop's 2rem bottom padding
- **result**: excessive whitespace below content on mobile

## solution

add mobile media query to restore 1.25rem bottom padding on screens ≤768px wide.

desktop padding unchanged (2rem).

## testing

verified mobile padding matches pre-#266 behavior on:
- homepage
- liked tracks
- artist pages  
- album detail pages