### PR TITLE
fix: remove og:audio to let iframely use og:video for player

### DIFF
--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -97,12 +97,8 @@ $effect(() => {
 		<meta property="og:image:height" content="1200" />
 		<meta property="og:image:alt" content="{track.title} by {track.artist}" />
 	{/if}
-	{#if track.r2_url}
-		<meta property="og:audio" content="{track.r2_url}" />
-		<meta property="og:audio:type" content="audio/{track.file_type}" />
-	{/if}
-
 	<!-- og:video for iframely to discover our embed iframe as the player -->
+	<!-- NOTE: og:audio removed - it caused iframely to use raw MP3 instead of embed iframe -->
 	<meta property="og:video" content="{APP_CANONICAL_URL}/embed/track/{track.id}" />
 	<meta property="og:video:secure_url" content="{APP_CANONICAL_URL}/embed/track/{track.id}" />
 	<meta property="og:video:type" content="text/html" />


### PR DESCRIPTION
## Summary
- Remove `og:audio` meta tags from track pages
- iframely prefers `og:audio` over `og:video`, so it was returning the raw MP3 as `links.player` instead of our embed iframe

## Test plan
- [ ] Deploy to Cloudflare Pages
- [ ] Refresh iframely cache for a track URL
- [ ] Verify `links.player` now has our embed iframe URL instead of raw MP3
- [ ] Test in Leaflet.pub

🤖 Generated with [Claude Code](https://claude.com/claude-code)