### PR TITLE
fix: include patterns in bufo cache key

### DIFF
--- a/frontend/src/lib/components/BufoEasterEgg.svelte
+++ b/frontend/src/lib/components/BufoEasterEgg.svelte
@@ -58,13 +58,6 @@
 	}
 
 	async function fetchBufos() {
-		// check cache first
-		const cached = getCached(query);
-		if (cached) {
-			bufos = cached;
-			return;
-		}
-
 		try {
 			// get patterns from props or config
 			let exclude = excludePatterns;
@@ -73,6 +66,14 @@
 				const config = await getServerConfig();
 				exclude = config.bufo_exclude_patterns ?? [];
 				include = config.bufo_include_patterns ?? [];
+			}
+
+			// cache key includes patterns so config changes invalidate cache
+			const cacheKey = `${query}|${exclude.sort().join(',')}|${include.sort().join(',')}`;
+			const cached = getCached(cacheKey);
+			if (cached) {
+				bufos = cached;
+				return;
 			}
 
 			const params = new URLSearchParams({
@@ -91,7 +92,7 @@
 				const data = await response.json();
 				bufos = data.results || [];
 				if (bufos.length > 0) {
-					setCache(query, bufos);
+					setCache(cacheKey, bufos);
 				}
 			}
 		} catch (e) {


### PR DESCRIPTION
## Summary
- fixes stale cache issue where pattern config changes didn't invalidate cached bufo results
- cache key now includes exclude/include patterns, not just the query

## Problem
cache key was just the track title, so changing `BUFO_EXCLUDE_PATTERNS` or `BUFO_INCLUDE_PATTERNS` had no effect until the 1-week TTL expired.

## Test plan
- [ ] visit a bufo-tagged track
- [ ] verify new patterns take effect immediately (no need to clear localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)