### PR TITLE
fix: invalidate genre predictions when audio file changes

### DIFF
--- a/backend/src/backend/_internal/background_tasks.py
+++ b/backend/src/backend/_internal/background_tasks.py
@@ -685,6 +685,7 @@ async def classify_genres(track_id: int, audio_url: str) -> None:
 
         extra = dict(track.extra) if track.extra else {}
         extra["genre_predictions"] = predictions
+        extra["genre_predictions_file_id"] = track.file_id
         track.extra = extra
         await db.commit()
 

--- a/scripts/backfill_genres.py
+++ b/scripts/backfill_genres.py
@@ -93,6 +93,7 @@ async def _classify_one(
                 if db_track:
                     extra = dict(db_track.extra) if db_track.extra else {}
                     extra["genre_predictions"] = predictions
+                    extra["genre_predictions_file_id"] = db_track.file_id
                     db_track.extra = extra
                     await db.commit()
 


### PR DESCRIPTION
## Summary
- store `genre_predictions_file_id` alongside predictions in `track.extra` so cached results are invalidated when audio is replaced
- all three write sites updated: background task, on-demand endpoint, backfill script
- existing predictions without a file_id will reclassify on next request (safe rollout)

## Test plan
- [x] new test: `test_recommended_tags_reclassifies_when_file_id_changes` — verifies stale predictions are discarded
- [x] existing tests updated with `genre_predictions_file_id` in fixture
- [x] full suite passes (394 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)