### PR TITLE
refactor: move platform stats from sidebar to header

### DIFF
--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -3,6 +3,7 @@
 	import type { User } from '$lib/types';
 	import SettingsMenu from './SettingsMenu.svelte';
 	import LinksMenu from './LinksMenu.svelte';
+	import PlatformStats from './PlatformStats.svelte';
 	import { APP_NAME, APP_TAGLINE } from '$lib/branding';
 
 	interface Props {
@@ -15,6 +16,10 @@
 </script>
 
 <header>
+	<!-- Stats positioned on far left, outside main header flow -->
+	<div class="stats-left desktop-only">
+		<PlatformStats variant="header" />
+	</div>
 	<div class="header-content">
 		<div class="left-section">
 			<!-- desktop: show icons inline -->
@@ -84,6 +89,7 @@
 	header {
 		border-bottom: 1px solid #333;
 		margin-bottom: 2rem;
+		position: relative;
 	}
 
 	.header-content {
@@ -122,6 +128,13 @@
 
 	.mobile-only {
 		display: none;
+	}
+
+	.stats-left {
+		position: absolute;
+		left: calc((100vw - 800px) / 4);
+		top: 50%;
+		transform: translate(-50%, -50%);
 	}
 
 	.bluesky-link,

--- a/frontend/src/lib/components/PlatformStats.svelte
+++ b/frontend/src/lib/components/PlatformStats.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { fade } from 'svelte/transition';
 	import { API_URL } from '$lib/config';
 
 	interface Props {
-		variant?: 'bar' | 'menu';
+		variant?: 'header' | 'menu';
 	}
 
-	let { variant = 'bar' }: Props = $props();
+	let { variant = 'header' }: Props = $props();
 
 	interface Stats {
 		total_plays: number;
@@ -40,45 +39,29 @@
 	});
 </script>
 
-{#if variant === 'bar'}
-	<div class="stats-sidebar">
-		{#if loading}
-			<div class="sidebar-stat">
-				<span class="skeleton-icon"></span>
-				<span class="skeleton-value"></span>
-			</div>
-			<div class="sidebar-stat">
-				<span class="skeleton-icon"></span>
-				<span class="skeleton-value"></span>
-			</div>
-			<div class="sidebar-stat">
-				<span class="skeleton-icon"></span>
-				<span class="skeleton-value"></span>
-			</div>
-		{:else if stats}
-			<div class="sidebar-stat" in:fade={{ duration: 300 }}>
-				<svg class="stat-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+{#if variant === 'header'}
+	<div class="stats-header">
+		{#if !loading && stats}
+			<div class="header-stat" title="{stats.total_plays.toLocaleString()} {pluralize(stats.total_plays, 'play', 'plays')}">
+				<svg class="header-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 					<polygon points="5 3 19 12 5 21 5 3"></polygon>
 				</svg>
-				<span class="stat-value">{stats.total_plays.toLocaleString()}</span>
-				<span class="stat-label">{pluralize(stats.total_plays, 'play', 'plays')}</span>
+				<span class="header-value">{stats.total_plays.toLocaleString()}</span>
 			</div>
-			<div class="sidebar-stat" in:fade={{ duration: 300, delay: 50 }}>
-				<svg class="stat-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+			<div class="header-stat" title="{stats.total_tracks.toLocaleString()} {pluralize(stats.total_tracks, 'track', 'tracks')}">
+				<svg class="header-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
 					<path d="M9 18V5l12-2v13"></path>
 					<circle cx="6" cy="18" r="3"></circle>
 					<circle cx="18" cy="16" r="3"></circle>
 				</svg>
-				<span class="stat-value">{stats.total_tracks.toLocaleString()}</span>
-				<span class="stat-label">{pluralize(stats.total_tracks, 'track', 'tracks')}</span>
+				<span class="header-value">{stats.total_tracks.toLocaleString()}</span>
 			</div>
-			<div class="sidebar-stat" in:fade={{ duration: 300, delay: 100 }}>
-				<svg class="stat-icon" width="14" height="14" viewBox="0 0 16 16" fill="none">
+			<div class="header-stat" title="{stats.total_artists.toLocaleString()} {pluralize(stats.total_artists, 'artist', 'artists')}">
+				<svg class="header-icon" width="14" height="14" viewBox="0 0 16 16" fill="none">
 					<circle cx="8" cy="5" r="3" stroke="currentColor" stroke-width="1.5" fill="none" />
 					<path d="M3 14c0-2.5 2-4.5 5-4.5s5 2 5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
 				</svg>
-				<span class="stat-value">{stats.total_artists.toLocaleString()}</span>
-				<span class="stat-label">{pluralize(stats.total_artists, 'artist', 'artists')}</span>
+				<span class="header-value">{stats.total_artists.toLocaleString()}</span>
 			</div>
 		{/if}
 	</div>
@@ -137,54 +120,38 @@
 {/if}
 
 <style>
-	/* Sidebar variant - clean, minimal */
-	.stats-sidebar {
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-	}
-
-	.sidebar-stat {
+	/* Header variant - inline, compact */
+	.stats-header {
 		display: flex;
 		align-items: center;
-		gap: 0.5rem;
+		gap: 0.75rem;
 	}
 
-	.stat-icon {
-		color: var(--text-muted);
-		opacity: 0.5;
-		flex-shrink: 0;
-	}
-
-	.stat-value {
-		color: var(--text-primary);
-		font-weight: 600;
-		font-size: 1.1rem;
-		font-variant-numeric: tabular-nums;
-		line-height: 1;
-	}
-
-	.stat-label {
-		color: var(--text-tertiary);
+	.header-stat {
+		display: flex;
+		align-items: center;
+		gap: 0.3rem;
+		color: var(--text-secondary);
 		font-size: 0.8rem;
-		text-transform: lowercase;
+		transition: color 0.2s;
 	}
 
-	.skeleton-icon {
-		width: 14px;
-		height: 14px;
-		background: rgba(255, 255, 255, 0.04);
-		border-radius: 3px;
+	.header-stat:hover {
+		color: var(--text-primary);
+	}
+
+	.header-icon {
+		opacity: 0.6;
 		flex-shrink: 0;
 	}
 
-	.skeleton-value {
-		width: 50px;
-		height: 1.1rem;
-		background: linear-gradient(90deg, rgba(255, 255, 255, 0.03) 0%, rgba(255, 255, 255, 0.06) 50%, rgba(255, 255, 255, 0.03) 100%);
-		background-size: 200% 100%;
-		animation: shimmer 1.5s ease-in-out infinite;
-		border-radius: 3px;
+	.header-stat:hover .header-icon {
+		opacity: 0.8;
+	}
+
+	.header-value {
+		font-variant-numeric: tabular-nums;
+		font-weight: 500;
 	}
 
 	@keyframes shimmer {
@@ -197,7 +164,6 @@
 	}
 
 	@media (prefers-reduced-motion: reduce) {
-		.skeleton-value,
 		.skeleton-text {
 			animation: none;
 		}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -4,7 +4,6 @@
 	import TrackItem from '$lib/components/TrackItem.svelte';
 	import Header from '$lib/components/Header.svelte';
 	import WaveLoading from '$lib/components/WaveLoading.svelte';
-	import PlatformStats from '$lib/components/PlatformStats.svelte';
 	import { player } from '$lib/player.svelte';
 	import { queue } from '$lib/queue.svelte';
 	import { tracksCache } from '$lib/tracks.svelte';
@@ -71,11 +70,7 @@
 
 <Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={logout} />
 
-<div class="page-layout">
-	<aside class="stats-sidebar">
-		<PlatformStats />
-	</aside>
-	<main>
+<main>
 		<section class="tracks">
 		<h2>
 			<button
@@ -114,34 +109,8 @@
 		{/if}
 	</section>
 </main>
-</div>
 
 <style>
-	.page-layout {
-		display: block;
-		max-width: 800px;
-		margin: 0 auto;
-		padding: 0 1rem calc(var(--player-height, 120px) + env(safe-area-inset-bottom, 0px));
-	}
-
-	/* Hide by default - only show on wide screens */
-	.stats-sidebar {
-		display: none;
-	}
-
-	/* Show sidebar centered in left margin */
-	@media (min-width: 1300px) {
-		.stats-sidebar {
-			display: block;
-			position: fixed;
-			/* Center in the left margin: halfway between left edge and content */
-			left: calc((100vw - 800px) / 4);
-			transform: translateX(-50%);
-			top: 160px;
-			width: auto;
-		}
-	}
-
 	.loading-container {
 		display: flex;
 		justify-content: center;
@@ -149,7 +118,9 @@
 	}
 
 	main {
-		width: 100%;
+		max-width: 800px;
+		margin: 0 auto;
+		padding: 0 1rem calc(var(--player-height, 120px) + env(safe-area-inset-bottom, 0px));
 	}
 
 	.tracks h2 {


### PR DESCRIPTION
## Summary
- Move platform stats from floating sidebar to header navigation
- Stats positioned in left margin on desktop, centered in available space
- Collapses into LinksMenu on narrow screens (<1300px)
- Cleaner layout that fits naturally with existing header elements

## Test plan
- [ ] Verify stats display in header on wide screens (≥1300px)
- [ ] Verify stats collapse into LinksMenu on narrow screens
- [ ] Check centering in left margin looks balanced
- [ ] Hover states work on stat items

🤖 Generated with [Claude Code](https://claude.com/claude-code)