### PR TITLE
fix: top tracks — horizontal cards, working tooltip, proper avatar

### DIFF
--- a/frontend/src/lib/components/TrackCard.svelte
+++ b/frontend/src/lib/components/TrackCard.svelte
@@ -18,8 +18,7 @@
 	let showLikersTooltip = $state(false);
 	let likersTooltipTimeout: ReturnType<typeof setTimeout> | null = null;
 
-	function handleLikesMouseEnter(e: Event) {
-		e.stopPropagation();
+	function openLikers() {
 		if (likersTooltipTimeout) {
 			clearTimeout(likersTooltipTimeout);
 			likersTooltipTimeout = null;
@@ -27,12 +26,21 @@
 		showLikersTooltip = true;
 	}
 
-	function handleLikesMouseLeave(e: Event) {
-		e.stopPropagation();
+	function closeLikers() {
 		likersTooltipTimeout = setTimeout(() => {
 			showLikersTooltip = false;
 			likersTooltipTimeout = null;
 		}, 150);
+	}
+
+	function handleLikesMouseEnter(e: Event) {
+		e.stopPropagation();
+		openLikers();
+	}
+
+	function handleLikesMouseLeave(e: Event) {
+		e.stopPropagation();
+		closeLikers();
 	}
 </script>
 
@@ -42,7 +50,7 @@
 	class:tooltip-open={showLikersTooltip}
 	onclick={() => onPlay(track)}
 >
-	<div class="artwork-wrapper" class:gated={track.gated}>
+	<div class="artwork" class:gated={track.gated}>
 		{#if track.image_url}
 			<SensitiveImage src={track.image_url}>
 				<img
@@ -57,59 +65,73 @@
 					src={track.artist_avatar_url}
 					alt={track.artist}
 					loading={imageLoading}
+					class="avatar"
 				/>
 			</SensitiveImage>
 		{:else}
 			<div class="placeholder">
-				<svg width="24" height="24" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
-					<circle cx="8" cy="5" r="3" stroke="currentColor" stroke-width="1.5" fill="none" />
-					<path d="M3 14c0-2.5 2-4.5 5-4.5s5 2 5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+				<svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
+					<circle cx="8" cy="5" r="3" fill="none" />
+					<path d="M3 14c0-2.5 2-4.5 5-4.5s5 2 5 4.5" stroke-linecap="round" />
 				</svg>
 			</div>
 		{/if}
 		{#if track.gated}
 			<div class="gated-badge" title="supporters only">
-				<svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+				<svg width="8" height="8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
 					<path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"/>
 				</svg>
 			</div>
 		{/if}
 	</div>
-	<span class="title" title={track.title}>{track.title}</span>
-	<a
-		href="/u/{track.artist_handle}"
-		class="artist"
-		onclick={(e) => e.stopPropagation()}
-	>
-		{track.artist}
-	</a>
-	<span class="stats">
-		{track.play_count} {track.play_count === 1 ? 'play' : 'plays'}{#if likeCount > 0}<span class="meta-sep">&middot;</span><span
-				class="likes"
-				role="button"
-				tabindex="0"
-				aria-label="{likeCount} {likeCount === 1 ? 'like' : 'likes'}"
-				aria-expanded={showLikersTooltip}
-				onmouseenter={handleLikesMouseEnter}
-				onmouseleave={handleLikesMouseLeave}
-				onfocus={handleLikesMouseEnter}
-				onblur={handleLikesMouseLeave}
-			>{likeCount} {likeCount === 1 ? 'like' : 'likes'}{#if showLikersTooltip}<LikersTooltip
-						trackId={track.id}
-						likeCount={likeCount}
-						onMouseEnter={() => handleLikesMouseEnter(new Event('mouseenter'))}
-						onMouseLeave={() => handleLikesMouseLeave(new Event('mouseleave'))}
-					/>{/if}</span>{/if}
-	</span>
+	<div class="info">
+		<span class="title" title={track.title}>{track.title}</span>
+		<a
+			href="/u/{track.artist_handle}"
+			class="artist"
+			onclick={(e) => e.stopPropagation()}
+		>
+			{track.artist}
+		</a>
+		<div class="meta">
+			<span>{track.play_count} {track.play_count === 1 ? 'play' : 'plays'}</span>
+			{#if likeCount > 0}
+				<span class="meta-sep">&middot;</span>
+				<span
+					class="likes"
+					role="button"
+					tabindex="0"
+					aria-label="{likeCount} {likeCount === 1 ? 'like' : 'likes'}"
+					aria-expanded={showLikersTooltip}
+					onmouseenter={handleLikesMouseEnter}
+					onmouseleave={handleLikesMouseLeave}
+					onfocus={handleLikesMouseEnter}
+					onblur={handleLikesMouseLeave}
+				>
+					{likeCount} {likeCount === 1 ? 'like' : 'likes'}
+					{#if showLikersTooltip}
+						<LikersTooltip
+							trackId={track.id}
+							{likeCount}
+							onMouseEnter={openLikers}
+							onMouseLeave={closeLikers}
+						/>
+					{/if}
+				</span>
+			{/if}
+		</div>
+	</div>
 </button>
 
 <style>
+	/* horizontal card: artwork left, text right */
 	.track-card {
 		display: flex;
-		flex-direction: column;
-		gap: 0.375rem;
-		min-width: 140px;
-		max-width: 140px;
+		flex-direction: row;
+		align-items: center;
+		gap: 0.625rem;
+		min-width: 240px;
+		max-width: 240px;
 		padding: 0.5rem;
 		background: var(--bg-secondary);
 		border: 1px solid var(--border-subtle);
@@ -119,6 +141,7 @@
 		font-family: inherit;
 		color: inherit;
 		transition: border-color 0.15s, background 0.15s;
+		position: relative;
 	}
 
 	.track-card:hover {
@@ -135,28 +158,35 @@
 		z-index: 60;
 	}
 
-	.artwork-wrapper {
+	/* artwork — small square thumbnail */
+	.artwork {
 		position: relative;
-		width: 100%;
-		aspect-ratio: 1;
+		width: 48px;
+		height: 48px;
+		flex-shrink: 0;
 		border-radius: var(--radius-sm);
 		overflow: hidden;
 		background: var(--bg-tertiary);
 	}
 
-	.artwork-wrapper.gated::after {
+	.artwork img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	.artwork img.avatar {
+		border-radius: var(--radius-full);
+		border: 1.5px solid var(--border-default);
+	}
+
+	.artwork.gated::after {
 		content: '';
 		position: absolute;
 		inset: 0;
 		background: rgba(0, 0, 0, 0.3);
 		pointer-events: none;
-	}
-
-	.artwork-wrapper img {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-		display: block;
 	}
 
 	.placeholder {
@@ -170,10 +200,10 @@
 
 	.gated-badge {
 		position: absolute;
-		bottom: -4px;
-		right: -4px;
-		width: 18px;
-		height: 18px;
+		bottom: -3px;
+		right: -3px;
+		width: 16px;
+		height: 16px;
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -182,6 +212,15 @@
 		border-radius: var(--radius-full);
 		color: white;
 		z-index: 1;
+	}
+
+	/* text content — stacked vertically */
+	.info {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
 	}
 
 	.title {
@@ -208,16 +247,16 @@
 		color: var(--accent);
 	}
 
-	.stats {
+	/* meta row — no overflow hidden so tooltip escapes */
+	.meta {
+		display: flex;
+		align-items: center;
+		gap: 0.25em;
 		font-size: var(--text-xs);
 		color: var(--text-tertiary);
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
 	}
 
 	.meta-sep {
-		margin: 0 0.25em;
 		color: var(--text-muted);
 	}
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -138,8 +138,8 @@
 		<section class="top-tracks">
 			<h2>
 				<svg class="section-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-					<path d="M8 1C8 1 6.5 4.5 6.5 7a1.5 1.5 0 1 0 3 0C9.5 4.5 8 1 8 1Z" fill="currentColor" opacity="0.6"/>
-					<path d="M8 2.5C5.5 5.5 4 7.5 4 10a4 4 0 0 0 8 0c0-2.5-1.5-4.5-4-7.5Z" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+					<path d="M2 12l4-4 3 2 5-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+					<path d="M10 4h4v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 				</svg>
 				top tracks
 			</h2>
@@ -151,8 +151,8 @@
 		<section class="top-tracks">
 			<h2>
 				<svg class="section-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-					<path d="M8 1C8 1 6.5 4.5 6.5 7a1.5 1.5 0 1 0 3 0C9.5 4.5 8 1 8 1Z" fill="currentColor" opacity="0.6"/>
-					<path d="M8 2.5C5.5 5.5 4 7.5 4 10a4 4 0 0 0 8 0c0-2.5-1.5-4.5-4-7.5Z" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+					<path d="M2 12l4-4 3 2 5-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+					<path d="M10 4h4v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 				</svg>
 				top tracks
 			</h2>


### PR DESCRIPTION
## Summary
- redesign TrackCard as **horizontal card** (48px artwork left, text right, 240px wide) — compact and proportional to network artist cards instead of towering vertical columns
- avatar fallback renders as a **circle inside the square** (same as TrackItem) — no more ugly circle-in-visible-square
- **fix LikersTooltip**: stats now in a flex div without `overflow: hidden` so the absolutely-positioned tooltip actually renders
- replace flame icon with **trending line** (chart arrow going up-right)

## Test plan
- [ ] top tracks cards are horizontal, compact, roughly same height as network artist cards
- [ ] hover like count → likers tooltip appears with actual avatars
- [ ] avatar fallback tracks show circular avatar in the 48px thumbnail
- [ ] trending line icon next to "top tracks" heading
- [ ] playing card shows accent styling
- [ ] horizontal scroll works

🤖 Generated with [Claude Code](https://claude.com/claude-code)