### PR TITLE
feat: track SDK/MCP client usage in Logfire spans

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -198,7 +198,7 @@ async def test_exchange_token_cannot_be_reused(db_session: AsyncSession):
     # consume token first time
     result = await consume_exchange_token(token)
     assert result is not None
-    returned_session_id, is_dev_token = result
+    returned_session_id, _is_dev_token = result
     assert returned_session_id == session_id
 
     # try to consume again - should return None

--- a/backend/tests/test_user_agent.py
+++ b/backend/tests/test_user_agent.py
@@ -1,0 +1,71 @@
+"""tests for user-agent parsing and span enrichment."""
+
+import pytest
+
+from backend.main import parse_plyrfm_user_agent
+
+
+class TestParsePlyrfmUserAgent:
+    """tests for parse_plyrfm_user_agent function."""
+
+    def test_sdk_user_agent(self) -> None:
+        """sdk user-agent returns client_type=sdk with version."""
+        result = parse_plyrfm_user_agent("plyrfm/0.1.0")
+        assert result == {"client_type": "sdk", "client_version": "0.1.0"}
+
+    def test_mcp_user_agent(self) -> None:
+        """mcp user-agent returns client_type=mcp with version."""
+        result = parse_plyrfm_user_agent("plyrfm-mcp/0.2.1")
+        assert result == {"client_type": "mcp", "client_version": "0.2.1"}
+
+    def test_browser_user_agent(self) -> None:
+        """standard browser user-agent returns client_type=browser."""
+        result = parse_plyrfm_user_agent(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        )
+        assert result == {"client_type": "browser"}
+        assert "client_version" not in result
+
+    def test_none_user_agent(self) -> None:
+        """missing user-agent returns client_type=browser."""
+        result = parse_plyrfm_user_agent(None)
+        assert result == {"client_type": "browser"}
+
+    def test_empty_user_agent(self) -> None:
+        """empty string user-agent returns client_type=browser."""
+        result = parse_plyrfm_user_agent("")
+        assert result == {"client_type": "browser"}
+
+    def test_curl_user_agent(self) -> None:
+        """curl user-agent returns client_type=browser (generic fallback)."""
+        result = parse_plyrfm_user_agent("curl/8.4.0")
+        assert result == {"client_type": "browser"}
+
+    @pytest.mark.parametrize(
+        ("user_agent", "expected_type", "expected_version"),
+        [
+            ("plyrfm/1.0.0", "sdk", "1.0.0"),
+            ("plyrfm/0.0.1", "sdk", "0.0.1"),
+            ("plyrfm/10.20.30", "sdk", "10.20.30"),
+            ("plyrfm-mcp/1.0.0", "mcp", "1.0.0"),
+            ("plyrfm-mcp/0.0.1", "mcp", "0.0.1"),
+        ],
+    )
+    def test_version_variations(
+        self, user_agent: str, expected_type: str, expected_version: str
+    ) -> None:
+        """various version formats are parsed correctly."""
+        result = parse_plyrfm_user_agent(user_agent)
+        assert result["client_type"] == expected_type
+        assert result["client_version"] == expected_version
+
+    def test_plyrfm_prefix_not_at_start(self) -> None:
+        """plyrfm in middle of string is not matched (browser fallback)."""
+        result = parse_plyrfm_user_agent("Mozilla/5.0 plyrfm/1.0.0")
+        assert result == {"client_type": "browser"}
+
+    def test_invalid_version_format(self) -> None:
+        """invalid version format falls back to browser."""
+        result = parse_plyrfm_user_agent("plyrfm/v1.0")
+        assert result == {"client_type": "browser"}

--- a/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
@@ -71,8 +71,8 @@
 	{/if}
 </svelte:head>
 
+<Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={() => goto('/login')} />
 <div class="container">
-	<Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={() => goto('/login')} />
 	<main>
 		<div class="album-hero">
 			{#if album.metadata.image_url}


### PR DESCRIPTION
## Summary
- Add `request_attributes_mapper` to parse User-Agent headers from SDK/MCP clients
- Enrich Logfire spans with `client_type` (sdk/mcp/browser) and `client_version`
- Fix stats positioning on album detail page (Header was inside container)

## Details

The Python SDK and MCP server now send User-Agent headers:
- `plyrfm/{version}` - direct SDK/CLI usage
- `plyrfm-mcp/{version}` - MCP server traffic

This PR adds span enrichment so we can filter/cluster traffic by source in Logfire UI.

## Test plan
- [x] 13 unit tests for user-agent parsing
- [ ] Verify stats positioning on album detail page
- [ ] Deploy to staging and check Logfire for new span attributes

closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)