### PR TITLE
fix: moderation admin UI polish

### DIFF
--- a/moderation/static/admin.css
+++ b/moderation/static/admin.css
@@ -210,6 +210,13 @@ h1 {
     color: var(--error);
 }
 
+.badge.env {
+    background: rgba(139, 92, 246, 0.15);
+    color: #a78bfa;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
 /* matches section */
 .matches {
     background: var(--bg-primary);
@@ -314,6 +321,15 @@ h1 {
 }
 .htmx-request.htmx-indicator {
     opacity: 1;
+}
+
+/* refresh button with inline indicator */
+.btn-secondary .htmx-indicator {
+    display: none;
+    margin-right: 6px;
+}
+.btn-secondary.htmx-request .htmx-indicator {
+    display: inline;
 }
 
 /* mobile */

--- a/moderation/static/admin.html
+++ b/moderation/static/admin.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>moderation · plyr.fm</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🛡️</text></svg>">
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
     <link rel="stylesheet" href="/static/admin.css">
 </head>

--- a/moderation/static/admin.js
+++ b/moderation/static/admin.js
@@ -1,16 +1,27 @@
+// Set up auth header listener first (before any htmx requests)
+let currentToken = null;
+
+document.body.addEventListener('htmx:configRequest', function(evt) {
+    if (currentToken) {
+        evt.detail.headers['X-Moderation-Key'] = currentToken;
+    }
+});
+
 // Check for saved token on load
 const savedToken = localStorage.getItem('mod_token');
 if (savedToken) {
     document.getElementById('auth-token').value = '••••••••';
+    currentToken = savedToken;
     showMain();
-    setAuthHeader(savedToken);
+    // Trigger load after DOM is ready and htmx is initialized
+    setTimeout(() => htmx.trigger('#flags-list', 'load'), 0);
 }
 
 function authenticate() {
     const token = document.getElementById('auth-token').value;
     if (token && token !== '••••••••') {
         localStorage.setItem('mod_token', token);
-        setAuthHeader(token);
+        currentToken = token;
         showMain();
         htmx.trigger('#flags-list', 'load');
     }
@@ -20,16 +31,11 @@ function showMain() {
     document.getElementById('main-content').style.display = 'block';
 }
 
-function setAuthHeader(token) {
-    document.body.addEventListener('htmx:configRequest', function(evt) {
-        evt.detail.headers['X-Moderation-Key'] = token;
-    });
-}
-
 // Handle auth errors
 document.body.addEventListener('htmx:responseError', function(evt) {
     if (evt.detail.xhr.status === 401) {
         localStorage.removeItem('mod_token');
+        currentToken = null;
         showToast('invalid token', 'error');
     }
 });


### PR DESCRIPTION
## Summary
- add favicon (shield emoji)
- fix flags list to load automatically on page load with saved token
- fix refresh button indicator styling (hide when not loading)
- add environment badges (dev/stg) for non-production namespace flags

## Changes
- `admin.html`: add inline SVG favicon
- `admin.js`: set up auth header listener before htmx requests, trigger load on saved token
- `admin.css`: fix indicator styling, add env badge style
- `admin.rs`: extract namespace from URI, add env badge for dev/stg flags

## Test plan
- [ ] Verify favicon shows in browser tab
- [ ] Verify flags load automatically when token is saved
- [ ] Verify refresh button text is centered
- [ ] Verify dev/stg flags show purple environment badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)