### PR TITLE
fix: constrain track title link width to content only

### DIFF
--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -602,6 +602,8 @@
 		text-overflow: ellipsis;
 		text-decoration: none;
 		transition: color 0.15s;
+		width: fit-content;
+		max-width: 100%;
 	}
 
 	.track-title:hover {


### PR DESCRIPTION
## Summary
- fixed track title anchor stretching to full width of flex container
- clicking to the right of the title text now plays the track as expected
- only the actual title text navigates to detail page

## Test plan
- [ ] hover over track title - only text should show link cursor
- [ ] click title text - navigates to /track/[id]
- [ ] click to the right of title (but in same row) - plays track

🤖 Generated with [Claude Code](https://claude.com/claude-code)