### PR TITLE
fix: improve background settings UX and fix pointer events

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -536,6 +536,7 @@
 		filter: blur(var(--bg-blur, 0px));
 		transform: scale(1.1); /* prevent blur edge artifacts */
 		z-index: -1;
+		pointer-events: none;
 	}
 
 	.app-layout {

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -177,7 +177,7 @@
 
 	async function saveUsePlayingArtwork(enabled: boolean) {
 		await preferences.updateUiSettings({ use_playing_artwork_as_background: enabled });
-		toast.success(enabled ? 'using playing artwork as background' : 'using custom background');
+		toast.success(enabled ? 'playing artwork background enabled' : 'playing artwork background disabled');
 	}
 
 	function selectTheme(theme: Theme) {
@@ -457,7 +457,7 @@
 				<div class="setting-row">
 					<div class="setting-info">
 						<h3>background image</h3>
-						<p>set a custom background image (URL)</p>
+						<p>set a custom background image (URL){#if usePlayingArtwork} — used as fallback when nothing is playing{/if}</p>
 					</div>
 					<div class="background-controls">
 						<input
@@ -467,9 +467,8 @@
 							bind:value={backgroundInput}
 							onblur={saveBackgroundImage}
 							onkeydown={(e) => e.key === 'Enter' && saveBackgroundImage()}
-							disabled={usePlayingArtwork}
 						/>
-						{#if backgroundImageUrl && !usePlayingArtwork}
+						{#if backgroundImageUrl}
 							<label class="tile-toggle">
 								<input
 									type="checkbox"
@@ -485,7 +484,7 @@
 				<div class="setting-row">
 					<div class="setting-info">
 						<h3>playing artwork as background</h3>
-						<p>use the currently playing track's artwork as background (overrides custom image)</p>
+						<p>use currently playing track's artwork as background (falls back to custom image when nothing is playing)</p>
 					</div>
 					<label class="toggle-switch">
 						<input


### PR DESCRIPTION
## Summary

- add `pointer-events: none` to `body::before` background overlay (fixes input blocking when blur is active)
- remove disabled state from background URL input - users can set a fallback image while using playing artwork
- fix toast message: "playing artwork background disabled" instead of misleading "using custom background"
- update descriptions to clarify the fallback behavior
- always show tile checkbox when background URL is set (not hidden when playing artwork is on)

## Test plan
- [x] svelte check passes
- [x] eslint passes
- [ ] verify background URL input is editable with playing artwork toggle on
- [ ] verify toast messages are accurate
- [ ] verify custom background works as fallback when nothing is playing

🤖 Generated with [Claude Code](https://claude.com/claude-code)