### PR TITLE
fix: update atproto fork and fix confidential client tests

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -287,8 +287,8 @@ wheels = [
 
 [[package]]
 name = "atproto"
-version = "0.0.1.dev461"
-source = { git = "https://github.com/zzstoatzz/atproto?rev=main#57bb99a28c916a5b5c960ade00e4f82695860af1" }
+version = "0.0.1.dev469"
+source = { git = "https://github.com/zzstoatzz/atproto?rev=main#dfbaf0002fed21d5a0ca28a6219e2b6b42384259" }
 dependencies = [
     { name = "click" },
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
- Update atproto fork to include aud claim fix (dfbaf00)
- Fix auth tests to explicitly mock OAUTH_JWK setting

## Changes
- **uv.lock**: Updated atproto to `v0.0.1.dev469` with aud claim fix
- **tests/test_auth.py**: Tests now mock `oauth_jwk` setting instead of relying on it being unset

## Context
The atproto fork fix (zzstoatzz/atproto#6) changes client assertion JWTs to use the Authorization Server's issuer URL as the `aud` claim instead of the token endpoint URL. This is required by the ATProto OAuth spec and was causing "unexpected aud claim value" errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)