### PR TITLE
fix: TrackCard artist link causes full navigation, killing player

### DIFF
--- a/frontend/src/lib/components/TrackCard.svelte
+++ b/frontend/src/lib/components/TrackCard.svelte
@@ -92,7 +92,6 @@
 		<a
 			href="/u/{track.artist_handle}"
 			class="artist"
-			onclick={(e) => e.stopPropagation()}
 		>
 			{track.artist}
 		</a>


### PR DESCRIPTION
## Summary
- Removed `stopPropagation()` from the artist link in TrackCard
- `stopPropagation()` prevented click events from reaching the document, so SvelteKit's router never intercepted them — causing full browser navigation that destroyed player state and auth
- TrackItem already handles this correctly: no `stopPropagation()` on links, just the anchor guard on the parent button's `onclick`

## Test plan
- [ ] Play a track, then click artist name in the top tracks row — playback continues, page navigates client-side
- [ ] Click the TrackCard itself (not the link) — track plays as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)