### PR TITLE
fix: cold start latency + unified search results

### DIFF
--- a/clap/app.py
+++ b/clap/app.py
@@ -36,6 +36,7 @@ clap_image = (
 @app.cls(
     image=clap_image,
     scaledown_window=300,
+    min_containers=1,
     cpu=2.0,
     memory=4096,
 )

--- a/frontend/src/lib/components/SearchModal.svelte
+++ b/frontend/src/lib/components/SearchModal.svelte
@@ -221,8 +221,9 @@
 							<span class="result-title">{getResultTitle(result)}</span>
 							<span class="result-subtitle">{getResultSubtitle(result)}</span>
 						</div>
-						{#if search.semanticBoundary >= 0 && index >= search.semanticBoundary}
-							<span class="result-type mood">mood</span>
+						{#if result.type === 'track' && search.semanticResultIds.has(result.id)}
+							{@const pct = Math.round((search.semanticSimilarityMap.get(result.id) ?? 0) * 100)}
+							<span class="result-type mood">{pct}%</span>
 						{:else}
 							<span class="result-type">{result.type}</span>
 						{/if}


### PR DESCRIPTION
## Summary
- **CLAP cold start**: add `min_containers=1` to keep one container warm — eliminates 15s cold starts (~$14/mo)
- **Unified search**: interleave semantic results with keyword results instead of separate "mood" section at bottom
- **Similarity badge**: semantic results show percentage (e.g., "48%") with accent color instead of generic "mood" label

## Test plan
- [ ] Wait 6+ min, curl text embed endpoint — should respond in <2s (no cold start)
- [ ] Open search modal, type "dark ambient" — one unified list, semantic results interleaved with keyword tracks
- [ ] Semantic results show similarity % badge, keyword results show type badge ("track", "artist", etc.)
- [ ] Non-track results (artists, albums, tags, playlists) still appear at top of results

🤖 Generated with [Claude Code](https://claude.com/claude-code)