### PR TITLE
fix: restore STATUS.md intro + clean up podcast script

### DIFF
--- a/.github/workflows/status-maintenance.yml
+++ b/.github/workflows/status-maintenance.yml
@@ -86,6 +86,7 @@ jobs:
                - two hosts having a casual conversation
                - focus on shipped features from the top of STATUS.md
                - format: "Host: ..." and "Cohost: ..." lines
+               - IMPORTANT: "plyr.fm" is pronounced "player FM" (not "plir" or spelling it out)
 
                temporal awareness:
                - use the git history to understand WHEN things actually shipped
@@ -102,13 +103,15 @@ jobs:
 
             2. run: uv run scripts/generate_tts.py podcast_script.txt update.wav
 
-            3. DO NOT upload to plyr.fm yet - that happens after PR merge
+            3. delete the podcast script (we only need the audio): rm podcast_script.txt
+
+            4. DO NOT upload to plyr.fm yet - that happens after PR merge
 
             ## task 4: open PR with changes
 
             if any files changed (.status_history/*, STATUS.md) OR audio was generated:
             1. create a new branch: git checkout -b status-maintenance-<date>
-            2. git add .status_history/ STATUS.md update.wav (include the audio file!)
+            2. git add .status_history/ STATUS.md update.wav (do NOT add podcast_script.txt)
             3. commit with message "chore: weekly status maintenance"
             4. push the branch: git push -u origin status-maintenance-<date>
             5. create a PR using: gh pr create --title "chore: weekly status maintenance" --body "automated status archival and audio overview"

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,3 +1,46 @@
+# plyr.fm - status
+
+## long-term vision
+
+### the problem
+
+today's music streaming is fundamentally broken:
+- spotify and apple music trap your data in proprietary silos
+- artists pay distribution fees and streaming cuts to multiple gatekeepers
+- listeners can't own their music collections - they rent them
+- switching platforms means losing everything: playlists, play history, social connections
+
+### the atproto solution
+
+plyr.fm is built on the AT Protocol (the protocol powering Bluesky) and enables:
+- **portable identity**: your music collection, playlists, and listening history belong to you, stored in your personal data server (PDS)
+- **decentralized distribution**: artists publish directly to the network without platform gatekeepers
+- **interoperable data**: any client can read your music records - you're not locked into plyr.fm
+- **authentic social**: artist profiles are real ATProto identities with verifiable handles (@artist.bsky.social)
+
+### the dream state
+
+plyr.fm should become:
+
+1. **for artists**: the easiest way to publish music to the decentralized web
+   - upload once, available everywhere in the ATProto network
+   - direct connection to listeners without platform intermediaries
+   - real ownership of audience relationships
+
+2. **for listeners**: a streaming platform where you actually own your data
+   - your collection lives in your PDS, playable by any ATProto music client
+   - switch between plyr.fm and other clients freely - your data travels with you
+   - share tracks as native ATProto posts to Bluesky
+
+3. **for developers**: a reference implementation showing how to build on ATProto
+   - open source end-to-end example of ATProto integration
+   - demonstrates OAuth, record creation, federation patterns
+   - proves decentralized music streaming is viable
+
+---
+
+## recent work
+
 ### ATProto labeler and admin UI improvements (PRs #385-395, Nov 29-Dec 1, 2025)
 
 **motivation**: integrate with ATProto labeling protocol for proper copyright violation signaling, and improve admin tooling for reviewing flagged content.


### PR DESCRIPTION
## Summary
- Restore long-term vision section to STATUS.md (silo problem, ATProto solution, dream state)
- Add `## recent work` header to separate vision from updates
- Update workflow to delete `podcast_script.txt` after TTS generation

## Changes
- **STATUS.md**: Added back the intro that was lost when we started tracking it again
- **status-maintenance.yml**: Added step 3 to `rm podcast_script.txt` after generating audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)