### PR TITLE
fix: refresh auth state after account switch/login

### DIFF
--- a/frontend/src/lib/auth.svelte.ts
+++ b/frontend/src/lib/auth.svelte.ts
@@ -71,6 +71,11 @@ class AuthManager {
 		this.initialized = false;
 	}
 
+	async refresh(): Promise<void> {
+		this.initialized = false;
+		await this.initialize();
+	}
+
 	async logout(): Promise<void> {
 		try {
 			await fetch(`${API_URL}/auth/logout`, {

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -41,7 +41,7 @@
 				if (exchangeResponse.ok) {
 					// invalidate all load functions so they rerun with the new session cookie
 					await invalidateAll();
-					await auth.initialize();
+					await auth.refresh();
 					await preferences.fetch();
 				}
 			} catch (_e) {

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -122,7 +122,7 @@
 				if (exchangeResponse.ok) {
 					// invalidate all load functions so they rerun with the new session cookie
 					await invalidateAll();
-					await auth.initialize();
+					await auth.refresh();
 					await preferences.fetch();
 				}
 			} catch (_e) {

--- a/frontend/src/routes/profile/setup/+page.svelte
+++ b/frontend/src/routes/profile/setup/+page.svelte
@@ -33,7 +33,7 @@
 				if (exchangeResponse.ok) {
 					// invalidate all load functions so they rerun with the new session cookie
 					await invalidateAll();
-					await auth.initialize();
+					await auth.refresh();
 				}
 			} catch (_e) {
 				console.error('failed to exchange token:', _e);

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -79,7 +79,7 @@
 						showTokenOverlay = true; // show full-page overlay immediately
 					} else if (isScopeUpgrade) {
 						// reload auth state with new session
-						await auth.initialize();
+						await auth.refresh();
 						await preferences.fetch();
 						toast.success('teal.fm scrobbling connected!');
 					}


### PR DESCRIPTION
## Summary
- Adds `refresh()` method to `AuthManager` that resets the `initialized` flag before re-fetching user data
- Replaces `auth.initialize()` with `auth.refresh()` in all 4 exchange-token flows (portal, library, profile/setup, settings)
- Fixes stale handle in portal button after logging in as a different account

## Root cause
`AuthManager.initialize()` guards with `this.initialized` — once the layout's `onMount` sets it, subsequent calls from exchange-token flows silently no-op, leaving stale user data.

## Test plan
- [ ] Log in as account A, then log in as account B via OAuth — portal button should show account B's handle
- [ ] `just frontend check` passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)