### PR TITLE
fix: preserve kid in JWKS endpoint output

### DIFF
--- a/backend/src/backend/_internal/auth.py
+++ b/backend/src/backend/_internal/auth.py
@@ -142,6 +142,10 @@ def get_public_jwks() -> dict | None:
         public_jwk["use"] = "sig"
         public_jwk["alg"] = "ES256"
 
+        # preserve kid from original JWK (python-jose's to_dict() doesn't include it)
+        if "kid" in jwk_data:
+            public_jwk["kid"] = jwk_data["kid"]
+
         return {"keys": [public_jwk]}
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- Preserve `kid` (key ID) field in JWKS endpoint output

## Problem
`python-jose`'s `to_dict()` method doesn't include the `kid` field from the original JWK. ATProto OAuth requires the `kid` for key identification when validating client assertions.

## Fix
Explicitly copy the `kid` from the input JWK data to the public key output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)