### PR TITLE
docs: add Dec 10-12 work to STATUS.md, update background-tasks docs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -69,6 +69,30 @@ plyr.fm should become:
 
 ---
 
+#### mobile UI polish & background task expansion (PRs #558-572, Dec 10-12)
+
+**background task expansion** (PRs #558, #561):
+- moved like/unlike and comment PDS writes to docket background tasks
+- API responses now immediate; PDS sync happens asynchronously
+- added targeted album list sync background task for ATProto record updates
+
+**performance caching** (PR #566):
+- added Redis cache for copyright label lookups (5-minute TTL)
+- fixed 2-3s latency spikes on `/tracks/` endpoint
+- batch operations via `mget`/pipeline for efficiency
+
+**mobile UX improvements** (PRs #569, #572):
+- mobile action menus now open from top with all actions visible
+- UI polish for album and artist pages on small screens
+
+**misc** (PRs #559, #562, #563, #570):
+- reduced docket Redis polling from 250ms to 5s (lower resource usage)
+- added atprotofans support link mode for ko-fi integration
+- added alpha badge to header branding
+- fixed web manifest ID for PWA stability
+
+---
+
 #### confidential OAuth client (PRs #578, #580-582, Dec 12-13)
 
 **confidential client support** (PR #578):

--- a/docs/backend/background-tasks.md
+++ b/docs/backend/background-tasks.md
@@ -9,6 +9,9 @@ background tasks handle operations that shouldn't block the request/response cyc
 - **media export** - downloads all tracks, zips them, and uploads to R2
 - **ATProto sync** - syncs records to user's PDS on login
 - **teal scrobbling** - scrobbles plays to user's PDS
+- **album list sync** - updates ATProto list records when album metadata changes
+- **PDS like/unlike** - syncs like records to user's PDS asynchronously
+- **PDS comment create/update/delete** - syncs comment records to user's PDS asynchronously
 
 ## architecture
 


### PR DESCRIPTION
## Summary

Fills in the gap in STATUS.md for Dec 10-12 work that wasn't documented, and updates background-tasks.md to reflect new task types.

### STATUS.md additions

Added section for **Dec 10-12** covering:

**background task expansion** (PRs #558, #561):
- moved like/unlike and comment PDS writes to docket background tasks
- API responses now immediate; PDS sync happens asynchronously
- added targeted album list sync background task

**performance caching** (PR #566):
- Redis cache for copyright label lookups (5-minute TTL)
- fixed 2-3s latency spikes on `/tracks/` endpoint

**mobile UX improvements** (PRs #569, #572):
- mobile action menus now open from top
- UI polish for album and artist pages

**misc** (PRs #559, #562, #563, #570):
- reduced docket Redis polling interval
- atprotofans support link mode
- alpha badge
- web manifest ID fix

### background-tasks.md

Added three new task types to the overview:
- album list sync
- PDS like/unlike
- PDS comment create/update/delete

## Test plan

- [x] Documentation only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)