### PR TITLE
fix: improve export progress messaging

### DIFF
--- a/backend/src/backend/api/exports.py
+++ b/backend/src/backend/api/exports.py
@@ -86,16 +86,19 @@ async def _process_export_background(export_id: str, artist_did: str) -> None:
                         key = f"audio/{track.file_id}.{track.file_type}"
 
                         try:
-                            # update progress
+                            # update progress (current_track is 1-indexed for display)
+                            current_track = processed + 1
                             pct = (processed / total) * 100
                             await job_service.update_progress(
                                 export_id,
                                 JobStatus.PROCESSING,
-                                f"downloading {track.title}...",
+                                f"downloading track {current_track} of {total}...",
                                 progress_pct=pct,
                                 result={
                                     "processed_count": processed,
                                     "total_count": total,
+                                    "current_track": current_track,
+                                    "current_title": track.title,
                                 },
                             )
 

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -456,10 +456,7 @@
 
 				// show progress messages
 				if (update.message && update.status === 'processing') {
-					const progressInfo = update.total_count
-						? ` (${update.processed_count}/${update.total_count})`
-						: '';
-					toast.update(toastId, `${update.message}${progressInfo}`);
+					toast.update(toastId, update.message);
 				}
 
 				if (update.status === 'completed') {


### PR DESCRIPTION
## Summary
- Progress message now says "downloading track X of Y" instead of confusing "downloading title (5/6)" format
- The old format showed completed count while downloading the next track, which was misleading
- Frontend simplified to just display the message directly

## Test plan
- [ ] Test export and verify toast shows "downloading track 1 of 6...", "downloading track 2 of 6...", etc.
- [ ] Verify "finalizing export..." appears after all tracks downloaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)