### PR TITLE
docs: document docket worker settings and 2025-12-30 incident

### DIFF
--- a/backend/src/backend/_internal/background.py
+++ b/backend/src/backend/_internal/background.py
@@ -55,6 +55,8 @@ async def background_worker_lifespan() -> AsyncGenerator[Docket, None]:
         extra={"docket_name": settings.docket.name, "url": settings.docket.url},
     )
 
+    # WARNING: do not modify Docket() or Worker() constructor args without
+    # reading docs/backend/background-tasks.md - see 2025-12-30 incident
     async with Docket(
         name=settings.docket.name,
         url=settings.docket.url,

--- a/docs/backend/background-tasks.md
+++ b/docs/backend/background-tasks.md
@@ -39,6 +39,23 @@ DOCKET_NAME=plyr              # queue namespace
 DOCKET_WORKER_CONCURRENCY=10  # concurrent task limit
 ```
 
+### ⚠️ worker settings - do not modify
+
+the worker is initialized in `backend/_internal/background.py` with pydocket's defaults. **do not change these settings without extensive testing:**
+
+| setting | default | why it matters |
+|---------|---------|----------------|
+| `heartbeat_interval` | 2s | changing this broke all task execution (2025-12-30 incident) |
+| `minimum_check_interval` | 1s | affects how quickly tasks are picked up |
+| `scheduling_resolution` | 1s | affects scheduled task precision |
+
+**2025-12-30 incident**: setting `heartbeat_interval=30s` caused all scheduled tasks (likes, comments, exports) to silently fail while perpetual tasks continued running. root cause unclear - correlation was definitive but mechanism wasn't found in pydocket source. reverted in PR #669.
+
+if you need to tune worker settings:
+1. test extensively in staging with real task volume
+2. verify ALL task types execute (not just perpetual tasks)
+3. check logfire for task execution spans
+
 when `DOCKET_URL` is not set, docket is disabled and tasks fall back to `asyncio.create_task()` (fire-and-forget).
 
 ### local development


### PR DESCRIPTION
## Summary
- Documents which docket worker settings should not be modified
- Records the 2025-12-30 incident where `heartbeat_interval=30s` broke task execution
- Adds testing requirements if settings must be changed
- Adds code comment in `background.py` referencing the docs

Also filed upstream: https://github.com/chrisguidry/docket/issues/267

## Test plan
- [x] Documentation renders correctly in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)