### PR TITLE
fix: send all non-false-positive flags to batch for human review

### DIFF
--- a/scripts/moderation_loop.py
+++ b/scripts/moderation_loop.py
@@ -295,9 +295,9 @@ async def run_loop(
         result = await analyzer.run(f"analyze {len(pending)} flags:\n\n{desc}")
         analyses = result.output
 
-        # auto-resolve false positives
+        # auto-resolve false positives, everything else goes to human review
         auto = [a for a in analyses if a.category == "FALSE_POSITIVE"]
-        human = [a for a in analyses if a.category == "NEEDS_HUMAN"]
+        human = [a for a in analyses if a.category != "FALSE_POSITIVE"]
         console.print(f"analysis: {len(auto)} auto-resolve, {len(human)} need human")
 
         for a in auto:


### PR DESCRIPTION
## Summary
- Fixes bug where VIOLATION flags were ignored and left in pending limbo
- Now anything that isn't auto-resolved as FALSE_POSITIVE goes to the batch for human review

The previous logic only sent `NEEDS_HUMAN` flags to batches, leaving `VIOLATION` flags stuck in pending forever with no action taken.

## Test plan
- [ ] Run moderation loop with --dry-run
- [ ] Verify all non-false-positive flags are included in batch count

🤖 Generated with [Claude Code](https://claude.com/claude-code)