### PR TITLE
fix: auth and CI for moderation service

### DIFF
--- a/.github/workflows/deploy-moderation.yml
+++ b/.github/workflows/deploy-moderation.yml
@@ -1,0 +1,30 @@
+name: deploy moderation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "moderation/src/**"
+      - "moderation/Cargo.toml"
+      - "moderation/Cargo.lock"
+      - "moderation/Dockerfile"
+      - "moderation/fly.toml"
+      - ".github/workflows/deploy-moderation.yml"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: deploy moderation
+    runs-on: ubuntu-latest
+    concurrency: deploy-moderation
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: deploy to fly.io
+        run: flyctl deploy --config moderation/fly.toml --remote-only -a plyr-moderation
+        working-directory: moderation
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_MODERATION }}

--- a/moderation/src/auth.rs
+++ b/moderation/src/auth.rs
@@ -12,16 +12,18 @@ pub async fn auth_middleware(
     let path = req.uri().path();
 
     // Public endpoints - no auth required
+    // Note: /admin serves HTML, auth is handled client-side for API calls
     if path == "/"
         || path == "/health"
+        || path == "/admin"
         || path.starts_with("/xrpc/com.atproto.label.")
     {
         return Ok(next.run(req).await);
     }
 
     let Some(expected_token) = auth_token else {
-        warn!("no MODERATION_AUTH_TOKEN set - accepting all requests");
-        return Ok(next.run(req).await);
+        warn!("no MODERATION_AUTH_TOKEN set - rejecting protected request");
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
     };
 
     let token = req


### PR DESCRIPTION
## Summary

- **Security fix**: reject protected requests if `MODERATION_AUTH_TOKEN` not set (was accepting all)
- **Auth fix**: make `/admin` public so HTML page loads (auth is handled client-side for API calls)
- **CI**: add workflow to auto-deploy moderation service on push to main when `moderation/**` changes

## Setup required

Need to add `FLY_API_TOKEN_MODERATION` secret in GitHub repo settings for CI to work.

## Test plan

- [ ] merge PR
- [ ] verify CI workflow runs and deploys
- [ ] visit https://moderation.plyr.fm/admin - should show login page
- [ ] authenticate with token - should show flagged tracks list

🤖 Generated with [Claude Code](https://claude.com/claude-code)