### PR TITLE
feat: show copyright flag indicator in artist portal

### DIFF
--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -63,6 +63,9 @@ class TrackResponse(BaseModel):
     like_count: int
     comment_count: int
     album: AlbumSummary | None
+    copyright_flagged: bool | None = (
+        None  # None = not scanned, False = clear, True = flagged
+    )
 
     @classmethod
     async def from_track(
@@ -72,6 +75,7 @@ class TrackResponse(BaseModel):
         liked_track_ids: set[int] | None = None,
         like_counts: dict[int, int] | None = None,
         comment_counts: dict[int, int] | None = None,
+        copyright_flags: dict[int, bool] | None = None,
     ) -> "TrackResponse":
         """build track response from Track model.
 
@@ -81,6 +85,7 @@ class TrackResponse(BaseModel):
             liked_track_ids: optional set of liked track IDs for this user
             like_counts: optional dict of track_id -> like_count
             comment_counts: optional dict of track_id -> comment_count
+            copyright_flags: optional dict of track_id -> is_flagged (None if not scanned)
         """
         # check if user has liked this track
         is_liked = liked_track_ids is not None and track.id in liked_track_ids
@@ -116,6 +121,9 @@ class TrackResponse(BaseModel):
                 f"&rkey={rkey}"
             )
 
+        # get copyright flag status (None if not in dict = not scanned)
+        copyright_flagged = copyright_flags.get(track.id) if copyright_flags else None
+
         return cls(
             id=track.id,
             title=track.title,
@@ -135,4 +143,5 @@ class TrackResponse(BaseModel):
             like_count=like_count,
             comment_count=comment_count,
             album=album_data,
+            copyright_flagged=copyright_flagged,
         )

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -44,6 +44,7 @@ export interface Track {
 	created_at?: string;
 	image_url?: string;
 	is_liked?: boolean;
+	copyright_flagged?: boolean | null; // null = not scanned, false = clear, true = flagged
 }
 
 export interface User {

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -891,7 +891,7 @@
 			{:else}
 				<div class="tracks-list">
 					{#each tracks as track}
-						<div class="track-item" class:editing={editingTrackId === track.id}>
+						<div class="track-item" class:editing={editingTrackId === track.id} class:copyright-flagged={track.copyright_flagged}>
 							{#if editingTrackId === track.id}
 								<div class="edit-container">
 									<div class="edit-fields">
@@ -977,7 +977,34 @@
 									{/if}
 								</div>
 				<div class="track-info">
-					<div class="track-title">{track.title}</div>
+					<div class="track-title">
+						{track.title}
+						{#if track.copyright_flagged}
+							{#if track.atproto_record_url}
+								<a
+									href={track.atproto_record_url}
+									target="_blank"
+									rel="noopener noreferrer"
+									class="copyright-flag"
+									title="potential copyright match - click to view record"
+								>
+									<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+										<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+										<line x1="12" y1="9" x2="12" y2="13"></line>
+										<line x1="12" y1="17" x2="12.01" y2="17"></line>
+									</svg>
+								</a>
+							{:else}
+								<span class="copyright-flag" title="potential copyright match detected">
+									<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+										<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+										<line x1="12" y1="9" x2="12" y2="13"></line>
+										<line x1="12" y1="17" x2="12.01" y2="17"></line>
+									</svg>
+								</span>
+							{/if}
+						{/if}
+					</div>
 					<div class="track-meta">
 						{#if track.features && track.features.length > 0}
 							<div class="meta-features" title={`feat. ${track.features.map(f => f.display_name).join(', ')}`}>
@@ -1624,6 +1651,20 @@
 		align-items: stretch;
 	}
 
+	.track-item.copyright-flagged {
+		background: rgba(233, 165, 69, 0.08);
+		border-color: rgba(233, 165, 69, 0.3);
+	}
+
+	.track-item.copyright-flagged .track-title {
+		color: #e9a545;
+	}
+
+	.track-item.copyright-flagged .track-artwork img,
+	.track-item.copyright-flagged .track-artwork-placeholder {
+		opacity: 0.6;
+	}
+
 	.track-artwork {
 		flex-shrink: 0;
 		width: 48px;
@@ -1695,6 +1736,29 @@
 		font-size: 1rem;
 		margin-bottom: 0.25rem;
 		color: #fff;
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.copyright-flag {
+		display: inline-flex;
+		align-items: center;
+		color: #e9a545;
+		flex-shrink: 0;
+		text-decoration: none;
+	}
+
+	.copyright-flag:hover {
+		color: #ffb860;
+	}
+
+	a.copyright-flag {
+		cursor: pointer;
+	}
+
+	a.copyright-flag:hover {
+		transform: scale(1.1);
 	}
 
 	.track-meta {


### PR DESCRIPTION
## Summary

- Adds `copyright_flagged` field to track API responses (tri-state: `null` = not scanned, `false` = clear, `true` = flagged)
- Displays warning indicator next to flagged tracks in the artist portal
- Flagged tracks have amber-tinted styling (background, border, title color, dimmed artwork)
- Warning icon is clickable when ATProto record URL is available, linking to the record

## Test plan

- [ ] Upload a track and verify it gets scanned (requires `MODERATION_AUTH_TOKEN` env var)
- [ ] Confirm flagged tracks show warning icon and amber styling in portal
- [ ] Verify clicking warning icon opens ATProto record in new tab
- [ ] Check that non-flagged and unscanned tracks render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)