### PR TITLE
fix: pass kid to OAuthClient for client assertion JWT header

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -287,8 +287,8 @@ wheels = [
 
 [[package]]
 name = "atproto"
-version = "0.0.1.dev469"
-source = { git = "https://github.com/zzstoatzz/atproto?rev=main#dfbaf0002fed21d5a0ca28a6219e2b6b42384259" }
+version = "0.0.1.dev470"
+source = { git = "https://github.com/zzstoatzz/atproto?rev=main#6710edb64d144a0ff2757526ade34fa1625a46e6" }
 dependencies = [
     { name = "click" },
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
Fix confidential OAuth client to include `kid` in client assertion JWT header.

## Problem
The ATProto OAuth spec requires client assertions to include the `kid` (key ID) in the JWT header so the PDS knows which public key from the JWKS to use for verification. Without it, the PDS rejects with "kid required in client_assertion".

## Changes
- Rename `_load_client_secret_key()` to `_load_client_secret()` returning `(key, kid)` tuple
- Validate that `OAUTH_JWK` includes the `kid` field
- Pass `client_secret_kid` to `OAuthClient`
- Update atproto fork to v0.0.1.dev470 with kid support (zzstoatzz/atproto#7)

## Testing
- [x] All 20 auth tests pass
- [x] Local OAuth flow tested successfully with confidential client

🤖 Generated with [Claude Code](https://claude.com/claude-code)