### PR TITLE
fix: docker build context and validation workflow

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,25 @@
+name: validate docker build
+
+on:
+  pull_request:
+    paths:
+      - "backend/src/**"
+      - "backend/Dockerfile"
+      - "backend/pyproject.toml"
+      - "backend/uv.lock"
+      - "README.md"
+      - ".github/workflows/build-docker.yml"
+
+jobs:
+  build:
+    name: build backend image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: set up docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: build docker image
+        # Build from root context using backend/Dockerfile
+        run: docker build -f backend/Dockerfile .

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -25,7 +25,6 @@ jobs:
           if [ "${{ steps.changes.outputs.migrations }}" == "true" ]; then
             echo "🔄 migrations detected - will run via release_command before deployment"
           fi
-          cd backend
-          flyctl deploy --config fly.toml --remote-only -a relay-api
+          flyctl deploy --config backend/fly.toml --remote-only -a relay-api
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -36,7 +36,6 @@ jobs:
           if [ "${{ steps.changes.outputs.migrations }}" == "true" ]; then
             echo "🔄 migrations detected - will run via release_command before deployment"
           fi
-          cd backend
-          flyctl deploy --config fly.staging.toml --remote-only -a relay-api-staging
+          flyctl deploy --config backend/fly.staging.toml --remote-only -a relay-api-staging
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_STAGING }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,16 +9,17 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 WORKDIR /app
 
 # install dependencies (separate layer for better caching)
-COPY pyproject.toml uv.lock README.md ./
+# COPY paths are relative to the build context (root)
+COPY backend/pyproject.toml backend/uv.lock README.md ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-install-project --compile-bytecode
 
 # copy application code
-COPY src ./src
+COPY backend/src ./src
 
 # copy alembic migration files
-COPY alembic.ini ./
-COPY alembic ./alembic
+COPY backend/alembic.ini .
+COPY backend/alembic ./alembic
 
 # install the project itself with bytecode compilation
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/backend/fly.staging.toml
+++ b/backend/fly.staging.toml
@@ -7,6 +7,8 @@ app = 'relay-api-staging'
 primary_region = 'iad'
 
 [build]
+  dockerfile = "backend/Dockerfile"
+  ignore_file = "backend/.dockerignore"
 
 [deploy]
   release_command = 'uv run alembic upgrade head'

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -2,6 +2,8 @@ app = 'relay-api'
 primary_region = 'iad'
 
 [build]
+  dockerfile = "backend/Dockerfile"
+  ignore_file = "backend/.dockerignore"
 
 [deploy]
   release_command = "uv run alembic upgrade head"


### PR DESCRIPTION
Updates `backend/Dockerfile` and Fly configurations to build from the project root context. This resolves build errors where `README.md` (symlinked from root) could not be accessed.

Adds a new GitHub Action `validate docker build` to ensure the backend Docker image builds successfully on future PRs.

Reverts `cd backend` in deployment workflows as we now deploy from root.