### PR TITLE
fix: prevent duplicate teal.fm scrobbles from race condition

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -238,7 +238,7 @@
 		// only load new track if it actually changed
 		if (player.currentTrack.id !== previousTrackId) {
 			previousTrackId = player.currentTrack.id;
-			player.playCountedForTrack = null;
+			player.resetPlayCount();
 			isLoadingTrack = true;
 
 			player.audioElement.src = `${API_URL}/audio/${player.currentTrack.file_id}`;


### PR DESCRIPTION
## Summary

- fixes race condition in play count tracking that caused duplicate teal.fm scrobbles
- duplicates were ~50-125ms apart due to svelte's batched reactive updates
- adds synchronous (non-reactive) guard that blocks immediately before async fetch

## Root cause

the `$effect` that calls `incrementPlayCount()` runs on every `currentTime` update (~4x/second). when the playback threshold is first crossed:

1. effect runs, threshold met, sets `playCountedForTrack = currentTrack.id`
2. fires async fetch
3. effect runs again before svelte's batched reactive update propagates
4. guard check fails → second fetch fires

evidence from PDS (timestamps ~50-125ms apart):
```
"SNES VGM Battle Theme":
  - 02:06:13.131730Z
  - 02:06:13.073944Z

"the entire oppenheimer soundtrack at once":
  - 02:04:31.614469Z
  - 02:04:31.564342Z
```

## Test plan

- [ ] play a track past the 30% / 30s threshold
- [ ] check PDS via `uvx pdsx --pds <pds-url> -r <handle> ls fm.teal.alpha.feed.play`
- [ ] verify only one record created per play

🤖 Generated with [Claude Code](https://claude.com/claude-code)