### PR TITLE
feat: add logfire instrumentation to R2 get_url operations

### DIFF
--- a/src/backend/storage/r2.py
+++ b/src/backend/storage/r2.py
@@ -142,8 +142,6 @@ class R2Storage:
                         return f"{self.public_audio_bucket_url}/{key}"
                     except client.exceptions.NoSuchKey:
                         continue
-                    except Exception:
-                        continue
 
                 # try image formats
                 from backend._internal.image import ImageFormat
@@ -155,8 +153,6 @@ class R2Storage:
                         await client.head_object(Bucket=self.image_bucket_name, Key=key)
                         return f"{self.public_image_bucket_url}/{key}"
                     except client.exceptions.NoSuchKey:
-                        continue
-                    except Exception:
                         continue
 
                 return None


### PR DESCRIPTION
adds logfire span instrumentation to R2 get_url method to track performance of image URL resolution.

hypothesis: slow GET /tracks/ requests (2-2.5s) are caused by uninstrumented R2 head_object calls when resolving image URLs for tracks without cached image_url values.

this will allow us to verify if R2 operations are the bottleneck and measure their actual contribution to request latency.