### PR TITLE
feat(admin): show flag count in filter row

### DIFF
--- a/moderation/src/admin.rs
+++ b/moderation/src/admin.rs
@@ -465,16 +465,25 @@ fn render_flags_list(tracks: &[FlaggedTrack], current_filter: &str) -> String {
     let resolved_active = if current_filter == "resolved" { " active" } else { "" };
     let all_active = if current_filter == "all" { " active" } else { "" };
 
+    let count = tracks.len();
+    let count_label = match current_filter {
+        "pending" => format!("{} pending", count),
+        "resolved" => format!("{} resolved", count),
+        _ => format!("{} total", count),
+    };
+
     let filter_buttons = format!(
         "<div class=\"filter-row\">\
             <span class=\"filter-label\">show:</span>\
             <button type=\"button\" class=\"filter-btn{}\" hx-get=\"/admin/flags-html?filter=pending\" hx-target=\"#flags-list\">pending</button>\
             <button type=\"button\" class=\"filter-btn{}\" hx-get=\"/admin/flags-html?filter=resolved\" hx-target=\"#flags-list\">resolved</button>\
             <button type=\"button\" class=\"filter-btn{}\" hx-get=\"/admin/flags-html?filter=all\" hx-target=\"#flags-list\">all</button>\
+            <span class=\"filter-count\">{}</span>\
         </div>",
         pending_active,
         resolved_active,
         all_active,
+        count_label,
     );
 
     if tracks.is_empty() {

--- a/moderation/static/admin.css
+++ b/moderation/static/admin.css
@@ -165,6 +165,12 @@ h1 {
     border-color: var(--accent);
 }
 
+.filter-count {
+    margin-left: auto;
+    color: var(--text-tertiary);
+    font-size: 0.85rem;
+}
+
 .header-row h2 {
     margin: 0;
     font-size: 1.1rem;


### PR DESCRIPTION
## Summary
- Adds count display to the filter row showing how many flags match current filter
- Count updates when switching between pending/resolved/all filters
- Right-aligned in filter row for quick visibility

Example: `show: [pending] [resolved] [all]          27 pending`

## Test plan
- [ ] Check admin panel shows count next to filter buttons
- [ ] Verify count updates when switching filters
- [ ] Verify count matches actual number of displayed cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)