### PR TITLE
fix: restore admin-only DM on copyright flags

### DIFF
--- a/backend/src/backend/_internal/moderation.py
+++ b/backend/src/backend/_internal/moderation.py
@@ -4,10 +4,13 @@ import logging
 from typing import Any
 
 import logfire
+from sqlalchemy import select
+from sqlalchemy.orm import joinedload
 
 from backend._internal.clients.moderation import get_moderation_client
+from backend._internal.notifications import notification_service
 from backend.config import settings
-from backend.models import CopyrightScan
+from backend.models import CopyrightScan, Track
 from backend.utilities.database import db_session
 
 logger = logging.getLogger(__name__)
@@ -77,6 +80,21 @@ async def _store_scan_result(track_id: int, result: Any) -> None:
             highest_score=scan.highest_score,
             match_count=len(scan.matches),
         )
+
+        # notify admin only — never DM the artist
+        if result.is_flagged:
+            track = await db.scalar(
+                select(Track)
+                .options(joinedload(Track.artist))
+                .where(Track.id == track_id)
+            )
+            if track and track.artist:
+                await notification_service.send_copyright_flag_notification(
+                    track_id=track_id,
+                    track_title=track.title,
+                    artist_handle=track.artist.handle,
+                    matches=scan.matches,
+                )
 
 
 async def _store_scan_error(track_id: int, error: str) -> None:

--- a/backend/src/backend/_internal/notifications.py
+++ b/backend/src/backend/_internal/notifications.py
@@ -153,6 +153,46 @@ class NotificationService:
                     error_type=error_type,
                 )
 
+    async def send_copyright_flag_notification(
+        self,
+        track_id: int,
+        track_title: str,
+        artist_handle: str,
+        matches: list[dict],
+    ) -> NotificationResult | None:
+        """send admin-only notification about a copyright flag."""
+        if not self.recipient_did:
+            logger.warning("recipient not set, skipping notification")
+            return None
+
+        primary_match = None
+        if matches:
+            m = matches[0]
+            primary_match = (
+                f"{m.get('title', 'Unknown')} by {m.get('artist', 'Unknown')}"
+            )
+
+        track_url = None
+        frontend_url = settings.frontend.url
+        if frontend_url and "localhost" not in frontend_url:
+            track_url = f"{frontend_url}/track/{track_id}"
+
+        message_text = (
+            f"copyright flag on {settings.app.name}\n\n"
+            f"track: '{track_title}'\n"
+            f"artist: @{artist_handle}\n"
+            f"matches: {len(matches)}\n"
+        )
+        if primary_match:
+            message_text += f"primary: {primary_match}\n"
+        if track_url:
+            message_text += f"\n{track_url}"
+
+        result = await self._send_dm_to_did(self.recipient_did, message_text)
+        if result.success:
+            logger.info(f"sent copyright flag notification for track {track_id}")
+        return result
+
     async def send_image_flag_notification(
         self,
         image_id: str,


### PR DESCRIPTION
## Summary

- PR #941 removed all copyright notification DMs including admin — this restores the admin DM
- new `send_copyright_flag_notification` method on NotificationService sends only to `recipient_did` (admin)
- artist never gets DMed about copyright flags

## Test plan

- [x] 459 tests pass, 13 skipped
- [x] pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)