### PR TITLE
fix: mobile action menus open from top, add missing actions

### DIFF
--- a/frontend/src/lib/components/TrackActionsMenu.svelte
+++ b/frontend/src/lib/components/TrackActionsMenu.svelte
@@ -422,22 +422,22 @@
 
 	.menu-panel {
 		position: fixed;
-		bottom: 0;
+		top: 0;
 		left: 0;
 		right: 0;
 		background: var(--bg-secondary);
-		border-radius: 16px 16px 0 0;
-		box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.4);
+		border-radius: 0 0 16px 16px;
+		box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
 		z-index: 101;
-		animation: slideUp 0.2s ease-out;
-		padding-bottom: env(safe-area-inset-bottom, 0);
+		animation: slideDown 0.2s ease-out;
+		padding-top: env(safe-area-inset-top, 0);
 		max-height: 70vh;
 		overflow-y: auto;
 	}
 
-	@keyframes slideUp {
+	@keyframes slideDown {
 		from {
-			transform: translateY(100%);
+			transform: translateY(-100%);
 		}
 		to {
 			transform: translateY(0);

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -115,6 +115,7 @@
 
 	function addToQueue() {
 		queue.addTracks([track]);
+		toast.success(`queued ${track.title}`, 1800);
 	}
 
 	async function loadComments() {
@@ -465,6 +466,8 @@ $effect(() => {
 								trackUri={track.atproto_record_uri}
 								trackCid={track.atproto_record_cid}
 								initialLiked={track.is_liked || false}
+								shareUrl={shareUrl}
+								onQueue={addToQueue}
 							/>
 						{/if}
 						<ShareButton url={shareUrl} title="share track" />


### PR DESCRIPTION
## Summary

- AddToMenu now includes queue and share actions (matching TrackActionsMenu)
- Both menus open from top on mobile instead of bottom (doesn't cover player)
- Added backdrop for proper dismissal on mobile
- Track detail page passes shareUrl and onQueue props to AddToMenu

## Test plan

- [ ] On mobile/narrow screen, tap heart button on track detail page - menu opens from top
- [ ] Menu shows all 4 actions: like, playlist, queue, share
- [ ] On homepage mobile, tap 3-dot menu - also opens from top
- [ ] Player remains visible and usable while menu is open
- [ ] Tapping backdrop closes menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)