### PR TITLE
docs: document audio persistence known issue in bluesky in-app browser

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -268,6 +268,7 @@ listen receipts shipped - share links now track who clicked and played. legal fo
 
 ### known issues
 - iOS PWA audio may hang on first play after backgrounding
+- audio may persist after closing bluesky in-app browser on iOS ([#779](https://github.com/zzstoatzz/plyr.fm/issues/779)) - user reported audio and lock screen controls continue after dismissing SFSafariViewController. expo-web-browser has a [known fix](https://github.com/expo/expo/issues/22406) that calls `dismissBrowser()` on close, and bluesky uses a version with the fix, but it didn't help in this case. we [opened an upstream issue](https://github.com/expo/expo/issues/42454) then closed it as duplicate after finding prior art. root cause unclear - may be iOS version specific or edge case timing issue.
 
 ### backlog
 - audio transcoding pipeline integration (#153) - transcoder service deployed, integration deferred


### PR DESCRIPTION
## summary

documents a known issue where audio may persist after closing bluesky's in-app browser on iOS.

## investigation summary

- user reported audio and lock screen controls continue after dismissing SFSafariViewController
- bluesky uses expo-web-browser which presents SFSafariViewController on iOS
- expo-web-browser had this exact bug ([#22406](https://github.com/expo/expo/issues/22406)) - fix was merged in 2023
- verified bluesky uses expo-web-browser ~15.0.10 which includes the fix
- fix calls `dismissBrowser()` in finally block, but didn't help in this case
- we [opened an upstream issue](https://github.com/expo/expo/issues/42454) then closed it as duplicate after finding prior art

## conclusion

root cause unclear. could be:
- iOS version specific
- edge case timing issue  
- user had older cached app version

without reproduction steps from the reporter (iOS version, bluesky app version), can't investigate further.

## changes

- adds known issue to STATUS.md with links to our issue and the upstream investigation

refs #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)