### PR TITLE
fix: multi-step confirmation for false positive resolution

### DIFF
--- a/moderation/src/admin.rs
+++ b/moderation/src/admin.rs
@@ -337,37 +337,12 @@ fn render_flag_card(track: &FlaggedTrack) -> String {
             notes_text, reason_text
         )
     } else {
+        // Multi-step flow: button -> reason select -> confirm
         format!(
-            r#"<div class="resolve-dropdown">
-                <button type="button" class="btn btn-warning dropdown-toggle" onclick="toggleDropdown(this)">
+            r#"<div class="resolve-flow" data-uri="{}" data-val="{}">
+                <button type="button" class="btn btn-warning" onclick="showReasonSelect(this)">
                     mark false positive
                 </button>
-                <div class="dropdown-menu">
-                    <form hx-post="/admin/resolve-htmx" hx-swap="none">
-                        <input type="hidden" name="uri" value="{}">
-                        <input type="hidden" name="val" value="{}">
-                        <button type="submit" name="reason" value="original_artist" class="dropdown-item">
-                            original artist
-                            <span class="item-desc">artist uploaded their own work</span>
-                        </button>
-                        <button type="submit" name="reason" value="licensed" class="dropdown-item">
-                            licensed
-                            <span class="item-desc">has rights/permission</span>
-                        </button>
-                        <button type="submit" name="reason" value="fingerprint_noise" class="dropdown-item">
-                            fingerprint noise
-                            <span class="item-desc">matcher false positive</span>
-                        </button>
-                        <button type="submit" name="reason" value="cover_version" class="dropdown-item">
-                            cover/remix
-                            <span class="item-desc">legal derivative work</span>
-                        </button>
-                        <button type="submit" name="reason" value="other" class="dropdown-item">
-                            other
-                            <span class="item-desc">see notes</span>
-                        </button>
-                    </form>
-                </div>
             </div>"#,
             html_escape(&track.uri),
             html_escape(&track.val)

--- a/moderation/static/admin.css
+++ b/moderation/static/admin.css
@@ -275,64 +275,79 @@ h1 {
     cursor: help;
 }
 
-/* dropdown for reason selection */
-.resolve-dropdown {
-    position: relative;
-    display: inline-block;
-}
-
-.dropdown-toggle::after {
-    content: ' ▼';
-    font-size: 0.7em;
-}
-
-.dropdown-menu {
-    display: none;
-    position: absolute;
-    right: 0;
-    bottom: 100%;
-    margin-bottom: 4px;
-    background: var(--bg-tertiary);
-    border: 1px solid var(--border-default);
-    border-radius: 8px;
-    min-width: 220px;
-    z-index: 100;
-    box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.4);
-    overflow: hidden;
-}
-
-.resolve-dropdown.open .dropdown-menu {
-    display: block;
-}
-
-.dropdown-item {
+/* multi-step resolve flow */
+.resolve-flow {
     display: flex;
-    flex-direction: column;
-    width: 100%;
-    padding: 12px 16px;
-    background: transparent;
-    border: none;
-    border-bottom: 1px solid var(--border-subtle);
-    color: var(--text-primary);
+    gap: 8px;
+    align-items: center;
+}
+
+/* reason selection (step 2) */
+.reason-select {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.reason-btn {
     font-family: inherit;
-    font-size: 0.85rem;
-    text-align: left;
+    font-size: 0.8rem;
+    padding: 6px 12px;
+    border-radius: 4px;
+    border: 1px solid var(--border-default);
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
     cursor: pointer;
-    transition: background 0.1s ease;
+    transition: all 0.15s ease;
 }
 
-.dropdown-item:last-child {
-    border-bottom: none;
-}
-
-.dropdown-item:hover {
+.reason-btn:hover {
     background: var(--bg-hover);
+    border-color: var(--border-emphasis);
+    color: var(--text-primary);
 }
 
-.dropdown-item .item-desc {
+.reason-btn.selected {
+    background: var(--warning);
+    color: var(--bg-primary);
+    border-color: var(--warning);
+}
+
+.reason-btn.cancel {
+    background: transparent;
+    border-color: var(--border-subtle);
     color: var(--text-muted);
-    font-size: 0.75rem;
-    margin-top: 2px;
+}
+
+.reason-btn.cancel:hover {
+    border-color: var(--error);
+    color: var(--error);
+}
+
+/* confirm step (step 3) */
+.confirm-step {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.confirm-text {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.confirm-text strong {
+    color: var(--warning);
+}
+
+.btn-confirm {
+    background: var(--error);
+    color: white;
+}
+
+.btn-confirm:hover {
+    background: #dc2626;
 }
 
 /* states */


### PR DESCRIPTION
## Summary

Fixes the UX issues from #408 - the previous dropdown was always visible and allowed accidental one-click resolutions.

## New flow

1. `[mark false positive]` - initial button
2. Click → `[original artist] [licensed] [fp noise] [cover/remix] [other] [✕]` - inline reason buttons
3. Click reason → `resolve as **original artist**? [confirm] [cancel]` - confirmation
4. Click confirm → resolves and refreshes

Can cancel at any step to return to the original button.

## Test plan

- [ ] Click "mark false positive" → reason buttons appear inline
- [ ] Click ✕ → returns to original button
- [ ] Click a reason → confirmation prompt appears
- [ ] Click cancel → returns to original button
- [ ] Click confirm → flag resolves, list refreshes, toast shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)