### PR TITLE
fix: add trailing slash to preferences API calls

### DIFF
--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -165,7 +165,7 @@
 
 	async function loadPreferences() {
 		try {
-			const response = await fetch(`${API_URL}/preferences`, {
+			const response = await fetch(`${API_URL}/preferences/`, {
 				credentials: 'include'
 			});
 			if (response.ok) {
@@ -179,7 +179,7 @@
 
 	async function saveAllowComments(enabled: boolean) {
 		try {
-			const response = await fetch(`${API_URL}/preferences`, {
+			const response = await fetch(`${API_URL}/preferences/`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				credentials: 'include',


### PR DESCRIPTION
## Summary
- Portal page was calling `/preferences` without trailing slash
- Backend route is defined as `/preferences/`, so requests without trailing slash get 307 redirected
- Behind Fly's proxy, these redirects generated `http://` URLs causing mixed content errors
- Fixed by adding trailing slash to match the pattern already used in SettingsMenu.svelte

## The bug
```
curl -sI "https://api-stg.plyr.fm/preferences"
location: http://api-stg.plyr.fm/preferences/  # ← http caused mixed content
```

SettingsMenu.svelte already used `/preferences/` (with slash) and worked fine.
Portal used `/preferences` (without slash) and triggered the redirect.

## Test plan
- [x] verify SettingsMenu pattern uses trailing slash
- [ ] deploy to staging
- [ ] verify preferences load/save work without mixed content errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)