### PR TITLE
fix: show Bluesky avatars for atprotofans supporters

### DIFF
--- a/frontend/src/lib/atprotofans.ts
+++ b/frontend/src/lib/atprotofans.ts
@@ -85,13 +85,23 @@ export async function getAtprotofansSupporters(
 			if (artistsResponse.ok) {
 				const artistsMap = await artistsResponse.json();
 				data.supporters = data.supporters.map(
-					(s: { did: string; handle: string; displayName?: string }) => {
+					(s: {
+						did: string;
+						handle: string;
+						displayName?: string;
+						avatar?: { ref?: { $link?: string } };
+					}) => {
 						const artist = artistsMap[s.did];
+						const blobCid = s.avatar?.ref?.['$link'];
 						return {
 							did: s.did,
 							handle: artist?.handle || s.handle,
 							display_name: artist?.display_name || s.displayName || s.handle,
-							avatar_url: artist?.avatar_url
+							avatar_url:
+								artist?.avatar_url ||
+								(blobCid
+									? `https://cdn.bsky.app/img/avatar/plain/${s.did}/${blobCid}@jpeg`
+									: undefined)
 						};
 					}
 				);


### PR DESCRIPTION
## Summary
- supporters who have Bluesky accounts but haven't used plyr.fm were showing only their initial letter on artist profiles (e.g. goose.art's 2 supporters)
- root cause: `POST /artists/batch` only returns DIDs in our database, so non-plyr.fm supporters got no `avatar_url`
- fix: fall back to constructing a Bluesky CDN URL from the atprotofans API's avatar blob data (`avatar.ref.$link` CID)

## Test plan
- [ ] visit https://plyr.fm/u/goose.art and verify both supporter avatars now render
- [ ] verify existing supporters who ARE plyr.fm users still show correct avatars

🤖 Generated with [Claude Code](https://claude.com/claude-code)