### PR TITLE
fix: spread check for semantic results, rename vibe to mood

### DIFF
--- a/backend/src/backend/api/search.py
+++ b/backend/src/backend/api/search.py
@@ -428,6 +428,14 @@ async def semantic_search(
     if not vector_results:
         return SemanticSearchResponse(results=[], query=q)
 
+    # spread check: if the gap between the best and worst result is too small,
+    # the rankings are essentially random (corpus too small or query too vague).
+    min_spread = 0.005
+    best_dist = vector_results[0].distance
+    worst_dist = vector_results[-1].distance
+    if worst_dist - best_dist < min_spread:
+        return SemanticSearchResponse(results=[], query=q)
+
     # hydrate from DB (get image_url, display_name, etc.)
     track_ids = [r.track_id for r in vector_results]
     distance_by_id = {r.track_id: r.distance for r in vector_results}

--- a/frontend/src/lib/components/SearchModal.svelte
+++ b/frontend/src/lib/components/SearchModal.svelte
@@ -222,7 +222,7 @@
 							<span class="result-subtitle">{getResultSubtitle(result)}</span>
 						</div>
 						{#if search.semanticBoundary >= 0 && index >= search.semanticBoundary}
-							<span class="result-type vibe">vibe</span>
+							<span class="result-type mood">mood</span>
 						{:else}
 							<span class="result-type">{result.type}</span>
 						{/if}
@@ -231,7 +231,7 @@
 				{#if search.semanticLoading}
 					<div class="semantic-loading">
 						<div class="search-spinner-small"></div>
-						<span>searching by vibe...</span>
+						<span>searching by mood...</span>
 					</div>
 				{/if}
 			</div>
@@ -240,7 +240,7 @@
 				<div class="search-empty">no matches by name</div>
 				<div class="semantic-loading">
 					<div class="search-spinner-small"></div>
-					<span>searching by vibe...</span>
+					<span>searching by mood...</span>
 				</div>
 			</div>
 		{:else if search.query.length >= 2 && !search.loading && !search.semanticLoading && search.activeResults.length === 0}
@@ -460,7 +460,7 @@
 		flex-shrink: 0;
 	}
 
-	.result-type.vibe {
+	.result-type.mood {
 		color: var(--accent);
 		background: color-mix(in srgb, var(--accent) 10%, transparent);
 	}


### PR DESCRIPTION
## Summary
- add minimum distance spread check (0.005) to semantic search: if the gap between best and worst result is smaller than this, the rankings are effectively random noise and we return empty results instead of misleading ones
- rename all "vibe" UI text to "mood" (badge label, loading indicator)

On staging's small corpus, every query returns the same ordering because all tracks are equidistant from every text embedding. The spread check catches this and returns nothing rather than pretending "burnout" is the best match for "jazz", "electronic", and "heavy metal" simultaneously.

## Test plan
- [ ] `just backend test` passes (388 passed)
- [ ] `just frontend check` passes (0 errors)
- [ ] on staging: queries that produced identical orderings now return no semantic results (spread too small)
- [ ] on production (larger corpus): queries with meaningful spread still return results
- [ ] no "vibe" text anywhere in the search UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)