### PR TITLE
fix: fail upload when ATProto sync fails

### DIFF
--- a/.claude/commands/check-spans.md
+++ b/.claude/commands/check-spans.md
@@ -1,0 +1,15 @@
+---
+description: Investigate Logfire spans and traces to answer questions about application behavior
+argument-hint: [your question about what happened]
+---
+
+First read the Logfire documentation: @docs/tools/logfire.md
+
+Investigate: $ARGUMENTS
+
+Query the `records` table using SQL patterns from the docs. Key points:
+- Search by `message` for logfire.info() events, `span_name` for spans
+- Use `trace_id` to follow a full user action flow
+- Check `otel_status_message` for errors (not exception.message)
+- Filter by `start_timestamp` for time ranges
+- Extract metadata from `attributes` JSONB field


### PR DESCRIPTION
## context
Uploads previously swallowed ATProto errors (lines 248-251 in `uploads.py`), which left tracks
in the database/R2 without fm.plyr.track records. Users saw "success" but nothing synced to their PDS.

## changes
- introduce a shared helper in the background task to mark the upload as failed when
  ATProto sync can\'t complete (missing R2 URL, exception, or empty response)
- propagate the failure through the upload tracker with an `atproto` phase + error message
- eagerly delete the audio/image blobs so R2 doesn\'t collect orphaned files
- document a `check-spans` Claude command so we can quickly inspect Logfire traces next time

## testing
- `uv run pytest tests/test_token_refresh.py`
