### PR TITLE
fix: semantic search quality and UX

### DIFF
--- a/frontend/src/lib/components/SearchModal.svelte
+++ b/frontend/src/lib/components/SearchModal.svelte
@@ -173,9 +173,6 @@
 		{#if search.activeResults.length > 0}
 			<div class="search-results">
 				{#each search.activeResults as result, index (result.type + '-' + ('did' in result ? result.did : result.id))}
-					{#if index === search.semanticBoundary && search.semanticBoundary > 0}
-						<div class="semantic-separator">sounds like</div>
-					{/if}
 					{@const imageUrl = getResultImage(result)}
 					<button
 						class="search-result"
@@ -224,8 +221,8 @@
 							<span class="result-title">{getResultTitle(result)}</span>
 							<span class="result-subtitle">{getResultSubtitle(result)}</span>
 						</div>
-						{#if search.semanticBoundary >= 0 && index >= search.semanticBoundary && 'similarity' in result}
-							<span class="result-type">{Math.round(result.similarity * 100)}%</span>
+						{#if search.semanticBoundary >= 0 && index >= search.semanticBoundary}
+							<span class="result-type vibe">vibe</span>
 						{:else}
 							<span class="result-type">{result.type}</span>
 						{/if}
@@ -463,21 +460,9 @@
 		flex-shrink: 0;
 	}
 
-	.semantic-separator {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		padding: 0.5rem 0.75rem;
-		color: var(--text-muted);
-		font-size: var(--text-xs);
-	}
-
-	.semantic-separator::before,
-	.semantic-separator::after {
-		content: '';
-		flex: 1;
-		height: 1px;
-		background: var(--border-subtle);
+	.result-type.vibe {
+		color: var(--accent);
+		background: color-mix(in srgb, var(--accent) 10%, transparent);
 	}
 
 	.semantic-loading {


### PR DESCRIPTION
## Summary
- replace broken relative normalization (always mapped best→100%, worst→0% regardless of actual similarity) with raw cosine similarity
- add distance ceiling of 0.995 to filter out noise-floor results — CLAP cross-modal distances cluster around 0.98-1.0, anything above 0.995 is indistinguishable from random
- cap semantic results at 5 (was unbounded 10) to avoid flooding the list with low-quality matches
- remove "sounds like" separator — semantic results now integrate inline with a subtle "vibe" badge
- remove misleading similarity percentages from result badges

Follows up on #851. Addresses issues found during staging QA: identical audio getting 100% vs 0% scores (relative normalization artifact), too many low-quality results shown, and jarring visual separation between keyword and semantic sections.

## Test plan
- [ ] `just backend test` passes (388 passed)
- [ ] `just frontend check` passes (0 errors)
- [ ] type "lofi" — semantic results appear inline with "vibe" badge, no separator, max 5 results
- [ ] results with cosine distance > 0.995 are filtered out (garbage results gone)
- [ ] identical audio tracks no longer show wildly different scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)