### PR TITLE
fix: add og:video meta tags for iframely embed discovery

### DIFF
--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -102,6 +102,13 @@ $effect(() => {
 		<meta property="og:audio:type" content="audio/{track.file_type}" />
 	{/if}
 
+	<!-- og:video for iframely to discover our embed iframe as the player -->
+	<meta property="og:video" content="{APP_CANONICAL_URL}/embed/track/{track.id}" />
+	<meta property="og:video:secure_url" content="{APP_CANONICAL_URL}/embed/track/{track.id}" />
+	<meta property="og:video:type" content="text/html" />
+	<meta property="og:video:width" content="400" />
+	<meta property="og:video:height" content="165" />
+
 	<!-- Twitter -->
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content="{track.title}" />


### PR DESCRIPTION
## Summary
- Add `og:video` meta tags to track pages pointing to the embed URL
- This should make iframely return our embed iframe as the `links.player` instead of the raw MP3 from `og:audio`
- Fixes Leaflet.pub showing black HTML5 audio box instead of our player

## Root cause
iframely debug output showed it was returning the raw MP3 URL from `og:audio` as the player link:
```json
"links": [{
  "href": "https://pub-d4ed8a1e39d44dac85263d86ad5676fd.r2.dev/audio/0502e019e721dd1e.mp3",
  "rel": ["player", "ssl", "html5", "audio"],
  "type": "audio/mpeg"
}]
```

By adding `og:video` with `type="text/html"`, iframely should recognize our embed iframe URL as the proper player.

## Test plan
- [ ] Deploy to Cloudflare Pages via CI
- [ ] Clear iframely cache for a plyr.fm track URL
- [ ] Test in iframely.com/try - verify `links.player` now has our embed iframe URL
- [ ] Test in Leaflet.pub - verify embed shows our player instead of black box

🤖 Generated with [Claude Code](https://claude.com/claude-code)