### PR TITLE
feat: suggested genre tags in track edit modal

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -159,7 +159,7 @@ max_lines = 2168
 
 [[rules]]
 path = "frontend/src/routes/portal/+page.svelte"
-max_lines = 3313
+max_lines = 3410
 
 [[rules]]
 path = "frontend/src/routes/settings/+page.svelte"


### PR DESCRIPTION
## Summary
- when editing a track on the portal, fetch recommended tags from `GET /tracks/{id}/recommended-tags`
- display as clickable dashed-border chips below the tag input with a "suggested" label
- WaveLoading spinner shown while fetching (~2s for uncached tracks, instant for cached)
- clicking a chip adds it to the track's tags and removes it from suggestions
- `$derived` reactively hides suggestions that match tags added via manual typing
- all failures/empty/unavailable states silently hide the section (enhancement, not critical path)

## Test plan
- [ ] open portal, click edit on a track — "suggested" label + loading wave appears
- [ ] chips appear after load — click one, it moves to tags
- [ ] type a tag manually that matches a suggestion — chip disappears
- [ ] edit a track with no predictions — no suggested section
- [ ] `just frontend check` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)