### PR TITLE
fix: hide logout button when not authenticated

### DIFF
--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -27,9 +27,11 @@
 		<SearchTrigger />
 	</div>
 	<!-- Logout positioned on far right, mirroring stats -->
-	<div class="logout-right desktop-only">
-		<button onclick={onLogout} class="btn-logout-outer" title="log out">logout</button>
-	</div>
+	{#if isAuthenticated}
+		<div class="logout-right desktop-only">
+			<button onclick={onLogout} class="btn-logout-outer" title="log out">logout</button>
+		</div>
+	{/if}
 	<div class="header-content">
 		<div class="left-section">
 			<!-- desktop: show icons inline -->


### PR DESCRIPTION
## Summary

- Fix desktop header showing both "log in" and "logout" buttons simultaneously when logged out
- Wrapped the far-right logout button in `{#if isAuthenticated}` check

**Root cause:** The logout button at `Header.svelte:29-32` was rendered outside the auth conditional block, so it always appeared on desktop regardless of auth state.

**Mobile is unaffected** - the logout button has `desktop-only` class which hides it below 1299px, and mobile uses `ProfileMenu` which is correctly inside the auth check.

## Test plan

- [ ] Visit plyr.fm logged out on desktop - should only see "log in" button
- [ ] Log in - should see user nav links and logout button in far right
- [ ] Verify mobile still works correctly (only ProfileMenu visible when authenticated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)