### PR TITLE
fix: polish top tracks cards

### DIFF
--- a/frontend/src/lib/components/TrackCard.svelte
+++ b/frontend/src/lib/components/TrackCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SensitiveImage from './SensitiveImage.svelte';
+	import LikersTooltip from './LikersTooltip.svelte';
 	import type { Track } from '$lib/types';
 
 	interface Props {
@@ -13,11 +14,32 @@
 
 	let imageLoading = $derived(index < 3 ? 'eager' as const : 'lazy' as const);
 	let likeCount = $derived(track.like_count || 0);
+
+	let showLikersTooltip = $state(false);
+	let likersTooltipTimeout: ReturnType<typeof setTimeout> | null = null;
+
+	function handleLikesMouseEnter(e: Event) {
+		e.stopPropagation();
+		if (likersTooltipTimeout) {
+			clearTimeout(likersTooltipTimeout);
+			likersTooltipTimeout = null;
+		}
+		showLikersTooltip = true;
+	}
+
+	function handleLikesMouseLeave(e: Event) {
+		e.stopPropagation();
+		likersTooltipTimeout = setTimeout(() => {
+			showLikersTooltip = false;
+			likersTooltipTimeout = null;
+		}, 150);
+	}
 </script>
 
 <button
 	class="track-card"
 	class:playing={isPlaying}
+	class:tooltip-open={showLikersTooltip}
 	onclick={() => onPlay(track)}
 >
 	<div class="artwork-wrapper" class:gated={track.gated}>
@@ -35,7 +57,6 @@
 					src={track.artist_avatar_url}
 					alt={track.artist}
 					loading={imageLoading}
-					class="avatar"
 				/>
 			</SensitiveImage>
 		{:else}
@@ -63,7 +84,22 @@
 		{track.artist}
 	</a>
 	<span class="stats">
-		{track.play_count} {track.play_count === 1 ? 'play' : 'plays'}{#if likeCount > 0}&nbsp;· {likeCount} {likeCount === 1 ? 'like' : 'likes'}{/if}
+		{track.play_count} {track.play_count === 1 ? 'play' : 'plays'}{#if likeCount > 0}<span class="meta-sep">&middot;</span><span
+				class="likes"
+				role="button"
+				tabindex="0"
+				aria-label="{likeCount} {likeCount === 1 ? 'like' : 'likes'}"
+				aria-expanded={showLikersTooltip}
+				onmouseenter={handleLikesMouseEnter}
+				onmouseleave={handleLikesMouseLeave}
+				onfocus={handleLikesMouseEnter}
+				onblur={handleLikesMouseLeave}
+			>{likeCount} {likeCount === 1 ? 'like' : 'likes'}{#if showLikersTooltip}<LikersTooltip
+						trackId={track.id}
+						likeCount={likeCount}
+						onMouseEnter={() => handleLikesMouseEnter(new Event('mouseenter'))}
+						onMouseLeave={() => handleLikesMouseLeave(new Event('mouseleave'))}
+					/>{/if}</span>{/if}
 	</span>
 </button>
 
@@ -95,6 +131,10 @@
 		border-color: color-mix(in srgb, var(--accent) 25%, var(--border-subtle));
 	}
 
+	.track-card.tooltip-open {
+		z-index: 60;
+	}
+
 	.artwork-wrapper {
 		position: relative;
 		width: 100%;
@@ -117,10 +157,6 @@
 		height: 100%;
 		object-fit: cover;
 		display: block;
-	}
-
-	.artwork-wrapper img.avatar {
-		border-radius: var(--radius-full);
 	}
 
 	.placeholder {
@@ -178,5 +214,20 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
+	}
+
+	.meta-sep {
+		margin: 0 0.25em;
+		color: var(--text-muted);
+	}
+
+	.likes {
+		position: relative;
+		cursor: help;
+		transition: color 0.15s;
+	}
+
+	.likes:hover {
+		color: var(--accent);
 	}
 </style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -133,18 +133,30 @@
 <Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={logout} />
 
 <main>
-	<!-- trending section -->
+	<!-- top tracks section -->
 	{#if loadingTopTracks}
-		<section class="trending">
-			<h2>trending</h2>
+		<section class="top-tracks">
+			<h2>
+				<svg class="section-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+					<path d="M8 1C8 1 6.5 4.5 6.5 7a1.5 1.5 0 1 0 3 0C9.5 4.5 8 1 8 1Z" fill="currentColor" opacity="0.6"/>
+					<path d="M8 2.5C5.5 5.5 4 7.5 4 10a4 4 0 0 0 8 0c0-2.5-1.5-4.5-4-7.5Z" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+				</svg>
+				top tracks
+			</h2>
 			<div class="loading-container compact">
 				<WaveLoading size="sm" message="loading..." />
 			</div>
 		</section>
 	{:else if hasTopTracks}
-		<section class="trending">
-			<h2>trending</h2>
-			<div class="trending-grid">
+		<section class="top-tracks">
+			<h2>
+				<svg class="section-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+					<path d="M8 1C8 1 6.5 4.5 6.5 7a1.5 1.5 0 1 0 3 0C9.5 4.5 8 1 8 1Z" fill="currentColor" opacity="0.6"/>
+					<path d="M8 2.5C5.5 5.5 4 7.5 4 10a4 4 0 0 0 8 0c0-2.5-1.5-4.5-4-7.5Z" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+				</svg>
+				top tracks
+			</h2>
+			<div class="top-tracks-grid">
 				{#each topTracks as track, i}
 					<TrackCard
 						{track}
@@ -157,7 +169,7 @@
 		</section>
 	{/if}
 
-	<!-- artists from your bluesky follow graph -->
+	<!-- artists from your bluesky network -->
 	{#if hasNetworkArtists}
 		<section class="network-artists">
 			<h2>from your network</h2>
@@ -242,18 +254,28 @@
 		padding: 1.5rem 1rem;
 	}
 
-	.trending {
+	.top-tracks {
 		margin-bottom: 2.5rem;
 	}
 
-	.trending h2 {
+	.top-tracks h2 {
 		font-size: var(--text-page-heading);
 		font-weight: 700;
 		color: var(--text-primary);
 		margin: 0 0 1rem 0;
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
 	}
 
-	.trending-grid {
+	.section-icon {
+		width: 1.1em;
+		height: 1.1em;
+		color: var(--accent);
+		flex-shrink: 0;
+	}
+
+	.top-tracks-grid {
 		display: flex;
 		gap: 0.75rem;
 		overflow-x: auto;
@@ -404,7 +426,7 @@
 		}
 
 		.section-header h2,
-		.trending h2,
+		.top-tracks h2,
 		.network-artists h2 {
 			font-size: var(--text-2xl);
 		}


### PR DESCRIPTION
## Summary
- add LikersTooltip to TrackCard so hovering like count shows who liked it
- remove circular avatar crop — avatars fill the square like track artwork
- rename "trending" back to "top tracks" (data is most-liked, not trending)
- add flame icon next to "top tracks" heading

## Test plan
- [ ] hover like count on a top track card → likers tooltip appears
- [ ] tracks with avatar fallback (no artwork) show square-cropped avatar, not circle-in-square
- [ ] heading reads "top tracks" with flame icon in accent color
- [ ] tooltip z-index renders above sibling cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)