### PR TITLE
fix: use auth singleton in library/liked pages after layout simplification

### DIFF
--- a/frontend/src/routes/library/+page.ts
+++ b/frontend/src/routes/library/+page.ts
@@ -1,6 +1,7 @@
 import { browser } from '$app/environment';
 import { redirect } from '@sveltejs/kit';
 import { API_URL } from '$lib/config';
+import { auth } from '$lib/auth.svelte';
 import type { LoadEvent } from '@sveltejs/kit';
 import type { Playlist, Track } from '$lib/types';
 
@@ -11,14 +12,14 @@ export interface PageData {
 
 export const ssr = false;
 
-export async function load({ parent, fetch }: LoadEvent): Promise<PageData> {
+export async function load({ fetch }: LoadEvent): Promise<PageData> {
 	if (!browser) {
 		return { likedCount: 0, playlists: [] };
 	}
 
-	// check auth from parent layout data
-	const { isAuthenticated } = await parent();
-	if (!isAuthenticated) {
+	// ensure auth is initialized before checking
+	await auth.initialize();
+	if (!auth.isAuthenticated) {
 		throw redirect(302, '/');
 	}
 

--- a/frontend/src/routes/liked/+page.ts
+++ b/frontend/src/routes/liked/+page.ts
@@ -1,8 +1,8 @@
 import { browser } from '$app/environment';
 import { redirect } from '@sveltejs/kit';
 import { fetchLikedTracks } from '$lib/tracks.svelte';
+import { auth } from '$lib/auth.svelte';
 import type { Track } from '$lib/types';
-import type { LoadEvent } from '@sveltejs/kit';
 
 export interface PageData {
 	tracks: Track[];
@@ -10,14 +10,14 @@ export interface PageData {
 
 export const ssr = false;
 
-export async function load({ parent }: LoadEvent): Promise<PageData> {
+export async function load(): Promise<PageData> {
 	if (!browser) {
 		return { tracks: [] };
 	}
 
-	// check auth from parent layout data
-	const { isAuthenticated } = await parent();
-	if (!isAuthenticated) {
+	// ensure auth is initialized before checking
+	await auth.initialize();
+	if (!auth.isAuthenticated) {
 		throw redirect(302, '/');
 	}
 


### PR DESCRIPTION
## Summary
- fixes library and liked pages not navigating after PR #781 merged
- pages were using `await parent()` to get `isAuthenticated` from layout data
- but layout no longer provides this after simplification (undefined = always redirect to /)
- now both pages use `await auth.initialize()` directly

## Test plan
- [ ] log in, click library button → should navigate to /library
- [ ] log in, click liked tracks → should navigate to /liked
- [ ] log out, navigate to /library or /liked directly → should redirect to /

🤖 Generated with [Claude Code](https://claude.com/claude-code)