### PR TITLE
fix: exclude reverted PR #846 from status maintenance filter

### DIFF
--- a/.github/workflows/status-maintenance.yml
+++ b/.github/workflows/status-maintenance.yml
@@ -65,8 +65,8 @@ jobs:
             ```bash
             date
             # get the most recently merged status-maintenance PR (filter by branch name, sort by merge date)
-            # NOTE: excluding #724 which was reverted - remove this exclusion after next successful run
-            gh pr list --state merged --search "status-maintenance" --limit 20 --json number,title,mergedAt,headRefName | jq '[.[] | select(.headRefName | startswith("status-maintenance-")) | select(.number != 724)] | sort_by(.mergedAt) | reverse | .[0]'
+            # NOTE: excluding #724 and #846 which were reverted - remove these exclusions after next successful run
+            gh pr list --state merged --search "status-maintenance" --limit 20 --json number,title,mergedAt,headRefName | jq '[.[] | select(.headRefName | startswith("status-maintenance-")) | select(.number != 724 and .number != 846)] | sort_by(.mergedAt) | reverse | .[0]'
             git log --oneline -50
             ls -la .status_history/ 2>/dev/null || echo "no archive directory yet"
             wc -l STATUS.md


### PR DESCRIPTION
## Summary

- Add #846 to the exclusion list in the status maintenance jq filter (alongside existing #724 exclusion)
- Without this, the action uses #846's merge date (Feb 7) as the time window, missing 2+ weeks of work since PR #775 (Jan 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)