### PR TITLE
fix: improve upload progress toast display

### DIFF
--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -288,7 +288,7 @@ async def _transcode_audio(
     await job_service.update_progress(
         upload_id,
         JobStatus.PROCESSING,
-        "transcoding audio (this may take a moment)...",
+        "transcoding audio...",
         phase="transcode",
         progress_pct=0.0,
     )

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -161,9 +161,10 @@ class UploaderState {
 
 						// show backend processing messages
 						if (update.message && update.status === 'processing') {
-							// if we have server-side progress, show it
+							// if we have meaningful server-side progress, show it
+							// (skip 0% as it looks wrong during phase transitions)
 							const serverProgress = update.server_progress_pct;
-							if (serverProgress !== undefined && serverProgress !== null) {
+							if (serverProgress !== undefined && serverProgress !== null && serverProgress > 0) {
 								toast.update(task.toastId, `${update.message} (${Math.round(serverProgress)}%)`);
 							} else {
 								toast.update(task.toastId, update.message);


### PR DESCRIPTION
## Summary
- Don't show 0% during phase transitions (looked awkward: "saving track metadata... (0%)")
- Shorten transcoding message from "transcoding audio (this may take a moment)..." to "transcoding audio..."

## Context
When uploading lossless files that need transcoding, the toast showed percentages at awkward times (0% during phase transitions) and had verbose messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)