### PR TITLE
fix: reduce mobile embed background overlay opacity

### DIFF
--- a/frontend/src/routes/embed/track/[id]/+page.svelte
+++ b/frontend/src/routes/embed/track/[id]/+page.svelte
@@ -322,7 +322,7 @@
 			display: block;
 			position: absolute;
 			inset: 0;
-			background: rgba(0, 0, 0, 0.35);
+			background: rgba(0, 0, 0, 0.2);
 			z-index: 0;
 			pointer-events: none;
 		}


### PR DESCRIPTION
## Summary
- Reduce overlay opacity from 0.35 to 0.2 to let more album art colors show through

The blurred background was too dark and washing out the album art colors.

## Test plan
- [ ] Test mobile embed with colorful album art
- [ ] Verify text is still readable against the lighter background

🤖 Generated with [Claude Code](https://claude.com/claude-code)