### PR TITLE
fix: avatar fallback + follow-age ordering for network discovery

### DIFF
--- a/backend/src/backend/api/discover.py
+++ b/backend/src/backend/api/discover.py
@@ -1,6 +1,7 @@
 """discovery endpoints — social graph powered artist discovery."""
 
 import logging
+from dataclasses import dataclass
 from typing import Annotated
 
 import httpx
@@ -33,10 +34,23 @@ class NetworkArtistResponse(BaseModel):
         return normalize_avatar_url(v)
 
 
-async def _get_follows(did: str) -> set[str]:
-    """fetch all DIDs a user follows on bluesky (public API, no auth needed)."""
-    follows: set[str] = set()
+@dataclass(frozen=True, slots=True)
+class FollowInfo:
+    """metadata about a follow relationship from bluesky."""
+
+    index: int  # enumeration position (0 = most recent, higher = older)
+    avatar_url: str | None  # avatar from bluesky profile
+
+
+async def _get_follows(did: str) -> dict[str, FollowInfo]:
+    """fetch all DIDs a user follows on bluesky with profile metadata.
+
+    returns a mapping of DID -> FollowInfo. enumeration order approximates
+    follow age (0 = most recently followed) since the API paginates by TID.
+    """
+    follows: dict[str, FollowInfo] = {}
     cursor: str | None = None
+    index = 0
 
     async with httpx.AsyncClient() as client:
         while True:
@@ -54,7 +68,12 @@ async def _get_follows(did: str) -> set[str]:
                 break
 
             data = resp.json()
-            follows.update(f["did"] for f in data.get("follows", []))
+            for f in data.get("follows", []):
+                follows[f["did"]] = FollowInfo(
+                    index=index,
+                    avatar_url=normalize_avatar_url(f.get("avatar")),
+                )
+                index += 1
 
             if not (cursor := data.get("cursor")):
                 break
@@ -78,16 +97,19 @@ async def get_network_artists(
         .join(Track, Track.artist_did == Artist.did)
         .where(Artist.did.in_(follow_dids))
         .group_by(Artist.did)
-        .order_by(func.count(Track.id).desc())
     )
 
-    return [
+    artists = [
         NetworkArtistResponse(
             did=artist.did,
             handle=artist.handle,
             display_name=artist.display_name,
-            avatar_url=artist.avatar_url,
+            avatar_url=artist.avatar_url or follow_dids[artist.did].avatar_url,
             track_count=track_count,
         )
         for artist, track_count in result.all()
     ]
+
+    # sort by follow index DESC — oldest follows first ("people you know the most")
+    artists.sort(key=lambda a: follow_dids[a.did].index, reverse=True)
+    return artists

--- a/backend/tests/api/test_discover.py
+++ b/backend/tests/api/test_discover.py
@@ -9,6 +9,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, require_auth
+from backend.api.discover import FollowInfo
 from backend.main import app
 from backend.models import Artist, Track
 
@@ -99,7 +100,10 @@ async def test_network_excludes_artists_with_zero_tracks(
     with patch(
         "backend.api.discover._get_follows",
         new_callable=AsyncMock,
-        return_value={artist_with_tracks.did, artist_without_tracks.did},
+        return_value={
+            artist_with_tracks.did: FollowInfo(index=0, avatar_url=None),
+            artist_without_tracks.did: FollowInfo(index=1, avatar_url=None),
+        },
     ):
         async with AsyncClient(
             transport=ASGITransport(app=test_app), base_url="http://test"
@@ -121,7 +125,10 @@ async def test_network_returns_empty_when_no_follows_are_artists(
     with patch(
         "backend.api.discover._get_follows",
         new_callable=AsyncMock,
-        return_value={"did:plc:stranger1", "did:plc:stranger2"},
+        return_value={
+            "did:plc:stranger1": FollowInfo(index=0, avatar_url=None),
+            "did:plc:stranger2": FollowInfo(index=1, avatar_url=None),
+        },
     ):
         async with AsyncClient(
             transport=ASGITransport(app=test_app), base_url="http://test"
@@ -140,7 +147,7 @@ async def test_network_returns_empty_when_no_follows(
     with patch(
         "backend.api.discover._get_follows",
         new_callable=AsyncMock,
-        return_value=set(),
+        return_value={},
     ):
         async with AsyncClient(
             transport=ASGITransport(app=test_app), base_url="http://test"
@@ -149,3 +156,73 @@ async def test_network_returns_empty_when_no_follows(
 
     assert response.status_code == 200
     assert response.json() == []
+
+
+async def test_network_avatar_fallback_from_bluesky(
+    test_app: FastAPI,
+    db_session: AsyncSession,
+    artist_with_tracks: Artist,
+) -> None:
+    """when artist has no avatar, use the bluesky avatar from follow data."""
+    assert artist_with_tracks.avatar_url is None  # fixture has no avatar
+
+    bsky_avatar = "https://cdn.bsky.app/img/avatar/did:plc:has_tracks/abc@jpeg"
+    with patch(
+        "backend.api.discover._get_follows",
+        new_callable=AsyncMock,
+        return_value={
+            artist_with_tracks.did: FollowInfo(index=0, avatar_url=bsky_avatar),
+        },
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.get("/discover/network")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["avatar_url"] == bsky_avatar
+
+
+async def test_network_ordered_by_follow_age(
+    test_app: FastAPI,
+    db_session: AsyncSession,
+) -> None:
+    """results are sorted by follow index DESC — oldest follows appear first."""
+    for did, handle, name in [
+        ("did:plc:recent", "recent.bsky.social", "Recent Follow"),
+        ("did:plc:old", "old.bsky.social", "Old Follow"),
+    ]:
+        artist = Artist(did=did, handle=handle, display_name=name)
+        db_session.add(artist)
+        await db_session.flush()
+        db_session.add(
+            Track(
+                title=f"Track by {name}",
+                file_id=f"file_{did}",
+                file_type="audio/mpeg",
+                artist_did=did,
+            )
+        )
+    await db_session.commit()
+
+    with patch(
+        "backend.api.discover._get_follows",
+        new_callable=AsyncMock,
+        return_value={
+            "did:plc:recent": FollowInfo(index=0, avatar_url=None),  # most recent
+            "did:plc:old": FollowInfo(index=5, avatar_url=None),  # oldest
+        },
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.get("/discover/network")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    # oldest follow (highest index) should be first
+    assert data[0]["did"] == "did:plc:old"
+    assert data[1]["did"] == "did:plc:recent"


### PR DESCRIPTION
## Summary
- `_get_follows` now returns `dict[str, FollowInfo]` with avatar URL and follow index from Bluesky API (zero extra cost)
- Network artists use Bluesky avatar as fallback when plyr.fm avatar is null
- Results sorted by follow age (oldest follows first — "people you know the most")

## Test plan
- [x] Existing tests updated for new `FollowInfo` return type
- [x] New test: avatar fallback from Bluesky when artist has no plyr.fm avatar
- [x] New test: ordering by follow age (oldest first)
- [ ] Check staging after merge — brookie.blog should show avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)