### PR TITLE
fix: stats position adjusts when queue opens/closes

### DIFF
--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -132,9 +132,10 @@
 
 	.stats-left {
 		position: absolute;
-		left: calc((100vw - 800px) / 4);
+		left: calc((100vw - var(--queue-width, 0px) - 800px) / 4);
 		top: 50%;
 		transform: translate(-50%, -50%);
+		transition: left 0.3s ease;
 	}
 
 	.bluesky-link,

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -69,6 +69,13 @@
 		updateTitle();
 	});
 
+	// set CSS custom property for queue width adjustment
+	$effect(() => {
+		if (!browser) return;
+		const queueWidth = showQueue && !isEmbed ? '360px' : '0px';
+		document.documentElement.style.setProperty('--queue-width', queueWidth);
+	});
+
 	function handleQueueShortcut(event: KeyboardEvent) {
 		// ignore modifier keys
 		if (event.metaKey || event.ctrlKey || event.altKey) {
@@ -223,6 +230,9 @@
 	}
 
 	:global(:root) {
+		/* layout */
+		--queue-width: 0px;
+
 		/* accent colors - configurable */
 		--accent: #6a9fff;
 		--accent-hover: #8ab3ff;


### PR DESCRIPTION
## Summary
- Platform stats in the header now shift left when the queue sidebar opens
- Uses a CSS custom property (`--queue-width`) that updates dynamically with queue visibility
- Includes smooth transition animation matching other header elements

## Test plan
- [ ] Open plyr.fm on desktop (>1300px viewport)
- [ ] Verify stats are visible in the top left corner of the header
- [ ] Toggle the queue with the button or 'Q' key
- [ ] Verify stats shift left along with the bluesky/status icons and don't overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)