### PR TITLE
fix: add targeted logfire span for PDS record fetching

### DIFF
--- a/backend/src/backend/_internal/atproto/records/fm_plyr/track.py
+++ b/backend/src/backend/_internal/atproto/records/fm_plyr/track.py
@@ -151,6 +151,7 @@ async def get_record_public(
         Exception: if fetch fails
     """
     import httpx
+    import logfire
 
     repo, collection, rkey = parse_at_uri(record_uri)
 
@@ -158,8 +159,14 @@ async def get_record_public(
     url = f"{base_url}/xrpc/com.atproto.repo.getRecord"
     params = {"repo": repo, "collection": collection, "rkey": rkey}
 
-    async with httpx.AsyncClient() as client:
-        response = await client.get(url, params=params, timeout=10.0)
+    with logfire.span(
+        "pds_get_record {collection}",
+        collection=collection,
+        rkey=rkey,
+        pds_host=base_url.replace("https://", ""),
+    ):
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, params=params, timeout=10.0)
 
     if response.status_code != 200:
         raise Exception(


### PR DESCRIPTION
## Summary
- Adds surgical `logfire.span()` around `get_record_public()` to capture actual PDS HTTP call duration
- The album endpoint was showing ~205ms average but HTTP Request spans to PDS were showing 0ms - an instrumentation gap
- This captures timing without flooding spans like global `logfire.instrument_httpx()` would

## Test plan
- [x] Verified locally - span shows `pds_get_record {collection}` with actual `duration_ms` (~89ms)
- [ ] Check staging/prod traces after merge to verify album endpoint timing breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)