### PR TITLE
feat: playlist track recommendations

### DIFF
--- a/backend/src/backend/_internal/clients/tpuf.py
+++ b/backend/src/backend/_internal/clients/tpuf.py
@@ -111,6 +111,55 @@ async def query(
         return results
 
 
+async def get_vectors(track_ids: list[int]) -> dict[int, list[float]]:
+    """fetch embedding vectors for given track IDs.
+
+    uses a zero vector query with ID filter to retrieve stored embeddings.
+
+    args:
+        track_ids: database IDs of tracks to fetch embeddings for
+
+    returns:
+        mapping of track_id -> embedding vector (only tracks with embeddings)
+    """
+    if not track_ids:
+        return {}
+
+    async with AsyncTurbopuffer(
+        api_key=settings.turbopuffer.api_key.get_secret_value(),
+        region=settings.turbopuffer.region,
+    ) as client:
+        ns = client.namespace(settings.turbopuffer.namespace)
+        # use a zero vector to satisfy rank_by requirement, filter by ID
+        zero_vector = [0.0] * 512
+        try:
+            response = await ns.query(
+                rank_by=("vector", "ANN", zero_vector),
+                top_k=len(track_ids),
+                filters=("id", "In", track_ids),
+                include_attributes=["vector"],
+            )
+        except NotFoundError:
+            logger.warning(
+                "turbopuffer namespace %r not found (no embeddings yet?)",
+                settings.turbopuffer.namespace,
+            )
+            return {}
+
+        result: dict[int, list[float]] = {}
+        for row in response.rows or []:
+            vec = row["vector"]
+            if vec is not None and not isinstance(vec, str):
+                result[int(row.id)] = [float(v) for v in vec]
+
+        logfire.info(
+            "fetched {count}/{requested} vectors",
+            count=len(result),
+            requested=len(track_ids),
+        )
+        return result
+
+
 async def delete(track_id: int) -> None:
     """delete a track embedding from turbopuffer.
 

--- a/backend/src/backend/_internal/recommendations.py
+++ b/backend/src/backend/_internal/recommendations.py
@@ -1,0 +1,183 @@
+"""playlist track recommendations using CLAP embeddings.
+
+computes recommendations by querying turbopuffer for tracks similar
+to those already in a playlist. uses adaptive strategy based on
+playlist size: direct query (1 track), per-track query with RRF merge
+(2-5 tracks), or k-means clustered centroids with RRF merge (6+).
+"""
+
+import asyncio
+import logging
+import random
+
+from backend._internal.clients.tpuf import VectorSearchResult, get_vectors, query
+
+logger = logging.getLogger(__name__)
+
+# type alias for embedding vectors
+Vector = list[float]
+
+
+def rrf_merge(
+    ranked_lists: list[list[VectorSearchResult]],
+    exclude_ids: set[int],
+    k: int = 60,
+) -> list[VectorSearchResult]:
+    """merge multiple ranked result lists using Reciprocal Rank Fusion.
+
+    args:
+        ranked_lists: list of ranked result lists from separate queries
+        exclude_ids: track IDs to exclude (already in playlist)
+        k: RRF constant (default 60, standard value)
+
+    returns:
+        merged results sorted by combined RRF score, descending
+    """
+    scores: dict[int, float] = {}
+    best_result: dict[int, VectorSearchResult] = {}
+
+    for results in ranked_lists:
+        for rank, result in enumerate(results):
+            if result.track_id in exclude_ids:
+                continue
+            scores[result.track_id] = scores.get(result.track_id, 0.0) + 1.0 / (
+                k + rank + 1
+            )
+            # keep the result with best distance
+            if result.track_id not in best_result or (
+                result.distance < best_result[result.track_id].distance
+            ):
+                best_result[result.track_id] = result
+
+    # sort by RRF score descending
+    sorted_ids = sorted(scores.keys(), key=lambda tid: scores[tid], reverse=True)
+    return [best_result[tid] for tid in sorted_ids]
+
+
+def _squared_distance(a: Vector, b: Vector) -> float:
+    """squared euclidean distance between two vectors."""
+    return sum((x - y) ** 2 for x, y in zip(a, b, strict=True))
+
+
+def _vec_add(a: Vector, b: Vector) -> Vector:
+    """element-wise addition of two vectors."""
+    return [x + y for x, y in zip(a, b, strict=True)]
+
+
+def _vec_scale(v: Vector, s: float) -> Vector:
+    """scale a vector by a scalar."""
+    return [x * s for x in v]
+
+
+def _kmeans(vectors: list[Vector], k: int, max_iter: int = 20) -> list[Vector]:
+    """simple k-means clustering using pure python.
+
+    operates on small inputs (N<=20 vectors of 512 dims).
+
+    args:
+        vectors: list of N vectors
+        k: number of clusters
+        max_iter: maximum iterations
+
+    returns:
+        list of k cluster centroids
+    """
+    n = len(vectors)
+
+    # initialize centroids by random selection
+    rng = random.Random(42)
+    indices = rng.sample(range(n), k)
+    centroids = [list(vectors[i]) for i in indices]
+
+    for _ in range(max_iter):
+        # assign each vector to nearest centroid
+        assignments = []
+        for vec in vectors:
+            best_c = 0
+            best_dist = _squared_distance(vec, centroids[0])
+            for c in range(1, k):
+                d = _squared_distance(vec, centroids[c])
+                if d < best_dist:
+                    best_dist = d
+                    best_c = c
+            assignments.append(best_c)
+
+        # update centroids
+        new_centroids: list[Vector] = []
+        for c in range(k):
+            members = [vectors[i] for i in range(n) if assignments[i] == c]
+            if members:
+                count = len(members)
+                summed = members[0][:]
+                for m in members[1:]:
+                    summed = _vec_add(summed, m)
+                new_centroids.append(_vec_scale(summed, 1.0 / count))
+            else:
+                new_centroids.append(list(centroids[c]))
+
+        # check convergence
+        converged = all(
+            _squared_distance(centroids[c], new_centroids[c]) < 1e-12 for c in range(k)
+        )
+        centroids = new_centroids
+        if converged:
+            break
+
+    return centroids
+
+
+async def get_playlist_recommendations(
+    track_ids: list[int],
+    limit: int = 3,
+) -> list[VectorSearchResult]:
+    """get track recommendations for a playlist.
+
+    uses adaptive strategy based on playlist size:
+    - 1 track: query turbopuffer with that track's embedding directly
+    - 2-5 tracks: query with each track's embedding, merge via RRF
+    - 6+ tracks: k-means cluster, query centroids, RRF merge
+
+    args:
+        track_ids: IDs of tracks currently in the playlist
+        limit: max number of recommendations to return
+
+    returns:
+        list of recommended tracks (excluding playlist tracks)
+    """
+    if not track_ids:
+        return []
+
+    # fetch embeddings for playlist tracks
+    vectors = await get_vectors(track_ids)
+    if not vectors:
+        return []
+
+    exclude_ids = set(track_ids)
+    # request more than needed to account for exclusions
+    top_k = limit + len(track_ids) + 5
+
+    n_vectors = len(vectors)
+
+    if n_vectors == 1:
+        # single track: query directly with its embedding
+        embedding = next(iter(vectors.values()))
+        results = await query(embedding, top_k=top_k)
+        return [r for r in results if r.track_id not in exclude_ids][:limit]
+
+    vec_list = list(vectors.values())
+
+    if n_vectors <= 5:
+        # query each track embedding in parallel, merge with RRF
+        tasks = [query(vec, top_k=top_k) for vec in vec_list]
+        ranked_lists = await asyncio.gather(*tasks)
+        merged = rrf_merge(list(ranked_lists), exclude_ids)
+        return merged[:limit]
+
+    # 6+ tracks: k-means cluster, query centroids
+    n_clusters = min(3, n_vectors // 2)
+    centroids = _kmeans(vec_list, n_clusters)
+
+    tasks = [query(centroid, top_k=top_k) for centroid in centroids]
+    ranked_lists = await asyncio.gather(*tasks)
+    merged = rrf_merge(list(ranked_lists), exclude_ids)
+    return merged[:limit]

--- a/backend/src/backend/api/lists.py
+++ b/backend/src/backend/api/lists.py
@@ -1,6 +1,7 @@
 """lists api endpoints for ATProto list records."""
 
 import contextlib
+import json
 import logging
 from io import BytesIO
 from pathlib import Path
@@ -13,6 +14,7 @@ from fastapi import (
     File,
     Form,
     HTTPException,
+    Query,
     Request,
     UploadFile,
 )
@@ -29,11 +31,14 @@ from backend._internal.atproto.records import (
     update_list_record,
 )
 from backend._internal.auth import get_session
+from backend._internal.recommendations import get_playlist_recommendations
+from backend.config import settings
 from backend.models import Artist, Playlist, Track, TrackLike, UserPreferences, get_db
 from backend.schemas import DeletedResponse, TrackResponse
 from backend.storage import storage
 from backend.utilities.aggregations import get_comment_counts, get_like_counts
 from backend.utilities.hashing import CHUNK_SIZE
+from backend.utilities.redis import get_async_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +98,23 @@ class ReorderResponse(BaseModel):
 
     uri: str
     cid: str
+
+
+class RecommendedTrack(BaseModel):
+    """a recommended track for a playlist."""
+
+    id: int
+    title: str
+    artist_handle: str
+    artist_display_name: str
+    image_url: str | None
+
+
+class PlaylistRecommendationsResponse(BaseModel):
+    """response for playlist recommendations."""
+
+    tracks: list[RecommendedTrack]
+    available: bool
 
 
 @router.put("/liked/reorder")
@@ -863,3 +885,145 @@ async def update_playlist(
         atproto_record_uri=playlist.atproto_record_uri,
         created_at=playlist.created_at.isoformat(),
     )
+
+
+@router.get(
+    "/playlists/{playlist_id}/recommendations",
+    response_model=PlaylistRecommendationsResponse,
+)
+async def get_playlist_recommendations_endpoint(
+    playlist_id: str,
+    session: AuthSession = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+    limit: int = Query(3, ge=1, le=10, description="max recommendations"),
+) -> PlaylistRecommendationsResponse:
+    """get track recommendations for a playlist.
+
+    uses CLAP embeddings to find tracks similar to what's in the playlist.
+    requires auth (owner only — recommendations are for editing).
+    results are cached per playlist CID (auto-invalidates on track changes).
+    """
+    unavailable = PlaylistRecommendationsResponse(tracks=[], available=False)
+
+    if not settings.turbopuffer.enabled:
+        return unavailable
+
+    # fetch playlist and verify ownership
+    result = await db.execute(
+        select(Playlist, Artist)
+        .join(Artist, Playlist.owner_did == Artist.did)
+        .where(Playlist.id == playlist_id)
+    )
+    row = result.first()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="playlist not found")
+
+    playlist, artist = row
+
+    if playlist.owner_did != session.did:
+        raise HTTPException(status_code=403, detail="not playlist owner")
+
+    if playlist.track_count == 0:
+        return unavailable
+
+    # check Redis cache using playlist CID as cache key
+    cid = playlist.atproto_record_cid or ""
+    cache_key = f"plyr:recommendations:{playlist_id}:{cid}"
+
+    try:
+        redis = get_async_redis_client()
+        cached = await redis.get(cache_key)
+        if cached:
+            data = json.loads(cached)
+            return PlaylistRecommendationsResponse(**data)
+    except Exception as e:
+        logger.debug("redis cache miss/error for recommendations: %s", e)
+
+    # get track IDs from the playlist's ATProto record
+    from backend._internal.atproto.records import get_record_public
+
+    try:
+        record_data = await get_record_public(
+            record_uri=playlist.atproto_record_uri,
+            pds_url=artist.pds_url,
+        )
+    except Exception as e:
+        logger.warning("failed to fetch playlist record for recommendations: %s", e)
+        return unavailable
+
+    items = record_data.get("value", {}).get("items", [])
+    track_uris = [
+        item.get("subject", {}).get("uri") for item in items if item.get("subject")
+    ]
+    track_uris = [uri for uri in track_uris if uri]
+
+    if not track_uris:
+        return unavailable
+
+    # resolve URIs to track IDs
+    track_result = await db.execute(
+        select(Track.id).where(Track.atproto_record_uri.in_(track_uris))
+    )
+    track_ids = list(track_result.scalars().all())
+
+    if not track_ids:
+        return unavailable
+
+    # compute recommendations
+    try:
+        recs = await get_playlist_recommendations(track_ids, limit=limit)
+    except Exception as e:
+        logger.warning("recommendation computation failed: %s", e)
+        return unavailable
+
+    if not recs:
+        return PlaylistRecommendationsResponse(tracks=[], available=True)
+
+    # hydrate from DB
+    rec_ids = [r.track_id for r in recs]
+    stmt = (
+        select(Track, Artist)
+        .join(Artist, Track.artist_did == Artist.did)
+        .where(Track.id.in_(rec_ids))
+    )
+    hydrate_result = await db.execute(stmt)
+    hydrate_rows = hydrate_result.all()
+
+    track_lookup: dict[int, tuple[Track, Artist]] = {}
+    for track, rec_artist in hydrate_rows:
+        track_lookup[track.id] = (track, rec_artist)
+
+    # preserve recommendation order
+    recommended_tracks: list[RecommendedTrack] = []
+    for rec in recs:
+        if rec.track_id not in track_lookup:
+            continue
+        track, rec_artist = track_lookup[rec.track_id]
+        recommended_tracks.append(
+            RecommendedTrack(
+                id=track.id,
+                title=track.title,
+                artist_handle=rec_artist.handle,
+                artist_display_name=rec_artist.display_name,
+                image_url=track.image_url,
+            )
+        )
+
+    response = PlaylistRecommendationsResponse(
+        tracks=recommended_tracks,
+        available=True,
+    )
+
+    # cache result
+    try:
+        redis = get_async_redis_client()
+        await redis.set(
+            cache_key,
+            response.model_dump_json(),
+            ex=86400,  # 24h TTL
+        )
+    except Exception as e:
+        logger.debug("failed to cache recommendations: %s", e)
+
+    return response

--- a/backend/tests/test_recommendations.py
+++ b/backend/tests/test_recommendations.py
@@ -1,0 +1,186 @@
+"""tests for playlist track recommendation logic."""
+
+from unittest.mock import AsyncMock, patch
+
+from backend._internal.clients.tpuf import VectorSearchResult
+from backend._internal.recommendations import (
+    _kmeans,
+    get_playlist_recommendations,
+    rrf_merge,
+)
+
+# --- rrf_merge tests ---
+
+
+def test_rrf_merge_single_list() -> None:
+    """rrf_merge with a single list just filters excluded IDs."""
+    results = [
+        VectorSearchResult(track_id=1, distance=0.1),
+        VectorSearchResult(track_id=2, distance=0.2),
+        VectorSearchResult(track_id=3, distance=0.3),
+    ]
+    merged = rrf_merge([results], exclude_ids={2})
+
+    assert [r.track_id for r in merged] == [1, 3]
+
+
+def test_rrf_merge_multiple_lists() -> None:
+    """rrf_merge combines rankings — tracks appearing in multiple lists rank higher."""
+    list_a = [
+        VectorSearchResult(track_id=10, distance=0.1),
+        VectorSearchResult(track_id=20, distance=0.2),
+        VectorSearchResult(track_id=30, distance=0.3),
+    ]
+    list_b = [
+        VectorSearchResult(track_id=20, distance=0.15),
+        VectorSearchResult(track_id=40, distance=0.25),
+        VectorSearchResult(track_id=10, distance=0.35),
+    ]
+
+    merged = rrf_merge([list_a, list_b], exclude_ids=set())
+
+    # track 20 and 10 appear in both lists so should rank highest
+    ids = [r.track_id for r in merged]
+    assert 20 in ids[:2]
+    assert 10 in ids[:2]
+    assert len(ids) == 4  # 10, 20, 30, 40
+
+
+def test_rrf_merge_excludes_playlist_tracks() -> None:
+    """tracks in exclude_ids are not in the result."""
+    results = [
+        VectorSearchResult(track_id=1, distance=0.1),
+        VectorSearchResult(track_id=2, distance=0.2),
+    ]
+    merged = rrf_merge([results], exclude_ids={1, 2})
+    assert merged == []
+
+
+def test_rrf_merge_empty_lists() -> None:
+    """rrf_merge with empty input returns empty."""
+    assert rrf_merge([], exclude_ids=set()) == []
+    assert rrf_merge([[]], exclude_ids=set()) == []
+
+
+def test_rrf_merge_keeps_best_distance() -> None:
+    """when a track appears in multiple lists, keep the best (lowest) distance."""
+    list_a = [VectorSearchResult(track_id=1, distance=0.5)]
+    list_b = [VectorSearchResult(track_id=1, distance=0.2)]
+
+    merged = rrf_merge([list_a, list_b], exclude_ids=set())
+    assert len(merged) == 1
+    assert merged[0].distance == 0.2
+
+
+# --- k-means tests ---
+
+
+def test_kmeans_basic() -> None:
+    """k-means produces correct number of centroids and finds clusters."""
+    # two clusters: around [0,0] and [10,10]
+    vectors: list[list[float]] = [
+        [0.0, 0.1],
+        [0.1, 0.0],
+        [-0.1, 0.0],
+        [10.0, 10.1],
+        [10.1, 10.0],
+        [9.9, 10.0],
+    ]
+    centroids = _kmeans(vectors, k=2)
+    assert len(centroids) == 2
+    assert len(centroids[0]) == 2
+
+    # centroids should be near [0,0] and [10,10]
+    centroid_sorted = sorted(centroids, key=lambda c: c[0])
+    assert abs(centroid_sorted[0][0]) < 1.0
+    assert abs(centroid_sorted[1][0] - 10.0) < 1.0
+
+
+def test_kmeans_single_cluster() -> None:
+    """k-means with k=1 returns the mean."""
+    vectors: list[list[float]] = [[1.0, 2.0], [3.0, 4.0]]
+    centroids = _kmeans(vectors, k=1)
+    assert len(centroids) == 1
+    assert abs(centroids[0][0] - 2.0) < 1e-6
+    assert abs(centroids[0][1] - 3.0) < 1e-6
+
+
+# --- adaptive strategy tests ---
+
+
+@patch("backend._internal.recommendations.get_vectors")
+@patch("backend._internal.recommendations.query")
+async def test_single_track_strategy(
+    mock_query: AsyncMock, mock_get_vectors: AsyncMock
+) -> None:
+    """1 track: queries turbopuffer directly with the track's embedding."""
+    mock_get_vectors.return_value = {1: [0.1] * 512}
+    mock_query.return_value = [
+        VectorSearchResult(track_id=99, distance=0.1),
+        VectorSearchResult(track_id=1, distance=0.0),  # should be excluded
+    ]
+
+    results = await get_playlist_recommendations([1], limit=3)
+
+    mock_query.assert_called_once()
+    assert len(results) == 1
+    assert results[0].track_id == 99
+
+
+@patch("backend._internal.recommendations.get_vectors")
+@patch("backend._internal.recommendations.query")
+async def test_multi_track_rrf_strategy(
+    mock_query: AsyncMock, mock_get_vectors: AsyncMock
+) -> None:
+    """2-5 tracks: queries each embedding, merges with RRF."""
+    mock_get_vectors.return_value = {
+        1: [0.1] * 512,
+        2: [0.2] * 512,
+        3: [0.3] * 512,
+    }
+    mock_query.return_value = [
+        VectorSearchResult(track_id=99, distance=0.1),
+        VectorSearchResult(track_id=98, distance=0.2),
+    ]
+
+    results = await get_playlist_recommendations([1, 2, 3], limit=3)
+
+    # should have queried 3 times (one per track)
+    assert mock_query.call_count == 3
+    assert all(r.track_id not in {1, 2, 3} for r in results)
+
+
+@patch("backend._internal.recommendations.get_vectors")
+@patch("backend._internal.recommendations.query")
+async def test_large_playlist_kmeans_strategy(
+    mock_query: AsyncMock, mock_get_vectors: AsyncMock
+) -> None:
+    """6+ tracks: clusters into centroids, queries each centroid."""
+    # 8 tracks -> min(3, 8//2) = 3 clusters
+    vecs = {i: [float(i) / 10] * 512 for i in range(1, 9)}
+    mock_get_vectors.return_value = vecs
+    mock_query.return_value = [
+        VectorSearchResult(track_id=99, distance=0.1),
+    ]
+
+    results = await get_playlist_recommendations(list(range(1, 9)), limit=3)
+
+    # should have queried 3 times (one per cluster centroid)
+    assert mock_query.call_count == 3
+    assert all(r.track_id not in set(range(1, 9)) for r in results)
+
+
+@patch("backend._internal.recommendations.get_vectors")
+async def test_empty_playlist_returns_empty(mock_get_vectors: AsyncMock) -> None:
+    """empty playlist returns empty recommendations."""
+    results = await get_playlist_recommendations([], limit=3)
+    assert results == []
+    mock_get_vectors.assert_not_called()
+
+
+@patch("backend._internal.recommendations.get_vectors")
+async def test_no_embeddings_returns_empty(mock_get_vectors: AsyncMock) -> None:
+    """playlist with no embedded tracks returns empty."""
+    mock_get_vectors.return_value = {}
+    results = await get_playlist_recommendations([1, 2], limit=3)
+    assert results == []

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -316,8 +316,6 @@
 	.input-label {
 		color: var(--text-secondary);
 		font-size: var(--text-base);
-		& .atmosphere-link { color: var(--accent); text-decoration: none; }
-		& .atmosphere-link:hover { text-decoration: underline; }
 		& .handle-label-link { color: var(--text-secondary); text-decoration: none; border-bottom: 1px dashed var(--border-default); }
 		& .handle-label-link:hover { color: var(--text-primary); border-bottom-color: var(--text-tertiary); }
 		& .home-link { color: var(--accent); text-decoration: none; border-bottom: 1px solid var(--accent); }
@@ -395,7 +393,6 @@
 		& p.welcome { color: var(--text-primary); font-weight: 500; }
 		& a { color: var(--accent); text-decoration: none; }
 		& a:hover { text-decoration: underline; }
-		& code { background: var(--bg-secondary); padding: 0.15rem 0.4rem; border-radius: var(--radius-sm); font-size: 0.85em; }
 	}
 
 	.link-button {

--- a/frontend/src/routes/playlist/[id]/+page.svelte
+++ b/frontend/src/routes/playlist/[id]/+page.svelte
@@ -125,6 +125,11 @@
 	let coverInputElement = $state<HTMLInputElement | null>(null);
 	let uploadingCover = $state(false);
 
+	// recommendations state
+	let recommendations = $state<any[]>([]);
+	let loadingRecommendations = $state(false);
+	let recommendationsAvailable = $state(true);
+
 	// drag state
 	let draggedIndex = $state<number | null>(null);
 	let dragOverIndex = $state<number | null>(null);
@@ -200,6 +205,30 @@
 		}
 	}
 
