### PR TITLE
fix: catch ClientError 404s in R2 get_url to prevent serialization failures

### DIFF
--- a/src/backend/storage/r2.py
+++ b/src/backend/storage/r2.py
@@ -7,6 +7,7 @@ import aioboto3
 import boto3
 import logfire
 from botocore.config import Config
+from botocore.exceptions import ClientError
 from sqlalchemy import func, select
 
 from backend._internal.audio import AudioFormat
@@ -142,6 +143,10 @@ class R2Storage:
                         return f"{self.public_audio_bucket_url}/{key}"
                     except client.exceptions.NoSuchKey:
                         continue
+                    except ClientError as e:
+                        if e.response.get("Error", {}).get("Code") == "404":
+                            continue
+                        raise
 
                 # try image formats
                 from backend._internal.image import ImageFormat
@@ -154,6 +159,10 @@ class R2Storage:
                         return f"{self.public_image_bucket_url}/{key}"
                     except client.exceptions.NoSuchKey:
                         continue
+                    except ClientError as e:
+                        if e.response.get("Error", {}).get("Code") == "404":
+                            continue
+                        raise
 
                 return None
 


### PR DESCRIPTION
fixes track serialization failures when R2 image files are missing.

## problem
after removing broad exception swallowing in PR #271, R2 get_url() started raising unhandled ClientError exceptions with 404 status codes when image files don't exist. this was causing entire track serialization to fail.

logfire shows multiple tracks failing with:
```
ClientError: An error occurred (404) when calling the HeadObject operation: Not Found
```

tracks 37, 38, 39, 70, 72 were all hitting this, with each 404 taking 150-600ms and failing the request.

## root cause
R2/S3 can raise ClientError with code '404' instead of the specific NoSuchKey exception. we were only catching NoSuchKey, so these 404s were propagating up and killing track serialization.

## fix
catch ClientError and check for 404 status code, treating it the same as NoSuchKey (continue trying other formats).

## testing
verified with sandbox/test_r2_404.py using actual R2 credentials - confirmed R2 raises ClientError with code '404', not NoSuchKey.

## impact
tracks with missing images will now serialize successfully instead of failing the entire request.