### PR TITLE
fix: mobile keyboard opens when tapping search

### DIFF
--- a/frontend/src/lib/search.svelte.ts
+++ b/frontend/src/lib/search.svelte.ts
@@ -64,10 +64,22 @@ class SearchState {
 	error = $state<string | null>(null);
 	selectedIndex = $state(0);
 
+	// reference to input element for direct focus (mobile keyboard workaround)
+	inputRef: HTMLInputElement | null = null;
+
 	// debounce timer
 	private searchTimeout: ReturnType<typeof setTimeout> | null = null;
 
+	setInputRef(el: HTMLInputElement | null) {
+		this.inputRef = el;
+	}
+
 	open() {
+		// focus input FIRST (before state change) for mobile keyboard to open
+		// iOS/mobile browsers only open keyboard when focus() is in direct user gesture
+		if (this.inputRef) {
+			this.inputRef.focus();
+		}
 		this.isOpen = true;
 		this.query = '';
 		this.results = [];


### PR DESCRIPTION
## Summary
- Fix mobile keyboard not opening when tapping search button
- iOS/mobile browsers require `focus()` to be called directly in user gesture handler
- Always render SearchModal (hidden via CSS) so input exists in DOM
- Focus input directly in `search.open()` before state change

## Technical details
The previous approach used a Svelte `$effect` to focus the input after the modal opened. This broke the "user gesture chain" that mobile browsers require for keyboard activation.

Now the SearchModal is always in the DOM (but hidden with `visibility: hidden` and `opacity: 0`), and the input ref is registered with the search state. When `search.open()` is called, it focuses the input first (while still in the click handler), then sets `isOpen = true`.

## Test plan
- [ ] On iOS Safari: tap search icon, keyboard should open
- [ ] On Android Chrome: tap search icon, keyboard should open
- [ ] On desktop: unchanged behavior (Cmd+K still works)
- [ ] Search modal shows/hides correctly with fade transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)