### PR TITLE
fix: profile setup UX polish

### DIFF
--- a/frontend/src/routes/profile/setup/+page.svelte
+++ b/frontend/src/routes/profile/setup/+page.svelte
@@ -1,6 +1,5 @@
 
 <script lang="ts">
-	import { APP_NAME } from '$lib/branding';
 	import { onMount } from 'svelte';
 	import { invalidateAll, replaceState } from '$app/navigation';
 	import { API_URL } from '$lib/config';
@@ -129,7 +128,7 @@
 		<div class="setup-container">
 			<h1>set up your artist profile</h1>
 			<p class="subtitle">
-			welcome to {APP_NAME}! please set up your artist profile to start uploading audio.
+			one more step - set up your artist profile to start uploading audio.
 			</p>
 
 			{#if error}
@@ -298,6 +297,7 @@
 		color: white;
 		border: none;
 		border-radius: var(--radius-sm);
+		font-family: inherit;
 		font-size: var(--text-lg);
 		font-weight: 600;
 		cursor: pointer;


### PR DESCRIPTION
## Summary
- remove duplicate "welcome to plyr.fm" message (already shown in terms overlay, now says "one more step")
- fix "create profile" button font to use monospace like rest of app

## Test plan
- [ ] login with new account, accept terms, verify setup page no longer says "welcome to plyr.fm"
- [ ] verify "create profile" button uses monospace font

🤖 Generated with [Claude Code](https://claude.com/claude-code)