### PR TITLE
fix: use full URL in moderation DM notifications

### DIFF
--- a/scripts/moderation_loop.py
+++ b/scripts/moderation_loop.py
@@ -253,7 +253,10 @@ async def run_loop(
 
             if not dry_run:
                 batch = await mod.create_batch(human_uris, created_by="moderation_loop")
-                msg = f"{get_header(env)} {batch['flag_count']} need review:\n{batch['url']}"
+                full_url = f"{mod.base_url.rstrip('/')}{batch['url']}"
+                msg = (
+                    f"{get_header(env)} {batch['flag_count']} need review:\n{full_url}"
+                )
                 await dm.send(msg)
                 console.print(f"[green]sent batch {batch['id']}[/green]")
             else:


### PR DESCRIPTION
## Summary
- DM was showing relative path `/review/70e06f5ffc77` instead of full URL
- Now prepends `mod.base_url` to get `https://moderation.plyr.fm/review/70e06f5ffc77`

## Test plan
- [x] Trigger moderation loop with `dry_run=false`
- [ ] Verify DM contains clickable full URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)