### PR TITLE
fix: prevent logo from overlapping title in embed

### DIFF
--- a/frontend/src/routes/embed/track/[id]/+page.svelte
+++ b/frontend/src/routes/embed/track/[id]/+page.svelte
@@ -185,7 +185,8 @@
 	.meta {
 		flex: 1;
 		min-width: 0;
-        padding-top: 4px;
+		padding-top: 4px;
+		padding-right: 60px; /* leave room for logo */
 	}
 
 	.title {
@@ -308,6 +309,10 @@
 
 		.artist {
 			font-size: 12px;
+		}
+
+		.meta {
+			padding-right: 50px;
 		}
 
 		.logo {


### PR DESCRIPTION
## Summary
- adds padding-right to the meta container so the title/artist text doesn't overlap with the absolutely-positioned plyr.fm logo
- adjusts padding for narrow screens as well

follow-up to #349

## Test plan
- [ ] verify title text truncates before reaching the logo
- [ ] test at various widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)