### PR TITLE
feat: responsive embed v2 - container query units and width-first modes

### DIFF
--- a/frontend/src/routes/embed/track/[id]/+page.svelte
+++ b/frontend/src/routes/embed/track/[id]/+page.svelte
@@ -120,33 +120,62 @@
 		color: var(--text-primary);
 	}
 
+	/* ===========================================
+	   BASE STYLES - Default "wide rail" layout
+	   Art on left, content on right
+	   =========================================== */
 	.embed-container {
 		display: flex;
-		min-height: 165px;
 		height: 100%;
 		background: var(--bg-tertiary);
 		overflow: hidden;
 		position: relative;
 		container-type: size;
+
+		/* Scale tokens using container query units */
+		--pad: clamp(8px, 4cqi, 16px);
+		--gap: clamp(8px, 3cqi, 16px);
+		--play-size: clamp(32px, 12cqi, 52px);
+		--icon-size: clamp(16px, 6cqi, 26px);
+		--title-size: clamp(13px, 4.5cqi, 18px);
+		--artist-size: clamp(11px, 3.5cqi, 14px);
+		--time-size: clamp(10px, 3cqi, 12px);
+		--logo-size: clamp(8px, 2.5cqi, 12px);
 	}
 
-	/* background image - hidden on desktop */
+	/* Background image - hidden by default */
 	.bg-image {
 		display: none;
+		position: absolute;
+		inset: 0;
+		background-size: cover;
+		background-position: center;
+		filter: blur(24px);
+		transform: scale(1.3);
+		z-index: 0;
+		pointer-events: none;
 	}
 
+	/* Gradient overlay instead of flat color */
 	.bg-overlay {
 		display: none;
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(
+			to bottom,
+			rgba(0, 0, 0, 0.4) 0%,
+			rgba(0, 0, 0, 0.2) 40%,
+			rgba(0, 0, 0, 0.5) 100%
+		);
+		z-index: 0;
+		pointer-events: none;
 	}
 
+	/* Art container - percentage based sizing */
 	.art-container {
-		width: auto;
+		flex: 0 0 clamp(100px, 35cqi, 320px);
 		height: 100%;
-		aspect-ratio: 1;
-		flex-shrink: 0;
 		position: relative;
-		min-width: 120px;
-		max-width: 200px;
 	}
 
 	.art {
@@ -162,13 +191,14 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		font-size: 48px;
+		font-size: clamp(24px, 10cqi, 48px);
 		color: var(--text-muted);
 	}
 
+	/* Content area */
 	.content {
 		flex: 1;
-		padding: 16px;
+		padding: var(--pad);
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;
@@ -177,15 +207,17 @@
 		z-index: 1;
 	}
 
+	/* Header uses CSS grid for proper spacing */
 	.header {
-		display: flex;
-		align-items: flex-start;
-		gap: 16px;
+		display: grid;
+		grid-template-columns: auto 1fr auto;
+		gap: var(--gap);
+		align-items: start;
 	}
 
 	.play-btn {
-		width: 48px;
-		height: 48px;
+		width: var(--play-size);
+		height: var(--play-size);
 		border-radius: var(--radius-full);
 		background: #fff;
 		color: #000;
@@ -203,27 +235,27 @@
 	}
 
 	.icon {
-		width: 24px;
-		height: 24px;
+		width: var(--icon-size);
+		height: var(--icon-size);
 	}
 
