### PR TITLE
feat: unified search with parallel keyword + semantic

### DIFF
--- a/frontend/src/lib/components/SearchModal.svelte
+++ b/frontend/src/lib/components/SearchModal.svelte
@@ -9,7 +9,11 @@
 
 	let inputRef: HTMLInputElement | null = $state(null);
 	let isMobile = $state(false);
-	let hasSemanticSearch = $derived(auth.user?.enabled_flags?.includes(VIBE_SEARCH_FLAG) ?? false);
+
+	// sync semantic search availability from user flags
+	$effect(() => {
+		search.semanticEnabled = auth.user?.enabled_flags?.includes(VIBE_SEARCH_FLAG) ?? false;
+	});
 
 	// detect mobile on mount
 	$effect(() => {
@@ -141,121 +145,129 @@
 	role="presentation"
 	onclick={handleBackdropClick}
 >
-		<div class="search-modal" role="dialog" aria-modal="true" aria-label="search">
-			<div class="search-input-wrapper">
-				<svg class="search-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-					<circle cx="11" cy="11" r="8"></circle>
-					<line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-				</svg>
-				<input
-					bind:this={inputRef}
-					type="text"
-					class="search-input"
-					placeholder={search.semanticMode ? 'describe a vibe...' : 'search tracks, artists, albums, playlists...'}
-					value={search.query}
-					oninput={(e) => search.setQuery(e.currentTarget.value)}
-					autocomplete="off"
-					autocorrect="off"
-					autocapitalize="off"
-					spellcheck="false"
-				/>
-				{#if hasSemanticSearch}
-					<button
-						class="semantic-toggle"
-						class:active={search.semanticMode}
-						onclick={() => search.toggleSemanticMode()}
-					>
-						vibe
-					</button>
-				{/if}
-				{#if search.loading}
-					<div class="search-spinner"></div>
-				{:else if !isMobile}
-					<kbd class="search-shortcut">{getShortcutHint()}</kbd>
-				{/if}
-			</div>
-
-			{#if search.activeResults.length > 0}
-				<div class="search-results">
-					{#each search.activeResults as result, index (result.type + '-' + ('did' in result ? result.did : result.id))}
-						{@const imageUrl = getResultImage(result)}
-						<button
-							class="search-result"
-							class:selected={index === search.selectedIndex}
-							onclick={() => navigateToResult(result)}
-							onmouseenter={() => (search.selectedIndex = index)}
-						>
-							<span class="result-icon" data-type={result.type}>
-								{#if imageUrl}
-									<SensitiveImage src={imageUrl} compact>
-										<img src={imageUrl} alt="" class="result-image" loading="lazy" />
-									</SensitiveImage>
-								{:else if result.type === 'track'}
-									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-										<path d="M9 18V5l12-2v13"></path>
-										<circle cx="6" cy="18" r="3"></circle>
-										<circle cx="18" cy="16" r="3"></circle>
-									</svg>
-								{:else if result.type === 'artist'}
-									<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
-										<circle cx="8" cy="5" r="3" fill="none" />
-										<path d="M3 14c0-2.5 2-4.5 5-4.5s5 2 5 4.5" stroke-linecap="round" />
-									</svg>
-								{:else if result.type === 'album'}
-									<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
-										<rect x="2" y="2" width="12" height="12" fill="none" />
-										<circle cx="8" cy="8" r="2.5" fill="currentColor" stroke="none" />
-									</svg>
-								{:else if result.type === 'tag'}
-									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-										<path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path>
-										<line x1="7" y1="7" x2="7.01" y2="7"></line>
-									</svg>
-								{:else if result.type === 'playlist'}
-									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-										<line x1="8" y1="6" x2="21" y2="6"></line>
-										<line x1="8" y1="12" x2="21" y2="12"></line>
-										<line x1="8" y1="18" x2="21" y2="18"></line>
-										<line x1="3" y1="6" x2="3.01" y2="6"></line>
-										<line x1="3" y1="12" x2="3.01" y2="12"></line>
-										<line x1="3" y1="18" x2="3.01" y2="18"></line>
-									</svg>
-								{/if}
-							</span>
-							<div class="result-content">
-								<span class="result-title">{getResultTitle(result)}</span>
-								<span class="result-subtitle">{getResultSubtitle(result)}</span>
-							</div>
-							{#if search.semanticMode && 'similarity' in result}
-								<span class="result-type">{Math.round(result.similarity * 100)}%</span>
-							{:else}
-								<span class="result-type">{result.type}</span>
-							{/if}
-						</button>
-					{/each}
-				</div>
-			{:else if search.query.length >= (search.semanticMode ? 3 : 2) && !search.loading}
-				<div class="search-empty">
-					no results for "{search.query}"
-				</div>
-			{:else if search.query.length === 0}
-				<div class="search-hints">
-					<p>start typing to search across all content</p>
-					{#if !isMobile}
-						<div class="hint-shortcuts">
-							<span><kbd>↑</kbd><kbd>↓</kbd> navigate</span>
-							<span><kbd>↵</kbd> select</span>
-							<span><kbd>esc</kbd> close</span>
-						</div>
-					{/if}
-				</div>
-			{/if}
-
-			{#if search.error}
-				<div class="search-error">{search.error}</div>
+	<div class="search-modal" role="dialog" aria-modal="true" aria-label="search">
+		<div class="search-input-wrapper">
+			<svg class="search-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+				<circle cx="11" cy="11" r="8"></circle>
+				<line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+			</svg>
+			<input
+				bind:this={inputRef}
+				type="text"
+				class="search-input"
+				placeholder="search tracks, artists, albums, playlists..."
+				value={search.query}
+				oninput={(e) => search.setQuery(e.currentTarget.value)}
+				autocomplete="off"
+				autocorrect="off"
+				autocapitalize="off"
+				spellcheck="false"
+			/>
+			{#if search.loading || search.semanticLoading}
+				<div class="search-spinner"></div>
+			{:else if !isMobile}
+				<kbd class="search-shortcut">{getShortcutHint()}</kbd>
 			{/if}
 		</div>
+
+		{#if search.activeResults.length > 0}
+			<div class="search-results">
+				{#each search.activeResults as result, index (result.type + '-' + ('did' in result ? result.did : result.id))}
+					{#if index === search.semanticBoundary && search.semanticBoundary > 0}
+						<div class="semantic-separator">sounds like</div>
+					{/if}
+					{@const imageUrl = getResultImage(result)}
+					<button
+						class="search-result"
+						class:selected={index === search.selectedIndex}
+						onclick={() => navigateToResult(result)}
+						onmouseenter={() => (search.selectedIndex = index)}
+					>
+						<span class="result-icon" data-type={result.type}>
+							{#if imageUrl}
+								<SensitiveImage src={imageUrl} compact>
+									<img src={imageUrl} alt="" class="result-image" loading="lazy" />
+								</SensitiveImage>
+							{:else if result.type === 'track'}
+								<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+									<path d="M9 18V5l12-2v13"></path>
+									<circle cx="6" cy="18" r="3"></circle>
+									<circle cx="18" cy="16" r="3"></circle>
+								</svg>
+							{:else if result.type === 'artist'}
+								<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+									<circle cx="8" cy="5" r="3" fill="none" />
+									<path d="M3 14c0-2.5 2-4.5 5-4.5s5 2 5 4.5" stroke-linecap="round" />
+								</svg>
+							{:else if result.type === 'album'}
+								<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+									<rect x="2" y="2" width="12" height="12" fill="none" />
+									<circle cx="8" cy="8" r="2.5" fill="currentColor" stroke="none" />
+								</svg>
+							{:else if result.type === 'tag'}
+								<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+									<path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path>
+									<line x1="7" y1="7" x2="7.01" y2="7"></line>
+								</svg>
+							{:else if result.type === 'playlist'}
+								<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+									<line x1="8" y1="6" x2="21" y2="6"></line>
+									<line x1="8" y1="12" x2="21" y2="12"></line>
+									<line x1="8" y1="18" x2="21" y2="18"></line>
+									<line x1="3" y1="6" x2="3.01" y2="6"></line>
+									<line x1="3" y1="12" x2="3.01" y2="12"></line>
+									<line x1="3" y1="18" x2="3.01" y2="18"></line>
+								</svg>
+							{/if}
+						</span>
+						<div class="result-content">
+							<span class="result-title">{getResultTitle(result)}</span>
+							<span class="result-subtitle">{getResultSubtitle(result)}</span>
+						</div>
+						{#if search.semanticBoundary >= 0 && index >= search.semanticBoundary && 'similarity' in result}
+							<span class="result-type">{Math.round(result.similarity * 100)}%</span>
+						{:else}
+							<span class="result-type">{result.type}</span>
+						{/if}
+					</button>
+				{/each}
+				{#if search.semanticLoading}
+					<div class="semantic-loading">
+						<div class="search-spinner-small"></div>
+						<span>searching by vibe...</span>
+					</div>
+				{/if}
+			</div>
+		{:else if search.query.length >= 2 && !search.loading && search.semanticLoading}
+			<div class="search-results">
+				<div class="search-empty">no matches by name</div>
+				<div class="semantic-loading">
+					<div class="search-spinner-small"></div>
+					<span>searching by vibe...</span>
+				</div>
+			</div>
+		{:else if search.query.length >= 2 && !search.loading && !search.semanticLoading && search.activeResults.length === 0}
+			<div class="search-empty">
+				no results for "{search.query}"
+			</div>
+		{:else if search.query.length === 0}
+			<div class="search-hints">
+				<p>start typing to search across all content</p>
+				{#if !isMobile}
+					<div class="hint-shortcuts">
+						<span><kbd>↑</kbd><kbd>↓</kbd> navigate</span>
+						<span><kbd>↵</kbd> select</span>
+						<span><kbd>esc</kbd> close</span>
+					</div>
+				{/if}
+			</div>
+		{/if}
+
+		{#if search.error}
+			<div class="search-error">{search.error}</div>
+		{/if}
 	</div>
+</div>
 
 <style>
 	.search-backdrop {
@@ -333,31 +345,6 @@
 		font-family: inherit;
 	}
 
-	.semantic-toggle {
-		font-size: var(--text-xs);
-		padding: 0.2rem 0.5rem;
-		background: var(--bg-tertiary);
-		border: 1px solid var(--border-default);
-		border-radius: var(--radius-full);
-		color: var(--text-muted);
-		font-family: inherit;
-		cursor: pointer;
-		transition: all 0.15s;
-		white-space: nowrap;
-		flex-shrink: 0;
-	}
-
-	.semantic-toggle:hover {
-		border-color: var(--accent);
-		color: var(--text-secondary);
-	}
-
-	.semantic-toggle.active {
-		background: color-mix(in srgb, var(--accent) 15%, transparent);
-		border-color: var(--accent);
-		color: var(--accent);
-	}
-
 	.search-spinner {
 		width: 16px;
 		height: 16px;
@@ -381,23 +368,10 @@
 		scrollbar-color: var(--border-default) transparent;
 	}
 
-	.search-results::-webkit-scrollbar {
-		width: 8px;
-	}
-
-	.search-results::-webkit-scrollbar-track {
-		background: transparent;
-		border-radius: var(--radius-sm);
-	}
-
-	.search-results::-webkit-scrollbar-thumb {
-		background: var(--border-default);
-		border-radius: var(--radius-sm);
-	}
-
-	.search-results::-webkit-scrollbar-thumb:hover {
-		background: var(--border-emphasis);
-	}
+	.search-results::-webkit-scrollbar { width: 8px; }
+	.search-results::-webkit-scrollbar-track { background: transparent; border-radius: var(--radius-sm); }
+	.search-results::-webkit-scrollbar-thumb { background: var(--border-default); border-radius: var(--radius-sm); }
+	.search-results::-webkit-scrollbar-thumb:hover { background: var(--border-emphasis); }
 
 	.search-result {
 		display: flex;
@@ -448,25 +422,11 @@
 		border-radius: var(--radius-md);
 	}
 
-	.result-icon[data-type='track'] {
-		color: var(--accent);
-	}
-
-	.result-icon[data-type='artist'] {
-		color: #a78bfa;
-	}
-
-	.result-icon[data-type='album'] {
-		color: #34d399;
-	}
-
-	.result-icon[data-type='tag'] {
-		color: #fbbf24;
-	}
-
-	.result-icon[data-type='playlist'] {
-		color: #f472b6;
-	}
+	.result-icon[data-type='track'] { color: var(--accent); }
+	.result-icon[data-type='artist'] { color: #a78bfa; }
+	.result-icon[data-type='album'] { color: #34d399; }
+	.result-icon[data-type='tag'] { color: #fbbf24; }
+	.result-icon[data-type='playlist'] { color: #f472b6; }
 
 	.result-content {
 		flex: 1;
@@ -501,6 +461,42 @@
 		background: var(--bg-tertiary);
 		border-radius: var(--radius-sm);
 		flex-shrink: 0;
+	}
+
+	.semantic-separator {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.5rem 0.75rem;
+		color: var(--text-muted);
+		font-size: var(--text-xs);
+	}
+
+	.semantic-separator::before,
+	.semantic-separator::after {
+		content: '';
+		flex: 1;
+		height: 1px;
+		background: var(--border-subtle);
+	}
+
+	.semantic-loading {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		padding: 0.75rem;
+		color: var(--text-muted);
+		font-size: var(--text-xs);
+	}
+
+	.search-spinner-small {
+		width: 12px;
+		height: 12px;
+		border: 1.5px solid var(--border-default);
+		border-top-color: var(--accent);
+		border-radius: var(--radius-full);
+		animation: spin 0.6s linear infinite;
 	}
 
 	.search-empty {
@@ -586,7 +582,8 @@
 
 	/* respect reduced motion */
 	@media (prefers-reduced-motion: reduce) {
-		.search-spinner {
+		.search-spinner,
+		.search-spinner-small {
 			animation: none;
 		}
 	}


### PR DESCRIPTION
## Summary
- keyword and semantic searches now fire in parallel (two separate HTTP requests) instead of a mode toggle
- keyword results appear instantly (~50ms), semantic results append with a "sounds like" separator when ready (~1-2s)
- backend returns graceful `available: false` response instead of 502/503 for degraded CLAP/turbopuffer services
- stale query guards prevent slow semantic responses from overwriting results for a newer query
- client-side deduplication: tracks already in keyword results are filtered from semantic results

## Test plan
- [ ] `just backend test` passes (388 passed)
- [ ] `just frontend check` passes (0 errors)
- [ ] `curl /search/semantic?q=test` with services disabled returns `{"results": [], "query": "test", "available": false}`
- [ ] type "burnout" — keyword results appear immediately, semantic results append after ~1-2s
- [ ] type "dark ambient bass" — shows "no matches by name" + spinner, then semantic results
- [ ] type "zz" (2 chars) — keyword fires, semantic does not (min 3 chars)
- [ ] rapid typing — stale results don't appear
- [ ] user without `vibe-search` flag — only keyword results, no semantic request
- [ ] Modal/turbopuffer disabled — keyword works, no semantic section shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)