### PR TITLE
feat: fall back to album artwork in player

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -16,8 +16,11 @@
 		const artwork: MediaImage[] = [];
 		if (track.image_url) {
 			artwork.push({ src: track.image_url, sizes: '512x512', type: 'image/jpeg' });
+		} else if (track.album?.image_url) {
+			// fall back to album artwork if no track artwork
+			artwork.push({ src: track.album.image_url, sizes: '512x512', type: 'image/jpeg' });
 		} else if (track.artist_avatar_url) {
-			// fall back to artist avatar if no track artwork
+			// fall back to artist avatar if no album artwork
 			artwork.push({ src: track.artist_avatar_url, sizes: '256x256', type: 'image/jpeg' });
 		}
 

--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -55,10 +55,10 @@
 
 <div class="player-track">
 	<a href="/track/{track.id}" class="player-artwork" aria-label={`view ${track.title}`}>
-		{#if track.image_url && !imageError}
-			<img 
-				src={track.image_url} 
-				alt="{track.title} artwork" 
+		{#if (track.image_url || track.album?.image_url) && !imageError}
+			<img
+				src={track.image_url || track.album?.image_url}
+				alt="{track.title} artwork"
 				onerror={() => imageError = true}
 			/>
 		{:else}


### PR DESCRIPTION
## Summary
- when a track has no artwork but belongs to an album with artwork, use the album artwork as fallback
- applies to player thumbnail and media session metadata (CarPlay, lock screen, etc.)

## Test plan
- [ ] play a track that has no `image_url` but has an album with `image_url`
- [ ] verify album artwork appears in player instead of placeholder icon
- [ ] verify media session shows album artwork on lock screen / system controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)