### PR TITLE
fix: correct ATProto vs Bluesky terminology

### DIFF
--- a/.github/workflows/status-maintenance.yml
+++ b/.github/workflows/status-maintenance.yml
@@ -212,6 +212,11 @@ jobs:
             the TTS engine will mispronounce "plyr" as "plir" or "p-l-y-r" if you write it that way.
             write phonetically for correct pronunciation: "player FM", "player dot FM".
 
+            ### terminology
+
+            plyr.fm is built on **ATProto** (the protocol), not Bluesky (the app).
+            say "ATProto identities" or just "identities" - never "Bluesky accounts".
+
             ### identifying what actually shipped
 
             read the commit messages and PR bodies carefully to understand what changed.

--- a/STATUS.md
+++ b/STATUS.md
@@ -49,9 +49,9 @@ plyr.fm should become:
 
 #### multi-account experience (PRs #707, #710, #712-714, Jan 3-5)
 
-**why**: many users have multiple Bluesky identities (personal, artist, label). forcing re-authentication to switch was friction that discouraged uploads from secondary accounts.
+**why**: many users have multiple ATProto identities (personal, artist, label). forcing re-authentication to switch was friction that discouraged uploads from secondary accounts.
 
-**users can now link multiple Bluesky accounts** to a single browser session:
+**users can now link multiple identities** to a single browser session:
 - add additional accounts via "add account" in user menu (triggers OAuth with `prompt=login`)
 - switch between linked accounts instantly without re-authenticating
 - logout from individual accounts or all at once
@@ -378,7 +378,7 @@ stabilization and polish after multi-account release. monitoring production for 
 
 **core functionality**
 - ✅ ATProto OAuth 2.1 authentication
-- ✅ multi-account support (link multiple Bluesky accounts)
+- ✅ multi-account support (link multiple ATProto identities)
 - ✅ secure session management via HttpOnly cookies
 - ✅ developer tokens with independent OAuth grants
 - ✅ platform stats and Media Session API


### PR DESCRIPTION
## Summary

fixes incorrect terminology in STATUS.md and adds guidance to the status maintenance prompt.

### Problem

PR #724 generated audio that said "Bluesky accounts" when it should have said "ATProto identities". plyr.fm operates at the protocol layer (ATProto), not the application layer (Bluesky).

### Changes

**STATUS.md**:
- "multiple Bluesky identities" → "multiple ATProto identities"
- "link multiple Bluesky accounts" → "link multiple identities"

**status-maintenance.yml**:
- added terminology section to prevent this mistake in future audio scripts

### Context

read `/Users/nate/tangled.sh/@zzstoatzz.io/notes/protocols/atproto/` to understand the distinction:
- ATProto is the protocol (like HTTP)
- Bluesky is one application on ATProto (like a website)
- plyr.fm is another application on ATProto
- users have ATProto identities (DIDs + handles) that work across all apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)