### PR TITLE
fix: update atproto SDK for permission set scope validation

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -287,8 +287,8 @@ wheels = [
 
 [[package]]
 name = "atproto"
-version = "0.0.1.dev470"
-source = { git = "https://github.com/zzstoatzz/atproto?rev=main#6710edb64d144a0ff2757526ade34fa1625a46e6" }
+version = "0.0.1.dev471"
+source = { git = "https://github.com/zzstoatzz/atproto?rev=main#0de1a49c6592ae2c3193948bda1b3a0861316cb5" }
 dependencies = [
     { name = "click" },
     { name = "cryptography" },

--- a/docs/research/2026-01-01-atproto-oauth-permission-sets.md
+++ b/docs/research/2026-01-01-atproto-oauth-permission-sets.md
@@ -128,7 +128,9 @@ await client.com.atproto.repo.putRecord(
 )
 ```
 
-**DNS requirement:** `plyr.fm` must have a TXT record `did=did:plc:...` pointing to the repo containing the lexicons.
+**DNS requirement:** lexicon resolution uses `_lexicon` prefix (distinct from `_atproto` for handles):
+- `_lexicon.plyr.fm` → `did=did:plc:vs3hnzq2daqbszxlysywzy54` (production)
+- `_lexicon.stg.plyr.fm` → `did=did:plc:vs3hnzq2daqbszxlysywzy54` (staging)
 
 ### official bluesky permission sets
 
@@ -177,7 +179,9 @@ additional permission sets (e.g., listener-only, read-only) can be added when th
 
 ## resolved questions
 
-1. **DNS setup**: `_atproto.plyr.fm` already has TXT record `did=did:plc:vs3hnzq2daqbszxlysywzy54`
+1. **DNS setup**: lexicon resolution requires `_lexicon` TXT records (not `_atproto` which is for handles):
+   - production: `_lexicon.plyr.fm` → `did=did:plc:vs3hnzq2daqbszxlysywzy54`
+   - staging: `_lexicon.stg.plyr.fm` → `did=did:plc:vs3hnzq2daqbszxlysywzy54`
 
 2. **which repo?**: the `plyr.fm` account (did:plc:vs3hnzq2daqbszxlysywzy54) on bsky.network - just publish to `com.atproto.lexicon.schema` collection
 

--- a/scripts/publish_permission_set.py
+++ b/scripts/publish_permission_set.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""publish permission set lexicon to ATProto repo with specific rkey."""
+
+import asyncio
+import os
+
+from atproto import AsyncClient
+
+
+async def main():
+    handle = os.environ["PLYRFM_HANDLE"]
+    password = os.environ["PLYRFM_PASSWORD"]
+    namespace = os.environ.get("NAMESPACE", "fm.plyr")
+
+    client = AsyncClient()
+    await client.login(handle, password)
+
+    permission_set_id = f"{namespace}.authFullApp"
+
+    record = {
+        "$type": "com.atproto.lexicon.schema",
+        "lexicon": 1,
+        "id": permission_set_id,
+        "defs": {
+            "main": {
+                "type": "permission-set",
+                "title": "plyr.fm",
+                "description": "Upload and manage audio content, playlists, likes, and comments.",
+                "permissions": [
+                    {
+                        "type": "permission",
+                        "resource": "repo",
+                        "action": ["create", "update", "delete"],
+                        "collection": [
+                            f"{namespace}.track",
+                            f"{namespace}.like",
+                            f"{namespace}.comment",
+                            f"{namespace}.list",
+                            f"{namespace}.actor.profile",
+                        ],
+                    }
+                ],
+            }
+        },
+    }
+
+    result = await client.com.atproto.repo.put_record(
+        {
+            "repo": client.me.did,
+            "collection": "com.atproto.lexicon.schema",
+            "rkey": permission_set_id,
+            "record": record,
+        }
+    )
+
+    print(f"created: {result.uri}")
+    print(f"cid: {result.cid}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- Updates atproto dependency to include fix for OAuth scope validation with permission sets
- The PDS expands `include:` scopes into `repo?collection=` format - SDK now handles this
- Updates docs with correct DNS prefix (`_lexicon` not `_atproto`)
- Adds `scripts/publish_permission_set.py` for publishing permission set lexicons

## Test plan
- [ ] Merge to deploy to staging
- [ ] Test OAuth login on staging with permission sets enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)