### PR TITLE
docs: fix documentation drift

### DIFF
--- a/docs/backend/background-tasks.md
+++ b/docs/backend/background-tasks.md
@@ -12,6 +12,8 @@ background tasks handle operations that shouldn't block the request/response cyc
 - **album list sync** - updates ATProto list records when album metadata changes
 - **PDS like/unlike** - syncs like records to user's PDS asynchronously
 - **PDS comment create/update/delete** - syncs comment records to user's PDS asynchronously
+- **move track audio** - moves files between public/private R2 buckets when support_gate is toggled
+- **sync copyright resolutions** (perpetual) - syncs copyright label resolutions from ATProto labeler every 5 minutes
 
 ## architecture
 


### PR DESCRIPTION
## summary

fixes documentation drift identified during docs audit:

**authentication.md** (HIGH priority)
- added `ensure_artist_exists()` to OAuth flow (step 5)
- documented why Artist records are created on login (handle display in share stats, likers, commenters)
- explained implementation location and how profile setup updates existing records

**state-management.md** (MEDIUM priority)
- added share link ref tracking section
- documented `ref` and `_refTrackId` state
- explained the guard against cross-track attribution

**background-tasks.md** (LOW priority)
- added `move_track_audio` task (support_gate bucket transitions)
- added `sync_copyright_resolutions` perpetual task

## context

audited docs after listen receipts and Artist record fix shipped. these were the only areas with meaningful drift.