### PR TITLE
fix: check expiry on session cache hits

### DIFF
--- a/backend/src/backend/_internal/auth/session.py
+++ b/backend/src/backend/_internal/auth/session.py
@@ -181,6 +181,15 @@ async def get_session(session_id: str) -> Session | None:
         redis = get_async_redis_client()
         if cached := await redis.get(cache_key):
             data = json.loads(cached)
+            now = datetime.now(UTC)
+            if (exp := data.get("expires_at")) and now > datetime.fromisoformat(exp):
+                await redis.delete(cache_key)
+                return None
+            if (
+                rexp := data.get("refresh_expires_at")
+            ) and now > datetime.fromisoformat(rexp):
+                await redis.delete(cache_key)
+                return None
             return Session(
                 session_id=data["session_id"],
                 did=data["did"],
@@ -236,6 +245,12 @@ async def get_session(session_id: str) -> Session | None:
                     "did": session.did,
                     "handle": session.handle,
                     "oauth_session": session.oauth_session,
+                    "expires_at": user_session.expires_at.isoformat()
+                    if user_session.expires_at
+                    else None,
+                    "refresh_expires_at": refresh_expires_at.isoformat()
+                    if refresh_expires_at
+                    else None,
                 }
             ),
             ex=SESSION_CACHE_TTL_SECONDS,

--- a/backend/tests/_internal/test_session_cache.py
+++ b/backend/tests/_internal/test_session_cache.py
@@ -1,6 +1,7 @@
 """integration tests for session Redis caching."""
 
 import json
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -129,3 +130,24 @@ async def test_graceful_degradation_on_redis_failure(
         assert session is not None
         assert session.did == "did:plc:testcache"
         assert session.handle == "cachetest.bsky.social"
+
+
+async def test_cache_hit_checks_expiry(session_id: str) -> None:
+    """cached session with expired expires_at returns None and deletes cache entry."""
+    redis = get_async_redis_client()
+    cache_key = _session_cache_key(session_id)
+
+    # populate cache via normal flow
+    session = await get_session(session_id)
+    assert session is not None
+
+    # overwrite cache entry with an already-expired expires_at
+    cached_raw = await redis.get(cache_key)
+    assert cached_raw is not None
+    data = json.loads(cached_raw)
+    data["expires_at"] = (datetime.now(UTC) - timedelta(seconds=10)).isoformat()
+    await redis.set(cache_key, json.dumps(data), ex=SESSION_CACHE_TTL_SECONDS)
+
+    # get_session should detect expiry, delete cache, and return None
+    assert await get_session(session_id) is None
+    assert await redis.get(cache_key) is None


### PR DESCRIPTION
## Summary
- Store `expires_at` and `refresh_expires_at` in the Redis cache payload when writing sessions
- On cache hit, check both timestamps before returning — if expired, delete the stale entry and return `None`
- Prevents serving cached sessions up to 60s past expiration

## Test plan
- [x] New test `test_cache_hit_checks_expiry` verifies expired cache entries are rejected and deleted
- [x] All existing session cache tests pass (`just backend test`)

Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)