### PR TITLE
fix: iOS Safari AddToMenu visibility issue

### DIFF
--- a/frontend/src/lib/components/AddToMenu.svelte
+++ b/frontend/src/lib/components/AddToMenu.svelte
@@ -754,8 +754,10 @@
 			left: 0;
 			right: 0;
 			bottom: 0;
-			z-index: 100;
+			z-index: 199;
 			background: rgba(0, 0, 0, 0.4);
+			-webkit-transform: translateZ(0);
+			transform: translateZ(0);
 		}
 
 		.menu-dropdown {
@@ -764,20 +766,14 @@
 			bottom: auto;
 			left: 0;
 			right: 0;
+			width: 100%;
 			min-width: 100%;
+			max-width: 100vw;
 			border-radius: 0 0 16px 16px;
 			padding-top: env(safe-area-inset-top, 0);
-			animation: slideDown 0.2s ease-out;
-			z-index: 101;
-		}
-
-		@keyframes slideDown {
-			from {
-				transform: translateY(-100%);
-			}
-			to {
-				transform: translateY(0);
-			}
+			z-index: 200;
+			-webkit-transform: translateZ(0);
+			transform: translateZ(0);
 		}
 
 		.menu-item {


### PR DESCRIPTION
## Summary
- disable slideDown animation on mobile AddToMenu to test iOS Safari compatibility

## Background
On real iOS Safari (both PWA and browser), the AddToMenu backdrop shows (background dims) but the dropdown menu doesn't appear. This works fine on desktop with narrow viewport simulation.

The hypothesis is that iOS Safari has issues with CSS animations on dynamically inserted elements. This change removes the animation to test if the element renders at all.

## Test plan
- [ ] open track detail page on iOS Safari
- [ ] tap heart button when logged in
- [ ] verify menu appears from top (without animation for now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)