### PR TITLE
fix: remove R2 impl detail from user-facing copy

### DIFF
--- a/frontend/src/lib/components/PdsAudioUploadsToggle.svelte
+++ b/frontend/src/lib/components/PdsAudioUploadsToggle.svelte
@@ -23,7 +23,7 @@
 	<div class="setting-row">
 		<div class="setting-info">
 			<h3>store audio on your pds</h3>
-			<p>attempt to store uploaded audio blobs on your pds (falls back to r2 if too large)</p>
+			<p>store uploaded audio on your pds (falls back to plyr.fm storage if too large)</p>
 		</div>
 		<label class="toggle-switch">
 			<input type="checkbox" checked={enabled} onchange={handleToggle} />

--- a/frontend/src/lib/components/PdsUploadNote.svelte
+++ b/frontend/src/lib/components/PdsUploadNote.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
 	import { auth } from "$lib/auth.svelte";
 	import { PDS_AUDIO_UPLOADS_FLAG } from "$lib/config";
+	import { preferences } from "$lib/preferences.svelte";
+
+	let hasFlag = $derived(auth.user?.enabled_flags?.includes(PDS_AUDIO_UPLOADS_FLAG) ?? false);
+	let enabled = $derived(preferences.uiSettings.pds_audio_uploads_enabled ?? false);
 </script>
 
-{#if auth.user?.enabled_flags?.includes(PDS_AUDIO_UPLOADS_FLAG)}
+{#if hasFlag && !enabled}
 	<p class="pds-note">
 		pds audio uploads available in <a href="/settings">settings</a>
 	</p>
+{:else if hasFlag && enabled}
+	<p class="pds-note">uploads will be stored on your pds</p>
 {/if}
 
 <style>


### PR DESCRIPTION
## Summary
- settings toggle: "falls back to r2" → "falls back to plyr.fm storage"
- upload note: state-aware — shows settings nudge when off, confirmation when on

🤖 Generated with [Claude Code](https://claude.com/claude-code)