### PR TITLE
feat: discover artists from your bluesky follow graph

### DIFF
--- a/backend/src/backend/api/__init__.py
+++ b/backend/src/backend/api/__init__.py
@@ -2,6 +2,7 @@
 
 from backend.api.account import router as account_router
 from backend.api.artists import router as artists_router
+from backend.api.discover import router as discover_router
 from backend.api.meta import router as meta_router
 from backend.api.audio import router as audio_router
 from backend.api.auth import router as auth_router
@@ -22,6 +23,7 @@ __all__ = [
     "artists_router",
     "audio_router",
     "auth_router",
+    "discover_router",
     "exports_router",
     "meta_router",
     "moderation_router",

--- a/backend/src/backend/api/discover.py
+++ b/backend/src/backend/api/discover.py
@@ -1,0 +1,94 @@
+"""discovery endpoints — social graph powered artist discovery."""
+
+import logging
+from typing import Annotated
+
+import httpx
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, field_validator
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import Session, require_auth
+from backend._internal.atproto.profile import BSKY_API_BASE, normalize_avatar_url
+from backend.models import Artist, Track, get_db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/discover", tags=["discover"])
+
+
+class NetworkArtistResponse(BaseModel):
+    """artist from your bluesky follow graph who has music on plyr.fm."""
+
+    did: str
+    handle: str
+    display_name: str
+    avatar_url: str | None
+    track_count: int
+
+    @field_validator("avatar_url", mode="before")
+    @classmethod
+    def normalize_avatar(cls, v: str | None) -> str | None:
+        return normalize_avatar_url(v)
+
+
+async def _get_follows(did: str) -> set[str]:
+    """fetch all DIDs a user follows on bluesky (public API, no auth needed)."""
+    follows: set[str] = set()
+    cursor: str | None = None
+
+    async with httpx.AsyncClient() as client:
+        while True:
+            params: dict[str, str | int] = {"actor": did, "limit": 100}
+            if cursor:
+                params["cursor"] = cursor
+
+            resp = await client.get(
+                f"{BSKY_API_BASE}/app.bsky.graph.getFollows",
+                params=params,
+                timeout=10.0,
+            )
+            if resp.status_code != 200:
+                logger.warning(f"getFollows failed for {did}: {resp.status_code}")
+                break
+
+            data = resp.json()
+            follows.update(f["did"] for f in data.get("follows", []))
+
+            if not (cursor := data.get("cursor")):
+                break
+
+    return follows
+
+
+@router.get("/network")
+async def get_network_artists(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    auth_session: Session = Depends(require_auth),
+) -> list[NetworkArtistResponse]:
+    """discover artists on plyr.fm that you follow on bluesky."""
+    follow_dids = await _get_follows(auth_session.did)
+    if not follow_dids:
+        return []
+
+    # find artists in our DB whose DID is in the user's follow set, with track counts
+    result = await db.execute(
+        select(Artist, func.count(Track.id).label("track_count"))
+        .outerjoin(Track, Track.artist_did == Artist.did)
+        .where(Artist.did.in_(follow_dids))
+        .group_by(Artist.did)
+        .having(func.count(Track.id) > 0)
+        .order_by(func.count(Track.id).desc())
+    )
+
+    return [
+        NetworkArtistResponse(
+            did=artist.did,
+            handle=artist.handle,
+            display_name=artist.display_name,
+            avatar_url=artist.avatar_url,
+            track_count=track_count,
+        )
+        for artist, track_count in result.all()
+    ]

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -19,6 +19,7 @@ from backend.api import (
     artists_router,
     audio_router,
     auth_router,
+    discover_router,
     exports_router,
     meta_router,
     moderation_router,
@@ -119,6 +120,7 @@ app.add_middleware(SlowAPIMiddleware)  # type: ignore[arg-type]
 app.include_router(auth_router)
 app.include_router(account_router)
 app.include_router(artists_router)
+app.include_router(discover_router)
 app.include_router(tracks_router)
 app.include_router(albums_router)
 app.include_router(lists_router)

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -11,6 +11,15 @@
 	import type { Track } from '$lib/types';
 	import { auth } from '$lib/auth.svelte';
 	import { APP_NAME, APP_TAGLINE, APP_CANONICAL_URL } from '$lib/branding';
+	import { API_URL } from '$lib/config';
+
+	interface NetworkArtist {
+		did: string;
+		handle: string;
+		display_name: string;
+		avatar_url: string | null;
+		track_count: number;
+	}
 
 	// use cached tracks
 	let tracks = $derived(tracksCache.tracks);
@@ -24,6 +33,10 @@
 	let topTracks = $state<Track[]>([]);
 	let loadingTopTracks = $state(true);
 	let hasTopTracks = $derived(topTracks.length > 0);
+
+	// network artists (people you follow on bluesky who have music here)
+	let networkArtists = $state<NetworkArtist[]>([]);
+	let hasNetworkArtists = $derived(networkArtists.length > 0);
 
 	// show loading during initial load or when actively loading with no cached data
 	let showLoading = $derived((initialLoad && !hasTracks) || (loadingTracks && !hasTracks));
@@ -43,6 +56,14 @@
 		topTracks = topResult;
 		loadingTopTracks = false;
 		initialLoad = false;
+
+		// fetch network artists in the background (only when authenticated)
+		if (auth.isAuthenticated) {
+			fetch(`${API_URL}/discover/network`, { credentials: 'include' })
+				.then((r) => (r.ok ? r.json() : []))
+				.then((artists) => (networkArtists = artists))
+				.catch(() => {});
+		}
 	});
 
 	// set up IntersectionObserver for infinite scroll
