### PR TITLE
docs: update oauth client metadata path references

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -38,6 +38,6 @@ primary_region = 'iad'
 # - DATABASE_URL
 # - AWS_ACCESS_KEY_ID
 # - AWS_SECRET_ACCESS_KEY
-# - ATPROTO_CLIENT_ID (will be https://api.plyr.fm/client-metadata.json after deployment)
+# - ATPROTO_CLIENT_ID (will be https://api.plyr.fm/oauth-client-metadata.json after deployment)
 # - ATPROTO_REDIRECT_URI (will be https://api.plyr.fm/auth/callback after deployment)
 # - OAUTH_ENCRYPTION_KEY (44-character base64 Fernet key, generate with: python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')

--- a/docs/backend/atproto-identity.md
+++ b/docs/backend/atproto-identity.md
@@ -29,21 +29,21 @@ ATProto OAuth uses **client metadata discovery** - there is no central registry 
 ### how it works
 
 1. **client ID is a URL**: your `ATPROTO_CLIENT_ID` must be a publicly accessible HTTPS URL that serves client metadata JSON
-2. **backend serves metadata**: plyr.fm serves this at `/client-metadata.json` on the API domain
+2. **backend serves metadata**: plyr.fm serves this at `/oauth-client-metadata.json` on the API domain
 3. **automatic discovery**: when users authenticate, their PDS fetches the client metadata from your client ID URL
 
 ### configuration per environment
 
 **production**:
-- `ATPROTO_CLIENT_ID=https://api.plyr.fm/client-metadata.json`
+- `ATPROTO_CLIENT_ID=https://api.plyr.fm/oauth-client-metadata.json`
 - `ATPROTO_REDIRECT_URI=https://api.plyr.fm/auth/callback`
 
 **staging**:
-- `ATPROTO_CLIENT_ID=https://api-stg.plyr.fm/client-metadata.json`
+- `ATPROTO_CLIENT_ID=https://api-stg.plyr.fm/oauth-client-metadata.json`
 - `ATPROTO_REDIRECT_URI=https://api-stg.plyr.fm/auth/callback`
 
 **local development**:
-- `ATPROTO_CLIENT_ID=http://localhost:8001/client-metadata.json`
+- `ATPROTO_CLIENT_ID=http://localhost:8001/oauth-client-metadata.json`
 - `ATPROTO_REDIRECT_URI=http://localhost:8001/auth/callback`
 
 ### important notes
@@ -58,7 +58,7 @@ ATProto OAuth uses **client metadata discovery** - there is no central registry 
 check that your client metadata is accessible:
 
 ```bash
-curl https://api.plyr.fm/client-metadata.json
+curl https://api.plyr.fm/oauth-client-metadata.json
 ```
 
 should return JSON with your OAuth configuration including redirect URIs and scopes.

--- a/docs/backend/configuration.md
+++ b/docs/backend/configuration.md
@@ -70,7 +70,7 @@ all settings can be configured via environment variables. the variable names mat
 DATABASE_URL=postgresql+psycopg://user:pass@host/db
 
 # oauth (uses client metadata discovery - no registration required)
-ATPROTO_CLIENT_ID=https://your-domain.com/client-metadata.json
+ATPROTO_CLIENT_ID=https://your-domain.com/oauth-client-metadata.json
 ATPROTO_CLIENT_SECRET=<optional-client-secret>
 ATPROTO_REDIRECT_URI=https://your-domain.com/auth/callback
 OAUTH_ENCRYPTION_KEY=<base64-encoded-32-byte-key>

--- a/docs/deployment/environments.md
+++ b/docs/deployment/environments.md
@@ -116,9 +116,8 @@ all secrets configured via `flyctl secrets set`. key environment variables:
   - staging: `fm.plyr.stg`
   - production: `fm.plyr`
 - `ATPROTO_CLIENT_ID`, `ATPROTO_REDIRECT_URI` → oauth config (env-specific, must use custom domains for cookie-based auth)
-  - production: `https://api.plyr.fm/client-metadata.json` and `https://api.plyr.fm/auth/callback`
-  - staging: `https://api-stg.plyr.fm/client-metadata.json` and `https://api-stg.plyr.fm/auth/callback`
-- `OAUTH_ENCRYPTION_KEY` → unique per environment
+  - production: `https://api.plyr.fm/oauth-client-metadata.json` and `https://api.plyr.fm/auth/callback`
+  - staging: `https://api-stg.plyr.fm/oauth-client-metadata.json` and `https://api-stg.plyr.fm/auth/callback`- `OAUTH_ENCRYPTION_KEY` → unique per environment
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` → r2 credentials
 - `LOGFIRE_WRITE_TOKEN`, `LOGFIRE_ENVIRONMENT` → observability config
 

--- a/docs/local-development/setup.md
+++ b/docs/local-development/setup.md
@@ -45,7 +45,7 @@ DATABASE_URL=postgresql+asyncpg://localhost/plyr  # local
 # DATABASE_URL=<neon-dev-connection-string>        # neon dev
 
 # oauth (uses client metadata discovery - no registration required)
-ATPROTO_CLIENT_ID=http://localhost:8001/client-metadata.json
+ATPROTO_CLIENT_ID=http://localhost:8001/oauth-client-metadata.json
 ATPROTO_CLIENT_SECRET=<your-client-secret>
 ATPROTO_REDIRECT_URI=http://localhost:5173/auth/callback
 OAUTH_ENCRYPTION_KEY=<base64-encoded-32-byte-key>
@@ -304,7 +304,7 @@ bun --version
 # should be: http://localhost:5173/auth/callback
 
 # check ATPROTO_CLIENT_ID is accessible (should return client metadata JSON)
-curl http://localhost:8001/client-metadata.json
+curl http://localhost:8001/oauth-client-metadata.json
 ```
 
 ### r2 upload failures


### PR DESCRIPTION
Updates documentation and comments to reflect the change from /client-metadata.json to /oauth-client-metadata.json.