### PR TITLE
always put an id in your web manifest, kids

### DIFF
--- a/frontend/static/manifest.webmanifest
+++ b/frontend/static/manifest.webmanifest
@@ -1,5 +1,6 @@
 {
   "name": "plyr.fm",
+  "id": "fm.plyr",
   "short_name": "Plyr",
   "start_url": "/",
   "display": "standalone",


### PR DESCRIPTION
## summary

without an explicit `id` field in the PWA manifest, iOS may conflate different PWAs when routing media session events.

**the bug**: tapping track metadata in iOS control center opened leaflet.pub instead of plyr.fm

**the fix**: add `"id": "fm.plyr"` to the manifest

## context

- leaflet.pub has `"id": "leaflet"` in their manifest
- plyr.fm had no `id` field
- iOS appears to use this field (or lack thereof) when determining which home screen web app should receive media session taps

## testing

1. deploy to production
2. remove plyr.fm from iOS home screen  
3. re-add it (to pick up new manifest)
4. play a track, lock screen, tap metadata in control center
5. should now open plyr.fm, not some other random PWA

## references

- [Chrome: PWA manifest id property](https://developer.chrome.com/docs/capabilities/pwa-manifest-id)
- [W3C manifest issue: Add a unique identifier for a PWA](https://github.com/w3c/manifest/issues/586)

🤖 Generated with [Claude Code](https://claude.com/claude-code)