### PR TITLE
chore: standardize justfile commands across modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@
 
 ## 💻 Development Commands
 *   **Backend:** `just backend run`
-*   **Frontend:** `just frontend dev`
+*   **Frontend:** `just frontend run`
 *   **Tests:** `just backend test` (run from repo root, not from backend/)
 *   **Linting:** `just backend lint` (Python) / `just frontend check` (Svelte)
 *   **Migrations:** `just backend migrate "message"` (create), `just backend migrate-up` (apply)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ just dev-services
 just backend run
 
 # run frontend (hot reloads at http://localhost:5173)
-just frontend dev
+just frontend run
 ```
 
 ### useful commands

--- a/backend/justfile
+++ b/backend/justfile
@@ -2,6 +2,8 @@
 set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
 default := "run"
 
+alias r := run
+
 # run backend server (hot reloads)
 run:
     uv run uvicorn backend.main:app --reload --host 0.0.0.0 --port ${PORT:-8001}

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,7 @@ key namespaces:
 just backend run
 
 # frontend
-just frontend dev
+just frontend run
 
 # run tests
 just backend test

--- a/docs/deployment/environments.md
+++ b/docs/deployment/environments.md
@@ -22,7 +22,7 @@ just dev-services
 DOCKET_URL=redis://localhost:6379 just backend run
 
 # terminal 3: start frontend
-just frontend dev
+just frontend run
 
 # optional: start transcoder
 just transcoder run

--- a/frontend/justfile
+++ b/frontend/justfile
@@ -1,10 +1,13 @@
 set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
-default := "dev"
+default := "run"
+
+alias r := run
+alias dev := run
 
 # run frontend dev server (hot reloads)
-dev:
-    cd {{justfile_directory()}}/frontend && bun run dev --host 0.0.0.0
+run:
+    bun run dev --host 0.0.0.0
 
 # check svelte types
 check:
-    cd {{justfile_directory()}}/frontend && bun run check
+    bun run check

--- a/justfile
+++ b/justfile
@@ -36,3 +36,7 @@ dev-services:
 # stop dev services
 dev-services-down:
     docker compose down
+
+# expose backend via ngrok tunnel
+tunnel:
+    ngrok http 8001 --domain tunnel.zzstoatzz.io


### PR DESCRIPTION
## Summary
- frontend: rename `dev` to `run` (keep `dev` as alias for backward compat)
- add `r` alias to backend and frontend (matches transcoder/moderation pattern)
- add `just tunnel` command for ngrok
- update docs to reference `just frontend run`

## Test plan
- [x] `just frontend run` starts dev server
- [x] `just frontend dev` still works (alias)
- [x] `just backend r` works (new alias)
- [x] `just tunnel` starts ngrok

🤖 Generated with [Claude Code](https://claude.com/claude-code)