### PR TITLE
optimize R2 image lookups with file_type parameter

### DIFF
--- a/scripts/backfill_image_urls.py
+++ b/scripts/backfill_image_urls.py
@@ -93,7 +93,7 @@ async def backfill_image_urls(dry_run: bool = False) -> None:
         ) -> tuple[int, str | None, Exception | None]:
             """compute image_url for a track and return (track_id, url, error)."""
             try:
-                url = await storage.get_url(track.image_id)
+                url = await storage.get_url(track.image_id, file_type="image")
                 return (track.id, url, None)
             except Exception as e:
                 return (track.id, None, e)

--- a/src/backend/models/album.py
+++ b/src/backend/models/album.py
@@ -61,5 +61,5 @@ class Album(Base):
         from backend.storage.r2 import R2Storage
 
         if isinstance(storage, R2Storage):
-            return await storage.get_url(self.image_id)
+            return await storage.get_url(self.image_id, file_type="image")
         return None

--- a/src/backend/models/track.py
+++ b/src/backend/models/track.py
@@ -104,7 +104,7 @@ class Track(Base):
         from backend.storage.r2 import R2Storage
 
         if isinstance(storage, R2Storage):
-            return await storage.get_url(self.image_id)
+            return await storage.get_url(self.image_id, file_type="image")
         return None
 
     # relationships


### PR DESCRIPTION
## summary

reduces image URL lookups from ~800ms to ~100-200ms by adding a `file_type` parameter to `R2Storage.get_url()`.

## changes

- add `file_type: "audio" | "image" | None` parameter to `R2Storage.get_url()` src/backend/storage/r2.py:128
- when `file_type="image"`, skip checking all audio formats (saves 5 head_object calls)
- update `Track.get_image_url()` and `Album.get_image_url()` to pass `file_type="image"` src/backend/models/track.py:107, src/backend/models/album.py:64
- update backfill script to use optimized lookups scripts/backfill_image_urls.py:96

## background

from the [performance investigation](https://github.com/zzstoatzz/plyr.fm/blob/feat/image-moderation-marvin/sandbox/retrospective-performance-investigation-2025-11-17.md):

- tracks with `image_id` but missing R2 files were causing 800ms delays per lookup
- `get_url()` was checking 5 audio formats + 5 image formats = 10 sequential R2 API calls
- with the `file_type` hint, image lookups only check 5 image formats

## test plan

- [x] type checking passes
- [x] no functional changes to existing behavior (file_type=None still checks both)
- [ ] verify image lookups are faster in production (check Logfire spans)

## related

- orphaned `image_id` references cleaned up separately in production database
- see `sandbox/retrospective-performance-investigation-2025-11-17.md` for full investigation details

🤖 Generated with [Claude Code](https://claude.com/claude-code)