### PR TITLE
fix: reduce docket redis polling from 250ms to 5s

### DIFF
--- a/backend/src/backend/_internal/background.py
+++ b/backend/src/backend/_internal/background.py
@@ -15,6 +15,7 @@ import asyncio
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from datetime import timedelta
 
 from docket import Docket, Worker
 
@@ -69,6 +70,13 @@ async def background_worker_lifespan() -> AsyncGenerator[Docket, None]:
             async with Worker(
                 docket,
                 concurrency=settings.docket.worker_concurrency,
+                # reduce polling frequency to save Redis costs (default is 250ms)
+                minimum_check_interval=timedelta(
+                    seconds=settings.docket.check_interval_seconds
+                ),
+                scheduling_resolution=timedelta(
+                    seconds=settings.docket.scheduling_resolution_seconds
+                ),
             ) as worker:
                 worker_task = asyncio.create_task(
                     worker.run_forever(),

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -576,6 +576,14 @@ class DocketSettings(AppSettingsSection):
         default=10,
         description="Number of concurrent tasks per worker",
     )
+    check_interval_seconds: float = Field(
+        default=5.0,
+        description="How often to check for new tasks (seconds). Default 5s reduces Redis costs vs docket's 250ms default.",
+    )
+    scheduling_resolution_seconds: float = Field(
+        default=5.0,
+        description="How often to run the scheduler loop (seconds). Default 5s reduces Redis costs vs docket's 250ms default.",
+    )
 
 
 class RateLimitSettings(AppSettingsSection):

--- a/scripts/costs/export_costs.py
+++ b/scripts/costs/export_costs.py
@@ -60,13 +60,13 @@ FIXED_COSTS = {
     # the copyright_scans table was created Nov 24 but first scan recorded Nov 30
     # so we hardcode this period from AudD dashboard. DELETE THIS after Dec 24 -
     # future periods will use live database counts.
-    # source: https://dashboard.audd.io - checked 2025-12-09
+    # source: https://dashboard.audd.io - checked 2025-12-10
     "audd": {
-        "total_requests": 6781,
+        "total_requests": 7826,  # 6000 included + 1826 billable
         "included_requests": 6000,  # 1000 + 5000 bonus
-        "billable_requests": 781,
+        "billable_requests": 1826,
         "cost_per_request": 0.005,  # $5 per 1000
-        "cost": 3.91,  # 781 * $0.005
+        "cost": 9.13,  # 1826 * $0.005
         "note": "copyright detection API (indie plan)",
     },
 }


### PR DESCRIPTION
## Summary

- reduces docket worker polling frequency from 250ms to 5s (configurable via `DOCKET_CHECK_INTERVAL_SECONDS` and `DOCKET_SCHEDULING_RESOLUTION_SECONDS`)
- updates AudD costs in export_costs.py from $3.91 to $9.13 (current billing period has 1826 billable requests)

## Problem

The default docket worker polls Redis every 250ms (4 times per second), even when idle. This caused:
- ~3.4M Redis commands in 2 days
- $6.73 in Upstash costs (on a ~$360/year budget)

## Solution

Increase polling intervals to 5 seconds by default. For background tasks like copyright scans and exports that run occasionally, 5 second latency is perfectly acceptable.

**Expected cost reduction:** ~95% for idle polling overhead

## Test plan

- [x] all tests pass (320 passed, 1 skipped)
- [x] lint passes
- [ ] deploy and monitor Redis command count in Upstash dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)