### PR TITLE
docs: note scale to zero disabled for cold start prevention

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -61,6 +61,7 @@ plyr.fm should become:
 - increased `pool_size` from 5 → 10 (handle more concurrent cold start requests)
 - increased `max_overflow` from 0 → 5 (allow burst to 15 connections)
 - increased `connection_timeout` from 3s → 10s (wait for Neon wake-up)
+- disabled scale to zero on production compute (`suspend_timeout_seconds: -1`) to eliminate cold starts entirely
 
 **related**: this is a recurrence of the Nov 17 incident. that fix addressed the queue listener's asyncpg connection but not the SQLAlchemy pool connections.
 


### PR DESCRIPTION
## Summary
- Documents that scale to zero was disabled on production Neon compute to eliminate cold starts

This is a follow-up to #422 - while the pool size changes handle cold starts more gracefully, disabling scale to zero removes the root cause entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)