### PR TITLE
docs: audit and update documentation for Dec 10

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -47,6 +47,26 @@ plyr.fm should become:
 
 ### December 2025
 
+#### pagination & album management (PRs #550-554, Dec 9-10)
+
+**tracks list pagination** (PR #554):
+- cursor-based pagination on `/tracks/` endpoint (default 50 per page)
+- infinite scroll on homepage using native IntersectionObserver
+- zero new dependencies - uses browser APIs only
+- pagination state persisted to localStorage for fast subsequent loads
+
+**album management improvements** (PRs #550-552):
+- album delete and track reorder fixes
+- album page edit mode matching playlist UX (inline title editing, cover upload)
+- optimistic UI updates for album title changes (instant feedback)
+- ATProto record sync when album title changes (updates all track records + list record)
+
+**playlist show on profile** (PR #553):
+- restored "show on profile" toggle that was lost during inline editing refactor
+- users can now control whether playlists appear on their public profile
+
+---
+
 #### public cost dashboard (PR #548, Dec 9)
 
 - `/costs` page showing live platform infrastructure costs
@@ -354,4 +374,4 @@ plyr.fm/
 
 ---
 
-this is a living document. last updated 2025-12-09.
+this is a living document. last updated 2025-12-10.

--- a/docs/backend/background-tasks.md
+++ b/docs/backend/background-tasks.md
@@ -7,6 +7,8 @@ plyr.fm uses [pydocket](https://github.com/PrefectHQ/pydocket) for durable backg
 background tasks handle operations that shouldn't block the request/response cycle:
 - **copyright scanning** - analyzes uploaded tracks for potential copyright matches
 - **media export** - downloads all tracks, zips them, and uploads to R2
+- **ATProto sync** - syncs records to user's PDS on login
+- **teal scrobbling** - scrobbles plays to user's PDS
 
 ## architecture
 

--- a/docs/frontend/state-management.md
+++ b/docs/frontend/state-management.md
@@ -124,7 +124,9 @@ plyr.fm uses global state managers following the Svelte 5 runes pattern for cros
 ### tracks cache (`frontend/src/lib/tracks.svelte.ts`)
 - caches track list globally in localStorage
 - provides instant navigation by serving cached data
-- invalidates on new uploads
+- cursor-based pagination with `fetchMore()` for infinite scroll
+- pagination state (`nextCursor`, `hasMore`) persisted alongside tracks
+- invalidates on new uploads (resets to first page)
 - includes like status for each track (when authenticated)
 - simple invalidation model - no time-based expiry
 


### PR DESCRIPTION
## Summary
- Update STATUS.md with PRs #550-554 (pagination, album management, playlist toggle)
- Add pagination support to tracks cache docs
- Add ATProto sync and teal scrobbling to background tasks docs

Preparing for memory blocks being disabled - capturing recent work in persistent documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)