### PR TITLE
feat: add light/dark theme support with CSS variables

### DIFF
--- a/docs/frontend/keyboard-shortcuts.md
+++ b/docs/frontend/keyboard-shortcuts.md
@@ -10,7 +10,7 @@ shortcuts are handled in the root layout (`frontend/src/routes/+layout.svelte`) 
 
 ### Q - toggle queue
 
-**location**: `frontend/src/routes/+layout.svelte:27-48`
+**location**: `frontend/src/routes/+layout.svelte`
 
 toggles the queue sidebar visibility.
 
@@ -79,6 +79,7 @@ potential shortcuts to consider:
 - **shift + arrow** - navigate queue
 - **/** - focus search (common pattern)
 - **esc** - close overlays/modals
+- **T** - cycle theme (dark/light/system)
 
 ## design principles
 

--- a/frontend/src/lib/components/AlbumSelect.svelte
+++ b/frontend/src/lib/components/AlbumSelect.svelte
@@ -100,10 +100,10 @@
 	.album-input {
 		width: 100%;
 		padding: 0.75rem;
-		background: #0a0a0a;
-		border: 1px solid #333;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
-		color: white;
+		color: var(--text-primary);
 		font-size: 1rem;
 		font-family: inherit;
 		transition: all 0.2s;
@@ -111,7 +111,7 @@
 
 	.album-input:focus {
 		outline: none;
-		border-color: #3a7dff;
+		border-color: var(--accent);
 	}
 
 	.album-input:disabled {
@@ -125,8 +125,8 @@
 		width: 100%;
 		max-height: 300px;
 		overflow-y: auto;
-		background: #1a1a1a;
-		border: 1px solid #333;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
 		margin-top: 0.25rem;
 		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
@@ -138,23 +138,23 @@
 	}
 
 	.album-results::-webkit-scrollbar-track {
-		background: #0a0a0a;
+		background: var(--bg-primary);
 		border-radius: 4px;
 	}
 
 	.album-results::-webkit-scrollbar-thumb {
-		background: #333;
+		background: var(--border-default);
 		border-radius: 4px;
 	}
 
 	.album-results::-webkit-scrollbar-thumb:hover {
-		background: #444;
+		background: var(--border-emphasis);
 	}
 
 	/* firefox scrollbar */
 	.album-results {
 		scrollbar-width: thin;
-		scrollbar-color: #333 #0a0a0a;
+		scrollbar-color: var(--border-default) var(--bg-primary);
 	}
 
 	.album-result-item {
@@ -165,8 +165,8 @@
 		padding: 0.75rem;
 		background: transparent;
 		border: none;
-		border-bottom: 1px solid #2a2a2a;
-		color: white;
+		border-bottom: 1px solid var(--border-subtle);
+		color: var(--text-primary);
 		text-align: left;
 		font-family: inherit;
 		cursor: pointer;
@@ -179,12 +179,12 @@
 	}
 
 	.album-result-item:hover {
-		background: #222;
+		background: var(--bg-hover);
 	}
 
 	.album-result-item.exact-match {
-		background: rgba(58, 125, 255, 0.1);
-		border-left: 3px solid #3a7dff;
+		background: color-mix(in srgb, var(--accent) 10%, transparent);
+		border-left: 3px solid var(--accent);
 	}
 
 	.album-info {
@@ -195,7 +195,7 @@
 
 	.album-title {
 		font-weight: 500;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		margin-bottom: 0.125rem;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -204,7 +204,7 @@
 
 	.album-stats {
 		font-size: 0.85rem;
-		color: #888;
+		color: var(--text-tertiary);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -213,7 +213,7 @@
 	.similar-hint {
 		margin-top: 0.5rem;
 		font-size: 0.85rem;
-		color: #ff9800;
+		color: var(--warning);
 		font-style: italic;
 		margin-bottom: 0;
 	}

--- a/frontend/src/lib/components/BrokenTracks.svelte
+++ b/frontend/src/lib/components/BrokenTracks.svelte
@@ -192,8 +192,8 @@
 
 	.broken-tracks-section {
 		margin-bottom: 3rem;
-		background: rgba(255, 152, 0, 0.05);
-		border: 1px solid rgba(255, 152, 0, 0.2);
+		background: color-mix(in srgb, var(--warning) 5%, transparent);
+		border: 1px solid color-mix(in srgb, var(--warning) 20%, transparent);
 		border-radius: 8px;
 		padding: 1.5rem;
 	}
@@ -215,15 +215,15 @@
 	.section-header h2 {
 		font-size: 1.5rem;
 		margin: 0;
-		color: #ff9800;
+		color: var(--warning);
 	}
 
 	.restore-all-btn {
 		padding: 0.5rem 1rem;
-		background: rgba(255, 152, 0, 0.2);
-		border: 1px solid rgba(255, 152, 0, 0.5);
+		background: color-mix(in srgb, var(--warning) 20%, transparent);
+		border: 1px solid color-mix(in srgb, var(--warning) 50%, transparent);
 		border-radius: 4px;
-		color: #ff9800;
+		color: var(--warning);
 		font-family: inherit;
 		font-size: 0.9rem;
 		font-weight: 600;
@@ -233,8 +233,8 @@
 	}
 
 	.restore-all-btn:hover:not(:disabled) {
-		background: rgba(255, 152, 0, 0.3);
-		border-color: #ff9800;
+		background: color-mix(in srgb, var(--warning) 30%, transparent);
+		border-color: var(--warning);
 		transform: translateY(-1px);
 	}
 
@@ -245,8 +245,8 @@
 	}
 
 	.count-badge {
-		background: rgba(255, 152, 0, 0.2);
-		color: #ff9800;
+		background: color-mix(in srgb, var(--warning) 20%, transparent);
+		color: var(--warning);
 		padding: 0.25rem 0.6rem;
 		border-radius: 12px;
 		font-size: 0.85rem;
@@ -261,8 +261,8 @@
 	}
 
 	.broken-track-item {
-		background: #1a1a1a;
-		border: 1px solid rgba(255, 152, 0, 0.3);
+		background: var(--bg-tertiary);
+		border: 1px solid color-mix(in srgb, var(--warning) 30%, transparent);
 		border-radius: 6px;
 		padding: 1rem;
 		display: flex;
@@ -293,26 +293,26 @@
 		font-weight: 600;
 		font-size: 1rem;
 		margin-bottom: 0.25rem;
-		color: #fff;
+		color: var(--text-primary);
 	}
 
 	.track-meta {
 		font-size: 0.9rem;
-		color: #aaa;
+		color: var(--text-secondary);
 		margin-bottom: 0.5rem;
 	}
 
 	.issue-description {
 		font-size: 0.85rem;
-		color: #ff9800;
+		color: var(--warning);
 	}
 
 	.restore-btn {
 		padding: 0.5rem 1rem;
-		background: rgba(255, 152, 0, 0.15);
-		border: 1px solid rgba(255, 152, 0, 0.4);
+		background: color-mix(in srgb, var(--warning) 15%, transparent);
+		border: 1px solid color-mix(in srgb, var(--warning) 40%, transparent);
 		border-radius: 4px;
-		color: #ff9800;
+		color: var(--warning);
 		font-family: inherit;
 		font-size: 0.9rem;
 		font-weight: 500;
@@ -323,8 +323,8 @@
 	}
 
 	.restore-btn:hover:not(:disabled) {
-		background: rgba(255, 152, 0, 0.25);
-		border-color: #ff9800;
+		background: color-mix(in srgb, var(--warning) 25%, transparent);
+		border-color: var(--warning);
 		transform: translateY(-1px);
 	}
 
@@ -335,17 +335,17 @@
 	}
 
 	.info-box {
-		background: #0a0a0a;
-		border: 1px solid #2a2a2a;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-subtle);
 		border-radius: 6px;
 		padding: 1rem;
 		font-size: 0.9rem;
-		color: #aaa;
+		color: var(--text-secondary);
 	}
 
 	.info-box strong {
 		display: block;
-		color: #ff9800;
+		color: var(--warning);
 		margin-bottom: 0.5rem;
 	}
 

--- a/frontend/src/lib/components/HandleAutocomplete.svelte
+++ b/frontend/src/lib/components/HandleAutocomplete.svelte
@@ -126,10 +126,10 @@
 	.input-wrapper input {
 		width: 100%;
 		padding: 0.75rem;
-		background: #0a0a0a;
-		border: 1px solid #333;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
-		color: white;
+		color: var(--text-primary);
 		font-size: 1rem;
 		font-family: inherit;
 		transition: border-color 0.2s;
@@ -138,7 +138,7 @@
 
 	.input-wrapper input:focus {
 		outline: none;
-		border-color: var(--accent, #3a7dff);
+		border-color: var(--accent);
 	}
 
 	.input-wrapper input:disabled {
@@ -147,7 +147,7 @@
 	}
 
 	.input-wrapper input::placeholder {
-		color: #666;
+		color: var(--text-muted);
 	}
 
 	.spinner {
@@ -155,7 +155,7 @@
 		right: 0.75rem;
 		top: 50%;
 		transform: translateY(-50%);
-		color: #666;
+		color: var(--text-muted);
 		font-size: 0.85rem;
 	}
 
@@ -165,13 +165,13 @@
 		width: 100%;
 		max-height: 240px;
 		overflow-y: auto;
-		background: #1a1a1a;
-		border: 1px solid #333;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
 		margin-top: 0.25rem;
 		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
 		scrollbar-width: thin;
-		scrollbar-color: #333 #0a0a0a;
+		scrollbar-color: var(--border-default) var(--bg-primary);
 	}
 
 	.results::-webkit-scrollbar {
@@ -179,17 +179,17 @@
 	}
 
 	.results::-webkit-scrollbar-track {
-		background: #0a0a0a;
+		background: var(--bg-primary);
 		border-radius: 4px;
 	}
 
 	.results::-webkit-scrollbar-thumb {
-		background: #333;
+		background: var(--border-default);
 		border-radius: 4px;
 	}
 
 	.results::-webkit-scrollbar-thumb:hover {
-		background: #444;
+		background: var(--border-emphasis);
 	}
 
 	.result-item {
@@ -200,8 +200,8 @@
 		padding: 0.75rem;
 		background: transparent;
 		border: none;
-		border-bottom: 1px solid #2a2a2a;
-		color: white;
+		border-bottom: 1px solid var(--border-subtle);
+		color: var(--text-primary);
 		text-align: left;
 		font-family: inherit;
 		cursor: pointer;
@@ -213,7 +213,7 @@
 	}
 
 	.result-item:hover {
-		background: #222;
+		background: var(--bg-hover);
 	}
 
 	.avatar {
@@ -221,7 +221,7 @@
 		height: 36px;
 		border-radius: 50%;
 		object-fit: cover;
-		border: 2px solid #333;
+		border: 2px solid var(--border-default);
 		flex-shrink: 0;
 	}
 
@@ -229,7 +229,7 @@
 		width: 36px;
 		height: 36px;
 		border-radius: 50%;
-		background: #333;
+		background: var(--border-default);
 		flex-shrink: 0;
 	}
 
@@ -241,7 +241,7 @@
 
 	.display-name {
 		font-weight: 500;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		margin-bottom: 0.125rem;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -250,7 +250,7 @@
 
 	.handle {
 		font-size: 0.85rem;
-		color: #888;
+		color: var(--text-tertiary);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;

--- a/frontend/src/lib/components/HandleSearch.svelte
+++ b/frontend/src/lib/components/HandleSearch.svelte
@@ -172,10 +172,10 @@
 	.search-input {
 		width: 100%;
 		padding: 0.75rem;
-		background: #0a0a0a;
-		border: 1px solid #333;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
-		color: white;
+		color: var(--text-primary);
 		font-size: 1rem;
 		font-family: inherit;
 		transition: all 0.2s;
@@ -183,7 +183,7 @@
 
 	.search-input:focus {
 		outline: none;
-		border-color: #3a7dff;
+		border-color: var(--accent);
 	}
 
 	.search-input:disabled {
@@ -197,7 +197,7 @@
 		top: 50%;
 		transform: translateY(-50%);
 		font-size: 0.85rem;
-		color: #666;
+		color: var(--text-muted);
 	}
 
 	.search-results {
@@ -206,8 +206,8 @@
 		width: 100%;
 		max-height: 300px;
 		overflow-y: auto;
-		background: #1a1a1a;
-		border: 1px solid #333;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
 		margin-top: 0.25rem;
 		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
@@ -219,23 +219,23 @@
 	}
 
 	.search-results::-webkit-scrollbar-track {
-		background: #0a0a0a;
+		background: var(--bg-primary);
 		border-radius: 4px;
 	}
 
 	.search-results::-webkit-scrollbar-thumb {
-		background: #333;
+		background: var(--border-default);
 		border-radius: 4px;
 	}
 
 	.search-results::-webkit-scrollbar-thumb:hover {
-		background: #444;
+		background: var(--border-emphasis);
 	}
 
 	/* firefox scrollbar */
 	.search-results {
 		scrollbar-width: thin;
-		scrollbar-color: #333 #0a0a0a;
+		scrollbar-color: var(--border-default) var(--bg-primary);
 	}
 
 	.search-result-item {
@@ -246,8 +246,8 @@
 		padding: 0.75rem;
 		background: transparent;
 		border: none;
-		border-bottom: 1px solid #2a2a2a;
-		color: white;
+		border-bottom: 1px solid var(--border-subtle);
+		color: var(--text-primary);
 		text-align: left;
 		font-family: inherit;
 		cursor: pointer;
@@ -260,7 +260,7 @@
 	}
 
 	.search-result-item:hover:not(:disabled) {
-		background: #222;
+		background: var(--bg-hover);
 	}
 
 	.search-result-item.selected,
@@ -274,7 +274,7 @@
 		height: 36px;
 		border-radius: 50%;
 		object-fit: cover;
-		border: 2px solid #333;
+		border: 2px solid var(--border-default);
 		flex-shrink: 0;
 	}
 
@@ -286,7 +286,7 @@
 
 	.result-name {
 		font-weight: 500;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		margin-bottom: 0.125rem;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -295,7 +295,7 @@
 
 	.result-handle {
 		font-size: 0.85rem;
-		color: #888;
+		color: var(--text-tertiary);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -313,10 +313,10 @@
 		align-items: center;
 		gap: 0.5rem;
 		padding: 0.5rem 0.75rem;
-		background: #1a2330;
-		border: 1px solid #2a3a4a;
+		background: color-mix(in srgb, var(--accent) 10%, var(--bg-tertiary));
+		border: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border-subtle));
 		border-radius: 20px;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		font-size: 0.9rem;
 	}
 
@@ -325,7 +325,7 @@
 		height: 24px;
 		border-radius: 50%;
 		object-fit: cover;
-		border: 1px solid #333;
+		border: 1px solid var(--border-default);
 	}
 
 	.chip-name {
@@ -335,7 +335,7 @@
 	.chip-remove {
 		background: transparent;
 		border: none;
-		color: #888;
+		color: var(--text-tertiary);
 		font-size: 1.3rem;
 		font-family: inherit;
 		line-height: 1;
@@ -350,7 +350,7 @@
 	}
 
 	.chip-remove:hover:not(:disabled) {
-		color: #ff6b6b;
+		color: var(--error);
 	}
 
 	.chip-remove:disabled {
@@ -361,16 +361,16 @@
 	.max-features-message {
 		margin-top: 0.5rem;
 		font-size: 0.85rem;
-		color: #ff9966;
+		color: var(--warning);
 	}
 
 	.no-results-message {
 		margin-top: 0.5rem;
 		padding: 0.75rem;
-		background: #2a1a1a;
-		border: 1px solid #4a3030;
+		background: color-mix(in srgb, var(--warning) 10%, var(--bg-primary));
+		border: 1px solid color-mix(in srgb, var(--warning) 20%, var(--border-subtle));
 		border-radius: 4px;
-		color: #ff9966;
+		color: var(--warning);
 		font-size: 0.9rem;
 		text-align: center;
 	}

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -87,9 +87,10 @@
 
 <style>
 	header {
-		border-bottom: 1px solid #333;
+		border-bottom: 1px solid var(--border-default);
 		margin-bottom: 2rem;
 		position: relative;
+		z-index: 50;
 	}
 
 	.header-content {
@@ -194,8 +195,8 @@
 
 	.nav-link:hover {
 		color: var(--text-primary);
-		background: #1a1a1a;
-		border-color: #333;
+		background: var(--bg-tertiary);
+		border-color: var(--border-default);
 	}
 
 	.nav-link svg {
@@ -208,9 +209,9 @@
 		text-decoration: none;
 		font-size: 0.9rem;
 		padding: 0.4rem 0.75rem;
-		background: #1a1a1a;
+		background: var(--bg-tertiary);
 		border-radius: 6px;
-		border: 1px solid #333;
+		border: 1px solid var(--border-default);
 		transition: all 0.2s;
 		white-space: nowrap;
 	}
@@ -218,7 +219,7 @@
 	.user-handle:hover {
 		border-color: var(--accent);
 		color: var(--accent);
-		background: #222;
+		background: var(--bg-hover);
 	}
 
 	.btn-primary {
@@ -241,8 +242,8 @@
 
 	.btn-logout {
 		background: transparent;
-		border: 1px solid #444;
-		color: #b0b0b0;
+		border: 1px solid var(--border-emphasis);
+		color: var(--text-secondary);
 		padding: 0.5rem 1rem;
 		border-radius: 6px;
 		font-size: 0.9rem;

--- a/frontend/src/lib/components/HiddenTagsFilter.svelte
+++ b/frontend/src/lib/components/HiddenTagsFilter.svelte
@@ -193,8 +193,8 @@
 	}
 
 	.tag-chip:hover {
-		border-color: rgba(255, 107, 107, 0.5);
-		color: #ff6b6b;
+		border-color: color-mix(in srgb, var(--error) 50%, transparent);
+		color: var(--error);
 	}
 
 	.tag-chip:active {

--- a/frontend/src/lib/components/LikeButton.svelte
+++ b/frontend/src/lib/components/LikeButton.svelte
@@ -84,15 +84,15 @@
 		align-items: center;
 		justify-content: center;
 		background: transparent;
-		border: 1px solid #333;
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
-		color: #888;
+		color: var(--text-tertiary);
 		cursor: pointer;
 		transition: all 0.2s;
 	}
 
 	.like-button:hover {
-		background: #1a1a1a;
+		background: var(--bg-tertiary);
 		border-color: var(--accent);
 		color: var(--accent);
 	}
@@ -114,14 +114,14 @@
 
 	.like-button.disabled-state {
 		opacity: 0.4;
-		border-color: #555;
-		color: #666;
+		border-color: var(--text-muted);
+		color: var(--text-muted);
 	}
 
 	.like-button.disabled-state:hover {
 		background: transparent;
-		border-color: #555;
-		color: #666;
+		border-color: var(--text-muted);
+		color: var(--text-muted);
 	}
 
 	.like-button.loading {

--- a/frontend/src/lib/components/LikersTooltip.svelte
+++ b/frontend/src/lib/components/LikersTooltip.svelte
@@ -110,8 +110,8 @@
 		left: 50%;
 		transform: translateX(-50%);
 		margin-bottom: 0.5rem;
-		background: #1a1a1a;
-		border: 1px solid #333;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-default);
 		border-radius: 8px;
 		padding: 0.75rem;
 		min-width: 240px;
@@ -124,14 +124,14 @@
 	.loading,
 	.error,
 	.empty {
-		color: #888;
+		color: var(--text-tertiary);
 		font-size: 0.85rem;
 		text-align: center;
 		padding: 0.5rem;
 	}
 
 	.error {
-		color: #e74c3c;
+		color: var(--error);
 	}
 
 	.likers-list {
@@ -151,7 +151,7 @@
 	}
 
 	.liker:hover {
-		background: #252525;
+		background: var(--bg-hover);
 	}
 
 	.avatar,
@@ -164,15 +164,15 @@
 
 	.avatar {
 		object-fit: cover;
-		border: 1px solid #333;
+		border: 1px solid var(--border-default);
 	}
 
 	.avatar-placeholder {
-		background: #333;
+		background: var(--border-default);
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		color: #888;
+		color: var(--text-tertiary);
 		font-weight: 600;
 		font-size: 0.9rem;
 	}
@@ -183,7 +183,7 @@
 	}
 
 	.display-name {
-		color: #e8e8e8;
+		color: var(--text-primary);
 		font-weight: 500;
 		font-size: 0.9rem;
 		white-space: nowrap;
@@ -192,7 +192,7 @@
 	}
 
 	.handle {
-		color: #888;
+		color: var(--text-tertiary);
 		font-size: 0.8rem;
 		white-space: nowrap;
 		overflow: hidden;
@@ -200,7 +200,7 @@
 	}
 
 	.liked-time {
-		color: #666;
+		color: var(--text-muted);
 		font-size: 0.75rem;
 		flex-shrink: 0;
 	}
@@ -211,15 +211,15 @@
 	}
 
 	.likers-list::-webkit-scrollbar-track {
-		background: #1a1a1a;
+		background: var(--bg-tertiary);
 	}
 
 	.likers-list::-webkit-scrollbar-thumb {
-		background: #333;
+		background: var(--border-default);
 		border-radius: 3px;
 	}
 
 	.likers-list::-webkit-scrollbar-thumb:hover {
-		background: #444;
+		background: var(--border-emphasis);
 	}
 </style>

--- a/frontend/src/lib/components/LinksMenu.svelte
+++ b/frontend/src/lib/components/LinksMenu.svelte
@@ -120,7 +120,7 @@
 		width: 32px;
 		height: 32px;
 		background: transparent;
-		border: 1px solid #333;
+		border: 1px solid var(--border-default);
 		border-radius: 6px;
 		color: var(--text-secondary);
 		cursor: pointer;
@@ -128,7 +128,7 @@
 	}
 
 	.menu-button:hover {
-		background: #1a1a1a;
+		background: var(--bg-tertiary);
 		border-color: var(--accent);
 		color: var(--accent);
 	}

--- a/frontend/src/lib/components/MigrationBanner.svelte
+++ b/frontend/src/lib/components/MigrationBanner.svelte
@@ -150,8 +150,8 @@
 
 <style>
 	.migration-banner {
-		background: var(--background-alt, #1a1a1a);
-		border: 1px solid var(--border-color, #333);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-default);
 		border-radius: 8px;
 		padding: 1rem;
 		margin-bottom: 1.5rem;
@@ -171,25 +171,25 @@
 
 	.migration-message strong {
 		font-size: 1.1em;
-		color: var(--text-primary, #fff);
+		color: var(--text-primary);
 	}
 
 	.migration-message p {
 		margin: 0;
-		color: var(--text-secondary, #aaa);
+		color: var(--text-secondary);
 		font-size: 0.9em;
 	}
 
 	.error {
-		color: var(--error-color, #ff6b6b);
+		color: var(--error);
 	}
 
 	.success-message {
 		display: flex;
 		align-items: center;
 		gap: 1rem;
-		background: rgba(81, 207, 102, 0.1);
-		border: 1px solid rgba(81, 207, 102, 0.3);
+		background: color-mix(in srgb, var(--success) 10%, transparent);
+		border: 1px solid color-mix(in srgb, var(--success) 30%, transparent);
 		border-radius: 6px;
 		padding: 1rem;
 		animation: slideIn 0.3s ease-out;
@@ -197,18 +197,18 @@
 
 	.success-icon {
 		font-size: 2rem;
-		color: var(--success-color, #51cf66);
+		color: var(--success);
 		animation: checkmark 0.5s ease-out;
 	}
 
 	.success-title {
 		font-weight: 600;
-		color: var(--success-color, #51cf66);
+		color: var(--success);
 		margin: 0;
 	}
 
 	.success-detail {
-		color: var(--text-secondary, #aaa);
+		color: var(--text-secondary);
 		margin: 0.25rem 0 0 0;
 		font-size: 0.85em;
 	}
@@ -237,23 +237,23 @@
 	}
 
 	.collection-name {
-		background: rgba(255, 255, 255, 0.05);
+		background: color-mix(in srgb, var(--text-primary) 5%, transparent);
 		padding: 0.15em 0.4em;
 		border-radius: 3px;
 		font-family: monospace;
 		font-size: 0.95em;
-		color: var(--text-primary, #fff);
+		color: var(--text-primary);
 	}
 
 	.collection-link {
-		color: var(--accent, #6a9fff);
+		color: var(--accent);
 		text-decoration: none;
 		border-bottom: 1px solid transparent;
 		transition: border-color 0.2s;
 	}
 
 	.collection-link:hover {
-		border-bottom-color: var(--accent, #6a9fff);
+		border-bottom-color: var(--accent);
 	}
 
 	.migration-actions {
@@ -274,7 +274,7 @@
 	}
 
 	.migrate-button {
-		background: var(--primary-color, #007bff);
+		background: var(--accent);
 		color: white;
 	}
 
@@ -284,12 +284,12 @@
 
 	.dismiss-button {
 		background: transparent;
-		color: var(--text-secondary, #aaa);
-		border: 1px solid var(--border-color, #333);
+		color: var(--text-secondary);
+		border: 1px solid var(--border-default);
 	}
 
 	.dismiss-button:hover:not(:disabled) {
-		background: var(--background-hover, #222);
+		background: var(--bg-hover);
 	}
 
 	button:disabled {

--- a/frontend/src/lib/components/PlatformStats.svelte
+++ b/frontend/src/lib/components/PlatformStats.svelte
@@ -181,7 +181,7 @@
 		display: block;
 		width: 100%;
 		height: 60px;
-		background: linear-gradient(90deg, #1a1a1a 0%, #242424 50%, #1a1a1a 100%);
+		background: linear-gradient(90deg, var(--bg-tertiary) 0%, var(--bg-hover) 50%, var(--bg-tertiary) 100%);
 		background-size: 200% 100%;
 		animation: shimmer 1.5s ease-in-out infinite;
 		border-radius: 6px;

--- a/frontend/src/lib/components/SettingsMenu.svelte
+++ b/frontend/src/lib/components/SettingsMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { queue } from '$lib/queue.svelte';
-	import { preferences } from '$lib/preferences.svelte';
+	import { preferences, type Theme } from '$lib/preferences.svelte';
 
 	let showSettings = $state(false);
 
@@ -14,9 +14,16 @@
 		{ name: 'red', value: '#ef4444' }
 	];
 
+	const themes: { value: Theme; label: string; icon: string }[] = [
+		{ value: 'dark', label: 'dark', icon: 'moon' },
+		{ value: 'light', label: 'light', icon: 'sun' },
+		{ value: 'system', label: 'system', icon: 'auto' }
+	];
+
 	// derive from preferences store
 	let currentColor = $derived(preferences.accentColor ?? '#6a9fff');
 	let autoAdvance = $derived(preferences.autoAdvance);
+	let currentTheme = $derived(preferences.theme);
 
 	// apply color when it changes
 	$effect(() => {
@@ -74,6 +81,10 @@
 		localStorage.setItem('autoAdvance', value ? '1' : '0');
 		await preferences.update({ auto_advance: value });
 	}
+
+	function selectTheme(theme: Theme) {
+		preferences.setTheme(theme);
+	}
 </script>
 
 <div class="settings-menu">
@@ -90,6 +101,38 @@
 				<span>settings</span>
 				<button class="close-btn" onclick={toggleSettings}>×</button>
 			</div>
+
+			<section class="settings-section">
+				<h3>theme</h3>
+				<div class="theme-buttons">
+					{#each themes as theme}
+						<button
+							class="theme-btn"
+							class:active={currentTheme === theme.value}
+							onclick={() => selectTheme(theme.value)}
+							title={theme.label}
+						>
+							{#if theme.icon === 'moon'}
+								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+									<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+								</svg>
+							{:else if theme.icon === 'sun'}
+								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+									<circle cx="12" cy="12" r="5" />
+									<path d="M12 1v2m0 18v2M4.22 4.22l1.42 1.42m12.72 12.72 1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+								</svg>
+							{:else}
+								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+									<circle cx="12" cy="12" r="9" />
+									<path d="M12 3v18" />
+									<path d="M12 3a9 9 0 0 1 0 18" fill="currentColor" opacity="0.3" />
+								</svg>
+							{/if}
+							<span>{theme.label}</span>
+						</button>
+					{/each}
+				</div>
+			</section>
 
 			<section class="settings-section">
 				<h3>accent color</h3>
@@ -120,6 +163,7 @@
 				</label>
 				<p class="toggle-hint">when a track ends, start the next item in your queue</p>
 			</section>
+
 		</div>
 	{/if}
 </div>
@@ -155,7 +199,7 @@
 		border: 1px solid var(--border-default);
 		border-radius: 8px;
 		padding: 1.25rem;
-		min-width: 260px;
+		min-width: 280px;
 		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.45);
 		z-index: 1000;
 		display: flex;
@@ -202,6 +246,48 @@
 		text-transform: uppercase;
 		letter-spacing: 0.08em;
 		color: var(--text-tertiary);
+	}
+
+	.theme-buttons {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.theme-btn {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.35rem;
+		padding: 0.6rem 0.5rem;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-default);
+		border-radius: 6px;
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: all 0.2s;
+	}
+
+	.theme-btn:hover {
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+
+	.theme-btn.active {
+		background: color-mix(in srgb, var(--accent) 15%, transparent);
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+
+	.theme-btn svg {
+		width: 18px;
+		height: 18px;
+	}
+
+	.theme-btn span {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
 	}
 
 	.color-picker-row {
@@ -278,6 +364,7 @@
 		cursor: pointer;
 		transition: background 0.2s, border 0.2s;
 		border: 1px solid var(--border-default);
+		flex-shrink: 0;
 	}
 
 	.toggle input::after {
@@ -315,5 +402,18 @@
 		color: var(--text-tertiary);
 		font-size: 0.8rem;
 		line-height: 1.3;
+	}
+
+	@media (max-width: 768px) {
+		.settings-panel {
+			position: fixed;
+			top: auto;
+			bottom: calc(var(--player-height, 0px) + 1rem);
+			right: 1rem;
+			left: 1rem;
+			min-width: auto;
+			max-height: 70vh;
+			overflow-y: auto;
+		}
 	}
 </style>

--- a/frontend/src/lib/components/ShareButton.svelte
+++ b/frontend/src/lib/components/ShareButton.svelte
@@ -37,12 +37,12 @@
 <style>
 	.share-btn {
 		background: transparent;
-		border: 1px solid #333;
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
 		width: 32px;
 		height: 32px;
 		padding: 0;
-		color: #888;
+		color: var(--text-tertiary);
 		cursor: pointer;
 		display: flex;
 		align-items: center;
@@ -62,7 +62,7 @@
 		top: -2rem;
 		left: 50%;
 		transform: translateX(-50%);
-		background: #1a1a1a;
+		background: var(--bg-tertiary);
 		border: 1px solid var(--accent);
 		color: var(--accent);
 		padding: 0.25rem 0.75rem;

--- a/frontend/src/lib/components/TagInput.svelte
+++ b/frontend/src/lib/components/TagInput.svelte
@@ -192,9 +192,9 @@
 		align-items: center;
 		gap: 0.35rem;
 		padding: 0.35rem 0.6rem;
-		background: rgba(138, 179, 255, 0.1);
-		border: 1px solid rgba(138, 179, 255, 0.2);
-		color: #8ab3ff;
+		background: color-mix(in srgb, var(--accent) 10%, transparent);
+		border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
+		color: var(--accent-hover);
 		border-radius: 20px;
 		font-size: 0.9rem;
 		font-weight: 500;
@@ -218,7 +218,7 @@
 	}
 
 	.tag-remove:hover {
-		color: #ff6b6b;
+		color: var(--error);
 	}
 
 	.tag-remove:disabled {

--- a/frontend/src/lib/components/TrackActionsMenu.svelte
+++ b/frontend/src/lib/components/TrackActionsMenu.svelte
@@ -153,15 +153,15 @@
 		align-items: center;
 		justify-content: center;
 		background: transparent;
-		border: 1px solid #333;
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
-		color: #888;
+		color: var(--text-tertiary);
 		cursor: pointer;
 		transition: all 0.2s;
 	}
 
 	.menu-button:hover {
-		background: #1a1a1a;
+		background: var(--bg-tertiary);
 		border-color: var(--accent);
 		color: var(--accent);
 	}

--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -270,24 +270,24 @@
 		display: flex;
 		align-items: center;
 		gap: 0.75rem;
-		background: #141414;
-		border: 1px solid #282828;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-subtle);
 		border-left: 3px solid transparent;
 		padding: 1rem;
 		transition: all 0.15s ease-in-out;
 	}
 
 	.track-container:hover {
-		background: #1a1a1a;
+		background: var(--bg-tertiary);
 		border-left-color: var(--accent);
-		border-color: #333;
+		border-color: var(--border-default);
 		transform: translateX(2px);
 	}
 
 	.track-container.playing {
-		background: #1a2330;
+		background: color-mix(in srgb, var(--accent) 10%, var(--bg-tertiary));
 		border-left-color: var(--accent);
-		border-color: #2a3a4a;
+		border-color: color-mix(in srgb, var(--accent) 20%, var(--border-subtle));
 	}
 
 	.track {
@@ -314,8 +314,8 @@
 		justify-content: center;
 		border-radius: 4px;
 		overflow: hidden;
-		background: #1a1a1a;
-		border: 1px solid #282828;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-subtle);
 	}
 
 	.track-avatar {
@@ -342,12 +342,12 @@
 	}
 
 	.track-image-placeholder {
-		color: #606060;
+		color: var(--text-muted);
 	}
 
 	.track-avatar img {
 		border-radius: 50%;
-		border: 2px solid #333;
+		border: 2px solid var(--border-default);
 		transition: border-color 0.2s;
 	}
 
@@ -384,7 +384,7 @@
 		font-family: inherit;
 		font-weight: 600;
 		font-size: 1.05rem;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -395,7 +395,7 @@
 		flex-direction: column;
 		align-items: flex-start;
 		gap: 0.15rem;
-		color: #b0b0b0;
+		color: var(--text-secondary);
 		font-size: 0.9rem;
 		font-family: inherit;
 		min-width: 0;
@@ -420,7 +420,7 @@
 	}
 
 	.artist-link {
-		color: #b0b0b0;
+		color: var(--text-secondary);
 		text-decoration: none;
 		transition: color 0.2s;
 		font-weight: 500;
@@ -440,18 +440,18 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.25rem;
-		color: #b5bed1;
+		color: var(--text-secondary);
 		white-space: nowrap;
 	}
 
 	.features-label {
-		color: #8ab3ff;
+		color: var(--accent-hover);
 		font-weight: 500;
 		text-transform: lowercase;
 	}
 
 	.feature-link {
-		color: #8ab3ff;
+		color: var(--accent-hover);
 		text-decoration: none;
 		font-weight: 500;
 		transition: color 0.2s;
@@ -463,11 +463,11 @@
 	}
 
 	.feature-separator {
-		color: #8ab3ff;
+		color: var(--accent-hover);
 	}
 
 	.album {
-		color: #909090;
+		color: var(--text-tertiary);
 		display: inline-flex;
 		align-items: center;
 		gap: 0.35rem;
@@ -476,7 +476,7 @@
 	}
 
 	.album-link {
-		color: #909090;
+		color: var(--text-tertiary);
 		text-decoration: none;
 		transition: color 0.2s;
 		display: inline-block;
@@ -508,8 +508,8 @@
 	.tag-badge {
 		display: inline-block;
 		padding: 0.1rem 0.4rem;
-		background: rgba(138, 179, 255, 0.15);
-		color: #8ab3ff;
+		background: color-mix(in srgb, var(--accent) 15%, transparent);
+		color: var(--accent-hover);
 		border-radius: 3px;
 		font-size: 0.75rem;
 		font-weight: 500;
@@ -518,30 +518,30 @@
 	}
 
 	.tag-badge:hover {
-		background: rgba(138, 179, 255, 0.25);
-		color: #a8c8ff;
+		background: color-mix(in srgb, var(--accent) 25%, transparent);
+		color: var(--accent);
 	}
 
 	.track-meta {
 		font-size: 0.8rem;
-		color: #808080;
+		color: var(--text-tertiary);
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
 	}
 
 	.plays {
-		color: #999;
+		color: var(--text-tertiary);
 		font-family: inherit;
 	}
 
 	.meta-separator {
-		color: #555;
+		color: var(--text-muted);
 		font-size: 0.7rem;
 	}
 
 	.likes {
-		color: #999;
+		color: var(--text-tertiary);
 		font-family: inherit;
 		position: relative;
 		cursor: help;
@@ -553,7 +553,7 @@
 	}
 
 	.comments {
-		color: #999;
+		color: var(--text-tertiary);
 		font-family: inherit;
 		display: inline-flex;
 		align-items: center;
@@ -583,16 +583,16 @@
 		align-items: center;
 		justify-content: center;
 		background: transparent;
-		border: 1px solid #333;
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
-		color: #888;
+		color: var(--text-tertiary);
 		cursor: pointer;
 		transition: all 0.2s;
 		text-decoration: none;
 	}
 
 	.action-button:hover {
-		background: #1a1a1a;
+		background: var(--bg-tertiary);
 		border-color: var(--accent);
 		color: var(--accent);
 	}

--- a/frontend/src/lib/components/player/PlaybackControls.svelte
+++ b/frontend/src/lib/components/player/PlaybackControls.svelte
@@ -254,7 +254,7 @@
 
 	.control-btn:hover {
 		color: var(--accent);
-		background: rgba(106, 159, 255, 0.1);
+		background: color-mix(in srgb, var(--accent) 10%, transparent);
 	}
 
 	.control-btn.play-pause:active {
@@ -311,7 +311,7 @@
 
 	.time {
 		font-size: 0.85rem;
-		color: #909090;
+		color: var(--text-tertiary);
 		min-width: 45px;
 		font-variant-numeric: tabular-nums;
 	}
@@ -325,7 +325,7 @@
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
-		color: #909090;
+		color: var(--text-tertiary);
 		min-width: 140px;
 		position: relative;
 	}
@@ -337,7 +337,7 @@
 	}
 
 	.volume-icon.muted {
-		color: #ff6b6b;
+		color: var(--error);
 		animation: shake 0.5s ease-in-out;
 	}
 
@@ -395,7 +395,7 @@
 	}
 
 	input[type="range"].muted::-webkit-slider-thumb {
-		background: #ff6b6b;
+		background: var(--error);
 	}
 
 	input[type="range"].max::-webkit-slider-thumb {
@@ -432,7 +432,7 @@
 	}
 
 	input[type="range"].muted::-moz-range-thumb {
-		background: #ff6b6b;
+		background: var(--error);
 	}
 
 	input[type="range"].max::-moz-range-thumb {

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -350,8 +350,8 @@
 		bottom: 0;
 		left: 0;
 		right: 0;
-		background: #1a1a1a;
-		border-top: 1px solid #333;
+		background: var(--bg-tertiary);
+		border-top: 1px solid var(--border-default);
 		padding: 0.75rem 2rem;
 		padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
 		z-index: 100;

--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -155,8 +155,8 @@
 		height: 56px;
 		border-radius: 4px;
 		overflow: hidden;
-		background: #1a1a1a;
-		border: 1px solid #333;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-default);
 		display: block;
 		text-decoration: none;
 		transition: transform 0.18s ease, border-color 0.2s ease;
@@ -180,7 +180,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		color: #666;
+		color: var(--text-muted);
 	}
 
 	.player-info {
@@ -196,7 +196,7 @@
 	.player-title-link {
 		font-size: 0.95rem;
 		font-weight: 600;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		margin-bottom: 0;
 		position: relative;
 		overflow: hidden;
@@ -253,7 +253,7 @@
 		flex-direction: column;
 		justify-content: center;
 		gap: 0.15rem;
-		color: #a0a0a0;
+		color: var(--text-secondary);
 		font-size: 0.82rem;
 		min-width: 0;
 		height: 32px;
@@ -303,7 +303,7 @@
 	}
 
 	.features-inline {
-		color: #b5b5b5;
+		color: var(--text-secondary);
 		display: inline-flex;
 		align-items: center;
 		gap: 0.25rem;

--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -3,18 +3,22 @@ import { browser } from '$app/environment';
 import { API_URL } from '$lib/config';
 import { auth } from '$lib/auth.svelte';
 
+export type Theme = 'dark' | 'light' | 'system';
+
 export interface Preferences {
 	accent_color: string | null;
 	auto_advance: boolean;
 	allow_comments: boolean;
 	hidden_tags: string[];
+	theme: Theme;
 }
 
 const DEFAULT_PREFERENCES: Preferences = {
 	accent_color: null,
 	auto_advance: true,
 	allow_comments: true,
-	hidden_tags: ['ai']
+	hidden_tags: ['ai'],
+	theme: 'dark'
 };
 
 class PreferencesManager {
@@ -42,6 +46,32 @@ class PreferencesManager {
 		return this.data?.allow_comments ?? DEFAULT_PREFERENCES.allow_comments;
 	}
 
+	get theme(): Theme {
+		return this.data?.theme ?? DEFAULT_PREFERENCES.theme;
+	}
+
+	setTheme(theme: Theme): void {
+		if (browser) {
+			localStorage.setItem('theme', theme);
+			this.applyTheme(theme);
+		}
+		this.update({ theme });
+	}
+
+	applyTheme(theme: Theme): void {
+		if (!browser) return;
+		const root = document.documentElement;
+		root.classList.remove('theme-dark', 'theme-light');
+
+		let effectiveTheme: 'dark' | 'light';
+		if (theme === 'system') {
+			effectiveTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+		} else {
+			effectiveTheme = theme;
+		}
+		root.classList.add(`theme-${effectiveTheme}`);
+	}
+
 	async initialize(): Promise<void> {
 		if (!browser || this.initialized || this.loading) return;
 		this.initialized = true;
@@ -62,10 +92,15 @@ class PreferencesManager {
 					accent_color: data.accent_color ?? null,
 					auto_advance: data.auto_advance ?? DEFAULT_PREFERENCES.auto_advance,
 					allow_comments: data.allow_comments ?? DEFAULT_PREFERENCES.allow_comments,
-					hidden_tags: data.hidden_tags ?? DEFAULT_PREFERENCES.hidden_tags
+					hidden_tags: data.hidden_tags ?? DEFAULT_PREFERENCES.hidden_tags,
+					theme: data.theme ?? DEFAULT_PREFERENCES.theme
 				};
 			} else {
 				this.data = { ...DEFAULT_PREFERENCES };
+			}
+			// apply theme after fetching
+			if (browser) {
+				this.applyTheme(this.data.theme);
 			}
 		} catch (error) {
 			console.error('failed to fetch preferences:', error);

--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -56,20 +56,20 @@
 
 	h1 {
 		font-size: 4rem;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		margin: 0 0 1rem 0;
 		font-weight: 700;
 	}
 
 	.error-message {
 		font-size: 1.25rem;
-		color: #b0b0b0;
+		color: var(--text-secondary);
 		margin: 0 0 0.5rem 0;
 	}
 
 	.error-detail {
 		font-size: 1rem;
-		color: #808080;
+		color: var(--text-tertiary);
 		margin: 0 0 2rem 0;
 	}
 
@@ -85,7 +85,7 @@
 
 	.home-link:hover {
 		background: var(--accent);
-		color: #000;
+		color: var(--bg-primary);
 	}
 
 	@media (max-width: 768px) {

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -14,7 +14,8 @@ const DEFAULT_PREFERENCES: Preferences = {
 	accent_color: null,
 	auto_advance: true,
 	allow_comments: true,
-	hidden_tags: ['ai']
+	hidden_tags: ['ai'],
+	theme: 'dark'
 };
 
 export async function load({ fetch }: LoadEvent): Promise<LayoutData> {
@@ -46,7 +47,8 @@ export async function load({ fetch }: LoadEvent): Promise<LayoutData> {
 						accent_color: data.accent_color ?? null,
 						auto_advance: data.auto_advance ?? true,
 						allow_comments: data.allow_comments ?? true,
-						hidden_tags: data.hidden_tags ?? ['ai']
+						hidden_tags: data.hidden_tags ?? ['ai'],
+						theme: data.theme ?? 'dark'
 					};
 				}
 			} catch (e) {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -157,7 +157,7 @@
 	}
 
 	.empty {
-		color: #808080;
+		color: var(--text-tertiary);
 		padding: 2rem;
 		text-align: center;
 	}

--- a/frontend/src/routes/embed/track/[id]/+page.svelte
+++ b/frontend/src/routes/embed/track/[id]/+page.svelte
@@ -114,14 +114,14 @@
 		padding: 0;
 		overflow: hidden;
 		font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', 'Consolas', monospace;
-		background: #000;
-		color: #fff;
+		background: var(--bg-primary);
+		color: var(--text-primary);
 	}
 
 	.embed-container {
 		display: flex;
 		height: 165px;
-		background: #1a1a1a;
+		background: var(--bg-tertiary);
 		overflow: hidden;
 		position: relative;
 	}
@@ -151,12 +151,12 @@
 	.art-placeholder {
 		width: 100%;
 		height: 100%;
-		background: #333;
+		background: var(--border-default);
 		display: flex;
 		align-items: center;
 		justify-content: center;
 		font-size: 48px;
-		color: #555;
+		color: var(--text-muted);
 	}
 
 	.content {
@@ -216,7 +216,7 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		text-decoration: none;
-		color: #fff;
+		color: var(--text-primary);
 	}
 
 	.title:hover {
@@ -226,7 +226,7 @@
 	.artist {
 		display: block;
 		font-size: 14px;
-		color: #aaa;
+		color: var(--text-secondary);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -243,14 +243,14 @@
 		right: 16px;
 		font-size: 12px;
 		font-weight: 700;
-		color: #444;
+		color: var(--border-emphasis);
 		text-decoration: none;
 		text-transform: uppercase;
 		letter-spacing: 1px;
 	}
 
 	.logo:hover {
-		color: #666;
+		color: var(--text-muted);
 	}
 
 	.player-controls {
@@ -262,7 +262,7 @@
 
 	.time {
 		font-size: 12px;
-		color: #777;
+		color: var(--text-tertiary);
 		font-variant-numeric: tabular-nums;
 		width: 35px;
 		text-align: center;
@@ -280,7 +280,7 @@
 	.progress-bg {
 		width: 100%;
 		height: 4px;
-		background: #333;
+		background: var(--border-default);
 		border-radius: 2px;
 	}
 
@@ -289,13 +289,13 @@
 		left: 0;
 		top: 10px; /* (24 - 4) / 2 */
 		height: 4px;
-		background: #fff;
+		background: var(--text-primary);
 		border-radius: 2px;
 		pointer-events: none;
 	}
 
 	.progress-bar:hover .progress-fill {
-		background: #3b82f6; /* blue-500 */
+		background: var(--accent);
 	}
 
 	/* mobile: background image layout */

--- a/frontend/src/routes/liked/+page.svelte
+++ b/frontend/src/routes/liked/+page.svelte
@@ -114,7 +114,7 @@
 
 	.subtitle {
 		font-size: 0.95rem;
-		color: #888;
+		color: var(--text-tertiary);
 		margin: 0;
 	}
 
@@ -146,18 +146,18 @@
 	.empty-state {
 		text-align: center;
 		padding: 4rem 1rem;
-		color: #888;
+		color: var(--text-tertiary);
 	}
 
 	.empty-state svg {
 		margin: 0 auto 1.5rem;
-		color: #555;
+		color: var(--text-muted);
 	}
 
 	.empty-state h2 {
 		font-size: 1.5rem;
 		font-weight: 600;
-		color: #b0b0b0;
+		color: var(--text-secondary);
 		margin: 0 0 0.5rem 0;
 	}
 

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -64,13 +64,13 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		background: #0a0a0a;
+		background: var(--bg-primary);
 		padding: 1rem;
 	}
 
 	.login-card {
-		background: #1a1a1a;
-		border: 1px solid #2a2a2a;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-subtle);
 		border-radius: 8px;
 		padding: 3rem;
 		max-width: 400px;
@@ -80,12 +80,12 @@
 	h1 {
 		font-size: 2.5rem;
 		margin: 0 0 0.5rem 0;
-		color: #fff;
+		color: var(--text-primary);
 		text-align: center;
 	}
 
 	p {
-		color: #888;
+		color: var(--text-tertiary);
 		text-align: center;
 		margin: 0 0 2rem 0;
 		font-size: 0.95rem;
@@ -103,7 +103,7 @@
 	}
 
 	label {
-		color: #aaa;
+		color: var(--text-secondary);
 		font-size: 0.9rem;
 	}
 
@@ -122,7 +122,7 @@
 	.input-help {
 		margin: 0.5rem 0 0 0;
 		font-size: 0.85rem;
-		color: #888;
+		color: var(--text-tertiary);
 	}
 
 	.input-help a {
@@ -139,7 +139,7 @@
 	button {
 		width: 100%;
 		padding: 0.75rem;
-		background: #3a7dff;
+		background: var(--accent);
 		color: white;
 		border: none;
 		border-radius: 4px;
@@ -151,9 +151,9 @@
 	}
 
 	button:hover:not(:disabled) {
-		background: #2868e6;
+		background: var(--accent-hover);
 		transform: translateY(-1px);
-		box-shadow: 0 4px 12px rgba(58, 125, 255, 0.3);
+		box-shadow: 0 4px 12px color-mix(in srgb, var(--accent) 30%, transparent);
 	}
 
 	button:disabled {

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -1395,7 +1395,7 @@
 		align-items: center;
 		justify-content: center;
 		min-height: 100vh;
-		color: #888;
+		color: var(--text-tertiary);
 		gap: 1rem;
 	}
 
@@ -1450,9 +1450,9 @@
 		text-decoration: none;
 		font-size: 0.9rem;
 		padding: 0.4rem 0.75rem;
-		background: #1a1a1a;
+		background: var(--bg-tertiary);
 		border-radius: 6px;
-		border: 1px solid #333;
+		border: 1px solid var(--border-default);
 		transition: all 0.2s;
 		white-space: nowrap;
 	}
@@ -1460,14 +1460,14 @@
 	.view-profile-link:hover {
 		border-color: var(--accent);
 		color: var(--accent);
-		background: #222;
+		background: var(--bg-hover);
 	}
 
 	form {
-		background: #1a1a1a;
+		background: var(--bg-tertiary);
 		padding: 2rem;
 		border-radius: 8px;
-		border: 1px solid #2a2a2a;
+		border: 1px solid var(--border-subtle);
 	}
 
 	.form-group {
@@ -1476,7 +1476,7 @@
 
 	label {
 		display: block;
-		color: #aaa;
+		color: var(--text-secondary);
 		margin-bottom: 0.5rem;
 		font-size: 0.9rem;
 	}
@@ -1484,10 +1484,10 @@
 	input[type='text'] {
 		width: 100%;
 		padding: 0.75rem;
-		background: #0a0a0a;
-		border: 1px solid #333;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
-		color: white;
+		color: var(--text-primary);
 		font-size: 1rem;
 		font-family: inherit;
 		transition: all 0.2s;
@@ -1495,7 +1495,7 @@
 
 	input[type='text']:focus {
 		outline: none;
-		border-color: #3a7dff;
+		border-color: var(--accent);
 	}
 
 	input[type='text']:disabled {
@@ -1506,10 +1506,10 @@
 	textarea {
 		width: 100%;
 		padding: 0.75rem;
-		background: #0a0a0a;
-		border: 1px solid #333;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
-		color: white;
+		color: var(--text-primary);
 		font-size: 1rem;
 		font-family: inherit;
 		transition: all 0.2s;
@@ -1519,7 +1519,7 @@
 
 	textarea:focus {
 		outline: none;
-		border-color: #3a7dff;
+		border-color: var(--accent);
 	}
 
 	textarea:disabled {
@@ -1530,7 +1530,7 @@
 	.hint {
 		margin-top: 0.5rem;
 		font-size: 0.85rem;
-		color: #666;
+		color: var(--text-muted);
 	}
 
 	.message {
@@ -1540,15 +1540,15 @@
 	}
 
 	.message.success {
-		background: rgba(46, 160, 67, 0.1);
-		border: 1px solid rgba(46, 160, 67, 0.3);
-		color: #5ce87b;
+		background: color-mix(in srgb, var(--success) 10%, transparent);
+		border: 1px solid color-mix(in srgb, var(--success) 30%, transparent);
+		color: var(--success);
 	}
 
 	.message.error {
-		background: rgba(233, 69, 96, 0.1);
-		border: 1px solid rgba(233, 69, 96, 0.3);
-		color: #ff6b6b;
+		background: color-mix(in srgb, var(--error) 10%, transparent);
+		border: 1px solid color-mix(in srgb, var(--error) 30%, transparent);
+		color: var(--error);
 	}
 
 	.avatar-preview {
@@ -1563,16 +1563,16 @@
 		height: 64px;
 		border-radius: 50%;
 		object-fit: cover;
-		border: 2px solid #333;
+		border: 2px solid var(--border-default);
 	}
 
 	input[type='file'] {
 		width: 100%;
 		padding: 0.75rem;
-		background: #0a0a0a;
-		border: 1px solid #333;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
-		color: white;
+		color: var(--text-primary);
 		font-size: 0.9rem;
 		font-family: inherit;
 		cursor: pointer;
@@ -1586,20 +1586,20 @@
 	.format-hint {
 		margin-top: 0.25rem;
 		font-size: 0.8rem;
-		color: #888;
+		color: var(--text-tertiary);
 	}
 
 	.file-info {
 		margin-top: 0.5rem;
 		font-size: 0.85rem;
-		color: #666;
+		color: var(--text-muted);
 	}
 
 	button {
 		width: 100%;
 		padding: 0.75rem;
-		background: #3a7dff;
-		color: white;
+		background: var(--accent);
+		color: var(--text-primary);
 		border: none;
 		border-radius: 4px;
 		font-size: 1rem;
@@ -1610,9 +1610,9 @@
 	}
 
 	button:hover:not(:disabled) {
-		background: #2868e6;
+		background: var(--accent-hover);
 		transform: translateY(-1px);
-		box-shadow: 0 4px 12px rgba(58, 125, 255, 0.3);
+		box-shadow: 0 4px 12px color-mix(in srgb, var(--accent) 30%, transparent);
 	}
 
 	button:disabled {
@@ -1635,12 +1635,12 @@
 	}
 
 	.empty {
-		color: #666;
+		color: var(--text-muted);
 		padding: 2rem;
 		text-align: center;
-		background: #1a1a1a;
+		background: var(--bg-tertiary);
 		border-radius: 8px;
-		border: 1px solid #2a2a2a;
+		border: 1px solid var(--border-subtle);
 	}
 
 	.tracks-list {
@@ -1654,8 +1654,8 @@
 		align-items: flex-start;
 		justify-content: space-between;
 		gap: 1rem;
-		background: #1a1a1a;
-		border: 1px solid #2a2a2a;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-subtle);
 		border-radius: 6px;
 		padding: 1rem;
 		transition: all 0.2s;
@@ -1667,12 +1667,12 @@
 	}
 
 	.track-item.copyright-flagged {
-		background: rgba(233, 165, 69, 0.08);
-		border-color: rgba(233, 165, 69, 0.3);
+		background: color-mix(in srgb, var(--warning) 8%, transparent);
+		border-color: color-mix(in srgb, var(--warning) 30%, transparent);
 	}
 
 	.track-item.copyright-flagged .track-title {
-		color: #e9a545;
+		color: var(--warning);
 	}
 
 	.track-item.copyright-flagged .track-artwork img,
@@ -1686,8 +1686,8 @@
 		height: 48px;
 		border-radius: 4px;
 		overflow: hidden;
-		background: #0f0f0f;
-		border: 1px solid #282828;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-subtle);
 	}
 
 	.track-artwork img {
@@ -1702,12 +1702,12 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		color: #555;
+		color: var(--text-muted);
 	}
 
 	.track-item:hover {
-		background: #222;
-		border-color: #333;
+		background: var(--bg-hover);
+		border-color: var(--border-default);
 	}
 
 	.track-info {
@@ -1743,14 +1743,14 @@
 
 	.edit-label {
 		font-size: 0.85rem;
-		color: #aaa;
+		color: var(--text-secondary);
 	}
 
 	.track-title {
 		font-weight: 600;
 		font-size: 1rem;
 		margin-bottom: 0.25rem;
-		color: #fff;
+		color: var(--text-primary);
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
@@ -1759,13 +1759,13 @@
 	.copyright-flag {
 		display: inline-flex;
 		align-items: center;
-		color: #e9a545;
+		color: var(--warning);
 		flex-shrink: 0;
 		text-decoration: none;
 	}
 
 	.copyright-flag:hover {
-		color: #ffb860;
+		color: color-mix(in srgb, var(--warning) 80%, white);
 	}
 
 	a.copyright-flag {
@@ -1778,7 +1778,7 @@
 
 	.track-meta {
 		font-size: 0.9rem;
-		color: #b0b0b0;
+		color: var(--text-secondary);
 		margin-bottom: 0.25rem;
 		display: flex;
 		flex-direction: column;
@@ -1799,23 +1799,23 @@
 	}
 
 	.features-label {
-		color: #8ab3ff;
+		color: var(--accent-hover);
 		font-weight: 600;
 	}
 
 	.features-list {
-		color: #8ab3ff;
+		color: var(--accent-hover);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}
 
 	.meta-album {
-		color: #909090;
+		color: var(--text-tertiary);
 	}
 
 	.album-link {
-		color: #909090;
+		color: var(--text-tertiary);
 		text-decoration: none;
 		transition: color 0.2s;
 		white-space: nowrap;
@@ -1843,8 +1843,8 @@
 	.meta-tag {
 		display: inline-block;
 		padding: 0.1rem 0.4rem;
-		background: rgba(138, 179, 255, 0.15);
-		color: #8ab3ff;
+		background: color-mix(in srgb, var(--accent) 15%, transparent);
+		color: var(--accent-hover);
 		border-radius: 3px;
 		font-size: 0.8rem;
 		font-weight: 500;
@@ -1853,13 +1853,13 @@
 	}
 
 	.meta-tag:hover {
-		background: rgba(138, 179, 255, 0.25);
-		color: #a8c8ff;
+		background: color-mix(in srgb, var(--accent) 25%, transparent);
+		color: var(--accent-hover);
 	}
 
 	.track-date {
 		font-size: 0.85rem;
-		color: #666;
+		color: var(--text-muted);
 	}
 
 	.track-actions {
@@ -1875,9 +1875,9 @@
 		height: 36px;
 		padding: 0;
 		background: transparent;
-		border: 1px solid #444;
+		border: 1px solid var(--border-emphasis);
 		border-radius: 4px;
-		color: #888;
+		color: var(--text-tertiary);
 		font-size: 1.2rem;
 		line-height: 1;
 		cursor: pointer;
@@ -1885,8 +1885,8 @@
 	}
 
 	.edit-btn:hover {
-		background: rgba(106, 159, 255, 0.1);
-		border-color: rgba(106, 159, 255, 0.5);
+		background: color-mix(in srgb, var(--accent) 10%, transparent);
+		border-color: color-mix(in srgb, var(--accent) 50%, transparent);
 		color: var(--accent);
 		transform: none;
 		box-shadow: none;
@@ -1897,25 +1897,25 @@
 	}
 
 	.delete-btn:hover {
-		background: rgba(233, 69, 96, 0.1);
-		border-color: rgba(233, 69, 96, 0.5);
-		color: #ff6b6b;
+		background: color-mix(in srgb, var(--error) 10%, transparent);
+		border-color: color-mix(in srgb, var(--error) 50%, transparent);
+		color: var(--error);
 		transform: none;
 		box-shadow: none;
 	}
 
 	.save-btn:hover {
-		background: rgba(46, 160, 67, 0.1);
-		border-color: rgba(46, 160, 67, 0.5);
-		color: #5ce87b;
+		background: color-mix(in srgb, var(--success) 10%, transparent);
+		border-color: color-mix(in srgb, var(--success) 50%, transparent);
+		color: var(--success);
 		transform: none;
 		box-shadow: none;
 	}
 
 	.cancel-btn:hover {
-		background: rgba(136, 136, 136, 0.1);
-		border-color: rgba(136, 136, 136, 0.5);
-		color: #aaa;
+		background: color-mix(in srgb, var(--text-tertiary) 10%, transparent);
+		border-color: color-mix(in srgb, var(--text-tertiary) 50%, transparent);
+		color: var(--text-secondary);
 		transform: none;
 		box-shadow: none;
 	}
@@ -1923,10 +1923,10 @@
 	.edit-input {
 		width: 100%;
 		padding: 0.5rem;
-		background: #0a0a0a;
-		border: 1px solid #333;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
-		color: white;
+		color: var(--text-primary);
 		font-size: 0.9rem;
 		font-family: inherit;
 	}
@@ -1936,8 +1936,8 @@
 		align-items: center;
 		gap: 0.75rem;
 		padding: 0.5rem;
-		background: #0a0a0a;
-		border: 1px solid #333;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
 		margin-bottom: 0.5rem;
 	}
@@ -1950,7 +1950,7 @@
 	}
 
 	.current-image-label {
-		color: #888;
+		color: var(--text-tertiary);
 		font-size: 0.85rem;
 	}
 
@@ -1988,8 +1988,8 @@
 	}
 
 	.album-card {
-		background: #1a1a1a;
-		border: 1px solid #2a2a2a;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-subtle);
 		border-radius: 8px;
 		padding: 1rem;
 		transition: all 0.2s;
@@ -1999,7 +1999,7 @@
 	}
 
 	.album-card:hover {
-		border-color: #3a3a3a;
+		border-color: var(--border-emphasis);
 		transform: translateY(-2px);
 	}
 
@@ -2012,8 +2012,8 @@
 		aspect-ratio: 1;
 		border-radius: 6px;
 		overflow: hidden;
-		background: #0f0f0f;
-		border: 1px solid #282828;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-subtle);
 	}
 
 	.album-cover {
@@ -2029,13 +2029,13 @@
 		flex-direction: column;
 		align-items: center;
 		justify-content: center;
-		color: #606060;
+		color: var(--text-muted);
 		gap: 0.5rem;
 	}
 
 	.album-cover-placeholder .file-name {
 		font-size: 0.85rem;
-		color: #888;
+		color: var(--text-tertiary);
 		text-align: center;
 		word-break: break-word;
 		padding: 0 0.5rem;
@@ -2043,7 +2043,7 @@
 
 	.album-cover-placeholder .file-size {
 		font-size: 0.75rem;
-		color: #666;
+		color: var(--text-muted);
 	}
 
 	.album-info {
@@ -2053,7 +2053,7 @@
 	.album-title {
 		font-size: 1rem;
 		font-weight: 600;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		margin: 0 0 0.25rem 0;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -2062,7 +2062,7 @@
 
 	.album-stats {
 		font-size: 0.85rem;
-		color: #888;
+		color: var(--text-tertiary);
 		margin: 0;
 	}
 
@@ -2074,8 +2074,8 @@
 
 	.edit-cover-btn {
 		padding: 0.5rem;
-		background: #2a2a2a;
-		border: 1px solid #3a3a3a;
+		background: var(--border-subtle);
+		border: 1px solid var(--border-emphasis);
 		border-radius: 4px;
 		cursor: pointer;
 		transition: all 0.2s;
@@ -2085,7 +2085,7 @@
 	}
 
 	.edit-cover-btn:hover {
-		background: #3a3a3a;
+		background: var(--border-emphasis);
 		border-color: var(--accent);
 		color: var(--accent);
 	}
@@ -2101,8 +2101,8 @@
 		aspect-ratio: 1;
 		border-radius: 6px;
 		overflow: hidden;
-		background: #0f0f0f;
-		border: 1px solid #282828;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-subtle);
 	}
 
 	.album-edit-actions {
@@ -2113,23 +2113,23 @@
 
 	.file-input-label {
 		font-size: 0.85rem;
-		color: #b0b0b0;
+		color: var(--text-secondary);
 		font-weight: 500;
 		margin-bottom: 0.25rem;
 	}
 
 	.album-edit-actions .file-input {
 		padding: 0.5rem;
-		background: #2a2a2a;
-		border: 1px solid #3a3a3a;
+		background: var(--border-subtle);
+		border: 1px solid var(--border-emphasis);
 		border-radius: 4px;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		font-size: 0.85rem;
 		cursor: pointer;
 	}
 
 	.album-edit-actions .file-input:hover {
-		background: #3a3a3a;
+		background: var(--border-emphasis);
 		border-color: var(--accent);
 	}
 
@@ -2151,8 +2151,8 @@
 
 	.data-control {
 		padding: 1.5rem;
-		background: #1a1a1a;
-		border: 1px solid #2a2a2a;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-subtle);
 		border-radius: 8px;
 		display: flex;
 		justify-content: space-between;
@@ -2169,19 +2169,19 @@
 		font-size: 1rem;
 		font-weight: 600;
 		margin: 0 0 0.25rem 0;
-		color: #e8e8e8;
+		color: var(--text-primary);
 	}
 
 	.control-description {
 		font-size: 0.85rem;
-		color: #888;
+		color: var(--text-tertiary);
 		margin: 0;
 	}
 
 	.export-btn {
 		padding: 0.6rem 1.25rem;
-		background: #3a7dff;
-		color: white;
+		background: var(--accent);
+		color: var(--text-primary);
 		border: none;
 		border-radius: 6px;
 		font-size: 0.9rem;
@@ -2193,9 +2193,9 @@
 	}
 
 	.export-btn:hover:not(:disabled) {
-		background: #2868e6;
+		background: var(--accent-hover);
 		transform: translateY(-1px);
-		box-shadow: 0 4px 12px rgba(58, 125, 255, 0.3);
+		box-shadow: 0 4px 12px color-mix(in srgb, var(--accent) 30%, transparent);
 	}
 
 	.export-btn:disabled {
@@ -2206,30 +2206,30 @@
 
 	/* danger zone / account deletion */
 	.danger-zone {
-		border-color: #4a2020;
-		background: #1a1010;
+		border-color: color-mix(in srgb, var(--error) 30%, var(--bg-tertiary));
+		background: color-mix(in srgb, var(--error) 8%, var(--bg-tertiary));
 		flex-direction: column;
 		align-items: stretch;
 	}
 
 	.danger-zone .control-info h3 {
-		color: #ff6b6b;
+		color: var(--error);
 	}
 
 	.danger-zone .control-description a {
-		color: #888;
+		color: var(--text-tertiary);
 		text-decoration: underline;
 	}
 
 	.danger-zone .control-description a:hover {
-		color: #aaa;
+		color: var(--text-secondary);
 	}
 
 	.delete-account-btn {
 		padding: 0.6rem 1.25rem;
 		background: transparent;
-		color: #ff6b6b;
-		border: 1px solid #ff6b6b;
+		color: var(--error);
+		border: 1px solid var(--error);
 		border-radius: 6px;
 		font-size: 0.9rem;
 		font-weight: 600;
@@ -2239,18 +2239,18 @@
 	}
 
 	.delete-account-btn:hover {
-		background: #ff6b6b;
-		color: white;
+		background: var(--error);
+		color: var(--text-primary);
 	}
 
 	.delete-confirm-panel {
 		margin-top: 1rem;
 		padding-top: 1rem;
-		border-top: 1px solid #3a2020;
+		border-top: 1px solid color-mix(in srgb, var(--error) 25%, var(--bg-tertiary));
 	}
 
 	.delete-warning {
-		color: #ff8888;
+		color: color-mix(in srgb, var(--error) 80%, white);
 		font-size: 0.9rem;
 		margin: 0 0 1rem 0;
 		line-height: 1.5;
@@ -2265,7 +2265,7 @@
 		align-items: center;
 		gap: 0.5rem;
 		font-size: 0.9rem;
-		color: #aaa;
+		color: var(--text-secondary);
 		cursor: pointer;
 	}
 
@@ -2278,46 +2278,46 @@
 	.atproto-note {
 		margin: 0.5rem 0 0 0;
 		font-size: 0.85rem;
-		color: #777;
+		color: var(--text-muted);
 	}
 
 	.atproto-note a {
-		color: #999;
+		color: var(--text-tertiary);
 		text-decoration: underline;
 	}
 
 	.atproto-note a:hover {
-		color: #bbb;
+		color: var(--text-secondary);
 	}
 
 	.atproto-warning {
 		margin: 0.75rem 0 0 0;
 		padding: 0.75rem;
-		background: rgba(255, 107, 107, 0.1);
-		border-left: 2px solid #ff6b6b;
+		background: color-mix(in srgb, var(--error) 10%, transparent);
+		border-left: 2px solid var(--error);
 		font-size: 0.85rem;
-		color: #cc8888;
+		color: color-mix(in srgb, var(--error) 70%, var(--text-secondary));
 		line-height: 1.5;
 	}
 
 	.confirm-prompt {
 		font-size: 0.9rem;
-		color: #888;
+		color: var(--text-tertiary);
 		margin: 0 0 0.5rem 0;
 	}
 
 	.confirm-prompt strong {
-		color: #e8e8e8;
+		color: var(--text-primary);
 		font-family: monospace;
 	}
 
 	.confirm-input {
 		width: 100%;
 		padding: 0.75rem;
-		background: #0a0505;
-		border: 1px solid #3a2020;
+		background: color-mix(in srgb, var(--error) 5%, var(--bg-primary));
+		border: 1px solid color-mix(in srgb, var(--error) 25%, var(--bg-tertiary));
 		border-radius: 6px;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		font-size: 0.9rem;
 		font-family: monospace;
 		margin-bottom: 1rem;
@@ -2325,11 +2325,11 @@
 
 	.confirm-input:focus {
 		outline: none;
-		border-color: #ff6b6b;
+		border-color: var(--error);
 	}
 
 	.confirm-input::placeholder {
-		color: #555;
+		color: var(--text-muted);
 	}
 
 	.delete-actions {
@@ -2341,8 +2341,8 @@
 	.cancel-btn {
 		padding: 0.6rem 1.25rem;
 		background: transparent;
-		color: #888;
-		border: 1px solid #444;
+		color: var(--text-tertiary);
+		border: 1px solid var(--border-emphasis);
 		border-radius: 6px;
 		font-size: 0.9rem;
 		cursor: pointer;
@@ -2350,8 +2350,8 @@
 	}
 
 	.cancel-btn:hover:not(:disabled) {
-		border-color: #666;
-		color: #aaa;
+		border-color: var(--text-muted);
+		color: var(--text-secondary);
 	}
 
 	.cancel-btn:disabled {
@@ -2361,8 +2361,8 @@
 
 	.confirm-delete-btn {
 		padding: 0.6rem 1.25rem;
-		background: #ff4444;
-		color: white;
+		background: var(--error);
+		color: var(--text-primary);
 		border: none;
 		border-radius: 6px;
 		font-size: 0.9rem;
@@ -2372,7 +2372,7 @@
 	}
 
 	.confirm-delete-btn:hover:not(:disabled) {
-		background: #ff2222;
+		background: color-mix(in srgb, var(--error) 80%, black);
 	}
 
 	.confirm-delete-btn:disabled {
@@ -2395,7 +2395,7 @@
 	.toggle-slider {
 		width: 44px;
 		height: 24px;
-		background: #333;
+		background: var(--border-default);
 		border-radius: 12px;
 		position: relative;
 		transition: background 0.2s;
@@ -2408,23 +2408,23 @@
 		left: 2px;
 		width: 20px;
 		height: 20px;
-		background: #888;
+		background: var(--text-tertiary);
 		border-radius: 50%;
 		transition: all 0.2s;
 	}
 
 	.toggle-switch input:checked + .toggle-slider {
-		background: var(--accent, #3a7dff);
+		background: var(--accent);
 	}
 
 	.toggle-switch input:checked + .toggle-slider::after {
 		left: 22px;
-		background: white;
+		background: var(--text-primary);
 	}
 
 	.toggle-label {
 		font-size: 0.85rem;
-		color: #888;
+		color: var(--text-tertiary);
 		min-width: 60px;
 	}
 
@@ -2451,15 +2451,15 @@
 		align-items: center;
 		gap: 0.5rem;
 		font-size: 0.9rem;
-		color: #888;
+		color: var(--text-tertiary);
 	}
 
 	.expires-select {
 		padding: 0.5rem 0.75rem;
-		background: #0a0a0a;
-		border: 1px solid #333;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
-		color: white;
+		color: var(--text-primary);
 		font-size: 0.9rem;
 		font-family: inherit;
 		cursor: pointer;
@@ -2499,8 +2499,8 @@
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
-		background: #0a0a0a;
-		border: 1px solid #333;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
 		border-radius: 6px;
 		padding: 0.75rem;
 		overflow: hidden;
@@ -2510,7 +2510,7 @@
 		flex: 1;
 		font-family: monospace;
 		font-size: 0.85rem;
-		color: #5ce87b;
+		color: var(--success);
 		word-break: break-all;
 		user-select: all;
 	}
@@ -2518,10 +2518,10 @@
 	.copy-btn,
 	.dismiss-btn {
 		padding: 0.4rem 0.75rem;
-		background: #2a2a2a;
-		border: 1px solid #3a3a3a;
+		background: var(--border-subtle);
+		border: 1px solid var(--border-emphasis);
 		border-radius: 4px;
-		color: #888;
+		color: var(--text-tertiary);
 		font-size: 0.85rem;
 		cursor: pointer;
 		transition: all 0.2s;
@@ -2529,20 +2529,20 @@
 	}
 
 	.copy-btn:hover {
-		background: #3a3a3a;
+		background: var(--border-emphasis);
 		border-color: var(--accent);
 		color: var(--accent);
 	}
 
 	.dismiss-btn:hover {
-		background: #3a3a3a;
-		border-color: #666;
-		color: #aaa;
+		background: var(--border-emphasis);
+		border-color: var(--text-muted);
+		color: var(--text-secondary);
 	}
 
 	.token-warning {
 		font-size: 0.85rem;
-		color: #e9a545;
+		color: var(--warning);
 		margin: 0;
 	}
 
@@ -2555,7 +2555,7 @@
 	.tokens-header {
 		font-size: 0.9rem;
 		font-weight: 600;
-		color: #888;
+		color: var(--text-tertiary);
 		margin: 0 0 0.75rem 0;
 	}
 
@@ -2571,8 +2571,8 @@
 		align-items: center;
 		gap: 1rem;
 		padding: 0.75rem;
-		background: #0a0a0a;
-		border: 1px solid #2a2a2a;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-subtle);
 		border-radius: 6px;
 	}
 
@@ -2587,7 +2587,7 @@
 	.token-name {
 		font-family: monospace;
 		font-size: 0.9rem;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -2595,15 +2595,15 @@
 
 	.token-meta {
 		font-size: 0.8rem;
-		color: #666;
+		color: var(--text-muted);
 	}
 
 	.revoke-btn {
 		padding: 0.4rem 0.75rem;
 		background: transparent;
-		border: 1px solid #4a2020;
+		border: 1px solid color-mix(in srgb, var(--error) 30%, var(--bg-tertiary));
 		border-radius: 4px;
-		color: #ff6b6b;
+		color: var(--error);
 		font-size: 0.85rem;
 		cursor: pointer;
 		transition: all 0.2s;
@@ -2612,8 +2612,8 @@
 	}
 
 	.revoke-btn:hover:not(:disabled) {
-		background: rgba(255, 107, 107, 0.1);
-		border-color: #ff6b6b;
+		background: color-mix(in srgb, var(--error) 10%, transparent);
+		border-color: var(--error);
 	}
 
 	.revoke-btn:disabled {
@@ -2623,10 +2623,10 @@
 
 	.token-name-input {
 		padding: 0.5rem 0.75rem;
-		background: #0a0a0a;
-		border: 1px solid #333;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
-		color: white;
+		color: var(--text-primary);
 		font-size: 0.9rem;
 		font-family: inherit;
 		min-width: 150px;
@@ -2644,7 +2644,7 @@
 
 	.loading-tokens {
 		font-size: 0.9rem;
-		color: #666;
+		color: var(--text-muted);
 		margin: 0;
 	}
 </style>

--- a/frontend/src/routes/profile/setup/+page.svelte
+++ b/frontend/src/routes/profile/setup/+page.svelte
@@ -191,7 +191,7 @@
 		align-items: center;
 		justify-content: center;
 		min-height: 100vh;
-		color: #888;
+		color: var(--text-tertiary);
 	}
 
 	main {
@@ -213,7 +213,7 @@
 	}
 
 	.subtitle {
-		color: #aaa;
+		color: var(--text-secondary);
 		margin-bottom: 2rem;
 		line-height: 1.5;
 	}
@@ -222,16 +222,16 @@
 		padding: 1rem;
 		border-radius: 4px;
 		margin-bottom: 1.5rem;
-		background: rgba(233, 69, 96, 0.1);
-		border: 1px solid rgba(233, 69, 96, 0.3);
-		color: #ff6b6b;
+		background: color-mix(in srgb, var(--error) 10%, transparent);
+		border: 1px solid color-mix(in srgb, var(--error) 30%, transparent);
+		color: var(--error);
 	}
 
 	form {
-		background: #1a1a1a;
+		background: var(--bg-tertiary);
 		padding: 2rem;
 		border-radius: 8px;
-		border: 1px solid #2a2a2a;
+		border: 1px solid var(--border-subtle);
 	}
 
 	.form-group {
@@ -244,7 +244,7 @@
 
 	label {
 		display: block;
-		color: #aaa;
+		color: var(--text-secondary);
 		margin-bottom: 0.5rem;
 		font-size: 0.9rem;
 		font-weight: 500;
@@ -255,10 +255,10 @@
 	textarea {
 		width: 100%;
 		padding: 0.75rem;
-		background: #0a0a0a;
-		border: 1px solid #333;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
-		color: white;
+		color: var(--text-primary);
 		font-size: 1rem;
 		font-family: inherit;
 		transition: all 0.2s;
@@ -268,7 +268,7 @@
 	input[type='url']:focus,
 	textarea:focus {
 		outline: none;
-		border-color: #3a7dff;
+		border-color: var(--accent);
 	}
 
 	input[type='text']:disabled,
@@ -286,13 +286,13 @@
 	.hint {
 		margin-top: 0.5rem;
 		font-size: 0.85rem;
-		color: #666;
+		color: var(--text-muted);
 	}
 
 	button {
 		width: 100%;
 		padding: 0.75rem;
-		background: #3a7dff;
+		background: var(--accent);
 		color: white;
 		border: none;
 		border-radius: 4px;
@@ -303,9 +303,9 @@
 	}
 
 	button:hover:not(:disabled) {
-		background: #2868e6;
+		background: var(--accent-hover);
 		transform: translateY(-1px);
-		box-shadow: 0 4px 12px rgba(58, 125, 255, 0.3);
+		box-shadow: 0 4px 12px color-mix(in srgb, var(--accent) 30%, transparent);
 	}
 
 	button:disabled {

--- a/frontend/src/routes/tag/[name]/+page.svelte
+++ b/frontend/src/routes/tag/[name]/+page.svelte
@@ -124,7 +124,7 @@
 		gap: 0.4rem;
 		font-size: var(--text-page-heading);
 		font-weight: 700;
-		color: #8ab3ff;
+		color: var(--accent-hover);
 		margin: 0 0 0.5rem 0;
 	}
 

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -637,9 +637,9 @@ $effect(() => {
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		background: #1a1a1a;
-		border: 1px solid #282828;
-		color: #606060;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-subtle);
+		color: var(--text-muted);
 	}
 
 	.track-info-wrapper {
@@ -672,7 +672,7 @@ $effect(() => {
 	.track-title {
 		font-size: 2rem;
 		font-weight: 700;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		margin: 0;
 		line-height: 1.2;
 		text-align: center;
@@ -684,17 +684,17 @@ $effect(() => {
 		justify-content: center;
 		gap: 0.75rem;
 		flex-wrap: wrap;
-		color: #b0b0b0;
+		color: var(--text-secondary);
 		font-size: 1.1rem;
 	}
 
 	.separator {
-		color: #555;
+		color: var(--text-muted);
 		font-size: 0.8rem;
 	}
 
 	.artist-link {
-		color: #b0b0b0;
+		color: var(--text-secondary);
 		text-decoration: none;
 		font-weight: 500;
 		transition: color 0.2s;
@@ -712,12 +712,12 @@ $effect(() => {
 	}
 
 	.features-label {
-		color: #8ab3ff;
+		color: var(--accent-hover);
 		font-weight: 500;
 	}
 
 	.feature-link {
-		color: #8ab3ff;
+		color: var(--accent-hover);
 		text-decoration: none;
 		font-weight: 500;
 		transition: color 0.2s;
@@ -729,11 +729,11 @@ $effect(() => {
 	}
 
 	.feature-separator {
-		color: #8ab3ff;
+		color: var(--accent-hover);
 	}
 
 	.album {
-		color: #909090;
+		color: var(--text-tertiary);
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
@@ -743,7 +743,7 @@ $effect(() => {
 
 	.album-link {
 		text-decoration: none;
-		color: #909090;
+		color: var(--text-tertiary);
 		transition: color 0.2s;
 		display: flex;
 		align-items: center;
@@ -770,7 +770,7 @@ $effect(() => {
 	}
 
 	.track-stats {
-		color: #808080;
+		color: var(--text-tertiary);
 		font-size: 0.95rem;
 		display: flex;
 		align-items: center;
@@ -792,8 +792,8 @@ $effect(() => {
 	.tag-badge {
 		display: inline-block;
 		padding: 0.25rem 0.6rem;
-		background: rgba(138, 179, 255, 0.15);
-		color: #8ab3ff;
+		background: color-mix(in srgb, var(--accent) 15%, transparent);
+		color: var(--accent-hover);
 		border-radius: 4px;
 		font-size: 0.85rem;
 		font-weight: 500;
@@ -802,8 +802,8 @@ $effect(() => {
 	}
 
 	.tag-badge:hover {
-		background: rgba(138, 179, 255, 0.25);
-		color: #a8c8ff;
+		background: color-mix(in srgb, var(--accent) 25%, transparent);
+		color: var(--accent-hover);
 	}
 
 	.mobile-side-buttons {
@@ -828,7 +828,7 @@ $effect(() => {
 		gap: 0.5rem;
 		padding: 0.75rem 1.5rem;
 		background: var(--accent);
-		color: #000;
+		color: var(--bg-primary);
 		border: none;
 		border-radius: 24px;
 		font-size: 0.95rem;
@@ -853,8 +853,8 @@ $effect(() => {
 		gap: 0.5rem;
 		padding: 0.75rem 1.5rem;
 		background: transparent;
-		color: #e8e8e8;
-		border: 1px solid #404040;
+		color: var(--text-primary);
+		border: 1px solid var(--border-emphasis);
 		border-radius: 24px;
 		font-size: 0.95rem;
 		font-weight: 500;
@@ -866,7 +866,7 @@ $effect(() => {
 	.btn-queue:hover {
 		border-color: var(--accent);
 		color: var(--accent);
-		background: rgba(138, 179, 255, 0.1);
+		background: color-mix(in srgb, var(--accent) 10%, transparent);
 	}
 
 	@media (max-width: 768px) {
@@ -963,13 +963,13 @@ $effect(() => {
 		max-width: 500px;
 		margin: 1.5rem auto 0;
 		padding-top: 1.5rem;
-		border-top: 1px solid #2a2a2a;
+		border-top: 1px solid var(--border-subtle);
 	}
 
 	.comments-title {
 		font-size: 1rem;
 		font-weight: 600;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		margin: 0 0 0.75rem 0;
 		display: flex;
 		align-items: center;
@@ -977,7 +977,7 @@ $effect(() => {
 	}
 
 	.comment-count {
-		color: #888;
+		color: var(--text-tertiary);
 		font-weight: 400;
 	}
 
@@ -990,10 +990,10 @@ $effect(() => {
 	.comment-input {
 		flex: 1;
 		padding: 0.6rem 0.8rem;
-		background: #1a1a1a;
-		border: 1px solid #333;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-default);
 		border-radius: 6px;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		font-size: 0.9rem;
 		font-family: inherit;
 	}
@@ -1004,13 +1004,13 @@ $effect(() => {
 	}
 
 	.comment-input::placeholder {
-		color: #666;
+		color: var(--text-muted);
 	}
 
 	.comment-submit {
 		padding: 0.6rem 1rem;
 		background: var(--accent);
-		color: #000;
+		color: var(--bg-primary);
 		border: none;
 		border-radius: 6px;
 		font-size: 0.9rem;
@@ -1030,7 +1030,7 @@ $effect(() => {
 	}
 
 	.login-prompt {
-		color: #888;
+		color: var(--text-tertiary);
 		font-size: 0.9rem;
 		margin-bottom: 1rem;
 	}
@@ -1045,7 +1045,7 @@ $effect(() => {
 	}
 
 	.no-comments {
-		color: #666;
+		color: var(--text-muted);
 		font-size: 0.9rem;
 		text-align: center;
 		padding: 1rem;
@@ -1058,7 +1058,7 @@ $effect(() => {
 		max-height: 300px;
 		overflow-y: auto;
 		scrollbar-width: thin;
-		scrollbar-color: #333 #0a0a0a;
+		scrollbar-color: var(--border-default) var(--bg-primary);
 	}
 
 	.comments-list::-webkit-scrollbar {
@@ -1066,17 +1066,17 @@ $effect(() => {
 	}
 
 	.comments-list::-webkit-scrollbar-track {
-		background: #0a0a0a;
+		background: var(--bg-primary);
 		border-radius: 4px;
 	}
 
 	.comments-list::-webkit-scrollbar-thumb {
-		background: #333;
+		background: var(--border-default);
 		border-radius: 4px;
 	}
 
 	.comments-list::-webkit-scrollbar-thumb:hover {
-		background: #444;
+		background: var(--border-emphasis);
 	}
 
 	.comment {
@@ -1084,20 +1084,20 @@ $effect(() => {
 		align-items: flex-start;
 		gap: 0.6rem;
 		padding: 0.5rem 0.6rem;
-		background: #1a1a1a;
+		background: var(--bg-tertiary);
 		border-radius: 6px;
 		transition: background 0.15s;
 	}
 
 	.comment:hover {
-		background: #222;
+		background: var(--bg-hover);
 	}
 
 	.comment-timestamp {
 		font-size: 0.8rem;
 		font-weight: 600;
 		color: var(--accent);
-		background: rgba(138, 179, 255, 0.1);
+		background: color-mix(in srgb, var(--accent) 10%, transparent);
 		padding: 0.2rem 0.5rem;
 		border-radius: 4px;
 		white-space: nowrap;
@@ -1109,7 +1109,7 @@ $effect(() => {
 	}
 
 	.comment-timestamp:hover {
-		background: rgba(138, 179, 255, 0.25);
+		background: color-mix(in srgb, var(--accent) 25%, transparent);
 		transform: scale(1.05);
 	}
 
@@ -1127,13 +1127,13 @@ $effect(() => {
 	}
 
 	.comment-separator {
-		color: #444;
+		color: var(--border-emphasis);
 		font-size: 0.6rem;
 	}
 
 	.comment-time {
 		font-size: 0.75rem;
-		color: #666;
+		color: var(--text-muted);
 	}
 
 	.comment-avatar {
@@ -1147,13 +1147,13 @@ $effect(() => {
 		width: 20px;
 		height: 20px;
 		border-radius: 50%;
-		background: #333;
+		background: var(--border-default);
 	}
 
 	.comment-author {
 		font-size: 0.85rem;
 		font-weight: 500;
-		color: #b0b0b0;
+		color: var(--text-secondary);
 		text-decoration: none;
 	}
 
@@ -1163,7 +1163,7 @@ $effect(() => {
 
 	.comment-text {
 		font-size: 0.9rem;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		margin: 0;
 		line-height: 1.4;
 		word-break: break-word;
@@ -1180,7 +1180,7 @@ $effect(() => {
 	}
 
 	.edited-indicator {
-		color: #555;
+		color: var(--text-muted);
 		font-style: italic;
 	}
 
@@ -1201,7 +1201,7 @@ $effect(() => {
 		background: none;
 		border: none;
 		padding: 0;
-		color: #666;
+		color: var(--text-muted);
 		font-size: 0.8rem;
 		cursor: pointer;
 		transition: color 0.15s;
@@ -1213,7 +1213,7 @@ $effect(() => {
 	}
 
 	.comment-action-btn.delete:hover {
-		color: #ff6b6b;
+		color: var(--error);
 	}
 
 	/* mobile: always show actions */
@@ -1233,10 +1233,10 @@ $effect(() => {
 	.comment-edit-input {
 		width: 100%;
 		padding: 0.5rem;
-		background: #0a0a0a;
-		border: 1px solid #333;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
 		border-radius: 4px;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		font-size: 0.9rem;
 		font-family: inherit;
 	}
@@ -1263,7 +1263,7 @@ $effect(() => {
 
 	.edit-form-btn.save {
 		background: var(--accent);
-		color: #000;
+		color: var(--bg-primary);
 		border: none;
 		font-weight: 500;
 	}
@@ -1274,13 +1274,13 @@ $effect(() => {
 
 	.edit-form-btn.cancel {
 		background: transparent;
-		color: #888;
-		border: 1px solid #444;
+		color: var(--text-tertiary);
+		border: 1px solid var(--border-emphasis);
 	}
 
 	.edit-form-btn.cancel:hover {
-		border-color: #666;
-		color: #aaa;
+		border-color: var(--text-muted);
+		color: var(--text-secondary);
 	}
 
 	/* comments container prevents layout shift during transition */
@@ -1294,15 +1294,15 @@ $effect(() => {
 	}
 
 	.comment.skeleton:hover {
-		background: #1a1a1a;
+		background: var(--bg-tertiary);
 	}
 
 	.skeleton-bar {
 		background: linear-gradient(
 			90deg,
-			#1a1a1a 0%,
-			#242424 50%,
-			#1a1a1a 100%
+			var(--bg-tertiary) 0%,
+			var(--bg-hover) 50%,
+			var(--bg-tertiary) 100%
 		);
 		background-size: 200% 100%;
 		animation: shimmer 1.5s ease-in-out infinite;

--- a/frontend/src/routes/u/[handle]/+error.svelte
+++ b/frontend/src/routes/u/[handle]/+error.svelte
@@ -92,20 +92,20 @@
 
 	h1 {
 		font-size: 4rem;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		margin: 0 0 1rem 0;
 		font-weight: 700;
 	}
 
 	.error-message {
 		font-size: 1.25rem;
-		color: #b0b0b0;
+		color: var(--text-secondary);
 		margin: 0 0 0.5rem 0;
 	}
 
 	.error-detail {
 		font-size: 1rem;
-		color: #808080;
+		color: var(--text-tertiary);
 		margin: 0 0 2rem 0;
 	}
 
@@ -130,17 +130,17 @@
 
 	.bsky-link {
 		background: var(--accent);
-		color: #000;
+		color: var(--bg-primary);
 	}
 
 	.bsky-link:hover {
-		background: #6a9fff;
-		border-color: #6a9fff;
+		background: var(--accent-hover);
+		border-color: var(--accent-hover);
 	}
 
 	.home-link:hover {
 		background: var(--accent);
-		color: #000;
+		color: var(--bg-primary);
 	}
 
 	@media (max-width: 768px) {

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -356,8 +356,8 @@ $effect(() => {
 		gap: 2rem;
 		margin-bottom: 3rem;
 		padding: 2rem;
-		background: #141414;
-		border: 1px solid #282828;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-subtle);
 		border-radius: 8px;
 	}
 
@@ -390,20 +390,20 @@ $effect(() => {
 		height: 120px;
 		border-radius: 50%;
 		object-fit: cover;
-		border: 3px solid #333;
+		border: 3px solid var(--border-default);
 	}
 
 	.artist-info h1 {
 		font-size: 2.5rem;
 		margin: 0 0 0.5rem 0;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		word-wrap: break-word;
 		overflow-wrap: break-word;
 		hyphens: auto;
 	}
 
 	.handle {
-		color: #909090;
+		color: var(--text-tertiary);
 		font-size: 1.1rem;
 		margin: 0 0 1rem 0;
 		text-decoration: none;
@@ -416,7 +416,7 @@ $effect(() => {
 	}
 
 	.bio {
-		color: #b0b0b0;
+		color: var(--text-secondary);
 		line-height: 1.6;
 		margin: 0;
 	}
@@ -427,7 +427,7 @@ $effect(() => {
 
 	.analytics h2 {
 		margin-bottom: 1.5rem;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		font-size: 1.8rem;
 	}
 
@@ -448,7 +448,7 @@ $effect(() => {
 	}
 
 	.section-header span {
-		color: #808080;
+		color: var(--text-tertiary);
 		font-size: 0.9rem;
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
@@ -465,8 +465,8 @@ $effect(() => {
 		gap: 1rem;
 		align-items: center;
 		padding: 1rem;
-		background: #141414;
-		border: 1px solid #282828;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-subtle);
 		border-radius: 10px;
 		color: inherit;
 		text-decoration: none;
@@ -484,8 +484,8 @@ $effect(() => {
 		border-radius: 6px;
 		overflow: hidden;
 		flex-shrink: 0;
-		background: #1a1a1a;
-		border: 1px solid #333;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-default);
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -499,7 +499,7 @@ $effect(() => {
 	}
 
 	.album-cover-placeholder {
-		color: #666;
+		color: var(--text-muted);
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -510,7 +510,7 @@ $effect(() => {
 	.album-card-meta h3 {
 		margin: 0 0 0.35rem 0;
 		font-size: 1.05rem;
-		color: #fafafa;
+		color: var(--text-primary);
 		text-transform: lowercase;
 		white-space: nowrap;
 		overflow: hidden;
@@ -529,7 +529,7 @@ $effect(() => {
 
 	.album-card-meta p {
 		margin: 0;
-		color: #9a9a9a;
+		color: var(--text-tertiary);
 		font-size: 0.9rem;
 		display: flex;
 		align-items: center;
@@ -538,19 +538,19 @@ $effect(() => {
 
 	.album-card-meta .dot {
 		font-size: 0.65rem;
-		color: #555;
+		color: var(--text-muted);
 	}
 
 	.stat-card {
-		background: #141414;
-		border: 1px solid #282828;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-subtle);
 		border-radius: 8px;
 		padding: 1.5rem;
 		transition: border-color 0.2s;
 	}
 
 	.stat-card:hover {
-		border-color: #404040;
+		border-color: var(--border-emphasis);
 	}
 
 	.stat-value {
@@ -562,7 +562,7 @@ $effect(() => {
 	}
 
 	.stat-label {
-		color: #909090;
+		color: var(--text-tertiary);
 		font-size: 0.9rem;
 		text-transform: lowercase;
 		line-height: 1;
@@ -578,12 +578,12 @@ $effect(() => {
 	.stat-card.top-item:hover {
 		border-color: var(--accent);
 		transform: translateY(-2px);
-		box-shadow: 0 4px 12px rgba(138, 179, 255, 0.2);
+		box-shadow: 0 4px 12px color-mix(in srgb, var(--accent) 20%, transparent);
 	}
 
 	.top-item-title {
 		font-size: 1.2rem;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		margin: 0.5rem 0;
 		font-weight: 500;
 		line-height: 1;
@@ -605,9 +605,9 @@ $effect(() => {
 	.skeleton-bar {
 		background: linear-gradient(
 			90deg,
-			#1a1a1a 0%,
-			#242424 50%,
-			#1a1a1a 100%
+			var(--bg-tertiary) 0%,
+			var(--bg-hover) 50%,
+			var(--bg-tertiary) 100%
 		);
 		background-size: 200% 100%;
 		animation: shimmer 1.5s ease-in-out infinite;
@@ -652,14 +652,14 @@ $effect(() => {
 
 	.tracks h2 {
 		margin-bottom: 1.5rem;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		font-size: 1.8rem;
 	}
 
 	.tracks-loading {
 		margin-left: 0.75rem;
 		font-size: 0.95rem;
-		color: #9ea5b4;
+		color: var(--text-secondary);
 		font-weight: 400;
 		text-transform: lowercase;
 	}
@@ -673,19 +673,19 @@ $effect(() => {
 	.empty-state {
 		text-align: center;
 		padding: 3rem;
-		background: #141414;
-		border: 1px solid #282828;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-subtle);
 		border-radius: 8px;
 	}
 
 	.empty-message {
-		color: #b0b0b0;
+		color: var(--text-secondary);
 		font-size: 1.25rem;
 		margin: 0 0 0.5rem 0;
 	}
 
 	.empty-detail {
-		color: #808080;
+		color: var(--text-tertiary);
 		margin: 0 0 1.5rem 0;
 	}
 
@@ -702,7 +702,7 @@ $effect(() => {
 
 	.bsky-link:hover {
 		background: var(--accent);
-		color: #000;
+		color: var(--bg-primary);
 	}
 
 	/* respect reduced motion preference */

--- a/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
@@ -178,12 +178,12 @@
 		width: 200px;
 		height: 200px;
 		border-radius: 8px;
-		background: #1a1a1a;
-		border: 1px solid #282828;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-subtle);
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		color: #606060;
+		color: var(--text-muted);
 	}
 
 	.album-info-wrapper {
@@ -217,7 +217,7 @@
 		font-size: 0.75rem;
 		font-weight: 600;
 		letter-spacing: 0.1em;
-		color: #808080;
+		color: var(--text-tertiary);
 		margin: 0;
 	}
 
@@ -225,7 +225,7 @@
 		font-size: 3rem;
 		font-weight: 700;
 		margin: 0;
-		color: #ffffff;
+		color: var(--text-primary);
 		line-height: 1.1;
 		word-wrap: break-word;
 		overflow-wrap: break-word;
@@ -237,11 +237,11 @@
 		align-items: center;
 		gap: 0.75rem;
 		font-size: 0.95rem;
-		color: #b0b0b0;
+		color: var(--text-secondary);
 	}
 
 	.artist-link {
-		color: #b0b0b0;
+		color: var(--text-secondary);
 		text-decoration: none;
 		font-weight: 600;
 		transition: color 0.2s;
@@ -252,7 +252,7 @@
 	}
 
 	.meta-separator {
-		color: #555;
+		color: var(--text-muted);
 		font-size: 0.7rem;
 	}
 
@@ -279,7 +279,7 @@
 
 	.play-button {
 		background: var(--accent);
-		color: #000;
+		color: var(--bg-primary);
 	}
 
 	.play-button:hover {
@@ -288,8 +288,8 @@
 
 	.queue-button {
 		background: transparent;
-		color: #e8e8e8;
-		border: 1px solid #333;
+		color: var(--text-primary);
+		border: 1px solid var(--border-default);
 	}
 
 	.queue-button:hover {
@@ -305,7 +305,7 @@
 	.section-heading {
 		font-size: 1.25rem;
 		font-weight: 600;
-		color: #e8e8e8;
+		color: var(--text-primary);
 		margin-bottom: 1rem;
 		text-transform: lowercase;
 	}


### PR DESCRIPTION
## Summary
- Replace hardcoded colors across 35 files with CSS custom properties (semantic tokens like `--bg-primary`, `--text-secondary`, `--accent`)
- Add theme switcher in settings menu with dark/light/system options
- Light theme properly adapts all UI elements including track items, header, tags, tooltips
- Remove zen mode feature (was only toggling visibility of a few elements)

## Test plan
- [ ] Toggle between dark, light, and system themes in settings
- [ ] Verify all UI elements render correctly in both themes
- [ ] Test accent color picker works with both themes
- [ ] Check system theme follows OS preference when set to "system"
- [ ] Verify theme persists across page refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)