+	async function fetchRecommendations() {
+		loadingRecommendations = true;
+		try {
+			const res = await fetch(
+				`${API_URL}/lists/playlists/${playlist.id}/recommendations?limit=3`,
+				{ credentials: "include" },
+			);
+			if (!res.ok) {
+				recommendationsAvailable = false;
+				return;
+			}
+			const data = await res.json();
+			recommendationsAvailable = data.available;
+			// filter out any tracks already in the playlist
+			recommendations = data.tracks.filter(
+				(t: any) => !tracks.some((pt) => pt.id === t.id),
+			);
+		} catch {
+			recommendationsAvailable = false;
+		} finally {
+			loadingRecommendations = false;
+		}
+	}
+
 	async function addTrack(track: any) {
 		addingTrack = track.id;
 
@@ -247,8 +276,14 @@
 			// update playlist track count
 			playlist.track_count = tracks.length;
 
-			// remove from search results
+			// remove from search results and recommendations
 			searchResults = searchResults.filter((r) => r.id !== track.id);
+			recommendations = recommendations.filter((r) => r.id !== track.id);
+
+			// re-fetch recommendations (playlist context changed)
+			if (isEditMode) {
+				void fetchRecommendations();
+			}
 
 			toast.success(`added "${trackData.title}" to playlist`);
 		} catch (e) {
@@ -299,10 +334,15 @@
 		if (isEditMode) {
 			// exiting edit mode - save changes
 			saveAllChanges();
+			recommendations = [];
 		} else {
 			// entering edit mode - initialize edit state
 			editName = playlist.name;
 			editShowOnProfile = playlist.show_on_profile;
+			// fetch recommendations in background
+			if (tracks.length > 0) {
+				void fetchRecommendations();
+			}
 		}
 		isEditMode = !isEditMode;
 	}
