### PR TITLE
fix: adopt Svelte 5.25+ patterns and improve accessibility

### DIFF
--- a/docs/frontend/state-management.md
+++ b/docs/frontend/state-management.md
@@ -38,6 +38,40 @@ use `$state()` for any variable that:
 - is bound to form inputs (`bind:value={title}`)
 - is checked in reactive blocks (`$effect(() => { ... })`)
 
+### overridable `$derived` for optimistic UI (Svelte 5.25+)
+
+as of Svelte 5.25, `$derived` values can be temporarily overridden by reassignment. this is the recommended pattern for optimistic UI where you want to:
+1. sync with a prop value (derived behavior)
+2. temporarily override for immediate feedback (state behavior)
+3. auto-reset when the prop updates
+
+```typescript
+// ✅ RECOMMENDED for optimistic UI (Svelte 5.25+)
+let liked = $derived(initialLiked);
+
+async function toggleLike() {
+    const previous = liked;
+    liked = !liked;  // optimistic update - works in 5.25+!
+
+    try {
+        await saveLike(liked);
+    } catch {
+        liked = previous;  // revert on failure
+    }
+}
+```
+
+this replaces the older pattern of `$state` + `$effect` to sync with props:
+
+```typescript
+// ❌ OLD pattern - still works but more verbose
+let liked = $state(initialLiked);
+
+$effect(() => {
+    liked = initialLiked;  // sync with prop
+});
+```
+
 use plain `let` for:
 - constants that never change
 - variables only used in functions/callbacks (not template)

--- a/frontend/src/lib/components/LikeButton.svelte
+++ b/frontend/src/lib/components/LikeButton.svelte
@@ -14,13 +14,9 @@
 
 	let { trackId, trackTitle, fileId, initialLiked = false, disabled = false, disabledReason, onLikeChange }: Props = $props();
 
-	let liked = $state(initialLiked);
+	// use overridable $derived (Svelte 5.25+) - syncs with prop but can be overridden for optimistic UI
+	let liked = $derived(initialLiked);
 	let loading = $state(false);
-
-	// update liked state when initialLiked changes
-	$effect(() => {
-		liked = initialLiked;
-	});
 
 	async function toggleLike(e: Event) {
 		e.stopPropagation();
@@ -70,6 +66,7 @@
 	class:disabled-state={disabled}
 	onclick={toggleLike}
 	title={disabled && disabledReason ? disabledReason : (liked ? 'unlike' : 'like')}
+	aria-label={disabled && disabledReason ? disabledReason : (liked ? 'unlike' : 'like')}
 	disabled={loading || disabled}
 >
 	<svg width="16" height="16" viewBox="0 0 24 24" fill={liked ? 'currentColor' : 'none'} stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
## Summary

- **LikeButton.svelte**: use overridable `$derived` instead of `$state` + `$effect` for optimistic UI, add `aria-label` for icon-only button accessibility
- **TrackItem.svelte**: use `$derived` for `likeCount`/`commentCount` that sync with props, use `$effect.pre` for resetting local UI state on track change
- **docs/frontend/state-management.md**: document the overridable `$derived` pattern introduced in Svelte 5.25

## Context

Reviewed the frontend codebase against the new Svelte MCP autofixer. The autofixer flagged:
1. Missing `aria-label` on icon-only buttons
2. Using `$state` + `$effect` to sync with props when overridable `$derived` is now available (Svelte 5.25+)

Since we're on Svelte 5.39.5, we can use the newer pattern.

## Test plan

- [ ] Verify like button still works with optimistic updates
- [ ] Verify like button resyncs when `initialLiked` prop changes
- [ ] Verify TrackItem resets error/expanded states when track changes (component recycling)
- [ ] Run `just frontend check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)