### PR TITLE
docs: genre classification updates and February STATUS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ organized knowledge base for plyr.fm development.
   - [connection-pool-exhaustion](./runbooks/connection-pool-exhaustion.md) - 500s, stuck connections
 
 ### backend
-- **[background-tasks.md](./backend/background-tasks.md)** - docket-based task system (copyright scan, export, scrobble)
+- **[background-tasks.md](./backend/background-tasks.md)** - docket-based task system (copyright scan, export, scrobble, genre classification)
 - **[configuration.md](./backend/configuration.md)** - environment setup and settings
 - **[database/](./backend/database/)** - connection pooling, neon-specific patterns
 - **[feature-flags.md](./backend/feature-flags.md)** - per-user feature rollout system

--- a/docs/backend/background-tasks.md
+++ b/docs/backend/background-tasks.md
@@ -12,6 +12,7 @@ background tasks handle operations that shouldn't block the request/response cyc
 - **album list sync** - updates ATProto list records when album metadata changes
 - **PDS like/unlike** - syncs like records to user's PDS asynchronously
 - **PDS comment create/update/delete** - syncs comment records to user's PDS asynchronously
+- **genre classification** - classifies tracks via Replicate effnet-discogs, stores predictions in `track.extra`
 - **move track audio** - moves files between public/private R2 buckets when support_gate is toggled
 - **sync copyright resolutions** (perpetual) - syncs copyright label resolutions from ATProto labeler every 5 minutes
 


### PR DESCRIPTION
## Summary
- add cache invalidation (`genre_predictions_file_id`) and frontend UX sections to `genre-classification.md`
- add February 2026 section to `STATUS.md` covering PRs #864-868
- add Replicate to cost structure in STATUS.md
- add genre classification to background-tasks.md task list
- update docs README description

🤖 Generated with [Claude Code](https://claude.com/claude-code)