### PR TITLE
fix: match track card shape to artist cards, move icon right

### DIFF
--- a/frontend/src/lib/components/TrackCard.svelte
+++ b/frontend/src/lib/components/TrackCard.svelte
@@ -124,20 +124,20 @@
 </button>
 
 <style>
-	/* horizontal card: artwork left, text right */
+	/* vertical card — matches artist-card shape */
 	.track-card {
 		display: flex;
-		flex-direction: row;
+		flex-direction: column;
 		align-items: center;
-		gap: 0.625rem;
-		min-width: 240px;
-		max-width: 240px;
-		padding: 0.5rem;
+		gap: 0.5rem;
+		min-width: 120px;
+		max-width: 120px;
+		padding: 0.75rem;
 		background: var(--bg-secondary);
 		border: 1px solid var(--border-subtle);
 		border-radius: var(--radius-md);
 		cursor: pointer;
-		text-align: left;
+		text-align: center;
 		font-family: inherit;
 		color: inherit;
 		transition: border-color 0.15s, background 0.15s;
@@ -158,11 +158,11 @@
 		z-index: 60;
 	}
 
-	/* artwork — small square thumbnail */
+	/* artwork — square thumbnail matching artist avatar size */
 	.artwork {
 		position: relative;
-		width: 48px;
-		height: 48px;
+		width: 56px;
+		height: 56px;
 		flex-shrink: 0;
 		border-radius: var(--radius-sm);
 		overflow: hidden;
@@ -214,13 +214,14 @@
 		z-index: 1;
 	}
 
-	/* text content — stacked vertically */
+	/* text content — stacked vertically, centered */
 	.info {
-		flex: 1;
-		min-width: 0;
 		display: flex;
 		flex-direction: column;
+		align-items: center;
 		gap: 0.125rem;
+		min-width: 0;
+		width: 100%;
 	}
 
 	.title {
@@ -230,6 +231,7 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
+		max-width: 100%;
 		line-height: 1.3;
 	}
 
@@ -240,6 +242,7 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
+		max-width: 100%;
 		transition: color 0.15s;
 	}
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -137,11 +137,11 @@
 	{#if loadingTopTracks}
 		<section class="top-tracks">
 			<h2>
+				top tracks
 				<svg class="section-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
 					<path d="M2 12l4-4 3 2 5-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 					<path d="M10 4h4v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 				</svg>
-				top tracks
 			</h2>
 			<div class="loading-container compact">
 				<WaveLoading size="sm" message="loading..." />
@@ -150,11 +150,11 @@
 	{:else if hasTopTracks}
 		<section class="top-tracks">
 			<h2>
+				top tracks
 				<svg class="section-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
 					<path d="M2 12l4-4 3 2 5-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 					<path d="M10 4h4v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 				</svg>
-				top tracks
 			</h2>
 			<div class="top-tracks-grid">
 				{#each topTracks as track, i}


### PR DESCRIPTION
## Summary
- TrackCard now uses same vertical column layout and 120px width as the network artist cards for visual consistency
- Trending icon moved to the right of "top tracks" heading text

## Test plan
- [ ] Top tracks cards and network artist cards look consistent in shape/size
- [ ] Icon appears to the right of "top tracks" heading
- [ ] Cards still scroll horizontally
- [ ] LikersTooltip still works on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)