### PR TITLE
chore: concurrent backfill, rename docs to mood-search

### DIFF
--- a/scripts/backfill_embeddings.py
+++ b/scripts/backfill_embeddings.py
@@ -3,7 +3,7 @@
 
 ## Context
 
-Vibe search uses CLAP embeddings stored in turbopuffer to match text
+Mood search uses CLAP embeddings stored in turbopuffer to match text
 descriptions to audio content. New uploads generate embeddings automatically,
 but existing tracks need to be backfilled.
 
@@ -23,17 +23,18 @@ uv run scripts/backfill_embeddings.py --dry-run
 # embed first 5 tracks
 uv run scripts/backfill_embeddings.py --limit 5
 
-# full backfill (sequential, gentle on Modal)
+# full backfill with 10 concurrent workers (default)
 uv run scripts/backfill_embeddings.py
 
-# custom batch size (default 10)
-uv run scripts/backfill_embeddings.py --batch-size 5
+# custom concurrency
+uv run scripts/backfill_embeddings.py --concurrency 20
 ```
 """
 
 import argparse
 import asyncio
 import logging
+import time
 
 import httpx
 from sqlalchemy import select
@@ -51,10 +52,61 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+async def _embed_one(
+    track: Track,
+    artist: Artist,
+    http: httpx.AsyncClient,
+    clap_client: object,
+    sem: asyncio.Semaphore,
+    counter: dict[str, int],
+    total: int,
+) -> None:
+    """embed a single track, guarded by semaphore."""
+    async with sem:
+        r2_url = f"{settings.storage.r2_public_bucket_url}/audio/{track.file_id}.{track.file_type}"
+        idx = counter["started"] + 1
+        counter["started"] += 1
+
+        try:
+            logger.info(
+                "embedding [%d/%d] track %d: %s", idx, total, track.id, track.title
+            )
+
+            resp = await http.get(r2_url)
+            resp.raise_for_status()
+            audio_bytes = resp.content
+
+            embed_result = await clap_client.embed_audio(audio_bytes)
+
+            if not embed_result.success or not embed_result.embedding:
+                logger.warning(
+                    "embedding failed for track %d: %s", track.id, embed_result.error
+                )
+                counter["failed"] += 1
+                return
+
+            await upsert(
+                track_id=track.id,
+                embedding=embed_result.embedding,
+                title=track.title,
+                artist_handle=artist.handle,
+                artist_did=artist.did,
+            )
+
+            counter["embedded"] += 1
+            logger.info(
+                "embedded track %d (%d dims)", track.id, embed_result.dimensions
+            )
+
+        except Exception:
+            logger.exception("failed to process track %d", track.id)
+            counter["failed"] += 1
+
+
 async def backfill_embeddings(
     dry_run: bool = False,
     limit: int | None = None,
-    batch_size: int = 10,
+    concurrency: int = 10,
 ) -> None:
     """backfill CLAP embeddings for tracks missing from turbopuffer."""
 
@@ -83,7 +135,7 @@ async def backfill_embeddings(
         logger.info("no tracks found to embed")
         return
 
-    logger.info("found %d tracks to process", len(rows))
+    logger.info("found %d tracks to process (concurrency=%d)", len(rows), concurrency)
 
     if dry_run:
         for track, artist in rows:
@@ -96,71 +148,25 @@ async def backfill_embeddings(
         return
 
     clap_client = get_clap_client()
-    embedded = 0
-    failed = 0
+    sem = asyncio.Semaphore(concurrency)
+    counter: dict[str, int] = {"started": 0, "embedded": 0, "failed": 0}
+    t0 = time.monotonic()
 
-    for i in range(0, len(rows), batch_size):
-        batch = rows[i : i + batch_size]
+    async with httpx.AsyncClient(timeout=httpx.Timeout(120.0)) as http:
+        tasks = [
+            _embed_one(track, artist, http, clap_client, sem, counter, len(rows))
+            for track, artist in rows
+        ]
+        await asyncio.gather(*tasks)
 
-        for track, artist in batch:
-            r2_url = f"{settings.storage.r2_public_bucket_url}/audio/{track.file_id}.{track.file_type}"
-
-            try:
-                logger.info(
-                    "embedding [%d/%d] track %d: %s",
-                    embedded + failed + 1,
-                    len(rows),
-                    track.id,
-                    track.title,
-                )
-
-                # download audio
-                async with httpx.AsyncClient(
-                    timeout=httpx.Timeout(60.0),
-                ) as client:
-                    resp = await client.get(r2_url)
-                    resp.raise_for_status()
-                    audio_bytes = resp.content
-
-                # generate embedding
-                embed_result = await clap_client.embed_audio(audio_bytes)
-
-                if not embed_result.success or not embed_result.embedding:
-                    logger.warning(
-                        "embedding failed for track %d: %s",
-                        track.id,
-                        embed_result.error,
-                    )
-                    failed += 1
-                    continue
-
-                # upsert to turbopuffer
-                await upsert(
-                    track_id=track.id,
-                    embedding=embed_result.embedding,
-                    title=track.title,
-                    artist_handle=artist.handle,
-                    artist_did=artist.did,
-                )
-
-                embedded += 1
-                logger.info(
-                    "embedded track %d (%d dims)", track.id, embed_result.dimensions
-                )
-
-            except Exception:
-                logger.exception("failed to process track %d", track.id)
-                failed += 1
-
-        # brief pause between batches to be gentle on Modal
-        if i + batch_size < len(rows):
-            await asyncio.sleep(1.0)
-
+    elapsed = time.monotonic() - t0
     logger.info(
-        "backfill complete: %d embedded, %d failed, %d total",
-        embedded,
-        failed,
+        "backfill complete: %d embedded, %d failed, %d total in %.0fs (%.1f tracks/s)",
+        counter["embedded"],
+        counter["failed"],
         len(rows),
+        elapsed,
+        len(rows) / elapsed if elapsed > 0 else 0,
     )
 
 
@@ -170,7 +176,9 @@ async def main() -> None:
         "--dry-run", action="store_true", help="show what would be done"
     )
     parser.add_argument("--limit", type=int, default=None, help="max tracks to process")
-    parser.add_argument("--batch-size", type=int, default=10, help="tracks per batch")
+    parser.add_argument(
+        "--concurrency", type=int, default=10, help="concurrent workers"
+    )
     args = parser.parse_args()
 
     if args.dry_run:
@@ -179,7 +187,7 @@ async def main() -> None:
     await backfill_embeddings(
         dry_run=args.dry_run,
         limit=args.limit,
-        batch_size=args.batch_size,
+        concurrency=args.concurrency,
     )
 
 


### PR DESCRIPTION
## Summary
- Rewrites `scripts/backfill_embeddings.py` from sequential batch processing to asyncio concurrency with `Semaphore` (`--concurrency` flag, default 10). ~10x faster backfill.
- Renames `docs/backend/vibe-search.md` → `docs/backend/mood-search.md` with comprehensive updates: correct CLAP model name, parallel search architecture, cost table, API docs.

## Context
Production backfill just completed: **546/575 tracks embedded** (29 timeouts on large files). Semantic search is live and returning good results.

## Test plan
- [x] Backfill script tested on 575 production tracks with --concurrency 10
- [x] Verified `GET /search/semantic?q=dark+ambient+bass` returns differentiated results on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)