### PR TITLE
feat: auto-tag tracks with recommended genres at upload time

### DIFF
--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -70,6 +70,7 @@ class UploaderState {
 		image: File | null | undefined,
 		tags: string[],
 		supportGated: boolean,
+		autoTag: boolean,
 		onSuccess?: () => void,
 		callbacks?: UploadProgressCallback
 	): void {
@@ -108,6 +109,9 @@ class UploaderState {
 		}
 		if (supportGated) {
 			formData.append('support_gate', JSON.stringify({ type: 'any' }));
+		}
+		if (autoTag) {
+			formData.append('auto_tag', 'true');
 		}
 
 		const xhr = new XMLHttpRequest();

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -62,6 +62,7 @@
 	let hasUnresolvedFeaturesInput = $state(false);
 	let attestedRights = $state(false);
 	let supportGated = $state(false);
+	let autoTag = $state(false);
 
 	// albums for selection
 	let albums = $state<AlbumSummary[]>([]);
@@ -124,6 +125,7 @@
 		const uploadImage = imageFile;
 		const tagsToUpload = [...uploadTags];
 		const isGated = supportGated;
+		const shouldAutoTag = autoTag;
 
 		const clearForm = () => {
 			title = "";
@@ -134,6 +136,7 @@
 			uploadTags = [];
 			attestedRights = false;
 			supportGated = false;
+			autoTag = false;
 
 			const fileInput = document.getElementById(
 				"file-input",
@@ -153,6 +156,7 @@
 			uploadImage,
 			tagsToUpload,
 			isGated,
+			shouldAutoTag,
 			async () => {
 				await loadMyAlbums();
 			},
@@ -291,6 +295,10 @@
 					}}
 					placeholder="type to search tags..."
 				/>
+				<label class="checkbox-label" style="margin-top: 0.75rem;">
+					<input type="checkbox" bind:checked={autoTag} />
+					<span class="checkbox-text">auto-tag with recommended genres</span>
+				</label>
 			</div>
 
 			<div class="form-group">

--- a/loq.toml
+++ b/loq.toml
@@ -47,7 +47,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1100
+max_lines = 1110
 
 [[rules]]
 path = "backend/src/backend/config.py"
@@ -179,7 +179,7 @@ max_lines = 1293
 
 [[rules]]
 path = "frontend/src/routes/upload/+page.svelte"
-max_lines = 670
+max_lines = 680
 
 [[rules]]
 path = "moderation/src/admin.rs"


### PR DESCRIPTION
## Summary
- adds "auto-tag with recommended genres" checkbox to the upload form
- after genre classification completes, automatically applies top tags using ratio-to-top filter (>= 50% of top score, capped at 5)
- additive with manual tags — user can add their own AND get auto-tags
- flag stored in `track.extra`, cleaned up after use (no migration needed)

## Test plan
- [ ] upload with "auto-tag" checked, no manual tags → track gets genre tags after classification
- [ ] upload with "auto-tag" checked AND manual tags → both appear
- [ ] upload with "auto-tag" unchecked → no auto-tags, same behavior as before
- [ ] verify `auto_tag` flag is cleaned from `track.extra` after classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)