### PR TITLE
fix: play button toggle works after pause on playlist/album pages

### DIFF
--- a/frontend/src/routes/playlist/[id]/+page.svelte
+++ b/frontend/src/routes/playlist/[id]/+page.svelte
@@ -608,12 +608,14 @@
 	// check if user owns this playlist
 	const isOwner = $derived(auth.user?.did === playlist.owner_did);
 
-	// check if this playlist is currently playing
-	const isPlaylistPlaying = $derived(
+	// check if current track is from this playlist (active, regardless of paused state)
+	const isPlaylistActive = $derived(
 		player.currentTrack !== null &&
-		!player.paused &&
 		tracks.some(t => t.id === player.currentTrack?.id)
 	);
+
+	// check if actively playing (not paused)
+	const isPlaylistPlaying = $derived(isPlaylistActive && !player.paused);
 </script>
 
 <svelte:window on:keydown={handleKeydown} />
@@ -875,7 +877,7 @@
 			<button
 				class="play-button"
 				class:is-playing={isPlaylistPlaying}
-				onclick={() => isPlaylistPlaying ? player.togglePlayPause() : playNow()}
+				onclick={() => isPlaylistActive ? player.togglePlayPause() : playNow()}
 			>
 				{#if isPlaylistPlaying}
 					<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">

--- a/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
@@ -35,12 +35,14 @@
 	// can only reorder if owner and album has an ATProto list
 	const canReorder = $derived(isOwner && !!albumMetadata.list_uri);
 
-	// check if this album is currently playing
-	const isAlbumPlaying = $derived(
+	// check if current track is from this album (active, regardless of paused state)
+	const isAlbumActive = $derived(
 		player.currentTrack !== null &&
-		!player.paused &&
 		tracks.some(t => t.id === player.currentTrack?.id)
 	);
+
+	// check if actively playing (not paused)
+	const isAlbumPlaying = $derived(isAlbumActive && !player.paused);
 
 	// edit mode state
 	let isEditMode = $state(false);
@@ -555,7 +557,7 @@
 			<button
 				class="play-button"
 				class:is-playing={isAlbumPlaying}
-				onclick={() => isAlbumPlaying ? player.togglePlayPause() : playNow()}
+				onclick={() => isAlbumActive ? player.togglePlayPause() : playNow()}
 			>
 				{#if isAlbumPlaying}
 					<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">


### PR DESCRIPTION
## Summary
- fixes regression from #667 where play button on playlist/album pages didn't resume after pausing
- issue: `isPlaylistPlaying` included `!player.paused`, so when paused it called `playNow()` instead of `togglePlayPause()`
- since queue already had the track, `setQueue` did nothing and playback didn't resume

## Changes
- separate `isPlaylistActive` (current track is from this playlist) from `isPlaylistPlaying` (active AND not paused)
- button uses `isActive` to decide toggle vs start fresh
- `isPlaying` still controls the glow animation visual state

## Test plan
- [ ] go to playlist page, click "play now" → plays
- [ ] click button again → pauses (shows play icon)
- [ ] click button again → resumes (shows pause icon)
- [ ] same for album page

🤖 Generated with [Claude Code](https://claude.com/claude-code)