### PR TITLE
fix: standardize AT Protocol naming and add links

### DIFF
--- a/frontend/src/routes/privacy/+page.svelte
+++ b/frontend/src/routes/privacy/+page.svelte
@@ -33,7 +33,8 @@
 		</p>
 
 		<p class="intro-secondary">
-			this policy explains what data we collect, what's public by design on ATProto,
+			this policy explains what data we collect, what's public by design on the
+			<a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a>,
 			and your rights.
 		</p>
 
@@ -46,8 +47,8 @@
 			<p>
 				<strong>public by design:</strong> your DID, handle, profile, tracks, likes, comments,
 				and playlists are stored on your PDS (Personal Data Server) and remain under your
-				control. ATProto is a public data protocol—this data is accessible to any ATProto
-				application, not just {APP_NAME}.
+				control. the AT Protocol is a public data protocol—this data is accessible to any
+				AT Protocol application, not just {APP_NAME}.
 			</p>
 			<p>
 				<strong>your PDS:</strong> {APP_NAME} does not operate a PDS—we write records to
@@ -62,7 +63,7 @@
 
 		<section>
 			<h2>2. data we collect</h2>
-			<p><strong>you provide:</strong> your ATProto identity when you log in, audio files
+			<p><strong>you provide:</strong> your AT Protocol identity when you log in, audio files
 				and metadata you upload, and preferences like accent color.</p>
 			<p><strong>automatically:</strong> play counts, IP addresses, browser info, and
 				session cookies for authentication.</p>
@@ -78,12 +79,12 @@
 			<h2>4. third parties</h2>
 			<p>we use:</p>
 			<ul>
-				<li><strong>Cloudflare</strong> - CDN, storage (R2)</li>
-				<li><strong>Fly.io</strong> - backend hosting</li>
-				<li><strong>Neon</strong> - database</li>
-				<li><strong>Logfire</strong> - error monitoring</li>
-				<li><strong>AudD</strong> - audio fingerprinting for copyright detection</li>
-				<li><strong>Anthropic</strong> - image analysis for content moderation</li>
+				<li><strong><a href="https://cloudflare.com" target="_blank" rel="noopener">Cloudflare</a></strong> - CDN, storage (R2)</li>
+				<li><strong><a href="https://fly.io" target="_blank" rel="noopener">Fly.io</a></strong> - backend hosting</li>
+				<li><strong><a href="https://neon.tech" target="_blank" rel="noopener">Neon</a></strong> - database</li>
+				<li><strong><a href="https://logfire.pydantic.dev" target="_blank" rel="noopener">Logfire</a></strong> - error monitoring</li>
+				<li><strong><a href="https://audd.io" target="_blank" rel="noopener">AudD</a></strong> - audio fingerprinting for copyright detection</li>
+				<li><strong><a href="https://anthropic.com" target="_blank" rel="noopener">Anthropic</a></strong> - image analysis for content moderation</li>
 			</ul>
 		</section>
 
@@ -92,7 +93,7 @@
 			<p>you can access, correct, or delete your data through settings. when you delete your
 				account, we remove your files from our storage and your data from our database.</p>
 			<p>
-				<strong>we cannot delete:</strong> your DID (you control it), data on other ATProto
+				<strong>we cannot delete:</strong> your DID (you control it), data on other AT Protocol
 				servers, or records in other users' PDSes.
 			</p>
 		</section>

--- a/frontend/src/routes/terms/+page.svelte
+++ b/frontend/src/routes/terms/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { APP_NAME } from '$lib/branding';
+	import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
 	import type { PageData } from './$types';
 
 	const FALLBACK_EMAIL = 'plyrdotfm@proton.me';
@@ -21,23 +21,28 @@
 		<p class="last-updated">last updated: january 19, 2026</p>
 
 		<p class="intro">
-			these terms govern your use of {APP_NAME}, a music streaming platform built on the AT
-			Protocol. by using the service, you agree to these terms.
+			{APP_NAME} ("we", "us", or "our") is a music streaming application built on the
+			<a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a>.
+			these terms of service apply to the instance at
+			<a href={APP_CANONICAL_URL}>{APP_CANONICAL_URL}</a> (the "site").
+		</p>
+
+		<p class="intro">
+			{APP_NAME} is open source under the MIT license. other instances or derivatives
+			hosted elsewhere are not covered by these terms.
+		</p>
+
+		<p class="intro-secondary">
+			by using the service, you agree to these terms. if you disagree with any part,
+			you may not use the service.
 		</p>
 
 		<section>
