### PR TITLE
feat: add lossless format support to data model

### DIFF
--- a/backend/alembic/versions/2026_01_25_012502_38dd0d1af1b7_add_original_file_columns_to_tracks.py
+++ b/backend/alembic/versions/2026_01_25_012502_38dd0d1af1b7_add_original_file_columns_to_tracks.py
@@ -1,0 +1,31 @@
+"""add_original_file_columns_to_tracks
+
+Revision ID: 38dd0d1af1b7
+Revises: 1a94c1ea171d
+Create Date: 2026-01-25 01:25:02.312562
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "38dd0d1af1b7"
+down_revision: str | Sequence[str] | None = "1a94c1ea171d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("tracks", sa.Column("original_file_id", sa.String(), nullable=True))
+    op.add_column("tracks", sa.Column("original_file_type", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("tracks", "original_file_type")
+    op.drop_column("tracks", "original_file_id")

--- a/backend/src/backend/_internal/audio.py
+++ b/backend/src/backend/_internal/audio.py
@@ -10,6 +10,8 @@ class AudioFormat(str, Enum):
     MP3 = "mp3"
     WAV = "wav"
     M4A = "m4a"
+    AIFF = "aiff"
+    FLAC = "flac"
 
     @property
     def extension(self) -> str:
@@ -23,8 +25,15 @@ class AudioFormat(str, Enum):
             AudioFormat.MP3: "audio/mpeg",
             AudioFormat.WAV: "audio/wav",
             AudioFormat.M4A: "audio/mp4",
+            AudioFormat.AIFF: "audio/aiff",
+            AudioFormat.FLAC: "audio/flac",
         }
         return media_types[self]
+
+    @property
+    def is_web_playable(self) -> bool:
+        """browsers can play this format natively (no transcoding needed)."""
+        return self in {AudioFormat.MP3, AudioFormat.WAV, AudioFormat.M4A}
 
     @classmethod
     def from_extension(cls, ext: str) -> Self | None:

--- a/backend/src/backend/models/track.py
+++ b/backend/src/backend/models/track.py
@@ -29,6 +29,10 @@ class Track(Base):
     title: Mapped[str] = mapped_column(String, nullable=False)
     file_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
     file_type: Mapped[str] = mapped_column(String, nullable=False)
+
+    # original file (for transcoded uploads - preserves lossless original for export)
+    original_file_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    original_file_type: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),

--- a/loq.toml
+++ b/loq.toml
@@ -42,7 +42,7 @@ max_lines = 664
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 750
+max_lines = 760
 
 [[rules]]
 path = "backend/src/backend/config.py"


### PR DESCRIPTION
## Summary

Phase 2 of transcoding integration - data model changes to support lossless formats:

- Add AIFF and FLAC to `AudioFormat` enum
- Add `is_web_playable` property (False for AIFF/FLAC, True for MP3/WAV/M4A)
- Add `original_file_id` and `original_file_type` columns to tracks table

These columns will store the original lossless file when a track is transcoded to a web-playable format, preserving the original for export.

## Test plan

- [x] Linting passes
- [x] Migration applies cleanly
- [x] `AudioFormat.AIFF.is_web_playable` returns `False`
- [x] `AudioFormat.MP3.is_web_playable` returns `True`
- [x] Track model has new columns

## Notes

- Upload pipeline still rejects AIFF/FLAC - that comes in phase 3
- Purely additive schema change (nullable columns)
- Safe to merge and deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)