### PR TITLE
fix: use dedicated plyr-stats R2 bucket

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -267,14 +267,12 @@ class StorageSettings(AppSettingsSection):
         validation_alias="R2_PUBLIC_IMAGE_BUCKET_URL",
         description="R2 public bucket URL for image files",
     )
-
-    @computed_field
-    @property
-    def costs_json_url(self) -> str:
-        """URL for the public costs dashboard JSON."""
-        if self.r2_public_bucket_url:
-            return f"{self.r2_public_bucket_url.rstrip('/')}/stats/costs.json"
-        return ""
+    # dedicated stats bucket - shared across all environments
+    costs_json_url: str = Field(
+        default="https://pub-68f2c7379f204d81bdf65152b0ff0207.r2.dev/costs.json",
+        validation_alias="COSTS_JSON_URL",
+        description="URL for public costs dashboard JSON",
+    )
 
     @computed_field
     @property


### PR DESCRIPTION
## Summary
- created `plyr-stats` R2 bucket with public dev-url access
- costs data now lives in dedicated bucket, shared across all environments
- fixes 502 error on staging (was trying to fetch from staging audio bucket)

## Test plan
- [ ] verify https://pub-68f2c7379f204d81bdf65152b0ff0207.r2.dev/costs.json is accessible
- [ ] verify `/costs` page works on staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)