### PR TITLE
fix: queue listener reconnection strategy and test isolation

### DIFF
--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -149,7 +149,7 @@ class DatabaseSettings(RelaySettingsSection):
         description="Timeout in seconds for establishing database connections. Fails fast when database is slow or unresponsive.",
     )
     queue_connect_timeout: float = Field(
-        default=3.0,
+        default=15.0,
         validation_alias="QUEUE_CONNECT_TIMEOUT",
         description="Timeout in seconds for queue listener database connections",
     )


### PR DESCRIPTION
### Description

Fixes an issue where aggressive reconnection attempts (3s timeout) caused database overload during outages. Also fixes test suite isolation issues.

### Changes

- **Configuration**: Increased `QUEUE_CONNECT_TIMEOUT` from 3.0s to 15.0s to allow more headroom during high load or instability.
- **Queue Service**: Implemented exponential backoff for the listener loop.
  - Starts at 5s, doubles after each failure, caps at 60s.
  - Resets to initial delay on successful connection.
- **Tests**: Added `_truncate_tables` helper to `tests/conftest.py` to ensure a clean database state at the start of the test session, fixing local test failures.