### PR TITLE
fix: install ffmpeg for lossless integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -59,6 +59,10 @@ jobs:
         if: steps.check-tokens.outputs.has_tokens == 'true'
         run: cd backend && uv sync --locked
 
+      - name: install ffmpeg
+        if: steps.check-tokens.outputs.has_tokens == 'true'
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - name: run integration tests
         if: steps.check-tokens.outputs.has_tokens == 'true'
         env:


### PR DESCRIPTION
## Summary
- Adds ffmpeg installation step to integration tests workflow
- Required for generating FLAC/AIFF/AIF test files

## Test plan
- [ ] Merge and re-run integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)