### PR TITLE
fix: add --no-dev to release command to prevent dev dep installation

### DIFF
--- a/backend/fly.staging.toml
+++ b/backend/fly.staging.toml
@@ -11,7 +11,7 @@ primary_region = 'iad'
   ignore_file = ".dockerignore"
 
 [deploy]
-  release_command = 'uv run alembic upgrade head'
+  release_command = 'uv run --no-dev alembic upgrade head'
 
 [env]
   ATPROTO_PDS_URL = 'https://pds.zzstoatzz.io'

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -6,7 +6,7 @@ primary_region = 'iad'
   ignore_file = ".dockerignore"
 
 [deploy]
-  release_command = "uv run alembic upgrade head"
+  release_command = "uv run --no-dev alembic upgrade head"
 
 [http_service]
   internal_port = 8000


### PR DESCRIPTION
## Summary
- Add `--no-dev` flag to `uv run alembic upgrade head` in both prod and staging fly.toml files
- Without this flag, `uv run` syncs all dependencies including dev deps (ruff, jedi, etc.), causing the release command to hang while downloading ~28 packages

## Test plan
- [x] Verified deploy works locally with the fix
- [x] Release command completes quickly without downloading dev dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)