@@ -1137,6 +1177,57 @@
 							</svg>
 							add tracks
 						</button>
+						{#if recommendationsAvailable && (recommendations.length > 0 || loadingRecommendations)}
+							<div class="recommendations-section">
+								<div class="recommendations-header">
+									<span class="recommendations-title">recommended</span>
+									<span class="recommendations-subtitle">based on this playlist</span>
+								</div>
+								{#if loadingRecommendations && recommendations.length === 0}
+									<div class="recommendations-loading">
+										<span class="spinner"></span>
+									</div>
+								{:else}
+									{#each recommendations as rec (rec.id)}
+										<div class="recommendation-item">
+											{#if rec.image_url}
+												<img
+													src={rec.image_url}
+													alt=""
+													class="rec-image"
+												/>
+											{:else}
+												<div class="rec-image-placeholder">
+													<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+														<circle cx="12" cy="12" r="10"></circle>
+														<circle cx="12" cy="12" r="3"></circle>
+													</svg>
+												</div>
+											{/if}
+											<div class="rec-info">
+												<span class="rec-title">{rec.title}</span>
+												<span class="rec-artist">{rec.artist_display_name}</span>
+											</div>
+											<button
+												class="rec-add-btn"
+												onclick={() => addTrack(rec)}
+												disabled={addingTrack === rec.id}
+												aria-label="add {rec.title} to playlist"
+											>
+												{#if addingTrack === rec.id}
+													<span class="spinner"></span>
+												{:else}
+													<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+														<line x1="12" y1="5" x2="12" y2="19"></line>
+														<line x1="5" y1="12" x2="19" y2="12"></line>
+													</svg>
+												{/if}
+											</button>
+										</div>
+									{/each}
+								{/if}
+							</div>
+						{/if}
 					{/if}
 				</div>
 			{/if}
@@ -2080,6 +2171,122 @@
 		to {
 			transform: rotate(360deg);
 		}
+	}
+
+	/* recommendations */
+	.recommendations-section {
+		margin-top: 1rem;
+		padding-top: 1rem;
+		border-top: 1px solid var(--border-subtle);
+	}
+
+	.recommendations-header {
+		display: flex;
+		align-items: baseline;
+		gap: 0.5rem;
+		margin-bottom: 0.75rem;
+	}
+
+	.recommendations-title {
+		font-size: var(--text-sm);
+		font-weight: 600;
+		color: var(--text-secondary);
+		text-transform: lowercase;
+	}
+
+	.recommendations-subtitle {
+		font-size: var(--text-xs);
+		color: var(--text-muted);
+	}
+
+	.recommendations-loading {
+		display: flex;
+		justify-content: center;
+		padding: 1rem;
+	}
+
+	.recommendation-item {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.5rem 0.75rem;
+		border-radius: var(--radius-md);
+		transition: background 0.15s;
+	}
+
+	.recommendation-item:hover {
+		background: var(--bg-hover);
+	}
+
+	.rec-image,
+	.rec-image-placeholder {
+		width: 36px;
+		height: 36px;
+		border-radius: var(--radius-base);
+		flex-shrink: 0;
+	}
+
+	.rec-image {
+		object-fit: cover;
+	}
+
+	.rec-image-placeholder {
+		background: var(--bg-tertiary);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--text-muted);
+	}
+
+	.rec-info {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+	}
+
+	.rec-title {
+		font-size: var(--text-sm);
+		font-weight: 500;
+		color: var(--text-primary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.rec-artist {
+		font-size: var(--text-xs);
+		color: var(--text-tertiary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.rec-add-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		background: transparent;
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-md);
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: all 0.15s;
+		flex-shrink: 0;
+	}
+
+	.rec-add-btn:hover:not(:disabled) {
+		border-color: var(--accent);
+		color: var(--accent);
+		background: color-mix(in srgb, var(--accent) 8%, transparent);
+	}
+
+	.rec-add-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 
 	@media (max-width: 768px) {

--- a/loq.toml
+++ b/loq.toml
@@ -31,7 +31,7 @@ max_lines = 790
 
 [[rules]]
 path = "backend/src/backend/api/lists.py"
-max_lines = 865
+max_lines = 1029
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
@@ -151,7 +151,7 @@ max_lines = 540
 
 [[rules]]
 path = "frontend/src/routes/playlist/\\[id\\]/+page.svelte"
-max_lines = 2168
+max_lines = 2375
 
 [[rules]]
 path = "frontend/src/routes/portal/+page.svelte"


### PR DESCRIPTION
## Summary

- adds inline track recommendations when editing a playlist, using existing CLAP embeddings in turbopuffer
- adaptive strategy: direct query (1 track), per-track RRF merge (2-5 tracks), k-means + RRF (6+ tracks)
- results cached in Redis keyed on playlist CID — auto-invalidates when tracks are added/removed/reordered
- gracefully degrades if turbopuffer is disabled or no embeddings exist
- removes unused CSS selectors from login page (`.atmosphere-link`, `code`)

## Test plan

- [x] `just backend lint` — all checks passed
- [x] `just frontend check` — 0 errors, 0 warnings
- [x] 12 new unit tests for RRF merge, k-means, adaptive strategy, edge cases
- [ ] manual: create playlist with 2+ embedded tracks, enter edit mode, verify recommendations appear below track list
- [ ] manual: tap "add" on a recommendation, verify it moves to playlist and recommendations refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)