### PR TITLE
feat: add tag autocomplete to hidden tags filter

### DIFF
--- a/frontend/src/lib/components/HiddenTagsFilter.svelte
+++ b/frontend/src/lib/components/HiddenTagsFilter.svelte
@@ -2,14 +2,62 @@
 	import { tracksCache } from '$lib/tracks.svelte';
 	import { auth } from '$lib/auth.svelte';
 	import { preferences } from '$lib/preferences.svelte';
+	import { API_URL } from '$lib/config';
+
+	interface TagSuggestion {
+		name: string;
+		track_count: number;
+	}
 
 	let isExpanded = $state(false);
 	let addingTag = $state(false);
 	let newTag = $state('');
 	let inputEl = $state<HTMLInputElement | null>(null);
 
+	// autocomplete state
+	let suggestions = $state<TagSuggestion[]>([]);
+	let showSuggestions = $state(false);
+	let selectedIndex = $state(-1);
+	let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+
 	// derive hidden tags from preferences store
 	let hiddenTags = $derived(preferences.data?.hidden_tags ?? []);
+
+	async function searchTags(query: string) {
+		if (!query.trim()) {
+			suggestions = [];
+			showSuggestions = false;
+			return;
+		}
+		try {
+			const res = await fetch(`${API_URL}/tracks/tags?q=${encodeURIComponent(query.trim())}&limit=10`);
+			if (!res.ok) return;
+			const data: TagSuggestion[] = await res.json();
+			suggestions = data.filter((t) => !hiddenTags.includes(t.name));
+			showSuggestions = suggestions.length > 0;
+			selectedIndex = -1;
+		} catch {
+			suggestions = [];
+			showSuggestions = false;
+		}
+	}
+
+	function handleInput() {
+		if (searchTimeout) clearTimeout(searchTimeout);
+		searchTimeout = setTimeout(() => {
+			searchTags(newTag);
+		}, 200);
+	}
+
+	function clearSuggestions() {
+		suggestions = [];
+		showSuggestions = false;
+		selectedIndex = -1;
+		if (searchTimeout) {
+			clearTimeout(searchTimeout);
+			searchTimeout = null;
+		}
+	}
 
 	async function removeTag(tag: string) {
 		const updated = hiddenTags.filter((t) => t !== tag);
@@ -23,6 +71,7 @@
 		// clear input state immediately to avoid visual duplication
 		newTag = '';
 		addingTag = false;
+		clearSuggestions();
 
 		if (normalized && !hiddenTags.includes(normalized)) {
 			const updated = [...hiddenTags, normalized];
@@ -32,14 +81,62 @@
 		}
 	}
 