+	/* Meta fills middle column */
 	.meta {
-		flex: 1;
 		min-width: 0;
-		padding-top: 4px;
-		padding-right: 60px; /* leave room for logo */
+		padding-top: 2px;
 	}
 
 	.title {
 		display: block;
-		font-size: 18px;
+		font-size: var(--title-size);
 		font-weight: 700;
-		margin: 0 0 4px;
+		margin: 0 0 2px;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		text-decoration: none;
 		color: var(--text-primary);
+		line-height: 1.3;
 	}
 
 	.title:hover {
@@ -232,61 +264,63 @@
 
 	.artist {
 		display: block;
-		font-size: 14px;
+		font-size: var(--artist-size);
 		color: var(--text-secondary);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		text-decoration: none;
+		line-height: 1.3;
 	}
 
 	.artist:hover {
 		text-decoration: underline;
 	}
 
+	/* Logo in grid column 3 */
 	.logo {
-		position: absolute;
-		top: 16px;
-		right: 16px;
-		font-size: 12px;
+		font-size: var(--logo-size);
 		font-weight: 700;
 		color: var(--border-emphasis);
 		text-decoration: none;
 		text-transform: uppercase;
-		letter-spacing: 1px;
+		letter-spacing: 0.5px;
+		white-space: nowrap;
+		padding-top: 4px;
 	}
 
 	.logo:hover {
 		color: var(--text-muted);
 	}
 
+	/* Player controls with flexible gaps */
 	.player-controls {
 		display: flex;
 		align-items: center;
-		gap: 12px;
-		margin-bottom: 4px;
+		gap: var(--gap);
 	}
 
 	.time {
-		font-size: 12px;
+		font-size: var(--time-size);
 		color: var(--text-tertiary);
 		font-variant-numeric: tabular-nums;
-		width: 35px;
+		min-width: 2.5em;
 		text-align: center;
 	}
 
 	.progress-bar {
 		flex: 1;
-		height: 24px; /* larger hit area */
+		height: clamp(20px, 6cqi, 28px);
 		display: flex;
 		align-items: center;
 		cursor: pointer;
 		position: relative;
+		min-width: 40px;
 	}
 
 	.progress-bg {
 		width: 100%;
-		height: 4px;
+		height: clamp(3px, 1cqi, 5px);
 		background: var(--border-default);
 		border-radius: 2px;
 	}
@@ -294,8 +328,9 @@
 	.progress-fill {
 		position: absolute;
 		left: 0;
-		top: 10px; /* (24 - 4) / 2 */
-		height: 4px;
+		top: 50%;
+		transform: translateY(-50%);
+		height: clamp(3px, 1cqi, 5px);
 		background: var(--text-primary);
 		border-radius: 2px;
 		pointer-events: none;
@@ -305,122 +340,139 @@
 		background: var(--accent);
 	}
 
-	/* square-ish container: stack artwork on top */
-	@container (aspect-ratio <= 1.5) and (min-height: 200px) {
-		.embed-container {
-			flex-direction: column;
-		}
-
-		.art-container {
-			width: 100%;
-			height: auto;
-			flex: 1;
-			min-height: 80px;
-			max-height: calc(100% - 100px); /* leave room for controls */
-		}
-
-		.art {
-			width: 100%;
-			height: 100%;
-			object-fit: cover;
-		}
-
-		.art-placeholder {
-			font-size: 36px;
-		}
-
-		.content {
-			flex: none;
-			padding: 12px 16px;
-		}
-
-		.header {
-			gap: 12px;
-		}
-
-		.play-btn {
-			width: 40px;
-			height: 40px;
-		}
-
-		.icon {
-			width: 20px;
-			height: 20px;
-		}
-
-		.meta {
-			padding-top: 2px;
-		}
-
-		.title {
-			font-size: 15px;
-			margin-bottom: 2px;
-		}
-
-		.artist {
-			font-size: 12px;
-		}
-
-		.logo {
-			top: auto;
-			bottom: auto;
-			font-size: 10px;
-		}
-
-		.player-controls {
-			margin-top: 8px;
-			margin-bottom: 0;
-			gap: 10px;
-		}
-
-		.time {
-			font-size: 11px;
-			width: 32px;
-		}
-	}
-
-	/* very square/tall: use blurred background like mobile */
-	@container (aspect-ratio <= 1) and (min-height: 165px) {
-		/* show blurred background */
+	/* ===========================================
+	   MODE: NARROW (width < 280px)
+	   Blurred background, compact controls
+	   =========================================== */
+	@container (max-width: 279px) {
 		.bg-image {
 			display: block;
-			position: absolute;
-			inset: 0;
-			background-size: cover;
-			background-position: center;
-			filter: blur(20px);
-			transform: scale(1.2);
-			z-index: 0;
-			pointer-events: none;
 		}
 
 		.bg-overlay {
 			display: block;
-			position: absolute;
-			inset: 0;
-			background: rgba(0, 0, 0, 0.3);
-			z-index: 0;
-			pointer-events: none;
 		}
 
-		/* hide side art for very square containers */
 		.art-container {
 			display: none;
 		}
 
 		.content {
-			flex: 1;
+			justify-content: center;
+			gap: var(--gap);
+		}
+
+		.title,
+		.artist {
+			color: #fff;
+			text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+		}
+
+		.artist {
+			color: rgba(255, 255, 255, 0.85);
+		}
+
+		.logo {
+			color: rgba(255, 255, 255, 0.5);
+		}
+
+		.logo:hover {
+			color: rgba(255, 255, 255, 0.75);
+		}
+
+		.time {
+			color: rgba(255, 255, 255, 0.6);
+		}
+
+		.progress-bg {
+			background: rgba(255, 255, 255, 0.25);
+		}
+
+		.progress-fill {
+			background: #fff;
+		}
+	}
+
+	/* ===========================================
+	   MODE: MICRO (width < 200px)
+	   Hide time labels, minimal UI
+	   =========================================== */
+	@container (max-width: 199px) {
+		.time {
+			display: none;
+		}
+
+		.header {
+			grid-template-columns: auto 1fr;
+		}
+
+		.logo {
+			display: none;
+		}
+	}
+
+	/* ===========================================
+	   MODE: SQUARE/TALL (aspect-ratio <= 1.2, width >= 200px)
+	   Art on top, content below, 2-line title
+	   =========================================== */
+	@container (aspect-ratio <= 1.2) and (min-width: 200px) and (min-height: 200px) {
+		.embed-container {
+			flex-direction: column;
+		}
+
+		.art-container {
+			flex: 1 1 auto;
+			width: 100%;
+			height: auto;
+			min-height: 0;
+		}
+
+		.content {
+			flex: 0 0 auto;
+			justify-content: flex-start;
+			gap: clamp(6px, 2cqi, 12px);
+		}
+
+		/* Allow 2-line title in tall layouts */
+		.title {
+			white-space: normal;
+			display: -webkit-box;
+			-webkit-line-clamp: 2;
+			line-clamp: 2;
+			-webkit-box-orient: vertical;
+			overflow: hidden;
+		}
+	}
+
+	/* ===========================================
+	   MODE: VERY TALL (aspect-ratio <= 0.7)
+	   Blurred background, larger art influence
+	   =========================================== */
+	@container (aspect-ratio <= 0.7) and (min-width: 200px) {
+		.bg-image {
+			display: block;
+		}
+
+		.bg-overlay {
+			display: block;
+		}
+
+		.art-container {
+			display: none;
+		}
+
+		.content {
 			justify-content: center;
 		}
 
-		.title {
+		.title,
+		.artist {
 			color: #fff;
-			text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+			text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
 		}
 
 		.artist {
-			color: rgba(255, 255, 255, 0.8);
-			text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+			color: rgba(255, 255, 255, 0.85);
 		}
 
 		.logo {
@@ -428,7 +480,7 @@
 		}
 
 		.logo:hover {
-			color: rgba(255, 255, 255, 0.7);
+			color: rgba(255, 255, 255, 0.75);
 		}
 
 		.time {
@@ -436,7 +488,7 @@
 		}
 
 		.progress-bg {
-			background: rgba(255, 255, 255, 0.2);
+			background: rgba(255, 255, 255, 0.25);
 		}
 
 		.progress-fill {
@@ -444,105 +496,27 @@
 		}
 	}
 
-	/* mobile: background image layout */
-	@media (max-width: 400px) {
-		.embed-container {
-			min-height: 165px;
-			height: 100%;
-			flex-direction: column;
-		}
-
-		/* show blurred background */
-		.bg-image {
-			display: block;
-			position: absolute;
-			inset: 0;
-			background-size: cover;
-			background-position: center;
-			filter: blur(20px);
-			transform: scale(1.2); /* prevent blur edges */
-			z-index: 0;
-			pointer-events: none;
-		}
-
-		.bg-overlay {
-			display: block;
-			position: absolute;
-			inset: 0;
-			background: rgba(0, 0, 0, 0.2);
-			z-index: 0;
-			pointer-events: none;
-		}
-
-		/* hide side art */
+	/* ===========================================
+	   MODE: WIDE (width >= 400px)
+	   Ensure art doesn't get too small
+	   =========================================== */
+	@container (min-width: 400px) {
 		.art-container {
-			display: none;
+			flex: 0 0 clamp(140px, 30cqi, 280px);
+		}
+	}
+
+	/* ===========================================
+	   MODE: VERY WIDE (width >= 600px)
+	   Larger art, more breathing room
+	   =========================================== */
+	@container (min-width: 600px) {
+		.art-container {
+			flex: 0 0 clamp(180px, 28cqi, 320px);
 		}
 
 		.content {
-			flex: 1;
-			padding: 16px;
-			justify-content: space-between;
-		}
-
-		.header {
-			gap: 12px;
-		}
-
-		.play-btn {
-			width: 44px;
-			height: 44px;
-		}
-
-		.icon {
-			width: 22px;
-			height: 22px;
-		}
-
-		.meta {
-			padding-right: 55px;
-		}
-
-		.title {
-			font-size: 16px;
-			color: #fff;
-			text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
-		}
-
-		.artist {
-			font-size: 13px;
-			color: rgba(255, 255, 255, 0.8);
-			text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
-		}
-
-		.logo {
-			top: 16px;
-			right: 16px;
-			font-size: 10px;
-			color: rgba(255, 255, 255, 0.5);
-			z-index: 2;
-		}
-
-		.logo:hover {
-			color: rgba(255, 255, 255, 0.7);
-		}
-
-		.player-controls {
-			gap: 10px;
-		}
-
-		.time {
-			font-size: 11px;
-			color: rgba(255, 255, 255, 0.6);
-			width: 32px;
-		}
-
-		.progress-bg {
-			background: rgba(255, 255, 255, 0.2);
-		}
-
-		.progress-fill {
-			background: #fff;
+			padding: clamp(16px, 4cqi, 24px);
 		}
 	}
 </style>


### PR DESCRIPTION
## Summary

Complete rewrite of embed CSS addressing feedback from the previous attempt. This implementation uses **width-first thresholds** and **container query units** for truly proportional scaling.

## Layout Modes

| Mode | Trigger | Behavior |
|------|---------|----------|
| **Wide** | width >= 400px | Side art, proportional sizing |
| **Very wide** | width >= 600px | Larger art, more breathing room |
| **Square/tall** | aspect <= 1.2, width >= 200px | Art on top, 2-line titles |
| **Very tall** | aspect <= 0.7, width >= 200px | Blurred background overlay |
| **Narrow** | width < 280px | Compact blurred background |
| **Micro** | width < 200px | Hide time labels + logo |

## Key Changes

- **Container query units**: All sizes use `clamp()` with `cqi` units (e.g., `--play-size: clamp(32px, 12cqi, 52px)`)
- **Grid header**: `grid-template-columns: auto 1fr auto` - no more absolute logo positioning
- **Percentage-based art**: `flex: 0 0 clamp(100px, 35cqi, 320px)` scales with container
- **Gradient overlay**: Top-heavy to bottom-heavy gradient instead of flat rgba
- **2-line titles**: `line-clamp: 2` in square/tall modes

## Test Matrix

Test at these sizes to verify behavior:
- 150×150 (micro)
- 200×200 (narrow/square)
- 240×160 (narrow/wide)
- 320×180 (medium/wide)
- 320×320 (square)
- 480×240 (wide)
- 640×240 (very wide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)