### PR TITLE
fix: deploy workflows and documentation paths

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -25,6 +25,7 @@ jobs:
           if [ "${{ steps.changes.outputs.migrations }}" == "true" ]; then
             echo "🔄 migrations detected - will run via release_command before deployment"
           fi
-          flyctl deploy --config backend/fly.toml --remote-only -a relay-api
+          cd backend
+          flyctl deploy --config fly.toml --remote-only -a relay-api
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -36,6 +36,7 @@ jobs:
           if [ "${{ steps.changes.outputs.migrations }}" == "true" ]; then
             echo "🔄 migrations detected - will run via release_command before deployment"
           fi
-          flyctl deploy --config backend/fly.staging.toml --remote-only -a relay-api-staging
+          cd backend
+          flyctl deploy --config fly.staging.toml --remote-only -a relay-api-staging
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_STAGING }}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ using [just](https://github.com/casey/just):
 
 ```bash
 # install dependencies
-uv sync
+cd backend && uv sync
 just frontend install
 
 # run backend (hot reloads at http://localhost:8001)
@@ -77,17 +77,20 @@ just transcoder run
 
 ```
 plyr.fm/
-├── src/backend/
-│   ├── api/              # public endpoints
-│   ├── _internal/        # internal services (auth, atproto, uploads)
-│   ├── models/           # database schemas
-│   └── storage/          # r2 and filesystem storage
-├── frontend/
-│   ├── src/lib/          # components, state managers, types
+├── backend/              # FastAPI app & Python tooling
+│   ├── src/backend/      # application code
+│   │   ├── api/          # public endpoints
+│   │   ├── _internal/    # internal services
+│   │   ├── models/       # database schemas
+│   │   └── storage/      # storage adapters
+│   ├── tests/            # pytest suite
+│   └── alembic/          # database migrations
+├── frontend/             # SvelteKit app
+│   ├── src/lib/          # components & state
 │   └── src/routes/       # pages
-├── tests/                # pytest suite
-├── docs/                 # organized guides
-└── Justfile              # task runner
+├── transcoder/           # Rust audio service
+├── docs/                 # documentation
+└── justfile              # task runner
 ```
 
 </details>


### PR DESCRIPTION
Fixes deployment failures by ensuring `flyctl deploy` runs from the `backend/` directory where the Dockerfile resides.
Updates root `README.md` to reflect the new monorepo structure.
Recovers `STATUS.md` which was accidentally deleted.