### PR TITLE
feat: add playback keyboard shortcuts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - check the justfiles. there's a root one, one for the backend, one for the frontend, and one for the transcoder etc
 
 ## 🚨 Critical Rules & Workflows
-*   **Read `STATUS.md` First:** Always check for active tasks and known issues. This file is NEVER tracked in git.
+*   **Read `STATUS.md` First:** Always check for active tasks and known issues.
 *   **Workflow:**
     *   Use **GitHub Issues** (not Linear).
     *   **PRs:** Always create for review; never push to main directly.
@@ -52,7 +52,7 @@ plyr.fm/
 │   └── src/lib/      # Components & State (.svelte.ts)
 ├── scripts/          # Admin scripts (uv run scripts/...)
 ├── docs/             # Architecture & Guides
-└── STATUS.md         # Living status document (Untracked)
+└── STATUS.md         # Living status document
 ```
 
 this file ("AGENTS.md") is symlinked to `CLAUDE.md` and `GEMINI.md` for maximal compatibility.

--- a/docs/frontend/keyboard-shortcuts.md
+++ b/docs/frontend/keyboard-shortcuts.md
@@ -49,6 +49,38 @@ toggles the queue sidebar visibility.
 - `aria-label="toggle queue (Q)"` for screen readers
 - tooltip shows keyboard hint
 
+---
+
+## playback shortcuts
+
+all playback shortcuts require a track to be loaded and are disabled when the search modal is open.
+
+### Space - play/pause
+
+toggles playback of the current track.
+
+### Left Arrow - seek backward
+
+seeks backward 10 seconds in the current track.
+
+### Right Arrow - seek forward
+
+seeks forward 10 seconds in the current track.
+
+### J - previous track
+
+goes to the previous track in the queue. if more than 3 seconds into the current track, restarts it instead.
+
+### L - next track
+
+advances to the next track in the queue (if available).
+
+### M - mute/unmute
+
+toggles mute. restores previous volume level when unmuting.
+
+---
+
 ## adding new shortcuts
 
 when adding keyboard shortcuts:
@@ -95,11 +127,9 @@ onDestroy(() => {
 ## future candidates
 
 potential shortcuts to consider:
-- **space** - play/pause (when not focused on button)
-- **arrow keys** - skip forward/back (context-aware)
-- **shift + arrow** - navigate queue
 - **/** - focus search (alternative to Cmd/Ctrl+K)
 - **T** - cycle theme (dark/light/system)
+- **S** - shuffle queue
 
 ## design principles
 


### PR DESCRIPTION
## Summary
- Adds keyboard shortcuts for playback control: Space (play/pause), arrow keys (seek ±10s), J/L (prev/next track), M (mute)
- All shortcuts respect input focus and disabled when search modal is open
- Updates docs and fixes AGENTS.md to reflect STATUS.md is now tracked

## Test plan
- [ ] Load a track, press Space to toggle play/pause
- [ ] Press Left/Right arrows to seek
- [ ] Press J/L to navigate queue
- [ ] Press M to mute/unmute
- [ ] Verify shortcuts don't fire in search modal or text inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)