### PR TITLE
docs: document developer token scoping

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -458,23 +458,22 @@ backend settings in `AuthSettings`:
 
 ### how it works
 
-developer tokens are sessions with their own independent OAuth grant. when you create a dev token, you go through a full OAuth authorization flow at your PDS, which gives the token its own access/refresh credentials. this means:
+developer tokens are sessions with their own independent OAuth grant — **not app passwords**. when you create a dev token, you go through a full OAuth authorization flow at your PDS, which gives the token its own access/refresh credentials. this means:
 - dev tokens can refresh independently (no staleness when browser session refreshes)
 - each token has its own DPoP keypair for request signing
-- logging out of browser doesn't affect dev tokens (cookie isolation)
-- revoking browser session doesn't affect dev tokens
+- browser logout/revocation doesn't affect dev tokens (cookie isolation)
 
-dev tokens can:
-- read your data (tracks, likes, profile)
-- upload tracks (creates ATProto records on your PDS)
-- perform any authenticated action
+### scoping
 
-**security notes**:
-- tokens have full account access - treat like passwords
-- revoke individual tokens via the portal or API
-- each token is independent - revoking one doesn't affect others
-- token names help identify which token is used where
-- tokens require explicit OAuth consent at your PDS
+developer tokens are **scoped to plyr.fm's lexicon namespace** via ATProto OAuth. the grant requests only the collections plyr.fm needs (e.g. `atproto blob:*/* include:fm.plyr.authFullApp` via [permission sets](https://atproto.com/specs/oauth#permission-sets), or granular `repo:fm.plyr.track repo:fm.plyr.like ...` scopes as fallback).
+
+- **can** read/write plyr.fm data (tracks, likes, comments, playlists, profile) and upload blobs
+- **cannot** read or write your Bluesky posts, follows, blocks, or any other app's data
+- **cannot** modify your ATProto identity or account settings
+
+the PDS enforces these scopes at the protocol level — not just plyr.fm's API. rather than app passwords (full repo access, coupled to Bluesky), plyr.fm issues OAuth grants scoped to the minimum permissions needed.
+
+**security notes**: tokens grant full access to plyr.fm features, but are namespace-scoped at the protocol level. each token is independent — revoke individually via the portal or API.
 
 ## OAuth client types: public vs confidential
 

--- a/docs/backend/configuration.md
+++ b/docs/backend/configuration.md
@@ -150,12 +150,20 @@ f"{settings.atproto.app_namespace}.track"
 
 ### `settings.atproto.resolved_scope`
 
-constructs the oauth scope from the collection(s):
+constructs the OAuth scope from the app's lexicon collections. this scope is used for all OAuth grants — browser sessions and [developer tokens](../authentication.md#scoping) alike — ensuring tokens can only access plyr.fm's namespace on the user's PDS.
+
 ```python
-# base scopes: our track collection + our like collection
+# with permission sets (default when lexicons are published):
+"atproto blob:*/* include:fm.plyr.authFullApp"
+
+# fallback: granular repo scopes for each collection
 scopes = [
+    "blob:*/*",
     f"repo:{settings.atproto.track_collection}",
-    f"repo:{settings.atproto.app_namespace}.like",
+    f"repo:{settings.atproto.like_collection}",
+    f"repo:{settings.atproto.comment_collection}",
+    f"repo:{settings.atproto.list_collection}",
+    f"repo:{settings.atproto.profile_collection}",
 ]
 
 # if we have an old namespace, add old track collection too
@@ -163,7 +171,7 @@ if settings.atproto.old_app_namespace:
     scopes.append(f"repo:{settings.atproto.old_track_collection}")
 
 return f"atproto {' '.join(scopes)}"
-# default: "atproto repo:fm.plyr.track repo:fm.plyr.like"
+# default: "atproto blob:*/* repo:fm.plyr.track repo:fm.plyr.like repo:fm.plyr.comment repo:fm.plyr.list repo:fm.plyr.actor.profile"
 ```
 
 can be overridden with `ATPROTO_SCOPE_OVERRIDE` if needed.
@@ -178,8 +186,11 @@ ATPROTO_APP_NAMESPACE=fm.plyr  # default
 
 this defines the collections:
 - `track_collection` → `"fm.plyr.track"`
-- `like_collection` → `"fm.plyr.like"` (implicit)
-- `resolved_scope` → `"atproto repo:fm.plyr.track repo:fm.plyr.like"`
+- `like_collection` → `"fm.plyr.like"`
+- `comment_collection` → `"fm.plyr.comment"`
+- `list_collection` → `"fm.plyr.list"`
+- `profile_collection` → `"fm.plyr.actor.profile"`
+- `resolved_scope` → `"atproto blob:*/* include:fm.plyr.authFullApp"` (with permission sets)
 
 ### environment-specific namespaces
 
@@ -224,9 +235,9 @@ optionally supports migration from an old namespace:
 ATPROTO_OLD_APP_NAMESPACE=app.relay  # optional, for migration
 ```
 
-when set, OAuth scopes will include both old and new namespaces:
+when set, OAuth scopes will include the old track collection alongside current collections:
 - `old_track_collection` → `"app.relay.track"`
-- `resolved_scope` → `"atproto repo:fm.plyr.track repo:fm.plyr.like repo:app.relay.track"`
+- `resolved_scope` includes `repo:app.relay.track` in addition to all `fm.plyr.*` scopes
 
 ## usage in code
 


### PR DESCRIPTION
## Summary
- fixes misleading "tokens have full account access" language in developer tokens docs — they're actually scoped to `fm.plyr.*` via ATProto OAuth, enforced by the PDS
- adds scoping subsection explaining what tokens can/cannot do and why this is a deliberate design choice vs app passwords
- fixes stale `resolved_scope` examples in configuration docs (was missing blob, comment, list, profile collections; didn't mention permission sets)
- cross-links configuration docs to the scoping explanation

## Context
prompted by [this thread](https://bsky.app/profile/knowtheory.net/post/3mejk7nh2uk22) discussing CLI auth patterns in ATProto — app passwords vs scoped OAuth grants. plyr.fm already does the right thing here but the docs didn't reflect it.

## Test plan
- [ ] docs render correctly on GitHub
- [ ] cross-link from configuration.md to authentication.md#scoping resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)