### PR TITLE
refactor(ui): unify play button behavior across detail pages

### DIFF
--- a/frontend/src/routes/playlist/[id]/+page.svelte
+++ b/frontend/src/routes/playlist/[id]/+page.svelte
@@ -881,14 +881,14 @@
 			>
 				{#if isPlaylistPlaying}
 					<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-						<rect x="6" y="4" width="4" height="16" />
-						<rect x="14" y="4" width="4" height="16" />
+						<path d="M6 4h4v16H6zM14 4h4v16h-4z"/>
 					</svg>
+					pause
 				{:else}
 					<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
 						<path d="M8 5v14l11-7z" />
 					</svg>
-					play now
+					play
 				{/if}
 			</button>
 			<button class="queue-button" onclick={addToQueue}>

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -928,7 +928,7 @@ $effect(() => {
 	}
 
 	.btn-play.playing {
-		opacity: 0.8;
+		animation: ethereal-glow 3s ease-in-out infinite;
 	}
 
 	.btn-queue {

--- a/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
@@ -561,14 +561,14 @@
 			>
 				{#if isAlbumPlaying}
 					<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-						<rect x="6" y="4" width="4" height="16" />
-						<rect x="14" y="4" width="4" height="16" />
+						<path d="M6 4h4v16H6zM14 4h4v16h-4z"/>
 					</svg>
+					pause
 				{:else}
 					<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
 						<path d="M8 5v14l11-7z"/>
 					</svg>
-					play now
+					play
 				{/if}
 			</button>
 			<button class="queue-button" onclick={addToQueue}>


### PR DESCRIPTION
## Summary
- Adopts the track detail page pattern for playlist and album detail pages
- Show "play" / "pause" text consistently (not "play now" / icon-only)
- Add ethereal-glow animation to track page for visual consistency

## Test plan
- [ ] Visit a track detail page, verify play/pause button toggles with text and glow animation
- [ ] Visit a playlist detail page, verify same behavior
- [ ] Visit an album detail page, verify same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)