### PR TITLE
Align queue auth with layout state

### DIFF
--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -2,6 +2,7 @@ import { browser } from '$app/environment';
 import type { QueueResponse, QueueState, Track } from './types';
 import { API_URL } from './config';
 import { APP_BROADCAST_PREFIX } from './branding';
+import { auth } from './auth.svelte';
 
 const SYNC_DEBOUNCE_MS = 250;
 
@@ -141,7 +142,7 @@ class Queue {
 
 	private isAuthenticated(): boolean {
 		if (!browser) return false;
-		return !!localStorage.getItem('session_id');
+		return auth.isAuthenticated;
 	}
 
 	async fetchQueue(force = false) {
@@ -188,6 +189,7 @@ class Queue {
 			this.revision = data.revision;
 			this.etag = newEtag;
 
+			this.lastUpdateWasLocal = false;
 			this.applySnapshot(data);
 		} catch (error) {
 			console.error('failed to fetch queue:', error);

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -47,6 +47,9 @@
 			preferences.data = data.preferences;
 			// fetch explicit images list (public, no auth needed)
 			moderation.initialize();
+			if (data.isAuthenticated && queue.revision === null) {
+				void queue.fetchQueue();
+			}
 		}
 	});
 


### PR DESCRIPTION
## Summary
- use shared auth state for queue authentication checks (no localStorage session IDs)
- trigger initial queue hydration when layout auth resolves
- ensure remote queue snapshots don’t inherit local update flags

Closes #731

## Testing
- just frontend check
