### PR TITLE
revert: remove og:video, restore og:audio

### DIFF
--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -97,13 +97,10 @@ $effect(() => {
 		<meta property="og:image:height" content="1200" />
 		<meta property="og:image:alt" content="{track.title} by {track.artist}" />
 	{/if}
-	<!-- og:video for iframely to discover our embed iframe as the player -->
-	<!-- NOTE: og:audio removed - it caused iframely to use raw MP3 instead of embed iframe -->
-	<meta property="og:video" content="{APP_CANONICAL_URL}/embed/track/{track.id}" />
-	<meta property="og:video:secure_url" content="{APP_CANONICAL_URL}/embed/track/{track.id}" />
-	<meta property="og:video:type" content="text/html" />
-	<meta property="og:video:width" content="400" />
-	<meta property="og:video:height" content="165" />
+	{#if track.r2_url}
+		<meta property="og:audio" content="{track.r2_url}" />
+		<meta property="og:audio:type" content="audio/{track.file_type}" />
+	{/if}
 
 	<!-- Twitter -->
 	<meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
## Summary
- Remove og:video meta tags (iframely doesn't create links.player from them for unknown providers)
- Restore og:audio for platforms that use it directly
- oEmbed endpoint remains functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)