### PR TITLE
fix: split genre/subgenre into separate tags

### DIFF
--- a/docs/backend/genre-classification.md
+++ b/docs/backend/genre-classification.md
@@ -23,7 +23,7 @@ track uploaded (or on-demand request)
 
 1. audio URL is sent to Replicate's effnet-discogs model
 2. model returns genre labels from the [Discogs taxonomy](https://www.discogs.com/search/) with confidence scores
-3. raw labels use `Genre---Subgenre` format (e.g., `Electronic---Ambient`) — we clean these to `subgenre genre` lowercase (`ambient electronic`)
+3. raw labels use `Genre---Subgenre` format (e.g., `Electronic---Ambient`) — we split these into separate tags (`electronic`, `ambient`) and deduplicate, keeping the highest confidence score
 4. predictions are stored in `track.extra["genre_predictions"]` as JSON
 
 ### when classification runs
@@ -61,9 +61,10 @@ predictions are stored in `track.extra["genre_predictions"]`:
 
 ```json
 [
-  {"name": "ambient electronic", "confidence": 0.1999},
-  {"name": "experimental electronic", "confidence": 0.1673},
-  {"name": "synth-pop electronic", "confidence": 0.122}
+  {"name": "electronic", "confidence": 0.1999},
+  {"name": "ambient", "confidence": 0.1999},
+  {"name": "experimental", "confidence": 0.1673},
+  {"name": "synth-pop", "confidence": 0.122}
 ]
 ```
 


### PR DESCRIPTION
## Summary
- split Discogs `Genre---Subgenre` pairs into separate tags instead of joining them
- `Electronic---Deep Techno` now produces `electronic` + `deep techno` (not `deep techno electronic`)
- deduplicates across predictions, keeping the highest confidence score
- e.g. if 5 predictions all have "electronic", it appears once with the top score

## Before/after

**before**: `techno electronic`, `progressive house electronic`, `deep techno electronic`
**after**: `electronic`, `techno`, `progressive house`, `deep techno`

## Test plan
- [x] all 394 tests pass
- [x] lint clean
- [ ] after deploy, clear stale predictions and re-test: `curl .../recommended-tags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)