### PR TITLE
fix: use float literals for progress_pct to satisfy beartype

### DIFF
--- a/backend/src/backend/_internal/background_tasks.py
+++ b/backend/src/backend/_internal/background_tasks.py
@@ -281,7 +281,7 @@ async def process_export(export_id: str, artist_did: str) -> None:
                 export_id,
                 JobStatus.PROCESSING,
                 f"downloading {total} tracks...",
-                progress_pct=0,
+                progress_pct=0.0,
                 result={"processed_count": 0, "total_count": total},
             )
 
@@ -304,7 +304,7 @@ async def process_export(export_id: str, artist_did: str) -> None:
                 export_id,
                 JobStatus.PROCESSING,
                 "creating zip archive...",
-                progress_pct=100,
+                progress_pct=100.0,
                 result={
                     "processed_count": len(successful_downloads),
                     "total_count": total,

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -126,7 +126,7 @@ async def _save_audio_to_storage(
         JobStatus.PROCESSING,
         "uploading to storage...",
         phase="upload",
-        progress_pct=0,
+        progress_pct=0.0,
     )
     try:
         async with R2ProgressTracker(


### PR DESCRIPTION
## Summary
- Changed `progress_pct=0` to `progress_pct=0.0` in upload and export code
- Changed `progress_pct=100` to `progress_pct=100.0` in export code

beartype runtime type checking requires exact type matches. Passing `0` (int) fails validation against `float | None` type hint.

**Error:** `BeartypeCallHintParamViolation: parameter progress_pct=0 violates type hint float | None`

## Test plan
- [x] Backend tests pass (342 passed)
- [ ] Upload a track and verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)