### PR TITLE
chore: mirror to tangled on release

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -115,6 +115,10 @@ def main() -> int:
 
     print("✓ production frontend deployment starting...")
 
+    # mirror to tangled
+    subprocess.run(["git", "push", "tangled", "main", "--tags"], check=True)
+    print("✓ mirrored to tangled")
+
     return 0
 
 


### PR DESCRIPTION
## Summary
- adds `git push tangled main --tags` to the release script
- ensures tangled mirror stays in sync automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)