### PR TITLE
feat: add automated image moderation via Claude vision

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -566,6 +566,10 @@ class ModerationSettings(AppSettingsSection):
         default=300,
         description="TTL in seconds for cached copyright label status (default 5 min)",
     )
+    image_moderation_enabled: bool = Field(
+        default=True,
+        description="Enable image moderation via Claude vision on upload",
+    )
 
 
 class DocketSettings(AppSettingsSection):

--- a/moderation/Cargo.lock
+++ b/moderation/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -466,6 +467,15 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1203,6 +1213,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "base64",
  "bytes",
  "chrono",
  "futures",
@@ -1221,6 +1232,23 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]

--- a/moderation/Cargo.toml
+++ b/moderation/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-axum = { version = "0.7", features = ["macros", "json", "ws"] }
+axum = { version = "0.7", features = ["macros", "json", "ws", "multipart"] }
+base64 = "0.22"
 rand = "0.8"
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/moderation/src/claude.rs
+++ b/moderation/src/claude.rs
@@ -1,0 +1,193 @@
+//! Claude API client for image moderation using structured outputs.
+
+use base64::{engine::general_purpose::STANDARD, Engine};
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+const CLAUDE_API_URL: &str = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const STRUCTURED_OUTPUTS_BETA: &str = "structured-outputs-2025-11-13";
+
+/// Result of image moderation analysis.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModerationResult {
+    pub is_safe: bool,
+    pub violated_categories: Vec<String>,
+    pub severity: String,
+    pub explanation: String,
+}
+
+/// Claude API client for image moderation.
+pub struct ClaudeClient {
+    api_key: String,
+    model: String,
+    http: reqwest::Client,
+}
+
+impl ClaudeClient {
+    pub fn new(api_key: String, model: Option<String>) -> Self {
+        Self {
+            api_key,
+            model: model.unwrap_or_else(|| "claude-sonnet-4-5-20250514".to_string()),
+            http: reqwest::Client::new(),
+        }
+    }
+
+    /// Analyze an image for policy violations using structured outputs.
+    pub async fn analyze_image(
+        &self,
+        image_bytes: &[u8],
+        media_type: &str,
+    ) -> anyhow::Result<ModerationResult> {
+        let b64 = STANDARD.encode(image_bytes);
+
+        // Build request with structured output schema
+        let request = serde_json::json!({
+            "model": self.model,
+            "max_tokens": 1024,
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": MODERATION_PROMPT
+                    },
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": media_type,
+                            "data": b64
+                        }
+                    }
+                ]
+            }],
+            // Structured output schema - guarantees valid JSON matching this schema
+            "output_format": {
+                "type": "json_schema",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "is_safe": {
+                            "type": "boolean",
+                            "description": "Whether the image passes moderation"
+                        },
+                        "violated_categories": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "List of policy categories violated, empty if safe"
+                        },
+                        "severity": {
+                            "type": "string",
+                            "enum": ["safe", "low", "medium", "high"],
+                            "description": "Severity level of the violation"
+                        },
+                        "explanation": {
+                            "type": "string",
+                            "description": "Brief explanation of the moderation decision"
+                        }
+                    },
+                    "required": ["is_safe", "violated_categories", "severity", "explanation"],
+                    "additionalProperties": false
+                }
+            }
+        });
+
+        info!(model = %self.model, "analyzing image with structured outputs");
+
+        let response = self
+            .http
+            .post(CLAUDE_API_URL)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .header("anthropic-beta", STRUCTURED_OUTPUTS_BETA)
+            .header("content-type", "application/json")
+            .json(&request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("claude API error {status}: {body}");
+        }
+
+        let response: ClaudeResponse = response.json().await?;
+
+        // Check for refusal
+        if response.stop_reason == Some("refusal".to_string()) {
+            anyhow::bail!("claude refused to analyze the image");
+        }
+
+        // Check for max_tokens cutoff
+        if response.stop_reason == Some("max_tokens".to_string()) {
+            anyhow::bail!("response was cut off due to max_tokens limit");
+        }
+
+        // Extract text content - guaranteed to be valid JSON matching our schema
+        let text = response
+            .content
+            .into_iter()
+            .find_map(|block| {
+                if block.content_type == "text" {
+                    block.text
+                } else {
+                    None
+                }
+            })
+            .ok_or_else(|| anyhow::anyhow!("no text content in response"))?;
+
+        // Direct JSON parse - no string manipulation needed thanks to structured outputs
+        serde_json::from_str(&text)
+            .map_err(|e| anyhow::anyhow!("failed to parse structured output: {e}"))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeResponse {
+    content: Vec<ContentBlock>,
+    stop_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ContentBlock {
+    #[serde(rename = "type")]
+    content_type: String,
+    text: Option<String>,
+}
+
+const MODERATION_PROMPT: &str = r#"You are a content moderator for a music streaming platform. Analyze the provided image (album/track cover art) for policy violations.
+
+Check for:
+1. Explicit sexual content (nudity, pornography)
+2. Extreme violence or gore
+3. Hate symbols or content
+4. Illegal content
+5. Graphic drug use imagery
+
+Note: Artistic nudity in album art (like classic rock covers) may be acceptable if not explicit/pornographic.
+
+Analyze the image and provide your moderation decision."#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_safe_response() {
+        let response = r#"{"is_safe": true, "violated_categories": [], "severity": "safe", "explanation": "Normal album artwork"}"#;
+        let result: ModerationResult = serde_json::from_str(response).unwrap();
+        assert!(result.is_safe);
+        assert!(result.violated_categories.is_empty());
+        assert_eq!(result.severity, "safe");
+    }
+
+    #[test]
+    fn test_parse_unsafe_response() {
+        let response = r#"{"is_safe": false, "violated_categories": ["explicit_sexual"], "severity": "high", "explanation": "Contains explicit nudity"}"#;
+        let result: ModerationResult = serde_json::from_str(response).unwrap();
+        assert!(!result.is_safe);
+        assert_eq!(result.violated_categories, vec!["explicit_sexual"]);
+        assert_eq!(result.severity, "high");
+    }
+}

