### PR TITLE
test: add integration tests for lossless audio uploads

### DIFF
--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from .utils.audio import save_drone
+from .utils.audio import save_drone, save_drone_as
 
 if TYPE_CHECKING:
     from plyrfm import AsyncPlyrClient
@@ -144,4 +144,31 @@ def drone_c4(tmp_path: Path) -> Generator[Path, None, None]:
     """generate a 2-second C4 drone (262Hz)."""
     path = tmp_path / "drone_c4.wav"
     save_drone(path, "C4", duration_sec=2.0)
+    yield path
+
+
+# lossless format fixtures (require ffmpeg)
+
+
+@pytest.fixture
+def drone_flac(tmp_path: Path) -> Generator[Path, None, None]:
+    """generate a 2-second A4 drone as FLAC."""
+    path = tmp_path / "drone_a4.flac"
+    save_drone_as(path, "A4", duration_sec=2.0)
+    yield path
+
+
+@pytest.fixture
+def drone_aiff(tmp_path: Path) -> Generator[Path, None, None]:
+    """generate a 2-second A4 drone as AIFF."""
+    path = tmp_path / "drone_a4.aiff"
+    save_drone_as(path, "A4", duration_sec=2.0)
+    yield path
+
+
+@pytest.fixture
+def drone_aif(tmp_path: Path) -> Generator[Path, None, None]:
+    """generate a 2-second A4 drone as AIF (alias for AIFF)."""
+    path = tmp_path / "drone_a4.aif"
+    save_drone_as(path, "A4", duration_sec=2.0)
     yield path

--- a/backend/tests/integration/test_lossless_uploads.py
+++ b/backend/tests/integration/test_lossless_uploads.py
@@ -1,0 +1,86 @@
+"""integration tests for lossless audio uploads (FLAC, AIFF, AIF).
+
+these tests verify the transcoding pipeline:
+1. upload lossless format → transcoded to MP3 for browser playback
+2. if file_type is "mp3" after upload, transcoding succeeded
+
+requires:
+- ffmpeg installed (for generating test files)
+- test user must have 'lossless-uploads' feature flag enabled
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from plyrfm import AsyncPlyrClient
+
+pytestmark = [pytest.mark.integration, pytest.mark.timeout(180)]
+
+
+async def test_upload_flac(user1_client: AsyncPlyrClient, drone_flac: Path):
+    """upload FLAC file - should transcode to MP3."""
+    client = user1_client
+
+    result = await client.upload(
+        drone_flac,
+        "Test FLAC Upload",
+        tags={"integration-test", "lossless", "flac"},
+    )
+    track_id = result.track_id
+    assert track_id is not None
+
+    try:
+        track = await client.get_track(track_id)
+        assert track.title == "Test FLAC Upload"
+        # transcoded version is MP3 (proves transcoding worked)
+        assert track.file_type == "mp3", f"expected mp3, got {track.file_type}"
+
+    finally:
+        await client.delete(track_id)
+
+
+async def test_upload_aiff(user1_client: AsyncPlyrClient, drone_aiff: Path):
+    """upload AIFF file - should transcode to MP3."""
+    client = user1_client
+
+    result = await client.upload(
+        drone_aiff,
+        "Test AIFF Upload",
+        tags={"integration-test", "lossless", "aiff"},
+    )
+    track_id = result.track_id
+    assert track_id is not None
+
+    try:
+        track = await client.get_track(track_id)
+        assert track.title == "Test AIFF Upload"
+        assert track.file_type == "mp3", f"expected mp3, got {track.file_type}"
+
+    finally:
+        await client.delete(track_id)
+
+
+async def test_upload_aif(user1_client: AsyncPlyrClient, drone_aif: Path):
+    """upload AIF file (AIFF alias) - should transcode to MP3."""
+    client = user1_client
+
+    result = await client.upload(
+        drone_aif,
+        "Test AIF Upload",
+        tags={"integration-test", "lossless", "aif"},
+    )
+    track_id = result.track_id
+    assert track_id is not None
+
+    try:
+        track = await client.get_track(track_id)
+        assert track.title == "Test AIF Upload"
+        assert track.file_type == "mp3", f"expected mp3, got {track.file_type}"
+
+    finally:
+        await client.delete(track_id)


### PR DESCRIPTION
## Summary
- Adds integration tests for FLAC, AIFF, and AIF uploads
- Tests verify transcoding pipeline (lossless → MP3)
- Adds `save_drone_as()` utility to generate test files in any format via ffmpeg

## Test plan
- [ ] Merge to main → triggers staging deploy
- [ ] Integration tests run automatically after deploy
- [ ] Tests should pass if transcoding service is working

## Notes
- Test user (`zzstoatzz.io`) already has `lossless-uploads` feature flag on staging
- Tests require ffmpeg (available on ubuntu-latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)