### PR TITLE
fix: use artist DID as signer for atprotofans validation

### DIFF
--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -17,8 +17,6 @@
 	import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
 	import type { PageData } from './$types';
 
-	// atprotofans broker DID for validateSupporter calls
-	const ATPROTOFANS_BROKER_DID = 'did:plc:7ewx3bksukdk6a4vycoykhhw';
 
 	// receive server-loaded data
 	let { data }: { data: PageData } = $props();
@@ -161,7 +159,7 @@ $effect(() => {
 			const url = new URL('https://atprotofans.com/xrpc/com.atprotofans.validateSupporter');
 			url.searchParams.set('supporter', auth.user.did);
 			url.searchParams.set('subject', artist.did);
-			url.searchParams.set('signer', ATPROTOFANS_BROKER_DID);
+			url.searchParams.set('signer', artist.did);
 
 			const response = await fetch(url.toString());
 			if (response.ok) {


### PR DESCRIPTION
## Summary

- fix supporter badge not showing for direct atprotofans contributions
- use artist's DID as signer instead of broker DID
- broker DID only applies when plyr.fm is a registered platform

## Root cause

direct atprotofans contributions (not via platform registration) use the artist's own DID as the signer for the support template. the code was using the atprotofans broker DID, which only works for platform-mediated contributions.

## Test plan

- [ ] log in as plyr.fm account
- [ ] visit zzstoatzz.io artist page
- [ ] verify supporter badge appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)