### PR TITLE
fix: tooltip escapes scroll container + zigzag icon

### DIFF
--- a/frontend/src/lib/components/LikersTooltip.svelte
+++ b/frontend/src/lib/components/LikersTooltip.svelte
@@ -24,6 +24,10 @@
 	let tooltipElement: HTMLDivElement | null = $state(null);
 	let positionBelow = $state(false);
 
+	// fixed positioning for tooltips inside overflow containers
+	let fixedTop = $state(0);
+	let fixedLeft = $state(0);
+
 	// track which avatars have errored (by DID)
 	let avatarErrors = $state<Set<string>>(new Set());
 
@@ -55,10 +59,16 @@
 		return !url || avatarErrors.has(liker.did);
 	}
 
-	// check if tooltip should flip below based on viewport position
+	// position tooltip — use fixed positioning when forceBelow to escape overflow containers
 	$effect(() => {
 		if (forceBelow) {
 			positionBelow = true;
+			if (!tooltipElement) return;
+			const parent = tooltipElement.parentElement;
+			if (!parent) return;
+			const rect = parent.getBoundingClientRect();
+			fixedTop = rect.bottom + 8;
+			fixedLeft = rect.left + rect.width / 2;
 			return;
 		}
 
@@ -126,6 +136,8 @@
 	bind:this={tooltipElement}
 	class="likers-tooltip"
 	class:position-below={positionBelow}
+	class:position-fixed={forceBelow}
+	style={forceBelow ? `top: ${fixedTop}px; left: ${fixedLeft}px;` : ''}
 	role="tooltip"
 	onmouseenter={onMouseEnter}
 	onmouseleave={onMouseLeave}
@@ -192,6 +204,14 @@
 		top: 100%;
 		margin-bottom: 0;
 		margin-top: 0.625rem;
+	}
+
+	.likers-tooltip.position-fixed {
+		position: fixed;
+		bottom: auto;
+		top: auto;
+		left: auto;
+		margin: 0;
 	}
 
 	.loading,

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -139,8 +139,8 @@
 			<h2>
 				top tracks
 				<svg class="section-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-					<path d="M2 12C6 11 10 5 14 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-					<path d="M10 3h4v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+					<path d="M2 12C3 10 4.5 6 5.5 6C6.5 6 6.5 9 7.5 9C8.5 9 11 3 14 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+					<path d="M11 3h3v3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 				</svg>
 			</h2>
 			<div class="loading-container compact">
@@ -152,8 +152,8 @@
 			<h2>
 				top tracks
 				<svg class="section-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-					<path d="M2 12C6 11 10 5 14 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-					<path d="M10 3h4v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+					<path d="M2 12C3 10 4.5 6 5.5 6C6.5 6 6.5 9 7.5 9C8.5 9 11 3 14 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+					<path d="M11 3h3v3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 				</svg>
 			</h2>
 			<div class="top-tracks-grid">


### PR DESCRIPTION
## Summary
- LikersTooltip with `forceBelow` now uses `position: fixed` with calculated viewport coordinates, so it renders above the `overflow-x: auto` scroll container instead of being clipped
- Replaced the single smooth curve trending icon with a smooth zigzag (up-dip-up pattern)

## Test plan
- [ ] Hover "1 like" on a top track card — tooltip should appear below the card, fully visible
- [ ] Tooltip should dismiss cleanly on mouseleave
- [ ] Icon next to "top tracks" should look like a smooth trending chart (zigzag, not a straight line)
- [ ] LikersTooltip on TrackItem (latest tracks list) should still work as before (absolute positioning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)