### PR TITLE
fix: add blob scope to permission sets path

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -477,8 +477,9 @@ class AtprotoSettings(AppSettingsSection):
             return self.scope_override
 
         # use permission sets if enabled (requires lexicons to be published)
+        # blob scope must be requested directly (can't be in permission sets)
         if self.use_permission_sets:
-            return f"atproto include:{self.app_namespace}.authFullApp"
+            return f"atproto blob:*/* include:{self.app_namespace}.authFullApp"
 
         # fallback: granular repo scopes for each collection
         scopes = [


### PR DESCRIPTION
## Summary
- Add `blob:*/*` to the permission sets code path

The previous PR #826 only added the blob scope to the granular scopes fallback, but staging uses permission sets. Blob permissions can't be included in permission sets per atproto spec, so they must be requested directly.

## Test plan
- [ ] Deploy to staging
- [ ] Re-authenticate and verify blob scope appears in consent screen
- [ ] Test upload to PDS

🤖 Generated with [Claude Code](https://claude.com/claude-code)