### PR TITLE
fix: add /tag/ to hasPageMetadata check in layout

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -29,6 +29,7 @@
 		$page.url.pathname === '/' || // homepage
 		$page.url.pathname.startsWith('/track/') || // track detail
 		$page.url.pathname.startsWith('/playlist/') || // playlist detail
+		$page.url.pathname.startsWith('/tag/') || // tag detail
 		$page.url.pathname === '/liked' || // liked tracks
 		$page.url.pathname.match(/^\/u\/[^/]+$/) || // artist detail
 		$page.url.pathname.match(/^\/u\/[^/]+\/album\/[^/]+/) // album detail


### PR DESCRIPTION
## Summary
- Add `/tag/` to the `hasPageMetadata` list in layout
- Fixes OG tags not working for tag pages (layout was rendering defaults first)

## Test plan
- [ ] Visit `/tag/[name]` and check page source for correct OG tags
- [ ] Test link preview in Discord/Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)