### PR TITLE
feat: add links to moderation report cards

### DIFF
--- a/backend/src/backend/_internal/moderation_client.py
+++ b/backend/src/backend/_internal/moderation_client.py
@@ -258,6 +258,9 @@ class ModerationClient:
         target_type: str,
         target_id: str,
         reason: str,
+        reporter_handle: str | None = None,
+        target_name: str | None = None,
+        target_url: str | None = None,
         target_uri: str | None = None,
         description: str | None = None,
         screenshot_url: str | None = None,
@@ -269,6 +272,9 @@ class ModerationClient:
             target_type: type of entity (track, artist, album, playlist, tag, comment)
             target_id: ID of the entity being reported
             reason: reason for report (copyright, abuse, spam, explicit, other)
+            reporter_handle: handle of the user submitting the report
+            target_name: display name of the entity (e.g., "#explicit", "Song Title")
+            target_url: relative URL path to the entity (e.g., "/tag/explicit")
             target_uri: optional ATProto URI of the entity
             description: optional description from the reporter
             screenshot_url: optional URL of uploaded screenshot
@@ -286,6 +292,12 @@ class ModerationClient:
             "target_id": target_id,
             "reason": reason,
         }
+        if reporter_handle:
+            payload["reporter_handle"] = reporter_handle
+        if target_name:
+            payload["target_name"] = target_name
+        if target_url:
+            payload["target_url"] = target_url
         if target_uri:
             payload["target_uri"] = target_uri
         if description:

--- a/backend/src/backend/api/moderation.py
+++ b/backend/src/backend/api/moderation.py
@@ -47,6 +47,8 @@ class CreateReportRequest(BaseModel):
 
     target_type: Literal["track", "artist", "album", "playlist", "tag", "comment"]
     target_id: str = Field(..., min_length=1, max_length=100)
+    target_name: str | None = Field(None, max_length=200)
+    target_url: str | None = Field(None, max_length=200)
     reason: ReportReason
     description: str | None = Field(None, max_length=1000)
     screenshot_url: str | None = Field(None, max_length=500)
@@ -76,8 +78,11 @@ async def create_report(
     try:
         result = await client.create_report(
             reporter_did=session.did,
+            reporter_handle=session.handle,
             target_type=body.target_type,
             target_id=body.target_id,
+            target_name=body.target_name,
+            target_url=body.target_url,
             reason=body.reason.value,
             description=body.description,
             screenshot_url=body.screenshot_url,

--- a/frontend/src/lib/feedback.svelte.ts
+++ b/frontend/src/lib/feedback.svelte.ts
@@ -163,6 +163,21 @@ class FeedbackState {
 		}
 	}
 
+	getEntityUrl(entity: SearchResult): string {
+		switch (entity.type) {
+			case 'track':
+				return `/track/${entity.id}`;
+			case 'artist':
+				return `/u/${entity.handle}`;
+			case 'album':
+				return `/u/${entity.artist_handle}/album/${entity.slug}`;
+			case 'tag':
+				return `/tag/${entity.name}`;
+			case 'playlist':
+				return `/playlist/${entity.id}`;
+		}
+	}
+
 	canSubmit(): boolean {
 		return (
 			this.selectedEntity !== null &&
@@ -189,6 +204,8 @@ class FeedbackState {
 				body: JSON.stringify({
 					target_type: this.selectedEntity.type,
 					target_id: this.getEntityId(this.selectedEntity),
+					target_name: this.getEntityDisplayName(this.selectedEntity),
+					target_url: this.getEntityUrl(this.selectedEntity),
 					reason: this.reason,
 					description: this.description || null,
 					screenshot_url: this.screenshotUrl

--- a/loq.toml
+++ b/loq.toml
@@ -182,7 +182,7 @@ max_lines = 688
 
 [[rules]]
 path = "moderation/src/db.rs"
-max_lines = 1252
+max_lines = 1285
 
 [[rules]]
 path = "frontend/src/lib/components/FeedbackModal.svelte"
@@ -194,7 +194,11 @@ max_lines = 526
 
 [[rules]]
 path = "moderation/static/admin.css"
-max_lines = 745
+max_lines = 760
+
+[[rules]]
+path = "moderation/src/reports.rs"
+max_lines = 520
 
 [[rules]]
 path = "scripts/moderation_agent.py"

--- a/moderation/static/admin.css
+++ b/moderation/static/admin.css
@@ -722,6 +722,18 @@ h1 {
     border-color: var(--accent);
 }
 
+/* report links */
+.target-link,
+.reporter-link {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.target-link:hover,
+.reporter-link:hover {
+    text-decoration: underline;
+}
+
 /* mobile */
 @media (max-width: 640px) {
     body { padding: 16px; }


### PR DESCRIPTION
## Summary
- pass target_name, target_url, and reporter_handle through the entire report flow
- admin UI now displays meaningful links instead of raw IDs (e.g., "#explicit" instead of "tag: 2")
- reporter handles link to user profiles, target entities link to their pages
- adds idempotent ALTER TABLE statements for existing databases

## Test plan
- [ ] create a content report via the feedback modal
- [ ] verify the admin UI shows the entity name with a link
- [ ] verify the reporter shows as @handle with a profile link

🤖 Generated with [Claude Code](https://claude.com/claude-code)