### PR TITLE
fix: improve legal language accuracy

### DIFF
--- a/frontend/src/lib/components/TermsOverlay.svelte
+++ b/frontend/src/lib/components/TermsOverlay.svelte
@@ -34,17 +34,17 @@
 			<h2>key points</h2>
 			<ul>
 				<li>
-					<strong>your content:</strong> you own what you upload. we store it, stream it,
-					and transcode it. delete through {APP_NAME} and we clean up everything.
+					<strong>your content:</strong> you own what you upload. we store and stream it.
+					delete through {APP_NAME} and we remove it from our servers.
 				</li>
 				<li>
 					<strong>copyright:</strong> don't upload content you don't have rights to.
 					we follow DMCA takedown procedures.
 				</li>
 				<li>
-					<strong>AT Protocol:</strong> your identity is on your
+					<strong>AT Protocol:</strong> your identity lives on your
 					<a href="https://atproto.com/guides/glossary#pds-personal-data-server" target="_blank" rel="noopener">PDS</a>.
-					public interactions (likes, comments) are written to the network.
+					likes and comments are stored there as public records.
 				</li>
 				<li>
 					<strong>privacy:</strong> we don't sell your data or use it for ads.

--- a/frontend/src/routes/privacy/+page.svelte
+++ b/frontend/src/routes/privacy/+page.svelte
@@ -13,7 +13,7 @@
 <div class="legal-container">
 	<article class="legal-content">
 		<h1>privacy policy</h1>
-		<p class="last-updated">last updated: december 16, 2025</p>
+		<p class="last-updated">last updated: january 19, 2026</p>
 
 		<p class="intro">
 			this policy explains what data we collect, what's public by design on the AT Protocol,
@@ -28,8 +28,8 @@
 			</p>
 			<p>
 				<strong>public by design:</strong> your DID, handle, profile, tracks, likes, and comments
-				are stored on the decentralized AT Protocol network. this data is visible to anyone
-				on the network, not just {APP_NAME} users.
+				are stored on your PDS (Personal Data Server). for most users, this is Bluesky's servers.
+				this data is public and can be read by any AT Protocol application.
 			</p>
 			<p>
 				<strong>external PDS:</strong> if your account is hosted on Bluesky's PDS or another

--- a/frontend/src/routes/terms/+page.svelte
+++ b/frontend/src/routes/terms/+page.svelte
@@ -13,7 +13,7 @@
 <div class="legal-container">
 	<article class="legal-content">
 		<h1>terms of service</h1>
-		<p class="last-updated">last updated: december 16, 2025</p>
+		<p class="last-updated">last updated: january 19, 2026</p>
 
 		<p class="intro">
 			these terms govern your use of {APP_NAME}, a music streaming platform built on the


### PR DESCRIPTION
## summary

- remove 'transcode' claim from terms overlay (not implemented)
- clarify AT Protocol data storage: 'stored on your PDS' instead of vague 'written to the network'
- specify that most users' PDS is Bluesky's servers
- update last updated dates to today

## changes

**TermsOverlay.svelte:**
- "we store it, stream it, and transcode it" → "we store and stream it"
- "public interactions are written to the network" → "likes and comments are stored there as public records"

**privacy/+page.svelte:**
- "stored on the decentralized AT Protocol network" → "stored on your PDS (Personal Data Server). for most users, this is Bluesky's servers"