### PR TITLE
fix: add proper privacy intro, MIT license, and email fallbacks

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Nathan Nowack
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/frontend/src/routes/privacy/+page.svelte
+++ b/frontend/src/routes/privacy/+page.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
-	import { APP_NAME } from '$lib/branding';
+	import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
 	import type { PageData } from './$types';
 
+	const FALLBACK_EMAIL = 'plyrdotfm@proton.me';
+
 	let { data } = $props<{ data: PageData }>();
+
+	const privacyEmail = data.privacyEmail || FALLBACK_EMAIL;
+	const contactEmail = data.contactEmail || FALLBACK_EMAIL;
 </script>
 
 <svelte:head>
@@ -16,7 +21,19 @@
 		<p class="last-updated">last updated: january 19, 2026</p>
 
 		<p class="intro">
-			this policy explains what data we collect, what's public by design on the AT Protocol,
+			{APP_NAME} ("we", "us", or "our") is a music streaming application built on the
+			<a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a>.
+			this privacy policy applies to the instance at
+			<a href={APP_CANONICAL_URL}>{APP_CANONICAL_URL}</a> (the "site").
+		</p>
+
+		<p class="intro">
+			{APP_NAME} is open source under the MIT license. other instances or derivatives
+			hosted elsewhere are not covered by this policy.
+		</p>
+
+		<p class="intro-secondary">
+			this policy explains what data we collect, what's public by design on ATProto,
 			and your rights.
 		</p>
 
@@ -84,7 +101,7 @@
 			<h2>6. security</h2>
 			<p>we use HTTPS, encrypt sensitive data, and use HttpOnly cookies. no system is
 				perfectly secure—report vulnerabilities to
-				<a href="mailto:{data.contactEmail}">{data.contactEmail}</a>.</p>
+				<a href="mailto:{contactEmail}">{contactEmail}</a>.</p>
 		</section>
 
 		<section>
@@ -101,7 +118,7 @@
 		<section class="contact">
 			<h2>contact</h2>
 			<p>
-				questions? <a href="mailto:{data.privacyEmail}">{data.privacyEmail}</a>
+				questions? <a href="mailto:{privacyEmail}">{privacyEmail}</a>
 			</p>
 		</section>
 
@@ -135,6 +152,12 @@
 	}
 
 	.intro {
+		font-size: 1.05rem;
+		color: var(--text-secondary);
+		margin-bottom: 1rem;
+	}
+
+	.intro-secondary {
 		font-size: 1.05rem;
 		color: var(--text-secondary);
 		margin-bottom: 2rem;

--- a/frontend/src/routes/terms/+page.svelte
+++ b/frontend/src/routes/terms/+page.svelte
@@ -2,7 +2,12 @@
 	import { APP_NAME } from '$lib/branding';
 	import type { PageData } from './$types';
 
+	const FALLBACK_EMAIL = 'plyrdotfm@proton.me';
+
 	let { data } = $props<{ data: PageData }>();
+
+	const contactEmail = data.contactEmail || FALLBACK_EMAIL;
+	const dmcaEmail = data.dmcaEmail || FALLBACK_EMAIL;
 </script>
 
 <svelte:head>
@@ -72,7 +77,7 @@
 			<address class="dmca-agent">
 				Nathan Nowack<br />
 				DMCA Registration: {data.dmcaRegistrationNumber}<br />
-				Email: <a href="mailto:{data.dmcaEmail}">{data.dmcaEmail}</a>
+				Email: <a href="mailto:{dmcaEmail}">{dmcaEmail}</a>
 			</address>
 			<p>we terminate accounts of repeat infringers.</p>
 			<p>
@@ -106,7 +111,7 @@
 		<section class="contact">
 			<h2>contact</h2>
 			<p>
-				questions? <a href="mailto:{data.contactEmail}">{data.contactEmail}</a>
+				questions? <a href="mailto:{contactEmail}">{contactEmail}</a>
 			</p>
 		</section>
 


### PR DESCRIPTION
## Summary

**Privacy policy:**
- Added smokesignal-style intro: `plyr.fm ("we", "us", or "our") is a music streaming application built on the AT Protocol. this privacy policy applies to the instance at https://plyr.fm (the "site").`
- Added note: `plyr.fm is open source under the MIT license. other instances or derivatives hosted elsewhere are not covered by this policy.`
- Added email fallbacks (`plyrdotfm@proton.me`) so contact info always displays even if config fetch fails

**Terms:**
- Added same email fallbacks for DMCA and contact sections

**LICENSE:**
- Added MIT license file to repo root

## Test plan

- [ ] /privacy renders with proper intro
- [ ] /privacy contact section shows email
- [ ] /terms contact and DMCA sections show emails
- [ ] LICENSE file exists at repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)