### PR TITLE
fix: remove 3D wheel effect that broke button interactions

### DIFF
--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { browser } from '$app/environment';
 	import ShareButton from './ShareButton.svelte';
 	import AddToMenu from './AddToMenu.svelte';
 	import TrackActionsMenu from './TrackActionsMenu.svelte';
@@ -116,54 +114,12 @@
 		// also update the track object itself
 		track.like_count = likeCount;
 	}
-
-	// wheel effect: tracks rotate based on distance from viewport center
-	let containerEl: HTMLDivElement;
-	let rotateX = $state(0);
-	let translateZ = $state(0);
-
-	onMount(() => {
-		if (!browser) return;
-
-		const MAX_ROTATION = 2; // max degrees of rotation (very subtle)
-
-		function updateWheelPosition() {
-			if (!containerEl) return;
-
-			const rect = containerEl.getBoundingClientRect();
-			const viewportCenter = window.innerHeight / 2;
-			const itemCenter = rect.top + rect.height / 2;
-
-			// distance from viewport center, normalized (-1 to 1)
-			const distanceFromCenter = (itemCenter - viewportCenter) / viewportCenter;
-
-			// convex wheel: items above tilt toward viewer (positive), below tilt away (negative)
-			rotateX = -distanceFromCenter * MAX_ROTATION;
-
-			// z-translate: items at center are closest, edges recede slightly
-			translateZ = (1 - Math.abs(distanceFromCenter)) * 3 - 1.5;
-		}
-
-		// use passive scroll listener for performance
-		window.addEventListener('scroll', updateWheelPosition, { passive: true });
-		// also update on resize
-		window.addEventListener('resize', updateWheelPosition, { passive: true });
-		// initial position
-		updateWheelPosition();
-
-		return () => {
-			window.removeEventListener('scroll', updateWheelPosition);
-			window.removeEventListener('resize', updateWheelPosition);
-		};
-	});
 </script>
 
 <div
 	class="track-container"
 	class:playing={isPlaying}
 	class:likers-tooltip-open={showLikersTooltip}
-	bind:this={containerEl}
-	style="transform: perspective(1000px) rotateX({rotateX}deg) translateZ({translateZ}px);"
 >
 	{#if showIndex}
 		<span class="track-index">{index + 1}</span>
@@ -381,11 +337,8 @@
 		border-radius: 8px;
 		padding: 1rem;
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-		transform-origin: center center;
-		transform-style: preserve-3d;
-		will-change: transform;
 		transition:
-			box-shadow 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+			box-shadow 0.2s ease-out,
 			background 0.15s ease-out,
 			border-color 0.15s ease-out;
 	}


### PR DESCRIPTION
## Summary

The 3D wheel effect (`translateZ` transform) was causing tracks to overlap each other in 3D space, which blocked click events on the like and share buttons for all tracks below the first one.

The queue button worked because it was the rightmost element and less affected by the z-overlap from tracks above.

## Root cause

- `transform-style: preserve-3d` + `translateZ` created a stacking context where tracks with higher translateZ values (those nearer the viewport center) overlapped tracks below them
- This blocked pointer events on the overlapped areas

## Fix

Removed the wheel effect entirely. The visual effect wasn't worth the broken interactivity.

## Test plan
- [x] Verify like button works on all track items (not just the first)
- [x] Verify share button works on all track items
- [x] Verify queue button still works on all track items

🤖 Generated with [Claude Code](https://claude.com/claude-code)