### PR TITLE
fix: prevent uv runtime sync in production Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,4 +29,4 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 EXPOSE 8000
 
 # run the application
-CMD ["uv", "run", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uv", "run", "--no-sync", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary

- Add `--no-sync` to `uv run` in the Dockerfile CMD to prevent runtime dependency resolution

## Problem

Machine `683949dad37958` is dead (hit max restart count of 10). On every cold start, `uv run` without `--no-sync` triggers dependency resolution — downloading from PyPI, checking git deps, rebuilding the local package. When PyPI connections fail inside the Fly network ("connection reset by peer"), the process exits 1, Fly restarts it, same failure, and eventually the machine dies permanently.

This is the root cause of the production outages (backend not responding, 7-9s response times on the surviving machine).

## Fix

Dependencies are already installed at build time via `uv sync --frozen`. Adding `--no-sync` tells `uv run` to use the existing venv as-is without any resolution or downloads.

## Test plan

- [ ] Deploy to staging, verify machine starts without hitting PyPI
- [ ] Restart the dead production machine after deploy, verify it stays up
- [ ] Monitor Fly logs for clean startup (no "Downloading" or "Building" lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)