### PR TITLE
feat: auto-resolve flags for deleted tracks

### DIFF
--- a/moderation/src/db.rs
+++ b/moderation/src/db.rs
@@ -95,6 +95,8 @@ pub enum ResolutionReason {
     FingerprintNoise,
     /// Legal cover version or remix
     CoverVersion,
+    /// Content was deleted from plyr.fm
+    ContentDeleted,
     /// Other reason (see resolution_notes)
     Other,
 }
@@ -107,6 +109,7 @@ impl ResolutionReason {
             Self::Licensed => "licensed",
             Self::FingerprintNoise => "fingerprint noise",
             Self::CoverVersion => "cover/remix",
+            Self::ContentDeleted => "content deleted",
             Self::Other => "other",
         }
     }
@@ -118,6 +121,7 @@ impl ResolutionReason {
             "licensed" => Some(Self::Licensed),
             "fingerprint_noise" => Some(Self::FingerprintNoise),
             "cover_version" => Some(Self::CoverVersion),
+            "content_deleted" => Some(Self::ContentDeleted),
             "other" => Some(Self::Other),
             _ => None,
         }


### PR DESCRIPTION
## Summary
- Adds automatic detection and resolution of flags for tracks that have been deleted from plyr.fm
- Before running LLM analysis, checks each flagged track against the plyr.fm API
- If track returns 404, auto-resolves with reason `content_deleted`
- Adds `ContentDeleted` variant to `ResolutionReason` enum in Rust moderation service

## Why
Labels shouldn't persist in the ether for content that no longer exists. When a track is deleted from plyr.fm, any associated copyright flags should be resolved automatically rather than requiring manual intervention.

## Test plan
- [ ] Run moderation loop with `--dry-run` to verify deleted track detection
- [ ] Run moderation loop without dry-run to confirm auto-resolution works
- [ ] Verify remaining flags exclude deleted tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)