### PR TITLE
fix: allow public access to static files in moderation service

### DIFF
--- a/moderation/src/auth.rs
+++ b/moderation/src/auth.rs
@@ -13,9 +13,11 @@ pub async fn auth_middleware(
 
     // Public endpoints - no auth required
     // Note: /admin serves HTML, auth is handled client-side for API calls
+    // Static files must be public for admin UI CSS/JS to load
     if path == "/"
         || path == "/health"
         || path == "/admin"
+        || path.starts_with("/static/")
         || path.starts_with("/xrpc/com.atproto.label.")
     {
         return Ok(next.run(req).await);


### PR DESCRIPTION
## Summary
- Static files (/static/*) were returning 401 because auth middleware wasn't allowing them
- Admin UI CSS/JS couldn't load, breaking the styling

## Test plan
- [ ] Verify https://moderation.plyr.fm/static/admin.css returns 200 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)