### PR TITLE
feat: configurable bufo exclude/include patterns via env vars

### DIFF
--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -223,6 +223,8 @@ async def get_public_config() -> dict[str, int | list[str]]:
         "max_upload_size_mb": settings.storage.max_upload_size_mb,
         "max_image_size_mb": 20,  # hardcoded limit for cover art
         "default_hidden_tags": DEFAULT_HIDDEN_TAGS,
+        "bufo_exclude_patterns": list(settings.bufo.exclude_patterns),
+        "bufo_include_patterns": list(settings.bufo.include_patterns),
     }
 
 

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -6,6 +6,8 @@ interface ServerConfig {
 	max_upload_size_mb: number;
 	max_image_size_mb: number;
 	default_hidden_tags: string[];
+	bufo_exclude_patterns: string[];
+	bufo_include_patterns: string[];
 }
 
 let serverConfig: ServerConfig | null = null;


### PR DESCRIPTION
this PR removes the big bufo tiles when a track is tagged "bufo" by updating the upstream find-bufo.fly.dev

<details>

## AI Summary
- adds `BUFO_EXCLUDE_PATTERNS` and `BUFO_INCLUDE_PATTERNS` env vars
- `exclude`: regex patterns to filter out (default: `^bigbufo_`)
- `include`: allowlist that overrides exclude (default: `bigbufo_0_0`, `bigbufo_2_1`)
- adds reusable `CommaSeparatedStringSet` type for parsing comma-delimited env vars

## Changes
- **backend/config.py**: `BufoSettings` with `exclude_patterns` and `include_patterns`
- **backend/main.py**: expose both via `/config` endpoint
- **frontend/config.ts**: add both to `ServerConfig` interface
- **frontend/BufoEasterEgg.svelte**: fetch and pass both to find-bufo API

## Test plan
- [ ] verify default: all bigbufo tiles excluded except `0_0` and `2_1`
- [ ] test custom patterns via env vars
- [ ] visit a bufo-tagged track and verify correct behavior
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)