### PR TITLE
chore: improve status-update workflow and document auth stabilization

### DIFF
--- a/.claude/commands/status-update.md
+++ b/.claude/commands/status-update.md
@@ -1,35 +1,78 @@
 # status update
 
-update STATUS.md after completing significant work.
+update STATUS.md to reflect recent work.
 
-## when to update
+## workflow
 
-after shipping something notable:
-- new features or endpoints
-- bug fixes worth documenting
-- architectural changes
-- deployment/infrastructure changes
-- incidents and their resolutions
+### 1. understand current state
 
-**tip**: after running `/deploy`, consider running `/status-update` to document what shipped.
+read STATUS.md to understand:
+- what's already documented in `## recent work`
+- the last update date (noted at the bottom)
+- current priorities and known issues
 
-## how to update
+### 2. find undocumented work
 
-1. add a new subsection under `## recent work` with today's date
-2. describe what shipped, why it matters, and any relevant PR numbers
-3. update `## immediate priorities` if priorities changed
-4. update `## technical state` if architecture changed
+```bash
+# find the last STATUS.md update
+git log --oneline -1 -- STATUS.md
 
-## structure
+# get all commits since then
+git log --oneline <last-status-commit>..HEAD
+```
 
-STATUS.md follows this structure:
-- **long-term vision** - why the project exists
-- **recent work** - chronological log of what shipped (newest first)
-- **immediate priorities** - what's next
-- **technical state** - architecture, what's working, known issues
+for each significant commit or PR:
+- read the commit message and changed files
+- understand WHY the change was made, not just what changed
+- note architectural decisions, trade-offs, or lessons learned
 
-old content is automatically archived to `.status_history/` - you don't need to manage this.
+### 3. decide what to document
+
+not everything needs documentation. focus on:
+- **features**: new capabilities users or developers can use
+- **fixes**: bugs that affected users, especially if they might recur
+- **architecture**: changes to how systems connect or data flows
+- **decisions**: trade-offs made and why (future readers need context)
+- **incidents**: what broke, why, and how it was resolved
+
+skip:
+- routine maintenance (dependency bumps, typo fixes)
+- work-in-progress that didn't ship
+- changes already well-documented in the PR
+
+### 4. write the update
+
+add a new subsection under `## recent work` following existing patterns:
+
+```markdown
+#### brief title (PRs #NNN, date)
+
+**why**: the problem or motivation (1-2 sentences)
+
+**what shipped**:
+- concrete changes users or developers will notice
+- link to relevant docs if applicable
+
+**technical notes** (if architectural):
+- decisions made and why
+- trade-offs accepted
+```
+
+### 5. update other sections if needed
+
+- `## priorities` - if focus has shifted
+- `## known issues` - if bugs were fixed or discovered
+- `## technical state` - if architecture changed
 
 ## tone
 
-direct, technical, honest about limitations. useful for someone with no prior context.
+write for someone with no prior context who needs to understand:
+- what changed
+- why it matters
+- why this approach was chosen over alternatives
+
+be direct and technical. avoid marketing language.
+
+## after updating
+
+commit the STATUS.md changes and open a PR for review.

--- a/STATUS.md
+++ b/STATUS.md
@@ -79,6 +79,27 @@ these fixes came from reviewing [Bluesky's architecture deep dive](https://newsl
 
 ---
 
+#### auth stabilization (PRs #734-736, Jan 6-7)
+
+**why**: multi-account support introduced edge cases where auth state could become inconsistent between frontend components, and sessions could outlive their refresh tokens.
+
+**session expiry alignment** (PR #734):
+- sessions now track refresh token lifetime and respect it during validation
+- prevents sessions from appearing valid after their underlying OAuth grant expires
+- dev token expiration handling aligned with same pattern
+
+**queue auth boundary fix** (PR #735):
+- queue component now uses shared layout auth state instead of localStorage session IDs
+- fixes race condition where queue could attempt authenticated requests before layout resolved auth
+- ensures remote queue snapshots don't inherit local update flags during hydration
+
+**playlist cover upload fix** (PR #736):
+- `R2Storage.save()` was rejecting `BytesIO` objects due to beartype's strict `BinaryIO` protocol checking
+- changed type hint to `BinaryIO | BytesIO` to explicitly accept both
+- found via Logfire: only 2 failures in production, both on Jan 3
+
+---
+
 #### artist bio links (PRs #700-701, Jan 2)
 
 **links in artist bios now render as clickable** - supports full URLs and bare domains (e.g., "example.com"):
@@ -347,4 +368,4 @@ plyr.fm/
 
 ---
 
-this is a living document. last updated 2026-01-06.
+this is a living document. last updated 2026-01-07.


### PR DESCRIPTION
## Summary

**Two changes in one PR:**

### 1. Improved `/status-update` slash command

Rewrote the workflow to be more investigative:

1. **Understand current state** - read STATUS.md to see what's documented
2. **Find undocumented work** - `git log` since last STATUS.md update
3. **Understand WHY** - read commits/PRs to understand decisions, not just diffs
4. **Document for future readers** - write with context so decisions make sense later

### 2. Documented auth stabilization work (PRs #734-736)

Added new section covering recent fixes:

- **Session expiry alignment** (#734): sessions now respect refresh token lifetime
- **Queue auth boundary** (#735): queue uses shared layout auth state instead of localStorage
- **Playlist cover fix** (#736): BytesIO now accepted in R2Storage.save()

These were follow-up fixes after multi-account shipped, stabilizing auth edge cases.

## Test plan
- [x] STATUS.md follows existing format
- [x] Slash command is valid markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)