### PR TITLE
feat: derive AudD costs from track duration for accurate billing

### DIFF
--- a/.github/workflows/export-costs.yml
+++ b/.github/workflows/export-costs.yml
@@ -1,7 +1,10 @@
 # export platform costs to R2 for public dashboard
 #
-# runs daily at 6am UTC to update the costs.json file in R2
+# runs hourly to update the costs.json file in R2
 # the frontend /costs page fetches this static JSON
+#
+# AudD costs are derived from track duration (1 request = 12s of audio)
+# so this gives near real-time cost visibility as uploads happen
 #
 # required secrets:
 #   NEON_DATABASE_URL_PRD - production database URL
@@ -15,7 +18,7 @@ name: export costs
 
 on:
   schedule:
-    - cron: "0 6 * * *" # daily at 6am UTC
+    - cron: "0 * * * *" # hourly
   workflow_dispatch:
     inputs:
       dry_run:

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -132,6 +132,16 @@
 							<span>library</span>
 						</a>
 					{/if}
+					{#if $page.url.pathname !== '/upload'}
+						<a href="/upload" class="nav-link upload-link" title="upload a track">
+							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+								<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+								<polyline points="17 8 12 3 7 8"></polyline>
+								<line x1="12" y1="3" x2="12" y2="15"></line>
+							</svg>
+							<span>upload</span>
+						</a>
+					{/if}
 					{#if $page.url.pathname !== '/portal'}
 						<a href="/portal" class="user-handle" title="go to portal">@{user?.handle}</a>
 					{/if}
@@ -358,6 +368,16 @@
 		color: var(--accent);
 		background: var(--bg-tertiary);
 		border-color: var(--border-default);
+	}
+
+	.nav-link.upload-link {
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+
+	.nav-link.upload-link:hover {
+		background: var(--accent);
+		color: var(--bg-primary);
 	}
 
 	.nav-link svg {

--- a/frontend/src/routes/costs/+page.svelte
+++ b/frontend/src/routes/costs/+page.svelte
@@ -14,6 +14,7 @@
 		date: string;
 		scans: number;
 		flagged: number;
+		requests: number;
 	}
 
 	interface CostData {
@@ -36,9 +37,14 @@
 			};
 			audd: {
 				amount: number;
+				base_cost: number;
+				overage_cost: number;
 				scans_this_period: number;
-				included_free: number;
+				requests_this_period: number;
+				audio_seconds: number;
+				free_requests: number;
 				remaining_free: number;
+				billable_requests: number;
 				flag_rate: number;
 				daily: DailyData[];
 				note: string;
@@ -66,9 +72,9 @@
 			: 1
 	);
 
-	let maxScans = $derived(
+	let maxRequests = $derived(
 		data?.costs.audd.daily.length
-			? Math.max(...data.costs.audd.daily.map((d) => d.scans))
+			? Math.max(...data.costs.audd.daily.map((d) => d.requests))
 			: 1
 	);
 
@@ -213,29 +219,37 @@
 			<h2>copyright scanning (audd)</h2>
 			<div class="audd-stats">
 				<div class="stat">
-					<span class="stat-value">{data.costs.audd.scans_this_period.toLocaleString()}</span>
-					<span class="stat-label">scans this period</span>
+					<span class="stat-value">{data.costs.audd.requests_this_period.toLocaleString()}</span>
+					<span class="stat-label">API requests</span>
 				</div>
 				<div class="stat">
 					<span class="stat-value">{data.costs.audd.remaining_free.toLocaleString()}</span>
 					<span class="stat-label">free remaining</span>
 				</div>
 				<div class="stat">
-					<span class="stat-value">{data.costs.audd.flag_rate}%</span>
-					<span class="stat-label">flag rate</span>
+					<span class="stat-value">{data.costs.audd.scans_this_period.toLocaleString()}</span>
+					<span class="stat-label">tracks scanned</span>
 				</div>
 			</div>
 
+			<p class="audd-explainer">
+				1 request = 12s of audio. {data.costs.audd.free_requests.toLocaleString()} free/month,
+				then ${(5).toFixed(2)}/1k requests.
+				{#if data.costs.audd.billable_requests > 0}
+					<strong>{data.costs.audd.billable_requests.toLocaleString()} billable</strong> this period.
+				{/if}
+			</p>
+
 			{#if data.costs.audd.daily.length > 0}
 				<div class="daily-chart">
-					<h3>daily scans</h3>
+					<h3>daily requests</h3>
 					<div class="chart-bars">
 						{#each data.costs.audd.daily as day}
 							<div class="chart-bar-container">
 								<div
 									class="chart-bar"
-									style="height: {Math.max(4, (day.scans / maxScans) * 100)}%"
-									title="{day.date}: {day.scans} scans, {day.flagged} flagged"
+									style="height: {Math.max(4, (day.requests / maxRequests) * 100)}%"
+									title="{day.date}: {day.requests} requests ({day.scans} tracks)"
 								></div>
 								<span class="chart-label">{day.date.slice(5)}</span>
 							</div>
@@ -428,7 +442,18 @@
 		display: grid;
 		grid-template-columns: repeat(3, 1fr);
 		gap: 1rem;
+		margin-bottom: 1rem;
+	}
+
+	.audd-explainer {
+		font-size: 0.8rem;
+		color: var(--text-secondary);
 		margin-bottom: 1.5rem;
+		line-height: 1.5;
+	}
+
+	.audd-explainer strong {
+		color: var(--warning);
 	}
 
 	.stat {


### PR DESCRIPTION
## Summary

- Derive AudD API requests from track duration (`ceil(duration / 12)`) instead of counting scans
- Remove hardcoded Nov 24 billing period fallback - now fully dynamic from DB
- Add new cost fields: `requests_this_period`, `base_cost`, `overage_cost`, `billable_requests`
- Update daily chart to show requests instead of scan count
- Change GHA workflow from daily to hourly for near real-time cost visibility
- Update frontend to display request-based metrics with explainer text

**AudD billing model:** $5/mo base + $5/1k requests over 6,000 free tier

**Current period:** 11,899 requests → $34.50 AudD cost ($5 base + $29.50 overage)

## Test plan

- [x] `uv run scripts/costs/export_costs.py --dry-run` outputs correct JSON
- [x] `just frontend check` passes
- [ ] Manual test /costs page after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)