### PR TITLE
fix: use URLSearchParams for form submission

### DIFF
--- a/moderation/static/admin.js
+++ b/moderation/static/admin.js
@@ -99,18 +99,19 @@ function confirmResolve(btn, reason) {
     btn.disabled = true;
     btn.textContent = '...';
 
-    // Submit via fetch
-    const formData = new FormData();
-    formData.append('uri', uri);
-    formData.append('val', val);
-    formData.append('reason', reason);
+    // Submit via fetch (URLSearchParams for application/x-www-form-urlencoded)
+    const params = new URLSearchParams();
+    params.append('uri', uri);
+    params.append('val', val);
+    params.append('reason', reason);
 
     fetch('/admin/resolve-htmx', {
         method: 'POST',
         headers: {
-            'X-Moderation-Key': currentToken
+            'X-Moderation-Key': currentToken,
+            'Content-Type': 'application/x-www-form-urlencoded'
         },
-        body: formData
+        body: params
     })
     .then(response => {
         if (response.ok) {


### PR DESCRIPTION
## Problem

Clicking confirm on the false positive resolution gives 415 Unsupported Media Type.

## Cause

`FormData` sends `multipart/form-data`, but axum's `Form` extractor expects `application/x-www-form-urlencoded`.

## Fix

Use `URLSearchParams` instead of `FormData`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)