### PR TITLE
refactor(css): consolidate form styles and document design tokens

### DIFF
--- a/docs/frontend/design-tokens.md
+++ b/docs/frontend/design-tokens.md
@@ -1,0 +1,117 @@
+# design tokens
+
+CSS custom properties defined in `frontend/src/routes/+layout.svelte`. Use these instead of hardcoding values.
+
+## border radius
+
+```css
+--radius-sm: 4px;    /* tight corners (inputs, small elements) */
+--radius-base: 6px;  /* default for most elements */
+--radius-md: 8px;    /* cards, modals */
+--radius-lg: 12px;   /* larger containers */
+--radius-xl: 16px;   /* prominent elements */
+--radius-2xl: 24px;  /* hero elements */
+--radius-full: 9999px; /* pills, circles */
+```
+
+## typography
+
+```css
+/* scale */
+--text-xs: 0.75rem;   /* 12px - hints, captions */
+--text-sm: 0.85rem;   /* 13.6px - labels, secondary */
+--text-base: 0.9rem;  /* 14.4px - body default */
+--text-lg: 1rem;      /* 16px - body emphasized */
+--text-xl: 1.1rem;    /* 17.6px - subheadings */
+--text-2xl: 1.25rem;  /* 20px - section headings */
+--text-3xl: 1.5rem;   /* 24px - page headings */
+
+/* semantic aliases */
+--text-page-heading: var(--text-3xl);
+--text-section-heading: 1.2rem;
+--text-body: var(--text-lg);
+--text-small: var(--text-base);
+```
+
+## colors
+
+### accent
+
+```css
+--accent: #6a9fff;       /* primary brand color (user-customizable) */
+--accent-hover: #8ab3ff; /* hover state */
+--accent-muted: #4a7ddd; /* subdued variant */
+--accent-rgb: 106, 159, 255; /* for rgba() usage */
+```
+
+### backgrounds
+
+```css
+/* dark theme */
+--bg-primary: #0a0a0a;   /* main background */
+--bg-secondary: #141414; /* elevated surfaces */
+--bg-tertiary: #1a1a1a;  /* cards, modals */
+--bg-hover: #1f1f1f;     /* hover states */
+
+/* light theme overrides these automatically */
+```
+
+### borders
+
+```css
+--border-subtle: #282828;   /* barely visible */
+--border-default: #333333;  /* standard borders */
+--border-emphasis: #444444; /* highlighted borders */
+```
+
+### text
+
+```css
+--text-primary;   /* high contrast */
+--text-secondary; /* medium contrast */
+--text-tertiary;  /* low contrast */
+--text-muted;     /* very low contrast */
+```
+
+### semantic
+
+```css
+--success: #22c55e;
+--warning: #f59e0b;
+--error: #ef4444;
+```
+
+## usage
+
+```svelte
+<style>
+  .card {
+    border-radius: var(--radius-md);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-default);
+  }
+
+  .label {
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+  }
+
+  input:focus {
+    border-color: var(--accent);
+  }
+</style>
+```
+
+## anti-patterns
+
+```css
+/* bad - hardcoded values */
+border-radius: 8px;
+font-size: 14px;
+background: #1a1a1a;
+
+/* good - use tokens */
+border-radius: var(--radius-md);
+font-size: var(--text-base);
+background: var(--bg-tertiary);
+```

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -6,6 +6,7 @@ key patterns:
 - **state**: global managers in `lib/*.svelte.ts` using `$state` runes (player, queue, uploader, tracks cache)
 - **components**: reusable ui in `lib/components/` (LikeButton, Toast, Player, etc)
 - **routes**: pages in `routes/` with `+page.svelte` and `+page.ts` for data loading
+- **design tokens**: use CSS variables from `+layout.svelte` - never hardcode colors, radii, or font sizes (see `docs/frontend/design-tokens.md`)
 
 gotchas:
 - **svelte 5 runes mode**: component-local state MUST use `$state()` - plain `let` has no reactivity (see `docs/frontend/state-management.md`)

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -1262,28 +1262,8 @@
 		font-size: var(--text-sm);
 	}
 
-	input[type='text'] {
-		width: 100%;
-		padding: 0.6rem 0.75rem;
-		background: var(--bg-primary);
-		border: 1px solid var(--border-default);
-		border-radius: var(--radius-sm);
-		color: var(--text-primary);
-		font-size: var(--text-base);
-		font-family: inherit;
-		transition: all 0.15s;
-	}
-
-	input[type='text']:focus {
-		outline: none;
-		border-color: var(--accent);
-	}
-
-	input[type='text']:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-
+	input[type='text'],
+	input[type='url'],
 	textarea {
 		width: 100%;
 		padding: 0.6rem 0.75rem;
@@ -1294,18 +1274,25 @@
 		font-size: var(--text-base);
 		font-family: inherit;
 		transition: all 0.15s;
-		resize: vertical;
-		min-height: 80px;
 	}
 
+	input[type='text']:focus,
+	input[type='url']:focus,
 	textarea:focus {
 		outline: none;
 		border-color: var(--accent);
 	}
 
+	input[type='text']:disabled,
+	input[type='url']:disabled,
 	textarea:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
+	}
+
+	textarea {
+		resize: vertical;
+		min-height: 80px;
 	}
 
 	.hint {


### PR DESCRIPTION
## summary

- consolidate duplicate input/textarea styles in portal page (-12 lines)
- create `docs/frontend/design-tokens.md` documenting all CSS variables
- add design tokens guidance to `frontend/CLAUDE.md`

## changes

**portal/+page.svelte**: merged `input[type='text']`, `input[type='url']`, and `textarea` into combined selectors since they shared 8 identical properties.

**docs/frontend/design-tokens.md**: new documentation covering:
- border radius scale (--radius-sm through --radius-full)
- typography scale (--text-xs through --text-3xl)
- color tokens (accent, backgrounds, borders, text)
- usage examples and anti-patterns

**frontend/CLAUDE.md**: added design tokens to key patterns section.

## test plan

1. run `bun run dev` in frontend/
2. test forms in portal (track edit, profile edit)
3. verify no visual regressions

closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)