### PR TITLE
docs: update status and fix stale frontend docs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -47,6 +47,33 @@ plyr.fm should become:
 
 ### December 2025
 
+#### light/dark theme and mobile UX overhaul (Dec 2-3)
+
+**theme system** (PR #441):
+- replaced hardcoded colors across 35 files with CSS custom properties
+- semantic tokens: `--bg-primary`, `--text-secondary`, `--accent`, etc.
+- theme switcher in settings: dark / light / system (follows OS preference)
+- removed zen mode feature (superseded by proper theme support)
+
+**mobile UX improvements** (PR #443):
+- new `ProfileMenu` component — collapses profile, upload, settings, logout into touch-optimized menu (44px tap targets)
+- dedicated `/upload` page — extracted from portal for cleaner mobile flow
+- portal overhaul — tighter forms, track detail links under artwork, fixed icon alignment
+- standardized section headers across home and liked tracks pages
+
+**player scroll timing fix** (PR #445):
+- reduced title scroll cycle from 10s → 8s, artist/album from 15s → 10s
+- eliminated 1.5s invisible pause at end of scroll animation
+- fixed duplicate upload toast (was firing twice on success)
+- upload success toast now includes "view track" link
+
+**CI optimization** (PR #444):
+- pre-commit hooks now skip based on changed paths
+- result: ~10s for most PRs instead of ~1m20s
+- only installs tooling (uv, bun) needed for changed directories
+
+---
+
 #### tag filtering system and SDK tag support (Dec 2)
 
 **tag filtering** (PRs #431-434):
@@ -230,6 +257,7 @@ See `.status_history/2025-11.md` for detailed November development history inclu
 - no AIFF/AIF transcoding support (#153)
 
 ### new features
+- issue #440: unified search across tracks, artists, albums, and tags
 - issue #146: content-addressable storage (hash-based deduplication)
 - issue #155: add track metadata (genres, tags, descriptions)
 - issue #334: add 'share to bluesky' option for tracks
@@ -425,4 +453,4 @@ plyr.fm/
 
 ---
 
-this is a living document. last updated 2025-12-02.
+this is a living document. last updated 2025-12-03.

--- a/docs/frontend/state-management.md
+++ b/docs/frontend/state-management.md
@@ -142,12 +142,14 @@ plyr.fm uses global state managers following the Svelte 5 runes pattern for cros
 - integrates with main tracks cache for like status
 
 ### preferences
-- user preferences managed through `SettingsMenu.svelte`
+- user preferences managed through `ProfileMenu.svelte` (mobile) and `SettingsMenu.svelte` (desktop)
+- theme selection: dark / light / system (follows OS preference)
 - accent color customization
 - auto-play next track setting
+- hidden tags for discovery feed filtering
 - persisted to backend via `/preferences/` API
 - localStorage fallback for offline access
-- no dedicated state file - integrated into settings component
+- no dedicated state file - integrated into settings components
 
 ### toast (`frontend/src/lib/toast.svelte.ts`)
 - global notification system
@@ -182,12 +184,12 @@ export const globalState = new GlobalState();
 
 ### upload flow
 
-1. user clicks upload on portal page
+1. user clicks upload on dedicated `/upload` page (linked from portal or ProfileMenu)
 2. `uploader.upload()` called - returns immediately
 3. user navigates to homepage
 4. homepage renders cached tracks instantly (no blocking)
 5. upload completes in background
-6. success toast appears
+6. success toast appears with "view track" link
 7. cache refreshes, homepage updates with new track
 
 this avoids HTTP/1.1 connection pooling issues by using cached data instead of blocking on fresh fetches during long-running uploads.

--- a/docs/frontend/toast-notifications.md
+++ b/docs/frontend/toast-notifications.md
@@ -125,11 +125,26 @@ uses CSS custom properties from the global theme:
 - **type-safe**: full TypeScript support with exported types
 - **consistent patterns**: matches other Svelte 5 rune-based state managers
 
+### action links
+
+toasts can include an optional action link:
+
+```typescript
+export interface ToastAction {
+  label: string;
+  href: string;
+}
+
+// usage
+toast.success('track uploaded!', 3000, { label: 'view track', href: `/track/${trackId}` });
+```
+
+action links render as styled anchor tags. internal links stay in the same tab; external links open in new tabs.
+
 ## future enhancements
 
 potential additions (not currently implemented):
 - pause on hover to prevent auto-dismiss
 - manual dismiss buttons
 - progress bars for visual timing
-- action buttons (e.g., "undo" for reversible operations)
 - toast queue limiting to prevent spam


### PR DESCRIPTION
## Summary
- Update STATUS.md with recent work (PRs #441-445)
- Fix stale frontend documentation

### STATUS.md updates
- **theme system** (PR #441): CSS custom properties, dark/light/system toggle
- **mobile UX improvements** (PR #443): ProfileMenu, /upload page, portal overhaul  
- **player scroll timing fix** (PR #445): faster animations, "view track" link in toast
- **CI optimization** (PR #444): path-based hook skipping (~10s vs ~1m20s)
- Add issue #440 (unified search) to new features list

### doc fixes
- `docs/frontend/toast-notifications.md`: document action links (was listed as "not implemented")
- `docs/frontend/state-management.md`: update preferences to include theme/hidden tags, fix upload flow reference

## Test plan
- [ ] Review STATUS.md changes for accuracy
- [ ] Verify doc updates match current implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)