### PR TITLE
feat: add oEmbed endpoint for Leaflet.pub and other embed services

### DIFF
--- a/backend/src/backend/api/__init__.py
+++ b/backend/src/backend/api/__init__.py
@@ -4,6 +4,7 @@ from backend.api.artists import router as artists_router
 from backend.api.audio import router as audio_router
 from backend.api.auth import router as auth_router
 from backend.api.exports import router as exports_router
+from backend.api.oembed import router as oembed_router
 from backend.api.preferences import router as preferences_router
 from backend.api.queue import router as queue_router
 from backend.api.search import router as search_router
@@ -14,6 +15,7 @@ __all__ = [
     "audio_router",
     "auth_router",
     "exports_router",
+    "oembed_router",
     "preferences_router",
     "queue_router",
     "search_router",

--- a/backend/src/backend/api/oembed.py
+++ b/backend/src/backend/api/oembed.py
@@ -1,0 +1,108 @@
+"""oEmbed endpoint for track embeds.
+
+Enables services like Leaflet.pub (via iframely) to discover
+and use our embed player instead of raw HTML5 audio.
+"""
+
+import re
+from typing import Annotated
+from urllib.parse import unquote
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from backend.config import settings
+from backend.models import Track, get_db
+
+router = APIRouter(tags=["oembed"])
+
+# match /track/{id} or /track/{id}/ or /track/{id}?...
+TRACK_URL_PATTERN = re.compile(r"/track/(\d+)")
+
+
+class OEmbedResponse(BaseModel):
+    """oEmbed response for track embeds."""
+
+    version: str = "1.0"
+    type: str = "rich"
+    provider_name: str = "plyr.fm"
+    provider_url: str = "https://plyr.fm"
+    title: str
+    author_name: str
+    author_url: str
+    width: int = 400
+    height: int = 165
+    html: str
+    thumbnail_url: str | None = None
+    thumbnail_width: int | None = None
+    thumbnail_height: int | None = None
+
+
+@router.get("/oembed")
+async def get_oembed(
+    url: Annotated[str, Query(description="URL to get oEmbed data for")],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    maxwidth: Annotated[int | None, Query()] = None,
+    maxheight: Annotated[int | None, Query()] = None,
+    format: Annotated[str, Query()] = "json",
+) -> OEmbedResponse:
+    """Return oEmbed data for a track URL.
+
+    This enables services like iframely to discover our embed player.
+    """
+    if format != "json":
+        raise HTTPException(status_code=501, detail="only json format is supported")
+
+    # decode URL in case it's URL-encoded
+    decoded_url = unquote(url)
+
+    # extract track ID from URL
+    match = TRACK_URL_PATTERN.search(decoded_url)
+    if not match:
+        raise HTTPException(status_code=404, detail="invalid track URL")
+
+    track_id = int(match.group(1))
+
+    # fetch track from database
+    result = await db.execute(
+        select(Track).options(selectinload(Track.artist)).where(Track.id == track_id)
+    )
+    track = result.scalar_one_or_none()
+
+    if not track:
+        raise HTTPException(status_code=404, detail="track not found")
+
+    # determine frontend URL (use production in prod, localhost in dev)
+    frontend_url = settings.frontend.url
+
+    # build embed iframe HTML
+    embed_url = f"{frontend_url}/embed/track/{track_id}"
+    width = min(maxwidth or 400, 800)
+    height = min(maxheight or 165, 165)
+
+    html = (
+        f'<iframe src="{embed_url}" '
+        f'width="{width}" height="{height}" '
+        f'frameborder="0" allow="autoplay" '
+        f'style="border-radius: 8px;"></iframe>'
+    )
+
+    response = OEmbedResponse(
+        title=f"{track.title} - {track.artist.display_name}",
+        author_name=track.artist.display_name,
+        author_url=f"{frontend_url}/u/{track.artist.handle}",
+        width=width,
+        height=height,
+        html=html,
+    )
+
+    # add thumbnail if track has cover art
+    if track.image_url:
+        response.thumbnail_url = track.image_url
+        response.thumbnail_width = 300
+        response.thumbnail_height = 300
+
+    return response

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -26,6 +26,7 @@ from backend.api import (
     audio_router,
     auth_router,
     exports_router,
+    oembed_router,
     preferences_router,
     queue_router,
     search_router,
@@ -157,6 +158,7 @@ app.include_router(preferences_router)
 app.include_router(queue_router)
 app.include_router(migration_router)
 app.include_router(exports_router)
+app.include_router(oembed_router)
 
 
 @app.get("/health")

--- a/backend/tests/api/test_oembed.py
+++ b/backend/tests/api/test_oembed.py
@@ -1,0 +1,148 @@
+"""tests for oEmbed endpoint."""
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.main import app
+from backend.models import Artist, Track
+
+
+@pytest.fixture
+async def test_track(db_session: AsyncSession) -> Track:
+    """create a test track for oEmbed testing."""
+    artist = Artist(
+        did="did:plc:oembed123",
+        handle="test.artist.social",
+        display_name="Test Artist",
+    )
+    db_session.add(artist)
+    await db_session.flush()
+
+    track = Track(
+        title="Test Track",
+        artist_did=artist.did,
+        file_id="oembed_test_123",
+        file_type="mp3",
+        r2_url="https://cdn.example.com/audio/test.mp3",
+        image_url="https://cdn.example.com/images/cover.png",
+    )
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+
+    return track
+
+
+@pytest.fixture
+def test_app() -> FastAPI:
+    """get test app."""
+    return app
+
+
+async def test_oembed_returns_valid_response(
+    test_app: FastAPI, test_track: Track
+) -> None:
+    """test that oEmbed returns proper response for valid track URL."""
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/oembed",
+            params={"url": f"https://plyr.fm/track/{test_track.id}"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["version"] == "1.0"
+    assert data["type"] == "rich"
+    assert data["provider_name"] == "plyr.fm"
+    assert "Test Track" in data["title"]
+    assert "Test Artist" in data["title"]
+    assert data["author_name"] == "Test Artist"
+    assert f"/embed/track/{test_track.id}" in data["html"]
+    assert "iframe" in data["html"]
+    assert data["height"] == 165
+    # should have thumbnail since track has image
+    assert data["thumbnail_url"] == test_track.image_url
+
+
+async def test_oembed_handles_encoded_url(test_app: FastAPI, test_track: Track) -> None:
+    """test that oEmbed handles URL-encoded URLs."""
+    import urllib.parse
+
+    encoded_url = urllib.parse.quote(f"https://plyr.fm/track/{test_track.id}", safe="")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get("/oembed", params={"url": encoded_url})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert f"/embed/track/{test_track.id}" in data["html"]
+
+
+async def test_oembed_returns_404_for_invalid_url(test_app: FastAPI) -> None:
+    """test that oEmbed returns 404 for non-track URLs."""
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/oembed", params={"url": "https://plyr.fm/not-a-track"}
+        )
+
+    assert response.status_code == 404
+    assert "invalid track URL" in response.json()["detail"]
+
+
+async def test_oembed_returns_404_for_nonexistent_track(test_app: FastAPI) -> None:
+    """test that oEmbed returns 404 for track that doesn't exist."""
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/oembed", params={"url": "https://plyr.fm/track/99999"}
+        )
+
+    assert response.status_code == 404
+    assert "track not found" in response.json()["detail"]
+
+
+async def test_oembed_rejects_non_json_format(
+    test_app: FastAPI, test_track: Track
+) -> None:
+    """test that oEmbed returns 501 for non-JSON format."""
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/oembed",
+            params={
+                "url": f"https://plyr.fm/track/{test_track.id}",
+                "format": "xml",
+            },
+        )
+
+    assert response.status_code == 501
+    assert "only json format is supported" in response.json()["detail"]
+
+
+async def test_oembed_respects_maxwidth(test_app: FastAPI, test_track: Track) -> None:
+    """test that oEmbed respects maxwidth parameter."""
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/oembed",
+            params={
+                "url": f"https://plyr.fm/track/{test_track.id}",
+                "maxwidth": 300,
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["width"] == 300

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -112,6 +112,14 @@ $effect(() => {
 	{#if track.image_url}
 		<meta name="twitter:image" content="{track.image_url}" />
 	{/if}
+
+	<!-- oEmbed discovery for embed services like iframely -->
+	<link
+		rel="alternate"
+		type="application/json+oembed"
+		href="{API_URL}/oembed?url={encodeURIComponent(`${APP_CANONICAL_URL}/track/${track.id}`)}"
+		title="{track.title} - {track.artist}"
+	/>
 </svelte:head>
 
 <div class="page-container">


### PR DESCRIPTION
## Summary
- Add `/oembed` backend endpoint that returns oEmbed JSON for track URLs
- Add oEmbed discovery link (`<link rel="alternate" type="application/json+oembed" ...>`) to track page head
- Add 6 comprehensive tests for oEmbed endpoint

## Context
Services like Leaflet.pub use iframely for embed discovery. iframely looks for oEmbed endpoints to provide proper embed HTML instead of falling back to raw HTML5 audio players.

When a track URL is pasted into Leaflet.pub, iframely will now:
1. Find our oEmbed discovery link in the HTML head
2. Call our `/oembed` endpoint
3. Get back proper embed info with `links.player` containing our iframe URL
4. Render our nice embed player instead of a black HTML5 audio box

## oEmbed Response
```json
{
  "version": "1.0",
  "type": "rich",
  "provider_name": "plyr.fm",
  "provider_url": "https://plyr.fm",
  "title": "Track Title - Artist",
  "author_name": "Artist",
  "author_url": "https://plyr.fm/u/handle",
  "width": 400,
  "height": 165,
  "html": "<iframe src=\"https://plyr.fm/embed/track/92\" ...></iframe>",
  "thumbnail_url": "...",
  "thumbnail_width": 300,
  "thumbnail_height": 300
}
```

## Test plan
- [x] All 6 oEmbed tests pass
- [x] Svelte check passes
- [ ] Test with iframely.com/try after deploy
- [ ] Test in Leaflet.pub after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)