### PR TITLE
fix: track detail page liked state race condition

### DIFF
--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -305,6 +305,8 @@
 
 // track which track we've loaded data for to detect navigation
 let loadedForTrackId = $state<number | null>(null);
+// track if we've loaded liked state for this track (separate from general load)
+let likedStateLoadedForTrackId = $state<number | null>(null);
 
 // reload data when navigating between track pages
 // watch data.track.id (from server) not track.id (local state)
@@ -321,6 +323,7 @@ $effect(() => {
 		newCommentText = '';
 		editingCommentId = null;
 		editingCommentText = '';
+		likedStateLoadedForTrackId = null; // reset liked state tracking
 
 		// sync track from server data
 		track = data.track;
@@ -328,11 +331,20 @@ $effect(() => {
 		// mark as loaded for this track
 		loadedForTrackId = currentId;
 
-		// load fresh data
-		if (auth.isAuthenticated) {
-			void loadLikedState();
-		}
+		// load comments (doesn't require auth)
 		void loadComments();
+	}
+});
+
+// separate effect to load liked state when auth becomes available
+$effect(() => {
+	const currentId = data.track?.id;
+	if (!currentId || !browser) return;
+
+	// load liked state when authenticated and haven't loaded for this track yet
+	if (auth.isAuthenticated && likedStateLoadedForTrackId !== currentId) {
+		likedStateLoadedForTrackId = currentId;
+		void loadLikedState();
 	}
 });
 


### PR DESCRIPTION
## Summary

- Fixed race condition where liked state wasn't loading on track detail pages
- Root cause: auth loads asynchronously, but the effect that loads liked state only ran once on initial render (when auth wasn't ready yet)
- Split into two separate effects: one for general data, one specifically for liked state that waits for auth

## The Bug

1. Page loads, navigation effect runs immediately  
2. Effect sets `loadedForTrackId = currentId`
3. BUT `auth.isAuthenticated` is still `false` (async auth not resolved)
4. `loadLikedState()` is skipped
5. Auth resolves, `isAuthenticated` becomes `true`
6. Effect runs again, but `loadedForTrackId === currentId`, so nothing happens
7. **Liked state is never fetched** - heart always shows empty

## Test plan

- [ ] Navigate to a track you've liked while logged in
- [ ] Verify the heart icon shows as filled (liked state loaded correctly)
- [ ] Navigate between tracks, verify liked state updates correctly
- [ ] Refresh the page, verify liked state loads after auth resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)