### PR TITLE
feat: paginate portal tracks list

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -42,6 +42,10 @@ path = "backend/src/backend/api/lists.py"
 max_lines = 865
 
 [[rules]]
+path = "backend/src/backend/api/tracks/listing.py"
+max_lines = 517
+
+[[rules]]
 path = "backend/src/backend/api/tracks/mutations.py"
 max_lines = 850
 
@@ -159,7 +163,7 @@ max_lines = 2168
 
 [[rules]]
 path = "frontend/src/routes/portal/+page.svelte"
-max_lines = 3410
+max_lines = 3427
 
 [[rules]]
 path = "frontend/src/routes/settings/+page.svelte"


### PR DESCRIPTION
## Summary
- adds `limit`/`offset` pagination to `GET /tracks/me` (default 10 per page)
- portal now loads first 10 tracks with a "load more" button for the rest
- follows the same offset-based pattern already used by shares on the same page
- export section uses total count for accurate messaging

## Test plan
- [x] backend lint + tests pass (394 passed)
- [x] frontend check passes
- [ ] verify portal loads first 10 tracks for a user with many tracks
- [ ] verify "load more" button fetches next batch
- [ ] verify delete/edit still work correctly after pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)