### PR TITLE
fix: correct legal language for ATProto accuracy

### DIFF
--- a/frontend/src/lib/components/TermsOverlay.svelte
+++ b/frontend/src/lib/components/TermsOverlay.svelte
@@ -34,17 +34,19 @@
 			<h2>key points</h2>
 			<ul>
 				<li>
-					<strong>your content:</strong> you own what you upload. we store it, stream it,
-					and transcode it. delete through {APP_NAME} and we clean up everything.
+					<strong>your content:</strong> you own what you upload. audio files are stored
+					on our servers; track metadata is written to your PDS. delete through {APP_NAME}
+					and we remove it from our servers.
 				</li>
 				<li>
 					<strong>copyright:</strong> don't upload content you don't have rights to.
 					we follow DMCA takedown procedures.
 				</li>
 				<li>
-					<strong>AT Protocol:</strong> your identity is on your
+					<strong>AT Protocol:</strong> your identity and public data (likes, comments,
+					playlists) are stored on your
 					<a href="https://atproto.com/guides/glossary#pds-personal-data-server" target="_blank" rel="noopener">PDS</a>.
-					public interactions (likes, comments) are written to the network.
+					this data is public and accessible via ATProto.
 				</li>
 				<li>
 					<strong>privacy:</strong> we don't sell your data or use it for ads.

--- a/frontend/src/routes/privacy/+page.svelte
+++ b/frontend/src/routes/privacy/+page.svelte
@@ -13,7 +13,7 @@
 <div class="legal-container">
 	<article class="legal-content">
 		<h1>privacy policy</h1>
-		<p class="last-updated">last updated: december 16, 2025</p>
+		<p class="last-updated">last updated: january 19, 2026</p>
 
 		<p class="intro">
 			this policy explains what data we collect, what's public by design on the AT Protocol,
@@ -27,13 +27,15 @@
 				for identity and social features. this has important implications:
 			</p>
 			<p>
-				<strong>public by design:</strong> your DID, handle, profile, tracks, likes, and comments
-				are stored on the decentralized AT Protocol network. this data is visible to anyone
-				on the network, not just {APP_NAME} users.
+				<strong>public by design:</strong> your DID, handle, profile, tracks, likes, comments,
+				and playlists are stored on your PDS (Personal Data Server) and remain under your
+				control. ATProto is a public data protocol—this data is accessible to any ATProto
+				application, not just {APP_NAME}.
 			</p>
 			<p>
-				<strong>external PDS:</strong> if your account is hosted on Bluesky's PDS or another
-				provider (not ours), we do not control that data. their privacy policies govern it.
+				<strong>your PDS:</strong> {APP_NAME} does not operate a PDS—we write records to
+				wherever your account is hosted (e.g., bsky.social or a self-hosted PDS). we do not
+				control that data; their privacy policies govern it.
 			</p>
 			<p>
 				<strong>private data:</strong> session tokens, preferences, and server logs are stored

--- a/frontend/src/routes/terms/+page.svelte
+++ b/frontend/src/routes/terms/+page.svelte
@@ -13,7 +13,7 @@
 <div class="legal-container">
 	<article class="legal-content">
 		<h1>terms of service</h1>
-		<p class="last-updated">last updated: december 16, 2025</p>
+		<p class="last-updated">last updated: january 19, 2026</p>
 
 		<p class="intro">
 			these terms govern your use of {APP_NAME}, a music streaming platform built on the


### PR DESCRIPTION
- remove 'transcode' claim (not implemented)
- clarify: audio files on our servers, track metadata on user's PDS
- 'written to the network' → 'stored on your PDS, public and accessible via ATProto'
- clarify plyr.fm does not operate a PDS—writes to user's existing PDS
- update last updated dates