### PR TITLE
fix: track upload notification DM lost to detached session

### DIFF
--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
 from backend._internal import Session as AuthSession
 from backend._internal import has_flag, require_artist_profile
@@ -452,17 +453,22 @@ async def _transcode_audio(
     )
 
 
-async def _send_track_notification(db: AsyncSession, track: Track) -> None:
+async def _send_track_notification(db: AsyncSession, track_id: int) -> None:
     """send notification for new track upload."""
     from backend._internal.notifications import notification_service
 
     try:
-        await db.refresh(track, ["artist"])
+        track = await db.scalar(
+            select(Track).options(joinedload(Track.artist)).where(Track.id == track_id)
+        )
+        if not track:
+            logger.warning(f"track {track_id} not found for notification")
+            return
         await notification_service.send_track_notification(track)
         track.notification_sent = True
         await db.commit()
     except Exception as e:
-        logger.warning(f"failed to send notification for track {track.id}: {e}")
+        logger.warning(f"failed to send notification for track {track_id}: {e}")
 
 
 async def _validate_audio(ctx: UploadContext) -> AudioInfo:
@@ -744,7 +750,7 @@ async def _schedule_post_upload(
             and "integration-test" in (ctx.tags or [])
         )
         if not is_integration_test:
-            await _send_track_notification(db, track)
+            await _send_track_notification(db, track.id)
         if sr.r2_url and not is_integration_test:
             await schedule_copyright_scan(track.id, sr.r2_url)
 

--- a/backend/tests/settings/test_notifications.py
+++ b/backend/tests/settings/test_notifications.py
@@ -1,9 +1,11 @@
 """test notification settings."""
 
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.config import Settings
 from backend.models import Artist, Track
@@ -83,3 +85,54 @@ async def test_track_notification_sent_flag_prevents_duplicates(db_session):
 
     # our track should not appear in this list since notification_sent=True
     assert track_id not in [t.id for t in tracks_needing_notification]
+
+
+async def test_send_track_notification_refetches_from_session(
+    db_session: AsyncSession,
+) -> None:
+    """regression: _send_track_notification must re-fetch the track by ID.
+
+    previously it accepted a Track object and called db.refresh(), which failed
+    with 'Instance is not persistent within this Session' when the track was
+    created in a different session (the normal upload flow).
+    """
+    from backend.api.tracks.uploads import _send_track_notification
+
+    artist = Artist(
+        did="did:plc:notif_test",
+        handle="notif.test.social",
+        display_name="Notif Artist",
+    )
+    db_session.add(artist)
+    await db_session.commit()
+
+    track = Track(
+        title="Detached Track",
+        file_id="notif_test_file",
+        file_type="audio/mpeg",
+        artist_did=artist.did,
+        notification_sent=False,
+    )
+    db_session.add(track)
+    await db_session.commit()
+    track_id = track.id
+
+    mock_service = AsyncMock()
+    mock_service.send_track_notification = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "backend.api.tracks.uploads.notification_service", mock_service, create=True
+        ),
+        patch("backend._internal.notifications.notification_service", mock_service),
+    ):
+        # this used to raise DetachedInstanceError
+        await _send_track_notification(db_session, track_id)
+
+    mock_service.send_track_notification.assert_called_once()
+    called_track = mock_service.send_track_notification.call_args[0][0]
+    assert called_track.id == track_id
+    assert called_track.title == "Detached Track"
+
+    await db_session.refresh(track)
+    assert track.notification_sent is True


### PR DESCRIPTION
## Summary

- `_send_track_notification` received a `Track` object created in phase 6's `db_session()`, but phase 7 opens a **new** session — making the object detached
- `db.refresh(track, ["artist"])` raised `DetachedInstanceError`, caught by the blanket `except`, and the upload notification DM was silently dropped
- discovered via Logfire: `failed to send notification for track 673: Instance '<Track at 0x7f206e2c7e90>' is not persistent within this Session`
- fix: accept `track_id: int` and re-fetch with `joinedload(Track.artist)` from the current session

## Test plan

- [x] regression test: `test_send_track_notification_refetches_from_session` — verifies the function works when called with just a track ID (the old signature would blow up)
- [x] full suite: 425 passed, 13 skipped
- [x] lint clean (ruff check + ty check)
- [ ] verify DM arrives on next upload in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)