### PR TITLE
docs: fix stale file paths and missing index entries

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,9 @@ organized knowledge base for plyr.fm development.
 - **[transcoder.md](./backend/transcoder.md)** - rust audio conversion service (lossless support)
 - **[mood-search.md](./backend/mood-search.md)** - semantic search with CLAP embeddings (Modal + turbopuffer)
 - **[genre-classification.md](./backend/genre-classification.md)** - ML genre tagging via effnet-discogs (Replicate)
+- **[playlist-recommendations.md](./backend/playlist-recommendations.md)** - inline track suggestions via CLAP embeddings
+- **[liked-tracks.md](./backend/liked-tracks.md)** - like system and liked tracks endpoint
+- **[atproto-identity.md](./backend/atproto-identity.md)** - ATProto identity resolution and handle management
 
 ### frontend
 - **[state-management.md](./frontend/state-management.md)** - svelte 5 runes patterns

--- a/docs/backend/genre-classification.md
+++ b/docs/backend/genre-classification.md
@@ -67,7 +67,7 @@ users can check "auto-tag with recommended genres" on the upload form. when enab
 
 auto-tags are additive with manual tags — if the user also typed tags, both appear on the track.
 
-**key files**: `backend/src/backend/api/tracks/uploads.py` (form param + UploadContext), `backend/src/backend/_internal/background_tasks.py` (apply logic in `classify_genres`)
+**key files**: `backend/src/backend/api/tracks/uploads.py` (form param + UploadContext), `backend/src/backend/_internal/tasks/ml.py` (apply logic in `classify_genres`)
 
 ## auditing
 
@@ -148,8 +148,8 @@ when editing a track on the portal page, the edit modal fetches recommended tags
 
 ## key files
 
-- `backend/src/backend/_internal/replicate_client.py` — Replicate HTTP client
-- `backend/src/backend/_internal/background_tasks.py` — `classify_genres` task (+ auto-tag logic)
+- `backend/src/backend/_internal/clients/replicate.py` — Replicate HTTP client
+- `backend/src/backend/_internal/tasks/ml.py` — `classify_genres` task (+ auto-tag logic)
 - `backend/src/backend/api/tracks/uploads.py` — `auto_tag` form param and `UploadContext`
 - `backend/src/backend/api/tracks/tags.py` — `recommended-tags` endpoint
 - `backend/src/backend/config.py` — `ReplicateSettings`

--- a/docs/backend/mood-search.md
+++ b/docs/backend/mood-search.md
@@ -101,7 +101,7 @@ the namespace is created automatically on first write. querying a nonexistent na
 
 ### automatic (new uploads)
 
-when a track is uploaded and both Modal + turbopuffer are enabled, embedding generation is automatically scheduled as a docket background task. see `backend/src/backend/_internal/background_tasks.py` → `generate_embedding`.
+when a track is uploaded and both Modal + turbopuffer are enabled, embedding generation is automatically scheduled as a docket background task. see `backend/src/backend/_internal/tasks/ml.py` → `generate_embedding`.
 
 ### backfill (existing tracks)
 
@@ -202,10 +202,10 @@ results are cached in `track.extra["genre_predictions"]`. if no predictions are 
 ## key files
 
 - `services/clap/app.py` — Modal CLAP service
-- `backend/src/backend/_internal/clap_client.py` — Modal HTTP client
-- `backend/src/backend/_internal/tpuf_client.py` — turbopuffer client
+- `backend/src/backend/_internal/clients/clap.py` — Modal HTTP client
+- `backend/src/backend/_internal/clients/tpuf.py` — turbopuffer client
 - `backend/src/backend/api/search.py` — `/search/semantic` endpoint
-- `backend/src/backend/_internal/background_tasks.py` — `generate_embedding` task
+- `backend/src/backend/_internal/tasks/ml.py` — `generate_embedding` task
 - `scripts/backfill_embeddings.py` — batch indexing script
 - `frontend/src/lib/components/SearchModal.svelte` — search UI (mood badge, progressive results)
 - `frontend/src/lib/search.svelte.ts` — parallel keyword + semantic dispatch


### PR DESCRIPTION
## Summary

- Fix 7 stale file paths in mood-search.md and genre-classification.md that still referenced pre-split locations from PR #886
  - `_internal/background_tasks.py` → `_internal/tasks/ml.py`
  - `_internal/clap_client.py` → `_internal/clients/clap.py`
  - `_internal/tpuf_client.py` → `_internal/clients/tpuf.py`
  - `_internal/replicate_client.py` → `_internal/clients/replicate.py`
- Add 3 missing entries to docs/README.md index: playlist-recommendations, liked-tracks, atproto-identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)