### PR TITLE
fix: TrackCard link clicks + icon

### DIFF
--- a/frontend/src/lib/components/TrackCard.svelte
+++ b/frontend/src/lib/components/TrackCard.svelte
@@ -48,7 +48,10 @@
 	class="track-card"
 	class:playing={isPlaying}
 	class:tooltip-open={showLikersTooltip}
-	onclick={() => onPlay(track)}
+	onclick={(e) => {
+		if (e.target instanceof HTMLAnchorElement || (e.target as HTMLElement).closest('a')) return;
+		onPlay(track);
+	}}
 >
 	<div class="artwork" class:gated={track.gated}>
 		{#if track.image_url}
@@ -103,6 +106,8 @@
 					tabindex="0"
 					aria-label="{likeCount} {likeCount === 1 ? 'like' : 'likes'}"
 					aria-expanded={showLikersTooltip}
+					onclick={(e) => e.stopPropagation()}
+					onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') e.stopPropagation(); }}
 					onmouseenter={handleLikesMouseEnter}
 					onmouseleave={handleLikesMouseLeave}
 					onfocus={handleLikesMouseEnter}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -139,8 +139,8 @@
 			<h2>
 				top tracks
 				<svg class="section-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-					<path d="M2 12C3 10 4.5 6 5.5 6C6.5 6 6.5 9 7.5 9C8.5 9 11 3 14 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-					<path d="M11 3h3v3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+					<polyline points="2,11 5.5,6 8,9 14,3" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+					<polyline points="10,3 14,3 14,7" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
 				</svg>
 			</h2>
 			<div class="loading-container compact">
@@ -152,8 +152,8 @@
 			<h2>
 				top tracks
 				<svg class="section-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-					<path d="M2 12C3 10 4.5 6 5.5 6C6.5 6 6.5 9 7.5 9C8.5 9 11 3 14 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-					<path d="M11 3h3v3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+					<polyline points="2,11 5.5,6 8,9 14,3" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+					<polyline points="10,3 14,3 14,7" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
 				</svg>
 			</h2>
 			<div class="top-tracks-grid">


### PR DESCRIPTION
## Summary
- TrackCard button onclick now guards against anchor clicks (same pattern as TrackItem) — clicking artist link no longer disrupts the global player state
- Likes span gets stopPropagation so clicking it doesn't trigger track playback
- Replaced angular cubic bezier trending icon with clean polylines + round stroke joins

## Test plan
- [ ] Click artist name in a top track card — should navigate to artist page without affecting playback
- [ ] Click on "1 like" in a top track card — should not trigger track playback
- [ ] Click the card itself (not links) — should still play the track
- [ ] Icon should look like a clean trending chart with smooth rounded corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)