### PR TITLE
fix: import UploadFile from starlette for beartype compatibility

### DIFF
--- a/backend/src/backend/api/tracks/metadata_service.py
+++ b/backend/src/backend/api/tracks/metadata_service.py
@@ -6,9 +6,10 @@ import logging
 from io import BytesIO
 from typing import TYPE_CHECKING, Any
 
-from fastapi import HTTPException, UploadFile
+from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import attributes
+from starlette.datastructures import UploadFile
 
 from backend._internal.atproto.handles import resolve_handle
 from backend._internal.image import ImageFormat

--- a/backend/src/backend/api/tracks/mutations.py
+++ b/backend/src/backend/api/tracks/mutations.py
@@ -305,9 +305,9 @@ async def update_track_metadata(
         try:
             await _update_atproto_record(track, auth_session, image_url)
         except Exception as exc:
-            logger.error(
-                f"failed to update ATProto record for track {track.id}: {exc}",
-                exc_info=True,
+            logfire.exception(
+                "failed to update ATProto record",
+                track_id=track.id,
             )
             await db.rollback()
             raise HTTPException(


### PR DESCRIPTION
## Summary
- Import `UploadFile` from `starlette.datastructures` instead of `fastapi` in `metadata_service.py`
- beartype was failing because FastAPI passes starlette's UploadFile but we type-hinted fastapi's
- Also switched to `logfire.exception()` for better error visibility in Logfire

## Test plan
- [ ] Upload new track with cover art
- [ ] Update existing track's cover art via PATCH /tracks/{id}

🤖 Generated with [Claude Code](https://claude.com/claude-code)