### PR TITLE
fix: check auth once on mount instead of every navigation

### DIFF
--- a/frontend/src/lib/auth.svelte.ts
+++ b/frontend/src/lib/auth.svelte.ts
@@ -16,12 +16,19 @@ class AuthManager {
 	isAuthenticated = $state(false);
 	loading = $state(true);
 	scopeUpgradeRequired = $state(false);
+	private initialized = false;
 
 	async initialize(): Promise<void> {
 		if (!browser) {
 			this.loading = false;
 			return;
 		}
+
+		// only fetch once - subsequent calls are no-ops
+		if (this.initialized) {
+			return;
+		}
+		this.initialized = true;
 
 		try {
 			const response = await fetch(`${API_URL}/auth/me`, {
@@ -61,6 +68,7 @@ class AuthManager {
 		if (!browser) return;
 		this.user = null;
 		this.isAuthenticated = false;
+		this.initialized = false;
 	}
 
 	async logout(): Promise<void> {

--- a/frontend/src/lib/moderation.svelte.ts
+++ b/frontend/src/lib/moderation.svelte.ts
@@ -64,6 +64,18 @@ class ModerationManager {
 		return checkImageSensitive(url, this.data);
 	}
 
+	/**
+	 * initialize from pre-fetched SSR data (avoids redundant API call)
+	 */
+	initializeFromData(ssrData: SensitiveImagesData): void {
+		if (this.initialized) return;
+		this.initialized = true;
+		this.data = {
+			image_ids: new Set(ssrData.image_ids || []),
+			urls: new Set(ssrData.urls || [])
+		};
+	}
+
 	async initialize(): Promise<void> {
 		if (!browser || this.initialized || this.loading) return;
 		this.initialized = true;

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,100 +1,14 @@
-import { browser } from '$app/environment';
-import { API_URL } from '$lib/config';
-import type { User } from '$lib/types';
-import type { Preferences } from '$lib/preferences.svelte';
 import type { SensitiveImagesData } from '$lib/moderation.svelte';
 import type { LoadEvent } from '@sveltejs/kit';
 
 export interface LayoutData {
-	user: User | null;
-	isAuthenticated: boolean;
-	preferences: Preferences | null;
 	sensitiveImages: SensitiveImagesData;
 }
 
-const DEFAULT_PREFERENCES: Preferences = {
-	accent_color: null,
-	auto_advance: true,
-	allow_comments: true,
-	hidden_tags: ['ai'],
-	theme: 'dark',
-	enable_teal_scrobbling: false,
-	teal_needs_reauth: false,
-	show_sensitive_artwork: false,
-	show_liked_on_profile: false,
-	support_url: null,
-	ui_settings: {},
-	auto_download_liked: false,
-	terms_accepted_at: null
-};
-
-export async function load({ fetch, data }: LoadEvent): Promise<LayoutData> {
-	const sensitiveImages = data?.sensitiveImages ?? { image_ids: [], urls: [] };
-
-	if (!browser) {
-		return {
-			user: null,
-			isAuthenticated: false,
-			preferences: null,
-			sensitiveImages
-		};
-	}
-
-	try {
-		const response = await fetch(`${API_URL}/auth/me`, {
-			credentials: 'include'
-		});
-
-		if (response.ok) {
-			const user = await response.json();
-
-			// fetch preferences in parallel once we know user is authenticated
-			let preferences: Preferences = { ...DEFAULT_PREFERENCES };
-			try {
-				const prefsResponse = await fetch(`${API_URL}/preferences/`, {
-					credentials: 'include'
-				});
-				if (prefsResponse.ok) {
-					const prefsData = await prefsResponse.json();
-					// auto_download_liked is stored locally, not on server
-					const storedAutoDownload = typeof localStorage !== 'undefined'
-						? localStorage.getItem('autoDownloadLiked') === '1'
-						: false;
-					preferences = {
-						accent_color: prefsData.accent_color ?? null,
-						auto_advance: prefsData.auto_advance ?? true,
-						allow_comments: prefsData.allow_comments ?? true,
-						hidden_tags: prefsData.hidden_tags ?? ['ai'],
-						theme: prefsData.theme ?? 'dark',
-						enable_teal_scrobbling: prefsData.enable_teal_scrobbling ?? false,
-						teal_needs_reauth: prefsData.teal_needs_reauth ?? false,
-						show_sensitive_artwork: prefsData.show_sensitive_artwork ?? false,
-						show_liked_on_profile: prefsData.show_liked_on_profile ?? false,
-						support_url: prefsData.support_url ?? null,
-						ui_settings: prefsData.ui_settings ?? {},
-						auto_download_liked: storedAutoDownload,
-						terms_accepted_at: prefsData.terms_accepted_at ?? null
-					};
-				}
-			} catch (e) {
-				console.error('preferences fetch failed:', e);
-			}
-
-			return {
-				user,
-				isAuthenticated: true,
-				preferences,
-				sensitiveImages
-			};
-		}
-	} catch (e) {
-		console.error('auth check failed:', e);
-	}
-
+// auth and preferences are handled client-side via singletons
+// this load function just passes through server data (sensitive images)
+export async function load({ data }: LoadEvent): Promise<LayoutData> {
 	return {
-		user: null,
-		isAuthenticated: false,
-		preferences: null,
-		sensitiveImages
+		sensitiveImages: data?.sensitiveImages ?? { image_ids: [], urls: [] }
 	};
 }

--- a/loq.toml
+++ b/loq.toml
@@ -126,7 +126,7 @@ max_lines = 593
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"
-max_lines = 676
+max_lines = 680
 
 [[rules]]
 path = "frontend/src/routes/costs/+page.svelte"


### PR DESCRIPTION
## problem

`+layout.ts` was calling `/auth/me` on **every client-side navigation**. for unauthenticated users browsing around, this generated repeated 401s:

```
visit homepage → /auth/me → 401
click track → /auth/me → 401
click another track → /auth/me → 401
...
```

logfire showed ~117 such requests in 24 hours - wasteful since auth state doesn't change from clicking around.

## solution

check auth once on initial page load, cache the result in singletons:

1. **auth singleton** - added `initialized` guard to prevent redundant `/auth/me` calls
2. **+layout.ts** - simplified to only pass through SSR data (sensitive images)
3. **+layout.svelte** - moved auth/prefs init from `$effect` (runs on every data change) to `onMount` (runs once)
4. **moderation singleton** - added `initializeFromData()` to use SSR data directly instead of re-fetching

## before/after

| request | before | after |
|---------|--------|-------|
| `/auth/me` | every navigation | once on mount |
| `/preferences/` | every navigation (if authed) | once on mount |
| `/moderation/sensitive-images` | SSR + client fetch | SSR only |

## testing

- `bun run check` passes
- navigating around as unauthenticated user should only make one `/auth/me` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)