### PR TITLE
fix: tooltip clipping in top tracks + cleaner icon

### DIFF
--- a/frontend/src/lib/components/LikersTooltip.svelte
+++ b/frontend/src/lib/components/LikersTooltip.svelte
@@ -13,9 +13,10 @@
 		likeCount: number;
 		onMouseEnter?: () => void;
 		onMouseLeave?: () => void;
+		forceBelow?: boolean;
 	}
 
-	let { trackId, likeCount, onMouseEnter, onMouseLeave }: Props = $props();
+	let { trackId, likeCount, onMouseEnter, onMouseLeave, forceBelow = false }: Props = $props();
 
 	let likers = $state<LikerData[]>([]);
 	let loading = $state(true);
@@ -56,6 +57,11 @@
 
 	// check if tooltip should flip below based on viewport position
 	$effect(() => {
+		if (forceBelow) {
+			positionBelow = true;
+			return;
+		}
+
 		if (!tooltipElement) return;
 
 		const parent = tooltipElement.parentElement;

--- a/frontend/src/lib/components/TrackCard.svelte
+++ b/frontend/src/lib/components/TrackCard.svelte
@@ -115,6 +115,7 @@
 							{likeCount}
 							onMouseEnter={openLikers}
 							onMouseLeave={closeLikers}
+							forceBelow
 						/>
 					{/if}
 				</span>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -139,8 +139,8 @@
 			<h2>
 				top tracks
 				<svg class="section-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-					<path d="M2 12l4-4 3 2 5-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-					<path d="M10 4h4v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+					<path d="M2 12C6 11 10 5 14 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+					<path d="M10 3h4v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 				</svg>
 			</h2>
 			<div class="loading-container compact">
@@ -152,8 +152,8 @@
 			<h2>
 				top tracks
 				<svg class="section-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-					<path d="M2 12l4-4 3 2 5-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-					<path d="M10 4h4v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+					<path d="M2 12C6 11 10 5 14 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+					<path d="M10 3h4v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 				</svg>
 			</h2>
 			<div class="top-tracks-grid">


### PR DESCRIPTION
## Summary
- LikersTooltip now accepts `forceBelow` prop — used in TrackCard to render tooltip below the trigger, avoiding clipping by the horizontally-scrolling grid container
- Replaced jagged zigzag trending icon with a smooth bezier curve

## Root cause
`overflow-x: auto` on `.top-tracks-grid` forces `overflow-y: auto` per CSS spec, clipping the absolutely-positioned tooltip above the card.

## Test plan
- [ ] Hover "1 like" on a top track card — tooltip appears below, fully visible
- [ ] LikersTooltip on TrackItem (latest tracks) still works as before (above by default)
- [ ] Trending icon is a smooth curve, not jagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)