### PR TITLE
polish login page copy and UX

### DIFF
--- a/backend/src/backend/api/auth.py
+++ b/backend/src/backend/api/auth.py
@@ -94,6 +94,7 @@ class PdsOption(BaseModel):
     url: str
     recommended: bool = False
     description: str | None = None
+    info_url: str | None = None
 
 
 class PdsOptionsResponse(BaseModel):
@@ -119,6 +120,7 @@ async def get_pds_options() -> PdsOptionsResponse:
                 url=str(pds.get("url", "")),
                 recommended=bool(pds.get("recommended", False)),
                 description=str(pds["description"]) if pds.get("description") else None,
+                info_url=str(pds["info_url"]) if pds.get("info_url") else None,
             )
             for pds in settings.account_creation.recommended_pds
         ],

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -775,6 +775,8 @@ class AccountCreationSettings(AppSettingsSection):
             {
                 "name": "selfhosted.social",
                 "url": "https://selfhosted.social",
+                "description": "free, community-run PDS",
+                "info_url": "https://selfhosted.social/info",
             },
         ],
         description="List of recommended PDS options for account creation",

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -11,6 +11,7 @@
 		url: string;
 		recommended: boolean;
 		description?: string;
+		info_url?: string;
 	}
 
 	let mode = $state<Mode>('signin');
