### PR TITLE
fix: terms overlay hangs after accepting

### DIFF
--- a/frontend/src/lib/account.svelte.ts
+++ b/frontend/src/lib/account.svelte.ts
@@ -1,0 +1,32 @@
+// account-level actions (terms acceptance, account deletion, etc.)
+import { browser } from '$app/environment';
+import { API_URL } from '$lib/config';
+import { auth } from '$lib/auth.svelte';
+import { preferences } from '$lib/preferences.svelte';
+
+class AccountManager {
+	async acceptTerms(): Promise<boolean> {
+		if (!browser || !auth.isAuthenticated) return false;
+
+		try {
+			const response = await fetch(`${API_URL}/account/accept-terms`, {
+				method: 'POST',
+				credentials: 'include'
+			});
+			if (response.ok) {
+				const data = await response.json();
+				// update preferences state so UI reacts
+				if (preferences.data) {
+					preferences.data = { ...preferences.data, terms_accepted_at: data.terms_accepted_at };
+				}
+				return true;
+			}
+			return false;
+		} catch (error) {
+			console.error('failed to accept terms:', error);
+			return false;
+		}
+	}
+}
+
+export const account = new AccountManager();

--- a/frontend/src/lib/components/TermsOverlay.svelte
+++ b/frontend/src/lib/components/TermsOverlay.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { APP_NAME } from '$lib/branding';
 	import { auth } from '$lib/auth.svelte';
-	import { preferences } from '$lib/preferences.svelte';
+	import { account } from '$lib/account.svelte';
 
 	let accepting = $state(false);
 	let error = $state<string | null>(null);
@@ -10,12 +10,12 @@
 		accepting = true;
 		error = null;
 
-		const success = await preferences.acceptTerms();
+		const success = await account.acceptTerms();
 
 		if (!success) {
 			error = 'failed to accept terms. please try again.';
-			accepting = false;
 		}
+		accepting = false;
 	}
 
 	async function handleDecline() {

--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -100,14 +100,6 @@ class PreferencesManager {
 		return this.data?.auto_download_liked ?? DEFAULT_PREFERENCES.auto_download_liked;
 	}
 
-	get termsAcceptedAt(): string | null {
-		return this.data?.terms_accepted_at ?? null;
-	}
-
-	get hasAcceptedTerms(): boolean {
-		return this.data?.terms_accepted_at !== null;
-	}
-
 	setAutoDownloadLiked(enabled: boolean): void {
 		if (browser) {
 			localStorage.setItem('autoDownloadLiked', enabled ? '1' : '0');
@@ -247,28 +239,6 @@ class PreferencesManager {
 	clear(): void {
 		this.data = null;
 		this.initialized = false;
-	}
-
-	async acceptTerms(): Promise<boolean> {
-		if (!browser || !auth.isAuthenticated) return false;
-
-		try {
-			const response = await fetch(`${API_URL}/account/accept-terms`, {
-				method: 'POST',
-				credentials: 'include'
-			});
-			if (response.ok) {
-				const data = await response.json();
-				if (this.data) {
-					this.data = { ...this.data, terms_accepted_at: data.terms_accepted_at };
-				}
-				return true;
-			}
-			return false;
-		} catch (error) {
-			console.error('failed to accept terms:', error);
-			return false;
-		}
 	}
 }
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -41,10 +41,11 @@
 
 	// show terms overlay if authenticated but hasn't accepted terms
 	// exclude legal pages so users can read full terms/privacy/cookies
+	// uses preferences.data (client state) since acceptTerms() updates it
 	let showTermsOverlay = $derived(
 		data.isAuthenticated &&
-		data.preferences &&
-		!data.preferences.terms_accepted_at &&
+		preferences.data &&
+		!preferences.data.terms_accepted_at &&
 		!$page.url.pathname.startsWith('/terms') &&
 		!$page.url.pathname.startsWith('/privacy') &&
 		!$page.url.pathname.startsWith('/cookies')


### PR DESCRIPTION
## Summary
- Fixed overlay hanging after clicking "I accept"
- `showTermsOverlay` was checking server layout data, but `acceptTerms()` updated client state
- Created `account.svelte.ts` for account-level actions
- Moved `acceptTerms()` out of preferences (it's not a preference)

## Test plan
- [ ] Click "I accept" on terms overlay
- [ ] Overlay should close immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)