### PR TITLE
feat: frontend support for lossless audio uploads

### DIFF
--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -69,6 +69,7 @@ export interface User {
 	did: string;
 	handle: string;
 	linked_accounts: LinkedAccount[];
+	enabled_flags: string[];
 }
 
 export interface Artist {

--- a/loq.toml
+++ b/loq.toml
@@ -170,7 +170,7 @@ max_lines = 1293
 
 [[rules]]
 path = "frontend/src/routes/upload/+page.svelte"
-max_lines = 644
+max_lines = 670
 
 [[rules]]
 path = "moderation/src/admin.rs"


### PR DESCRIPTION
## Summary
- Add `enabled_flags` to frontend User type
- Upload page dynamically accepts AIFF/FLAC when user has `lossless-uploads` flag
- Format hint updates based on user's available formats

## Test plan
- [ ] Enable `lossless-uploads` flag for test user
- [ ] Verify upload page shows "mp3, wav, m4a, aiff, flac" in format hint
- [ ] Upload an AIFF or FLAC file
- [ ] Verify transcoding works and track plays as MP3

🤖 Generated with [Claude Code](https://claude.com/claude-code)