### PR TITLE
feat: add artist link to track embed

### DIFF
--- a/frontend/src/routes/embed/track/[id]/+page.svelte
+++ b/frontend/src/routes/embed/track/[id]/+page.svelte
@@ -71,7 +71,7 @@
 				<a href="https://plyr.fm/track/{track.id}" target="_blank" rel="noopener noreferrer" class="title">
 					{track.title}
 				</a>
-				<div class="artist">{track.artist}</div>
+				<a href="https://plyr.fm/u/{track.artist_handle}" target="_blank" rel="noopener noreferrer" class="artist">{track.artist}</a>
 			</div>
             
             <a href="https://plyr.fm" target="_blank" rel="noopener noreferrer" class="logo">
@@ -206,11 +206,17 @@
 	}
 
 	.artist {
+		display: block;
 		font-size: 14px;
 		color: #aaa;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
+		text-decoration: none;
+	}
+
+	.artist:hover {
+		text-decoration: underline;
 	}
 
     .logo {


### PR DESCRIPTION
## Summary
- makes the artist name in the embed clickable
- links to the artist's profile page (`/u/{handle}`)
- styled consistently with the title link (underline on hover)

## Test plan
- [ ] click artist name in embed, verify it opens artist profile in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)