### PR TITLE
feat: add security headers middleware

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,13 @@
 """pytest configuration for relay tests."""
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 
 import pytest
 import sqlalchemy as sa
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import (
     AsyncConnection,
     AsyncEngine,
@@ -203,3 +205,18 @@ async def db_session(
     """
     async with session_context(engine=_engine) as session:
         yield session
+
+
+@pytest.fixture
+def fastapi_app() -> FastAPI:
+    """provides the FastAPI app instance."""
+    from backend.main import app as main_app
+
+    return main_app
+
+
+@pytest.fixture
+def client(fastapi_app: FastAPI) -> Generator[TestClient, None, None]:
+    """provides a TestClient for testing the FastAPI application."""
+    with TestClient(fastapi_app) as tc:
+        yield tc

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,43 @@
+"""test security headers middleware."""
+
+from fastapi.testclient import TestClient
+
+from backend.config import settings
+
+
+def test_security_headers_present(client: TestClient):
+    """verify that security headers are present in responses."""
+    response = client.get("/health")
+    assert response.status_code == 200
+
+    headers = response.headers
+
+    # check basic security headers
+    assert headers["X-Content-Type-Options"] == "nosniff"
+    assert headers["X-Frame-Options"] == "DENY"
+    assert headers["X-XSS-Protection"] == "1; mode=block"
+    assert headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+
+
+def test_hsts_header_logic(client: TestClient):
+    """verify HSTS header logic based on debug mode."""
+    # save original setting
+    original_debug = settings.app.debug
+
+    try:
+        # case 1: debug=True (default in tests) -> no HSTS
+        settings.app.debug = True
+        response = client.get("/health")
+        assert "Strict-Transport-Security" not in response.headers
+
+        # case 2: debug=False (production) -> HSTS present
+        settings.app.debug = False
+        response = client.get("/health")
+        assert (
+            response.headers["Strict-Transport-Security"]
+            == "max-age=31536000; includeSubDomains"
+        )
+
+    finally:
+        # restore setting
+        settings.app.debug = original_debug


### PR DESCRIPTION
### Description

Adds a middleware to `src/backend/main.py` that sets standard HTTP security headers on all responses to improve client-side security.

### Headers Added

- `X-Content-Type-Options: nosniff`: Prevents MIME sniffing attacks.
- `X-Frame-Options: DENY`: Prevents clickjacking by disallowing iframe embedding.
- `X-XSS-Protection: 1; mode=block`: Enables browser XSS filtering.
- `Referrer-Policy: strict-origin-when-cross-origin`: Controls referrer information leakage.
- `Strict-Transport-Security`: Enforces HTTPS (enabled only when debug mode is disabled).

### Related Issue
Closes #205

### Verification
Verified locally using `curl -I`:
```
HTTP/1.1 307 Temporary Redirect
x-content-type-options: nosniff
x-frame-options: DENY
x-xss-protection: 1; mode=block
referrer-policy: strict-origin-when-cross-origin
strict-transport-security: max-age=31536000; includeSubDomains
...
```