### PR TITLE
chore: remove pds indicator from track UI

### DIFF
--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -368,16 +368,6 @@
 						{/if}
 					</span>
 				{/if}
-				{#if track.audio_storage === 'both' || track.audio_storage === 'pds'}
-					<span class="meta-separator">•</span>
-					<span class="pds-indicator" title="stored on PDS">
-						<svg width="12" height="12" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-							<circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.5" fill="none"/>
-							<path d="M5 8l2 2 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-						</svg>
-						<span class="pds-label">pds</span>
-					</span>
-				{/if}
 			</div>
 		</div>
 	</button>
@@ -925,31 +915,6 @@
 
 	.comment-count {
 		font-family: inherit;
-	}
-
-	.pds-indicator {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.25rem;
-		color: var(--text-tertiary);
-		cursor: help;
-		transition: color 0.2s;
-	}
-
-	.pds-indicator:hover {
-		color: var(--accent);
-	}
-
-	.pds-indicator svg {
-		width: 12px;
-		height: 12px;
-		flex-shrink: 0;
-	}
-
-	.pds-label {
-		font-family: inherit;
-		font-size: inherit;
-		text-transform: lowercase;
 	}
 
 	.action-button {

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -646,16 +646,6 @@ $effect(() => {
 								{/if}
 							</span>
 						{/if}
-						{#if track.audio_storage === 'both' || track.audio_storage === 'pds'}
-							<span class="separator">•</span>
-							<span class="pds-indicator" title="stored on PDS">
-								<svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-									<circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.5" fill="none"/>
-									<path d="M5 8l2 2 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-								</svg>
-								<span class="pds-label">pds</span>
-							</span>
-						{/if}
 					</div>
 
 					<div class="side-buttons">
@@ -1060,28 +1050,6 @@ $effect(() => {
 		background: color-mix(in srgb, var(--accent) 15%, transparent);
 		color: var(--accent);
 		outline: none;
-	}
-
-	.track-stats .pds-indicator {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.25rem;
-		cursor: help;
-		transition: color 0.2s;
-	}
-
-	.track-stats .pds-indicator:hover {
-		color: var(--accent);
-	}
-
-	.track-stats .pds-indicator svg {
-		flex-shrink: 0;
-	}
-
-	.track-stats .pds-label {
-		font-family: inherit;
-		font-size: inherit;
-		text-transform: lowercase;
 	}
 
 	.track-tags {


### PR DESCRIPTION
## Summary
- Remove the "pds" indicator from track detail page and track list items

PDS storage will be the default eventually, no need to call it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)