### PR TITLE
fix: playlist menus and link previews

### DIFF
--- a/frontend/src/lib/components/AddToMenu.svelte
+++ b/frontend/src/lib/components/AddToMenu.svelte
@@ -184,7 +184,13 @@
 
 	{#if menuOpen}
 		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-		<div class="menu-dropdown" role="menu" tabindex="-1" onclick={(e) => e.stopPropagation()}>
+		<div class="menu-dropdown" role="menu" tabindex="-1" onclick={(e) => {
+			// don't stop propagation for links - let SvelteKit handle navigation
+			if (e.target instanceof HTMLAnchorElement || (e.target as HTMLElement).closest('a')) {
+				return;
+			}
+			e.stopPropagation();
+		}}>
 			{#if !showPlaylistPicker}
 				<button class="menu-item" onclick={handleLike} disabled={loading}>
 					<svg width="18" height="18" viewBox="0 0 24 24" fill={liked ? 'currentColor' : 'none'} stroke="currentColor" stroke-width="2">

--- a/frontend/src/lib/components/TrackActionsMenu.svelte
+++ b/frontend/src/lib/components/TrackActionsMenu.svelte
@@ -190,7 +190,13 @@
 		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 		<div class="menu-backdrop" role="presentation" onclick={closeMenu}></div>
 		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-		<div class="menu-panel" role="menu" tabindex="-1" onclick={(e) => e.stopPropagation()}>
+		<div class="menu-panel" role="menu" tabindex="-1" onclick={(e) => {
+			// don't stop propagation for links - let SvelteKit handle navigation
+			if (e.target instanceof HTMLAnchorElement || (e.target as HTMLElement).closest('a')) {
+				return;
+			}
+			e.stopPropagation();
+		}}>
 			{#if !showPlaylistPicker}
 				{#if isAuthenticated}
 					<button class="menu-item" onclick={handleLike} disabled={loading || likeDisabled} class:disabled={likeDisabled}>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -28,6 +28,7 @@
 	let hasPageMetadata = $derived(
 		$page.url.pathname === '/' || // homepage
 		$page.url.pathname.startsWith('/track/') || // track detail
+		$page.url.pathname.startsWith('/playlist/') || // playlist detail
 		$page.url.pathname === '/liked' || // liked tracks
 		$page.url.pathname.match(/^\/u\/[^/]+$/) || // artist detail
 		$page.url.pathname.match(/^\/u\/[^/]+\/album\/[^/]+/) // album detail

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -5,7 +5,7 @@
 	import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
 	import { API_URL } from '$lib/config';
 	import Header from '$lib/components/Header.svelte';
-	import LikeButton from '$lib/components/LikeButton.svelte';
+	import AddToMenu from '$lib/components/AddToMenu.svelte';
 	import ShareButton from '$lib/components/ShareButton.svelte';
 	import TagEffects from '$lib/components/TagEffects.svelte';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
@@ -387,7 +387,13 @@ $effect(() => {
 			<div class="track-info-wrapper">
 				<div class="side-button-left">
 					{#if auth.isAuthenticated}
-						<LikeButton trackId={track.id} trackTitle={track.title} initialLiked={track.is_liked || false} />
+						<AddToMenu
+							trackId={track.id}
+							trackTitle={track.title}
+							trackUri={track.atproto_record_uri}
+							trackCid={track.atproto_record_cid}
+							initialLiked={track.is_liked || false}
+						/>
 					{/if}
 				</div>
 
@@ -439,7 +445,13 @@ $effect(() => {
 
 					<div class="mobile-side-buttons">
 						{#if auth.isAuthenticated}
-							<LikeButton trackId={track.id} trackTitle={track.title} initialLiked={track.is_liked || false} />
+							<AddToMenu
+								trackId={track.id}
+								trackTitle={track.title}
+								trackUri={track.atproto_record_uri}
+								trackCid={track.atproto_record_cid}
+								initialLiked={track.is_liked || false}
+							/>
 						{/if}
 						<ShareButton url={shareUrl} title="share track" />
 					</div>


### PR DESCRIPTION
## Summary
- Fix `stopPropagation` blocking "create new playlist" link clicks in AddToMenu and TrackActionsMenu components - the create playlist link now navigates properly without interrupting playback
- Add `/playlist/` routes to `hasPageMetadata` check in layout so the default OG tags don't duplicate/override page-specific playlist OG meta tags
- Replace LikeButton with AddToMenu on track detail page so users can add tracks to playlists from the track view

## Test plan
- [ ] Click heart on any track in a list → click "add to playlist" → click "create new playlist" link → should navigate to library without interrupting playback
- [ ] Share a playlist link (e.g. https://plyr.fm/playlist/...) → link preview should show playlist name and cover art, not default site OG tags
- [ ] Go to a track detail page → click the heart button → should see the full menu with like + add to playlist options

🤖 Generated with [Claude Code](https://claude.com/claude-code)