### PR TITLE
fix: capitalize sentence starts in legal docs

### DIFF
--- a/frontend/src/lib/components/TermsOverlay.svelte
+++ b/frontend/src/lib/components/TermsOverlay.svelte
@@ -13,7 +13,7 @@
 		const success = await account.acceptTerms();
 
 		if (!success) {
-			error = 'failed to accept terms. please try again.';
+			error = 'Failed to accept terms. Please try again.';
 		}
 		accepting = false;
 	}
@@ -34,22 +34,22 @@
 			<h2>Key Points</h2>
 			<ul>
 				<li>
-					<strong>your content:</strong> you own what you upload. audio files are stored
-					in public blob storage we control; track metadata is written to your PDS. delete
+					<strong>Your content:</strong> You own what you upload. Audio files are stored
+					in public blob storage we control; track metadata is written to your PDS. Delete
 					through {APP_NAME} and we remove the audio from storage.
 				</li>
 				<li>
-					<strong>copyright:</strong> don't upload content you don't have rights to.
-					we follow DMCA takedown procedures.
+					<strong>Copyright:</strong> Don't upload content you don't have rights to.
+					We follow DMCA takedown procedures.
 				</li>
 				<li>
-					<strong>AT Protocol:</strong> your identity and public data (likes, comments,
+					<strong>AT Protocol:</strong> Your identity and public data (likes, comments,
 					playlists) are stored on your
 					<a href="https://atproto.com/guides/glossary#pds-personal-data-server" target="_blank" rel="noopener">PDS</a>.
-					this data is public and accessible via ATProto.
+					This data is public and accessible via ATProto.
 				</li>
 				<li>
-					<strong>privacy:</strong> we don't sell your data or use it for ads.
+					<strong>Privacy:</strong> We don't sell your data or use it for ads.
 				</li>
 			</ul>
 		</div>
@@ -124,7 +124,6 @@
 		font-size: 0.9rem;
 		margin: 0 0 0.75rem 0;
 		color: var(--text-secondary);
-		text-transform: lowercase;
 	}
 
 	.terms-summary ul {

--- a/frontend/src/routes/privacy/+page.svelte
+++ b/frontend/src/routes/privacy/+page.svelte
@@ -23,17 +23,17 @@
 		<p class="intro">
 			{APP_NAME} ("we", "us", or "our") is a music streaming application built on the
 			<a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a>.
-			this privacy policy applies to the instance at
+			This privacy policy applies to the instance at
 			<a href={APP_CANONICAL_URL}>{APP_CANONICAL_URL}</a> (the "site").
 		</p>
 
 		<p class="intro">
-			{APP_NAME} is open source under the MIT license. other instances or derivatives
+			{APP_NAME} is open source under the MIT license. Other instances or derivatives
 			hosted elsewhere are not covered by this policy.
 		</p>
 
 		<p class="intro-secondary">
-			this policy explains what data we collect, what's public by design on the
+			This policy explains what data we collect, what's public by design on the
 			<a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a>,
 			and your rights.
 		</p>
@@ -42,37 +42,37 @@
 			<h2>1. The AT Protocol</h2>
 			<p>
 				{APP_NAME} uses the <a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a>
-				for identity and social features. this has important implications:
+				for identity and social features. This has important implications:
 			</p>
 			<p>
-				<strong>public by design:</strong> your DID, handle, profile, tracks, likes, comments,
+				<strong>Public by design:</strong> Your DID, handle, profile, tracks, likes, comments,
 				and playlists are stored on your PDS (Personal Data Server) and remain under your
-				control. the AT Protocol is a public data protocol—this data is accessible to any
+				control. The AT Protocol is a public data protocol—this data is accessible to any
 				AT Protocol application, not just {APP_NAME}.
 			</p>
 			<p>
-				<strong>your PDS:</strong> {APP_NAME} does not operate a PDS—we write records to
-				wherever your account is hosted (e.g., bsky.social or a self-hosted PDS). we do not
+				<strong>Your PDS:</strong> {APP_NAME} does not operate a PDS—we write records to
+				wherever your account is hosted (e.g., bsky.social or a self-hosted PDS). We do not
 				control that data; their privacy policies govern it.
 			</p>
 			<p>
-				<strong>private data:</strong> session tokens, preferences, and server logs are stored
+				<strong>Private data:</strong> Session tokens, preferences, and server logs are stored
 				only on our servers.
 			</p>
 		</section>
 
 		<section>
 			<h2>2. Data We Collect</h2>
-			<p><strong>you provide:</strong> your AT Protocol identity when you log in, audio files
+			<p><strong>You provide:</strong> Your AT Protocol identity when you log in, audio files
 				and metadata you upload, and preferences like accent color.</p>
-			<p><strong>automatically:</strong> play counts, IP addresses, browser info, and
+			<p><strong>Automatically:</strong> Play counts, IP addresses, browser info, and
 				session cookies for authentication.</p>
 		</section>
 
 		<section>
 			<h2>3. How We Use It</h2>
-			<p>we use your data to provide the service, maintain your session, and improve the
-				platform. we do not sell your data or use it for advertising.</p>
+			<p>We use your data to provide the service, maintain your session, and improve the
+				platform. We do not sell your data or use it for advertising.</p>
 		</section>
 
 		<section>
@@ -96,36 +96,36 @@
 
 		<section>
 			<h2>5. Your Rights</h2>
-			<p>you can access, correct, or delete your data through settings. when you delete your
+			<p>You can access, correct, or delete your data through settings. When you delete your
 				account, we remove your files from our storage and your data from our database.</p>
 			<p>
-				<strong>we cannot delete:</strong> your DID (you control it), data on other AT Protocol
+				<strong>We cannot delete:</strong> Your DID (you control it), data on other AT Protocol
 				servers, or records in other users' PDSes.
 			</p>
 		</section>
 
 		<section>
 			<h2>6. Security</h2>
-			<p>we use HTTPS, encrypt sensitive data, and use HttpOnly cookies. no system is
+			<p>We use HTTPS, encrypt sensitive data, and use HttpOnly cookies. No system is
 				perfectly secure—report vulnerabilities to
 				<a href="mailto:{contactEmail}">{contactEmail}</a>.</p>
 		</section>
 
 		<section>
 			<h2>7. Children</h2>
-			<p>{APP_NAME} is not for children under 13. we do not knowingly collect data from
+			<p>{APP_NAME} is not for children under 13. We do not knowingly collect data from
 				children.</p>
 		</section>
 
 		<section>
 			<h2>8. Changes</h2>
-			<p>we may update this policy. material changes will be posted with notice.</p>
+			<p>We may update this policy. Material changes will be posted with notice.</p>
 		</section>
 
 		<section class="contact">
 			<h2>Contact</h2>
 			<p>
-				questions? <a href="mailto:{privacyEmail}">{privacyEmail}</a>
+				Questions? <a href="mailto:{privacyEmail}">{privacyEmail}</a>
 			</p>
 		</section>
 

--- a/frontend/src/routes/terms/+page.svelte
+++ b/frontend/src/routes/terms/+page.svelte
@@ -23,17 +23,17 @@
 		<p class="intro">
 			{APP_NAME} ("we", "us", or "our") is a music streaming application built on the
 			<a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a>.
-			these terms of service apply to the instance at
+			These terms of service apply to the instance at
 			<a href={APP_CANONICAL_URL}>{APP_CANONICAL_URL}</a> (the "site").
 		</p>
 
 		<p class="intro">
-			{APP_NAME} is open source under the MIT license. other instances or derivatives
+			{APP_NAME} is open source under the MIT license. Other instances or derivatives
 			hosted elsewhere are not covered by these terms.
 		</p>
 
 		<p class="intro-secondary">
-			by using the service, you agree to these terms. if you disagree with any part,
+			By using the service, you agree to these terms. If you disagree with any part,
 			you may not use the service.
 		</p>
 
@@ -41,11 +41,11 @@
 			<h2>1. Accounts</h2>
 			<p>
 				{APP_NAME} uses the <a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a>
-				for authentication. your identity is your DID (decentralized identifier), not an account we
-				control. we do not store passwords.
+				for authentication. Your identity is your DID (decentralized identifier), not an account we
+				control. We do not store passwords.
 			</p>
 			<p>
-				we may terminate or suspend your access at any time, for any reason. termination removes
+				We may terminate or suspend your access at any time, for any reason. Termination removes
 				your content from {APP_NAME} but does not affect your DID or data on your PDS—we don't control
 				those.
 			</p>
@@ -54,40 +54,40 @@
 		<section>
 			<h2>2. Content</h2>
 			<p>
-				you retain ownership of content you upload. by uploading, you grant us a non-exclusive,
+				You retain ownership of content you upload. By uploading, you grant us a non-exclusive,
 				worldwide, royalty-free license to use, reproduce, modify, and distribute your content as
 				necessary to provide the service.
 			</p>
 			<p>
-				you represent that you own or have the necessary rights to the content you upload, and that
+				You represent that you own or have the necessary rights to the content you upload, and that
 				it does not infringe any third party's rights.
 			</p>
 		</section>
 
 		<section>
 			<h2>3. Acceptable Use</h2>
-			<p>you agree not to:</p>
+			<p>You agree not to:</p>
 			<ul>
-				<li>violate any applicable laws</li>
-				<li>infringe on others' rights</li>
-				<li>upload content that is illegal or infringes copyright</li>
-				<li>attempt unauthorized access to the service</li>
-				<li>interfere with or disrupt the service</li>
+				<li>Violate any applicable laws</li>
+				<li>Infringe on others' rights</li>
+				<li>Upload content that is illegal or infringes copyright</li>
+				<li>Attempt unauthorized access to the service</li>
+				<li>Interfere with or disrupt the service</li>
 			</ul>
 		</section>
 
 		<section>
 			<h2>4. Copyright & DMCA</h2>
-			<p>we respond to valid DMCA takedown notices. our designated agent is:</p>
+			<p>We respond to valid DMCA takedown notices. Our designated agent is:</p>
 			<address class="dmca-agent">
 				Nathan Nowack<br />
 				DMCA Registration: {data.dmcaRegistrationNumber}<br />
 				Email: <a href="mailto:{dmcaEmail}">{dmcaEmail}</a>
 			</address>
-			<p>we terminate accounts of repeat infringers.</p>
+			<p>We terminate accounts of repeat infringers.</p>
 			<p>
 				<strong><a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a> limitation:</strong>
-				audio files are stored in public blob storage that {APP_NAME} controls and can remove at any time
+				Audio files are stored in public blob storage that {APP_NAME} controls and can remove at any time
 				for policy violations. AT Protocol records referring to deleted audio files may persist in user
 				personal data servers (which {APP_NAME} does not control), but {APP_NAME} will not provide access
 				to violating or deleted content.
@@ -97,11 +97,11 @@
 		<section>
 			<h2>5. Disclaimers</h2>
 			<p>
-				the service is provided "as is" and "as available" without warranties of any kind. we do not
+				The service is provided "as is" and "as available" without warranties of any kind. We do not
 				guarantee uptime or that the service will be error-free.
 			</p>
 			<p>
-				we are not liable for any indirect, incidental, special, or consequential damages resulting
+				We are not liable for any indirect, incidental, special, or consequential damages resulting
 				from your use of the service.
 			</p>
 		</section>
@@ -109,14 +109,14 @@
 		<section>
 			<h2>6. Governing Law</h2>
 			<p>
-				these terms are governed by United States law, without regard to conflict-of-law provisions.
+				These terms are governed by United States law, without regard to conflict-of-law provisions.
 			</p>
 		</section>
 
 		<section>
 			<h2>7. Changes</h2>
 			<p>
-				we may update these terms. material changes will be posted with notice. continued use after
+				We may update these terms. Material changes will be posted with notice. Continued use after
 				changes constitutes acceptance.
 			</p>
 		</section>
@@ -124,7 +124,7 @@
 		<section class="contact">
 			<h2>Contact</h2>
 			<p>
-				questions? <a href="mailto:{contactEmail}">{contactEmail}</a>
+				Questions? <a href="mailto:{contactEmail}">{contactEmail}</a>
 			</p>
 		</section>
 


### PR DESCRIPTION
## Summary
- Capitalizes all sentence starts in privacy policy and terms of service
- Capitalizes list items and labels in TermsOverlay component
- Removes `text-transform: lowercase` CSS that was forcing headings to lowercase
- Capitalizes error message in TermsOverlay

## Test plan
- [ ] Visit /terms and /privacy pages, verify sentences start with capitals
- [ ] Trigger terms overlay (new user flow), verify list items are capitalized

🤖 Generated with [Claude Code](https://claude.com/claude-code)