### PR TITLE
fix: use data prop instead of parent() for sensitive images SSR

### DIFF
--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -24,12 +24,14 @@ const DEFAULT_PREFERENCES: Preferences = {
 };
 
 export async function load({ fetch, data }: LoadEvent): Promise<LayoutData> {
+	const sensitiveImages = data?.sensitiveImages ?? { image_ids: [], urls: [] };
+
 	if (!browser) {
 		return {
 			user: null,
 			isAuthenticated: false,
 			preferences: null,
-			sensitiveImages: data.sensitiveImages ?? { image_ids: [], urls: [] }
+			sensitiveImages
 		};
 	}
 
@@ -68,7 +70,7 @@ export async function load({ fetch, data }: LoadEvent): Promise<LayoutData> {
 				user,
 				isAuthenticated: true,
 				preferences,
-				sensitiveImages: data.sensitiveImages ?? { image_ids: [], urls: [] }
+				sensitiveImages
 			};
 		}
 	} catch (e) {
@@ -79,6 +81,6 @@ export async function load({ fetch, data }: LoadEvent): Promise<LayoutData> {
 		user: null,
 		isAuthenticated: false,
 		preferences: null,
-		sensitiveImages: data.sensitiveImages ?? { image_ids: [], urls: [] }
+		sensitiveImages
 	};
 }


### PR DESCRIPTION
## Problem

The `+layout.ts` file was incorrectly using `parent()` to access data from `+layout.server.ts`. In SvelteKit, data from a server load function in the same route comes via the `data` parameter, not `parent()`. `parent()` is only for accessing data from parent routes.

This was causing SSR meta tag generation for sensitive images to fail because `parentData.sensitiveImages` was undefined, falling back to empty arrays.

## Solution

- Changed `load({ fetch, parent })` to `load({ fetch, data })`
- Replaced all `parentData.sensitiveImages` references with `data.sensitiveImages`
- Fixed variable shadowing by renaming local `data` variable to `prefsData`

## Testing

The production API endpoint returns the correct data, and this fix ensures that data is properly propagated through the SSR load chain.