### PR TITLE
fix: add toast notification for track deletion

### DIFF
--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -295,12 +295,13 @@
 			if (response.ok) {
 				await loadMyTracks();
 				await loadMyAlbums();
+				toast.success('track deleted');
 			} else {
 				const error = await response.json();
-				alert(error.detail || 'failed to delete track');
+				toast.error(error.detail || 'failed to delete track');
 			}
 		} catch (e) {
-			alert(`network error: ${e instanceof Error ? e.message : 'unknown error'}`);
+			toast.error(`network error: ${e instanceof Error ? e.message : 'unknown error'}`);
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Added success toast when track is deleted ("track deleted")
- Replaced `alert()` with `toast.error()` for error cases (consistency with rest of app)

## Test plan

- [ ] Go to portal page
- [ ] Delete a track
- [ ] Verify toast appears saying "track deleted"
- [ ] Test error case (e.g., network disconnect) shows toast instead of browser alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)