### PR TITLE
fix: hydrate artist page likes client-side

### DIFF
--- a/frontend/src/routes/u/[handle]/+page.server.ts
+++ b/frontend/src/routes/u/[handle]/+page.server.ts
@@ -3,15 +3,8 @@ import type { Artist, Track, ArtistAlbumSummary } from '$lib/types';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ params, fetch, cookies }) => {
+export const load: PageServerLoad = async ({ params, fetch }) => {
 	try {
-		// get session cookie to forward to API for liked state
-		const sessionId = cookies.get('session_id');
-		const headers: HeadersInit = {};
-		if (sessionId) {
-			headers['Cookie'] = `session_id=${sessionId}`;
-		}
-
 		// fetch artist info server-side for SEO/link previews
 		const artistResponse = await fetch(`${API_URL}/artists/by-handle/${params.handle}`);
 
@@ -21,10 +14,8 @@ export const load: PageServerLoad = async ({ params, fetch, cookies }) => {
 
 		const artist: Artist = await artistResponse.json();
 
-		// fetch artist's tracks with session cookie for liked state
-		const tracksResponse = await fetch(`${API_URL}/tracks/?artist_did=${artist.did}`, {
-			headers
-		});
+		// fetch artist's tracks server-side (no cookie available on frontend host)
+		const tracksResponse = await fetch(`${API_URL}/tracks/?artist_did=${artist.did}`);
 		let tracks: Track[] = [];
 
 		if (tracksResponse.ok) {
@@ -32,9 +23,7 @@ export const load: PageServerLoad = async ({ params, fetch, cookies }) => {
 			tracks = data.tracks || [];
 		}
 
-		const albumsResponse = await fetch(`${API_URL}/albums/${params.handle}`, {
-			headers
-		});
+		const albumsResponse = await fetch(`${API_URL}/albums/${params.handle}`);
 		let albums: ArtistAlbumSummary[] = [];
 
 		if (albumsResponse.ok) {


### PR DESCRIPTION
## issue

Artist detail pages render server-side for SEO, but those SSR requests originate from the SvelteKit host, which never sees the `session_id` cookie (per `docs/authentication.md`). As a result, the backend can’t tell which tracks the viewer has liked, so every artist page shows unliked states even if you’re logged in.

## solution

- Keep the server load focused on public data (artist/tracks/albums) without trying to forward cookies it can’t access.
- After hydration, wait for the browser auth check to finish and then re-fetch the artist’s tracks with `credentials: 'include'` so the API can mark liked tracks.
- Update the track list binding so the response of that credentialed fetch replaces the SSR snapshot, and show a small “updating…” hint while the second fetch runs.

This keeps SSR/SEO intact and ensures logged-in users see accurate liked state once the client takes over.

## testing
- `bun run check`
