### PR TITLE
feat: add blob scope for PDS uploads

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -482,6 +482,7 @@ class AtprotoSettings(AppSettingsSection):
 
         # fallback: granular repo scopes for each collection
         scopes = [
+            "blob:*/*",  # upload blobs to user's PDS
             f"repo:{self.track_collection}",
             f"repo:{self.like_collection}",
             f"repo:{self.comment_collection}",


### PR DESCRIPTION
## Summary
- Add `blob:*/*` to OAuth scope so authenticated users can upload blobs to their PDS

This was missing from the PDS blob storage implementation in #823, causing uploads to fail with permission errors.

## Test plan
- [ ] Deploy to staging
- [ ] Test upload flow - should now successfully upload to PDS

🤖 Generated with [Claude Code](https://claude.com/claude-code)