### PR TITLE
docs: add content gating research notes for call

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -47,6 +47,30 @@ plyr.fm should become:
 
 ### January 2026
 
+#### content gating research (Jan 18)
+
+researched ATProtoFans architecture and JSONLogic rule evaluation. documented findings in `docs/content-gating-roadmap.md`:
+- current ATProtoFans records and API (supporter, supporterProof, brokerProof, terms)
+- the gap: terms exist but aren't exposed via validateSupporter
+- how magazi uses datalogic-rs for flexible rule evaluation
+- open questions about upcoming metadata extensions
+
+no implementation changes - waiting to align with what ATProtoFans will support.
+
+#### logout modal UX (PRs #755-757, Jan 17-18)
+
+**tooltip scroll fix** (PR #755):
+- leftmost avatar in likers/commenters tooltip was clipped with no way to scroll to it
+- changed `justify-content: center` to `flex-start` so most recent (leftmost) is always visible
+
+**logout modal copy** (PRs #756-757):
+- simplified from two confusing questions to one clear question
+- before: "stay logged in?" + "you're logging out of @handle?"
+- after: "switch accounts?"
+- "logout completely" → "log out of all accounts"
+
+---
+
 #### avatar refresh and tooltip polish (PRs #750-752, Jan 13)
 
 **avatar refresh from anywhere** (PR #751):
@@ -445,4 +469,4 @@ plyr.fm/
 
 ---
 
-this is a living document. last updated 2026-01-11.
+this is a living document. last updated 2026-01-18.

--- a/docs/content-gating-roadmap.md
+++ b/docs/content-gating-roadmap.md
@@ -1,0 +1,132 @@
+# Content Gating: Research Notes
+
+Reference material for understanding ATProtoFans and preparing for upcoming discussions.
+
+## Current State (plyr.fm)
+
+Binary supporter check:
+
+```python
+# backend/src/backend/_internal/atprotofans.py
+validate_supporter(supporter_did, artist_did, signer_did) -> bool
+```
+
+Track gating stored as:
+```json
+{"type": "any"}  // supporter or not, nothing else
+```
+
+## What ATProtoFans Provides Today
+
+Based on [ATProtoFans technical docs](https://atprotofans.leaflet.pub/3m7nlsl3vxk24):
+
+### Records
+
+1. **Supporter Record** (fan's repo) - `com.atprotofans.supporter`
+   - Links to supporterProof and brokerProof via strongRef
+
+2. **Supporter Proof** (creator's repo) - `com.atprotofans.supporterProof`
+   - Creator's attestation of the relationship
+
+3. **Broker Proof** (broker's repo) - `com.atprotofans.brokerProof`
+   - Third-party verification of the transaction
+
+4. **Terms Record** (broker's service) - `com.atprotofans.terms`
+   ```json
+   {
+     "$type": "com.atprotofans.terms#recurring",
+     "amount": 1000,      // cents
+     "currency": "USD",
+     "unit": "monthly",   // monthly, quarterly, biannually, yearly
+     "frequency": 1
+   }
+   ```
+
+### API
+
+```
+GET /xrpc/com.atprotofans.validateSupporter
+  ?supporter={did}&subject={creator_did}&signer={broker_did}
+
+Response: { "valid": true, "profile": {...} }
+```
+
+**The gap:** Terms exist but aren't exposed via `validateSupporter`. We can only check supporter yes/no, not *which terms* they agreed to.
+
+## What's Coming
+
+From ATProtoFans (Jan 2026):
+> "The successor is in the works that will support additional metadata and record extensions"
+
+## JSONLogic (datalogic-rs)
+
+Nick's [magazi](https://tangled.org/@ngerakines.me/magazi) uses [datalogic-rs](https://github.com/GoPlasmatic/datalogic-rs) for rule evaluation. Rules are JSON that evaluate against a context object.
+
+### Context Structure
+
+```json
+{
+  "authenticated": true,
+  "supporter": { ... },        // supporter record
+  "supporter_proof": { ... },  // from creator's repo
+  "broker_proof": { ... },     // from broker's repo
+  "terms": { ... }             // terms record (if exposed)
+}
+```
+
+### Example Rules
+
+**Any supporter (what we do now):**
+```json
+{ "!!": { "var": "supporter" } }
+```
+
+**Full attestation chain:**
+```json
+{
+  "and": [
+    { "!!": { "var": "supporter" } },
+    { "!!": { "var": "supporter_proof" } },
+    { "!!": { "var": "broker_proof" } }
+  ]
+}
+```
+
+**Minimum amount (requires terms access):**
+```json
+{
+  "and": [
+    { "!!": { "var": "supporter" } },
+    { ">=": [{ "var": "terms.amount" }, 1000] }
+  ]
+}
+```
+
+**Supporter tenure (requires createdAt):**
+```json
+{
+  "and": [
+    { "!!": { "var": "supporter" } },
+    { ">=": [
+      { "date_diff": [{ "now": [] }, { "var": "supporter.createdAt" }, "days"] },
+      30
+    ]}
+  ]
+}
+```
+
+The `!!` (double-bang) checks truthiness - returns true if field exists and is non-null.
+
+## Open Questions
+
+1. **Terms access:** Will `validateSupporter` return terms info, or separate endpoint?
+
+2. **Supporter metadata:** Plans for `supporterSince` or tenure data?
+
+3. **Context fields:** What fields will be available for rule evaluation?
+
+4. **serviceRef resolution:** Should apps resolve serviceRef to get terms, or will API surface this?
+
+5. **Caching:** Recommended TTL for validation results?
+
+6. **JSONLogic adoption:** Interest in standardizing rule format across ecosystem?


### PR DESCRIPTION
## Summary
Research notes for understanding ATProtoFans

**What's documented:**
- Current ATProtoFans records (supporter, supporterProof, brokerProof, terms)
- The gap: terms exist but aren't exposed via `validateSupporter`
- How magazi uses JSONLogic (datalogic-rs) for flexible rule evaluation
- Questions to ask Nick about upcoming metadata extensions

**No implementation** - waiting to align with what ATProtoFans will support.

Also updates STATUS.md with recent work (PRs #755-757).

🤖 Generated with [Claude Code](https://claude.com/claude-code)