### PR TITLE
refactor: centralize preferences loading in layout

### DIFF
--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -1,0 +1,106 @@
+// user preferences state management
+import { browser } from '$app/environment';
+import { API_URL } from '$lib/config';
+import { auth } from '$lib/auth.svelte';
+
+export interface Preferences {
+	accent_color: string | null;
+	auto_advance: boolean;
+	allow_comments: boolean;
+	hidden_tags: string[];
+}
+
+const DEFAULT_PREFERENCES: Preferences = {
+	accent_color: null,
+	auto_advance: true,
+	allow_comments: true,
+	hidden_tags: ['ai']
+};
+
+class PreferencesManager {
+	data = $state<Preferences | null>(null);
+	loading = $state(false);
+	private initialized = false;
+
+	get loaded(): boolean {
+		return this.data !== null;
+	}
+
+	get hiddenTags(): string[] {
+		return this.data?.hidden_tags ?? DEFAULT_PREFERENCES.hidden_tags;
+	}
+
+	get accentColor(): string | null {
+		return this.data?.accent_color ?? null;
+	}
+
+	get autoAdvance(): boolean {
+		return this.data?.auto_advance ?? DEFAULT_PREFERENCES.auto_advance;
+	}
+
+	get allowComments(): boolean {
+		return this.data?.allow_comments ?? DEFAULT_PREFERENCES.allow_comments;
+	}
+
+	async initialize(): Promise<void> {
+		if (!browser || this.initialized || this.loading) return;
+		this.initialized = true;
+		await this.fetch();
+	}
+
+	async fetch(): Promise<void> {
+		if (!browser || !auth.isAuthenticated) return;
+
+		this.loading = true;
+		try {
+			const response = await fetch(`${API_URL}/preferences/`, {
+				credentials: 'include'
+			});
+			if (response.ok) {
+				const data = await response.json();
+				this.data = {
+					accent_color: data.accent_color ?? null,
+					auto_advance: data.auto_advance ?? DEFAULT_PREFERENCES.auto_advance,
+					allow_comments: data.allow_comments ?? DEFAULT_PREFERENCES.allow_comments,
+					hidden_tags: data.hidden_tags ?? DEFAULT_PREFERENCES.hidden_tags
+				};
+			} else {
+				this.data = { ...DEFAULT_PREFERENCES };
+			}
+		} catch (error) {
+			console.error('failed to fetch preferences:', error);
+			this.data = { ...DEFAULT_PREFERENCES };
+		} finally {
+			this.loading = false;
+		}
+	}
+
+	async update(updates: Partial<Preferences>): Promise<void> {
+		if (!browser || !auth.isAuthenticated) return;
+
+		// optimistic update
+		if (this.data) {
+			this.data = { ...this.data, ...updates };
+		}
+
+		try {
+			await fetch(`${API_URL}/preferences/`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				credentials: 'include',
+				body: JSON.stringify(updates)
+			});
+		} catch (error) {
+			console.error('failed to save preferences:', error);
+			// revert on error by refetching
+			await this.fetch();
+		}
+	}
+
+	clear(): void {
+		this.data = null;
+		this.initialized = false;
+	}
+}
+
+export const preferences = new PreferencesManager();

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
 	import { page } from '$app/stores';
 	import { afterNavigate } from '$app/navigation';
 	import { auth } from '$lib/auth.svelte';
+	import { preferences } from '$lib/preferences.svelte';
 	import { player } from '$lib/player.svelte';
 	import { browser } from '$app/environment';
 	import type { LayoutData } from './$types';
@@ -30,12 +31,13 @@
 
 	let isEmbed = $derived($page.url.pathname.startsWith('/embed/'));
 
-	// sync auth state from layout data (fetched by +layout.ts)
+	// sync auth and preferences state from layout data (fetched by +layout.ts)
 	$effect(() => {
 		if (browser) {
 			auth.user = data.user;
 			auth.isAuthenticated = data.isAuthenticated;
 			auth.loading = false;
+			preferences.data = data.preferences;
 		}
 	});
 

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,18 +1,28 @@
 import { browser } from '$app/environment';
 import { API_URL } from '$lib/config';
 import type { User } from '$lib/types';
+import type { Preferences } from '$lib/preferences.svelte';
 import type { LoadEvent } from '@sveltejs/kit';
 
 export interface LayoutData {
 	user: User | null;
 	isAuthenticated: boolean;
+	preferences: Preferences | null;
 }
+
+const DEFAULT_PREFERENCES: Preferences = {
+	accent_color: null,
+	auto_advance: true,
+	allow_comments: true,
+	hidden_tags: ['ai']
+};
 
 export async function load({ fetch }: LoadEvent): Promise<LayoutData> {
 	if (!browser) {
 		return {
 			user: null,
-			isAuthenticated: false
+			isAuthenticated: false,
+			preferences: null
 		};
 	}
 
@@ -23,9 +33,30 @@ export async function load({ fetch }: LoadEvent): Promise<LayoutData> {
 
 		if (response.ok) {
 			const user = await response.json();
+
+			// fetch preferences in parallel once we know user is authenticated
+			let preferences: Preferences = { ...DEFAULT_PREFERENCES };
+			try {
+				const prefsResponse = await fetch(`${API_URL}/preferences/`, {
+					credentials: 'include'
+				});
+				if (prefsResponse.ok) {
+					const data = await prefsResponse.json();
+					preferences = {
+						accent_color: data.accent_color ?? null,
+						auto_advance: data.auto_advance ?? true,
+						allow_comments: data.allow_comments ?? true,
+						hidden_tags: data.hidden_tags ?? ['ai']
+					};
+				}
+			} catch (e) {
+				console.error('preferences fetch failed:', e);
+			}
+
 			return {
 				user,
-				isAuthenticated: true
+				isAuthenticated: true,
+				preferences
 			};
 		}
 	} catch (e) {
@@ -34,6 +65,7 @@ export async function load({ fetch }: LoadEvent): Promise<LayoutData> {
 
 	return {
 		user: null,
-		isAuthenticated: false
+		isAuthenticated: false,
+		preferences: null
 	};
 }


### PR DESCRIPTION
## Summary
- Creates centralized `preferences.svelte.ts` store following the same pattern as `auth.svelte.ts`
- Loads preferences in `+layout.ts` alongside auth check, so data is available before render
- Updates all components (HiddenTagsFilter, SettingsMenu, ColorSettings, portal page) to derive from the store instead of fetching independently

## Problem
The HiddenTagsFilter eye icon was showing incorrect state (uncrossed) briefly before preferences loaded, causing a visual flash. This was because each component was fetching preferences independently after mount.

## Solution
Following the pattern from PR #210 (centralize auth and improve data loading), preferences are now:
1. Fetched once in the layout loader alongside auth
2. Synced to a central store in `+layout.svelte`
3. Derived by components using `$derived()` runes

This ensures preferences are available immediately when components render, eliminating the flash.

## Test plan
- [ ] Verify eye icon in HiddenTagsFilter shows correct state on page load
- [ ] Verify accent color persists across page reloads
- [ ] Verify auto-advance setting persists
- [ ] Verify allow_comments toggle works in portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)