### PR TITLE
fix: fetch sensitive images server-side for SSR meta tags

### DIFF
--- a/frontend/src/lib/moderation.svelte.ts
+++ b/frontend/src/lib/moderation.svelte.ts
@@ -7,6 +7,50 @@ interface SensitiveImages {
 	urls: Set<string>;
 }
 
+// raw data format from API (arrays, not Sets) - used for SSR
+export interface SensitiveImagesData {
+	image_ids: string[];
+	urls: string[];
+}
+
+/**
+ * check if an image URL matches sensitive image data.
+ * works with both Set-based (client) and array-based (SSR) data.
+ */
+export function checkImageSensitive(
+	url: string | null | undefined,
+	data: { image_ids: Set<string> | string[]; urls: Set<string> | string[] }
+): boolean {
+	if (!url) return false;
+
+	// check full URL match
+	const urlsHas = Array.isArray(data.urls)
+		? data.urls.includes(url)
+		: data.urls.has(url);
+	if (urlsHas) return true;
+
+	// extract image_id from R2 URL patterns:
+	// - https://pub-*.r2.dev/{image_id}.{ext}
+	// - https://cdn.plyr.fm/images/{image_id}.{ext}
+	const r2Match = url.match(/r2\.dev\/([^/.]+)\./);
+	if (r2Match) {
+		const hasR2 = Array.isArray(data.image_ids)
+			? data.image_ids.includes(r2Match[1])
+			: data.image_ids.has(r2Match[1]);
+		if (hasR2) return true;
+	}
+
+	const cdnMatch = url.match(/\/images\/([^/.]+)\./);
+	if (cdnMatch) {
+		const hasCdn = Array.isArray(data.image_ids)
+			? data.image_ids.includes(cdnMatch[1])
+			: data.image_ids.has(cdnMatch[1]);
+		if (hasCdn) return true;
+	}
+
+	return false;
+}
+
 class ModerationManager {
 	private data = $state<SensitiveImages>({ image_ids: new Set(), urls: new Set() });
 	private initialized = false;
@@ -17,21 +61,7 @@ class ModerationManager {
 	 * checks both the full URL and extracts image_id from R2 URLs.
 	 */
 	isSensitive(url: string | null | undefined): boolean {
-		if (!url) return false;
-
-		// check full URL match
-		if (this.data.urls.has(url)) return true;
-
-		// extract image_id from R2 URL patterns:
-		// - https://pub-*.r2.dev/{image_id}.{ext}
-		// - https://cdn.plyr.fm/images/{image_id}.{ext}
-		const r2Match = url.match(/r2\.dev\/([^/.]+)\./);
-		if (r2Match && this.data.image_ids.has(r2Match[1])) return true;
-
-		const cdnMatch = url.match(/\/images\/([^/.]+)\./);
-		if (cdnMatch && this.data.image_ids.has(cdnMatch[1])) return true;
-
-		return false;
+		return checkImageSensitive(url, this.data);
 	}
 
 	async initialize(): Promise<void> {

--- a/frontend/src/routes/+layout.server.ts
+++ b/frontend/src/routes/+layout.server.ts
@@ -1,0 +1,24 @@
+import { API_URL } from '$lib/config';
+import type { LayoutServerLoad } from './$types';
+
+export interface SensitiveImages {
+	image_ids: string[];
+	urls: string[];
+}
+
+export const load: LayoutServerLoad = async ({ fetch }) => {
+	let sensitiveImages: SensitiveImages = { image_ids: [], urls: [] };
+
+	try {
+		const response = await fetch(`${API_URL}/moderation/sensitive-images`);
+		if (response.ok) {
+			sensitiveImages = await response.json();
+		}
+	} catch (e) {
+		console.error('failed to fetch sensitive images:', e);
+	}
+
+	return {
+		sensitiveImages
+	};
+};

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -2,12 +2,14 @@ import { browser } from '$app/environment';
 import { API_URL } from '$lib/config';
 import type { User } from '$lib/types';
 import type { Preferences } from '$lib/preferences.svelte';
+import type { SensitiveImagesData } from '$lib/moderation.svelte';
 import type { LoadEvent } from '@sveltejs/kit';
 
 export interface LayoutData {
 	user: User | null;
 	isAuthenticated: boolean;
 	preferences: Preferences | null;
+	sensitiveImages: SensitiveImagesData;
 }
 
 const DEFAULT_PREFERENCES: Preferences = {
@@ -21,12 +23,16 @@ const DEFAULT_PREFERENCES: Preferences = {
 	show_sensitive_artwork: false
 };
 
-export async function load({ fetch }: LoadEvent): Promise<LayoutData> {
+export async function load({ fetch, parent }: LoadEvent): Promise<LayoutData> {
+	// get server-loaded data (sensitiveImages)
+	const parentData = await parent();
+
 	if (!browser) {
 		return {
 			user: null,
 			isAuthenticated: false,
-			preferences: null
+			preferences: null,
+			sensitiveImages: parentData.sensitiveImages ?? { image_ids: [], urls: [] }
 		};
 	}
 
@@ -64,7 +70,8 @@ export async function load({ fetch }: LoadEvent): Promise<LayoutData> {
 			return {
 				user,
 				isAuthenticated: true,
-				preferences
+				preferences,
+				sensitiveImages: parentData.sensitiveImages ?? { image_ids: [], urls: [] }
 			};
 		}
 	} catch (e) {
@@ -74,6 +81,7 @@ export async function load({ fetch }: LoadEvent): Promise<LayoutData> {
 	return {
 		user: null,
 		isAuthenticated: false,
-		preferences: null
+		preferences: null,
+		sensitiveImages: parentData.sensitiveImages ?? { image_ids: [], urls: [] }
 	};
 }

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -9,7 +9,7 @@
 	import ShareButton from '$lib/components/ShareButton.svelte';
 	import TagEffects from '$lib/components/TagEffects.svelte';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
-	import { moderation } from '$lib/moderation.svelte';
+	import { checkImageSensitive } from '$lib/moderation.svelte';
 	import { player } from '$lib/player.svelte';
 	import { queue } from '$lib/queue.svelte';
 	import { auth } from '$lib/auth.svelte';
@@ -32,6 +32,12 @@
 	let { data }: { data: PageData } = $props();
 
 	let track = $state<Track>(data.track);
+
+	// SSR-safe sensitive image check using server-loaded data
+	function isImageSensitiveSSR(url: string | null | undefined): boolean {
+		if (!data.sensitiveImages) return false;
+		return checkImageSensitive(url, data.sensitiveImages);
+	}
 
 	// comments state - assume enabled until we know otherwise
 	let comments = $state<Comment[]>([]);
@@ -320,7 +326,7 @@ $effect(() => {
 	{#if track.album}
 		<meta property="music:album" content="{track.album.title}" />
 	{/if}
-	{#if track.image_url && !moderation.isSensitive(track.image_url)}
+	{#if track.image_url && !isImageSensitiveSSR(track.image_url)}
 		<meta property="og:image" content="{track.image_url}" />
 		<meta property="og:image:secure_url" content="{track.image_url}" />
 		<meta property="og:image:width" content="1200" />
@@ -339,7 +345,7 @@ $effect(() => {
 		name="twitter:description"
 		content="{track.artist}{track.album ? ` • ${track.album.title}` : ''}"
 	/>
-	{#if track.image_url && !moderation.isSensitive(track.image_url)}
+	{#if track.image_url && !isImageSensitiveSSR(track.image_url)}
 		<meta name="twitter:image" content="{track.image_url}" />
 	{/if}
 

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -8,7 +8,7 @@
 	import ShareButton from '$lib/components/ShareButton.svelte';
 	import Header from '$lib/components/Header.svelte';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
-	import { moderation } from '$lib/moderation.svelte';
+	import { checkImageSensitive } from '$lib/moderation.svelte';
 	import { player } from '$lib/player.svelte';
 	import { queue } from '$lib/queue.svelte';
 	import { auth } from '$lib/auth.svelte';
@@ -18,6 +18,12 @@
 
 	// receive server-loaded data
 	let { data }: { data: PageData } = $props();
+
+	// SSR-safe sensitive image check using server-loaded data
+	function isImageSensitiveSSR(url: string | null | undefined): boolean {
+		if (!data.sensitiveImages) return false;
+		return checkImageSensitive(url, data.sensitiveImages);
+	}
 
 	// use server-loaded data directly
 const artist = $derived(data.artist);
@@ -169,7 +175,7 @@ $effect(() => {
 		/>
 		<meta property="og:site_name" content={APP_NAME} />
 		<meta property="profile:username" content="{data.artist.handle}" />
-		{#if data.artist.avatar_url && !moderation.isSensitive(data.artist.avatar_url)}
+		{#if data.artist.avatar_url && !isImageSensitiveSSR(data.artist.avatar_url)}
 			<meta property="og:image" content="{data.artist.avatar_url}" />
 			<meta property="og:image:secure_url" content="{data.artist.avatar_url}" />
 			<meta property="og:image:width" content="400" />
@@ -184,7 +190,7 @@ $effect(() => {
 			name="twitter:description"
 			content="@{data.artist.handle} on {APP_NAME}"
 		/>
-		{#if data.artist.avatar_url && !moderation.isSensitive(data.artist.avatar_url)}
+		{#if data.artist.avatar_url && !isImageSensitiveSSR(data.artist.avatar_url)}
 			<meta name="twitter:image" content="{data.artist.avatar_url}" />
 		{/if}
 	{/if}


### PR DESCRIPTION
## Summary
Link previews weren't filtering sensitive images because the moderation data was only fetched client-side. Crawlers don't execute JavaScript, so they saw the initial HTML with the sensitive og:image tags.

## Fix
- Add `+layout.server.ts` to fetch sensitive images server-side
- Export `checkImageSensitive()` utility from moderation store for shared use
- Update track and artist pages to use SSR-safe checks for meta tags

## Test plan
- [ ] Share a track link with sensitive artwork - preview should not show the image
- [ ] Share an artist link with sensitive avatar - preview should not show the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)