### PR TITLE
fix: broken network artist avatars + rename to artists you know

### DIFF
--- a/backend/src/backend/api/discover.py
+++ b/backend/src/backend/api/discover.py
@@ -104,7 +104,7 @@ async def get_network_artists(
             did=artist.did,
             handle=artist.handle,
             display_name=artist.display_name,
-            avatar_url=artist.avatar_url or follow_dids[artist.did].avatar_url,
+            avatar_url=follow_dids[artist.did].avatar_url or artist.avatar_url,
             track_count=track_count,
         )
         for artist, track_count in result.all()

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -13,6 +13,11 @@
 	import { auth } from '$lib/auth.svelte';
 	import { APP_NAME, APP_TAGLINE, APP_CANONICAL_URL } from '$lib/branding';
 	import { API_URL } from '$lib/config';
+	import {
+		getRefreshedAvatar,
+		triggerAvatarRefresh,
+		hasAttemptedRefresh
+	} from '$lib/avatar-refresh.svelte';
 
 	interface NetworkArtist {
 		did: string;
@@ -164,12 +169,23 @@
 	<!-- artists from your bluesky network -->
 	{#if hasNetworkArtists}
 		<section class="network-artists">
-			<h2>from your network</h2>
+			<h2>artists you know</h2>
 			<div class="artist-grid">
 				{#each networkArtists as artist}
+					{@const refreshedUrl = getRefreshedAvatar(artist.did)}
+					{@const displayUrl = refreshedUrl ?? artist.avatar_url}
 					<a href="/u/{artist.handle}" class="artist-card">
-						{#if artist.avatar_url}
-							<img src={artist.avatar_url} alt={artist.display_name} class="artist-avatar" />
+						{#if displayUrl}
+							<img
+								src={displayUrl}
+								alt={artist.display_name}
+								class="artist-avatar"
+								onerror={() => {
+									if (!hasAttemptedRefresh(artist.did)) {
+										triggerAvatarRefresh(artist.did);
+									}
+								}}
+							/>
 						{:else}
 							<div class="artist-avatar placeholder"></div>
 						{/if}


### PR DESCRIPTION
## Summary
- **Backend**: `/discover/network` was preferring stale DB avatar URLs over fresh Bluesky URLs from the follow graph. Flipped the `or` to prefer the live Bluesky URL (e.g. brookie.blog's avatar was 404ing because the CID changed)
- **Frontend**: Added `onerror` → `triggerAvatarRefresh()` to network artist card images, matching the pattern used in TrackItem and LikersTooltip
- **Heading**: "from your network" → "artists you know"

## Test plan
- [ ] brookie.blog avatar loads correctly in the artists you know section
- [ ] Heading says "artists you know"
- [ ] If an avatar 404s, refresh is triggered and avatar updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)