### PR TITLE
fix: bypass service worker for audio to prevent iOS PWA hangs

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,6 +13,12 @@ export default defineConfig({
 				globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
 				runtimeCaching: [
 					{
+						// audio streaming: bypass SW entirely to avoid iOS PWA hangs
+						// (the redirect to R2 CDN + range requests don't play well with caching)
+						urlPattern: /^https:\/\/api\.plyr\.fm\/audio\/.*/i,
+						handler: 'NetworkOnly'
+					},
+					{
 						urlPattern: /^https:\/\/api\.plyr\.fm\/.*/i,
 						handler: 'NetworkFirst',
 						options: {


### PR DESCRIPTION
## Summary

- audio streaming was intermittently hanging in iOS standalone (PWA) mode
- the service worker was intercepting `/audio/{file_id}` requests with `NetworkFirst` caching
- this caused issues with 307 redirects to R2 CDN getting stale and range request headers not being handled properly on iOS Safari
- switched to `NetworkOnly` for audio routes so the SW passes through without interference

## Context

iOS Safari in standalone mode (home screen PWA) is particularly sensitive to service worker interference with audio streaming. the symptoms were:
- tap on track → cover art appears in player → audio doesn't start (or delays 10+ seconds)
- other functionality (likes, navigation) worked fine
- redeploying frontend would temporarily "fix" it

we were caching the redirect response, not the actual audio files. there's no functional loss from this change.

## Test plan

- [ ] deploy to staging
- [ ] test audio playback in iOS Safari standalone mode (home screen PWA)
- [ ] verify playback works immediately without hangs
- [ ] verify playback still works in regular browser mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)