### PR TITLE
fix: suppress autoplay error on timestamp deep links

### DIFF
--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -416,8 +416,8 @@ class Queue {
 		this.schedulePush();
 	}
 
-	playNow(track: Track) {
-		this.lastUpdateWasLocal = true;
+	playNow(track: Track, autoPlay = true) {
+		this.lastUpdateWasLocal = autoPlay;
 		const upNext = this.tracks.slice(this.currentIndex + 1);
 		this.tracks = [track, ...upNext];
 		this.originalOrder = [...this.tracks];

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -376,11 +376,11 @@ onMount(() => {
 		const seconds = parseInt(t, 10);
 		if (!isNaN(seconds) && seconds >= 0) {
 			pendingSeekMs = seconds * 1000;
-			// start playing the track
+			// load the track without auto-playing (browser blocks autoplay without interaction)
 			if (track.gated) {
 				void playTrack(track);
 			} else {
-				queue.playNow(track);
+				queue.playNow(track, false);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- add optional `autoPlay` param to `queue.playNow()` (defaults to `true` for backward compatibility)
- pass `false` when loading track from `?t=` timestamp URL
- eliminates console error: `playback failed: NotAllowedError: play() failed because the user didn't interact with the document first`

## Test plan
- [ ] visit `/track/X?t=30` → no console error, track loads at 0:30 paused
- [ ] click play → playback starts from 0:30
- [ ] normal playNow behavior unchanged (clicking play button still auto-plays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)