### PR TITLE
fix: raise sensitive-images rate limit from 10 to 120/min

### DIFF
--- a/backend/src/backend/api/moderation.py
+++ b/backend/src/backend/api/moderation.py
@@ -23,7 +23,7 @@ class SensitiveImagesResponse(BaseModel):
 
 
 @router.get("/sensitive-images")
-@limiter.limit("10/minute")
+@limiter.limit("120/minute")
 async def get_sensitive_images(
     request: Request,
 ) -> SensitiveImagesResponse:


### PR DESCRIPTION
## Summary
- Raised `/moderation/sensitive-images` rate limit from 10/minute to 120/minute

## Problem
The endpoint is called on every page load via SvelteKit SSR (`+layout.server.ts`). Since Cloudflare Pages SSR requests all share the same IP addresses, the 10/minute limit was getting hit immediately during normal navigation, causing 429 errors and page load hangs.

## Investigation
Logfire traces showed multiple 429 responses at 19:22-19:23 during rapid navigation:
```
19:23:22.490 - 429
19:23:22.438 - 429  
19:23:22.382 - 429
19:23:17.634 - 429
```

## Future improvement
Consider adding server-side caching to the moderation client for sensitive images (they don't change frequently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)