### PR TITLE
fix: center artist handle on mobile

### DIFF
--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -1058,6 +1058,10 @@ $effect(() => {
 			text-align: center;
 		}
 
+		.handle-row {
+			justify-content: center;
+		}
+
 		.artist-actions-desktop {
 			display: none;
 		}


### PR DESCRIPTION
## Summary
- fixes handle alignment on artist detail page for mobile viewports
- `.handle-row` uses flexbox which ignores `text-align: center` from parent
- added `justify-content: center` in the mobile media query

## Test plan
- [ ] view any artist page on mobile (or narrow viewport)
- [ ] verify handle appears centered below display name

🤖 Generated with [Claude Code](https://claude.com/claude-code)