### PR TITLE
feat: migrate media export to docket background tasks

### DIFF
--- a/backend/src/backend/_internal/background.py
+++ b/backend/src/backend/_internal/background.py
@@ -121,11 +121,12 @@ def _register_tasks(docket: Docket) -> None:
     add new task imports here as they're created.
     """
     # import task functions here to avoid circular imports
-    from backend._internal.background_tasks import scan_copyright
+    from backend._internal.background_tasks import process_export, scan_copyright
 
     docket.register(scan_copyright)
+    docket.register(process_export)
 
     logger.info(
         "registered background tasks",
-        extra={"tasks": ["scan_copyright"]},
+        extra={"tasks": ["scan_copyright", "process_export"]},
     )

--- a/backend/src/backend/_internal/background_tasks.py
+++ b/backend/src/backend/_internal/background_tasks.py
@@ -6,7 +6,14 @@ they should be self-contained and handle their own database sessions.
 
 import asyncio
 import logging
+import os
+import tempfile
+import zipfile
+from datetime import datetime
+from pathlib import Path
 
+import aioboto3
+import aiofiles
 import logfire
 
 from backend._internal.background import get_docket, is_docket_enabled
@@ -53,3 +60,246 @@ async def schedule_copyright_scan(track_id: int, audio_url: str) -> None:
 
     # fallback: fire-and-forget
     asyncio.create_task(scan_track_for_copyright(track_id, audio_url))  # noqa: RUF006
+
+
+async def process_export(export_id: str, artist_did: str) -> None:
+    """process a media export in the background.
+
+    downloads all tracks for the given artist, zips them, and uploads
+    to R2. progress is tracked via job_service.
+
+    args:
+        export_id: job ID for tracking progress
+        artist_did: DID of the artist whose tracks to export
+    """
+    from sqlalchemy import select
+
+    from backend._internal.jobs import job_service
+    from backend.config import settings
+    from backend.models import Track
+    from backend.models.job import JobStatus
+    from backend.storage.r2 import UploadProgressTracker
+    from backend.utilities.database import db_session
+    from backend.utilities.progress import R2ProgressTracker
+
+    try:
+        await job_service.update_progress(
+            export_id, JobStatus.PROCESSING, "fetching tracks..."
+        )
+
+        # query all tracks for the user
+        async with db_session() as db:
+            stmt = (
+                select(Track)
+                .where(Track.artist_did == artist_did)
+                .order_by(Track.created_at)
+            )
+            result = await db.execute(stmt)
+            tracks = result.scalars().all()
+
+        if not tracks:
+            await job_service.update_progress(
+                export_id,
+                JobStatus.FAILED,
+                "export failed",
+                error="no tracks found to export",
+            )
+            return
+
+        # use temp directory to avoid loading large files into memory
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            zip_path = temp_path / f"{export_id}.zip"
+            async_session = aioboto3.Session()
+
+            async with async_session.client(
+                "s3",
+                endpoint_url=settings.storage.r2_endpoint_url,
+                aws_access_key_id=settings.storage.aws_access_key_id,
+                aws_secret_access_key=settings.storage.aws_secret_access_key,
+            ) as s3_client:
+                with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zip_file:
+                    # track counter for duplicate titles
+                    title_counts: dict[str, int] = {}
+                    processed = 0
+                    total = len(tracks)
+
+                    for track in tracks:
+                        if not track.file_id or not track.file_type:
+                            logfire.warn(
+                                "skipping track: missing file_id or file_type",
+                                track_id=track.id,
+                            )
+                            continue
+
+                        # construct R2 key
+                        key = f"audio/{track.file_id}.{track.file_type}"
+
+                        try:
+                            # update progress (current_track is 1-indexed for display)
+                            current_track = processed + 1
+                            pct = (processed / total) * 100
+                            await job_service.update_progress(
+                                export_id,
+                                JobStatus.PROCESSING,
+                                f"downloading track {current_track} of {total}...",
+                                progress_pct=pct,
+                                result={
+                                    "processed_count": processed,
+                                    "total_count": total,
+                                    "current_track": current_track,
+                                    "current_title": track.title,
+                                },
+                            )
+
+                            # create safe filename
+                            # handle duplicate titles by appending counter
+                            base_filename = f"{track.title}.{track.file_type}"
+                            if base_filename in title_counts:
+                                title_counts[base_filename] += 1
+                                filename = f"{track.title} ({title_counts[base_filename]}).{track.file_type}"
+                            else:
+                                title_counts[base_filename] = 0
+                                filename = base_filename
+
+                            # sanitize filename (remove invalid chars)
+                            filename = "".join(
+                                c
+                                for c in filename
+                                if c.isalnum() or c in (" ", ".", "-", "_", "(", ")")
+                            )
+
+                            # download file to temp location, streaming to disk
+                            temp_file_path = temp_path / filename
+                            response = await s3_client.get_object(
+                                Bucket=settings.storage.r2_bucket,
+                                Key=key,
+                            )
+
+                            # stream to disk in chunks to avoid loading into memory
+                            async with aiofiles.open(temp_file_path, "wb") as f:
+                                async for chunk in response["Body"].iter_chunks():
+                                    await f.write(chunk)
+
+                            # add to zip from disk (streams from file, doesn't load into memory)
+                            zip_file.write(temp_file_path, arcname=filename)
+
+                            # remove temp file immediately to free disk space
+                            os.unlink(temp_file_path)
+
+                            processed += 1
+                            logfire.info(
+                                "added track to export: {track_title}",
+                                track_id=track.id,
+                                track_title=track.title,
+                                filename=filename,
+                            )
+
+                        except Exception as e:
+                            logfire.error(
+                                "failed to add track to export: {track_title}",
+                                track_id=track.id,
+                                track_title=track.title,
+                                error=str(e),
+                                _exc_info=True,
+                            )
+                            # continue with other tracks instead of failing entire export
+
+            # upload the zip file to R2 (still inside temp directory context)
+            r2_key = f"exports/{export_id}.zip"
+
+            try:
+                zip_size = zip_path.stat().st_size
+
+                # Generate user-friendly filename for download
+                download_filename = f"plyr-tracks-{datetime.now().date()}.zip"
+
+                async with (
+                    R2ProgressTracker(
+                        job_id=export_id,
+                        message="finalizing export...",
+                        phase="upload",
+                    ) as tracker,
+                    async_session.client(
+                        "s3",
+                        endpoint_url=settings.storage.r2_endpoint_url,
+                        aws_access_key_id=settings.storage.aws_access_key_id,
+                        aws_secret_access_key=settings.storage.aws_secret_access_key,
+                    ) as upload_client,
+                ):
+                    # Wrap callback with UploadProgressTracker to convert bytes to percentage
+                    bytes_to_pct = UploadProgressTracker(zip_size, tracker.on_progress)
+                    with open(zip_path, "rb") as zip_file_obj:
+                        await upload_client.upload_fileobj(
+                            zip_file_obj,
+                            settings.storage.r2_bucket,
+                            r2_key,
+                            ExtraArgs={
+                                "ContentType": "application/zip",
+                                "ContentDisposition": f'attachment; filename="{download_filename}"',
+                            },
+                            Callback=bytes_to_pct,
+                        )
+
+                # Final 100% update
+                await job_service.update_progress(
+                    export_id,
+                    JobStatus.PROCESSING,
+                    "finalizing export...",
+                    phase="upload",
+                    progress_pct=100.0,
+                )
+
+            except Exception as e:
+                logfire.error("failed to upload export zip", error=str(e))
+                raise
+
+            # get download URL
+            download_url = f"{settings.storage.r2_public_bucket_url}/{r2_key}"
+
+            # mark as completed
+            await job_service.update_progress(
+                export_id,
+                JobStatus.COMPLETED,
+                f"export completed - {processed} tracks ready",
+                result={
+                    "processed_count": processed,
+                    "total_count": len(tracks),
+                    "download_url": download_url,
+                },
+            )
+
+    except Exception as e:
+        logfire.exception(
+            "export failed with unexpected error",
+            export_id=export_id,
+        )
+        await job_service.update_progress(
+            export_id,
+            JobStatus.FAILED,
+            "export failed",
+            error=f"unexpected error: {e!s}",
+        )
+
+
+async def schedule_export(export_id: str, artist_did: str) -> None:
+    """schedule an export, using docket if enabled, else asyncio.
+
+    this is the entry point for scheduling exports. it handles
+    the docket vs asyncio fallback logic in one place.
+    """
+    if is_docket_enabled():
+        try:
+            docket = get_docket()
+            await docket.add(process_export)(export_id, artist_did)
+            logfire.info("scheduled export via docket", export_id=export_id)
+            return
+        except Exception as e:
+            logfire.warning(
+                "docket scheduling failed, falling back to asyncio",
+                export_id=export_id,
+                error=str(e),
+            )
+
+    # fallback: fire-and-forget
+    asyncio.create_task(process_export(export_id, artist_did))  # noqa: RUF006

--- a/backend/src/backend/api/exports.py
+++ b/backend/src/backend/api/exports.py
@@ -3,242 +3,27 @@
 import asyncio
 import json
 import logging
-import os
-import tempfile
-import zipfile
-from pathlib import Path
 from typing import Annotated
 
-import aioboto3
-import aiofiles
-import logfire
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import RedirectResponse, StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, require_auth
+from backend._internal.background_tasks import schedule_export
 from backend._internal.jobs import job_service
-from backend.config import settings
 from backend.models import Track, get_db
 from backend.models.job import JobStatus, JobType
-from backend.storage.r2 import UploadProgressTracker
-from backend.utilities.database import db_session
-from backend.utilities.progress import R2ProgressTracker
 
 router = APIRouter(prefix="/exports", tags=["exports"])
 logger = logging.getLogger(__name__)
-
-
-async def _process_export_background(export_id: str, artist_did: str) -> None:
-    """background task to process export."""
-    try:
-        await job_service.update_progress(
-            export_id, JobStatus.PROCESSING, "fetching tracks..."
-        )
-
-        # query all tracks for the user
-        async with db_session() as db:
-            stmt = (
-                select(Track)
-                .where(Track.artist_did == artist_did)
-                .order_by(Track.created_at)
-            )
-            result = await db.execute(stmt)
-            tracks = result.scalars().all()
-
-        if not tracks:
-            await job_service.update_progress(
-                export_id,
-                JobStatus.FAILED,
-                "export failed",
-                error="no tracks found to export",
-            )
-            return
-
-        # use temp directory to avoid loading large files into memory
-        with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
-            zip_path = temp_path / f"{export_id}.zip"
-            async_session = aioboto3.Session()
-
-            async with async_session.client(
-                "s3",
-                endpoint_url=settings.storage.r2_endpoint_url,
-                aws_access_key_id=settings.storage.aws_access_key_id,
-                aws_secret_access_key=settings.storage.aws_secret_access_key,
-            ) as s3_client:
-                with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zip_file:
-                    # track counter for duplicate titles
-                    title_counts: dict[str, int] = {}
-                    processed = 0
-                    total = len(tracks)
-
-                    for track in tracks:
-                        if not track.file_id or not track.file_type:
-                            logfire.warn(
-                                "skipping track: missing file_id or file_type",
-                                track_id=track.id,
-                            )
-                            continue
-
-                        # construct R2 key
-                        key = f"audio/{track.file_id}.{track.file_type}"
-
-                        try:
-                            # update progress (current_track is 1-indexed for display)
-                            current_track = processed + 1
-                            pct = (processed / total) * 100
-                            await job_service.update_progress(
-                                export_id,
-                                JobStatus.PROCESSING,
-                                f"downloading track {current_track} of {total}...",
-                                progress_pct=pct,
-                                result={
-                                    "processed_count": processed,
-                                    "total_count": total,
-                                    "current_track": current_track,
-                                    "current_title": track.title,
-                                },
-                            )
-
-                            # create safe filename
-                            # handle duplicate titles by appending counter
-                            base_filename = f"{track.title}.{track.file_type}"
-                            if base_filename in title_counts:
-                                title_counts[base_filename] += 1
-                                filename = f"{track.title} ({title_counts[base_filename]}).{track.file_type}"
-                            else:
-                                title_counts[base_filename] = 0
-                                filename = base_filename
-
-                            # sanitize filename (remove invalid chars)
-                            filename = "".join(
-                                c
-                                for c in filename
-                                if c.isalnum() or c in (" ", ".", "-", "_", "(", ")")
-                            )
-
-                            # download file to temp location, streaming to disk
-                            temp_file_path = temp_path / filename
-                            response = await s3_client.get_object(
-                                Bucket=settings.storage.r2_bucket,
-                                Key=key,
-                            )
-
-                            # stream to disk in chunks to avoid loading into memory
-                            async with aiofiles.open(temp_file_path, "wb") as f:
-                                async for chunk in response["Body"].iter_chunks():
-                                    await f.write(chunk)
-
-                            # add to zip from disk (streams from file, doesn't load into memory)
-                            zip_file.write(temp_file_path, arcname=filename)
-
-                            # remove temp file immediately to free disk space
-                            os.unlink(temp_file_path)
-
-                            processed += 1
-                            logfire.info(
-                                "added track to export: {track_title}",
-                                track_id=track.id,
-                                track_title=track.title,
-                                filename=filename,
-                            )
-
-                        except Exception as e:
-                            logfire.error(
-                                "failed to add track to export: {track_title}",
-                                track_id=track.id,
-                                track_title=track.title,
-                                error=str(e),
-                                _exc_info=True,
-                            )
-                            # continue with other tracks instead of failing entire export
-
-            # upload the zip file to R2 (still inside temp directory context)
-            r2_key = f"exports/{export_id}.zip"
-
-            try:
-                zip_size = zip_path.stat().st_size
-
-                # Generate user-friendly filename for download
-                from datetime import datetime
-
-                download_filename = f"plyr-tracks-{datetime.now().date()}.zip"
-
-                async with (
-                    R2ProgressTracker(
-                        job_id=export_id,
-                        message="finalizing export...",
-                        phase="upload",
-                    ) as tracker,
-                    async_session.client(
-                        "s3",
-                        endpoint_url=settings.storage.r2_endpoint_url,
-                        aws_access_key_id=settings.storage.aws_access_key_id,
-                        aws_secret_access_key=settings.storage.aws_secret_access_key,
-                    ) as upload_client,
-                ):
-                    # Wrap callback with UploadProgressTracker to convert bytes to percentage
-                    bytes_to_pct = UploadProgressTracker(zip_size, tracker.on_progress)
-                    with open(zip_path, "rb") as zip_file_obj:
-                        await upload_client.upload_fileobj(
-                            zip_file_obj,
-                            settings.storage.r2_bucket,
-                            r2_key,
-                            ExtraArgs={
-                                "ContentType": "application/zip",
-                                "ContentDisposition": f'attachment; filename="{download_filename}"',
-                            },
-                            Callback=bytes_to_pct,
-                        )
-
-                # Final 100% update
-                await job_service.update_progress(
-                    export_id,
-                    JobStatus.PROCESSING,
-                    "finalizing export...",
-                    phase="upload",
-                    progress_pct=100.0,
-                )
-
-            except Exception as e:
-                logfire.error("failed to upload export zip", error=str(e))
-                raise
-
-            # get download URL
-            download_url = f"{settings.storage.r2_public_bucket_url}/{r2_key}"
-
-            # mark as completed
-            await job_service.update_progress(
-                export_id,
-                JobStatus.COMPLETED,
-                f"export completed - {processed} tracks ready",
-                result={
-                    "processed_count": processed,
-                    "total_count": len(tracks),
-                    "download_url": download_url,
-                },
-            )
-
-    except Exception as e:
-        logfire.exception(
-            "export failed with unexpected error",
-            export_id=export_id,
-        )
-        await job_service.update_progress(
-            export_id,
-            JobStatus.FAILED,
-            "export failed",
-            error=f"unexpected error: {e!s}",
-        )
 
 
 @router.post("/media")
 async def export_media(
     session: Annotated[Session, Depends(require_auth)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    background_tasks: BackgroundTasks,
 ) -> dict:
     """start export of all tracks for authenticated user.
 
