### PR TITLE
fix: tpuf vector fetch + log unhandled exceptions

### DIFF
--- a/backend/src/backend/_internal/tpuf_client.py
+++ b/backend/src/backend/_internal/tpuf_client.py
@@ -129,7 +129,7 @@ async def get_vector(track_id: int) -> list[float] | None:
             response = await ns.query(
                 filters=("id", "Eq", track_id),
                 top_k=1,
-                include_vectors=True,
+                include_attributes=["vector"],
             )
         except NotFoundError:
             return None


### PR DESCRIPTION
## Summary
- fixes `TypeError: AsyncNamespacesResource.query() got an unexpected keyword argument 'include_vectors'` on `GET /tracks/{id}/recommended-tags`
- turbopuffer SDK uses `include_attributes=["vector"]`, not `include_vectors=True`
- adds global exception handler so unhandled 500s appear in Logfire with full tracebacks (previously silent)

## Test plan
- [x] `just backend test` — 394 passed
- [x] `just backend lint` — clean
- [ ] curl production after deploy to verify recommended-tags works
- [ ] trigger a 500 and verify exception details appear in Logfire

🤖 Generated with [Claude Code](https://claude.com/claude-code)