### PR TITLE
fix: remove aggressive non-R2 image blocking

### DIFF
--- a/frontend/src/lib/moderation.svelte.ts
+++ b/frontend/src/lib/moderation.svelte.ts
@@ -15,21 +15,12 @@ class ModerationManager {
 	/**
 	 * check if an image URL is flagged as sensitive.
 	 * checks both the full URL and extracts image_id from R2 URLs.
-	 * also flags non-R2 images as sensitive since they could be injected.
 	 */
 	isSensitive(url: string | null | undefined): boolean {
 		if (!url) return false;
 
 		// check full URL match
 		if (this.data.urls.has(url)) return true;
-
-		// check if it's a known R2 URL pattern
-		const isR2 = url.includes('r2.dev/') || url.includes('cdn.plyr.fm/');
-
-		if (!isR2) {
-			// non-R2 images are treated as sensitive - could be injected
-			return true;
-		}
 
 		// extract image_id from R2 URL patterns:
 		// - https://pub-*.r2.dev/{image_id}.{ext}


### PR DESCRIPTION
## Summary
Reverts the non-R2 image blocking - it was too aggressive and blocked all Bluesky avatars.

We'll deal with injected image URLs separately if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)