### PR TITLE
fix: validate r2_url before using in RedirectResponse

### DIFF
--- a/src/backend/api/audio.py
+++ b/src/backend/api/audio.py
@@ -33,8 +33,8 @@ async def stream_audio(file_id: str):
 
         r2_url, file_type = track_data
 
-    # if we have the r2_url already, use it directly (zero HEADs)
-    if r2_url:
+    # if we have a valid r2_url cached, use it directly (zero HEADs)
+    if r2_url and r2_url.startswith("http"):
         return RedirectResponse(url=r2_url)
 
     # otherwise, get it with the specific extension (single HEAD)


### PR DESCRIPTION
## Summary

Fixes 500 errors when trying to play tracks with empty or invalid `r2_url` in the database.

### Problem

Audio streaming endpoint was returning 500 errors in staging for file_id `0738e55d0bea9ee9`:

**Logfire evidence:**
- Trace: `019aa4c367586ff66295623fe5d5a59e`
- Database query succeeds (150ms)
- HTTP request returns 500 ERROR
- No exception details captured

**Root cause:**
```python
if r2_url:  # ❌ empty string "" passes this check in Python
    return RedirectResponse(url=r2_url)  # fails with invalid URL → 500
```

When `r2_url` is an empty string (not `None`), it's truthy in Python, so the code tries to redirect to `""` which causes a 500 error.

### Fix

Validate that `r2_url` is not just truthy, but actually a valid HTTP URL:

```python
if r2_url and r2_url.startswith("http"):  # ✅ validates URL format
    return RedirectResponse(url=r2_url)
```

Now empty strings and `None` values correctly fall through to the fallback logic:
```python
url = await storage.get_url(file_id, file_type="audio", extension=file_type)
```

### Testing

After merge + deploy to staging:

1. **Test the failing track**: Try playing the track with `file_id = 0738e55d0bea9ee9` that's currently 500ing
2. **Expected**: Track should play successfully via fallback URL generation
3. **Verify in Logfire**: No more 500 errors for `/audio/{file_id}` endpoint

The fix ensures tracks without cached R2 URLs still work by falling back to on-the-fly URL generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)