### PR TITLE
fix: add manual upload-audio workflow, fix grep -c bug

### DIFF
--- a/.github/workflows/status-maintenance.yml
+++ b/.github/workflows/status-maintenance.yml
@@ -288,7 +288,9 @@ jobs:
           YEAR=$(date +%Y)
 
           # count how many "plyr.fm update - {date}" tracks exist for today
-          TODAY_COUNT=$(echo "$EXISTING" | grep -c "plyr.fm update - $TODAY" || echo "0")
+          # grep -c returns exit code 1 on no match, so default to 0
+          TODAY_COUNT=$(echo "$EXISTING" | grep -c "plyr.fm update - $TODAY" || true)
+          TODAY_COUNT=${TODAY_COUNT:-0}
 
           if [ "$TODAY_COUNT" -gt 0 ]; then
             # already have one today, add episode number

--- a/.github/workflows/upload-audio.yml
+++ b/.github/workflows/upload-audio.yml
@@ -1,0 +1,74 @@
+# manual audio upload to plyr.fm
+#
+# uploads the most recent update.wav from the repo root to plyr.fm
+# via the plyrfm CLI. uses the plyr.fm bot account.
+#
+# required secrets:
+#   PLYR_BOT_TOKEN - plyr.fm developer token
+
+name: upload audio
+
+on:
+  workflow_dispatch:
+    inputs:
+      title:
+        description: "track title"
+        required: true
+        type: string
+      album:
+        description: "album name (default: current year)"
+        required: false
+        type: string
+      tags:
+        description: "comma-separated tags (default: ai)"
+        required: false
+        type: string
+        default: "ai"
+      delete_track_id:
+        description: "track ID to delete before uploading (optional)"
+        required: false
+        type: string
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Delete old track (if requested)
+        if: inputs.delete_track_id != ''
+        run: |
+          echo "Deleting track ${{ inputs.delete_track_id }}..."
+          uv run --with plyrfm -- plyrfm delete "${{ inputs.delete_track_id }}" --yes
+        env:
+          PLYR_TOKEN: ${{ secrets.PLYR_BOT_TOKEN }}
+
+      - name: Upload audio to plyr.fm
+        run: |
+          if [ ! -f update.wav ]; then
+            echo "::error::No update.wav found at repo root"
+            exit 1
+          fi
+
+          ALBUM="${{ inputs.album }}"
+          ALBUM=${ALBUM:-$(date +%Y)}
+
+          TAGS="${{ inputs.tags }}"
+          TAG_ARGS=""
+          if [ -n "$TAGS" ]; then
+            IFS=',' read -ra TAG_ARRAY <<< "$TAGS"
+            for tag in "${TAG_ARRAY[@]}"; do
+              TAG_ARGS="$TAG_ARGS -t $(echo "$tag" | xargs)"
+            done
+          fi
+
+          echo "Uploading: ${{ inputs.title }}"
+          echo "Album: $ALBUM"
+          echo "Tags: $TAGS"
+
+          eval uv run --with plyrfm -- plyrfm upload update.wav '"${{ inputs.title }}"' --album '"$ALBUM"' $TAG_ARGS
+        env:
+          PLYR_TOKEN: ${{ secrets.PLYR_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

- **New `upload-audio` workflow** — workflow_dispatch with form fields:
  - `title` (required): track title
  - `album` (optional, defaults to current year)
  - `tags` (optional, defaults to "ai")
  - `delete_track_id` (optional): delete a stale track before uploading
- **Fix `grep -c` bug** in status-maintenance upload job — `grep -c` returns exit code 1 on no match, so `|| echo "0"` produced `"0\n0"` (two lines). Fixed with `|| true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)