### PR TITLE
fix: add SSE timeout config for export progress streaming

### DIFF
--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -32,6 +32,10 @@ primary_region = 'iad'
     hard_limit = 250
     soft_limit = 200
 
+  [http_service.http_options]
+    idle_timeout = "90s"
+    response_timeout = "90s"
+
 [[vm]]
   memory = '1gb'
   cpu_kind = 'shared'


### PR DESCRIPTION
## summary
- fixes "lost connection to server" error when exporting tracks in staging
- fly.io's default 60s idle timeout was terminating SSE connections before exports completed

## root cause
- export progress uses Server-Sent Events (SSE) for real-time updates
- fly.io proxy has 60s default idle timeout for HTTP connections
- exports take ~30s, but default timeout kills SSE stream prematurely
- locally works fine because uvicorn has no such timeout

## changes
- add `http_options.idle_timeout = "90s"` to fly.staging.toml
- add `http_options.response_timeout = "90s"` for full export duration
- 90s provides sufficient headroom for ~30s exports

## testing
test in staging by exporting tracks and verifying:
- SSE connection stays alive through entire export
- progress updates display correctly
- download triggers automatically on completion

## references
- fly.io community: SSE connections require explicit timeout config
- default 60s timeout confirmed in multiple fly.io support threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)