### PR TITLE
fix: two-phase workflow + temporal context for transcripts

### DIFF
--- a/.github/workflows/status-maintenance.yml
+++ b/.github/workflows/status-maintenance.yml
@@ -1,7 +1,8 @@
 # weekly status maintenance via claude code
 #
-# archives old STATUS.md sections and optionally generates audio overviews.
-# runs every monday or on manual trigger.
+# two-phase workflow:
+# 1. workflow_dispatch: archives old STATUS.md sections, generates audio, opens PR
+# 2. on PR merge: uploads audio to plyr.fm
 #
 # required secrets:
 #   ANTHROPIC_API_KEY - claude code
@@ -20,9 +21,14 @@ on:
         description: "skip audio generation"
         type: boolean
         default: false
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 jobs:
+  # phase 1: archive + generate audio + open PR
   maintain:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -36,42 +42,29 @@ jobs:
 
       - uses: astral-sh/setup-uv@v4
 
-      - name: Create MCP config
-        run: |
-          cat > /tmp/mcp-config.json << 'EOF'
-          {
-            "mcpServers": {
-              "plyrfm": {
-                "command": "uvx",
-                "args": ["plyrfm-mcp"],
-                "env": {
-                  "PLYR_TOKEN": "${{ secrets.PLYR_BOT_TOKEN }}"
-                }
-              }
-            }
-          }
-          EOF
-
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          show_full_output: true
           claude_args: |
-            --allowedTools "Read,Write,Edit,Bash,mcp__plyrfm__list_tracks,mcp__plyrfm__my_tracks,mcp__plyrfm__get_track"
-            --mcp-config /tmp/mcp-config.json
+            --allowedTools "Read,Write,Edit,Bash"
           prompt: |
             you are maintaining the plyr.fm project status file.
 
             ## context
 
-            this may be the first time this workflow has run. handle gracefully:
+            - project started: november 2025
+            - today's date: run `date` to get current date
+            - this may be the first time this workflow has run
             - .status_history/ directory may not exist yet
-            - STATUS.md structure may vary
 
-            you have access to the plyrfm MCP server for interacting with plyr.fm.
-            PLYR_TOKEN is set in the environment for CLI uploads.
+            ## task 1: gather temporal context
 
-            ## task 1: archive old sections (if needed)
+            before writing any transcript, understand the timeline:
+            1. run `git log --oneline --since="1 week ago"` to see recent commits
+            2. run `git log --oneline -20` to see the last 20 commits with dates
+            3. note the actual dates of changes - don't present old work as "just shipped"
+
+            ## task 2: archive old sections (if needed)
 
             read STATUS.md and count the lines.
 
@@ -84,7 +77,7 @@ jobs:
 
             if 500 lines or fewer, skip archiving.
 
-            ## task 2: generate audio overview
+            ## task 3: generate audio overview
 
             skip_audio input: ${{ inputs.skip_audio }}
 
@@ -93,6 +86,12 @@ jobs:
                - two hosts having a casual conversation
                - focus on shipped features from the top of STATUS.md
                - format: "Host: ..." and "Cohost: ..." lines
+
+               temporal awareness:
+               - use the git history to understand WHEN things actually shipped
+               - if this is the first episode, acknowledge the project started in november 2025
+               - reference time correctly: "last week we shipped X" vs "back in november we built Y"
+               - don't present month-old work as if it just happened
 
                tone guidelines:
                - accessible to non-technical listeners, but don't dumb it down
@@ -103,13 +102,13 @@ jobs:
 
             2. run: uv run scripts/generate_tts.py podcast_script.txt update.wav
 
-            3. run: uv run --with plyrfm -- plyrfm upload update.wav "plyr.fm update - <today's date>" --album "$(date +%Y)"
+            3. DO NOT upload to plyr.fm yet - that happens after PR merge
 
-            ## task 3: open PR with changes
+            ## task 4: open PR with changes
 
-            if any files changed (.status_history/*, STATUS.md):
+            if any files changed (.status_history/*, STATUS.md) OR audio was generated:
             1. create a new branch: git checkout -b status-maintenance-<date>
-            2. git add .status_history/ STATUS.md (NOT audio files or temp scripts)
+            2. git add .status_history/ STATUS.md update.wav (include the audio file!)
             3. commit with message "chore: weekly status maintenance"
             4. push the branch: git push -u origin status-maintenance-<date>
             5. create a PR using: gh pr create --title "chore: weekly status maintenance" --body "automated status archival and audio overview"
@@ -118,4 +117,23 @@ jobs:
 
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+
+  # phase 2: upload audio after PR merge
+  upload-audio:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'status-maintenance-')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Upload audio to plyr.fm
+        run: |
+          if [ -f update.wav ]; then
+            uv run --with plyrfm -- plyrfm upload update.wav "plyr.fm update - $(date +'%B %d, %Y')" --album "$(date +%Y)"
+          else
+            echo "No update.wav found, skipping upload"
+          fi
+        env:
           PLYR_TOKEN: ${{ secrets.PLYR_BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- Split workflow into two phases:
  1. **workflow_dispatch**: archive STATUS.md, generate audio, open PR with audio file included
  2. **on PR merge**: upload audio to plyr.fm
- Add temporal awareness for transcript generation:
  - Check git history for actual commit dates before writing script
  - Reference project start (november 2025)
  - Don't present old work as "just shipped"
- Remove `show_full_output` (no longer debugging)
- Remove MCP config (not needed since upload happens in separate job)

## Why
Previously, audio was uploaded immediately before PR review. Now you can review the PR (and listen to the audio) before it goes live.

## Test plan
- [ ] Run workflow_dispatch
- [ ] Verify PR includes update.wav
- [ ] Merge PR and verify upload-audio job runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)