### PR TITLE
feat: add python SDK link to developer tokens section

### DIFF
--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -1179,7 +1179,8 @@
 				<div class="control-info">
 					<h3>developer tokens</h3>
 					<p class="control-description">
-						create tokens for programmatic API access (uploads, track management)
+						create tokens for programmatic API access (uploads, track management).
+						use with the <a href="https://github.com/zzstoatzz/plyr-python-client" target="_blank" rel="noopener">python SDK</a>
 					</p>
 				</div>
 


### PR DESCRIPTION
## Summary
- add link to python SDK in the developer tokens section of the portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)