### PR TITLE
fix: remove duplicate auto-download toggle

### DIFF
--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -540,21 +540,6 @@
 						<span class="toggle-slider"></span>
 					</label>
 				</div>
-
-				<div class="setting-row">
-					<div class="setting-info">
-						<h3>auto-download liked</h3>
-						<p>automatically download tracks for offline playback when you like them</p>
-					</div>
-					<label class="toggle-switch">
-						<input
-							type="checkbox"
-							checked={autoDownloadLiked}
-							onchange={(e) => handleAutoDownloadToggle((e.target as HTMLInputElement).checked)}
-						/>
-						<span class="toggle-slider"></span>
-					</label>
-				</div>
 			</div>
 		</section>
 


### PR DESCRIPTION
## Summary
- Removed duplicate "auto-download liked" toggle from the playback settings section
- The toggle remains in the experimental section where it belongs

## Test plan
- [ ] Visit /settings, confirm "auto-download liked" appears only once (under "experimental")
- [ ] Confirm the toggle still works correctly from the experimental section

🤖 Generated with [Claude Code](https://claude.com/claude-code)