### PR TITLE
feat: flexible login input accepting handles, DIDs, URLs

### DIFF
--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -8,11 +8,35 @@
 	let showHandleInfo = $state(false);
 	let showPdsInfo = $state(false);
 
+	/**
+	 * normalize user input to a valid identifier for OAuth
+	 *
+	 * accepts:
+	 * - handles: "user.bsky.social", "@user.bsky.social", "at://user.bsky.social"
+	 * - DIDs: "did:plc:abc123", "at://did:plc:abc123"
+	 */
+	function normalizeInput(input: string): string {
+		let value = input.trim();
+
+		// strip at:// prefix (valid for both handles and DIDs per AT-URI spec)
+		if (value.startsWith('at://')) {
+			value = value.slice(5);
+		}
+
+		// strip @ prefix from handles
+		if (value.startsWith('@')) {
+			value = value.slice(1);
+		}
+
+		return value;
+	}
+
 	function startOAuth(e: SubmitEvent) {
 		e.preventDefault();
 		if (!handle.trim()) return;
 		loading = true;
-		window.location.href = `${API_URL}/auth/start?handle=${encodeURIComponent(handle)}`;
+		const normalized = normalizeInput(handle);
+		window.location.href = `${API_URL}/auth/start?handle=${encodeURIComponent(normalized)}`;
 	}
 
 	function handleSelect(selected: string) {


### PR DESCRIPTION
## Summary
strips common prefixes from user input on the login page:

- `@user.bsky.social` → `user.bsky.social`
- `at://user.bsky.social` → `user.bsky.social`  
- `at://did:plc:abc123` → `did:plc:abc123`

the more complex features from Nick's post (URL handling, .bsky.social auto-append) need backend support and are deferred.

inspired by [Nick Gerakines' post on login UX](https://ngerakines.leaflet.pub/3ma7hed2kdk2x)

## Test plan
- [ ] enter `@username.bsky.social` → should work
- [ ] enter `at://user.bsky.social` → should work
- [ ] enter `at://did:plc:...` → should work
- [ ] enter normal handle → should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)