### PR TITLE
fix: remove debug console.log statements from LikersTooltip

### DIFF
--- a/frontend/src/lib/components/LikersTooltip.svelte
+++ b/frontend/src/lib/components/LikersTooltip.svelte
@@ -26,12 +26,9 @@
 			return;
 		}
 
-		console.log('fetching likers for track', trackId);
-
 		const fetchLikers = async () => {
 			try {
 				const url = `${API_URL}/tracks/${trackId}/likes`;
-				console.log('fetching from:', url);
 				const response = await fetch(url);
 
 				if (!response.ok) {
@@ -41,7 +38,6 @@
 				}
 
 				const data = await response.json();
-				console.log('received likers data:', data);
 				likers = data.users || [];
 			} catch (err) {
 				error = 'failed to load';


### PR DESCRIPTION
## Summary
- Removes debug `console.log` statements that were left in from initial development in PR #233
- Keeps `console.error` for actual error handling (failed fetch responses and caught exceptions)

## Test plan
- [x] `just frontend check` passes
- [ ] Verify no more debug logs in browser console when hovering like button

🤖 Generated with [Claude Code](https://claude.com/claude-code)