### PR TITLE
feat: docket background tasks + UI fixes

### DIFF
--- a/frontend/src/lib/components/AddToMenu.svelte
+++ b/frontend/src/lib/components/AddToMenu.svelte
@@ -503,6 +503,26 @@
 	.playlist-list {
 		max-height: 240px;
 		overflow-y: auto;
+		scrollbar-width: thin;
+		scrollbar-color: var(--border-default) transparent;
+	}
+
+	.playlist-list::-webkit-scrollbar {
+		width: 8px;
+	}
+
+	.playlist-list::-webkit-scrollbar-track {
+		background: transparent;
+		border-radius: 4px;
+	}
+
+	.playlist-list::-webkit-scrollbar-thumb {
+		background: var(--border-default);
+		border-radius: 4px;
+	}
+
+	.playlist-list::-webkit-scrollbar-thumb:hover {
+		background: var(--border-emphasis);
 	}
 
 	.playlist-item {

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -681,7 +681,6 @@ $effect(() => {
 		margin: 0 0 0.35rem 0;
 		font-size: 1.05rem;
 		color: var(--text-primary);
-		text-transform: lowercase;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

### docket integration
- migrate ATProto sync (login/scope upgrade) to docket background task
- migrate teal scrobbling (play count) to docket background task  
- remove all fallback/bifurcation code - Redis is always required now
- simplify `background.py` (remove `is_docket_enabled`)
- add Redis service to CI workflow

### UI fixes
- respect original album name casing on artist detail page (was forcing lowercase)
- add theme-aware scrollbar styling to AddToMenu playlist list (was white in dark mode)

## Test plan
- [ ] visit an artist page with albums - verify album names show original casing
- [ ] open AddToMenu, click "add to playlist" with enough playlists to scroll - verify scrollbar matches theme
- [ ] login and verify ATProto sync runs via docket (check logfire for "scheduled atproto sync")
- [ ] play a track with teal scrobbling enabled - verify scrobble runs via docket

🤖 Generated with [Claude Code](https://claude.com/claude-code)