--- a/moderation/src/config.rs
+++ b/moderation/src/config.rs
@@ -13,6 +13,10 @@ pub struct Config {
     pub database_url: Option<String>,
     pub labeler_did: Option<String>,
     pub labeler_signing_key: Option<String>,
+    /// Anthropic API key for Claude image moderation
+    pub claude_api_key: Option<String>,
+    /// Claude model to use (default: claude-sonnet-4-5-20250514)
+    pub claude_model: String,
 }
 
 impl Config {
@@ -32,7 +36,15 @@ impl Config {
             database_url: env::var("MODERATION_DATABASE_URL").ok(),
             labeler_did: env::var("MODERATION_LABELER_DID").ok(),
             labeler_signing_key: env::var("MODERATION_LABELER_SIGNING_KEY").ok(),
+            claude_api_key: env::var("ANTHROPIC_API_KEY").ok(),
+            claude_model: env::var("MODERATION_CLAUDE_MODEL")
+                .unwrap_or_else(|_| "claude-sonnet-4-5-20250514".to_string()),
         })
+    }
+
+    /// Check if Claude image moderation is enabled.
+    pub fn claude_enabled(&self) -> bool {
+        self.claude_api_key.is_some() && self.database_url.is_some()
     }
 
     /// Check if labeler is fully configured.


### PR DESCRIPTION
## Summary
- adds automated scanning of uploaded images (track covers, album covers) for policy violations using Claude Sonnet vision capabilities
- moderation service calls Claude API to analyze images
- unsafe images are automatically flagged to `sensitive_images` table (blurred in UI)
- cost tracking via `image_scans` table

## Changes

### Moderation Service (Rust)
- new `/scan-image` endpoint accepts multipart form with image + image_id
- `claude.rs`: Claude API client with vision support (~100 lines)
- `image_scans` table for cost tracking and audit trail
- auto-flags unsafe images to existing `sensitive_images` table

### Backend (Python)
- `ModerationClient.scan_image()` method for calling the new endpoint
- integration in `upload_track_image()` and album cover upload
- `image_moderation_enabled` setting (default: true)

## Behavior
- moderation is best-effort - failures are logged but don't block uploads
- flagged images are blurred in the UI (existing `SensitiveImage.svelte` behavior)
- Claude Sonnet checks for: explicit content, violence, hate symbols, illegal content, graphic drug imagery

## Test plan
- [ ] deploy to staging with `ANTHROPIC_API_KEY` set in moderation service
- [ ] test with curl: `curl -F "image=@test.png" -F "image_id=test123" https://api-stg.plyr.fm/scan-image`
- [ ] upload a track with cover art, verify scan logged
- [ ] verify normal images pass, test images flagged appropriately

## Config required
- `ANTHROPIC_API_KEY` environment variable on moderation service
- optional: `MODERATION_CLAUDE_MODEL` (default: `claude-sonnet-4-5-20250514`)
- optional: `MODERATION_IMAGE_MODERATION_ENABLED=false` to disable

closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)