@@ -257,8 +42,8 @@ async def export_media(
         JobType.EXPORT, session.did, "export queued for processing"
     )
 
-    # schedule background processing
-    background_tasks.add_task(_process_export_background, export_id, session.did)
+    # schedule background processing via docket (or asyncio fallback)
+    await schedule_export(export_id, session.did)
 
     return {
         "export_id": export_id,

--- a/backend/tests/test_background_tasks.py
+++ b/backend/tests/test_background_tasks.py
@@ -1,0 +1,125 @@
+"""tests for background task scheduling."""
+
+from unittest.mock import MagicMock, patch
+
+import backend._internal.background_tasks as bg_tasks
+
+
+async def test_schedule_export_uses_docket_when_enabled() -> None:
+    """when docket is enabled, schedule_export should add task to docket."""
+    calls: list[tuple[str, str]] = []
+
+    async def mock_schedule(export_id: str, artist_did: str) -> None:
+        calls.append((export_id, artist_did))
+
+    mock_docket = MagicMock()
+    mock_docket.add = MagicMock(return_value=mock_schedule)
+
+    with (
+        patch.object(bg_tasks, "is_docket_enabled", return_value=True),
+        patch.object(bg_tasks, "get_docket", return_value=mock_docket),
+        patch.object(bg_tasks, "process_export", MagicMock()),
+    ):
+        await bg_tasks.schedule_export("export-123", "did:plc:testuser")
+
+        mock_docket.add.assert_called_once()
+        assert calls == [("export-123", "did:plc:testuser")]
+
+
+async def test_schedule_export_falls_back_to_asyncio_when_disabled() -> None:
+    """when docket is disabled, schedule_export should use asyncio.create_task."""
+    create_task_calls: list[object] = []
+
+    def capture_create_task(coro: object) -> MagicMock:
+        create_task_calls.append(coro)
+        return MagicMock()
+
+    process_export_calls: list[tuple[str, str]] = []
+
+    def mock_process_export(export_id: str, artist_did: str) -> object:
+        process_export_calls.append((export_id, artist_did))
+        return MagicMock()  # return non-coroutine to avoid unawaited warning
+
+    with (
+        patch.object(bg_tasks, "is_docket_enabled", return_value=False),
+        patch.object(bg_tasks, "process_export", mock_process_export),
+        patch.object(bg_tasks.asyncio, "create_task", capture_create_task),
+    ):
+        await bg_tasks.schedule_export("export-456", "did:plc:testuser")
+
+        assert len(create_task_calls) == 1
+        assert process_export_calls == [("export-456", "did:plc:testuser")]
+
+
+async def test_schedule_export_falls_back_on_docket_error() -> None:
+    """if docket scheduling fails, should fall back to asyncio."""
+    mock_docket = MagicMock()
+    mock_docket.add.side_effect = Exception("redis connection failed")
+
+    create_task_calls: list[object] = []
+
+    def capture_create_task(coro: object) -> MagicMock:
+        create_task_calls.append(coro)
+        return MagicMock()
+
+    process_export_calls: list[tuple[str, str]] = []
+
+    def mock_process_export(export_id: str, artist_did: str) -> object:
+        process_export_calls.append((export_id, artist_did))
+        return MagicMock()
+
+    with (
+        patch.object(bg_tasks, "is_docket_enabled", return_value=True),
+        patch.object(bg_tasks, "get_docket", return_value=mock_docket),
+        patch.object(bg_tasks, "process_export", mock_process_export),
+        patch.object(bg_tasks.asyncio, "create_task", capture_create_task),
+    ):
+        await bg_tasks.schedule_export("export-789", "did:plc:testuser")
+
+        assert len(create_task_calls) == 1
+
+
+async def test_schedule_copyright_scan_uses_docket_when_enabled() -> None:
+    """when docket is enabled, schedule_copyright_scan should add task to docket."""
+    calls: list[tuple[int, str]] = []
+
+    async def mock_schedule(track_id: int, audio_url: str) -> None:
+        calls.append((track_id, audio_url))
+
+    mock_docket = MagicMock()
+    mock_docket.add = MagicMock(return_value=mock_schedule)
+
+    with (
+        patch.object(bg_tasks, "is_docket_enabled", return_value=True),
+        patch.object(bg_tasks, "get_docket", return_value=mock_docket),
+        patch.object(bg_tasks, "scan_copyright", MagicMock()),
+    ):
+        await bg_tasks.schedule_copyright_scan(123, "https://example.com/audio.mp3")
+
+        mock_docket.add.assert_called_once()
+        assert calls == [(123, "https://example.com/audio.mp3")]
+
+
+async def test_schedule_copyright_scan_falls_back_to_asyncio_when_disabled() -> None:
+    """when docket is disabled, schedule_copyright_scan should use asyncio."""
+    create_task_calls: list[object] = []
+
+    def capture_create_task(coro: object) -> MagicMock:
+        create_task_calls.append(coro)
+        return MagicMock()
+
+    scan_calls: list[tuple[int, str]] = []
+
+    def mock_scan(track_id: int, audio_url: str) -> object:
+        scan_calls.append((track_id, audio_url))
+        return MagicMock()
+
+    with (
+        patch.object(bg_tasks, "is_docket_enabled", return_value=False),
+        patch("backend._internal.moderation.scan_track_for_copyright", mock_scan),
+        patch.object(bg_tasks.asyncio, "create_task", capture_create_task),
+    ):
+        await bg_tasks.schedule_copyright_scan(456, "https://example.com/audio.mp3")
+
+        assert len(create_task_calls) == 1
+        assert scan_calls == [(456, "https://example.com/audio.mp3")]

--- a/docs/backend/background-tasks.md
+++ b/docs/backend/background-tasks.md
@@ -6,7 +6,7 @@ plyr.fm uses [pydocket](https://github.com/PrefectHQ/pydocket) for durable backg
 
 background tasks handle operations that shouldn't block the request/response cycle:
 - **copyright scanning** - analyzes uploaded tracks for potential copyright matches
-- (future) upload processing, notifications, etc.
+- **media export** - downloads all tracks, zips them, and uploads to R2
 
 ## architecture
 
@@ -69,10 +69,11 @@ note: use `rediss://` (with double 's') for TLS connections to Upstash.
 ### scheduling a task
 
 ```python
-from backend._internal.background_tasks import schedule_copyright_scan
+from backend._internal.background_tasks import schedule_copyright_scan, schedule_export
 
 # automatically uses docket if enabled, else asyncio.create_task
 await schedule_copyright_scan(track_id, audio_url)
+await schedule_export(export_id, artist_did)
 ```
 
 ### adding new tasks


### PR DESCRIPTION
## Summary

- migrate export processing from FastAPI `BackgroundTasks` to docket
- exports now benefit from docket's durability: if a worker crashes mid-export, the task will be retried on restart
- adds `schedule_export` helper with asyncio fallback when docket is disabled

## Test plan

- [x] all 309 tests pass
- [x] lint passes
- [x] test export with docket enabled (staging)
- [x] test export with docket disabled (asyncio fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)