### PR TITLE
fix: revert heartbeat_interval change breaking docket worker

### DIFF
--- a/backend/src/backend/_internal/background.py
+++ b/backend/src/backend/_internal/background.py
@@ -58,9 +58,6 @@ async def background_worker_lifespan() -> AsyncGenerator[Docket, None]:
     async with Docket(
         name=settings.docket.name,
         url=settings.docket.url,
-        # default 2s is for systems needing fast worker failure detection
-        # with our 5-minute perpetual task, 30s is plenty responsive
-        heartbeat_interval=timedelta(seconds=30),
     ) as docket:
         _docket = docket
 


### PR DESCRIPTION
## Summary
- Reverts the `heartbeat_interval=timedelta(seconds=30)` change from #653
- This change broke background task execution - likes since Dec 29 have null `atproto_like_uri`

## Evidence
- Like #180 (Dec 30): `atproto_like_uri = null` 
- Like #179 (Dec 27, before deploy): has URI ✓
- Logs show "scheduled pds like creation" but no execution

## Test plan
- [ ] Merge and deploy
- [ ] Like a track, verify ATProto record is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)