### PR TITLE
feat: show featured artists inline

### DIFF
--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -128,14 +128,18 @@
 		<div class="track-info">
 			<div class="track-title">{track.title}</div>
 			<div class="track-metadata">
-				{#if !hideArtist}
-					<div class="artist-line">
-						<a
-							href="/u/{track.artist_handle}"
-							class="artist-link"
-						>
-							{track.artist}
-						</a>
+				{#if (!hideArtist) || (track.features && track.features.length > 0)}
+					<div class="artist-line"
+						class:only-features={hideArtist && track.features && track.features.length > 0}
+					>
+						{#if !hideArtist}
+							<a
+								href="/u/{track.artist_handle}"
+								class="artist-link"
+							>
+								{track.artist}
+							</a>
+						{/if}
 						{#if track.features && track.features.length > 0}
 							<span class="features-inline">
 								<span class="features-label">feat.</span>
@@ -376,6 +380,10 @@
 		gap: 0.35rem;
 		min-width: 0;
 		flex-wrap: nowrap;
+	}
+
+	.artist-line.only-features {
+		gap: 0.25rem;
 	}
 
 	.metadata-separator {

--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -26,13 +26,11 @@
 			}
 			if (artistEl) {
 				const container = artistEl.querySelector('.text-container');
-				const span = container?.querySelector('span');
-				artistOverflows = span && container ? span.scrollWidth > container.clientWidth : false;
+				artistOverflows = container ? container.scrollWidth - 1 > container.clientWidth : false;
 			}
 			if (albumEl) {
 				const container = albumEl.querySelector('.text-container');
-				const span = container?.querySelector('span');
-				albumOverflows = span && container ? span.scrollWidth > container.clientWidth : false;
+				albumOverflows = container ? container.scrollWidth - 1 > container.clientWidth : false;
 			}
 		});
 	}
@@ -90,16 +88,18 @@
 					<path d="M3 14c0-2.5 2-4.5 5-4.5s5 2 5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
 				</svg>
 				<div class="text-container" class:scrolling={artistOverflows}>
-					<a href="/u/{track.artist_handle}" class="inline-artist">{track.artist}</a>
-					{#if track.features && track.features.length > 0}
-						<span class="features-inline">
-							<span class="features-label">feat.</span>
-							{#each track.features as feature, i}
-								{#if i > 0}<span class="feature-separator">, </span>{/if}
-								<a href="/u/{feature.handle}" class="feature-link">{feature.display_name}</a>
-							{/each}
-						</span>
-					{/if}
+					<span class="artist-inline">
+						<a href="/u/{track.artist_handle}" class="inline-artist">{track.artist}</a>
+						{#if track.features && track.features.length > 0}
+							<span class="features-inline">
+								<span class="features-label">feat.</span>
+								{#each track.features as feature, i}
+									{#if i > 0}<span class="feature-separator">, </span>{/if}
+									<a href="/u/{feature.handle}" class="feature-link">{feature.display_name}</a>
+								{/each}
+							</span>
+						{/if}
+					</span>
 				</div>
 			</div>
 			<div class="metadata-line">
@@ -223,12 +223,14 @@
 		-webkit-mask-image: linear-gradient(to right, black 0%, black calc(100% - 15px), transparent 100%);
 	}
 
-	.text-container span {
-		display: inline-block;
+	.text-container > span {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
 		white-space: nowrap;
 	}
 
-	.text-container.scrolling span {
+	.text-container.scrolling > span {
 		padding-right: 3rem;
 		animation: scroll-text 15s linear infinite;
 	}
@@ -285,8 +287,10 @@
 	}
 
 	.features-inline {
-		margin-left: 0.35rem;
 		color: #b5b5b5;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
 	}
 
 	.features-label {


### PR DESCRIPTION
## summary
- render featured artists inline with the primary artist in the player metadata, matching the scroll/truncation logic and linking to each artist page
- do the same for track lists (latest/liked/etc.) so features follow the artist name instead of forcing a new line

## testing
- bun run check
- manual verification with tracks that include features