### PR TITLE
fix: remove confidence score from copyright DM notifications

### DIFF
--- a/backend/src/backend/_internal/notifications.py
+++ b/backend/src/backend/_internal/notifications.py
@@ -198,7 +198,6 @@ class NotificationService:
             artist_message = (
                 f"⚠️ copyright notice for your track on {settings.app.name}\n\n"
                 f"track: '{track_title}'\n"
-                f"match confidence: {highest_score}%\n"
             )
             if primary_match:
                 artist_message += f"potential match: {primary_match}\n"
@@ -212,7 +211,6 @@ class NotificationService:
                 f"🚨 copyright flag on {settings.app.name}\n\n"
                 f"track: '{track_title}'\n"
                 f"artist: @{artist_handle}\n"
-                f"score: {highest_score}%\n"
                 f"matches: {match_count}\n"
             )
             if primary_match:


### PR DESCRIPTION
## Summary
- Remove misleading "match confidence: 0%" from artist DM and "score: 0%" from admin DM
- The enterprise AudD API doesn't return confidence values, so displaying them was incorrect

Closes #830

## Test plan
- [ ] Trigger a copyright flag on a track in staging
- [ ] Verify the DM no longer includes confidence/score lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)