### PR TITLE
hotfix: remove broken isinstance checks on storage proxy

### DIFF
--- a/src/backend/api/albums.py
+++ b/src/backend/api/albums.py
@@ -18,7 +18,6 @@ from backend._internal.auth import get_session
 from backend.models import Album, Artist, Track, TrackLike, get_db
 from backend.schemas import TrackResponse
 from backend.storage import storage
-from backend.storage.r2 import R2Storage
 from backend.utilities.aggregations import get_like_counts
 from backend.utilities.hashing import CHUNK_SIZE
 
@@ -361,11 +360,9 @@ async def upload_album_cover(
         # save returns the file_id (hash)
         image_id = await storage.save(image_obj, image.filename)
 
-        # construct R2 URL directly if using R2 storage
+        # construct R2 URL directly
         # storage.save uses just {file_id}{ext} for images (no subdirectory)
-        image_url = None
-        if isinstance(storage, R2Storage):
-            image_url = f"{storage.public_image_bucket_url}/{image_id}{ext}"
+        image_url = f"{storage.public_image_bucket_url}/{image_id}{ext}"
 
         # delete old image if exists (prevent R2 object leaks)
         if album.image_id:

--- a/src/backend/api/tracks/metadata_service.py
+++ b/src/backend/api/tracks/metadata_service.py
@@ -13,7 +13,6 @@ from backend._internal.atproto.handles import resolve_handle
 from backend._internal.image import ImageFormat
 from backend.models import Track
 from backend.storage import storage
-from backend.storage.r2 import R2Storage
 
 from .constants import MAX_FEATURES
 from .services import get_or_create_album
@@ -128,9 +127,6 @@ async def upload_track_image(image: UploadFile) -> tuple[str, str | None]:
 
     image_obj = BytesIO(image_data)
     image_id = await storage.save(image_obj, f"images/{image.filename}")
-
-    image_url = None
-    if isinstance(storage, R2Storage):
-        image_url = await storage.get_url(image_id, file_type="image")
+    image_url = await storage.get_url(image_id, file_type="image")
 
     return image_id, image_url

--- a/src/backend/api/tracks/uploads.py
+++ b/src/backend/api/tracks/uploads.py
@@ -24,7 +24,6 @@ from backend._internal.uploads import UploadStatus, upload_tracker
 from backend.config import settings
 from backend.models import Artist, Track
 from backend.storage import storage
-from backend.storage.r2 import R2Storage
 from backend.utilities.database import db_session
 from backend.utilities.hashing import CHUNK_SIZE
 
@@ -136,11 +135,9 @@ async def _process_upload_background(
                     return
 
             # get R2 URL
-            r2_url = None
-            if isinstance(storage, R2Storage):
-                r2_url = await storage.get_url(
-                    file_id, file_type="audio", extension=ext[1:]
-                )
+            r2_url = await storage.get_url(
+                file_id, file_type="audio", extension=ext[1:]
+            )
 
             # save image if provided
             image_id = None
@@ -162,11 +159,10 @@ async def _process_upload_background(
                             image_id = await storage.save(
                                 image_obj, f"images/{image_filename}"
                             )
-                            # get R2 URL for image if using R2 storage
-                            if isinstance(storage, R2Storage):
-                                image_url = await storage.get_url(
-                                    image_id, file_type="image"
-                                )
+                            # get R2 URL for image
+                            image_url = await storage.get_url(
+                                image_id, file_type="image"
+                            )
                     except Exception as e:
                         logger.warning(f"failed to save image: {e}", exc_info=True)
                         # continue without image - it's optional

--- a/src/backend/models/album.py
+++ b/src/backend/models/album.py
@@ -58,8 +58,5 @@ class Album(Base):
         if not self.image_id:
             return None
         from backend.storage import storage
-        from backend.storage.r2 import R2Storage
 
-        if isinstance(storage, R2Storage):
-            return await storage.get_url(self.image_id, file_type="image")
-        return None
+        return await storage.get_url(self.image_id, file_type="image")

--- a/src/backend/models/track.py
+++ b/src/backend/models/track.py
@@ -101,11 +101,8 @@ class Track(Base):
         if not self.image_id:
             return None
         from backend.storage import storage
-        from backend.storage.r2 import R2Storage
 
-        if isinstance(storage, R2Storage):
-            return await storage.get_url(self.image_id, file_type="image")
-        return None
+        return await storage.get_url(self.image_id, file_type="image")
 
     # relationships
     album_rel: Mapped["Album | None"] = relationship("Album", back_populates="tracks")


### PR DESCRIPTION
## summary

production uploads are failing with "no public audio URL available" error.

## root cause

when FilesystemStorage was removed in #288, `storage` became a `_StorageProxy` object that wraps `R2Storage`. all `isinstance(storage, R2Storage)` checks now return `False`, causing `get_url()` calls to be skipped.

## impact

- uploads fail after successful R2 upload because `r2_url` is `None`
- track/album image URLs not being resolved

## fix

removed all `isinstance(storage, R2Storage)` checks since storage is always R2Storage now.

affected:
- src/backend/api/tracks/uploads.py
- src/backend/api/tracks/metadata_service.py
- src/backend/api/albums.py
- src/backend/models/track.py
- src/backend/models/album.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)