### PR TITLE
fix: remove redundant queue/share from heart menu on track detail

### DIFF
--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -611,8 +611,6 @@ $effect(() => {
 								fileId={track.file_id}
 								gated={track.gated}
 								initialLiked={track.is_liked || false}
-								shareUrl={shareUrl}
-								onQueue={addToQueue}
 							/>
 						{/if}
 						<ShareButton url={shareUrl} title="share track" trackId={track.id} />


### PR DESCRIPTION
## Summary
- Remove `onQueue` and `shareUrl` props from `AddToMenu` on the track detail page
- These actions already exist as dedicated buttons (queue button below, ShareButton next to heart)
- The heart dropdown now only shows like + add to playlist on this page

## Test plan
- [ ] Track detail page: click heart → dropdown should show like and add-to-playlist only (no queue, no share)
- [ ] Track detail page: dedicated "add to queue" button still works
- [ ] Track detail page: ShareButton still works
- [ ] Home/feed page: TrackItem heart dropdown still shows all actions (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)