### PR TITLE
chore: adopt loq for file size enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ simple-build.log
 # gemini
 .gemini/
 .gemini-clipboard/
+.loq_cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
 fail_fast: false
 
 repos:
+  - repo: https://github.com/jakekaplan/loq
+    rev: v0.1.0-alpha.7
+    hooks:
+      - id: loq
+
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.24.1
     hooks:

--- a/loq.toml
+++ b/loq.toml
@@ -1,0 +1,193 @@
+default_max_lines = 500
+respect_gitignore = true
+
+# paths, files, or glob patterns to exclude
+exclude = [
+    ".git/**",
+    ".status_history/**",
+]
+
+# lock files don't need line limits
+[[rules]]
+path = "**/*.lock"
+max_lines = 10000
+
+[[rules]]
+path = "**/package-lock.json"
+max_lines = 10000
+
+[[rules]]
+path = "backend/src/backend/_internal/auth.py"
+max_lines = 1207
+
+[[rules]]
+path = "backend/src/backend/_internal/background_tasks.py"
+max_lines = 938
+
+[[rules]]
+path = "backend/src/backend/api/albums.py"
+max_lines = 714
+
+[[rules]]
+path = "backend/src/backend/api/auth.py"
+max_lines = 706
+
+[[rules]]
+path = "backend/src/backend/api/lists.py"
+max_lines = 865
+
+[[rules]]
+path = "backend/src/backend/api/tracks/mutations.py"
+max_lines = 664
+
+[[rules]]
+path = "backend/src/backend/api/tracks/uploads.py"
+max_lines = 750
+
+[[rules]]
+path = "backend/src/backend/config.py"
+max_lines = 768
+
+[[rules]]
+path = "backend/src/backend/storage/r2.py"
+max_lines = 661
+
+[[rules]]
+path = "backend/tests/api/test_albums.py"
+max_lines = 917
+
+[[rules]]
+path = "backend/tests/api/test_list_record_sync.py"
+max_lines = 554
+
+[[rules]]
+path = "backend/tests/api/test_track_comments.py"
+max_lines = 517
+
+[[rules]]
+path = "backend/tests/test_auth.py"
+max_lines = 569
+
+[[rules]]
+path = "backend/tests/test_moderation.py"
+max_lines = 513
+
+[[rules]]
+path = "docs/authentication.md"
+max_lines = 627
+
+[[rules]]
+path = "docs/backend/liked-tracks.md"
+max_lines = 503
+
+[[rules]]
+path = "docs/deployment/database-migrations.md"
+max_lines = 629
+
+[[rules]]
+path = "docs/tools/neon.md"
+max_lines = 519
+
+[[rules]]
+path = "frontend/src/lib/components/AddToMenu.svelte"
+max_lines = 801
+
+[[rules]]
+path = "frontend/src/lib/components/ProfileMenu.svelte"
+max_lines = 1087
+
+[[rules]]
+path = "frontend/src/lib/components/Queue.svelte"
+max_lines = 599
+
+[[rules]]
+path = "frontend/src/lib/components/SearchModal.svelte"
+max_lines = 557
+
+[[rules]]
+path = "frontend/src/lib/components/TrackActionsMenu.svelte"
+max_lines = 777
+
+[[rules]]
+path = "frontend/src/lib/components/TrackItem.svelte"
+max_lines = 998
+
+[[rules]]
+path = "frontend/src/lib/components/UserMenu.svelte"
+max_lines = 622
+
+[[rules]]
+path = "frontend/src/lib/components/player/Player.svelte"
+max_lines = 566
+
+[[rules]]
+path = "frontend/src/lib/queue.svelte.ts"
+max_lines = 593
+
+[[rules]]
+path = "frontend/src/routes/+layout.svelte"
+max_lines = 676
+
+[[rules]]
+path = "frontend/src/routes/costs/+page.svelte"
+max_lines = 724
+
+[[rules]]
+path = "frontend/src/routes/embed/track/\\[id\\]/+page.svelte"
+max_lines = 522
+
+[[rules]]
+path = "frontend/src/routes/library/+page.svelte"
+max_lines = 633
+
+[[rules]]
+path = "frontend/src/routes/liked/+page.svelte"
+max_lines = 540
+
+[[rules]]
+path = "frontend/src/routes/playlist/\\[id\\]/+page.svelte"
+max_lines = 2168
+
+[[rules]]
+path = "frontend/src/routes/portal/+page.svelte"
+max_lines = 3313
+
+[[rules]]
+path = "frontend/src/routes/settings/+page.svelte"
+max_lines = 1409
+
+[[rules]]
+path = "frontend/src/routes/track/\\[id\\]/+page.svelte"
+max_lines = 1667
+
+[[rules]]
+path = "frontend/src/routes/u/\\[handle\\]/+page.svelte"
+max_lines = 1436
+
+[[rules]]
+path = "frontend/src/routes/u/\\[handle\\]/album/\\[slug\\]/+page.svelte"
+max_lines = 1293
+
+[[rules]]
+path = "frontend/src/routes/upload/+page.svelte"
+max_lines = 644
+
+[[rules]]
+path = "moderation/src/admin.rs"
+max_lines = 688
+
+[[rules]]
+path = "moderation/src/db.rs"
+max_lines = 1086
+
+[[rules]]
+path = "moderation/src/review.rs"
+max_lines = 526
+
+[[rules]]
+path = "moderation/static/admin.css"
+max_lines = 505
+
+[[rules]]
+path = "scripts/moderation_agent.py"
+max_lines = 628


### PR DESCRIPTION
## summary

adopts [loq](https://github.com/jakekaplan/loq) to enforce file line limits and prevent files from growing unbounded.

## what's included

- `loq.toml` config with:
  - default 500 line limit
  - baseline rules for 44 existing oversized files (locked at current size)
  - excludes `.git/`, `.status_history/`, lock files
- pre-commit hook to check on every commit
- `.gitignore` entry for `.loq_cache`

## tech debt flagged

biggest files that should eventually be refactored:

| file | lines |
|------|-------|
| `portal/+page.svelte` | 3,313 |
| `playlist/[id]/+page.svelte` | 2,168 |
| `track/[id]/+page.svelte` | 1,667 |
| `u/[handle]/+page.svelte` | 1,436 |
| `settings/+page.svelte` | 1,409 |

## upstream issue

found a bug in loq where `baseline` doesn't escape brackets in paths (common in SvelteKit routes).

- issue: https://github.com/jakekaplan/loq/issues/46
- fix PR: https://github.com/jakekaplan/loq/pull/47

workaround in this PR: manually escaped bracket paths in `loq.toml` (e.g., `routes/track/\[id\]/+page.svelte`)