### PR TITLE
feat: genre classification via Replicate effnet-discogs

### DIFF
--- a/backend/src/backend/_internal/replicate_client.py
+++ b/backend/src/backend/_internal/replicate_client.py
@@ -1,0 +1,195 @@
+"""replicate genre classification client.
+
+client for classifying track genres via the effnet-discogs model on Replicate.
+uses the Replicate HTTP API directly (SDK incompatible with Python 3.14).
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Self
+
+import httpx
+import logfire
+
+from backend.config import settings
+
+logger = logging.getLogger(__name__)
+
+REPLICATE_API_BASE = "https://api.replicate.com/v1"
+EFFNET_DISCOGS_VERSION = (
+    "1532dd069fb4f0e27c6833e28815f6b8c194dfec76fd9cd73460540fd720ffe1"
+)
+
+
+@dataclass
+class GenrePrediction:
+    """a single genre prediction with confidence score."""
+
+    name: str
+    confidence: float
+
+
+@dataclass
+class ClassificationResult:
+    """result from a genre classification operation."""
+
+    success: bool
+    genres: list[GenrePrediction] = field(default_factory=list)
+    error: str | None = None
+
+
+class ReplicateClient:
+    """client for genre classification via Replicate's effnet-discogs model.
+
+    usage:
+        client = ReplicateClient.from_settings()
+        result = await client.classify(audio_url)
+    """
+
+    def __init__(
+        self,
+        api_token: str,
+        top_n: int,
+        timeout_seconds: float | int,
+    ) -> None:
+        self.api_token = api_token
+        self.top_n = top_n
+        self.timeout = httpx.Timeout(timeout_seconds)
+
+    @classmethod
+    def from_settings(cls) -> Self:
+        """create a client from application settings."""
+        return cls(
+            api_token=settings.replicate.api_token.get_secret_value(),
+            top_n=settings.replicate.top_n,
+            timeout_seconds=settings.replicate.timeout_seconds,
+        )
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_token}",
+            "Content-Type": "application/json",
+            "Prefer": "wait",
+        }
+
+    async def classify(self, audio_url: str) -> ClassificationResult:
+        """classify genres for an audio file.
+
+        args:
+            audio_url: public URL of the audio file
+
+        returns:
+            ClassificationResult with genre predictions or error
+        """
+        payload = {
+            "version": EFFNET_DISCOGS_VERSION,
+            "input": {
+                "audio": audio_url,
+                "top_n": self.top_n,
+                "output_format": "JSON",
+            },
+        }
+
+        logfire.info(
+            "requesting genre classification",
+            audio_url=audio_url,
+            top_n=self.top_n,
+        )
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                # create prediction (Prefer: wait blocks until complete)
+                response = await client.post(
+                    f"{REPLICATE_API_BASE}/predictions",
+                    headers=self._headers(),
+                    json=payload,
+                )
+                response.raise_for_status()
+                data = response.json()
+
+                status = data.get("status")
+                if status == "failed":
+                    error = data.get("error", "unknown error")
+                    logger.error("replicate prediction failed: %s", error)
+                    return ClassificationResult(
+                        success=False,
+                        error=f"prediction failed: {error}",
+                    )
+
+                if status != "succeeded":
+                    # shouldn't happen with Prefer: wait, but handle gracefully
+                    logger.warning(
+                        "replicate prediction not complete: status=%s", status
+                    )
+                    return ClassificationResult(
+                        success=False,
+                        error=f"prediction not complete: status={status}",
+                    )
+
+                output_url = data.get("output")
+                if not output_url:
+                    return ClassificationResult(
+                        success=False,
+                        error="no output URL in prediction response",
+                    )
+
+                # fetch the output JSON
+                output_response = await client.get(output_url)
+                output_response.raise_for_status()
+                predictions = output_response.json()
+
+                genres = [
+                    GenrePrediction(name=name, confidence=round(score, 4))
+                    for name, score in predictions.items()
+                ]
+                # sort by confidence descending
+                genres.sort(key=lambda g: g.confidence, reverse=True)
+
+                logfire.info(
+                    "genre classification complete",
+                    genre_count=len(genres),
+                    top_genre=genres[0].name if genres else None,
+                )
+
+                return ClassificationResult(success=True, genres=genres)
+
+        except httpx.TimeoutException as e:
+            logger.error("genre classification timed out: %s", e)
+            return ClassificationResult(
+                success=False,
+                error=f"classification timed out after {self.timeout.read}s",
+            )
+
+        except httpx.HTTPStatusError as e:
+            error_body = e.response.text[:500] if e.response.text else "no body"
+            logger.error(
+                "genre classification failed: %s - %s",
+                e.response.status_code,
+                error_body,
+            )
+            return ClassificationResult(
+                success=False,
+                error=f"replicate API returned {e.response.status_code}: {error_body}",
+            )
+
+        except Exception as e:
+            logger.exception("unexpected error during genre classification")
+            return ClassificationResult(
+                success=False,
+                error=f"unexpected error: {e}",
+            )
+
+
+# module-level singleton
+_client: ReplicateClient | None = None
+
+
+def get_replicate_client() -> ReplicateClient:
+    """get the Replicate client singleton.
+
+    creates the client on first call, reuses on subsequent calls.
+    """
+    global _client
+    if _client is None:
+        _client = ReplicateClient.from_settings()
+    return _client

--- a/backend/src/backend/api/tracks/tags.py
+++ b/backend/src/backend/api/tracks/tags.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-from collections import defaultdict
 from typing import Annotated
 
 from fastapi import Cookie, Depends, HTTPException, Query, Request
@@ -11,7 +10,6 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from backend._internal import tpuf_client
 from backend._internal.auth import get_session
 from backend.config import settings
 from backend.models import Artist, Tag, Track, TrackLike, TrackTag, get_db
@@ -158,14 +156,14 @@ async def list_tags(
 
 
 class RecommendedTag(BaseModel):
-    """a recommended tag with similarity-weighted score."""
+    """a recommended tag with confidence score."""
 
     name: str
     score: float
 
 
 class RecommendedTagsResponse(BaseModel):
-    """response for tag recommendations based on audio similarity."""
+    """response for tag recommendations based on genre classification."""
 
     track_id: int
     tags: list[RecommendedTag]
@@ -178,10 +176,10 @@ async def get_recommended_tags(
     db: Annotated[AsyncSession, Depends(get_db)],
     limit: Annotated[int, Query(ge=1, le=20)] = 5,
 ) -> RecommendedTagsResponse:
-    """recommend tags for a track based on similar-sounding tracks.
+    """recommend tags for a track based on ML genre classification.
 
-    uses CLAP audio embeddings to find similar tracks, then aggregates
-    their tags weighted by similarity score.
+    uses effnet-discogs via Replicate to classify audio into genre labels.
+    results are cached in track.extra["genre_predictions"].
     """
     # verify track exists
     result = await db.execute(select(Track).where(Track.id == track_id))
