### PR TITLE
fix: use dominant match detection for copyright flagging

### DIFF
--- a/moderation/src/config.rs
+++ b/moderation/src/config.rs
@@ -17,7 +17,8 @@ pub struct Config {
     pub claude_api_key: Option<String>,
     /// Claude model to use (default: claude-sonnet-4-5-20250929)
     pub claude_model: String,
-    /// Minimum AuDD score to flag as potential copyright violation (default: 85)
+    /// Minimum percentage of matches that must belong to a single song to flag (default: 30)
+    /// AudD doesn't return confidence scores, so we use match frequency as a proxy.
     pub copyright_score_threshold: i32,
 }
 
@@ -44,7 +45,7 @@ impl Config {
             copyright_score_threshold: env::var("MODERATION_COPYRIGHT_SCORE_THRESHOLD")
                 .ok()
                 .and_then(|v| v.parse().ok())
-                .unwrap_or(85),
+                .unwrap_or(30),
         })
     }
 

--- a/moderation/src/state.rs
+++ b/moderation/src/state.rs
@@ -24,7 +24,7 @@ pub struct AppState {
     pub label_tx: Option<broadcast::Sender<(i64, Label)>>,
     /// Claude client for image moderation (if configured)
     pub claude: Option<Arc<ClaudeClient>>,
-    /// Minimum AuDD score to flag as potential copyright violation
+    /// Minimum percentage of matches that must belong to a single song to flag
     pub copyright_score_threshold: i32,
 }
 


### PR DESCRIPTION
## Summary

- AudD doesn't return confidence scores - the `score` field was always 0
- #703 reintroduced score-based thresholding, which broke copyright detection
- New approach: flag if one song dominates >= 30% of matched segments

## Background

Investigated track 594 upload - MARINA's "BUTTERFLY" wasn't flagged despite 20+ matches because:
1. AudD enterprise API with `accurate_offsets=1` doesn't return scores
2. All matches had `score: 0`, so `highest_score >= 85` always failed

## Solution

Count matches per unique (artist, title). If one song appears in >= 30% of segments, flag it. This filters false positives where random segments match different songs.

Track 594 results:
- MARINA - BUTTERFLY: 18/53 matches (33%) ✓ flagged
- Eugenio Tokarev: 11/53 (20%)
- Others: scattered 1-2 matches each

## Test plan

- [ ] Deploy to staging
- [ ] Re-scan track 594, verify it gets flagged
- [ ] Verify DMs sent to artist + admin
- [ ] Spot check a few other recent uploads for false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)