### PR TITLE
fix: invalidate layout data after token exchange

### DIFF
--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { replaceState } from '$app/navigation';
+	import { invalidateAll, replaceState } from '$app/navigation';
 	import Header from '$lib/components/Header.svelte';
 	import HandleSearch from '$lib/components/HandleSearch.svelte';
 	import AlbumSelect from '$lib/components/AlbumSelect.svelte';
@@ -77,6 +77,8 @@
 				});
 
 				if (exchangeResponse.ok) {
+					// invalidate all load functions so they rerun with the new session cookie
+					await invalidateAll();
 					await auth.initialize();
 					await preferences.fetch();
 				}

--- a/frontend/src/routes/profile/setup/+page.svelte
+++ b/frontend/src/routes/profile/setup/+page.svelte
@@ -2,7 +2,7 @@
 <script lang="ts">
 	import { APP_NAME } from '$lib/branding';
 	import { onMount } from 'svelte';
-	import { replaceState } from '$app/navigation';
+	import { invalidateAll, replaceState } from '$app/navigation';
 	import { API_URL } from '$lib/config';
 	import { auth } from '$lib/auth.svelte';
 
@@ -32,6 +32,8 @@
 				});
 
 				if (exchangeResponse.ok) {
+					// invalidate all load functions so they rerun with the new session cookie
+					await invalidateAll();
 					await auth.initialize();
 				}
 			} catch (_e) {

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { invalidateAll } from '$app/navigation';
 	import Header from '$lib/components/Header.svelte';
 	import WaveLoading from '$lib/components/WaveLoading.svelte';
 	import type { TokenInfo } from '$lib/types';
@@ -65,6 +66,9 @@
 
 				if (exchangeResponse.ok) {
 					const data = await exchangeResponse.json();
+
+					// invalidate all load functions so they rerun with the new session cookie
+					await invalidateAll();
 
 					if (isDevToken) {
 						developerToken = data.session_id;


### PR DESCRIPTION
## Summary
- after exchanging the OAuth token for a session cookie, the root layout's cached data still has `isAuthenticated: false`
- this caused navigation to `/library` immediately after login to redirect to `/` 
- **the fix**: call `invalidateAll()` after successful token exchange so SvelteKit reruns all load functions with the new session cookie

## Root cause
1. OAuth callback redirects to `/portal?exchange_token=xxx`
2. Root layout's `+layout.ts` runs - calls `/auth/me` - but session cookie isn't set yet
3. `/auth/me` returns 401 → layout caches `isAuthenticated: false`
4. Portal's `onMount` exchanges token → cookie is now set
5. User clicks Library → `+page.ts` calls `await parent()` → gets cached stale data → redirects to `/`

## Test plan
- [ ] log out, log back in
- [ ] immediately click Library button
- [ ] verify it navigates to `/library` instead of redirecting to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)