### PR TITLE
feat: add top tracks section to homepage

### DIFF
--- a/backend/src/backend/utilities/aggregations.py
+++ b/backend/src/backend/utilities/aggregations.py
@@ -134,6 +134,26 @@ def _extract_primary_match(matches: list[dict[str, Any]]) -> str | None:
     return f"{title} by {artist}"
 
 
+async def get_top_track_ids(db: AsyncSession, limit: int = 10) -> list[int]:
+    """get track IDs ordered by like count (descending).
+
+    args:
+        db: database session
+        limit: max number of track IDs to return
+
+    returns:
+        list of track IDs ordered by like count (most liked first)
+    """
+    stmt = (
+        select(TrackLike.track_id)
+        .group_by(TrackLike.track_id)
+        .order_by(func.count(TrackLike.id).desc())
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
 async def get_track_tags(db: AsyncSession, track_ids: list[int]) -> dict[int, set[str]]:
     """get tags for multiple tracks in a single query.
 

--- a/frontend/src/lib/tracks.svelte.ts
+++ b/frontend/src/lib/tracks.svelte.ts
@@ -192,6 +192,23 @@ export async function unlikeTrack(trackId: number): Promise<boolean> {
 	}
 }
 
+export async function fetchTopTracks(limit = 10): Promise<Track[]> {
+	try {
+		const response = await fetch(`${API_URL}/tracks/top?limit=${limit}`, {
+			credentials: 'include'
+		});
+
+		if (!response.ok) {
+			throw new Error(`failed to fetch top tracks: ${response.statusText}`);
+		}
+
+		return await response.json();
+	} catch (e) {
+		console.error('failed to fetch top tracks:', e);
+		return [];
+	}
+}
+
 export async function fetchLikedTracks(): Promise<Track[]> {
 	try {
 		const response = await fetch(`${API_URL}/tracks/liked`, {


### PR DESCRIPTION
## Summary

- adds a "top tracks" section above the existing "latest tracks" feed
- shows the 10 most-liked tracks on the platform
- helps surface quality content instead of homepage being dominated by bulk uploads from a single user

## Changes

**backend:**
- new `/tracks/top` endpoint returning tracks ordered by like count
- `get_top_track_ids()` aggregation helper in `utilities/aggregations.py`

**frontend:**
- fetches top tracks concurrently with latest tracks on mount
- displays section only when there are liked tracks

## Test plan

- [ ] verify "top tracks" section appears above "latest tracks"
- [ ] verify tracks are ordered by like count (most liked first)
- [ ] verify section doesn't appear when no tracks have likes
- [ ] verify no performance regression on homepage load

🤖 Generated with [Claude Code](https://claude.com/claude-code)