### PR TITLE
fix: portal page reactivity issue with Svelte 5 runes

### DIFF
--- a/docs/tools/logfire.md
+++ b/docs/tools/logfire.md
@@ -6,6 +6,7 @@ Logfire uses PostgreSQL-flavored SQL to query trace data. All data is stored in 
 
 ## Key Fields
 
+- `deployment_environment` - environment name (local/staging/production) - **ALWAYS filter by this when investigating issues**
 - `is_exception` - boolean field to filter spans that contain exceptions
 - `kind` - either 'span' or 'event'
 - `trace_id` - unique identifier for a trace (group of related spans)

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -8,6 +8,7 @@ key patterns:
 - **routes**: pages in `routes/` with `+page.svelte` and `+page.ts` for data loading
 
 gotchas:
+- **svelte 5 runes mode**: component-local state MUST use `$state()` - plain `let` has no reactivity (see `docs/frontend/state-management.md`)
 - toast positioning: bottom-left above player footer (not top-right)
 - queue sync: uses BroadcastChannel for cross-tab, not SSE
 - preferences: managed in SettingsMenu component, not dedicated state file

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -26,43 +26,43 @@
 		return ACCEPTED_AUDIO_EXTENSIONS.includes(ext);
 	}
 
-	let loading = true;
-	let error = '';
-	let tracks: Track[] = [];
-	let loadingTracks = false;
+	let loading = $state(true);
+	let error = $state('');
+	let tracks = $state<Track[]>([]);
+	let loadingTracks = $state(false);
 
 	// upload form fields
-	let title = '';
-	let albumTitle = '';
-	let file: File | null = null;
-	let imageFile: File | null = null;
-	let featuredArtists: FeaturedArtist[] = [];
+	let title = $state('');
+	let albumTitle = $state('');
+	let file = $state<File | null>(null);
+	let imageFile = $state<File | null>(null);
+	let featuredArtists = $state<FeaturedArtist[]>([]);
 	let hasUnresolvedFeaturesInput = $state(false);
 
 	// track editing state
-	let editingTrackId: number | null = null;
-	let editTitle = '';
-	let editAlbum = '';
-	let editFeaturedArtists: FeaturedArtist[] = [];
-	let editImageFile: File | null = null;
+	let editingTrackId = $state<number | null>(null);
+	let editTitle = $state('');
+	let editAlbum = $state('');
+	let editFeaturedArtists = $state<FeaturedArtist[]>([]);
+	let editImageFile = $state<File | null>(null);
 	let hasUnresolvedEditFeaturesInput = $state(false);
 
 	// profile editing state
-	let displayName = '';
-	let bio = '';
-	let avatarUrl = '';
-	let savingProfile = false;
-	let profileSuccess = '';
-	let profileError = '';
+	let displayName = $state('');
+	let bio = $state('');
+	let avatarUrl = $state('');
+	let savingProfile = $state(false);
+	let profileSuccess = $state('');
+	let profileError = $state('');
 
 	// album management state
-	let albums: AlbumSummary[] = [];
-	let loadingAlbums = false;
-	let editingAlbumId: string | null = null;
-	let editAlbumCoverFile: File | null = null;
+	let albums = $state<AlbumSummary[]>([]);
+	let loadingAlbums = $state(false);
+	let editingAlbumId = $state<string | null>(null);
+	let editAlbumCoverFile = $state<File | null>(null);
 
 	// export state
-	let exportingMedia = false;
+	let exportingMedia = $state(false);
 
 	onMount(async () => {
 		// check if exchange_token is in URL (from OAuth callback)


### PR DESCRIPTION
## Summary

Fixes portal page hanging indefinitely on "loading tracks..." after PR #302.

### Problem
After merging PR #302, the portal page would hang showing "loading tracks..." forever in local and staging environments (production worked because it was running older code). Console logs showed all API calls completed successfully and state variables updated, but the UI never reflected the changes.

### Root Cause
Portal page uses Svelte 5 runes mode, but component-local state was declared with plain `let` instead of `let x = $state(...)`.

In Svelte 5 runes mode:
- Plain `let` variables are **not reactive** - they're just regular JavaScript variables
- Assignments don't trigger UI updates
- You must explicitly opt into reactivity with `$state()`

The bug was introduced when new state variables (`hasUnresolvedFeaturesInput`) were added with `$state()` while existing variables (`loading`, `tracks`, `loadingTracks`, etc.) remained as plain `let`, creating an inconsistent mix that made the issue harder to spot.

### Changes

**Fix:**
- Convert all reactive state in `portal/+page.svelte` to use `$state()`
- Clean up debug logging added during investigation

**Documentation (to prevent future occurrences):**
- Add comprehensive Svelte 5 runes section to `docs/frontend/state-management.md`:
  - When to use `$state()` vs plain `let`
  - Common mistakes (mixing reactive/non-reactive, copy-pasting from Svelte 4)
  - Debugging guide with symptom → diagnosis → fix workflow
- Add prominent gotcha to `frontend/CLAUDE.md` about `$state()` requirement
- Improve `docs/tools/logfire.md` with `deployment_environment` column for debugging

### Test Plan
- [x] Portal page loads correctly in local dev
- [x] State updates trigger UI changes
- [x] All pre-commit hooks pass (svelte check, eslint)
- [ ] Test in staging environment
- [ ] Verify no regressions in upload, edit, profile functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)