### PR TITLE
fix: AddToMenu open-upward override for mobile

### DIFF
--- a/frontend/src/lib/components/AddToMenu.svelte
+++ b/frontend/src/lib/components/AddToMenu.svelte
@@ -789,7 +789,8 @@
 			transform: translateZ(0);
 		}
 
-		.menu-dropdown {
+		.menu-dropdown,
+		.menu-dropdown.open-upward {
 			position: fixed;
 			top: 0;
 			bottom: auto;


### PR DESCRIPTION
## Summary
The `.open-upward` class was setting `top: auto` and `bottom: calc(100% + 4px)` which wasn't being overridden by the mobile media query, causing the dropdown to render off-screen at `top: -218px`.

## Root cause
Console logs revealed: `top: '-218px'` in computed styles. The `open-upward` class (used on desktop when there's no space below) was taking precedence over the mobile styles.

## Fix
Add `.menu-dropdown.open-upward` to the mobile media query selector to ensure mobile styles always win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)