### PR TITLE
fix: CLAP service m4a support and backfill fixes

### DIFF
--- a/clap/app.py
+++ b/clap/app.py
@@ -20,18 +20,22 @@ import modal
 
 app = modal.App("plyr-clap")
 
-clap_image = modal.Image.debian_slim(python_version="3.11").pip_install(
-    "transformers>=4.40.0",
-    "torch>=2.2.0",
-    "librosa>=0.10.0",
-    "numpy>=1.26.0",
-    "soundfile>=0.12.0",
+clap_image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .apt_install("ffmpeg")
+    .pip_install(
+        "transformers>=4.40.0",
+        "torch>=2.2.0",
+        "librosa>=0.10.0",
+        "numpy>=1.26.0",
+        "soundfile>=0.12.0",
+    )
 )
 
 
 @app.cls(
     image=clap_image,
-    container_idle_timeout=300,
+    scaledown_window=300,
     cpu=2.0,
     memory=4096,
 )
@@ -47,46 +51,101 @@ class ClapService:
         self.model.eval()
         self.device = "cpu"
 
-    @modal.web_endpoint(method="POST")
+    @modal.fastapi_endpoint(method="POST")
     def embed_audio(self, item: dict) -> dict:
         """generate embedding from base64-encoded audio bytes.
 
         expects: {"audio_b64": "<base64 string>"}
         returns: {"embedding": [float, ...], "dimensions": 512}
         """
-        import librosa
+        import subprocess
+        import tempfile
+        import traceback
+
+        import soundfile as sf
         import torch
 
         if not (audio_b64 := item.get("audio_b64")):
             return {"error": "missing audio_b64 field"}
 
-        audio_bytes = base64.b64decode(audio_b64)
+        try:
+            audio_bytes = base64.b64decode(audio_b64)
 
-        # load audio at 48kHz (CLAP's expected sample rate)
-        audio_array, sr = librosa.load(io.BytesIO(audio_bytes), sr=48000, mono=True)
+            # try soundfile first (handles wav, flac, ogg natively)
+            try:
+                audio_array, sr = sf.read(io.BytesIO(audio_bytes), dtype="float32")
+            except Exception:
+                # fall back to ffmpeg for m4a/aac/other formats
+                with tempfile.NamedTemporaryFile(suffix=".audio", delete=True) as tmp:
+                    tmp.write(audio_bytes)
+                    tmp.flush()
+                    result = subprocess.run(
+                        [
+                            "ffmpeg",
+                            "-i",
+                            tmp.name,
+                            "-f",
+                            "wav",
+                            "-acodec",
+                            "pcm_f32le",
+                            "-ac",
+                            "1",
+                            "-ar",
+                            "48000",
+                            "-v",
+                            "error",
+                            "pipe:1",
+                        ],
+                        capture_output=True,
+                    )
+                    if result.returncode != 0:
+                        return {
+                            "error": f"ffmpeg failed: {result.stderr.decode()[:500]}"
+                        }
+                    audio_array, sr = sf.read(
+                        io.BytesIO(result.stdout), dtype="float32"
+                    )
 
-        # CLAP works best with ~10s chunks; take the first 30s max
-        max_samples = 30 * sr
-        if len(audio_array) > max_samples:
-            audio_array = audio_array[:max_samples]
+            # convert to mono if stereo
+            if audio_array.ndim > 1:
+                audio_array = audio_array.mean(axis=1)
 
-        inputs = self.processor(
-            audios=[audio_array],
-            sampling_rate=sr,
-            return_tensors="pt",
-        )
+            # resample to 48kHz if needed
+            if sr != 48000:
+                import librosa
 
-        with torch.no_grad():
-            audio_embed = self.model.get_audio_features(**inputs)
+                audio_array = librosa.resample(audio_array, orig_sr=sr, target_sr=48000)
+                sr = 48000
 
-        embedding = audio_embed[0].cpu().numpy().tolist()
+            # CLAP works best with ~10s chunks; take the first 30s max
+            max_samples = 30 * sr
+            if len(audio_array) > max_samples:
+                audio_array = audio_array[:max_samples]
 
-        return {
-            "embedding": embedding,
-            "dimensions": len(embedding),
-        }
+            inputs = self.processor(
+                audio=[audio_array],
+                sampling_rate=sr,
+                return_tensors="pt",
+            )
 