@@ -189,51 +187,46 @@ async def get_recommended_tags(
     if not track:
         raise HTTPException(status_code=404, detail="track not found")
 
-    # check if embeddings are enabled
-    if not (settings.modal.enabled and settings.turbopuffer.enabled):
-        return RecommendedTagsResponse(track_id=track_id, tags=[], available=False)
+    # check for stored predictions
+    predictions: list[dict[str, str | float]] | None = (track.extra or {}).get(
+        "genre_predictions"
+    )
 
-    # fetch this track's embedding
-    embedding = await tpuf_client.get_vector(track_id)
-    if embedding is None:
+    if predictions is None and settings.replicate.enabled and track.r2_url:
+        # classify on-demand
+        from backend._internal.replicate_client import get_replicate_client
+
+        client = get_replicate_client()
+        classify_result = await client.classify(track.r2_url)
+
+        if classify_result.success and classify_result.genres:
+            predictions = [
+                {"name": g.name, "confidence": g.confidence}
+                for g in classify_result.genres
+            ]
+            # store for future requests
+            extra = dict(track.extra) if track.extra else {}
+            extra["genre_predictions"] = predictions
+            track.extra = extra
+            await db.commit()
+
+    if predictions is None:
+        if not settings.replicate.enabled:
+            return RecommendedTagsResponse(track_id=track_id, tags=[], available=False)
         return RecommendedTagsResponse(track_id=track_id, tags=[])
 
-    # find similar tracks
-    similar = await tpuf_client.query(embedding, top_k=21)
+    # get existing tags to exclude
+    tags_map = await get_track_tags(db, [track_id])
+    current_tags = {t.lower() for t in tags_map.get(track_id, set())}
 
-    # filter out self
-    neighbors = [r for r in similar if r.track_id != track_id][:20]
-    if not neighbors:
-        return RecommendedTagsResponse(track_id=track_id, tags=[])
-
-    neighbor_ids = [r.track_id for r in neighbors]
-    similarity_by_id = {r.track_id: 1.0 - r.distance for r in neighbors}
-
-    # fetch tags for neighbors and the target track
-    all_ids = [*neighbor_ids, track_id]
-    tags_map = await get_track_tags(db, all_ids)
-
-    current_tags = tags_map.get(track_id, set())
-
-    # aggregate: sum similarity scores per tag across neighbors
-    tag_scores: dict[str, float] = defaultdict(float)
-    for neighbor_id in neighbor_ids:
-        sim = similarity_by_id[neighbor_id]
-        for tag_name in tags_map.get(neighbor_id, set()):
-            if tag_name not in current_tags:
-                tag_scores[tag_name] += sim
-
-    if not tag_scores:
-        return RecommendedTagsResponse(track_id=track_id, tags=[])
-
-    # normalize to 0-1
-    max_score = max(tag_scores.values())
-    recommended = sorted(tag_scores.items(), key=lambda x: x[1], reverse=True)[:limit]
+    # filter out tags the track already has
+    recommended = [
+        RecommendedTag(name=str(p["name"]), score=float(p["confidence"]))
+        for p in predictions
+        if str(p["name"]).lower() not in current_tags
+    ][:limit]
 
     return RecommendedTagsResponse(
         track_id=track_id,
-        tags=[
-            RecommendedTag(name=name, score=round(score / max_score, 3))
-            for name, score in recommended
-        ],
+        tags=recommended,
     )

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -41,6 +41,7 @@ from backend._internal.background_tasks import (
     schedule_album_list_sync,
     schedule_copyright_scan,
     schedule_embedding_generation,
+    schedule_genre_classification,
 )
 from backend._internal.image import ImageFormat
 from backend._internal.jobs import job_service
@@ -818,6 +819,10 @@ async def _process_upload_background(ctx: UploadContext) -> None:
                         and settings.turbopuffer.enabled
                     ):
                         await schedule_embedding_generation(track.id, r2_url)
