### PR TITLE
fix: increase connection pool resilience for Neon cold starts

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -144,9 +144,9 @@ class DatabaseSettings(AppSettingsSection):
         description="Timeout in seconds for SQL statement execution. Prevents runaway queries from holding connections indefinitely.",
     )
     connection_timeout: float = Field(
-        default=3.0,
+        default=10.0,
         validation_alias="DATABASE_CONNECTION_TIMEOUT",
-        description="Timeout in seconds for establishing database connections. Fails fast when database is slow or unresponsive.",
+        description="Timeout in seconds for establishing database connections. Set higher than Neon cold start latency (~5-10s) to allow wake-up, but low enough to fail fast on true outages.",
     )
     queue_connect_timeout: float = Field(
         default=15.0,
@@ -155,13 +155,16 @@ class DatabaseSettings(AppSettingsSection):
     )
 
     # connection pool settings
+    # sized to handle Neon cold start scenarios where multiple requests arrive simultaneously
+    # after idle period. with pool_size=10 + max_overflow=5, we can handle 15 concurrent
+    # requests waiting for Neon to wake up without exhausting the pool.
     pool_size: int = Field(
-        default=5,
+        default=10,
         validation_alias="DATABASE_POOL_SIZE",
         description="Number of database connections to keep in the pool at all times.",
     )
     pool_max_overflow: int = Field(
-        default=0,
+        default=5,
         validation_alias="DATABASE_MAX_OVERFLOW",
         description="Maximum connections to create beyond pool_size when pool is exhausted. Total max connections = pool_size + pool_max_overflow.",
     )


### PR DESCRIPTION
## Summary

- increased `pool_size` from 5 → 10 to handle more concurrent cold start requests
- increased `max_overflow` from 0 → 5 for burst capacity (up to 15 total connections)
- increased `connection_timeout` from 3s → 10s to wait for Neon wake-up

## Context

~5 minute API outage (01:55-02:00 UTC on Dec 2) - all requests returned 500 errors.

**Root cause**: Neon serverless cold start after 5 minutes of idle traffic. The first 5 user requests each held a connection waiting for Neon to wake up (3-5 min each), exhausting the pool immediately. All subsequent requests got `QueuePool limit of size 5 overflow 0 reached`.

This is a recurrence of the Nov 17 incident. That fix addressed the queue listener's asyncpg connection timeout, but not the SQLAlchemy pool connections.

## Test plan

- [ ] verify staging deploys successfully
- [ ] simulate cold start scenario (idle → burst traffic)
- [ ] confirm increased pool handles concurrent wake-up requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)