### PR TITLE
feat: mobile UX improvements for header, portal, and upload

### DIFF
--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -3,6 +3,7 @@
 	import type { User } from '$lib/types';
 	import SettingsMenu from './SettingsMenu.svelte';
 	import LinksMenu from './LinksMenu.svelte';
+	import ProfileMenu from './ProfileMenu.svelte';
 	import PlatformStats from './PlatformStats.svelte';
 	import { APP_NAME, APP_TAGLINE } from '$lib/branding';
 
@@ -65,19 +66,57 @@
 			</a>
 		</div>
 
+		<!-- Mobile: navigation icons with flex spacer -->
+		<div class="mobile-center mobile-only">
+			{#if $page.url.pathname !== '/'}
+				<a href="/" class="nav-icon" title="go to feed">
+					<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<circle cx="12" cy="12" r="10"></circle>
+						<line x1="2" y1="12" x2="22" y2="12"></line>
+						<path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+					</svg>
+				</a>
+			{/if}
+			{#if isAuthenticated && $page.url.pathname !== '/liked'}
+				<a href="/liked" class="nav-icon" title="go to liked tracks">
+					<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+					</svg>
+				</a>
+			{/if}
+		</div>
+
 		<nav>
 			{#if isAuthenticated}
-			{#if $page.url.pathname !== '/liked'}
-				<a href="/liked" class="nav-link">
-						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-							<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
-						</svg>
-						<span>liked</span>
-					</a>
-				{/if}
-				<a href="/portal" class="user-handle">@{user?.handle}</a>
-				<SettingsMenu />
-				<button onclick={onLogout} class="btn-logout">logout</button>
+				<!-- Desktop nav -->
+				<div class="desktop-nav desktop-only">
+					{#if $page.url.pathname !== '/'}
+						<a href="/" class="nav-link" title="go to feed">
+							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+								<circle cx="12" cy="12" r="10"></circle>
+								<line x1="2" y1="12" x2="22" y2="12"></line>
+								<path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+							</svg>
+							<span>feed</span>
+						</a>
+					{/if}
+					{#if $page.url.pathname !== '/liked'}
+						<a href="/liked" class="nav-link" title="go to liked tracks">
+							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+								<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+							</svg>
+							<span>liked</span>
+						</a>
+					{/if}
+					<a href="/portal" class="user-handle" title="go to portal">@{user?.handle}</a>
+					<SettingsMenu />
+					<button onclick={onLogout} class="btn-logout" title="log out">logout</button>
+				</div>
+
+				<!-- Mobile nav: just ProfileMenu -->
+				<div class="mobile-only">
+					<ProfileMenu {user} {onLogout} />
+				</div>
 			{:else}
 				<a href="/login" class="btn-primary">log in</a>
 			{/if}
@@ -101,6 +140,7 @@
 		justify-content: space-between;
 		align-items: center;
 		gap: 1rem;
+		position: relative;
 	}
 
 	.left-section {
@@ -129,6 +169,41 @@
 
 	.mobile-only {
 		display: none;
+	}
+
+	.desktop-nav {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.mobile-center {
+		flex: 1;
+		justify-content: center;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
+	.nav-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 44px;
+		height: 44px;
+		border-radius: 10px;
+		color: var(--text-secondary);
+		text-decoration: none;
+		transition: all 0.15s;
+		-webkit-tap-highlight-color: transparent;
+	}
+
+	.nav-icon:hover {
+		color: var(--accent);
+		background: var(--bg-tertiary);
+	}
+
+	.nav-icon:active {
+		transform: scale(0.94);
 	}
 
 	.stats-left {
@@ -167,8 +242,9 @@
 
 	.brand p {
 		margin: 0;
-		font-size: 0.85rem;
+		font-size: 0.65rem;
 		color: var(--text-tertiary);
+		letter-spacing: 0.02em;
 	}
 
 	nav {
@@ -289,7 +365,7 @@
 		}
 
 		.brand p {
-			font-size: 0.7rem;
+			font-size: 0.55rem;
 		}
 
 		nav {

--- a/frontend/src/lib/components/HiddenTagsFilter.svelte
+++ b/frontend/src/lib/components/HiddenTagsFilter.svelte
@@ -88,7 +88,9 @@
 
 		{#if isExpanded}
 			<div class="tags-row">
-				<span class="filter-label">hiding:</span>
+				{#if hiddenTags.length > 0}
+					<span class="filter-label">hiding:</span>
+				{/if}
 				{#each hiddenTags as tag}
 					<button type="button" class="tag-chip" onclick={() => removeTag(tag)} title="unhide '{tag}'">
 						{tag}
@@ -109,13 +111,9 @@
 						class="add-input"
 					/>
 				{:else}
-					<button type="button" class="add-btn" onclick={startAddingTag}>
+					<button type="button" class="add-btn" onclick={startAddingTag} title="hide a tag">
 						+
 					</button>
-				{/if}
-
-				{#if hiddenTags.length === 0 && !addingTag}
-					<span class="empty-hint">none</span>
 				{/if}
 			</div>
 		{/if}
@@ -251,11 +249,6 @@
 
 	.add-input::placeholder {
 		color: var(--text-tertiary);
-	}
-
-	.empty-hint {
-		color: var(--text-tertiary);
-		font-size: 0.7rem;
 	}
 
 	/* mobile adjustments */

--- a/frontend/src/lib/components/ProfileMenu.svelte
+++ b/frontend/src/lib/components/ProfileMenu.svelte
@@ -1,0 +1,638 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
+	import { queue } from '$lib/queue.svelte';
+	import { preferences, type Theme } from '$lib/preferences.svelte';
+	import type { User } from '$lib/types';
+
+	interface Props {
+		user: User | null;
+		onLogout: () => Promise<void>;
+	}
+
+	let { user, onLogout }: Props = $props();
+	let isOnPortal = $derived($page.url.pathname === '/portal');
+	let isOnUpload = $derived($page.url.pathname === '/upload');
+	let showMenu = $state(false);
+	let showSettings = $state(false);
+
+	const presetColors = [
+		{ name: 'blue', value: '#6a9fff' },
+		{ name: 'purple', value: '#a78bfa' },
+		{ name: 'pink', value: '#f472b6' },
+		{ name: 'green', value: '#4ade80' },
+		{ name: 'orange', value: '#fb923c' },
+		{ name: 'red', value: '#ef4444' }
+	];
+
+	const themes: { value: Theme; label: string; icon: string }[] = [
+		{ value: 'dark', label: 'dark', icon: 'moon' },
+		{ value: 'light', label: 'light', icon: 'sun' },
+		{ value: 'system', label: 'auto', icon: 'auto' }
+	];
+
+	let currentColor = $derived(preferences.accentColor ?? '#6a9fff');
+	let autoAdvance = $derived(preferences.autoAdvance);
+	let currentTheme = $derived(preferences.theme);
+
+	$effect(() => {
+		if (currentColor) {
+			applyColorLocally(currentColor);
+		}
+	});
+
+	$effect(() => {
+		queue.setAutoAdvance(autoAdvance);
+	});
+
+	onMount(() => {
+		const savedAccent = localStorage.getItem('accentColor');
+		if (savedAccent) {
+			applyColorLocally(savedAccent);
+		}
+	});
+
+	function toggleMenu() {
+		showMenu = !showMenu;
+		if (!showMenu) {
+			showSettings = false;
+		}
+	}
+
+	function closeMenu() {
+		showMenu = false;
+		showSettings = false;
+	}
+
+	function applyColorLocally(color: string) {
+		document.documentElement.style.setProperty('--accent', color);
+		const r = parseInt(color.slice(1, 3), 16);
+		const g = parseInt(color.slice(3, 5), 16);
+		const b = parseInt(color.slice(5, 7), 16);
+		const hover = `rgb(${Math.min(255, r + 30)}, ${Math.min(255, g + 30)}, ${Math.min(255, b + 30)})`;
+		document.documentElement.style.setProperty('--accent-hover', hover);
+	}
+
+	async function applyColor(color: string) {
+		applyColorLocally(color);
+		localStorage.setItem('accentColor', color);
+		await preferences.update({ accent_color: color });
+	}
+
+	function handleColorInput(event: Event) {
+		const input = event.target as HTMLInputElement;
+		applyColor(input.value);
+	}
+
+	function selectPreset(color: string) {
+		applyColor(color);
+	}
+
+	async function handleAutoAdvanceToggle(event: Event) {
+		const input = event.target as HTMLInputElement;
+		const value = input.checked;
+		queue.setAutoAdvance(value);
+		localStorage.setItem('autoAdvance', value ? '1' : '0');
+		await preferences.update({ auto_advance: value });
+	}
+
+	function selectTheme(theme: Theme) {
+		preferences.setTheme(theme);
+	}
+
+	async function handleLogout() {
+		closeMenu();
+		await onLogout();
+	}
+</script>
+
+<div class="profile-menu">
+	<button class="menu-trigger" onclick={toggleMenu} title="menu">
+		<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" stroke="none">
+			<circle cx="12" cy="5" r="2"></circle>
+			<circle cx="12" cy="12" r="2"></circle>
+			<circle cx="12" cy="19" r="2"></circle>
+		</svg>
+	</button>
+
+	{#if showMenu}
+		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div class="menu-backdrop" onclick={closeMenu}></div>
+		<div class="menu-popover">
+			<div class="menu-header">
+				<span>{showSettings ? 'settings' : 'menu'}</span>
+				<button class="close-btn" onclick={closeMenu} aria-label="close">
+					<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<line x1="18" y1="6" x2="6" y2="18"></line>
+						<line x1="6" y1="6" x2="18" y2="18"></line>
+					</svg>
+				</button>
+			</div>
+
+			{#if !showSettings}
+				<nav class="menu-items">
+					{#if !isOnPortal}
+						<a href="/portal" class="menu-item" onclick={closeMenu}>
+							<svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+								<circle cx="8" cy="5" r="3" fill="none" />
+								<path d="M3 14c0-2.5 2-4.5 5-4.5s5 2 5 4.5" />
+							</svg>
+							<div class="item-content">
+								<span class="item-title">profile</span>
+								<span class="item-subtitle">@{user?.handle}</span>
+							</div>
+						</a>
+					{/if}
+
+					{#if !isOnUpload}
+						<a href="/upload" class="menu-item" onclick={closeMenu}>
+							<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+								<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+								<polyline points="17 8 12 3 7 8"></polyline>
+								<line x1="12" y1="3" x2="12" y2="15"></line>
+							</svg>
+							<div class="item-content">
+								<span class="item-title">upload</span>
+								<span class="item-subtitle">add a track</span>
+							</div>
+						</a>
+					{/if}
+
+					<button class="menu-item" onclick={() => showSettings = true}>
+						<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+							<path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path>
+							<circle cx="12" cy="12" r="3"></circle>
+						</svg>
+						<div class="item-content">
+							<span class="item-title">settings</span>
+							<span class="item-subtitle">theme, colors, playback</span>
+						</div>
+						<svg class="chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<polyline points="9 18 15 12 9 6"></polyline>
+						</svg>
+					</button>
+
+					<button class="menu-item logout" onclick={handleLogout}>
+						<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path>
+							<polyline points="16 17 21 12 16 7"></polyline>
+							<line x1="21" y1="12" x2="9" y2="12"></line>
+						</svg>
+						<div class="item-content">
+							<span class="item-title">logout</span>
+						</div>
+					</button>
+				</nav>
+			{:else}
+				<button class="back-btn" onclick={() => showSettings = false}>
+					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<polyline points="15 18 9 12 15 6"></polyline>
+					</svg>
+					<span>back</span>
+				</button>
+
+				<div class="settings-content">
+					<section class="settings-section">
+						<h3>theme</h3>
+						<div class="theme-buttons">
+							{#each themes as theme}
+								<button
+									class="theme-btn"
+									class:active={currentTheme === theme.value}
+									onclick={() => selectTheme(theme.value)}
+									title={theme.label}
+								>
+									{#if theme.icon === 'moon'}
+										<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+											<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+										</svg>
+									{:else if theme.icon === 'sun'}
+										<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+											<circle cx="12" cy="12" r="5" />
+											<path d="M12 1v2m0 18v2M4.22 4.22l1.42 1.42m12.72 12.72 1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+										</svg>
+									{:else}
+										<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+											<circle cx="12" cy="12" r="9" />
+											<path d="M12 3v18" />
+											<path d="M12 3a9 9 0 0 1 0 18" fill="currentColor" opacity="0.3" />
+										</svg>
+									{/if}
+									<span>{theme.label}</span>
+								</button>
+							{/each}
+						</div>
+					</section>
+
+					<section class="settings-section">
+						<h3>accent</h3>
+						<div class="color-row">
+							<input type="color" value={currentColor} oninput={handleColorInput} class="color-input" />
+							<div class="preset-grid">
+								{#each presetColors as preset}
+									<button
+										class="preset-btn"
+										class:active={currentColor.toLowerCase() === preset.value.toLowerCase()}
+										style="background: {preset.value}"
+										onclick={() => selectPreset(preset.value)}
+										title={preset.name}
+									></button>
+								{/each}
+							</div>
+						</div>
+					</section>
+
+					<section class="settings-section">
+						<h3>playback</h3>
+						<label class="toggle">
+							<input type="checkbox" checked={autoAdvance} oninput={handleAutoAdvanceToggle} />
+							<span class="toggle-text">auto-play next</span>
+						</label>
+					</section>
+				</div>
+			{/if}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.profile-menu {
+		position: relative;
+	}
+
+	.menu-trigger {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 44px;
+		height: 44px;
+		background: transparent;
+		border: 1px solid var(--border-default);
+		border-radius: 8px;
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: all 0.15s;
+		-webkit-tap-highlight-color: transparent;
+	}
+
+	.menu-trigger:hover {
+		background: var(--bg-tertiary);
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+
+	.menu-trigger:active {
+		transform: scale(0.96);
+	}
+
+	.menu-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		z-index: 100;
+		animation: fadeIn 0.12s ease-out;
+	}
+
+	.menu-popover {
+		position: fixed;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		width: min(340px, calc(100vw - 2rem));
+		max-height: calc(100vh - 4rem);
+		overflow-y: auto;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-default);
+		border-radius: 16px;
+		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+		z-index: 101;
+		animation: slideIn 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+	}
+
+	.menu-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 1rem 1.25rem;
+		border-bottom: 1px solid var(--border-subtle);
+	}
+
+	.menu-header span {
+		font-size: 0.9rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.close-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 36px;
+		height: 36px;
+		background: transparent;
+		border: none;
+		border-radius: 8px;
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: all 0.15s;
+		-webkit-tap-highlight-color: transparent;
+	}
+
+	.close-btn:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.close-btn:active {
+		transform: scale(0.94);
+	}
+
+	.menu-items {
+		display: flex;
+		flex-direction: column;
+		padding: 0.5rem;
+	}
+
+	.menu-item {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		padding: 1rem;
+		min-height: 56px;
+		background: transparent;
+		border: none;
+		border-radius: 12px;
+		text-decoration: none;
+		color: var(--text-primary);
+		font-family: inherit;
+		font-size: inherit;
+		cursor: pointer;
+		transition: all 0.15s;
+		text-align: left;
+		width: 100%;
+		-webkit-tap-highlight-color: transparent;
+	}
+
+	.menu-item:hover {
+		background: var(--bg-hover);
+	}
+
+	.menu-item:active {
+		transform: scale(0.98);
+	}
+
+	.menu-item svg:first-child {
+		flex-shrink: 0;
+		color: var(--text-secondary);
+		transition: color 0.15s;
+	}
+
+	.menu-item:hover svg:first-child {
+		color: var(--accent);
+	}
+
+	.menu-item.logout:hover svg:first-child {
+		color: var(--error);
+	}
+
+	.item-content {
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+		flex: 1;
+		min-width: 0;
+	}
+
+	.item-title {
+		font-size: 0.95rem;
+		font-weight: 500;
+		color: var(--text-primary);
+	}
+
+	.item-subtitle {
+		font-size: 0.8rem;
+		color: var(--text-tertiary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.chevron {
+		flex-shrink: 0;
+		color: var(--text-tertiary);
+	}
+
+	.back-btn {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin: 0.75rem 1rem 0.5rem;
+		padding: 0.5rem 0.75rem;
+		background: transparent;
+		border: none;
+		border-radius: 6px;
+		color: var(--text-secondary);
+		font-family: inherit;
+		font-size: 0.85rem;
+		cursor: pointer;
+		transition: all 0.15s;
+		-webkit-tap-highlight-color: transparent;
+	}
+
+	.back-btn:hover {
+		color: var(--accent);
+		background: var(--bg-hover);
+	}
+
+	.settings-content {
+		padding: 0.75rem 1.25rem 1.25rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+	}
+
+	.settings-section {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.settings-section h3 {
+		margin: 0;
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--text-tertiary);
+	}
+
+	.theme-buttons {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.theme-btn {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.35rem;
+		padding: 0.75rem 0.5rem;
+		min-height: 54px;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-default);
+		border-radius: 8px;
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: all 0.15s;
+		-webkit-tap-highlight-color: transparent;
+	}
+
+	.theme-btn:hover {
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+
+	.theme-btn:active {
+		transform: scale(0.96);
+	}
+
+	.theme-btn.active {
+		background: color-mix(in srgb, var(--accent) 15%, transparent);
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+
+	.theme-btn svg {
+		width: 18px;
+		height: 18px;
+	}
+
+	.theme-btn span {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.color-row {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.color-input {
+		width: 44px;
+		height: 44px;
+		border: 1px solid var(--border-default);
+		border-radius: 8px;
+		cursor: pointer;
+		background: transparent;
+		flex-shrink: 0;
+	}
+
+	.color-input::-webkit-color-swatch-wrapper {
+		padding: 3px;
+	}
+
+	.color-input::-webkit-color-swatch {
+		border-radius: 4px;
+		border: none;
+	}
+
+	.preset-grid {
+		display: flex;
+		gap: 0.5rem;
+		flex: 1;
+	}
+
+	.preset-btn {
+		width: 36px;
+		height: 36px;
+		border-radius: 6px;
+		border: 2px solid transparent;
+		cursor: pointer;
+		transition: all 0.15s;
+		padding: 0;
+		-webkit-tap-highlight-color: transparent;
+	}
+
+	.preset-btn:hover {
+		transform: scale(1.08);
+	}
+
+	.preset-btn:active {
+		transform: scale(0.96);
+	}
+
+	.preset-btn.active {
+		border-color: var(--text-primary);
+		box-shadow: 0 0 0 1px var(--bg-secondary);
+	}
+
+	.toggle {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		color: var(--text-primary);
+		font-size: 0.9rem;
+		cursor: pointer;
+		padding: 0.5rem 0;
+	}
+
+	.toggle input {
+		appearance: none;
+		width: 48px;
+		height: 28px;
+		border-radius: 999px;
+		background: var(--border-default);
+		position: relative;
+		cursor: pointer;
+		transition: background 0.15s, border 0.15s;
+		border: 1px solid var(--border-default);
+		flex-shrink: 0;
+	}
+
+	.toggle input::after {
+		content: '';
+		position: absolute;
+		top: 3px;
+		left: 3px;
+		width: 20px;
+		height: 20px;
+		border-radius: 50%;
+		background: var(--text-secondary);
+		transition: transform 0.15s, background 0.15s;
+	}
+
+	.toggle input:checked {
+		background: color-mix(in srgb, var(--accent) 65%, transparent);
+		border-color: var(--accent);
+	}
+
+	.toggle input:checked::after {
+		transform: translateX(20px);
+		background: var(--accent);
+	}
+
+	.toggle-text {
+		white-space: nowrap;
+	}
+
+	@keyframes fadeIn {
+		from { opacity: 0; }
+		to { opacity: 1; }
+	}
+
+	@keyframes slideIn {
+		from {
+			opacity: 0;
+			transform: translate(-50%, -48%) scale(0.96);
+		}
+		to {
+			opacity: 1;
+			transform: translate(-50%, -50%) scale(1);
+		}
+	}
+</style>

--- a/frontend/src/lib/components/SettingsMenu.svelte
+++ b/frontend/src/lib/components/SettingsMenu.svelte
@@ -88,7 +88,7 @@
 </script>
 
 <div class="settings-menu">
-	<button class="settings-toggle" onclick={toggleSettings} title="settings">
+	<button class="settings-toggle" onclick={toggleSettings} title="open settings">
 		<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 			<path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path>
 			<circle cx="12" cy="12" r="3"></circle>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -90,7 +90,9 @@
 					latest tracks
 				</button>
 			</h2>
-			<HiddenTagsFilter />
+			<div class="header-actions">
+				<HiddenTagsFilter />
+			</div>
 		</div>
 		{#if showLoading}
 			<div class="loading-container">
@@ -124,21 +126,29 @@
 	main {
 		max-width: 800px;
 		margin: 0 auto;
-		padding: 0 1rem calc(var(--player-height, 120px) + env(safe-area-inset-bottom, 0px));
+		padding: 0 1rem calc(var(--player-height, 0px) + 2rem + env(safe-area-inset-bottom, 0px));
 	}
 
 	.section-header {
 		display: flex;
+		justify-content: space-between;
 		align-items: center;
-		gap: 0.75rem;
+		gap: 1rem;
 		margin-bottom: 1.5rem;
 		flex-wrap: wrap;
 	}
 
-	.tracks h2 {
+	.section-header h2 {
 		font-size: var(--text-page-heading);
-		margin: 0;
+		font-weight: 700;
 		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.header-actions {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
 	}
 
 	.clickable-heading {
@@ -148,7 +158,7 @@
 		font: inherit;
 		color: inherit;
 		cursor: pointer;
-		transition: color 0.2s;
+		transition: color 0.15s;
 		user-select: none;
 	}
 
@@ -166,5 +176,15 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;
+	}
+
+	@media (max-width: 768px) {
+		main {
+			padding: 0 0.75rem calc(var(--player-height, 0px) + 1.25rem + env(safe-area-inset-bottom, 0px));
+		}
+
+		.section-header h2 {
+			font-size: 1.25rem;
+		}
 	}
 </style>

--- a/frontend/src/routes/liked/+page.svelte
+++ b/frontend/src/routes/liked/+page.svelte
@@ -33,17 +33,17 @@
 <Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={handleLogout} />
 
 <div class="page">
-	<header class="page-header">
-		<div class="header-top">
-			<div>
-				<h1>liked tracks</h1>
-				{#if data.tracks.length > 0}
-					<p class="subtitle">{data.tracks.length} {data.tracks.length === 1 ? 'track' : 'tracks'}</p>
-				{/if}
-			</div>
+	<div class="section-header">
+		<h2>
+			liked tracks
 			{#if data.tracks.length > 0}
-				<button class="btn-queue-all" onclick={queueAll} title="queue all liked tracks">
-					<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+				<span class="count">{data.tracks.length}</span>
+			{/if}
+		</h2>
+		{#if data.tracks.length > 0}
+			<div class="header-actions">
+				<button class="btn-action" onclick={queueAll} title="queue all liked tracks">
+					<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 						<line x1="8" y1="6" x2="21" y2="6"></line>
 						<line x1="8" y1="12" x2="21" y2="12"></line>
 						<line x1="8" y1="18" x2="21" y2="18"></line>
@@ -53,9 +53,9 @@
 					</svg>
 					<span>queue all</span>
 				</button>
-			{/if}
-		</div>
-	</header>
+			</div>
+		{/if}
+	</div>
 
 	{#if data.tracks.length === 0}
 		<div class="empty-state">
@@ -93,53 +93,66 @@
 		min-height: 100vh;
 	}
 
-	.page-header {
-		margin-bottom: 1.5rem;
-	}
-
-	.header-top {
+	.section-header {
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
 		gap: 1rem;
+		margin-bottom: 1.5rem;
 		flex-wrap: wrap;
 	}
 
-	.page-header h1 {
+	.section-header h2 {
 		font-size: var(--text-page-heading);
 		font-weight: 700;
 		color: var(--text-primary);
-		margin: 0 0 0.5rem 0;
-	}
-
-	.subtitle {
-		font-size: 0.95rem;
-		color: var(--text-tertiary);
 		margin: 0;
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
 	}
 
-	.btn-queue-all {
+	.count {
+		font-size: 0.85rem;
+		font-weight: 500;
+		color: var(--text-tertiary);
+		background: var(--bg-tertiary);
+		padding: 0.2rem 0.55rem;
+		border-radius: 4px;
+	}
+
+	.header-actions {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.btn-action {
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
-		padding: 0.6rem 1rem;
+		padding: 0.5rem 0.85rem;
 		background: transparent;
-		border: 1px solid var(--accent);
-		color: var(--accent);
+		border: 1px solid var(--border-default);
+		color: var(--text-secondary);
 		border-radius: 6px;
-		font-size: 0.9rem;
+		font-size: 0.85rem;
 		font-family: inherit;
 		cursor: pointer;
-		transition: all 0.2s;
+		transition: all 0.15s;
 		white-space: nowrap;
 	}
 
-	.btn-queue-all:hover {
-		background: var(--accent);
-		color: var(--bg-primary);
+	.btn-action:hover {
+		border-color: var(--accent);
+		color: var(--accent);
 	}
 
-	.btn-queue-all svg {
+	.btn-action:active {
+		transform: scale(0.97);
+	}
+
+	.btn-action svg {
 		flex-shrink: 0;
 	}
 
@@ -174,11 +187,16 @@
 
 	@media (max-width: 768px) {
 		.page {
-			padding: 1.25rem 0.75rem calc(var(--player-height, 0px) + 1.25rem + env(safe-area-inset-bottom, 0px));
+			padding: 0 0.75rem calc(var(--player-height, 0px) + 1.25rem + env(safe-area-inset-bottom, 0px));
 		}
 
-		.page-header h1 {
-			font-size: 1.35rem;
+		.section-header h2 {
+			font-size: 1.25rem;
+		}
+
+		.count {
+			font-size: 0.8rem;
+			padding: 0.15rem 0.45rem;
 		}
 
 		.empty-state {
@@ -189,45 +207,12 @@
 			font-size: 1.25rem;
 		}
 
-		.btn-queue-all {
-			padding: 0.5rem 0.75rem;
-			font-size: 0.85rem;
-		}
-
-		.btn-queue-all svg {
-			width: 18px;
-			height: 18px;
-		}
-	}
-
-	@media (max-width: 480px) {
-		.page {
-			padding: 1rem 0.65rem calc(var(--player-height, 0px) + 1rem + env(safe-area-inset-bottom, 0px));
-		}
-
-		.page-header {
-			margin-bottom: 1.5rem;
-		}
-
-		.header-top {
-			gap: 0.75rem;
-		}
-
-		.page-header h1 {
-			font-size: 1.2rem;
-			margin: 0 0 0.35rem 0;
-		}
-
-		.subtitle {
-			font-size: 0.85rem;
-		}
-
-		.btn-queue-all {
-			padding: 0.45rem 0.65rem;
+		.btn-action {
+			padding: 0.45rem 0.7rem;
 			font-size: 0.8rem;
 		}
 
-		.btn-queue-all svg {
+		.btn-action svg {
 			width: 16px;
 			height: 16px;
 		}

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -1,0 +1,402 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import Header from '$lib/components/Header.svelte';
+	import HandleSearch from '$lib/components/HandleSearch.svelte';
+	import AlbumSelect from '$lib/components/AlbumSelect.svelte';
+	import WaveLoading from '$lib/components/WaveLoading.svelte';
+	import TagInput from '$lib/components/TagInput.svelte';
+	import type { FeaturedArtist, AlbumSummary } from '$lib/types';
+	import { API_URL, getServerConfig } from '$lib/config';
+	import { uploader } from '$lib/uploader.svelte';
+	import { toast } from '$lib/toast.svelte';
+	import { auth } from '$lib/auth.svelte';
+
+	// browser-compatible audio formats only
+	const ACCEPTED_AUDIO_EXTENSIONS = ['.mp3', '.wav', '.m4a'];
+	const ACCEPTED_AUDIO_MIME_TYPES = ['audio/mpeg', 'audio/wav', 'audio/mp4'];
+	const FILE_INPUT_ACCEPT = [...ACCEPTED_AUDIO_EXTENSIONS, ...ACCEPTED_AUDIO_MIME_TYPES].join(',');
+
+	function isSupportedAudioFile(name: string): boolean {
+		const dotIndex = name.lastIndexOf('.');
+		if (dotIndex === -1) return false;
+		const ext = name.slice(dotIndex).toLowerCase();
+		return ACCEPTED_AUDIO_EXTENSIONS.includes(ext);
+	}
+
+	let loading = $state(true);
+
+	// upload form fields
+	let title = $state('');
+	let albumTitle = $state('');
+	let file = $state<File | null>(null);
+	let imageFile = $state<File | null>(null);
+	let featuredArtists = $state<FeaturedArtist[]>([]);
+	let uploadTags = $state<string[]>([]);
+	let hasUnresolvedFeaturesInput = $state(false);
+
+	// albums for selection
+	let albums = $state<AlbumSummary[]>([]);
+
+	onMount(async () => {
+		// wait for auth to finish loading
+		while (auth.loading) {
+			await new Promise(resolve => setTimeout(resolve, 50));
+		}
+
+		if (!auth.isAuthenticated) {
+			goto('/login');
+			return;
+		}
+
+		await loadMyAlbums();
+		loading = false;
+	});
+
+	async function loadMyAlbums() {
+		if (!auth.user) return;
+		try {
+			const response = await fetch(`${API_URL}/albums/${auth.user.handle}`);
+			if (response.ok) {
+				const data = await response.json();
+				albums = data.albums;
+			}
+		} catch (_e) {
+			console.error('failed to load albums:', _e);
+		}
+	}
+
+	function handleUpload(e: SubmitEvent) {
+		e.preventDefault();
+		if (!file) return;
+
+		const uploadFile = file;
+		const uploadTitle = title;
+		const uploadAlbum = albumTitle;
+		const uploadFeatures = [...featuredArtists];
+		const uploadImage = imageFile;
+		const tagsToUpload = [...uploadTags];
+
+		const clearForm = () => {
+			title = '';
+			albumTitle = '';
+			file = null;
+			imageFile = null;
+			featuredArtists = [];
+			uploadTags = [];
+
+			const fileInput = document.getElementById('file-input') as HTMLInputElement;
+			if (fileInput) fileInput.value = '';
+			const imageInput = document.getElementById('image-input') as HTMLInputElement;
+			if (imageInput) imageInput.value = '';
+		};
+
+		uploader.upload(
+			uploadFile,
+			uploadTitle,
+			uploadAlbum,
+			uploadFeatures,
+			uploadImage,
+			tagsToUpload,
+			async () => {
+				await loadMyAlbums();
+			},
+			{
+				onSuccess: () => {
+					clearForm();
+					toast.success('track uploaded successfully');
+				},
+				onError: () => {}
+			}
+		);
+	}
+
+	async function handleFileChange(e: Event) {
+		const target = e.target as HTMLInputElement;
+		if (target.files && target.files[0]) {
+			const selected = target.files[0];
+			if (!isSupportedAudioFile(selected.name)) {
+				toast.error(`unsupported file type. supported: ${ACCEPTED_AUDIO_EXTENSIONS.join(', ')}`);
+				target.value = '';
+				file = null;
+				return;
+			}
+
+			try {
+				const config = await getServerConfig();
+				const sizeMB = selected.size / (1024 * 1024);
+				if (sizeMB > config.max_upload_size_mb) {
+					toast.error(`audio file too large (${sizeMB.toFixed(1)}MB). max: ${config.max_upload_size_mb}MB`);
+					target.value = '';
+					file = null;
+					return;
+				}
+			} catch (_e) {
+				console.error('failed to validate file size:', _e);
+			}
+
+			file = selected;
+		}
+	}
+
+	async function handleImageChange(e: Event) {
+		const target = e.target as HTMLInputElement;
+		if (target.files && target.files[0]) {
+			const selected = target.files[0];
+
+			try {
+				const config = await getServerConfig();
+				const sizeMB = selected.size / (1024 * 1024);
+				if (sizeMB > config.max_image_size_mb) {
+					toast.error(`image too large (${sizeMB.toFixed(1)}MB). max: ${config.max_image_size_mb}MB`);
+					target.value = '';
+					imageFile = null;
+					return;
+				}
+			} catch (_e) {
+				console.error('failed to validate image size:', _e);
+			}
+
+			imageFile = selected;
+		}
+	}
+
+	async function logout() {
+		await auth.logout();
+		window.location.href = '/';
+	}
+</script>
+
+<svelte:head>
+	<title>upload track • plyr</title>
+</svelte:head>
+
+{#if loading}
+	<div class="loading">
+		<WaveLoading size="lg" message="loading..." />
+	</div>
+{:else}
+	<Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={logout} />
+	<main>
+		<div class="section-header">
+			<h2>upload track</h2>
+		</div>
+
+		<form onsubmit={handleUpload}>
+			<div class="form-group">
+				<label for="title">track title</label>
+				<input
+					id="title"
+					type="text"
+					bind:value={title}
+					required
+					placeholder="my awesome song"
+				/>
+			</div>
+
+			<div class="form-group">
+				<label for="album">album (optional)</label>
+				<AlbumSelect
+					{albums}
+					bind:value={albumTitle}
+				/>
+			</div>
+
+			<div class="form-group">
+				<label for="features">featured artists (optional)</label>
+				<HandleSearch
+					bind:selected={featuredArtists}
+					bind:hasUnresolvedInput={hasUnresolvedFeaturesInput}
+					onAdd={(artist) => { featuredArtists = [...featuredArtists, artist]; }}
+					onRemove={(did) => { featuredArtists = featuredArtists.filter(a => a.did !== did); }}
+				/>
+			</div>
+
+			<div class="form-group">
+				<label for="upload-tags">tags (optional)</label>
+				<TagInput
+					tags={uploadTags}
+					onAdd={(tag) => { uploadTags = [...uploadTags, tag]; }}
+					onRemove={(tag) => { uploadTags = uploadTags.filter(t => t !== tag); }}
+					placeholder="type to search tags..."
+				/>
+			</div>
+
+			<div class="form-group">
+				<label for="file-input">audio file</label>
+				<input
+					id="file-input"
+					type="file"
+					accept={FILE_INPUT_ACCEPT}
+					onchange={handleFileChange}
+					required
+				/>
+				<p class="format-hint">supported: mp3, wav, m4a</p>
+				{#if file}
+					<p class="file-info">{file.name} ({(file.size / 1024 / 1024).toFixed(2)} MB)</p>
+				{/if}
+			</div>
+
+			<div class="form-group">
+				<label for="image-input">artwork (optional)</label>
+				<input
+					id="image-input"
+					type="file"
+					accept=".jpg,.jpeg,.png,.webp,.gif,image/jpeg,image/png,image/webp,image/gif"
+					onchange={handleImageChange}
+				/>
+				<p class="format-hint">supported: jpg, png, webp, gif</p>
+				{#if imageFile}
+					<p class="file-info">{imageFile.name} ({(imageFile.size / 1024 / 1024).toFixed(2)} MB)</p>
+				{/if}
+			</div>
+
+			<button type="submit" disabled={!file || hasUnresolvedFeaturesInput} class="upload-btn" title={hasUnresolvedFeaturesInput ? "please select or clear featured artist" : ""}>
+				<span>upload track</span>
+			</button>
+		</form>
+	</main>
+{/if}
+
+<style>
+	.loading {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		min-height: 100vh;
+		color: var(--text-tertiary);
+		gap: 1rem;
+	}
+
+	main {
+		max-width: 800px;
+		margin: 0 auto;
+		padding: 0 1rem calc(var(--player-height, 120px) + 2rem + env(safe-area-inset-bottom, 0px));
+	}
+
+	.section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 1rem;
+		margin-bottom: 1.5rem;
+	}
+
+	.section-header h2 {
+		font-size: var(--text-page-heading);
+		font-weight: 700;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	form {
+		background: var(--bg-tertiary);
+		padding: 2rem;
+		border-radius: 8px;
+		border: 1px solid var(--border-subtle);
+	}
+
+	.form-group {
+		margin-bottom: 1.5rem;
+	}
+
+	label {
+		display: block;
+		color: var(--text-secondary);
+		margin-bottom: 0.5rem;
+		font-size: 0.9rem;
+	}
+
+	input[type='text'] {
+		width: 100%;
+		padding: 0.75rem;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
+		border-radius: 4px;
+		color: var(--text-primary);
+		font-size: 1rem;
+		font-family: inherit;
+		transition: all 0.2s;
+	}
+
+	input[type='text']:focus {
+		outline: none;
+		border-color: var(--accent);
+	}
+
+	input[type='file'] {
+		width: 100%;
+		padding: 0.75rem;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
+		border-radius: 4px;
+		color: var(--text-primary);
+		font-size: 0.9rem;
+		font-family: inherit;
+		cursor: pointer;
+	}
+
+	.format-hint {
+		margin-top: 0.25rem;
+		font-size: 0.8rem;
+		color: var(--text-tertiary);
+	}
+
+	.file-info {
+		margin-top: 0.5rem;
+		font-size: 0.85rem;
+		color: var(--text-muted);
+	}
+
+	button {
+		width: 100%;
+		padding: 0.75rem;
+		background: var(--accent);
+		color: var(--text-primary);
+		border: none;
+		border-radius: 4px;
+		font-size: 1rem;
+		font-weight: 600;
+		font-family: inherit;
+		cursor: pointer;
+		transition: all 0.2s;
+	}
+
+	button:hover:not(:disabled) {
+		background: var(--accent-hover);
+		transform: translateY(-1px);
+		box-shadow: 0 4px 12px color-mix(in srgb, var(--accent) 30%, transparent);
+	}
+
+	button:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+		transform: none;
+	}
+
+	button:active:not(:disabled) {
+		transform: translateY(0);
+	}
+
+	.upload-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+	}
+
+	@media (max-width: 768px) {
+		main {
+			padding: 0 0.75rem calc(var(--player-height, 120px) + 1.5rem + env(safe-area-inset-bottom, 0px));
+		}
+
+		form {
+			padding: 1.25rem;
+		}
+
+		.section-header h2 {
+			font-size: 1.25rem;
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary
- **ProfileMenu component** - Mobile menu that collapses profile, upload, settings, and logout into a single touch-optimized menu (44px tap targets, snappy animations)
- **Dedicated /upload page** - Extracted upload form from portal to its own page, portal now links to it with a clean card design
- **Standardized section headers** - Consistent layout between home page (latest tracks) and liked tracks page
- **Portal mobile overhaul** - Tighter forms, proper icon alignment, smaller typography for data section, track detail links under artwork, fixed token button alignment

## Changes
- `Header.svelte` - Restructured mobile layout with ProfileMenu on right, heart centered
- `ProfileMenu.svelte` - New component with nested settings view (theme, accent color, auto-play)
- `/upload/+page.svelte` - New dedicated upload page
- `/portal/+page.svelte` - Removed inline upload form, added upload card link, comprehensive mobile CSS, track detail links, fixed action button SVGs
- `/+page.svelte` & `/liked/+page.svelte` - Standardized section header layout

## Test plan
- [ ] Test mobile header layout on various screen sizes
- [ ] Verify ProfileMenu opens/closes correctly, hides profile link when on /portal
- [ ] Test upload flow from portal card and from ProfileMenu
- [ ] Check track edit/delete icons are properly aligned
- [ ] Verify "view" link under track artwork navigates correctly
- [ ] Test create token button alignment in developer section

🤖 Generated with [Claude Code](https://claude.com/claude-code)