+
+                    # classify genres via Replicate
+                    if r2_url and settings.replicate.enabled:
+                        await schedule_genre_classification(track.id, r2_url)
 
                     # sync album list record if track is in an album
                     if album_record:

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -160,7 +160,7 @@ class LegalSettings(AppSettingsSection):
         description="USPTO DMCA agent registration number",
     )
     terms_last_updated: datetime = Field(
-        default=datetime(2026, 2, 4),
+        default=datetime(2026, 2, 6),
         description="Date the terms/privacy were last materially updated. "
         "Users who accepted before this date will be prompted to re-accept.",
     )
@@ -700,6 +700,34 @@ class ModalSettings(AppSettingsSection):
     )
 
 
+class ReplicateSettings(AppSettingsSection):
+    """Replicate ML platform settings for effnet-discogs genre classification."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="REPLICATE_",
+        env_file=".env",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    enabled: bool = Field(
+        default=False,
+        description="Enable Replicate genre classification",
+    )
+    api_token: SecretStr = Field(
+        default=SecretStr(""),
+        description="Replicate API token (REPLICATE_API_TOKEN)",
+    )
+    top_n: int = Field(
+        default=10,
+        description="Number of top genre predictions to keep",
+    )
+    timeout_seconds: int = Field(
+        default=120,
+        description="Timeout for Replicate API requests",
+    )
+
+
 class TurbopufferSettings(AppSettingsSection):
     """Turbopuffer vector database settings for vibe search."""
 
@@ -912,6 +940,10 @@ class Settings(AppSettingsSection):
     turbopuffer: TurbopufferSettings = Field(
         default_factory=TurbopufferSettings,
         description="Turbopuffer vector search settings",
+    )
+    replicate: ReplicateSettings = Field(
+        default_factory=ReplicateSettings,
+        description="Replicate genre classification settings",
     )
 
 

--- a/docs/backend/mood-search.md
+++ b/docs/backend/mood-search.md
@@ -181,23 +181,23 @@ no auth required. returns tracks ranked by cosine similarity to the query text.
 
 ### `GET /tracks/{track_id}/recommended-tags?limit=5`
 
-no auth required. recommends tags for a track based on what similar-sounding tracks are tagged with.
+no auth required. recommends genre tags for a track based on ML classification via effnet-discogs on Replicate.
 
-uses the track's CLAP audio embedding to find the 20 nearest neighbors via turbopuffer, aggregates their tags weighted by cosine similarity, and excludes tags the track already has.
+results are cached in `track.extra["genre_predictions"]`. if no predictions are stored and Replicate is enabled, classification runs on-demand. excludes tags the track already has.
 
 **response**:
 ```json
 {
   "track_id": 76,
   "tags": [
-    {"name": "ambient", "score": 1.0},
-    {"name": "electronic", "score": 0.72}
+    {"name": "Techno", "score": 0.87},
+    {"name": "Electronic", "score": 0.72}
   ],
   "available": true
 }
 ```
 
-`available: false` when Modal/turbopuffer are disabled. empty `tags` with `available: true` means the track has no embedding or its neighbors have no tags.
+`available: false` when Replicate is disabled. empty `tags` with `available: true` means classification returned no results or the track has no R2 URL.
 
 ## key files
 

--- a/frontend/src/routes/privacy/+page.svelte
+++ b/frontend/src/routes/privacy/+page.svelte
@@ -18,7 +18,7 @@
 <div class="legal-container">
 	<article class="legal-content">
 		<h1>Privacy Policy</h1>
-		<p class="last-updated">Last updated: February 4, 2026</p>
+		<p class="last-updated">Last updated: February 6, 2026</p>
 
 		<p class="intro">
 			{APP_NAME} ("we", "us", or "our") is an audio streaming application built on the
@@ -88,6 +88,7 @@
 				<li><strong><a href="https://atprotofans.com" target="_blank" rel="noopener">ATProtoFans</a></strong> - supporter validation for gated content</li>
 				<li><strong><a href="https://modal.com" target="_blank" rel="noopener">Modal</a></strong> - audio processing for search embeddings</li>
 				<li><strong><a href="https://turbopuffer.com" target="_blank" rel="noopener">turbopuffer</a></strong> - vector storage for semantic search</li>
+			<li><strong><a href="https://replicate.com" target="_blank" rel="noopener">Replicate</a></strong> - ML inference for genre classification</li>
 			</ul>
 			<p>
 				We may also write records to your PDS using third-party lexicon namespaces

--- a/loq.toml
+++ b/loq.toml
@@ -51,7 +51,7 @@ max_lines = 1100
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 918
+max_lines = 950
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"

--- a/scripts/backfill_genres.py
+++ b/scripts/backfill_genres.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env -S uv run --script --quiet
+"""backfill genre classifications for existing tracks.
+
+## Context
+
+Genre classification uses the effnet-discogs model on Replicate to classify
+audio into genre labels. New uploads classify automatically, but existing
+tracks need to be backfilled.
+
+## What This Script Does
+
+1. Queries all tracks with an R2 audio URL missing genre_predictions in extra
+2. Classifies each track via Replicate
+3. Stores predictions in track.extra["genre_predictions"]
+
+## Usage
+
+```bash
+# dry run (show what would be classified, no API calls)
+uv run scripts/backfill_genres.py --dry-run
+
+# classify first 5 tracks
+uv run scripts/backfill_genres.py --limit 5
+
+# full backfill with 5 concurrent workers (default)
+uv run scripts/backfill_genres.py
+
+# custom concurrency
+uv run scripts/backfill_genres.py --concurrency 10
+```
+"""
+
+import argparse
+import asyncio
+import logging
+import time
+
+from sqlalchemy import select, text
+
+from backend._internal.replicate_client import get_replicate_client
+from backend.config import settings
+from backend.models import Artist, Track
+from backend.utilities.database import db_session
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+async def _classify_one(
+    track: Track,
+    artist: Artist,
+    client: object,
+    sem: asyncio.Semaphore,
+    counter: dict[str, int],
+    total: int,
+) -> None:
+    """classify a single track, guarded by semaphore."""
+    async with sem:
+        idx = counter["started"] + 1
+        counter["started"] += 1
+
+        try:
+            logger.info(
+                "classifying [%d/%d] track %d: %s by %s",
+                idx,
+                total,
+                track.id,
+                track.title,
+                artist.handle,
+            )
+
+            result = await client.classify(track.r2_url)
+
+            if not result.success or not result.genres:
+                logger.warning(
+                    "classification failed for track %d: %s",
+                    track.id,
+                    result.error,
+                )
+                counter["failed"] += 1
+                return
+
+            predictions = [
+                {"name": g.name, "confidence": g.confidence} for g in result.genres
+            ]
+
+            async with db_session() as db:
+                db_result = await db.execute(select(Track).where(Track.id == track.id))
+                db_track = db_result.scalar_one_or_none()
+                if db_track:
+                    extra = dict(db_track.extra) if db_track.extra else {}
+                    extra["genre_predictions"] = predictions
+                    db_track.extra = extra
+                    await db.commit()
+
+            counter["classified"] += 1
+            logger.info(
+                "classified track %d: top genre = %s (%.2f)",
+                track.id,
+                predictions[0]["name"],
+                predictions[0]["confidence"],
+            )
+
+        except Exception:
+            logger.exception("failed to process track %d", track.id)
+            counter["failed"] += 1
+
+
+async def backfill_genres(
+    dry_run: bool = False,
+    limit: int | None = None,
+    concurrency: int = 5,
+) -> None:
+    """backfill genre classifications for tracks missing predictions."""
+
+    if not dry_run:
+        if not settings.replicate.enabled:
+            logger.error("REPLICATE_ENABLED is not set — cannot classify genres")
+            return
+
+    async with db_session() as db:
+        stmt = (
+            select(Track, Artist)
+            .join(Artist, Track.artist_did == Artist.did)
+            .where(
+                Track.r2_url.isnot(None),
+                # filter tracks missing genre_predictions in extra
+                text("NOT (tracks.extra ? 'genre_predictions')"),
+            )
+            .order_by(Track.id)
+        )
+        if limit:
+            stmt = stmt.limit(limit)
+
+        result = await db.execute(stmt)
+        rows = result.all()
+
+    if not rows:
+        logger.info("no tracks found to classify")
+        return
+
+    logger.info("found %d tracks to classify (concurrency=%d)", len(rows), concurrency)
+
+    if dry_run:
+        for track, artist in rows:
+            logger.info(
+                "would classify: [%d] %s by %s",
+                track.id,
+                track.title,
+                artist.handle,
+            )
+        return
+
+    client = get_replicate_client()
+    sem = asyncio.Semaphore(concurrency)
+    counter: dict[str, int] = {"started": 0, "classified": 0, "failed": 0}
+    t0 = time.monotonic()
+
+    tasks = [
+        _classify_one(track, artist, client, sem, counter, len(rows))
+        for track, artist in rows
+    ]
+    await asyncio.gather(*tasks)
+
+    elapsed = time.monotonic() - t0
+    logger.info(
+        "backfill complete: %d classified, %d failed, %d total in %.0fs (%.1f tracks/s)",
+        counter["classified"],
+        counter["failed"],
+        len(rows),
+        elapsed,
+        len(rows) / elapsed if elapsed > 0 else 0,
+    )
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="backfill genre classifications")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="show what would be done"
+    )
+    parser.add_argument("--limit", type=int, default=None, help="max tracks to process")
+    parser.add_argument("--concurrency", type=int, default=5, help="concurrent workers")
+    args = parser.parse_args()
+
+    if args.dry_run:
+        logger.info("running in DRY RUN mode — no API calls will be made")
+
+    await backfill_genres(
+        dry_run=args.dry_run,
+        limit=args.limit,
+        concurrency=args.concurrency,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- replace CLAP-neighbor tag recommendations with ML genre classification using effnet-discogs on Replicate
- new `ReplicateClient` using httpx directly (replicate SDK broken on Python 3.14)
- predictions stored in `track.extra["genre_predictions"]`, classified on upload or on-demand
- removed `get_vector()` from tpuf_client (only used by old endpoint)
- adds Replicate to privacy policy third-party list, bumps terms date
- backfill script: `uv run scripts/backfill_genres.py`

## Test plan

- [x] `just backend test` — 393 passed
- [x] `just backend lint` — clean
- [ ] deploy, upload a track with `REPLICATE_ENABLED=true` → verify `genre_predictions` in track extra
- [ ] `curl /tracks/{id}/recommended-tags` → effnet-discogs labels
- [ ] `uv run scripts/backfill_genres.py --limit 5` → existing tracks get classified

🤖 Generated with [Claude Code](https://claude.com/claude-code)