### PR TITLE
fix: make playlist detail page publicly viewable

### DIFF
--- a/frontend/src/routes/playlist/[id]/+page.ts
+++ b/frontend/src/routes/playlist/[id]/+page.ts
@@ -1,5 +1,5 @@
 import { browser } from '$app/environment';
-import { redirect, error } from '@sveltejs/kit';
+import { error } from '@sveltejs/kit';
 import { API_URL } from '$lib/config';
 import type { LoadEvent } from '@sveltejs/kit';
 import type { PlaylistWithTracks, Playlist } from '$lib/types';
@@ -9,7 +9,7 @@ export interface PageData {
 	playlistMeta: Playlist | null;
 }
 
-export async function load({ params, parent, data }: LoadEvent): Promise<PageData> {
+export async function load({ params, data }: LoadEvent): Promise<PageData> {
 	// server data for OG tags
 	const serverData = data as { playlistMeta: Playlist | null } | undefined;
 
@@ -33,12 +33,7 @@ export async function load({ params, parent, data }: LoadEvent): Promise<PageDat
 		};
 	}
 
-	// check auth from parent layout data
-	const { isAuthenticated } = await parent();
-	if (!isAuthenticated) {
-		throw redirect(302, '/');
-	}
-
+	// playlist endpoint is public - no auth required
 	const response = await fetch(`${API_URL}/lists/playlists/${params.id}`, {
 		credentials: 'include'
 	});


### PR DESCRIPTION
## Summary

- Playlists are now publicly viewable without authentication
- Edit/delete buttons only appear for the playlist owner (client-side auth check)
- Added `get_record_public()` utility to `_internal/atproto/records.py` for unauthenticated ATProto record fetches

ATProto records are public by design - the previous auth requirement was unnecessary for read access. This fixes the issue where playlist URLs shared on social media would redirect unauthenticated users to the homepage.

## Test plan

- [ ] Visit a playlist URL while logged out - should display playlist content
- [ ] Visit same playlist while logged in as owner - should see edit/delete buttons
- [ ] Visit same playlist while logged in as non-owner - should not see edit/delete buttons
- [ ] Test playlist playback while logged out

🤖 Generated with [Claude Code](https://claude.com/claude-code)