### PR TITLE
feat: parallelize export downloads with asyncio.gather

### DIFF
--- a/backend/tests/test_background_tasks.py
+++ b/backend/tests/test_background_tasks.py
@@ -1,6 +1,8 @@
 """tests for background task scheduling."""
 
-from unittest.mock import MagicMock, patch
+import asyncio
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import backend._internal.background_tasks as bg_tasks
 
@@ -101,3 +103,98 @@ async def test_schedule_teal_scrobble_uses_docket() -> None:
         assert calls == [
             ("session-xyz", 42, "Test Track", "Test Artist", 180, "Test Album")
         ]
+
+
+async def test_process_export_downloads_concurrently() -> None:
+    """process_export should download tracks concurrently, not sequentially.
+
+    regression test: previously tracks were downloaded one at a time,
+    making exports slow for users with many tracks or large files.
+    """
+    download_times: list[float] = []
+    download_start_event = asyncio.Event()
+
+    async def mock_get_object(Bucket: str, Key: str) -> dict:
+        """track when downloads start and simulate network delay."""
+        download_times.append(asyncio.get_event_loop().time())
+        # signal that at least one download has started
+        download_start_event.set()
+        # simulate network delay
+        await asyncio.sleep(0.1)
+        # return mock response with async body
+        body = AsyncMock()
+        body.iter_chunks = lambda: async_chunk_gen()
+        return {"Body": body}
+
+    async def async_chunk_gen():
+        yield b"mock audio data"
+
+    # create mock tracks
+    mock_tracks = []
+    for i in range(4):
+        track = MagicMock()
+        track.id = i
+        track.title = f"Track {i}"
+        track.file_id = f"file_{i}"
+        track.file_type = "mp3"
+        mock_tracks.append(track)
+
+    # mock database query
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = mock_tracks
+
+    mock_db = AsyncMock()
+    mock_db.execute.return_value = mock_result
+
+    # mock S3 client
+    mock_s3 = AsyncMock()
+    mock_s3.get_object = mock_get_object
+
+    # mock session that returns mock s3 client
+    mock_session = MagicMock()
+    mock_session.client.return_value.__aenter__.return_value = mock_s3
+
+    # mock job service
+    mock_job_service = AsyncMock()
+
+    # mock aiofiles.open to be a no-op
+    mock_file = AsyncMock()
+    mock_file.__aenter__.return_value = mock_file
+    mock_file.__aexit__.return_value = None
+    mock_file.write = AsyncMock()
+
+    with (
+        patch(
+            "backend._internal.background_tasks.aioboto3.Session",
+            return_value=mock_session,
+        ),
+        patch(
+            "backend._internal.background_tasks.aiofiles.open", return_value=mock_file
+        ),
+        patch("backend._internal.background_tasks.zipfile.ZipFile"),
+        patch("backend._internal.background_tasks.os.unlink"),
+        patch("backend.utilities.database.db_session") as mock_db_session,
+        patch("backend._internal.jobs.job_service", mock_job_service),
+    ):
+        mock_db_session.return_value.__aenter__.return_value = mock_db
+
+        # run process_export but cancel before upload phase
+        # (we only care about testing download concurrency)
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(
+                bg_tasks.process_export("export-123", "did:plc:testuser"),
+                timeout=2.0,
+            )
+
+    # verify downloads started concurrently:
+    # if sequential, each download would start ~0.1s after the previous
+    # if concurrent, all 4 downloads should start within ~0.05s of each other
+    assert len(download_times) == 4, f"expected 4 downloads, got {len(download_times)}"
+
+    # check that all downloads started within a small time window (concurrent)
+    # not spread out over 0.4s (sequential)
+    time_spread = max(download_times) - min(download_times)
+    assert time_spread < 0.1, (
+        f"downloads should start concurrently (within 0.1s), "
+        f"but time spread was {time_spread:.3f}s - likely still sequential"
+    )


### PR DESCRIPTION
## Summary
- refactor `process_export` to download tracks concurrently using `asyncio.gather` with a semaphore (limit 4)
- zip creation remains sequential (required - `zipfile.ZipFile` isn't thread-safe)
- add regression test verifying downloads start concurrently

## Context
Previously tracks were downloaded one at a time, making exports slow for users with many tracks or large files. For a 6-track export with one 90-minute file, this was taking ~59 seconds because each download had to complete before the next started.

Now smaller tracks download in parallel with large ones, reducing total export time.

## Test plan
- [x] existing export scheduling test passes
- [x] new regression test verifies concurrent download behavior (downloads start within 0.1s of each other)
- [ ] manual test on staging with multi-track export

🤖 Generated with [Claude Code](https://claude.com/claude-code)