### PR TITLE
feat: add logfire instrumentation to track and album serialization

### DIFF
--- a/src/backend/schemas.py
+++ b/src/backend/schemas.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+import logfire
 from pydantic import BaseModel
 
 from backend.models import Album, Track
@@ -20,18 +21,19 @@ class AlbumSummary(BaseModel):
         cls, album: Album, artist_avatar_url: str | None = None
     ) -> "AlbumSummary":
         """build album summary from Album model."""
-        image_url = album.image_url
-        if not image_url and album.image_id:
-            image_url = await album.get_image_url()
-        if not image_url and artist_avatar_url:
-            image_url = artist_avatar_url
+        with logfire.span("serialize album", album_id=album.id):
+            image_url = album.image_url
+            if not image_url and album.image_id:
+                image_url = await album.get_image_url()
+            if not image_url and artist_avatar_url:
+                image_url = artist_avatar_url
 
-        return cls(
-            id=album.id,
-            slug=album.slug,
-            title=album.title,
-            image_url=image_url,
-        )
+            return cls(
+                id=album.id,
+                slug=album.slug,
+                title=album.title,
+                image_url=image_url,
+            )
 
 
 class FeaturedArtist(BaseModel):
@@ -79,53 +81,54 @@ class TrackResponse(BaseModel):
             liked_track_ids: optional set of liked track IDs for this user
             like_counts: optional dict of track_id -> like_count
         """
-        # check if user has liked this track
-        is_liked = liked_track_ids is not None and track.id in liked_track_ids
+        with logfire.span("serialize track", track_id=track.id):
+            # check if user has liked this track
+            is_liked = liked_track_ids is not None and track.id in liked_track_ids
 
-        # get like count
-        like_count = like_counts.get(track.id, 0) if like_counts else 0
+            # get like count
+            like_count = like_counts.get(track.id, 0) if like_counts else 0
 
-        # resolve image URL
-        image_url = track.image_url
-        if not image_url and track.image_id:
-            image_url = await track.get_image_url()
+            # resolve image URL
+            image_url = track.image_url
+            if not image_url and track.image_id:
+                image_url = await track.get_image_url()
 
-        # serialize album if present
-        album_data: AlbumSummary | None = None
-        if track.album_id and track.album_rel:
-            album_data = await AlbumSummary.from_album(
-                track.album_rel,
+            # serialize album if present
+            album_data: AlbumSummary | None = None
+            if track.album_id and track.album_rel:
+                album_data = await AlbumSummary.from_album(
+                    track.album_rel,
+                    artist_avatar_url=track.artist.avatar_url,
+                )
+
+            # construct atproto record URL
+            atproto_record_url: str | None = None
+            if track.atproto_record_uri and pds_url:
+                from backend.config import settings
+
+                rkey = track.atproto_record_uri.split("/")[-1]
+                atproto_record_url = (
+                    f"{pds_url}/xrpc/com.atproto.repo.getRecord"
+                    f"?repo={track.artist_did}&collection={settings.atproto.track_collection}"
+                    f"&rkey={rkey}"
+                )
+
+            return cls(
+                id=track.id,
+                title=track.title,
+                artist=track.artist.display_name,
+                artist_handle=track.artist.handle,
                 artist_avatar_url=track.artist.avatar_url,
+                file_id=track.file_id,
+                file_type=track.file_type,
+                features=track.features,
+                r2_url=track.r2_url,
+                atproto_record_uri=track.atproto_record_uri,
+                atproto_record_url=atproto_record_url,
+                play_count=track.play_count,
+                created_at=track.created_at.isoformat(),
+                image_url=image_url,
+                is_liked=is_liked,
+                like_count=like_count,
+                album=album_data,
             )
-
-        # construct atproto record URL
-        atproto_record_url: str | None = None
-        if track.atproto_record_uri and pds_url:
-            from backend.config import settings
-
-            rkey = track.atproto_record_uri.split("/")[-1]
-            atproto_record_url = (
-                f"{pds_url}/xrpc/com.atproto.repo.getRecord"
-                f"?repo={track.artist_did}&collection={settings.atproto.track_collection}"
-                f"&rkey={rkey}"
-            )
-
-        return cls(
-            id=track.id,
-            title=track.title,
-            artist=track.artist.display_name,
-            artist_handle=track.artist.handle,
-            artist_avatar_url=track.artist.avatar_url,
-            file_id=track.file_id,
-            file_type=track.file_type,
-            features=track.features,
-            r2_url=track.r2_url,
-            atproto_record_uri=track.atproto_record_uri,
-            atproto_record_url=atproto_record_url,
-            play_count=track.play_count,
-            created_at=track.created_at.isoformat(),
-            image_url=image_url,
-            is_liked=is_liked,
-            like_count=like_count,
-            album=album_data,
-        )


### PR DESCRIPTION
adds logfire span instrumentation to track and album serialization to identify what is taking 2.5 seconds in GET /tracks/ requests.

current traces show:
- database queries: ~35ms total
- overall request: 2.5 seconds
- missing time: ~2.4 seconds unaccounted for

this PR instruments:
- TrackResponse.from_track() with 'serialize track' span
- AlbumSummary.from_album() with 'serialize album' span

this will reveal which part of the serialization process (track image resolution, album serialization, or atproto URL construction) is causing the 2+ second delay.