### PR TITLE
fix: support .aif as alias for .aiff format

### DIFF
--- a/backend/src/backend/_internal/audio.py
+++ b/backend/src/backend/_internal/audio.py
@@ -39,6 +39,9 @@ class AudioFormat(str, Enum):
     def from_extension(cls, ext: str) -> Self | None:
         """get format from file extension (with or without dot)."""
         ext = ext.lower().lstrip(".")
+        # handle .aif as alias for .aiff
+        if ext == "aif":
+            ext = "aiff"
         for format in cls:
             if format.value == ext:
                 return format

--- a/backend/tests/test_audio_formats.py
+++ b/backend/tests/test_audio_formats.py
@@ -23,10 +23,13 @@ class TestAudioFormat:
             (".m4a", AudioFormat.M4A),
             ("m4a", AudioFormat.M4A),
             (".M4A", AudioFormat.M4A),
-            # aiff (lossless)
+            # aiff (lossless) - .aif is alias for .aiff
             (".aiff", AudioFormat.AIFF),
             ("aiff", AudioFormat.AIFF),
             (".AIFF", AudioFormat.AIFF),
+            (".aif", AudioFormat.AIFF),
+            ("aif", AudioFormat.AIFF),
+            (".AIF", AudioFormat.AIFF),
             # flac (lossless)
             (".flac", AudioFormat.FLAC),
             ("flac", AudioFormat.FLAC),
@@ -45,7 +48,6 @@ class TestAudioFormat:
             ".ogg",
             ".aac",
             ".wma",
-            ".aif",  # only .aiff is supported, not .aif
             "",
             "invalid",
         ],

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -16,8 +16,8 @@
 	const BASE_AUDIO_EXTENSIONS = [".mp3", ".wav", ".m4a"];
 	const BASE_AUDIO_MIME_TYPES = ["audio/mpeg", "audio/wav", "audio/mp4"];
 	// lossless formats (require transcoding, feature-flagged)
-	const LOSSLESS_EXTENSIONS = [".aiff", ".flac"];
-	const LOSSLESS_MIME_TYPES = ["audio/aiff", "audio/flac"];
+	const LOSSLESS_EXTENSIONS = [".aiff", ".aif", ".flac"];
+	const LOSSLESS_MIME_TYPES = ["audio/aiff", "audio/x-aiff", "audio/flac"];
 
 	// check if user has lossless uploads enabled
 	function hasLosslessUploads(): boolean {


### PR DESCRIPTION
## Summary
- Add `.aif` as alias for `.aiff` in backend AudioFormat
- Add `.aif` and `audio/x-aiff` mime type to frontend upload form
- Both extensions refer to the same Audio Interchange File Format

## Test plan
- [x] Backend tests pass (28 tests)
- [ ] Upload a `.aif` file in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)