### PR TITLE
fix: sync album slug when title is updated via PATCH

### DIFF
--- a/backend/src/backend/api/albums.py
+++ b/backend/src/backend/api/albums.py
@@ -34,6 +34,7 @@ from backend.utilities.aggregations import (
     get_track_tags,
 )
 from backend.utilities.hashing import CHUNK_SIZE
+from backend.utilities.slugs import slugify
 
 logger = logging.getLogger(__name__)
 
@@ -500,6 +501,9 @@ async def update_album(
 
     if title is not None:
         album.title = title.strip()
+        # sync slug when title changes so get_or_create_album lookups work
+        if title_changed:
+            album.slug = slugify(title.strip())
     if description is not None:
         album.description = description.strip() if description.strip() else None
 


### PR DESCRIPTION
## Summary
- fixes album duplication bug when adding tracks to renamed albums
- `PATCH /albums/{album_id}` now updates `slug` when `title` changes
- production data fixed: updated the Waybacks album slug via Neon

## Root cause
PR #550 added album renaming via `PATCH /albums/{album_id}`, but only updated `title` - not `slug`. When users later added tracks to renamed albums, `get_or_create_album()` couldn't find the album (it looks up by `artist_did + slugify(title)`), creating duplicates.

## Test plan
- [x] regression test `test_update_album_syncs_slug_on_title_change` added
- [x] all 13 album tests pass
- [x] linting passes
- [x] fixed production mismatch (Waybacks album)

🤖 Generated with [Claude Code](https://claude.com/claude-code)