### PR TITLE
docs: update redis references from upstash to self-hosted

### DIFF
--- a/backend/fly.staging.toml
+++ b/backend/fly.staging.toml
@@ -44,4 +44,4 @@ primary_region = 'iad'
 # - AWS_ACCESS_KEY_ID (cloudflare R2)
 # - AWS_SECRET_ACCESS_KEY (cloudflare R2)
 # - OAUTH_ENCRYPTION_KEY (generate: python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')
-# - DOCKET_URL (upstash redis: rediss://default:xxx@xxx.upstash.io:6379)
+# - DOCKET_URL (self-hosted redis: redis://plyr-redis-stg.internal:6379)

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -39,4 +39,4 @@ primary_region = 'iad'
 # - AWS_ACCESS_KEY_ID (cloudflare R2)
 # - AWS_SECRET_ACCESS_KEY (cloudflare R2)
 # - OAUTH_ENCRYPTION_KEY (generate: python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')
-# - DOCKET_URL (upstash redis: rediss://default:xxx@xxx.upstash.io:6379)
+# - DOCKET_URL (self-hosted redis: redis://plyr-redis.internal:6379)

--- a/docs/deployment/environments.md
+++ b/docs/deployment/environments.md
@@ -7,8 +7,8 @@ plyr.fm uses a simple three-tier deployment strategy: development â†’ staging â†
 | environment | trigger | backend URL | database | redis | frontend | storage |
 |-------------|---------|-------------|----------|-------|----------|---------|
 | **development** | local | localhost:8001 | plyr-dev (neon) | localhost:6379 (docker) | localhost:5173 | audio-dev, images-dev (r2) |
-| **staging** | push to main | api-stg.plyr.fm | plyr-stg (neon) | plyr-redis-stg (upstash) | stg.plyr.fm (main branch) | audio-staging, images-staging (r2) |
-| **production** | github release | api.plyr.fm | plyr-prd (neon) | plyr-redis-prd (upstash) | plyr.fm (production-fe branch) | audio-prod, images-prod (r2) |
+| **staging** | push to main | api-stg.plyr.fm | plyr-stg (neon) | plyr-redis-stg (fly.io) | stg.plyr.fm (main branch) | audio-staging, images-staging (r2) |
+| **production** | github release | api.plyr.fm | plyr-prd (neon) | plyr-redis (fly.io) | plyr.fm (production-fe branch) | audio-prod, images-prod (r2) |
 
 ## workflow
 

--- a/scripts/docket_runs.py
+++ b/scripts/docket_runs.py
@@ -38,17 +38,15 @@ def main():
         url = os.environ.get("DOCKET_URL_STAGING")
         if not url:
             print("error: DOCKET_URL_STAGING not set")
-            print(
-                "hint: export DOCKET_URL_STAGING=rediss://default:xxx@xxx.upstash.io:6379"
-            )
+            print("hint: flyctl proxy 6380:6379 -a plyr-redis-stg")
+            print("      export DOCKET_URL_STAGING=redis://localhost:6380")
             return 1
     elif args.env == "production":
         url = os.environ.get("DOCKET_URL_PRODUCTION")
         if not url:
             print("error: DOCKET_URL_PRODUCTION not set")
-            print(
-                "hint: export DOCKET_URL_PRODUCTION=rediss://default:xxx@xxx.upstash.io:6379"
-            )
+            print("hint: flyctl proxy 6381:6379 -a plyr-redis")
+            print("      export DOCKET_URL_PRODUCTION=redis://localhost:6381")
             return 1
 
     print(f"connecting to {args.env}...")


### PR DESCRIPTION
## Summary
- Updates stale Upstash references in docs after the self-hosted Redis migration (PR #674-675)

## Changes
- **environments.md**: update redis column to show fly.io apps instead of upstash
- **background-tasks.md**: update production/staging section with internal fly URLs and new pricing
- **docket_runs.py**: update hints to show `flyctl proxy` commands for remote access
- **fly.toml/fly.staging.toml**: update DOCKET_URL comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)