### PR TITLE
fix: reload page after switching accounts

### DIFF
--- a/frontend/src/lib/components/ProfileMenu.svelte
+++ b/frontend/src/lib/components/ProfileMenu.svelte
@@ -2,7 +2,6 @@
 	import { portal } from 'svelte-portal';
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
-	import { invalidateAll } from '$app/navigation';
 	import { queue } from '$lib/queue.svelte';
 	import { preferences, type Theme } from '$lib/preferences.svelte';
 	import { API_URL } from '$lib/config';
@@ -152,7 +151,7 @@
 				credentials: 'include'
 			});
 			if (response.ok) {
-				await invalidateAll();
+				window.location.reload();
 			} else {
 				console.error('logout with switch failed');
 			}
@@ -186,7 +185,7 @@
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ target_did: account.did })
 			});
-			await invalidateAll();
+			window.location.reload();
 		} catch (e) {
 			console.error('switch account failed:', e);
 		} finally {

--- a/frontend/src/lib/components/UserMenu.svelte
+++ b/frontend/src/lib/components/UserMenu.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { User, LinkedAccount } from '$lib/types';
 	import { API_URL } from '$lib/config';
-	import { invalidateAll } from '$app/navigation';
 	import HandleAutocomplete from './HandleAutocomplete.svelte';
 	import { logout } from '$lib/logout.svelte';
 
@@ -74,7 +73,7 @@
 				credentials: 'include'
 			});
 			if (response.ok) {
-				await invalidateAll();
+				window.location.reload();
 			} else {
 				console.error('logout with switch failed');
 			}
@@ -108,7 +107,7 @@
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ target_did: account.did })
 			});
-			await invalidateAll();
+			window.location.reload();
 		} catch (e) {
 			console.error('switch account failed:', e);
 		} finally {


### PR DESCRIPTION
## Summary

- Replace `invalidateAll()` with `window.location.reload()` when switching accounts

## Problem

`invalidateAll()` only re-runs SvelteKit load functions (`+page.ts`/`+page.server.ts`), but the portal page loads all its data client-side in `onMount`. When switching accounts, the page kept showing the previous user's tracks, albums, and profile data.

## Fix

Use `window.location.reload()` to ensure the page fetches fresh data for the new account. This is the same approach used for `logout-all`.

## Test plan

- [x] Frontend check passes
- [ ] Manual test: switch accounts on portal page, verify data refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)