### PR TITLE
perf(portal): parallelize API calls on mount

### DIFF
--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -106,10 +106,12 @@
 		}
 
 		try {
-			await loadMyTracks();
-			await loadArtistProfile();
-			await loadMyAlbums();
-			await loadMyPlaylists();
+			await Promise.all([
+				loadMyTracks(),
+				loadArtistProfile(),
+				loadMyAlbums(),
+				loadMyPlaylists()
+			]);
 		} catch (_e) {
 			console.error('error loading portal data:', _e);
 			error = 'failed to load portal data';


### PR DESCRIPTION
## Summary

- Parallelize the 4 independent API calls in portal `onMount` using `Promise.all()`
- Previously these ran sequentially, each waiting for the previous to complete

## Context

Cloudflare Web Analytics showed `/portal` as the worst LCP performer (significant yellow/red vs mostly green for other pages). The sequential API calls were a likely contributor - the page showed a loading spinner until all 4 calls completed one after another.

## Test plan

- [ ] Load `/portal` while authenticated - page should still render correctly
- [ ] Verify tracks, profile, albums, and playlists all load
- [ ] Check browser Network tab - the 4 API calls should now fire simultaneously

## Expected impact

~300-800ms LCP improvement depending on network latency (sequential → parallel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)