### PR TITLE
fix: add rate limit to /moderation/sensitive-images endpoint

### DIFF
--- a/backend/src/backend/api/moderation.py
+++ b/backend/src/backend/api/moderation.py
@@ -2,12 +2,13 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.models import SensitiveImage, get_db
+from backend.utilities.rate_limit import limiter
 
 router = APIRouter(prefix="/moderation", tags=["moderation"])
 
@@ -22,7 +23,9 @@ class SensitiveImagesResponse(BaseModel):
 
 
 @router.get("/sensitive-images")
+@limiter.limit("10/minute")
 async def get_sensitive_images(
+    request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> SensitiveImagesResponse:
     """get all flagged sensitive images.


### PR DESCRIPTION
## Summary
- Added 10/minute rate limit to `/moderation/sensitive-images` endpoint to prevent abuse

## Context
Investigation revealed suspicious activity targeting this specific endpoint:
- 72 requests in 17 seconds from a single IP
- Requests spaced ~230ms apart (too consistent for human browsing)
- No corresponding user activity (no page loads, audio streams, etc.)
- All requests had no User-Agent header
- Only 1 unique IP generating all traffic during the spike

## Test plan
- [ ] Verify endpoint still works normally for legitimate requests
- [ ] Confirm rate limit returns 429 after 10 requests/minute from same IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)