@@ -113,13 +114,21 @@
 		<form onsubmit={startOAuth}>
 			{#if mode === 'signin'}
 				<div class="input-group">
-					<label for="handle">internet handle</label>
+					<label for="handle">
+						<a href="https://internethandle.org" target="_blank" rel="noopener" class="handle-label-link">internet handle</a>
+					</label>
 					<HandleAutocomplete
 						bind:value={handle}
 						onSelect={handleSelect}
 						placeholder="you.bsky.social"
 						disabled={loading}
 					/>
+					<div class="handle-hint">
+						<span>your @handle from</span>
+						<a href="https://bsky.app" target="_blank" rel="noopener" class="service-inline bluesky"><svg viewBox="0 0 600 530" width="12" height="11"><path d="m135.72 44.03c66.496 49.921 138.02 151.14 164.28 205.46 26.262-54.316 97.782-155.54 164.28-205.46 47.98-36.021 125.72-63.892 125.72 24.795 0 17.712-10.155 148.79-16.111 170.07-20.703 73.984-96.144 92.854-163.25 81.433 117.3 19.964 147.14 86.092 82.697 152.22-122.39 125.59-175.91-31.511-189.63-71.766-2.514-7.3797-3.6904-10.832-3.7077-7.8964-0.0174-2.9357-1.1937 0.51669-3.7077 7.8964-13.714 40.255-67.233 197.36-189.63 71.766-64.444-66.128-34.605-132.26 82.697-152.22-67.108 11.421-142.55-7.4491-163.25-81.433-5.9562-21.282-16.111-152.36-16.111-170.07 0-88.687 77.742-60.816 125.72-24.795z" fill="currentColor"/></svg> Bluesky</a>
+						<span>or</span>
+						<a href="https://blackskyweb.xyz" target="_blank" rel="noopener" class="service-inline blacksky"><svg viewBox="0 0 88 75" width="11" height="10" fill="currentColor"><path d="M41.9565 74.9643L24.0161 74.9653L41.9565 74.9643ZM63.8511 74.9653H45.9097L63.8501 74.9643V57.3286H63.8511V74.9653ZM45.9097 44.5893C45.9099 49.2737 49.7077 53.0707 54.3921 53.0707H63.8501V57.3286H54.3921C49.7077 57.3286 45.9099 61.1257 45.9097 65.81V74.9643H41.9565V65.81C41.9563 61.1258 38.1593 57.3287 33.4751 57.3286H24.0161V53.0707H33.4741C38.1587 53.0707 41.9565 49.2729 41.9565 44.5883V35.1303H45.9097V44.5893ZM63.8511 53.0707H63.8501V35.1303H63.8511V53.0707Z"/><path d="M52.7272 9.83198C49.4148 13.1445 49.4148 18.5151 52.7272 21.8275L59.4155 28.5158L56.4051 31.5262L49.7169 24.8379C46.4044 21.5254 41.0338 21.5254 37.7213 24.8379L31.2482 31.3111L28.4527 28.5156L34.9259 22.0424C38.2383 18.7299 38.2383 13.3594 34.9259 10.0469L28.2378 3.35883L31.2482 0.348442L37.9365 7.03672C41.2489 10.3492 46.6195 10.3492 49.932 7.03672L56.6203 0.348442L59.4155 3.14371L52.7272 9.83198Z"/><path d="M24.3831 23.2335C23.1706 27.7584 25.8559 32.4095 30.3808 33.6219L39.5172 36.07L38.4154 40.182L29.2793 37.734C24.7544 36.5215 20.1033 39.2068 18.8909 43.7317L16.5215 52.5745L12.7028 51.5513L15.0721 42.7088C16.2846 38.1839 13.5993 33.5328 9.07434 32.3204L-0.0620117 29.8723L1.03987 25.76L10.1762 28.2081C14.7011 29.4206 19.3522 26.7352 20.5647 22.2103L23.0127 13.074L26.8311 14.0971L24.3831 23.2335Z"/><path d="M67.3676 22.0297C68.5801 26.5546 73.2311 29.2399 77.756 28.0275L86.8923 25.5794L87.9941 29.6914L78.8578 32.1394C74.3329 33.3519 71.6476 38.003 72.86 42.5279L75.2294 51.3707L71.411 52.3938L69.0417 43.5513C67.8293 39.0264 63.1782 36.3411 58.6533 37.5535L49.5169 40.0016L48.415 35.8894L57.5514 33.4413C62.0763 32.2288 64.7616 27.5778 63.5492 23.0528L61.1011 13.9165L64.9195 12.8934L67.3676 22.0297Z"/></svg> Blacksky</a>
+					</div>
 				</div>
 
 				<button type="submit" class="primary" disabled={loading || !handle.trim()}>
@@ -127,7 +136,7 @@
 				</button>
 			{:else}
 				<div class="input-group">
-					<span class="input-label">pick a home on <a href="https://atproto.com" target="_blank" rel="noopener" class="atmosphere-link">the atmosphere</a></span>
+					<span class="input-label">choose a <a href="https://at-me.zzstoatzz.io/view/?handle=zzstoatzz.io" target="_blank" rel="noopener" class="home-link">home</a> for your data</span>
 					<div class="pds-options">
 						{#each pdsOptions as pds (pds.url)}
 							<label class="pds-option" class:selected={selectedPds === pds.url}>
@@ -146,17 +155,19 @@
 										{/if}
 									</div>
 									{#if pds.description}
-										<span class="pds-description">{pds.description}</span>
+										{#if pds.info_url}
+											<a href={pds.info_url} target="_blank" rel="noopener" class="pds-description-link" onclick={(e) => e.stopPropagation()}>{pds.description}</a>
+										{:else}
+											<span class="pds-description">{pds.description}</span>
+										{/if}
 									{/if}
 								</div>
 							</label>
 						{/each}
 					</div>
 					<p class="pds-note">
-						or sign up directly with
-						<a href="https://bsky.app" target="_blank" rel="noopener">Bluesky</a>
-						or
-						<a href="https://blackskyweb.xyz" target="_blank" rel="noopener">Blacksky</a>
+						<a href="https://bsky.app" target="_blank" rel="noopener" class="service-inline"><svg viewBox="0 0 600 530" width="12" height="11" fill="currentColor"><path d="m135.72 44.03c66.496 49.921 138.02 151.14 164.28 205.46 26.262-54.316 97.782-155.54 164.28-205.46 47.98-36.021 125.72-63.892 125.72 24.795 0 17.712-10.155 148.79-16.111 170.07-20.703 73.984-96.144 92.854-163.25 81.433 117.3 19.964 147.14 86.092 82.697 152.22-122.39 125.59-175.91-31.511-189.63-71.766-2.514-7.3797-3.6904-10.832-3.7077-7.8964-0.0174-2.9357-1.1937 0.51669-3.7077 7.8964-13.714 40.255-67.233 197.36-189.63 71.766-64.444-66.128-34.605-132.26 82.697-152.22-67.108 11.421-142.55-7.4491-163.25-81.433-5.9562-21.282-16.111-152.36-16.111-170.07 0-88.687 77.742-60.816 125.72-24.795z"/></svg> Bluesky</a> and
+						<a href="https://blackskyweb.xyz" target="_blank" rel="noopener" class="service-inline"><svg viewBox="0 0 88 75" width="11" height="10" fill="currentColor"><path d="M41.9565 74.9643L24.0161 74.9653L41.9565 74.9643ZM63.8511 74.9653H45.9097L63.8501 74.9643V57.3286H63.8511V74.9653ZM45.9097 44.5893C45.9099 49.2737 49.7077 53.0707 54.3921 53.0707H63.8501V57.3286H54.3921C49.7077 57.3286 45.9099 61.1257 45.9097 65.81V74.9643H41.9565V65.81C41.9563 61.1258 38.1593 57.3287 33.4751 57.3286H24.0161V53.0707H33.4741C38.1587 53.0707 41.9565 49.2729 41.9565 44.5883V35.1303H45.9097V44.5893ZM63.8511 53.0707H63.8501V35.1303H63.8511V53.0707Z"/><path d="M52.7272 9.83198C49.4148 13.1445 49.4148 18.5151 52.7272 21.8275L59.4155 28.5158L56.4051 31.5262L49.7169 24.8379C46.4044 21.5254 41.0338 21.5254 37.7213 24.8379L31.2482 31.3111L28.4527 28.5156L34.9259 22.0424C38.2383 18.7299 38.2383 13.3594 34.9259 10.0469L28.2378 3.35883L31.2482 0.348442L37.9365 7.03672C41.2489 10.3492 46.6195 10.3492 49.932 7.03672L56.6203 0.348442L59.4155 3.14371L52.7272 9.83198Z"/><path d="M24.3831 23.2335C23.1706 27.7584 25.8559 32.4095 30.3808 33.6219L39.5172 36.07L38.4154 40.182L29.2793 37.734C24.7544 36.5215 20.1033 39.2068 18.8909 43.7317L16.5215 52.5745L12.7028 51.5513L15.0721 42.7088C16.2846 38.1839 13.5993 33.5328 9.07434 32.3204L-0.0620117 29.8723L1.03987 25.76L10.1762 28.2081C14.7011 29.4206 19.3522 26.7352 20.5647 22.2103L23.0127 13.074L26.8311 14.0971L24.3831 23.2335Z"/><path d="M67.3676 22.0297C68.5801 26.5546 73.2311 29.2399 77.756 28.0275L86.8923 25.5794L87.9941 29.6914L78.8578 32.1394C74.3329 33.3519 71.6476 38.003 72.86 42.5279L75.2294 51.3707L71.411 52.3938L69.0417 43.5513C67.8293 39.0264 63.1782 36.3411 58.6533 37.5535L49.5169 40.0016L48.415 35.8894L57.5514 33.4413C62.0763 32.2288 64.7616 27.5778 63.5492 23.0528L61.1011 13.9165L64.9195 12.8934L67.3676 22.0297Z"/></svg> Blacksky</a> also host accounts.
 					</p>
 				</div>
 
@@ -173,63 +184,19 @@
 					onclick={() => (showHandleInfo = !showHandleInfo)}
 					aria-expanded={showHandleInfo}
 				>
-					<span>what is an internet handle?</span>
-					<svg
-						class="chevron"
-						class:open={showHandleInfo}
-						width="16"
-						height="16"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-					>
+					<span>new to <a href="https://atproto.com" target="_blank" rel="noopener" class="toggle-link" onclick={(e) => e.stopPropagation()}>the atmosphere</a>?</span>
+					<svg class="chevron" class:open={showHandleInfo} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 						<polyline points="6 9 12 15 18 9"></polyline>
 					</svg>
 				</button>
 				{#if showHandleInfo}
 					<div class="faq-content">
+						<p class="welcome">hey, welcome in! you'll need an account.</p>
 						<p>
-							your internet handle is a domain that identifies you across apps built on
-							<a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a>.
-							if you signed up for Bluesky or another ATProto service, you already have one
-							(like <code>yourname.bsky.social</code>).
-						</p>
-						<p>
-							read more at <a href="https://internethandle.org" target="_blank" rel="noopener">internethandle.org</a>.
-						</p>
-					</div>
-				{/if}
-
-				<button
-					class="faq-toggle"
-					onclick={() => (showPdsInfo = !showPdsInfo)}
-					aria-expanded={showPdsInfo}
-				>
-					<span>don't have one?</span>
-					<svg
-						class="chevron"
-						class:open={showPdsInfo}
-						width="16"
-						height="16"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-					>
-						<polyline points="6 9 12 15 18 9"></polyline>
-					</svg>
-				</button>
-				{#if showPdsInfo}
-					<div class="faq-content">
-						<p>
-							pick a home on the atmosphere &mdash;
 							{#if creationEnabled}
-								<button class="link-button" onclick={switchToCreate}>create an account</button>
-							{:else}
-								sign up for <a href="https://bsky.app" target="_blank" rel="noopener">Bluesky</a>
+								<button class="link-button" onclick={switchToCreate}>create one here</button>, or
 							{/if}
-							to get started.
+							sign up with <a href="https://bsky.app" target="_blank" rel="noopener">Bluesky</a> or <a href="https://blackskyweb.xyz" target="_blank" rel="noopener">Blacksky</a> and come back.
 						</p>
 					</div>
 				{/if}
@@ -351,7 +318,20 @@
 		font-size: var(--text-base);
 		& .atmosphere-link { color: var(--accent); text-decoration: none; }
 		& .atmosphere-link:hover { text-decoration: underline; }
+		& .handle-label-link { color: var(--text-secondary); text-decoration: none; border-bottom: 1px dashed var(--border-default); }
+		& .handle-label-link:hover { color: var(--text-primary); border-bottom-color: var(--text-tertiary); }
+		& .home-link { color: var(--accent); text-decoration: none; border-bottom: 1px solid var(--accent); }
+		& .home-link:hover { border-bottom-style: dashed; }
 	}
+
+	.handle-hint {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		font-size: var(--text-sm);
+		color: var(--text-tertiary);
+	}
+
 
 	button.primary {
 		width: 100%;
@@ -397,18 +377,13 @@
 		text-align: left;
 	}
 
-	.faq-toggle:hover {
-		color: var(--text-primary);
-	}
+	.faq-toggle:hover { color: var(--text-primary); }
 
-	.chevron {
-		transition: transform 0.2s;
-		flex-shrink: 0;
-	}
+	.toggle-link { color: inherit; text-decoration: none; border-bottom: 1px dashed var(--border-default); }
+	.toggle-link:hover { color: var(--accent); border-bottom-color: var(--accent); }
 
-	.chevron.open {
-		transform: rotate(180deg);
-	}
+	.chevron { transition: transform 0.2s; flex-shrink: 0; }
+	.chevron.open { transform: rotate(180deg); }
 
 	.faq-content {
 		padding: 0 0 1rem 0;
@@ -417,6 +392,7 @@
 		line-height: 1.6;
 		& p { margin: 0 0 0.75rem 0; text-align: left; }
 		& p:last-child { margin-bottom: 0; }
+		& p.welcome { color: var(--text-primary); font-weight: 500; }
 		& a { color: var(--accent); text-decoration: none; }
 		& a:hover { text-decoration: underline; }
 		& code { background: var(--bg-secondary); padding: 0.15rem 0.4rem; border-radius: var(--radius-sm); font-size: 0.85em; }
@@ -496,18 +472,31 @@
 		border-radius: var(--radius-sm);
 	}
 
-	.pds-description {
+	.pds-description, .pds-description-link {
 		font-size: var(--text-sm);
 		color: var(--text-tertiary);
 	}
 
+	.pds-description-link { text-decoration: none; }
+	.pds-description-link:hover { color: var(--accent); }
+
 	.pds-note {
 		margin: 0.75rem 0 0;
-		font-size: var(--text-sm);
+		font-size: var(--text-xs);
 		color: var(--text-tertiary);
 		text-align: center;
 		& a { color: var(--accent); text-decoration: none; }
 		& a:hover { text-decoration: underline; }
+	}
+
+
+	.service-inline {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		& svg { vertical-align: middle; }
+		&.bluesky:hover { color: #0085ff; }
+		&.blacksky:hover { color: #fff; }
 	}
 
 	.back-link {

--- a/loq.toml
+++ b/loq.toml
@@ -35,7 +35,7 @@ max_lines = 714
 
 [[rules]]
 path = "backend/src/backend/api/auth.py"
-max_lines = 784
+max_lines = 790
 
 [[rules]]
 path = "backend/src/backend/api/lists.py"
@@ -51,7 +51,7 @@ max_lines = 976
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 843
+max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"


### PR DESCRIPTION
## Summary
- **Sign-in page**: "internet handle" links to internethandle.org, added Bluesky/Blacksky with logos and names in hint, consolidated FAQ into "new to the atmosphere?" toggle with linked header
- **Create account page**: changed to "choose a home for your data" with visual explainer link, moved PDS description inside card with link to info page, added Bluesky/Blacksky note with logos
- **Backend**: added `info_url` field to PdsOption model and selfhosted.social config

## Test plan
- [ ] Verify sign-in page shows Bluesky/Blacksky with logos and names
- [ ] Verify "internet handle" links to internethandle.org
- [ ] Verify "the atmosphere" in FAQ header links to atproto.com
- [ ] Verify create account shows "choose a home for your data" with working link
- [ ] Verify selfhosted.social description links to info page
- [ ] Verify Blacksky logo displays correctly (geometric icon, not butterfly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)