### PR TITLE
fix: mobile ui polish for album and artist pages

### DIFF
--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -635,7 +635,7 @@ $effect(() => {
 
 	.album-grid {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+		grid-template-columns: repeat(auto-fit, minmax(min(260px, 100%), 1fr));
 		gap: 1.25rem;
 	}
 

--- a/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
@@ -1094,6 +1094,8 @@
 		.mobile-buttons {
 			display: flex;
 			gap: 0.5rem;
+			justify-content: center;
+			align-items: center;
 		}
 
 		.album-title {


### PR DESCRIPTION
## Summary
- center share button on album detail page mobile view (matches playlist page behavior)
- fix album grid overflow on narrow mobile screens using `min(260px, 100%)` pattern

## Test plan
- [ ] open album detail page on mobile, verify share button is centered
- [ ] open artist detail page on mobile, verify album cards don't overflow horizontally

🤖 Generated with [Claude Code](https://claude.com/claude-code)