### PR TITLE
fix: hoist "create new playlist" CTA above existing playlists

### DIFF
--- a/frontend/src/lib/components/AddToMenu.svelte
+++ b/frontend/src/lib/components/AddToMenu.svelte
@@ -374,6 +374,13 @@
 						</div>
 					{:else}
 						<div class="playlist-list">
+							<button class="create-playlist-btn" onclick={(e) => { e.stopPropagation(); showCreateForm = true; }}>
+								<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+									<line x1="12" y1="5" x2="12" y2="19"></line>
+									<line x1="5" y1="12" x2="19" y2="12"></line>
+								</svg>
+								<span>create new playlist</span>
+							</button>
 							{#if loadingPlaylists}
 								<div class="loading-state">
 									<span class="spinner"></span>
@@ -411,13 +418,6 @@
 									</button>
 								{/each}
 							{/if}
-							<button class="create-playlist-btn" onclick={(e) => { e.stopPropagation(); showCreateForm = true; }}>
-								<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-									<line x1="12" y1="5" x2="12" y2="19"></line>
-									<line x1="5" y1="12" x2="19" y2="12"></line>
-								</svg>
-								<span>create new playlist</span>
-							</button>
 						</div>
 					{/if}
 				</div>

--- a/frontend/src/lib/components/TrackActionsMenu.svelte
+++ b/frontend/src/lib/components/TrackActionsMenu.svelte
@@ -356,6 +356,13 @@
 						</div>
 					{:else}
 						<div class="playlist-list">
+							<button class="create-playlist-btn" onclick={(e) => { e.stopPropagation(); showCreateForm = true; }}>
+								<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+									<line x1="12" y1="5" x2="12" y2="19"></line>
+									<line x1="5" y1="12" x2="19" y2="12"></line>
+								</svg>
+								<span>create new playlist</span>
+							</button>
 							{#if loadingPlaylists}
 								<div class="loading-state">
 									<span class="spinner"></span>
@@ -393,13 +400,6 @@
 									</button>
 								{/each}
 							{/if}
-							<button class="create-playlist-btn" onclick={(e) => { e.stopPropagation(); showCreateForm = true; }}>
-								<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-									<line x1="12" y1="5" x2="12" y2="19"></line>
-									<line x1="5" y1="12" x2="19" y2="12"></line>
-								</svg>
-								<span>create new playlist</span>
-							</button>
 						</div>
 					{/if}
 				</div>


### PR DESCRIPTION
## Summary
- Moves the "create new playlist" button to the top of the playlist picker in both `AddToMenu` and `TrackActionsMenu`
- Previously it sat below all existing playlists, now it's the first thing you see

## Test plan
- [ ] Open track detail page, click heart menu, click "add to playlist" — "create new playlist" should appear above existing playlists
- [ ] Same for the track actions menu (three-dot menu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)