### PR TITLE
fix: move filter icon inline with heading and cache stats

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -76,7 +76,6 @@ plyr.fm should become:
 - increased `pool_size` from 5 → 10 (handle more concurrent cold start requests)
 - increased `max_overflow` from 0 → 5 (allow burst to 15 connections)
 - increased `connection_timeout` from 3s → 10s (wait for Neon wake-up)
-- disabled scale to zero on production compute (`suspend_timeout_seconds: -1`) to eliminate cold starts entirely
 
 **related**: this is a recurrence of the Nov 17 incident. that fix addressed the queue listener's asyncpg connection but not the SQLAlchemy pool connections.
 

--- a/frontend/src/lib/components/HiddenTagsFilter.svelte
+++ b/frontend/src/lib/components/HiddenTagsFilter.svelte
@@ -128,7 +128,6 @@
 		align-items: center;
 		gap: 0.5rem;
 		flex-wrap: wrap;
-		padding: 0 0 0.5rem;
 		font-size: 0.8rem;
 	}
 

--- a/frontend/src/lib/components/PlatformStats.svelte
+++ b/frontend/src/lib/components/PlatformStats.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { API_URL } from '$lib/config';
+	import { statsCache } from '$lib/stats.svelte';
 
 	interface Props {
 		variant?: 'header' | 'menu';
@@ -8,34 +8,16 @@
 
 	let { variant = 'header' }: Props = $props();
 
-	interface Stats {
-		total_plays: number;
-		total_tracks: number;
-		total_artists: number;
-	}
-
-	let stats = $state<Stats | null>(null);
-	let loading = $state(true);
+	// derive from cache
+	let stats = $derived(statsCache.stats);
+	let loading = $derived(statsCache.loading && !stats);
 
 	function pluralize(count: number, singular: string, plural: string): string {
 		return count === 1 ? singular : plural;
 	}
 
-	async function loadStats() {
-		try {
-			const response = await fetch(`${API_URL}/stats`);
-			if (response.ok) {
-				stats = await response.json();
-			}
-		} catch (e) {
-			console.error('failed to load platform stats:', e);
-		} finally {
-			loading = false;
-		}
-	}
-
 	onMount(() => {
-		loadStats();
+		statsCache.fetch();
 	});
 </script>
 

--- a/frontend/src/lib/stats.svelte.ts
+++ b/frontend/src/lib/stats.svelte.ts
@@ -1,0 +1,45 @@
+// platform stats cache - prevents refetching on navigation
+import { browser } from '$app/environment';
+import { API_URL } from '$lib/config';
+
+export interface PlatformStats {
+	total_plays: number;
+	total_tracks: number;
+	total_artists: number;
+}
+
+class StatsCache {
+	data = $state<PlatformStats | null>(null);
+	loading = $state(false);
+	private lastFetch = 0;
+	private readonly CACHE_DURATION = 60_000; // 1 minute
+
+	get stats(): PlatformStats | null {
+		return this.data;
+	}
+
+	async fetch(force = false): Promise<void> {
+		if (!browser) return;
+
+		const now = Date.now();
+		const isCacheValid = this.data && now - this.lastFetch < this.CACHE_DURATION;
+
+		if (!force && isCacheValid) return;
+		if (this.loading) return;
+
+		this.loading = true;
+		try {
+			const response = await fetch(`${API_URL}/stats`);
+			if (response.ok) {
+				this.data = await response.json();
+				this.lastFetch = now;
+			}
+		} catch (e) {
+			console.error('failed to load platform stats:', e);
+		} finally {
+			this.loading = false;
+		}
+	}
+}
+
+export const statsCache = new StatsCache();

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -73,23 +73,25 @@
 
 <main>
 		<section class="tracks">
-		<h2>
-			<button
-				type="button"
-				class="clickable-heading"
-				onclick={refreshTracks}
-				onkeydown={(event) => {
-					if (event.key === 'Enter' || event.key === ' ') {
-						event.preventDefault();
-						refreshTracks();
-					}
-				}}
-				title="click to refresh"
-			>
-				latest tracks
-			</button>
-		</h2>
-		<HiddenTagsFilter />
+		<div class="section-header">
+			<h2>
+				<button
+					type="button"
+					class="clickable-heading"
+					onclick={refreshTracks}
+					onkeydown={(event) => {
+						if (event.key === 'Enter' || event.key === ' ') {
+							event.preventDefault();
+							refreshTracks();
+						}
+					}}
+					title="click to refresh"
+				>
+					latest tracks
+				</button>
+			</h2>
+			<HiddenTagsFilter />
+		</div>
 		{#if showLoading}
 			<div class="loading-container">
 				<WaveLoading size="lg" message="loading tracks..." />
@@ -125,9 +127,17 @@
 		padding: 0 1rem calc(var(--player-height, 120px) + env(safe-area-inset-bottom, 0px));
 	}
 
+	.section-header {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		margin-bottom: 1.5rem;
+		flex-wrap: wrap;
+	}
+
 	.tracks h2 {
 		font-size: var(--text-page-heading);
-		margin-bottom: 1.5rem;
+		margin: 0;
 		color: var(--text-primary);
 	}
 


### PR DESCRIPTION
## Summary
- Move HiddenTagsFilter to be inline with "latest tracks" heading instead of underneath it
- Create `stats.svelte.ts` cache to prevent stats from refetching when navigating

## Problems
1. The eye icon (HiddenTagsFilter) was sitting below the "latest tracks" heading, which looked awkward on mobile - it interrupted the start of the track list
2. Stats in the header were flickering/reloading when navigating between home and liked pages

## Solutions
1. Wrap heading and filter in a flex container so they're on the same line
2. Create a stats cache with 1-minute TTL so stats persist across navigation

## Test plan
- [ ] Verify eye icon appears inline with "latest tracks" heading
- [ ] Verify stats don't flicker when navigating between home and liked pages
- [ ] Verify tag filter still expands correctly when clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)