### PR TITLE
fix: tpuf get_vector needs rank_by

### DIFF
--- a/backend/src/backend/_internal/tpuf_client.py
+++ b/backend/src/backend/_internal/tpuf_client.py
@@ -114,12 +114,18 @@ async def query(
 async def get_vector(track_id: int) -> list[float] | None:
     """fetch a track's stored CLAP embedding by ID.
 
+    turbopuffer requires rank_by for queries, so we use a zero vector
+    with an ID filter to retrieve just the one row's vector.
+
     args:
         track_id: database ID of the track
 
     returns:
         embedding vector if found, None otherwise
     """
+    # CLAP embeddings are 512-dim
+    zero_vector = [0.0] * 512
+
     async with AsyncTurbopuffer(
         api_key=settings.turbopuffer.api_key.get_secret_value(),
         region=settings.turbopuffer.region,
@@ -127,6 +133,7 @@ async def get_vector(track_id: int) -> list[float] | None:
         ns = client.namespace(settings.turbopuffer.namespace)
         try:
             response = await ns.query(
+                rank_by=("vector", "ANN", zero_vector),
                 filters=("id", "Eq", track_id),
                 top_k=1,
                 include_attributes=["vector"],


### PR DESCRIPTION
## Summary
- turbopuffer requires `rank_by` for all queries — filter-only queries return 404
- `get_vector` was silently returning `None` because the `NotFoundError` was caught
- fix: use a zero vector with ID filter to retrieve the stored embedding

## Test plan
- [x] `just backend test` — passes
- [x] `just backend lint` — clean
- [ ] curl production: `curl 'https://api.plyr.fm/tracks/76/recommended-tags?limit=10'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)