### PR TITLE
fix: handle duplicate file_ids in audio endpoint

### DIFF
--- a/src/backend/api/audio.py
+++ b/src/backend/api/audio.py
@@ -1,8 +1,9 @@
 """audio streaming endpoint."""
 
+import logfire
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import RedirectResponse
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from backend.models import Track
 from backend.storage import storage
@@ -23,13 +24,30 @@ async def stream_audio(file_id: str):
     """
     # look up track to get r2_url and file_type
     async with db_session() as db:
-        result = await db.execute(
-            select(Track.r2_url, Track.file_type).where(Track.file_id == file_id)
+        # check for duplicates (multiple tracks with same file_id)
+        count_result = await db.execute(
+            select(func.count()).select_from(Track).where(Track.file_id == file_id)
         )
-        track_data = result.one_or_none()
+        count = count_result.scalar()
 
-        if not track_data:
+        if count == 0:
             raise HTTPException(status_code=404, detail="audio file not found")
+
+        if count > 1:
+            logfire.warn(
+                "multiple tracks found for file_id",
+                file_id=file_id,
+                count=count,
+            )
+
+        # get the best track: prefer non-null r2_url, then newest
+        result = await db.execute(
+            select(Track.r2_url, Track.file_type)
+            .where(Track.file_id == file_id)
+            .order_by(Track.r2_url.is_not(None).desc(), Track.created_at.desc())
+            .limit(1)
+        )
+        track_data = result.first()
 
         r2_url, file_type = track_data
 


### PR DESCRIPTION
## summary
- fixes `MultipleResultsFound` exception when multiple tracks share the same `file_id`
- preserves storage deduplication semantics (same audio file can have multiple track records)
- uses deterministic ordering to pick "best" track metadata

## changes
- add `COUNT` query to detect and log duplicates for monitoring
- use `ORDER BY Track.r2_url IS NOT NULL DESC, Track.created_at DESC LIMIT 1`
  - prefers tracks with cached `r2_url` (avoids storage lookup)
  - falls back to newest track when no `r2_url` available
- log warning with `file_id` and count when duplicates detected
- preserve existing fallback to `storage.get_url()` when `r2_url` is null

## testing
test in staging by playing track with `file_id = '0738e55d0bea9ee9'` (known duplicate)

## follow-up work
- data cleanup: verify `file_type` consistency across duplicate `file_id`s
- data cleanup: backfill missing `r2_url` values using canonical URL
- (optional) add partial uniqueness constraint: `UNIQUE (file_id, file_type)`

see `sandbox/audio-endpoint-duplicate-file-ids.md` for full design analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)