### PR TITLE
fix: prevent comments section flash when disabled

### DIFF
--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -468,8 +468,8 @@ $effect(() => {
 			</div>
 		</div>
 
-		<!-- comments section - show immediately with skeleton loading -->
-		{#if commentsEnabled !== false}
+		<!-- comments section - only render when we know comments are enabled -->
+		{#if commentsEnabled === true}
 			<section class="comments-section">
 				<h2 class="comments-title">
 					comments


### PR DESCRIPTION
## Summary
- fixes flash of comments section on track detail page when comments are disabled
- changed conditional from `commentsEnabled !== false` to `commentsEnabled === true`

## Root cause
`commentsEnabled` starts as `null`. The old condition `null !== false` evaluated to `true`, rendering the section. After the API returned `comments_enabled: false`, the section disappeared - causing a visible flash.

## Test plan
- [x] svelte-check passes
- [ ] manual test: view track with comments disabled, confirm no flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)