-    @modal.web_endpoint(method="POST")
+            with torch.no_grad():
+                audio_output = self.model.audio_model(
+                    input_features=inputs["input_features"],
+                    is_longer=inputs.get("is_longer"),
+                )
+                projected = self.model.audio_projection(audio_output.pooler_output)
+                normalized = torch.nn.functional.normalize(projected, dim=-1)
+
+            embedding = normalized[0].cpu().numpy().tolist()
+
+            return {
+                "embedding": embedding,
+                "dimensions": len(embedding),
+            }
+        except Exception:
+            return {"error": traceback.format_exc()[-1000:]}
+
+    @modal.fastapi_endpoint(method="POST")
     def embed_text(self, item: dict) -> dict:
         """generate embedding from text description.
 
@@ -105,9 +164,11 @@ class ClapService:
         )
 
         with torch.no_grad():
-            text_embed = self.model.get_text_features(**inputs)
+            text_output = self.model.text_model(**inputs)
+            projected = self.model.text_projection(text_output.pooler_output)
+            normalized = torch.nn.functional.normalize(projected, dim=-1)
 
-        embedding = text_embed[0].cpu().numpy().tolist()
+        embedding = normalized[0].cpu().numpy().tolist()
 
         return {
             "embedding": embedding,

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ organized knowledge base for plyr.fm development.
 - **[feature-flags.md](./backend/feature-flags.md)** - per-user feature rollout system
 - **[streaming-uploads.md](./backend/streaming-uploads.md)** - SSE progress tracking
 - **[transcoder.md](./backend/transcoder.md)** - rust audio conversion service (lossless support)
+- **[vibe-search.md](./backend/vibe-search.md)** - semantic search with CLAP embeddings (Modal + turbopuffer)
 
 ### frontend
 - **[state-management.md](./frontend/state-management.md)** - svelte 5 runes patterns

--- a/docs/backend/vibe-search.md
+++ b/docs/backend/vibe-search.md
@@ -1,0 +1,163 @@
+# vibe search
+
+semantic search over tracks using CLAP (Contrastive Language-Audio Pretraining) embeddings. users describe a mood or vibe in natural language and get matching tracks ranked by similarity.
+
+## architecture
+
+```
+user types "dark ambient techno"
+        │
+        ▼
+  Modal CLAP service          turbopuffer
+  (embed_text)          ──►   (vector ANN query)
+        │                           │
+        ▼                           ▼
+  512-dim text embedding      top-k similar tracks
+                                    │
+                                    ▼
+                              hydrate from postgres
+                              (Track + Artist join)
+```
+
+### components
+
+| component | service | purpose |
+|-----------|---------|---------|
+| CLAP model | Modal (`plyr-clap`) | generates 512-dim embeddings from audio or text |
+| vector store | turbopuffer | stores/queries embeddings with cosine distance |
+| search endpoint | FastAPI (`/search/semantic`) | orchestrates embed → query → hydrate |
+| backfill script | `scripts/backfill_embeddings.py` | indexes existing tracks |
+
+## services
+
+### Modal CLAP service
+
+**source**: `clap/app.py`
+
+hosts the `laion/larger_clap_music` model on Modal with two endpoints:
+
+- `POST /embed_audio` — base64-encoded audio → 512-dim embedding
+- `POST /embed_text` — text description → 512-dim embedding
+
+container specs: 2 CPU, 4GB RAM, 5-minute idle timeout (scales to zero).
+
+**deploy**:
+```bash
+uvx modal deploy clap/app.py
+```
+
+after deploy, Modal prints the endpoint URLs. set them as Fly secrets:
+
+```bash
+fly secrets set \
+  MODAL_ENABLED=true \
+  MODAL_EMBED_AUDIO_URL=https://<workspace>--plyr-clap-clapservice-embed-audio.modal.run \
+  MODAL_EMBED_TEXT_URL=https://<workspace>--plyr-clap-clapservice-embed-text.modal.run \
+  -a <fly-app-name>
+```
+
+**test**:
+```bash
+curl -X POST https://<workspace>--plyr-clap-clapservice-embed-text.modal.run \
+  -H "Content-Type: application/json" \
+  -d '{"text": "dark ambient techno"}'
+# → {"embedding": [...], "dimensions": 512}
+```
+
+first call is slow (~30s) due to cold start + model download. subsequent calls within 5 minutes are fast.
+
+### turbopuffer
+
+vector database for storing and querying track embeddings.
+
+**env vars**:
+```bash
+TURBOPUFFER_ENABLED=true
+TURBOPUFFER_API_KEY=tpuf_xxxxx
+TURBOPUFFER_NAMESPACE=plyr-tracks      # use plyr-tracks-stg for staging
+```
+
+each vector stores:
+- `id`: track_id
+- `vector`: 512-dim CLAP embedding
+- attributes: `title`, `artist_handle`, `artist_did`
+
+## indexing
+
+### automatic (new uploads)
+
+when a track is uploaded and both Modal + turbopuffer are enabled, embedding generation is automatically scheduled as a docket background task. see `backend/src/backend/api/tracks/uploads.py`.
+
+### backfill (existing tracks)
+
+```bash
+# dry run — shows eligible tracks
+uv run scripts/backfill_embeddings.py --dry-run
+
+# index first 5 tracks
+uv run scripts/backfill_embeddings.py --limit 5
+
+# full backfill
+uv run scripts/backfill_embeddings.py
+
+# custom batch size
+uv run scripts/backfill_embeddings.py --batch-size 5
+```
+
+the script downloads audio from R2, generates CLAP embeddings via Modal, and upserts to turbopuffer. runs sequentially to be gentle on Modal.
+
+## feature flag
+
+vibe search is gated behind the `vibe-search` per-user feature flag. users with the flag see a "vibe" toggle in the Cmd+K search modal. without the flag, the toggle is hidden and only regular text search is available.
+
+## environment variables
+
+| variable | purpose | default |
+|----------|---------|---------|
+| `MODAL_ENABLED` | enable CLAP embedding service | `false` |
+| `MODAL_EMBED_AUDIO_URL` | Modal endpoint for audio embeddings | — |
+| `MODAL_EMBED_TEXT_URL` | Modal endpoint for text embeddings | — |
+| `MODAL_TIMEOUT_SECONDS` | embedding request timeout | `120` |
+| `TURBOPUFFER_ENABLED` | enable vector storage | `false` |
+| `TURBOPUFFER_API_KEY` | turbopuffer API key | — |
+| `TURBOPUFFER_REGION` | turbopuffer API region | `api` |
+| `TURBOPUFFER_NAMESPACE` | vector namespace | `plyr-tracks` |
+
+## API
+
+### `GET /search/semantic?q=<query>&limit=10`
+
+no auth required. returns tracks ranked by cosine similarity to the query text.
+
+**requirements**: Modal + turbopuffer enabled, query 3-200 chars, limit 1-50.
+
+**response**:
+```json
+{
+  "results": [
+    {
+      "type": "track",
+      "id": 123,
+      "title": "Ambient Waves",
+      "artist_handle": "artist.bsky.social",
+      "artist_display_name": "Artist Name",
+      "image_url": "https://...",
+      "similarity": 0.873
+    }
+  ],
+  "query": "dark ambient techno"
+}
+```
+
+returns 503 if Modal/turbopuffer are disabled.
+
+## key files
+
+- `clap/app.py` — Modal CLAP service
+- `backend/src/backend/_internal/clap_client.py` — Modal HTTP client
+- `backend/src/backend/_internal/tpuf_client.py` — turbopuffer client
+- `backend/src/backend/api/search.py` — `/search/semantic` endpoint
+- `backend/src/backend/_internal/background_tasks.py` — `generate_embedding` task
+- `scripts/backfill_embeddings.py` — batch indexing script
+- `frontend/src/lib/components/SearchModal.svelte` — vibe toggle UI
+- `frontend/src/lib/search.svelte.ts` — semantic search state

--- a/scripts/backfill_embeddings.py
+++ b/scripts/backfill_embeddings.py
@@ -103,9 +103,7 @@ async def backfill_embeddings(
         batch = rows[i : i + batch_size]
 
         for track, artist in batch:
-            r2_url = (
-                f"{settings.storage.r2_public_url}/{track.file_id}{track.file_type}"
-            )
+            r2_url = f"{settings.storage.r2_public_bucket_url}/audio/{track.file_id}.{track.file_type}"
 
             try:
                 logger.info(


### PR DESCRIPTION
## Summary
- adds ffmpeg to the Modal CLAP container so m4a/aac audio files can be embedded (previously only wav/mp3/flac worked)
- uses soundfile + ffmpeg subprocess fallback instead of librosa.load, which avoids the soundfile-can't-read-m4a problem
- returns structured error responses instead of bare 500s when embedding fails
- fixes the R2 URL path in the backfill script (`audio/{file_id}.{file_type}`)
- updates deprecated Modal API calls (`container_idle_timeout` -> `scaledown_window`, `web_endpoint` -> `fastapi_endpoint`)
- uses explicit `audio_model` + `audio_projection` pipeline for consistent normalized embeddings

## Backfill status
- CLAP service already redeployed to Modal with these changes
- all 16 staging tracks successfully embedded and stored in turbopuffer (`plyr-tracks-stg`)
- semantic search verified working end-to-end

## Test plan
- [x] wav embedding works
- [x] mp3 embedding works  
- [x] m4a embedding works (was broken before)
- [x] text embedding works
- [x] all 16 staging tracks backfilled to turbopuffer
- [ ] test `/search/semantic` endpoint on staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)