### PR TITLE
docs: fix stale references and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ check the [plyr.fm artist page](https://plyr.fm/u/plyr.fm) for the latest [auto-
 - **styling**: vanilla CSS (lowercase aesthetic)
 
 ### services
-- **moderation**: Rust ATProto labeler for copyright/sensitive content
-- **transcoder**: Rust audio conversion service (ffmpeg)
+- **transcoder**: Rust audio conversion service (ffmpeg, Fly.io)
+- **moderation**: Rust ATProto labeler for copyright/sensitive content (Fly.io)
+- **mood search**: [CLAP](https://github.com/LAION-AI/CLAP) audio embeddings ([Modal](https://modal.com))
+- **genre classification**: [effnet-discogs](https://replicate.com/) ML tagging ([Replicate](https://replicate.com))
+- **vector search**: [turbopuffer](https://turbopuffer.com) for semantic audio queries
 
 </details>
 
@@ -81,23 +84,32 @@ just dev-services-down
 ### listening
 - audio playback with persistent queue across tabs
 - like tracks, add to playlists
-- browse artist profiles and discographies
-- share tracks, albums, and playlists with link previews
-- unified search with Cmd/Ctrl+K
-- teal.fm scrobbling
+- browse by artist, album, tag, or playlist
+- share tracks and albums with embeddable players and link previews
+- mood search - describe a vibe, get matching tracks (CLAP embeddings)
+- unified search with Cmd/Ctrl+K (fuzzy match across tracks, artists, albums, tags, playlists)
+- genre browsing and tag filtering
+- platform media controls (Media Session API)
+- teal.fm scrobbling and now-playing reporting
 
 ### creating
-- OAuth authentication via ATProto (bluesky accounts)
+- OAuth authentication via ATProto (bluesky accounts), multi-account support
 - upload tracks with title, artwork, tags, and featured artists
-- organize tracks into albums and playlists
-- drag-and-drop reordering
+- lossless audio support (AIFF/FLAC) with automatic MP3 transcoding for universal playback
+- auto-tagging via ML genre classification
+- organize tracks into albums and playlists with drag-and-drop reordering
 - timed comments with clickable timestamps
-- artist support links (ko-fi, patreon, etc.)
+- artist support links and supporter-gated content
+- copyright scanning via audio fingerprinting
+- content reporting and automated sensitive content filtering
 
 ### data ownership
 - tracks, likes, playlists synced to your PDS as ATProto records
+- bulk media export (download all your tracks)
 - portable identity - your data travels with you
 - public by default - any client can read your music records
+
+> some features may be paywalled in the future for the financial viability of the project. if you have thoughts on what should or shouldn't be gated, open a [discussion on GitHub](https://github.com/zzstoatzz/plyr.fm/discussions) or [tangled](https://tangled.sh/@zzstoatzz.io/plyr.fm).
 
 </details>
 
@@ -106,20 +118,19 @@ just dev-services-down
 
 ```
 plyr.fm/
-├── backend/              # FastAPI app
+├── backend/              # FastAPI app & Python tooling
 │   ├── src/backend/      # application code
-│   │   ├── api/          # public endpoints
-│   │   ├── _internal/    # services (auth, atproto, background tasks)
-│   │   ├── models/       # database schemas
-│   │   └── storage/      # R2 adapter
 │   ├── tests/            # pytest suite
-│   └── alembic/          # migrations
+│   └── alembic/          # database migrations
 ├── frontend/             # SvelteKit app
 │   ├── src/lib/          # components & state
 │   └── src/routes/       # pages
-├── moderation/           # Rust labeler service
-├── transcoder/           # Rust audio service
-├── redis/                # self-hosted Redis config
+├── services/
+│   ├── transcoder/       # Rust audio transcoding (Fly.io)
+│   ├── moderation/       # Rust content moderation (Fly.io)
+│   └── clap/             # ML embeddings (Python, Modal)
+├── infrastructure/
+│   └── redis/            # self-hosted Redis (Fly.io)
 ├── docs/                 # documentation
 └── justfile              # task runner
 ```
@@ -129,11 +140,13 @@ plyr.fm/
 <details>
 <summary>costs</summary>
 
-~$20/month:
-- fly.io (backend + redis + moderation): ~$14/month
+~$25/month:
+- fly.io (backend + transcoder + redis + moderation): ~$14/month
 - neon postgres: $5/month
 - cloudflare (pages + r2): ~$1/month
 - audd audio fingerprinting: $5-10/month (usage-based)
+- modal (CLAP embeddings): free tier / scales to zero
+- replicate (genre classification): <$1/month
 
 live dashboard: https://plyr.fm/costs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ organized knowledge base for plyr.fm development.
 - **[feature-flags.md](./backend/feature-flags.md)** - per-user feature rollout system
 - **[streaming-uploads.md](./backend/streaming-uploads.md)** - SSE progress tracking
 - **[transcoder.md](./backend/transcoder.md)** - rust audio conversion service (lossless support)
-- **[vibe-search.md](./backend/vibe-search.md)** - semantic search with CLAP embeddings (Modal + turbopuffer)
+- **[mood-search.md](./backend/mood-search.md)** - semantic search with CLAP embeddings (Modal + turbopuffer)
 - **[genre-classification.md](./backend/genre-classification.md)** - ML genre tagging via effnet-discogs (Replicate)
 
 ### frontend
@@ -32,6 +32,9 @@ organized knowledge base for plyr.fm development.
 - **[logfire.md](./tools/logfire.md)** - SQL query patterns for observability
 - **[neon.md](./tools/neon.md)** - postgres database management
 - **[pdsx.md](./tools/pdsx.md)** - ATProto PDS explorer
+- **[plyrfm.md](./tools/plyrfm.md)** - Python SDK and MCP server
+- **[tap.md](./tools/tap.md)** - ATProto sync utility for backfilling custom lexicons
+- **[status-maintenance.md](./tools/status-maintenance.md)** - automated status podcasts
 
 ### atproto
 - **[lexicons/](./lexicons/)** - record schemas (track, like, comment, list, profile)

--- a/docs/backend/database/connection-pooling.md
+++ b/docs/backend/database/connection-pooling.md
@@ -43,8 +43,8 @@ DATABASE_POOL_SIZE=10
 # additional connections to create on demand when pool is exhausted (default: 5)
 DATABASE_MAX_OVERFLOW=5
 
-# how long before recycling a connection, in seconds (default: 7200 = 2 hours)
-DATABASE_POOL_RECYCLE=7200
+# how long before recycling a connection, in seconds (default: 1800 = 30 minutes)
+DATABASE_POOL_RECYCLE=1800
 
 # verify connection health before using from pool (default: true)
 DATABASE_POOL_PRE_PING=true
@@ -67,7 +67,7 @@ total max connections = `pool_size` + `max_overflow` = 15 by default
 **pool_recycle:**
 - prevents stale connections from lingering
 - should be less than your database's connection timeout
-- 2 hours is a safe default for most PostgreSQL configurations
+- 30 minutes is a safe default for most PostgreSQL configurations
 
 **pool_pre_ping:**
 - adds small overhead (SELECT 1) before each connection use
@@ -148,7 +148,7 @@ DATABASE_STATEMENT_TIMEOUT=10.0
 DATABASE_CONNECTION_TIMEOUT=10.0
 
 # standard recycle
-DATABASE_POOL_RECYCLE=7200
+DATABASE_POOL_RECYCLE=1800
 ```
 
 this configuration:

--- a/docs/moderation/copyright-detection.md
+++ b/docs/moderation/copyright-detection.md
@@ -194,23 +194,23 @@ this is why we flag but don't enforce. human review is needed.
 ### list all flagged tracks
 
 ```sql
-SELECT t.id, t.title, a.handle, cf.confidence_score, cf.matched_tracks
-FROM copyright_flags cf
-JOIN tracks t ON t.id = cf.track_id
+SELECT t.id, t.title, a.handle, cs.highest_score, cs.matches
+FROM copyright_scans cs
+JOIN tracks t ON t.id = cs.track_id
 JOIN artists a ON a.did = t.artist_did
-WHERE cf.status = 'flagged'
-ORDER BY cf.confidence_score DESC;
+WHERE cs.is_flagged = true
+ORDER BY cs.highest_score DESC;
 ```
 
 ### scan statistics
 
 ```sql
 SELECT
-    status,
+    is_flagged,
     COUNT(*) as count,
-    AVG(confidence_score) as avg_score
-FROM copyright_flags
-GROUP BY status;
+    AVG(highest_score) as avg_score
+FROM copyright_scans
+GROUP BY is_flagged;
 ```
 
 ### tracks pending scan
@@ -218,8 +218,8 @@ GROUP BY status;
 ```sql
 SELECT t.id, t.title, t.created_at
 FROM tracks t
-LEFT JOIN copyright_flags cf ON cf.track_id = t.id
-WHERE cf.id IS NULL OR cf.status = 'pending'
+LEFT JOIN copyright_scans cs ON cs.track_id = t.id
+WHERE cs.id IS NULL
 ORDER BY t.created_at DESC;
 ```
 


### PR DESCRIPTION
## Summary
- fix broken/stale doc references (vibe-search link, pool_recycle values, copyright table names, background-tasks import paths)
- add semantic search + playlists to search.md
- add missing tools to docs index (plyrfm, tap, status-maintenance)
- update README to reflect full feature set (lossless, mood search, genre classification, embeddable players, multi-account, media export, content reporting, etc.)
- update README project structure, tech stack services, and costs

## Test plan
- [ ] all internal doc links verified (no dead links)
- [ ] no code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)