### PR TITLE
fix: audio endpoint serves lossless originals when requested

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -53,6 +53,10 @@ path = "backend/src/backend/storage/r2.py"
 max_lines = 661
 
 [[rules]]
+path = "backend/tests/api/test_audio.py"
+max_lines = 650
+
+[[rules]]
 path = "backend/tests/api/test_albums.py"
 max_lines = 917
 


### PR DESCRIPTION
## Summary

- fixes 404 error when Safari requests lossless audio via `original_file_id`
- audio endpoint now queries by either `file_id` OR `original_file_id`
- when requesting `original_file_id`, serves the lossless file (aiff/flac)
- when requesting `file_id`, uses cached r2_url for transcoded version

## Test plan

- [x] existing audio tests pass (46 tests)
- [x] new regression tests for lossless file serving
- [ ] manually test in Safari on staging with transcoded track

🤖 Generated with [Claude Code](https://claude.com/claude-code)