### PR TITLE
fix: gate PDS backfill behind pds-audio-uploads feature flag

### DIFF
--- a/frontend/src/lib/components/PdsBackfillControl.svelte
+++ b/frontend/src/lib/components/PdsBackfillControl.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import PdsMigrationModal from './PdsMigrationModal.svelte';
-	import { API_URL } from '$lib/config';
+	import { API_URL, PDS_AUDIO_UPLOADS_FLAG } from '$lib/config';
+	import { auth } from '$lib/auth.svelte';
 	import { toast } from '$lib/toast.svelte';
 	import type { Track } from '$lib/types';
 
@@ -14,6 +15,8 @@
 
 	let showModal = $state(false);
 	let migrating = $state(false);
+
+	let hasFlag = $derived(auth.user?.enabled_flags?.includes(PDS_AUDIO_UPLOADS_FLAG) ?? false);
 
 	let backfillableTrackCount = $derived(
 		tracks.filter(
@@ -95,7 +98,7 @@
 	}
 </script>
 
-{#if backfillableTrackCount > 0}
+{#if hasFlag && backfillableTrackCount > 0}
 	<div class="data-control">
 		<div class="control-info">
 			<h3>migrate audio to your PDS</h3>


### PR DESCRIPTION
## Summary
- `POST /pds-backfill/audio` now checks `pds-audio-uploads` feature flag, returns 403 without it
- `PdsBackfillControl` only renders in portal when user has the flag
- Previously the backfill path was ungated — any authenticated user could trigger PDS migration

## Test plan
- [ ] User without flag: no migration card in portal, POST returns 403
- [ ] User with flag: migration card visible, backfill works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)