+	function pickSuggestion(tag: TagSuggestion) {
+		addTag(tag.name);
+	}
+
+	function handleSuggestionMousedown(e: MouseEvent, tag: TagSuggestion) {
+		e.preventDefault();
+		pickSuggestion(tag);
+	}
+
 	function handleKeydown(e: KeyboardEvent) {
-		if (e.key === 'Enter') {
-			e.preventDefault();
-			addTag(newTag);
-		} else if (e.key === 'Escape') {
-			addingTag = false;
-			newTag = '';
+		if (showSuggestions && suggestions.length > 0) {
+			if (e.key === 'ArrowDown') {
+				e.preventDefault();
+				selectedIndex = selectedIndex < suggestions.length - 1 ? selectedIndex + 1 : 0;
+				return;
+			}
+			if (e.key === 'ArrowUp') {
+				e.preventDefault();
+				selectedIndex = selectedIndex > 0 ? selectedIndex - 1 : suggestions.length - 1;
+				return;
+			}
+			if (e.key === 'Enter') {
+				e.preventDefault();
+				if (selectedIndex >= 0 && selectedIndex < suggestions.length) {
+					pickSuggestion(suggestions[selectedIndex]);
+				} else {
+					addTag(newTag);
+				}
+				return;
+			}
+			if (e.key === 'Escape') {
+				e.preventDefault();
+				clearSuggestions();
+				return;
+			}
+		} else {
+			if (e.key === 'Enter') {
+				e.preventDefault();
+				addTag(newTag);
+				return;
+			}
+			if (e.key === 'Escape') {
+				addingTag = false;
+				newTag = '';
+				clearSuggestions();
+				return;
+			}
 		}
+	}
+
+	function handleBlur() {
+		// delay to allow click on suggestion to fire first
+		setTimeout(() => {
+			if (!newTag.trim()) addingTag = false;
+			clearSuggestions();
+		}, 150);
 	}
 
 	function toggleExpanded() {
@@ -47,11 +144,13 @@
 		if (!isExpanded) {
 			addingTag = false;
 			newTag = '';
+			clearSuggestions();
 		}
 	}
 
 	function startAddingTag() {
 		addingTag = true;
+		clearSuggestions();
 		setTimeout(() => inputEl?.focus(), 0);
 	}
 </script>
@@ -91,25 +190,46 @@
 				{#if hiddenTags.length > 0}
 					<span class="filter-label">hiding:</span>
 				{/if}
-				{#each hiddenTags as tag}
+				{#each hiddenTags as tag (tag)}
 					<button type="button" class="tag-chip" onclick={() => removeTag(tag)} title="unhide '{tag}'">
 						{tag}
-						<span class="remove-icon">×</span>
+						<span class="remove-icon">&times;</span>
 					</button>
 				{/each}
 
 				{#if addingTag}
-					<input
-						bind:this={inputEl}
-						type="text"
-						bind:value={newTag}
-						onkeydown={handleKeydown}
-						onblur={() => {
-							if (!newTag.trim()) addingTag = false;
-						}}
-						placeholder="tag"
-						class="add-input"
-					/>
+					<div class="input-wrapper" class:has-suggestions={showSuggestions}>
+						<input
+							bind:this={inputEl}
+							type="text"
+							bind:value={newTag}
+							onkeydown={handleKeydown}
+							oninput={handleInput}
+							onblur={handleBlur}
+							placeholder="tag"
+							class="add-input"
+							autocomplete="off"
+							autocapitalize="off"
+							spellcheck="false"
+						/>
+						{#if showSuggestions}
+							<ul class="suggestions" role="listbox">
+								{#each suggestions as suggestion, i (suggestion.name)}
+									<li
+										role="option"
+										aria-selected={i === selectedIndex}
+										class="suggestion-item"
+										class:selected={i === selectedIndex}
+										onmousedown={(e) => handleSuggestionMousedown(e, suggestion)}
+										onmouseenter={() => { selectedIndex = i; }}
+									>
+										<span class="suggestion-name">{suggestion.name}</span>
+										<span class="suggestion-count">{suggestion.track_count}</span>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+					</div>
 				{:else}
 					<button type="button" class="add-btn" onclick={startAddingTag} title="hide a tag">
 						+
@@ -231,6 +351,11 @@
 		color: var(--text-secondary);
 	}
 
+	.input-wrapper {
+		position: relative;
+		display: inline-flex;
+	}
+
 	.add-input {
 		padding: 0.2rem 0.4rem;
 		background: transparent;
@@ -242,6 +367,11 @@
 		width: 70px;
 		outline: none;
 		border-radius: var(--radius-sm);
+		transition: width 0.15s;
+	}
+
+	.has-suggestions .add-input {
+		width: 120px;
 	}
 
 	.add-input:focus {
@@ -250,6 +380,55 @@
 
 	.add-input::placeholder {
 		color: var(--text-tertiary);
+	}
+
+	.suggestions {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		margin-top: 2px;
+		min-width: 100%;
+		max-height: 160px;
+		overflow-y: auto;
+		list-style: none;
+		padding: 0.2rem 0;
+		background: var(--glass-bg, rgba(20, 20, 25, 0.92));
+		backdrop-filter: blur(12px);
+		-webkit-backdrop-filter: blur(12px);
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-sm);
+		z-index: 50;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+	}
+
+	.suggestion-item {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		padding: 0.25rem 0.5rem;
+		font-size: var(--text-xs);
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: background 0.1s;
+		white-space: nowrap;
+	}
+
+	.suggestion-item:hover,
+	.suggestion-item.selected {
+		background: var(--bg-hover, rgba(255, 255, 255, 0.06));
+		color: var(--text-primary);
+	}
+
+	.suggestion-name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.suggestion-count {
+		color: var(--text-tertiary);
+		font-size: 0.65rem;
+		flex-shrink: 0;
 	}
 
 	/* mobile adjustments */
@@ -271,6 +450,10 @@
 		.add-input {
 			min-height: 28px;
 			width: 80px;
+		}
+
+		.has-suggestions .add-input {
+			width: 130px;
 		}
 	}
 </style>


### PR DESCRIPTION
## Summary
- adds debounced autocomplete to the homepage hidden tag filter's "add tag" input
- fetches from `GET /tracks/tags?q=...` (same endpoint the portal tag editor uses)
- compact suggestions dropdown with glass-effect styling, keyboard nav (arrow keys + enter), mouse selection
- filters out tags already in the hidden list
- input widens smoothly when suggestions are visible

## Test plan
- [ ] expand the filter on homepage, click "+", type a partial tag name — suggestions should appear after ~200ms
- [ ] arrow keys cycle through suggestions, enter selects, escape closes dropdown
- [ ] clicking a suggestion adds it to hidden tags and refreshes the feed
- [ ] tags already hidden don't appear in suggestions
- [ ] mobile: dropdown renders correctly, input expands to 130px

🤖 Generated with [Claude Code](https://claude.com/claude-code)