### PR TITLE
fix: proper z-index stacking and flip positioning for likers tooltip

### DIFF
--- a/frontend/src/lib/components/LikersTooltip.svelte
+++ b/frontend/src/lib/components/LikersTooltip.svelte
@@ -22,6 +22,22 @@
 	let likers = $state<Liker[]>([]);
 	let loading = $state(true); // start as loading
 	let error = $state<string | null>(null);
+	let tooltipElement: HTMLDivElement | null = $state(null);
+	let positionBelow = $state(false);
+
+	// check if tooltip should flip below based on viewport position
+	$effect(() => {
+		if (!tooltipElement) return;
+
+		// get the parent element's position (the .likes span)
+		const parent = tooltipElement.parentElement;
+		if (!parent) return;
+
+		const parentRect = parent.getBoundingClientRect();
+		// if less than 300px from viewport top, flip tooltip below
+		// 300px accounts for tooltip max height (~240px) plus padding
+		positionBelow = parentRect.top < 300;
+	});
 
 	$effect(() => {
 		if (likeCount === 0) {
@@ -68,7 +84,9 @@
 </script>
 
 <div
+	bind:this={tooltipElement}
 	class="likers-tooltip"
+	class:position-below={positionBelow}
 	role="tooltip"
 	onmouseenter={onMouseEnter}
 	onmouseleave={onMouseLeave}
@@ -122,6 +140,14 @@
 		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
 		z-index: 1000;
 		pointer-events: auto;
+	}
+
+	/* flip tooltip below when near viewport top */
+	.likers-tooltip.position-below {
+		bottom: auto;
+		top: 100%;
+		margin-bottom: 0;
+		margin-top: 0.5rem;
 	}
 
 	.loading,

--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -224,6 +224,7 @@
 				<span class="meta-separator">•</span>
 				<span
 					class="likes"
+					class:tooltip-open={showLikersTooltip}
 					role="button"
 					tabindex="0"
 					aria-label={`${likeCount} ${likeCount === 1 ? 'like' : 'likes'} (focus to view users)`}
@@ -616,7 +617,12 @@
 		position: relative;
 		cursor: help;
 		transition: color 0.2s;
-		z-index: 100;
+	}
+
+	/* only elevate z-index when tooltip is open - this ensures the open tooltip
+	   renders above sibling track items without all tracks competing for z-index */
+	.likes.tooltip-open {
+		z-index: 10;
 	}
 
 	.likes:hover {


### PR DESCRIPTION
## Summary
Fixes the likers tooltip rendering behind other track items and colliding with the header.

### Z-index fix
- Removed static `z-index: 100` from `.likes` - this was causing all tracks to compete at the same z-index level
- Now only applies `z-index: 10` when tooltip is open (`.likes.tooltip-open`)
- The active tooltip's parent element now properly elevates above sibling tracks

### Flip detection
- Detects when likes element is <300px from viewport top
- Automatically flips tooltip to appear below instead of above
- Prevents tooltip from overlapping with the sticky header

## Test plan
- [ ] Hover on likes count for tracks in middle of list - tooltip should appear above
- [ ] Hover on likes count for tracks near top of page - tooltip should flip below
- [ ] Other tracks' content should never render on top of the tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)