### PR TITLE
fix: redirect to /library after login instead of /portal

### DIFF
--- a/backend/src/backend/api/auth.py
+++ b/backend/src/backend/api/auth.py
@@ -166,8 +166,8 @@ async def oauth_callback(
     # schedule ATProto sync (via docket if enabled, else asyncio)
     await schedule_atproto_sync(session_id, did)
 
-    # redirect to profile setup if needed, otherwise to portal
-    redirect_path = "/portal" if has_profile else "/profile/setup"
+    # redirect to profile setup if needed, otherwise to library
+    redirect_path = "/library" if has_profile else "/profile/setup"
 
     return RedirectResponse(
         url=f"{settings.frontend.url}{redirect_path}?exchange_token={exchange_token}",


### PR DESCRIPTION
## Summary

- Change the post-login redirect destination from `/portal` to `/library`
- Add exchange token handling to the library page

## Rationale

Most users are listeners first, uploaders second. Landing on the library (liked tracks, playlists, queue) is a better default experience than the portal (artist management, track uploads).

## Test plan

- [ ] Log in with a new session
- [ ] Verify you land on `/library` instead of `/portal`
- [ ] Verify auth state is correctly initialized (user menu shows your handle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)