### PR TITLE
remove logfire spans from track and album serialization

### DIFF
--- a/src/backend/schemas.py
+++ b/src/backend/schemas.py
@@ -2,7 +2,6 @@
 
 from typing import Any
 
-import logfire
 from pydantic import BaseModel
 
 from backend.models import Album, Track
@@ -21,19 +20,18 @@ class AlbumSummary(BaseModel):
         cls, album: Album, artist_avatar_url: str | None = None
     ) -> "AlbumSummary":
         """build album summary from Album model."""
-        with logfire.span("serialize album", album_id=album.id):
-            image_url = album.image_url
-            if not image_url and album.image_id:
-                image_url = await album.get_image_url()
-            if not image_url and artist_avatar_url:
-                image_url = artist_avatar_url
+        image_url = album.image_url
+        if not image_url and album.image_id:
+            image_url = await album.get_image_url()
+        if not image_url and artist_avatar_url:
+            image_url = artist_avatar_url
 
-            return cls(
-                id=album.id,
-                slug=album.slug,
-                title=album.title,
-                image_url=image_url,
-            )
+        return cls(
+            id=album.id,
+            slug=album.slug,
+            title=album.title,
+            image_url=image_url,
+        )
 
 
 class FeaturedArtist(BaseModel):
@@ -81,54 +79,53 @@ class TrackResponse(BaseModel):
             liked_track_ids: optional set of liked track IDs for this user
             like_counts: optional dict of track_id -> like_count
         """
-        with logfire.span("serialize track", track_id=track.id):
-            # check if user has liked this track
-            is_liked = liked_track_ids is not None and track.id in liked_track_ids
+        # check if user has liked this track
+        is_liked = liked_track_ids is not None and track.id in liked_track_ids
 
-            # get like count
-            like_count = like_counts.get(track.id, 0) if like_counts else 0
+        # get like count
+        like_count = like_counts.get(track.id, 0) if like_counts else 0
 
-            # resolve image URL
-            image_url = track.image_url
-            if not image_url and track.image_id:
-                image_url = await track.get_image_url()
+        # resolve image URL
+        image_url = track.image_url
+        if not image_url and track.image_id:
+            image_url = await track.get_image_url()
 
-            # serialize album if present
-            album_data: AlbumSummary | None = None
-            if track.album_id and track.album_rel:
-                album_data = await AlbumSummary.from_album(
-                    track.album_rel,
-                    artist_avatar_url=track.artist.avatar_url,
-                )
-
-            # construct atproto record URL
-            atproto_record_url: str | None = None
-            if track.atproto_record_uri and pds_url:
-                from backend.config import settings
-
-                rkey = track.atproto_record_uri.split("/")[-1]
-                atproto_record_url = (
-                    f"{pds_url}/xrpc/com.atproto.repo.getRecord"
-                    f"?repo={track.artist_did}&collection={settings.atproto.track_collection}"
-                    f"&rkey={rkey}"
-                )
-
-            return cls(
-                id=track.id,
-                title=track.title,
-                artist=track.artist.display_name,
-                artist_handle=track.artist.handle,
+        # serialize album if present
+        album_data: AlbumSummary | None = None
+        if track.album_id and track.album_rel:
+            album_data = await AlbumSummary.from_album(
+                track.album_rel,
                 artist_avatar_url=track.artist.avatar_url,
-                file_id=track.file_id,
-                file_type=track.file_type,
-                features=track.features,
-                r2_url=track.r2_url,
-                atproto_record_uri=track.atproto_record_uri,
-                atproto_record_url=atproto_record_url,
-                play_count=track.play_count,
-                created_at=track.created_at.isoformat(),
-                image_url=image_url,
-                is_liked=is_liked,
-                like_count=like_count,
-                album=album_data,
             )
+
+        # construct atproto record URL
+        atproto_record_url: str | None = None
+        if track.atproto_record_uri and pds_url:
+            from backend.config import settings
+
+            rkey = track.atproto_record_uri.split("/")[-1]
+            atproto_record_url = (
+                f"{pds_url}/xrpc/com.atproto.repo.getRecord"
+                f"?repo={track.artist_did}&collection={settings.atproto.track_collection}"
+                f"&rkey={rkey}"
+            )
+
+        return cls(
+            id=track.id,
+            title=track.title,
+            artist=track.artist.display_name,
+            artist_handle=track.artist.handle,
+            artist_avatar_url=track.artist.avatar_url,
+            file_id=track.file_id,
+            file_type=track.file_type,
+            features=track.features,
+            r2_url=track.r2_url,
+            atproto_record_uri=track.atproto_record_uri,
+            atproto_record_url=atproto_record_url,
+            play_count=track.play_count,
+            created_at=track.created_at.isoformat(),
+            image_url=image_url,
+            is_liked=is_liked,
+            like_count=like_count,
+            album=album_data,
+        )


### PR DESCRIPTION
## summary

removes logfire span wrappers from track and album serialization methods. these spans are extremely fast (<1ms) and just add noise to traces.

## motivation

now that R2 URL fetching is optimized, serialization is consistently fast. the `serialize track` and `serialize album` spans don't provide meaningful insights - they just clutter logfire traces with dozens of sub-millisecond spans.

## changes

- ✅ remove `logfire.span("serialize track")` wrapper from `TrackResponse.from_track()`
- ✅ remove `logfire.span("serialize album")` wrapper from `AlbumSummary.from_album()`
- ✅ remove unused `logfire` import from `schemas.py`

## impact

after merging, logfire traces will be cleaner and focus on meaningful operations (db queries, R2 fetches, HTTP requests) rather than sub-millisecond serialization steps.