### PR TITLE
fix: define showMain before calling it

### DIFF
--- a/moderation/static/admin.js
+++ b/moderation/static/admin.js
@@ -7,14 +7,8 @@ document.body.addEventListener('htmx:configRequest', function(evt) {
     }
 });
 
-// Check for saved token on load
-const savedToken = localStorage.getItem('mod_token');
-if (savedToken) {
-    document.getElementById('auth-token').value = '••••••••';
-    currentToken = savedToken;
-    showMain();
-    // Trigger load after DOM is ready and htmx is initialized
-    setTimeout(() => htmx.trigger('#flags-list', 'load'), 0);
+function showMain() {
+    document.getElementById('main-content').style.display = 'block';
 }
 
 function authenticate() {
@@ -27,8 +21,14 @@ function authenticate() {
     }
 }
 
-function showMain() {
-    document.getElementById('main-content').style.display = 'block';
+// Check for saved token on load
+const savedToken = localStorage.getItem('mod_token');
+if (savedToken) {
+    document.getElementById('auth-token').value = '••••••••';
+    currentToken = savedToken;
+    showMain();
+    // Trigger load after DOM is ready and htmx is initialized
+    setTimeout(() => htmx.trigger('#flags-list', 'load'), 0);
 }
 
 // Handle auth errors


### PR DESCRIPTION
## Problem

The "mark false positive" button does nothing when clicked - console shows:
```
Uncaught ReferenceError: showReasonSelect is not defined
```

## Root Cause

The JS file was calling `showMain()` on line 15 before the function was defined on line 30. When a user has a saved token in localStorage, this throws a ReferenceError that halts script execution, preventing all subsequent function definitions (including `showReasonSelect`).

## Fix

Move function definitions before the code that calls them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)