### PR TITLE
fix: album cache invalidation gaps

### DIFF
--- a/backend/src/backend/api/albums.py
+++ b/backend/src/backend/api/albums.py
@@ -771,11 +771,14 @@ async def delete_album(
         with contextlib.suppress(Exception):
             await storage.delete(album.image_id)
 
-    # invalidate cache before deleting
-    await invalidate_album_cache(auth_session.handle, album.slug)
+    # capture slug before deletion
+    album_slug = album.slug
 
     # delete album from database
     await db.delete(album)
     await db.commit()
+
+    # invalidate cache after commit so concurrent reads can't re-populate from pre-delete state
+    await invalidate_album_cache(auth_session.handle, album_slug)
 
     return DeleteAlbumResponse(cascade=cascade)

--- a/backend/src/backend/api/lists.py
+++ b/backend/src/backend/api/lists.py
@@ -205,6 +205,17 @@ async def reorder_list(
                 list_uri=list_uri,
                 items=body.items,
             )
+
+            # invalidate album cache if this list belongs to an album
+            from backend.api.albums import invalidate_album_cache
+            from backend.models import Album
+
+            result = await db.execute(
+                select(Album).where(Album.atproto_record_uri == list_uri)
+            )
+            if album := result.scalar_one_or_none():
+                await invalidate_album_cache(session.handle, album.slug)
+
             return ReorderResponse(uri=uri, cid=cid)
 
         except Exception as e:

--- a/backend/src/backend/api/tracks/mutations.py
+++ b/backend/src/backend/api/tracks/mutations.py
@@ -306,10 +306,10 @@ async def update_track_metadata(
     await db.commit()
     await db.refresh(track)
 
-    # sync album list records if album changed
-    if album_changed:
-        from backend.api.albums import invalidate_album_cache_by_id
+    # invalidate album cache if track metadata changed within an album
+    from backend.api.albums import invalidate_album_cache_by_id
 
+    if album_changed:
         # sync old album (track was removed)
         if old_album_id:
             await schedule_album_list_sync(auth_session.session_id, old_album_id)
@@ -318,6 +318,8 @@ async def update_track_metadata(
         if new_album_id:
             await schedule_album_list_sync(auth_session.session_id, new_album_id)
             await invalidate_album_cache_by_id(db, new_album_id)
+    elif metadata_changed and track.album_id:
+        await invalidate_album_cache_by_id(db, track.album_id)
 
     # move audio file between buckets if support_gate was toggled
     if move_to_private is not None:

--- a/loq.toml
+++ b/loq.toml
@@ -23,7 +23,7 @@ max_lines = 612
 
 [[rules]]
 path = "backend/src/backend/api/albums.py"
-max_lines = 781
+max_lines = 784
 
 [[rules]]
 path = "backend/src/backend/api/auth.py"
@@ -31,7 +31,7 @@ max_lines = 790
 
 [[rules]]
 path = "backend/src/backend/api/lists.py"
-max_lines = 1029
+max_lines = 1040
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"


### PR DESCRIPTION
## Summary

Follow-up to #933 — fixes three invalidation gaps caught in review:

- **Reorder**: `PUT /lists/{rkey}/reorder` now checks if the list belongs to an album and invalidates its cache
- **Same-album track edits**: `update_track_metadata` now invalidates album cache when track metadata changes (title, image, tags, etc.) even when the track stays in the same album
- **Delete race**: moved `invalidate_album_cache` after the DB commit in `delete_album` so a concurrent `get_album` between invalidation and commit can't re-populate cache from pre-delete state

## Test plan

- [x] `just backend test` — 459 passed
- [x] `just backend lint` — clean
- [ ] Deploy to staging, reorder album tracks, verify page reflects new order immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)