### PR TITLE
fix: eliminate unnecessary auth requests when logged out

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -12,8 +12,9 @@
 	import { page } from '$app/stores';
 	import { auth } from '$lib/auth.svelte';
 	import { browser } from '$app/environment';
+	import type { LayoutData } from './$types';
 
-	let { children } = $props();
+	let { children, data } = $props<{ children: any; data: LayoutData }>();
 	let showQueue = $state(false);
 
 	// only show default meta tags on pages without their own specific metadata
@@ -23,10 +24,14 @@
 		$page.url.pathname.match(/^\/u\/[^/]+\/album\/[^/]+/) // album pages have specific metadata
 	);
 
-	// initialize auth on mount
-	if (browser) {
-		void auth.initialize();
-	}
+	// sync auth state from layout data (fetched by +layout.ts)
+	$effect(() => {
+		if (browser) {
+			auth.user = data.user;
+			auth.isAuthenticated = data.isAuthenticated;
+			auth.loading = false;
+		}
+	});
 
 	function handleQueueShortcut(event: KeyboardEvent) {
 		// ignore modifier keys

--- a/frontend/src/routes/liked/+page.ts
+++ b/frontend/src/routes/liked/+page.ts
@@ -1,6 +1,8 @@
 import { browser } from '$app/environment';
+import { redirect } from '@sveltejs/kit';
 import { fetchLikedTracks } from '$lib/tracks.svelte';
 import type { Track } from '$lib/types';
+import type { LoadEvent } from '@sveltejs/kit';
 
 export interface PageData {
 	tracks: Track[];
@@ -8,9 +10,15 @@ export interface PageData {
 
 export const ssr = false;
 
-export async function load(): Promise<PageData> {
+export async function load({ parent }: LoadEvent): Promise<PageData> {
 	if (!browser) {
 		return { tracks: [] };
+	}
+
+	// check auth from parent layout data
+	const { isAuthenticated } = await parent();
+	if (!isAuthenticated) {
+		throw redirect(302, '/');
 	}
 
 	try {

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -72,6 +72,12 @@
 	async function hydrateTracksWithLikes() {
 		if (!browser || tracksHydrated) return;
 
+		// skip if not authenticated - no need to fetch liked tracks
+		if (!auth.isAuthenticated) {
+			tracksHydrated = true;
+			return;
+		}
+
 		tracksLoading = true;
 		try {
 			const likedTracks = await fetchLikedTracks();


### PR DESCRIPTION
## Summary
Eliminates unnecessary 401 errors in production logs caused by redundant auth checks when users are logged out.

## Problem
Production Logfire showed noise from expected-but-unnecessary 401s:
- **24 x `/auth/me` 401s** in 30min - duplicate calls per page load
- **3 x `/tracks/liked` 401s** - called when not authenticated

## Changes

### 1. Remove Duplicate `/auth/me` Call
**Before:**
- `+layout.ts` → fetches `/auth/me`
- `+layout.svelte` → calls `auth.initialize()` → fetches `/auth/me` again
- **Result:** 2 requests per page load (2 x 401 when logged out)

**After:**
- `+layout.ts` → fetches `/auth/me` (only call)
- `+layout.svelte` → syncs auth state from layout data via `$effect`
- **Result:** 1 request per page load (1 x 401 when logged out, if any)

### 2. Guard `/tracks/liked` Calls
**Before:**
- Artist pages called `fetchLikedTracks()` unconditionally → 401 when logged out
- `/liked` page called `fetchLikedTracks()` even when not authenticated

**After:**
- Artist pages: skip `fetchLikedTracks()` if `!auth.isAuthenticated`
- `/liked` page: redirect to `/` if not authenticated (via `parent()` data)

## Impact
- **Fewer 401s in logs** - cleaner observability
- **No functional changes** - user experience identical
- **Slightly faster page loads** when logged out (1 fewer request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)