### PR TITLE
fix: include image_url in playlist SSR data for og:image

### DIFF
--- a/frontend/src/routes/playlist/[id]/+page.ts
+++ b/frontend/src/routes/playlist/[id]/+page.ts
@@ -23,6 +23,7 @@ export async function load({ params, parent, data }: LoadEvent): Promise<PageDat
 				owner_did: serverData?.playlistMeta?.owner_did ?? '',
 				owner_handle: serverData?.playlistMeta?.owner_handle ?? '',
 				track_count: serverData?.playlistMeta?.track_count ?? 0,
+				image_url: serverData?.playlistMeta?.image_url,
 				show_on_profile: serverData?.playlistMeta?.show_on_profile ?? false,
 				atproto_record_uri: serverData?.playlistMeta?.atproto_record_uri ?? '',
 				created_at: serverData?.playlistMeta?.created_at ?? '',


### PR DESCRIPTION
## Summary
- the SSR fallback object in `+page.ts` was missing `image_url` from `playlistMeta`
- this caused `og:image` to be undefined in link previews even when the playlist has cover art

## Test plan
- [ ] share a playlist link with cover art (e.g., in Discord, Slack, or Bluesky)
- [ ] verify the cover art appears in the link preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)