### PR TITLE
fix: add friendly 404 pages with Bluesky integration

### DIFF
--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { APP_NAME } from '$lib/branding';
+
+	const status = $page.status;
+	const message = $page.error?.message || 'something went wrong';
+</script>
+
+<svelte:head>
+	<title>{status} - {APP_NAME}</title>
+</svelte:head>
+
+<div class="error-container">
+	{#if status === 404}
+		<div class="bufo-container">
+			<img
+				src="https://all-the.bufo.zone/bufo-shrug.png"
+				alt="bufo shrug"
+				class="bufo-img"
+			/>
+		</div>
+		<h1>404</h1>
+		<p class="error-message">we couldn't find what you're looking for</p>
+	{:else if status === 500}
+		<h1>500</h1>
+		<p class="error-message">something went wrong on our end</p>
+		<p class="error-detail">we've been notified and will look into it</p>
+	{:else}
+		<h1>{status}</h1>
+		<p class="error-message">{message}</p>
+	{/if}
+
+	<a href="/" class="home-link">go home</a>
+</div>
+
+<style>
+	.error-container {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		min-height: 100vh;
+		padding: 2rem;
+		text-align: center;
+	}
+
+	.bufo-container {
+		margin-bottom: 2rem;
+	}
+
+	.bufo-img {
+		width: 200px;
+		height: auto;
+		opacity: 0.9;
+	}
+
+	h1 {
+		font-size: 4rem;
+		color: #e8e8e8;
+		margin: 0 0 1rem 0;
+		font-weight: 700;
+	}
+
+	.error-message {
+		font-size: 1.25rem;
+		color: #b0b0b0;
+		margin: 0 0 0.5rem 0;
+	}
+
+	.error-detail {
+		font-size: 1rem;
+		color: #808080;
+		margin: 0 0 2rem 0;
+	}
+
+	.home-link {
+		color: var(--accent);
+		text-decoration: none;
+		font-size: 1.1rem;
+		padding: 0.75rem 1.5rem;
+		border: 1px solid var(--accent);
+		border-radius: 6px;
+		transition: all 0.2s;
+	}
+
+	.home-link:hover {
+		background: var(--accent);
+		color: #000;
+	}
+
+	@media (max-width: 768px) {
+		.bufo-img {
+			width: 150px;
+		}
+
+		h1 {
+			font-size: 3rem;
+		}
+
+		.error-message {
+			font-size: 1.1rem;
+		}
+	}
+</style>

--- a/frontend/src/routes/u/[handle]/+error.svelte
+++ b/frontend/src/routes/u/[handle]/+error.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
+	import { APP_NAME } from '$lib/branding';
+
+	const status = $page.status;
+	const handle = $page.params.handle;
+
+	let checkingBluesky = $state(false);
+	let blueskyProfileExists = $state(false);
+	let blueskyUrl = $state('');
+
+	onMount(async () => {
+		// if this is a 404, check if the handle exists on Bluesky
+		if (status === 404 && handle) {
+			checkingBluesky = true;
+			try {
+				// try to resolve the handle via ATProto
+				const response = await fetch(
+					`https://bsky.social/xrpc/com.atproto.identity.resolveHandle?handle=${handle}`
+				);
+
+				if (response.ok) {
+					const data = await response.json();
+					if (data.did) {
+						blueskyProfileExists = true;
+						blueskyUrl = `https://bsky.app/profile/${handle}`;
+					}
+				}
+			} catch (e) {
+				console.error('failed to check Bluesky:', e);
+			} finally {
+				checkingBluesky = false;
+			}
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>404 - artist not found - {APP_NAME}</title>
+</svelte:head>
+
+<div class="error-container">
+	<div class="bufo-container">
+		<img
+			src="https://all-the.bufo.zone/bufo-shrug.png"
+			alt="bufo shrug"
+			class="bufo-img"
+		/>
+	</div>
+
+	<h1>404</h1>
+
+	{#if checkingBluesky}
+		<p class="error-message">checking if @{handle} exists...</p>
+	{:else if blueskyProfileExists}
+		<p class="error-message">@{handle} hasn't joined {APP_NAME} yet</p>
+		<p class="error-detail">but they're on Bluesky!</p>
+		<div class="actions">
+			<a href={blueskyUrl} target="_blank" rel="noopener" class="bsky-link">
+				view their Bluesky profile
+			</a>
+			<a href="/" class="home-link">go home</a>
+		</div>
+	{:else}
+		<p class="error-message">we couldn't find anyone by @{handle}</p>
+		<p class="error-detail">the handle might not exist or could be misspelled</p>
+		<a href="/" class="home-link">go home</a>
+	{/if}
+</div>
+
+<style>
+	.error-container {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		min-height: 100vh;
+		padding: 2rem;
+		text-align: center;
+	}
+
+	.bufo-container {
+		margin-bottom: 2rem;
+	}
+
+	.bufo-img {
+		width: 200px;
+		height: auto;
+		opacity: 0.9;
+	}
+
+	h1 {
+		font-size: 4rem;
+		color: #e8e8e8;
+		margin: 0 0 1rem 0;
+		font-weight: 700;
+	}
+
+	.error-message {
+		font-size: 1.25rem;
+		color: #b0b0b0;
+		margin: 0 0 0.5rem 0;
+	}
+
+	.error-detail {
+		font-size: 1rem;
+		color: #808080;
+		margin: 0 0 2rem 0;
+	}
+
+	.actions {
+		display: flex;
+		gap: 1rem;
+		flex-wrap: wrap;
+		justify-content: center;
+	}
+
+	.home-link,
+	.bsky-link {
+		color: var(--accent);
+		text-decoration: none;
+		font-size: 1.1rem;
+		padding: 0.75rem 1.5rem;
+		border: 1px solid var(--accent);
+		border-radius: 6px;
+		transition: all 0.2s;
+		display: inline-block;
+	}
+
+	.bsky-link {
+		background: var(--accent);
+		color: #000;
+	}
+
+	.bsky-link:hover {
+		background: #6a9fff;
+		border-color: #6a9fff;
+	}
+
+	.home-link:hover {
+		background: var(--accent);
+		color: #000;
+	}
+
+	@media (max-width: 768px) {
+		.bufo-img {
+			width: 150px;
+		}
+
+		h1 {
+			font-size: 3rem;
+		}
+
+		.error-message {
+			font-size: 1.1rem;
+		}
+
+		.actions {
+			flex-direction: column;
+			width: 100%;
+			max-width: 300px;
+		}
+	}
+</style>

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -269,7 +269,20 @@ $effect(() => {
 				{/if}
 			</h2>
 			{#if tracks.length === 0}
-				<p class="empty">no tracks yet</p>
+				<div class="empty-state">
+					<p class="empty-message">no tracks yet</p>
+					<p class="empty-detail">
+						{artist.display_name} hasn't uploaded any music to {APP_NAME}.
+					</p>
+					<a
+						href="https://bsky.app/profile/{artist.handle}"
+						target="_blank"
+						rel="noopener"
+						class="bsky-link"
+					>
+						view their Bluesky profile
+					</a>
+				</div>
 			{:else}
 				<div class="track-list">
 		{#each tracks as track, i}
@@ -657,11 +670,39 @@ $effect(() => {
 		gap: 0.75rem;
 	}
 
-	.empty {
+	.empty-state {
 		text-align: center;
 		padding: 3rem;
+		background: #141414;
+		border: 1px solid #282828;
+		border-radius: 8px;
+	}
+
+	.empty-message {
+		color: #b0b0b0;
+		font-size: 1.25rem;
+		margin: 0 0 0.5rem 0;
+	}
+
+	.empty-detail {
 		color: #808080;
-		font-style: italic;
+		margin: 0 0 1.5rem 0;
+	}
+
+	.bsky-link {
+		color: var(--accent);
+		text-decoration: none;
+		font-size: 1rem;
+		padding: 0.75rem 1.5rem;
+		border: 1px solid var(--accent);
+		border-radius: 6px;
+		transition: all 0.2s;
+		display: inline-block;
+	}
+
+	.bsky-link:hover {
+		background: var(--accent);
+		color: #000;
 	}
 
 	/* respect reduced motion preference */


### PR DESCRIPTION
## Summary

Fixes #295 - improves error pages with contextual messaging and Bluesky integration.

## Changes

### Root Error Page ()
- Shows bufo shrug for 404s (https://all-the.bufo.zone/bufo-shrug.png)
- Handles 500s with friendly message
- Clean, branded design

### Artist 404 Page ()
- Checks if handle exists on Bluesky via ATProto resolution
- **If handle exists on Bluesky but not plyr.fm**: shows link to their Bluesky profile with message "@handle hasn't joined plyr.fm yet"
- **If handle doesn't exist**: shows helpful message "we couldn't find anyone by @handle"
- Always shows bufo shrug image

### Artist Page Empty State
When artist exists but has no tracks:
- Shows styled card with message "no tracks yet"
- Explains "{artist_name} hasn't uploaded any music to plyr.fm"
- Provides link to their Bluesky profile

## User Experience

**Before**: bare 404 page with "artist not found" → dead end

**After**:
- 404 for non-existent handle: bufo shrug + clear message
- 404 for valid Bluesky handle: bufo shrug + link to their Bluesky
- Artist with no tracks: friendly message + link to Bluesky

## Technical Details

- Uses  to check if handle exists on Bluesky
- Scoped error pages (route-level) override root error page
- Maintains consistent branding with bufo mascot
- Mobile responsive design

## Testing

Test scenarios:
1. Visit  → should show bufo + "couldn't find anyone"
2. Visit  (exists on Bluesky, not on plyr) → should show bufo + link to Bluesky
3. Visit artist page with no tracks → should show empty state card with Bluesky link