### PR TITLE
fix: correct upload progress tracking (bytes vs percentage mismatch)

### DIFF
--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -88,11 +88,8 @@ async def _process_upload_background(
             try:
                 logfire.info("preparing to save audio file", filename=filename)
 
-                file_size = Path(file_path).stat().st_size
-
                 async with R2ProgressTracker(
                     job_id=upload_id,
-                    total_size=file_size,
                     message="uploading to storage...",
                     phase="upload",
                 ) as tracker:

--- a/backend/tests/utilities/test_progress.py
+++ b/backend/tests/utilities/test_progress.py
@@ -1,0 +1,76 @@
+"""Tests for progress tracking utilities."""
+
+import pytest
+
+from backend.storage.r2 import UploadProgressTracker
+
+
+class TestUploadProgressTracker:
+    """Tests for UploadProgressTracker bytes-to-percentage conversion."""
+
+    def test_converts_bytes_to_percentage(self):
+        """Callback receives bytes, passes percentage to inner callback."""
+        received_percentages: list[float] = []
+
+        def capture_pct(pct: float) -> None:
+            received_percentages.append(pct)
+
+        tracker = UploadProgressTracker(
+            total_size=1000,
+            callback=capture_pct,
+            min_bytes_between_updates=100,  # Update every 100 bytes
+            min_time_between_updates=0,  # No time throttling for test
+        )
+
+        # Simulate boto3 calling with bytes
+        tracker(100)  # 10%
+        tracker(200)  # 30%
+        tracker(300)  # 60%
+        tracker(400)  # 100%
+
+        # Should have received percentage values, not bytes
+        assert len(received_percentages) == 4
+        assert received_percentages[0] == pytest.approx(10.0)
+        assert received_percentages[1] == pytest.approx(30.0)
+        assert received_percentages[2] == pytest.approx(60.0)
+        assert received_percentages[3] == pytest.approx(100.0)
+
+    def test_throttles_by_bytes_and_time(self):
+        """Updates are throttled based on bytes OR time threshold (OR logic)."""
+        received_percentages: list[float] = []
+
+        def capture_pct(pct: float) -> None:
+            received_percentages.append(pct)
+
+        # With min_time=0, every call triggers based on time threshold
+        # This matches the OR logic in UploadProgressTracker
+        tracker = UploadProgressTracker(
+            total_size=1000,
+            callback=capture_pct,
+            min_bytes_between_updates=500,
+            min_time_between_updates=0,  # Time threshold always met
+        )
+
+        # Every call triggers because time threshold (0) is always satisfied
+        tracker(100)
+        tracker(100)
+        assert len(received_percentages) == 2
+
+    def test_always_emits_near_completion(self):
+        """Always emits update when near 100% completion."""
+        received_percentages: list[float] = []
+
+        def capture_pct(pct: float) -> None:
+            received_percentages.append(pct)
+
+        tracker = UploadProgressTracker(
+            total_size=100,
+            callback=capture_pct,
+            min_bytes_between_updates=1000,  # Very high threshold
+            min_time_between_updates=1000,  # Very high threshold
+        )
+
+        # Near completion (99.9%+) should always emit
+        tracker(100)  # 100%
+        assert len(received_percentages) == 1
+        assert received_percentages[0] == pytest.approx(100.0)


### PR DESCRIPTION
## Summary

- Fixed `R2ProgressTracker` treating percentage values as bytes, causing "uploading to storage" progress to jump 0% → 100%
- `exports.py` now wraps boto3 callback with `UploadProgressTracker` for consistent bytes→percentage conversion
- Added regression tests for `UploadProgressTracker`

## Root cause

Two progress tracker classes were miscommunicating:
1. `UploadProgressTracker` (r2.py) receives bytes from boto3, calculates percentage, calls `callback(percentage)`
2. `R2ProgressTracker` (progress.py) was doing `_bytes_transferred += value`, treating percentage as bytes

## Test plan

- [ ] Deploy to staging
- [ ] Upload a large file (e.g., 90-minute audio)
- [ ] Verify "uploading to storage" toast shows gradual progress (10%, 25%, 50%, etc.) instead of jumping 0% → 100%
- [ ] Verify exports still show progress correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)