### PR TITLE
fix: search input focus not working when modal opens

### DIFF
--- a/frontend/src/lib/components/SearchModal.svelte
+++ b/frontend/src/lib/components/SearchModal.svelte
@@ -260,16 +260,14 @@
 		align-items: flex-start;
 		justify-content: center;
 		padding-top: 15vh;
-		/* hidden by default */
+		/* hidden by default - use opacity only (not visibility) so input remains focusable for mobile keyboard */
 		opacity: 0;
-		visibility: hidden;
 		pointer-events: none;
-		transition: opacity 0.15s, visibility 0.15s;
+		transition: opacity 0.15s;
 	}
 
 	.search-backdrop.open {
 		opacity: 1;
-		visibility: visible;
 		pointer-events: auto;
 	}
 


### PR DESCRIPTION
## Summary
- Fixes search input not receiving focus when opening the modal
- The backdrop was using `visibility: hidden` which prevents focus entirely
- Changed to use only `opacity: 0` so the input remains focusable

## Root Cause
The CSS rule `visibility: hidden` on `.search-backdrop` was preventing the input from receiving focus. The `search.open()` method calls `inputRef.focus()` synchronously (which is required for mobile keyboards to open), but the focus was being ignored because the element was invisible.

## Fix
Removed `visibility: hidden` / `visibility: visible` from the backdrop CSS. The existing `opacity: 0` / `opacity: 1` and `pointer-events: none` / `pointer-events: auto` properties already handle the visual hiding and interaction blocking.

## Test plan
- [ ] Desktop: Press Cmd+K - cursor should blink in search input immediately
- [ ] Desktop: Click search icon - cursor should blink in search input immediately
- [ ] Mobile: Tap search icon - keyboard should pop up immediately
- [ ] Search still closes on Escape, backdrop click, or selecting a result

🤖 Generated with [Claude Code](https://claude.com/claude-code)