### PR TITLE
fix: switch CLAP model to clap-htsat-unfused

### DIFF
--- a/backend/src/backend/_internal/tpuf_client.py
+++ b/backend/src/backend/_internal/tpuf_client.py
@@ -1,7 +1,7 @@
 """turbopuffer vector database client.
 
 client for storing and querying CLAP embeddings in turbopuffer.
-used for semantic vibe search (text-to-audio matching).
+used for semantic mood search (text-to-audio matching).
 """
 
 import logging

--- a/clap/app.py
+++ b/clap/app.py
@@ -2,7 +2,7 @@
 
 Hosts the CLAP (Contrastive Language-Audio Pretraining) model for generating
 audio and text embeddings in a shared vector space. Used by plyr.fm for
-semantic vibe search — users describe a mood and get matching tracks.
+semantic mood search — users describe a mood and get matching tracks.
 
 deploy:
     modal deploy clap/app.py
@@ -46,8 +46,8 @@ class ClapService:
     def load_model(self):
         from transformers import ClapModel, ClapProcessor
 
-        self.model = ClapModel.from_pretrained("laion/larger_clap_music")
-        self.processor = ClapProcessor.from_pretrained("laion/larger_clap_music")
+        self.model = ClapModel.from_pretrained("laion/clap-htsat-unfused")
+        self.processor = ClapProcessor.from_pretrained("laion/clap-htsat-unfused")
         self.model.eval()
 
     @modal.fastapi_endpoint(method="POST")


### PR DESCRIPTION
## Summary

- Switches CLAP model from `laion/larger_clap_music` to `laion/clap-htsat-unfused`
- Removes distance ceiling and spread check filters calibrated for the broken model
- Renames remaining "vibe" references to "mood"

## Root cause

`laion/larger_clap_music` has a broken text projection layer — biases are all zeros and weights have near-zero std (0.006). This collapses all text inputs to essentially the same point in embedding space (0.999 cosine similarity between "jazz standard" and "heavy metal"), making semantic search return the same results regardless of query.

`laion/clap-htsat-unfused` produces properly discriminative text embeddings:
- "jazz standard" vs "heavy metal": 0.21
- "heavy metal" vs "lofi chill": -0.01
- "jazz standard" vs "acoustic guitar": 0.50

## Deployment notes

- Modal CLAP service already redeployed with new model
- Staging audio embeddings already re-backfilled (16/16 tracks)
- **Production re-backfill needed after merge** — run `uv run scripts/backfill_embeddings.py` with production env vars

## Test plan

- [x] Backend tests pass (388 passed)
- [x] Verified text embeddings are distinct via deployed Modal endpoint
- [x] Verified different queries produce different result orderings on staging
- [ ] QA semantic search in staging UI after backend deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)