### PR TITLE
fix: use correct Claude Sonnet 4.5 model ID

### DIFF
--- a/moderation/src/claude.rs
+++ b/moderation/src/claude.rs
@@ -28,7 +28,7 @@ impl ClaudeClient {
     pub fn new(api_key: String, model: Option<String>) -> Self {
         Self {
             api_key,
-            model: model.unwrap_or_else(|| "claude-sonnet-4-5-20250514".to_string()),
+            model: model.unwrap_or_else(|| "claude-sonnet-4-5-20250929".to_string()),
             http: reqwest::Client::new(),
         }
     }

--- a/moderation/src/config.rs
+++ b/moderation/src/config.rs
@@ -15,7 +15,7 @@ pub struct Config {
     pub labeler_signing_key: Option<String>,
     /// Anthropic API key for Claude image moderation
     pub claude_api_key: Option<String>,
-    /// Claude model to use (default: claude-sonnet-4-5-20250514)
+    /// Claude model to use (default: claude-sonnet-4-5-20250929)
     pub claude_model: String,
 }
 
@@ -38,7 +38,7 @@ impl Config {
             labeler_signing_key: env::var("MODERATION_LABELER_SIGNING_KEY").ok(),
             claude_api_key: env::var("ANTHROPIC_API_KEY").ok(),
             claude_model: env::var("MODERATION_CLAUDE_MODEL")
-                .unwrap_or_else(|_| "claude-sonnet-4-5-20250514".to_string()),
+                .unwrap_or_else(|_| "claude-sonnet-4-5-20250929".to_string()),
         })
     }
 

--- a/moderation/src/handlers.rs
+++ b/moderation/src/handlers.rs
@@ -328,7 +328,7 @@ pub async fn scan_image(
         &result.violated_categories,
         &result.severity,
         &result.explanation,
-        "claude-sonnet-4-5-20250514", // TODO: get from client
+        "claude-sonnet-4-5-20250929", // TODO: get from client
     )
     .await?;
 


### PR DESCRIPTION
## Summary
- Update default Claude model from `claude-3-5-sonnet-latest` to `claude-sonnet-4-5-20250929`
- Fixes 404 errors when calling the Claude API for image moderation

## Test plan
- [x] Deployed to plyr-moderation on Fly.io
- [x] Tested `/scan-image` endpoint with real image
- [x] Verified correct structured output response

🤖 Generated with [Claude Code](https://claude.com/claude-code)