### PR TITLE
fix: artist page track pagination and mobile album card overflow

### DIFF
--- a/frontend/src/routes/u/[handle]/+page.server.ts
+++ b/frontend/src/routes/u/[handle]/+page.server.ts
@@ -17,10 +17,14 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 		// fetch artist's tracks server-side (no cookie available on frontend host)
 		const tracksResponse = await fetch(`${API_URL}/tracks/?artist_did=${artist.did}`);
 		let tracks: Track[] = [];
+		let hasMoreTracks = false;
+		let nextCursor: string | null = null;
 
 		if (tracksResponse.ok) {
 			const data = await tracksResponse.json();
 			tracks = data.tracks || [];
+			hasMoreTracks = data.has_more || false;
+			nextCursor = data.next_cursor || null;
 		}
 
 		const albumsResponse = await fetch(`${API_URL}/albums/${params.handle}`);
@@ -34,7 +38,9 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 		return {
 			artist,
 			tracks,
-			albums
+			albums,
+			hasMoreTracks,
+			nextCursor
 		};
 	} catch (e) {
 		console.error('failed to load artist:', e);


### PR DESCRIPTION
## Summary

- Artist pages with many tracks (e.g. pyxorium.com with 252 tracks) now show all tracks via pagination
- Mobile album cards no longer overflow the viewport

## Changes

**Track pagination:**
- Pass `hasMoreTracks` and `nextCursor` from API response to frontend
- Add "load more tracks" button when there are more tracks available
- Display total track count in section header (from analytics endpoint)

**Mobile album cards:**
- Smaller cover images (56px vs 72px)
- Tighter padding and gaps
- Smaller text sizes for title and metadata
- Explicit `overflow: hidden` and `max-width: 100%` on card container

## Test plan

- [ ] Visit https://plyr.fm/u/pyxorium.com and verify "load more tracks" button appears
- [ ] Click button to load additional tracks
- [ ] Verify track count shows "252 tracks" after analytics loads
- [ ] On mobile, verify album cards fit within viewport (no horizontal scroll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)