-			<h2>1. acceptance of terms</h2>
+			<h2>1. accounts</h2>
 			<p>
-				by accessing or using {APP_NAME}, you agree to be bound by these terms. if you disagree with
-				any part, you may not use the service.
-			</p>
-		</section>
-
-		<section>
-			<h2>2. accounts</h2>
-			<p>
-				{APP_NAME} uses AT Protocol for authentication. your identity is your DID (decentralized identifier),
-				not an account we control. we do not store passwords.
+				{APP_NAME} uses the <a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a>
+				for authentication. your identity is your DID (decentralized identifier), not an account we
+				control. we do not store passwords.
 			</p>
 			<p>
 				we may terminate or suspend your access at any time, for any reason. termination removes
@@ -47,7 +52,7 @@
 		</section>
 
 		<section>
-			<h2>3. content</h2>
+			<h2>2. content</h2>
 			<p>
 				you retain ownership of content you upload. by uploading, you grant us a non-exclusive,
 				worldwide, royalty-free license to use, reproduce, modify, and distribute your content as
@@ -60,7 +65,7 @@
 		</section>
 
 		<section>
-			<h2>4. acceptable use</h2>
+			<h2>3. acceptable use</h2>
 			<p>you agree not to:</p>
 			<ul>
 				<li>violate any applicable laws</li>
@@ -72,7 +77,7 @@
 		</section>
 
 		<section>
-			<h2>5. copyright & DMCA</h2>
+			<h2>4. copyright & DMCA</h2>
 			<p>we respond to valid DMCA takedown notices. our designated agent is:</p>
 			<address class="dmca-agent">
 				Nathan Nowack<br />
@@ -81,15 +86,16 @@
 			</address>
 			<p>we terminate accounts of repeat infringers.</p>
 			<p>
-				<strong>AT Protocol limitation:</strong> audio files are stored in public blob storage that {APP_NAME}
-				controls and can remove at any time for policy violations. ATProto records referring to deleted
-				audio files may persist in user personal data servers (which {APP_NAME} does not control), but
-				{APP_NAME} will not provide access to violating or deleted content.
+				<strong><a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a> limitation:</strong>
+				audio files are stored in public blob storage that {APP_NAME} controls and can remove at any time
+				for policy violations. AT Protocol records referring to deleted audio files may persist in user
+				personal data servers (which {APP_NAME} does not control), but {APP_NAME} will not provide access
+				to violating or deleted content.
 			</p>
 		</section>
 
 		<section>
-			<h2>6. disclaimers</h2>
+			<h2>5. disclaimers</h2>
 			<p>
 				the service is provided "as is" and "as available" without warranties of any kind. we do not
 				guarantee uptime or that the service will be error-free.
@@ -101,7 +107,7 @@
 		</section>
 
 		<section>
-			<h2>7. changes</h2>
+			<h2>6. changes</h2>
 			<p>
 				we may update these terms. material changes will be posted with notice. continued use after
 				changes constitutes acceptance.
@@ -145,6 +151,12 @@
 	}
 
 	.intro {
+		font-size: 1.05rem;
+		color: var(--text-secondary);
+		margin-bottom: 1rem;
+	}
+
+	.intro-secondary {
 		font-size: 1.05rem;
 		color: var(--text-secondary);
 		margin-bottom: 2rem;


### PR DESCRIPTION
## Summary

**ToS:**
- Added formal intro matching privacy policy format:
  - `plyr.fm ("we", "us", or "our")` definition
  - Canonical URL reference (https://plyr.fm)
  - Open source under MIT license note
- Merged redundant "acceptance of terms" section into intro
- Renumbered sections (7 → 6 sections)
- Added links to atproto.com when mentioning AT Protocol
- Changed "ATProto" to "AT Protocol" for consistency

**Privacy:**
- Standardized "ATProto" → "AT Protocol" (4 instances)
- Added links to all third parties:
  - [Cloudflare](https://cloudflare.com)
  - [Fly.io](https://fly.io)
  - [Neon](https://neon.tech)
  - [Logfire](https://logfire.pydantic.dev)
  - [AudD](https://audd.io)
  - [Anthropic](https://anthropic.com)

## Test plan

- [ ] /terms renders correctly with new intro format
- [ ] /privacy third party links all work
- [ ] All atproto.com links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)