### PR TITLE
fix: desktop hover tooltip, mobile bottom sheet for TrackCard likers

### DIFF
--- a/frontend/src/lib/components/TrackCard.svelte
+++ b/frontend/src/lib/components/TrackCard.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import SensitiveImage from './SensitiveImage.svelte';
+	import LikersTooltip from './LikersTooltip.svelte';
 	import { likersSheet } from '$lib/likers-sheet.svelte';
 	import type { Track } from '$lib/types';
 
@@ -14,11 +16,71 @@
 
 	let imageLoading = $derived(index < 3 ? 'eager' as const : 'lazy' as const);
 	let likeCount = $derived(track.like_count || 0);
+
+	let isMobile = $state(false);
+
+	$effect(() => {
+		if (browser) {
+			const mq = window.matchMedia('(max-width: 768px)');
+			isMobile = mq.matches;
+			const handler = (e: MediaQueryListEvent) => (isMobile = e.matches);
+			mq.addEventListener('change', handler);
+			return () => mq.removeEventListener('change', handler);
+		}
+	});
+
+	// desktop tooltip state
+	let showLikersTooltip = $state(false);
+	let likersTooltipTimeout: ReturnType<typeof setTimeout> | null = null;
+
+	function openLikers() {
+		if (likersTooltipTimeout) {
+			clearTimeout(likersTooltipTimeout);
+			likersTooltipTimeout = null;
+		}
+		showLikersTooltip = true;
+	}
+
+	function closeLikers() {
+		likersTooltipTimeout = setTimeout(() => {
+			showLikersTooltip = false;
+			likersTooltipTimeout = null;
+		}, 150);
+	}
+
+	function handleLikesClick(e: Event) {
+		e.stopPropagation();
+		if (isMobile) {
+			likersSheet.open(track.id, likeCount);
+		}
+	}
+
+	function handleLikesKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.stopPropagation();
+			if (isMobile) {
+				likersSheet.open(track.id, likeCount);
+			}
+		}
+	}
+
+	function handleLikesMouseEnter(e: Event) {
+		if (isMobile) return;
+		e.stopPropagation();
+		openLikers();
+	}
+
+	function handleLikesMouseLeave(e: Event) {
+		if (isMobile) return;
+		e.stopPropagation();
+		closeLikers();
+	}
 </script>
 
 <button
 	class="track-card"
 	class:playing={isPlaying}
+	class:tooltip-open={showLikersTooltip}
 	onclick={(e) => {
 		if (e.target instanceof HTMLAnchorElement || (e.target as HTMLElement).closest('a')) return;
 		onPlay(track);
@@ -75,18 +137,24 @@
 					role="button"
 					tabindex="0"
 					aria-label="{likeCount} {likeCount === 1 ? 'like' : 'likes'}"
-					onclick={(e) => {
-						e.stopPropagation();
-						likersSheet.open(track.id, likeCount);
-					}}
-					onkeydown={(e) => {
-						if (e.key === 'Enter' || e.key === ' ') {
-							e.stopPropagation();
-							likersSheet.open(track.id, likeCount);
-						}
-					}}
+					aria-expanded={showLikersTooltip}
+					onclick={handleLikesClick}
+					onkeydown={handleLikesKeydown}
+					onmouseenter={handleLikesMouseEnter}
+					onmouseleave={handleLikesMouseLeave}
+					onfocus={handleLikesMouseEnter}
+					onblur={handleLikesMouseLeave}
 				>
 					{likeCount} {likeCount === 1 ? 'like' : 'likes'}
+					{#if showLikersTooltip && !isMobile}
+						<LikersTooltip
+							trackId={track.id}
+							{likeCount}
+							onMouseEnter={openLikers}
+							onMouseLeave={closeLikers}
+							forceBelow
+						/>
+					{/if}
 				</span>
 			{/if}
 		</div>
@@ -124,6 +192,10 @@
 	.track-card.playing {
 		background: color-mix(in srgb, var(--accent) 10%, var(--track-bg-playing, var(--bg-tertiary)));
 		border-color: color-mix(in srgb, var(--accent) 20%, var(--track-border, var(--border-subtle)));
+	}
+
+	.track-card.tooltip-open {
+		z-index: 60;
 	}
 
 	.artwork {
@@ -236,11 +308,18 @@
 	}
 
 	.likes {
-		cursor: pointer;
+		position: relative;
+		cursor: help;
 		transition: color 0.15s;
 	}
 
 	.likes:hover {
 		color: var(--accent);
+	}
+
+	@media (max-width: 768px) {
+		.likes {
+			cursor: pointer;
+		}
 	}
 </style>


### PR DESCRIPTION
## Summary
- Desktop: hover tooltip (LikersTooltip with forceBelow) — same as before
- Mobile (<=768px): tap opens the bottom sheet (LikersSheet)
- Uses the same `(max-width: 768px)` breakpoint as SearchModal and the rest of the app

## Test plan
- [ ] Desktop: hover over like count on TrackCard — tooltip appears
- [ ] Mobile: tap like count — bottom sheet slides up, no tooltip
- [ ] Resize browser across 768px boundary — behavior switches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)