### PR TITLE
fix: simplify logout modal to single clear question

### DIFF
--- a/frontend/src/lib/components/LogoutModal.svelte
+++ b/frontend/src/lib/components/LogoutModal.svelte
@@ -16,8 +16,7 @@
 	onclick={handleBackdropClick}
 >
 	<div class="logout-modal" role="dialog" aria-modal="true" aria-label="logout options">
-		<div class="logout-modal-header">stay logged in?</div>
-		<p class="logout-modal-subtext">leaving @{logout.user?.handle}?</p>
+		<div class="logout-modal-header">switch accounts?</div>
 		<div class="logout-modal-accounts">
 			{#each logout.otherAccounts as account}
 				<button class="logout-modal-account" onclick={() => logout.logoutAndSwitch(account)}>
@@ -92,14 +91,7 @@
 		font-weight: 600;
 		color: var(--text-primary);
 		text-align: center;
-		margin-bottom: 0.25rem;
-	}
-
-	.logout-modal-subtext {
-		font-size: var(--text-sm);
-		color: var(--text-tertiary);
-		text-align: center;
-		margin: 0 0 1.25rem;
+		margin-bottom: 1.25rem;
 	}
 
 	.logout-modal-accounts {


### PR DESCRIPTION
## Summary
- Header changed to "switch accounts?" (single clear question)
- Removed confusing subtext ("leaving @handle?")
- Buttons are self-explanatory, no need for extra context

Before: Two questions stacked ("stay logged in?" + "leaving @handle?")
After: One question ("switch accounts?")

## Test plan
- [ ] Open logout modal with multiple accounts
- [ ] Verify the single question reads clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)