### PR TITLE
fix: update atproto to fix headers lost on DPoP retry

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -302,8 +302,8 @@ wheels = [
 
 [[package]]
 name = "atproto"
-version = "0.0.1.dev473"
-source = { git = "https://github.com/zzstoatzz/atproto?rev=main#d58ffbc2360d0070d30737aa109bbc5619e196ee" }
+version = "0.0.1.dev474"
+source = { git = "https://github.com/zzstoatzz/atproto?rev=main#d3f6a3d2862f7916bf937547433ccab1b23a0007" }
 dependencies = [
     { name = "click" },
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Updates atproto fork to include fix for PDS blob uploads failing with "Content-Type required but not provided".

## Problem

When uploading blobs to PDS, the OAuth client would lose the `Content-Type` header on DPoP nonce retry, causing:
```
400 {"error":"InvalidRequest","message":"Request encoding (Content-Type) required but not provided"}
```

## Fix

https://github.com/zzstoatzz/atproto/pull/9 - extract headers before retry loop

## Test plan

- [ ] Upload track on staging, verify PDS blob upload succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)