### PR TITLE
perf: hydrate artist likes faster

### DIFF
--- a/.claude/commands/status-update.md
+++ b/.claude/commands/status-update.md
@@ -69,7 +69,7 @@ Why certain choices were made:
 
 1. Read the current `README.md`, `CLAUDE.md`, recent status updates in `sandbox/`, and key source files
 2. Check `git status` and recent commits to understand current work
-3. Scan the codebase structure (`src/relay/`, `frontend/src/`)
+3. Scan the codebase structure (`src/backend/`, `frontend/src/`)
 4. Review the tech stack in `pyproject.toml` and `frontend/package.json`
 5. Synthesize into a clear, chronological narrative
 6. Write to `STATUS.md` in the root directory

--- a/docs/README.md
+++ b/docs/README.md
@@ -247,7 +247,7 @@ logger.info(
 
 **enforced by ATProto**: only user with valid OAuth session can create records in their repo
 
-**enforced by relay**: tracks are associated with `artist_did` and only owner can delete
+**enforced by backend**: tracks are associated with `artist_did` and only owner can delete
 
 ### rate limiting
 


### PR DESCRIPTION
## issue

Artist pages render server-side, so the initial JSON never includes  flags (the frontend host can’t read the session cookie). After the last fix we hydrate client-side, but the second fetch (full ) still makes likes pop in noticeably late.

## solution

- Reuse the existing  to prime liked flags as soon as the page hydrates, matching the home page behavior.
- Instead of re-fetching the entire artist catalog, hit  (user-scoped, much smaller payload) and merge the liked IDs onto the server-provided tracks.
- Keep the small “updating…” hint so users know the reconciliation fetch is running.
- Include docs touch-ups (, ).

## testing
- 
