### PR TITLE
fix: player scroll timing + upload toast improvements

### DIFF
--- a/frontend/src/lib/components/Toast.svelte
+++ b/frontend/src/lib/components/Toast.svelte
@@ -25,7 +25,12 @@
 				<span class="toast-message">
 					{item.message}
 					{#if item.action}
-						<a href={item.action.href} target="_blank" rel="noopener noreferrer" class="toast-action">
+						<a
+							href={item.action.href}
+							class="toast-action"
+							target={item.action.href.startsWith('/') ? undefined : '_blank'}
+							rel={item.action.href.startsWith('/') ? undefined : 'noopener noreferrer'}
+						>
 							{item.action.label}
 						</a>
 					{/if}

--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -228,7 +228,7 @@
 	.player-title.scrolling span,
 	.player-title-link.scrolling span {
 		padding-right: 2rem;
-		animation: scroll-text 10s linear infinite;
+		animation: scroll-text 8s linear infinite;
 	}
 
 	.text-container.scrolling {
@@ -245,7 +245,7 @@
 
 	.text-container.scrolling > span {
 		padding-right: 3rem;
-		animation: scroll-text 15s linear infinite;
+		animation: scroll-text 10s linear infinite;
 	}
 
 	.player-metadata {
@@ -338,10 +338,10 @@
 	}
 
 	@keyframes scroll-text {
-		0%, 15% {
+		0%, 20% {
 			transform: translateX(0);
 		}
-		85%, 100% {
+		100% {
 			transform: translateX(-100%);
 		}
 	}

--- a/frontend/src/lib/toast.svelte.ts
+++ b/frontend/src/lib/toast.svelte.ts
@@ -53,8 +53,8 @@ class ToastState {
 		}
 	}
 
-	success(message: string, duration = 3000): string {
-		return this.add(message, 'success', duration);
+	success(message: string, duration = 3000, action?: ToastAction): string {
+		return this.add(message, 'success', duration, action);
 	}
 
 	error(message: string, duration = 5000): string {

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -125,7 +125,11 @@ class UploaderState {
 							toast.dismiss(task.toastId);
 							this.activeUploads.delete(taskId);
 
-							toast.success('track uploaded successfully!');
+							const trackId = update.track_id;
+							toast.success('track uploaded successfully!', 5000, trackId ? {
+								label: 'view track',
+								href: `/track/${trackId}`
+							} : undefined);
 							tracksCache.invalidate();
 							tracksCache.fetch(true);
 							if (onSuccess) {

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -104,7 +104,6 @@
 			{
 				onSuccess: () => {
 					clearForm();
-					toast.success('track uploaded successfully');
 				},
 				onError: () => {}
 			}


### PR DESCRIPTION
## Summary

### Player scroll timing
The scrolling title was staying off-screen for too long before resetting.

**Before:** 1.5s pause at start → 7s scroll → **1.5s invisible at end**
**After:** 1.6s pause at start → 6.4s scroll → **immediately resets**

Also reduced animation durations (title: 10s→8s, artist/album: 15s→10s).

### Upload toast
- **Fixed duplicate toast** - was showing "track uploaded successfully" twice (once on file upload complete, again on processing complete)
- **Added "view track" link** - success toast now includes a link to the track detail page
- **Internal links stay in same tab** - toast action links only open new tab for external URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)