### PR TITLE
chore: sync legal docs with production pages

### DIFF
--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -1,22 +1,28 @@
 # privacy policy
 
-**last updated:** december 16, 2025
+> **note:** the source of truth is `frontend/src/routes/privacy/+page.svelte`. this markdown is a plain-text mirror for reference.
+
+**last updated:** february 6, 2026
+
+plyr.fm ("we", "us", or "our") is an audio streaming application built on the [AT Protocol](https://atproto.com). this privacy policy applies to the instance at https://plyr.fm (the "site").
+
+plyr.fm is open source under the MIT license. other instances or derivatives hosted elsewhere are not covered by this policy.
 
 this policy explains what data we collect, what's public by design on the AT Protocol, and your rights.
 
 ## 1. the AT Protocol
 
-plyr.fm uses the [AT Protocol](https://atproto.com) for identity and social features. this has important implications:
+plyr.fm uses the AT Protocol for identity and social features. this has important implications:
 
-**public by design:** your DID, handle, profile, tracks, likes, and comments are stored on the decentralized AT Protocol network. this data is visible to anyone on the network, not just plyr.fm users.
+**public by design:** your DID, handle, profile, tracks, likes, comments, and playlists are stored on your PDS (Personal Data Server) and remain under your control. the AT Protocol is a public data protocol—this data is accessible to any AT Protocol application, not just plyr.fm.
 
-**external PDS:** if your account is hosted on Bluesky's PDS or another provider (not ours), we do not control that data. their privacy policies govern it.
+**your PDS:** plyr.fm does not operate a PDS—we write records to wherever your account is hosted (e.g., bsky.social or a self-hosted PDS). we do not control that data; their privacy policies govern it.
 
 **private data:** session tokens, preferences, and server logs are stored only on our servers.
 
 ## 2. data we collect
 
-**you provide:** your ATProto identity when you log in, audio files and metadata you upload, and preferences like accent color.
+**you provide:** your AT Protocol identity when you log in, audio files and metadata you upload, and preferences like accent color.
 
 **automatically:** play counts, IP addresses, browser info, and session cookies for authentication.
 
@@ -28,17 +34,24 @@ we use your data to provide the service, maintain your session, and improve the 
 
 we use:
 
-- **Cloudflare** - CDN, storage (R2)
-- **Fly.io** - backend hosting
-- **Neon** - database
-- **Logfire** - error monitoring
-- **AT Protocol network** - public data federation
+- [Cloudflare](https://cloudflare.com) - CDN, storage (R2)
+- [Fly.io](https://fly.io) - backend hosting
+- [Neon](https://neon.tech) - database
+- [Logfire](https://logfire.pydantic.dev) - error monitoring
+- [AudD](https://audd.io) - audio fingerprinting for copyright detection
+- [Anthropic](https://anthropic.com) - image analysis for content moderation
+- [ATProtoFans](https://atprotofans.com) - supporter validation for gated content
+- [Modal](https://modal.com) - audio processing for search embeddings
+- [turbopuffer](https://turbopuffer.com) - vector storage for semantic search
+- [Replicate](https://replicate.com) - ML inference for genre classification
+
+we may also write records to your PDS using third-party lexicon namespaces (e.g., [teal.fm](https://teal.fm) for scrobbling) when you enable those features.
 
 ## 5. your rights
 
 you can access, correct, or delete your data through settings. when you delete your account, we remove your files from our storage and your data from our database.
 
-**we cannot delete:** your DID (you control it), data on other ATProto servers, or records in other users' PDSes.
+**we cannot delete:** your DID (you control it), data on other AT Protocol servers, or records in other users' PDSes.
 
 ## 6. security
 

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -1,26 +1,28 @@
 # terms of service
 
-**last updated:** december 16, 2025
+> **note:** the source of truth is `frontend/src/routes/terms/+page.svelte`. this markdown is a plain-text mirror for reference.
 
-these terms govern your use of plyr.fm, a music streaming platform built on the AT Protocol. by using the service, you agree to these terms.
+**last updated:** february 4, 2026
 
-## 1. acceptance of terms
+plyr.fm ("we", "us", or "our") is an audio streaming application built on the [AT Protocol](https://atproto.com). these terms of service apply to the instance at https://plyr.fm (the "site").
 
-by accessing or using plyr.fm, you agree to be bound by these terms. if you disagree with any part, you may not use the service.
+plyr.fm is open source under the MIT license. other instances or derivatives hosted elsewhere are not covered by these terms.
 
-## 2. accounts
+by using the service, you agree to these terms. if you disagree with any part, you may not use the service.
 
-plyr.fm uses AT Protocol for authentication. your identity is your DID (decentralized identifier), not an account we control. we do not store passwords.
+## 1. accounts
 
-we may terminate or suspend your access at any time, for any reason. termination removes or delists your content from plyr.fm and our storage, but does not affect your DID or any data stored on your PDS—we don't control those.
+plyr.fm uses the AT Protocol for authentication. your identity is your DID (decentralized identifier), not an account we control. we do not store passwords.
 
-## 3. content
+we may terminate or suspend your access at any time, for any reason. termination removes or delists your content from plyr.fm and our storage, but does not affect your DID or data on your PDS—we don't control those.
+
+## 2. content
 
 you retain ownership of content you upload. by uploading, you grant us a non-exclusive, worldwide, royalty-free license to use, reproduce, modify, and distribute your content (including copies stored on your PDS) as necessary to provide the service.
 
 you represent that you own or have the necessary rights to the content you upload, and that it does not infringe any third party's rights.
 
-## 4. acceptable use
+## 3. acceptable use
 
 you agree not to:
 
@@ -30,7 +32,7 @@ you agree not to:
 - attempt unauthorized access to the service
 - interfere with or disrupt the service
 
-## 5. copyright & DMCA
+## 4. copyright & DMCA
 
 we respond to valid DMCA takedown notices. our designated agent is:
 
@@ -40,13 +42,17 @@ we respond to valid DMCA takedown notices. our designated agent is:
 
 we terminate accounts of repeat infringers.
 
-**AT Protocol limitation:** we can only remove or delist content from our servers and the plyr.fm platform. we cannot delete content that has been published to other AT Protocol servers or your PDS.
+**AT Protocol limitation:** audio may be stored on your PDS and/or in storage that plyr.fm controls for streaming. we can remove or delist content on plyr.fm and delete our copies for policy violations, but AT Protocol records and blobs stored on your PDS may persist and are not under our control.
 
-## 6. disclaimers
+## 5. disclaimers
 
 the service is provided "as is" and "as available" without warranties of any kind. we do not guarantee uptime or that the service will be error-free.
 
 we are not liable for any indirect, incidental, special, or consequential damages resulting from your use of the service.
+
+## 6. governing law
+
+these terms are governed by United States law, without regard to conflict-of-law provisions.
 
 ## 7. changes
 


### PR DESCRIPTION
## Summary
- Synced `docs/legal/terms.md` and `docs/legal/privacy.md` with the actual production Svelte templates
- Added note that the Svelte pages are the source of truth, not these markdown mirrors
- Key updates: governing law section, updated AT Protocol/PDS language, 6 new third-party services (AudD, Anthropic, ATProtoFans, Modal, turbopuffer, Replicate), teal.fm scrobble mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)