### PR TITLE
fix: accept BytesIO in R2Storage.save() type hint

### DIFF
--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -2,6 +2,7 @@
 
 import time
 from collections.abc import Callable
+from io import BytesIO
 from pathlib import Path
 from typing import BinaryIO
 
@@ -120,7 +121,7 @@ class R2Storage:
 
     async def save(
         self,
-        file: BinaryIO,
+        file: BinaryIO | BytesIO,
         filename: str,
         progress_callback: Callable[[float], None] | None = None,
     ) -> str:
@@ -444,7 +445,7 @@ class R2Storage:
 
     async def save_gated(
         self,
-        file: BinaryIO,
+        file: BinaryIO | BytesIO,
         filename: str,
         progress_callback: Callable[[float], None] | None = None,
     ) -> str:

--- a/backend/tests/test_storage_types.py
+++ b/backend/tests/test_storage_types.py
@@ -1,0 +1,53 @@
+"""test storage type hints accept BytesIO.
+
+regression test for: https://github.com/zzstoatzz/plyr.fm/pull/736
+beartype was rejecting BytesIO for BinaryIO type hint in R2Storage.save()
+"""
+
+from io import BytesIO
+from unittest.mock import AsyncMock, patch
+
+from backend.storage.r2 import R2Storage
+
+
+async def test_r2_save_accepts_bytesio():
+    """R2Storage.save() should accept BytesIO objects.
+
+    BytesIO is the standard way to create in-memory binary streams,
+    and is used throughout the codebase for image uploads.
+
+    This test verifies that the type hint on save() is compatible
+    with BytesIO, which beartype validates at runtime.
+    """
+    # create a minimal image-like BytesIO
+    image_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100  # fake PNG header
+    file_obj = BytesIO(image_data)
+
+    # mock the R2 client internals
+    with (
+        patch.object(R2Storage, "__init__", lambda self: None),
+        patch("backend.storage.r2.hash_file_chunked", return_value="abc123def456"),
+    ):
+        storage = R2Storage()
+        storage.async_session = AsyncMock()
+        storage.image_bucket_name = "test-images"
+        storage.audio_bucket_name = "test-audio"
+
+        # mock the async context manager for S3 client
+        mock_client = AsyncMock()
+        mock_client.upload_fileobj = AsyncMock()
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+        storage.async_session.client = lambda *args, **kwargs: mock_cm
+        storage.endpoint_url = "https://test.r2.dev"
+        storage.aws_access_key_id = "test"
+        storage.aws_secret_access_key = "test"
+
+        # this should NOT raise a beartype error
+        # before the fix: BeartypeCallHintParamViolation
+        file_id = await storage.save(file_obj, "test.png")
+
+        assert file_id == "abc123def456"[:16]
+        mock_client.upload_fileobj.assert_called_once()


### PR DESCRIPTION
## Summary
- Fixes beartype rejecting `BytesIO` objects in `R2Storage.save()` and `save_gated()`
- Changed type hint from `BinaryIO` to `BinaryIO | BytesIO` to explicitly accept both
- Adds regression test verifying BytesIO acceptance

## Root Cause
`beartype_this_package()` enables strict runtime type checking. The `BinaryIO` protocol from `typing` doesn't satisfy beartype's protocol matching for `BytesIO` instances, even though `BytesIO` implements the same interface.

## Impact
Playlist cover uploads were failing with 500 errors when users tried to upload cover art. The error was:
```
BeartypeCallHintParamViolation: parameter file=<_io.BytesIO object> violates type hint <class 'typing.BinaryIO'>
```

Found via Logfire - only 2 occurrences in the last week, both on Jan 3.

## Test plan
- [x] Added regression test `test_r2_save_accepts_bytesio`
- [x] All 362 tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)