### PR TITLE
feat: add upload button to desktop header nav

### DIFF
--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -132,6 +132,16 @@
 							<span>library</span>
 						</a>
 					{/if}
+					{#if $page.url.pathname !== '/upload'}
+						<a href="/upload" class="nav-link upload-link" title="upload a track">
+							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+								<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+								<polyline points="17 8 12 3 7 8"></polyline>
+								<line x1="12" y1="3" x2="12" y2="15"></line>
+							</svg>
+							<span>upload</span>
+						</a>
+					{/if}
 					{#if $page.url.pathname !== '/portal'}
 						<a href="/portal" class="user-handle" title="go to portal">@{user?.handle}</a>
 					{/if}
@@ -358,6 +368,16 @@
 		color: var(--accent);
 		background: var(--bg-tertiary);
 		border-color: var(--border-default);
+	}
+
+	.nav-link.upload-link {
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+
+	.nav-link.upload-link:hover {
+		background: var(--accent);
+		color: var(--bg-primary);
 	}
 
 	.nav-link svg {


### PR DESCRIPTION
## Summary
- adds upload link between library and @handle in desktop nav
- styled with accent border/color as primary CTA (stands out from other nav links)
- hover fills with accent background
- hidden when already on /upload page (consistent with other nav links)

mirrors the mobile upload shortcut that exists in the three-dot menu.

## Test plan
- [ ] verify upload button appears on desktop when logged in
- [ ] verify accent styling makes it visually distinct
- [ ] verify hover state fills with accent color
- [ ] verify button hidden when on /upload page
- [ ] verify mobile layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)