### PR TITLE
fix: add missing images/ prefix in album cover URL

### DIFF
--- a/backend/src/backend/api/albums.py
+++ b/backend/src/backend/api/albums.py
@@ -360,9 +360,8 @@ async def upload_album_cover(
         # save returns the file_id (hash)
         image_id = await storage.save(image_obj, image.filename)
 
-        # construct R2 URL directly
-        # storage.save uses just {file_id}{ext} for images (no subdirectory)
-        image_url = f"{storage.public_image_bucket_url}/{image_id}{ext}"
+        # construct R2 URL directly (images are stored under images/ prefix)
+        image_url = f"{storage.public_image_bucket_url}/images/{image_id}{ext}"
 
         # delete old image if exists (prevent R2 object leaks)
         if album.image_id:


### PR DESCRIPTION
## Summary

Album cover uploads were constructing URLs without the `images/` prefix, causing 404s.

- Before: `https://...r2.dev/7e18dfa529a0e83c.png`
- After: `https://...r2.dev/images/7e18dfa529a0e83c.png`

## Root Cause

Line 364-365 had a wrong comment and missing prefix:
```python
# storage.save uses just {file_id}{ext} for images (no subdirectory)  <-- WRONG
image_url = f"{storage.public_image_bucket_url}/{image_id}{ext}"
```

But `storage.save` actually stores images under `images/{file_id}{ext}`.

## Test plan
- [ ] Upload album cover on staging, verify image displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)