### PR TITLE
fix: limit tracks on artist detail page

### DIFF
--- a/frontend/src/routes/u/[handle]/+page.server.ts
+++ b/frontend/src/routes/u/[handle]/+page.server.ts
@@ -15,7 +15,7 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 		const artist: Artist = await artistResponse.json();
 
 		// fetch artist's tracks server-side (no cookie available on frontend host)
-		const tracksResponse = await fetch(`${API_URL}/tracks/?artist_did=${artist.did}`);
+		const tracksResponse = await fetch(`${API_URL}/tracks/?artist_did=${artist.did}&limit=5`);
 		let tracks: Track[] = [];
 		let hasMoreTracks = false;
 		let nextCursor: string | null = null;

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -267,7 +267,7 @@ $effect(() => {
 		loadingMoreTracks = true;
 		try {
 			const response = await fetch(
-				`${API_URL}/tracks/?artist_did=${artist.did}&cursor=${encodeURIComponent(nextCursor)}`
+				`${API_URL}/tracks/?artist_did=${artist.did}&cursor=${encodeURIComponent(nextCursor)}&limit=10`
 			);
 			if (response.ok) {
 				const data = await response.json();


### PR DESCRIPTION
## Summary
- Initial load shows 5 tracks instead of 50 (backend default), so albums and collections aren't pushed below the fold
- "Load more" button fetches 10 tracks per click for progressive reveal
- Cursor-based pagination already existed — this just adds explicit limits

## Test plan
- [ ] Visit an artist page with many tracks — should see 5 initially
- [ ] Click "load more" — should add 10 tracks
- [ ] Verify albums section is visible without scrolling past dozens of tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)