### PR TITLE
fix: restore per-page padding, fix album track clearance

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -241,13 +241,6 @@
 		min-width: 0;
 		width: 100%;
 		transition: margin-right 0.3s ease;
-		padding-bottom: calc(var(--player-height, 0px) + 2rem + env(safe-area-inset-bottom, 0px));
-	}
-
-	@media (max-width: 768px) {
-		.main-content {
-			padding-bottom: calc(var(--player-height, 0px) + 1.25rem + env(safe-area-inset-bottom, 0px));
-		}
 	}
 
 	.main-content.with-queue {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -95,7 +95,7 @@
 	main {
 		max-width: 800px;
 		margin: 0 auto;
-		padding: 0 1rem 2rem;
+		padding: 0 1rem calc(var(--player-height, 120px) + env(safe-area-inset-bottom, 0px));
 	}
 
 	.tracks h2 {

--- a/frontend/src/routes/liked/+page.svelte
+++ b/frontend/src/routes/liked/+page.svelte
@@ -89,7 +89,7 @@
 	.page {
 		max-width: 800px;
 		margin: 0 auto;
-		padding: 0 1rem 2rem;
+		padding: 0 1rem calc(var(--player-height, 0px) + 2rem + env(safe-area-inset-bottom, 0px));
 		min-height: 100vh;
 	}
 

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -481,6 +481,7 @@ $effect(() => {
 	@media (max-width: 768px) {
 		main {
 			padding: 0.75rem;
+			padding-bottom: calc(var(--player-height, 10rem) + env(safe-area-inset-bottom, 0px));
 			align-items: flex-start;
 			justify-content: flex-start;
 		}

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -546,6 +546,7 @@
 	@media (max-width: 768px) {
 		main {
 			padding: 1rem;
+			padding-bottom: calc(var(--player-height, 10rem) + env(safe-area-inset-bottom, 0px));
 		}
 
 		.artist-header {

--- a/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
@@ -299,6 +299,7 @@
 
 	.tracks-section {
 		margin-top: 2rem;
+		padding-bottom: calc(var(--player-height, 120px) + env(safe-area-inset-bottom, 0px));
 	}
 
 	.section-heading {


### PR DESCRIPTION
## problem

PRs #266 and #267 attempted to centralize sticky player padding but created issues:
- mobile padding increased from 1.25rem to 2rem (too much whitespace)
- centralized approach made it harder to customize per-page

## solution

revert to per-page padding handling (pre-#266 approach) while keeping the fix for album tracks overlapping with sticky player.

## changes

- **removed** centralized padding from `+layout.svelte`
- **restored** per-page padding on:
  - homepage: `calc(var(--player-height, 120px) + env(safe-area-inset-bottom, 0px))`
  - liked tracks: `calc(var(--player-height, 0px) + 2rem + env(safe-area-inset-bottom, 0px))`
  - track detail (mobile): `calc(var(--player-height, 10rem) + env(safe-area-inset-bottom, 0px))`
  - artist pages (mobile): `calc(var(--player-height, 10rem) + env(safe-area-inset-bottom, 0px))`
- **restored** `.tracks-section` padding on album detail page to fix overlap issue from #265

## result

- mobile padding matches pre-#266 behavior (no excessive whitespace)
- album tracks properly clear sticky player
- each page controls its own padding for flexibility