### PR TITLE
fix: prevent leftmost avatar clipping in tooltip hover

### DIFF
--- a/frontend/src/lib/components/CommentersTooltip.svelte
+++ b/frontend/src/lib/components/CommentersTooltip.svelte
@@ -237,7 +237,9 @@
 
 	.commenters-avatars {
 		display: flex;
-		justify-content: center;
+		/* start from left so most recent (leftmost) is always visible */
+		/* scroll right to see older commenters */
+		justify-content: flex-start;
 		overflow-x: auto;
 		max-width: 240px;
 		padding: 0.5rem 0 0.125rem 0;

--- a/frontend/src/lib/components/LikersTooltip.svelte
+++ b/frontend/src/lib/components/LikersTooltip.svelte
@@ -235,7 +235,9 @@
 
 	.likers-avatars {
 		display: flex;
-		justify-content: center;
+		/* start from left so most recent (leftmost) is always visible */
+		/* scroll right to see older likers */
+		justify-content: flex-start;
 		overflow-x: auto;
 		max-width: 240px;
 		padding: 0.5rem 0 0.125rem 0;


### PR DESCRIPTION
## Summary

- change `justify-content` from `center` to `flex-start` in avatar tooltip containers
- most recent avatars (leftmost) are now always fully visible
- horizontal scroll reveals older avatars to the right

fixes both `LikersTooltip` and `CommentersTooltip`.

## Test plan

- [x] hover over like count on a track with many likes
- [x] verify leftmost avatar is fully visible
- [x] verify scrolling right shows older likers

🤖 Generated with [Claude Code](https://claude.com/claude-code)