### PR TITLE
rebrand: audio streaming app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # plyr.fm Developer Context
 
-**music streaming on AT Protocol**
+**audio streaming app**
 
 ## Reminders
 - i am already hot-reloading the backend and frontend. i might also have ngrok exposing 8001

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [plyr.fm](https://plyr.fm)
 
-music on [atproto](https://atproto.com)
+audio streaming app
 
 check the [plyr.fm artist page](https://plyr.fm/u/plyr.fm) for the latest [auto-generated](.github/workflows/status-maintenance.yml) development podcast!
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,14 +9,14 @@ FRONTEND_URL=http://localhost:5173
 # branding (optional)
 # backend branding settings
 # APP_NAME=plyr.fm
-# APP_TAGLINE=music streaming on atproto
+# APP_TAGLINE=audio streaming app
 # CANONICAL_HOST=plyr.fm
 # CANONICAL_URL_OVERRIDE=
 # BROADCAST_CHANNEL_PREFIX=plyr
 
 # frontend branding (requires VITE_ prefix for SvelteKit)
 # VITE_APP_NAME=plyr.fm
-# VITE_APP_TAGLINE=music streaming on atproto
+# VITE_APP_TAGLINE=audio streaming app
 # VITE_APP_CANONICAL_HOST=plyr.fm
 # VITE_APP_CANONICAL_URL=
 # VITE_APP_BROADCAST_PREFIX=plyr

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -105,7 +105,7 @@ class AppSettings(AppSettingsSection):
         description="Public-facing application name",
     )
     tagline: str = Field(
-        default="music streaming on atproto",
+        default="audio streaming app",
         description="Short marketing tagline for metadata",
     )
     debug: bool = Field(

--- a/frontend/src/lib/branding.ts
+++ b/frontend/src/lib/branding.ts
@@ -1,5 +1,5 @@
 const DEFAULT_APP_NAME = 'plyr.fm';
-const DEFAULT_TAGLINE = 'music on atproto';
+const DEFAULT_TAGLINE = 'audio streaming app';
 const DEFAULT_APP_STAGE = 'alpha';
 const DEFAULT_CANONICAL_HOST = 'plyr.fm';
 const DEFAULT_BROADCAST_PREFIX = 'plyr';

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -93,7 +93,7 @@
 
 <svelte:head>
 	<title>{APP_NAME} - {APP_TAGLINE}</title>
-	<meta name="description" content="discover and stream music on the atproto network" />
+	<meta name="description" content={APP_TAGLINE} />
 
 	<!-- Open Graph / Facebook -->
 	<meta property="og:type" content="website" />

--- a/frontend/src/routes/privacy/+page.svelte
+++ b/frontend/src/routes/privacy/+page.svelte
@@ -21,7 +21,7 @@
 		<p class="last-updated">Last updated: January 20, 2026</p>
 
 		<p class="intro">
-			{APP_NAME} ("we", "us", or "our") is a music streaming application built on the
+			{APP_NAME} ("we", "us", or "our") is an audio streaming application built on the
 			<a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a>.
 			This privacy policy applies to the instance at
 			<a href={APP_CANONICAL_URL}>{APP_CANONICAL_URL}</a> (the "site").

--- a/frontend/src/routes/terms/+page.svelte
+++ b/frontend/src/routes/terms/+page.svelte
@@ -21,7 +21,7 @@
 		<p class="last-updated">Last updated: January 20, 2026</p>
 
 		<p class="intro">
-			{APP_NAME} ("we", "us", or "our") is a music streaming application built on the
+			{APP_NAME} ("we", "us", or "our") is an audio streaming application built on the
 			<a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a>.
 			These terms of service apply to the instance at
 			<a href={APP_CANONICAL_URL}>{APP_CANONICAL_URL}</a> (the "site").

--- a/moderation/src/handlers.rs
+++ b/moderation/src/handlers.rs
@@ -135,7 +135,7 @@ pub async fn landing(State(state): State<AppState>) -> Html<String> {
     <p class="subtitle">ATProto labeler for audio content moderation</p>
 
     <p>This service provides content labels for <a href="https://plyr.fm">plyr.fm</a>,
-    the music streaming platform on ATProto.</p>
+    the audio streaming app.</p>
 
     <p><strong>Labeler DID:</strong> <code>{}</code></p>
 


### PR DESCRIPTION
## Summary
- drops redundant "on ATProto" (like HTTP, it's the fundamental layer now)
- changes "music" to "audio" to encourage podcasts and other audio content

## Changes
- frontend tagline: `'music on atproto'` → `'audio streaming app'`
- homepage meta description now uses `APP_TAGLINE` variable
- terms/privacy: "music streaming application" → "audio streaming application"  
- backend config default tagline
- moderation service landing page
- README and AGENTS.md

## Verified
- no explicit `APP_TAGLINE` set on Fly.io prod/staging (using defaults)
- new default will take effect on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)