### PR TITLE
docs: add python SDK to README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ plyr.fm/
 
 - **production**: https://plyr.fm
 - **API docs**: https://api.plyr.fm/docs
+- **python SDK**: [plyrfm](https://github.com/zzstoatzz/plyr-python-client) ([PyPI](https://pypi.org/project/plyrfm/))
 - **repository**: https://github.com/zzstoatzz/plyr.fm
 
 ## documentation


### PR DESCRIPTION
## Summary
- add link to plyrfm python SDK in README links section

🤖 Generated with [Claude Code](https://claude.com/claude-code)