### PR TITLE
feat(ui): add active state to play button on playlist/album pages

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -534,6 +534,16 @@
 		color: var(--accent-muted);
 	}
 
+	/* shared animation for active play buttons */
+	@keyframes -global-ethereal-glow {
+		0%, 100% {
+			box-shadow: 0 0 8px 1px color-mix(in srgb, var(--accent) 25%, transparent);
+		}
+		50% {
+			box-shadow: 0 0 14px 3px color-mix(in srgb, var(--accent) 45%, transparent);
+		}
+	}
+
 	:global(body) {
 		margin: 0;
 		padding: 0;

--- a/frontend/src/routes/playlist/[id]/+page.svelte
+++ b/frontend/src/routes/playlist/[id]/+page.svelte
@@ -607,6 +607,13 @@
 
 	// check if user owns this playlist
 	const isOwner = $derived(auth.user?.did === playlist.owner_did);
+
+	// check if this playlist is currently playing
+	const isPlaylistPlaying = $derived(
+		player.currentTrack !== null &&
+		!player.paused &&
+		tracks.some(t => t.id === player.currentTrack?.id)
+	);
 </script>
 
 <svelte:window on:keydown={handleKeydown} />
@@ -865,16 +872,22 @@
 		</div>
 
 		<div class="playlist-actions">
-			<button class="play-button" onclick={playNow}>
-				<svg
-					width="20"
-					height="20"
-					viewBox="0 0 24 24"
-					fill="currentColor"
-				>
-					<path d="M8 5v14l11-7z" />
-				</svg>
-				play now
+			<button
+				class="play-button"
+				class:is-playing={isPlaylistPlaying}
+				onclick={() => isPlaylistPlaying ? player.togglePlayPause() : playNow()}
+			>
+				{#if isPlaylistPlaying}
+					<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+						<rect x="6" y="4" width="4" height="16" />
+						<rect x="14" y="4" width="4" height="16" />
+					</svg>
+				{:else}
+					<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+						<path d="M8 5v14l11-7z" />
+					</svg>
+					play now
+				{/if}
 			</button>
 			<button class="queue-button" onclick={addToQueue}>
 				<svg
@@ -1579,6 +1592,10 @@
 
 	.play-button:hover {
 		transform: scale(1.05);
+	}
+
+	.play-button.is-playing {
+		animation: ethereal-glow 3s ease-in-out infinite;
 	}
 
 	.queue-button {


### PR DESCRIPTION
## Summary
- Play button on playlist and album detail pages now toggles between play/pause when the collection is actively playing
- Shows just a pause icon (no text) when playing, with a subtle breathing glow animation
- Clicking the button while playing pauses playback (same as spacebar)
- Shared animation keyframes in layout ensure consistent behavior

## Test plan
- [ ] Navigate to a playlist, click "play now" - button should change to pause icon with soft glow
- [ ] Click the pause icon - playback should pause
- [ ] Navigate to an album, verify same behavior
- [ ] Verify glow animation is subtle but visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)