### PR TITLE
fix: hide app chrome on embed routes and match font

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -24,6 +24,8 @@
 		$page.url.pathname.match(/^\/u\/[^/]+\/album\/[^/]+/) // album pages have specific metadata
 	);
 
+	let isEmbed = $derived($page.url.pathname.startsWith('/embed/'));
+
 	// sync auth state from layout data (fetched by +layout.ts)
 	$effect(() => {
 		if (browser) {
@@ -149,32 +151,34 @@
 </svelte:head>
 
 <div class="app-layout">
-	<main class="main-content" class:with-queue={showQueue}>
+	<main class="main-content" class:with-queue={showQueue && !isEmbed}>
 		{@render children?.()}
 	</main>
 
-	{#if showQueue}
+	{#if showQueue && !isEmbed}
 		<aside class="queue-sidebar">
 			<Queue />
 		</aside>
 	{/if}
 </div>
 
-<button
-	class="queue-toggle"
-	onclick={toggleQueue}
-	aria-pressed={showQueue}
-	aria-label="toggle queue (Q)"
-	title={showQueue ? 'hide queue (Q)' : 'show queue (Q)'}
->
-	<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-		<line x1="3" y1="6" x2="21" y2="6"></line>
-		<line x1="3" y1="12" x2="21" y2="12"></line>
-		<line x1="3" y1="18" x2="21" y2="18"></line>
-	</svg>
-</button>
+{#if !isEmbed}
+	<button
+		class="queue-toggle"
+		onclick={toggleQueue}
+		aria-pressed={showQueue}
+		aria-label="toggle queue (Q)"
+		title={showQueue ? 'hide queue (Q)' : 'show queue (Q)'}
+	>
+		<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+			<line x1="3" y1="6" x2="21" y2="6"></line>
+			<line x1="3" y1="12" x2="21" y2="12"></line>
+			<line x1="3" y1="18" x2="21" y2="18"></line>
+		</svg>
+	</button>
 
-<Player />
+	<Player />
+{/if}
 <Toast />
 
 <style>

--- a/frontend/src/routes/embed/track/[id]/+page.svelte
+++ b/frontend/src/routes/embed/track/[id]/+page.svelte
@@ -106,7 +106,7 @@
 		margin: 0;
 		padding: 0;
 		overflow: hidden;
-		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+		font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', 'Consolas', monospace;
 		background: #000;
 		color: #fff;
 	}


### PR DESCRIPTION
This PR hides the main application chrome (Player, Queue Sidebar, and Queue Toggle Button) when the user is on an embed route (e.g. `/embed/track/...`). This prevents the Queue button from appearing in external embeds where it doesn't make sense.

It also updates the font family in the embed player to match the main application's monospace font stack.