@@ -136,6 +157,28 @@
 		</section>
 	{/if}
 
+	<!-- artists from your bluesky follow graph -->
+	{#if hasNetworkArtists}
+		<section class="network-artists">
+			<h2>from your network</h2>
+			<div class="artist-grid">
+				{#each networkArtists as artist}
+					<a href="/u/{artist.handle}" class="artist-card">
+						{#if artist.avatar_url}
+							<img src={artist.avatar_url} alt={artist.display_name} class="artist-avatar" />
+						{:else}
+							<div class="artist-avatar placeholder"></div>
+						{/if}
+						<div class="artist-info">
+							<span class="artist-name">{artist.display_name}</span>
+							<span class="artist-meta">{artist.track_count} {artist.track_count === 1 ? 'track' : 'tracks'}</span>
+						</div>
+					</a>
+				{/each}
+			</div>
+		</section>
+	{/if}
+
 	<section class="tracks">
 		<div class="section-header">
 			<h2>
@@ -210,6 +253,80 @@
 		margin: 0 0 1.5rem 0;
 	}
 
+	.network-artists {
+		margin-bottom: 2.5rem;
+	}
+
+	.network-artists h2 {
+		font-size: var(--text-page-heading);
+		font-weight: 700;
+		color: var(--text-primary);
+		margin: 0 0 1rem 0;
+	}
+
+	.artist-grid {
+		display: flex;
+		gap: 0.75rem;
+		overflow-x: auto;
+		padding-bottom: 0.5rem;
+		scrollbar-width: thin;
+		scrollbar-color: var(--border) transparent;
+	}
+
+	.artist-card {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.75rem;
+		border-radius: var(--radius-md);
+		background: var(--surface-secondary);
+		border: 1px solid var(--border);
+		text-decoration: none;
+		color: inherit;
+		min-width: 120px;
+		transition: border-color 0.15s, background 0.15s;
+	}
+
+	.artist-card:hover {
+		border-color: var(--accent);
+		background: var(--surface-hover);
+	}
+
+	.artist-avatar {
+		width: 56px;
+		height: 56px;
+		border-radius: 50%;
+		object-fit: cover;
+	}
+
+	.artist-avatar.placeholder {
+		background: var(--surface-tertiary);
+	}
+
+	.artist-info {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.125rem;
+		text-align: center;
+	}
+
+	.artist-name {
+		font-size: var(--text-sm);
+		font-weight: 600;
+		color: var(--text-primary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 100px;
+	}
+
+	.artist-meta {
+		font-size: var(--text-xs);
+		color: var(--text-tertiary);
+	}
+
 	main {
 		max-width: 800px;
 		margin: 0 auto;
@@ -278,7 +395,8 @@
 		}
 
 		.section-header h2,
-		.top-tracks h2 {
+		.top-tracks h2,
+		.network-artists h2 {
 			font-size: var(--text-2xl);
 		}
 	}


### PR DESCRIPTION
## Summary
- adds `GET /discover/network` endpoint that reads the authenticated user's bluesky follow graph (public API, no new OAuth scopes) and cross-references with plyr.fm artists
- shows a "from your network" section on the homepage between top tracks and latest tracks — horizontally scrollable artist cards with avatar, name, and track count
- only visible when logged in and when there are matches; degrades to nothing otherwise

this is the simplest possible implementation of the shared social graph thesis that's been discussed across the ATmosphere — matt (@mmatt.net), eli (@iame.li), joe basser (spark), and others have all written about leveraging the bluesky follow graph for cross-app discovery. plyr.fm is a natural fit: "if there is an artist I find on plyr.fm, why not be able to keep that relationship to another music platform?"

no new database tables, no new lexicons, no PDS writes. just reading the public follow graph and checking it against existing artists.

## Test plan
- [ ] log in → verify "from your network" appears if any followed accounts have music
- [ ] verify artist cards link to correct `/u/{handle}` pages
- [ ] verify section does not appear when logged out
- [ ] verify section does not appear when no followed accounts have music
- [ ] verify horizontal scroll works on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)