### PR TITLE
fix: correct image upload path in R2 storage

### DIFF
--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -152,7 +152,7 @@ class R2Storage:
                 # try image format
                 image_format, is_valid = ImageFormat.validate_and_extract(filename)
                 if is_valid and image_format:
-                    key = f"{file_id}{ext}"
+                    key = f"images/{file_id}{ext}"
                     media_type = image_format.media_type
                 else:
                     raise ValueError(


### PR DESCRIPTION
This PR fixes a mismatch between where images were being saved and where they were being retrieved from in R2 storage.

**The Bug:**
- `save()` was uploading images to the root of the bucket (e.g., `abcd.png`).
- `get_url()` was looking for them in the `images/` directory (e.g., `images/abcd.png`).

**The Fix:**
- Updated `save()` to prepend `images/` to the key when uploading image files.

**Verification:**
- Confirmed via manual reproduction script (which was deleted) and unit test (which was deleted) that the path is now consistent.
- Manual backfill for affected Track 92 was performed in production.