### PR TITLE
feat: persist playback position across reloads

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -108,6 +108,11 @@
 		}
 	});
 
+	// sync playback position to queue for persistence
+	$effect(() => {
+		queue.progressMs = Math.round(player.currentTime * 1000);
+	});
+
 	// track play count when threshold is reached
 	$effect(() => { player.incrementPlayCount(); });
 
@@ -290,6 +295,9 @@
 		return `${API_URL}/audio/${file_id}`;
 	}
 
+	// track whether we've restored saved position on initial hydration
+	let positionRestored = false;
+
 	// track blob URLs we've created so we can revoke them
 	let currentBlobUrl: string | null = null;
 
@@ -370,6 +378,15 @@
 					player.audioElement.addEventListener(
 						'loadeddata',
 						() => {
+							// restore position on initial hydration only
+							if (!positionRestored && queue.progressMs > 0 && player.audioElement) {
+								const positionSec = queue.progressMs / 1000;
+								// don't restore if near the end (within 5s of duration)
+								if (player.duration === 0 || positionSec < player.duration - 5) {
+									player.audioElement.currentTime = positionSec;
+								}
+								positionRestored = true;
+							}
 							isLoadingTrack = false;
 						},
 						{ once: true }

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -13,6 +13,7 @@ class Queue {
 	shuffle = $state(false);
 	originalOrder = $state<Track[]>([]);
 	autoAdvance = $state(true);
+	progressMs = $state(0);
 
 	revision = $state<number | null>(null);
 	etag = $state<string | null>(null);
@@ -26,6 +27,8 @@ class Queue {
 	pendingSync = false;
 	channel: BroadcastChannel | null = null;
 	tabId: string | null = null;
+	private positionSaveInterval: number | null = null;
+	private lastSavedProgressMs = 0;
 
 	get currentTrack(): Track | null {
 		if (this.tracks.length === 0) return null;
@@ -114,6 +117,7 @@ class Queue {
 
 		document.addEventListener('visibilitychange', this.handleVisibilityChange);
 		window.addEventListener('beforeunload', this.handleBeforeUnload);
+		this.startPositionSave();
 	}
 
 	handleVisibilityChange = () => {
@@ -123,6 +127,7 @@ class Queue {
 	};
 
 	handleBeforeUnload = () => {
+		this.stopPositionSave();
 		void this.flushSync();
 		this.channel?.close();
 	};
@@ -136,6 +141,12 @@ class Queue {
 		}
 
 		if (this.pendingSync && !this.syncInProgress) {
+			await this.pushQueue();
+			return;
+		}
+
+		// always save position if playing something
+		if (this.tracks.length > 0 && !this.syncInProgress) {
 			await this.pushQueue();
 		}
 	}
@@ -251,6 +262,10 @@ class Queue {
 			this.autoAdvance = state.auto_advance;
 		}
 
+		if (state.progress_ms !== undefined) {
+			this.progressMs = state.progress_ms;
+		}
+
 		this.currentIndex = this.resolveCurrentIndex(
 			state.current_track_id,
 			state.current_index,
@@ -320,7 +335,8 @@ class Queue {
 				current_track_id: this.currentTrack?.file_id ?? null,
 				shuffle: this.shuffle,
 				original_order_ids: this.originalOrder.map((t) => t.file_id),
-				auto_advance: this.autoAdvance
+				auto_advance: this.autoAdvance,
+				progress_ms: this.progressMs
 			};
 
 			const headers: HeadersInit = {
@@ -335,6 +351,7 @@ class Queue {
 				credentials: 'include',
 				method: 'PUT',
 				headers,
+				keepalive: true,
 				body: JSON.stringify({ state })
 			});
 
@@ -575,6 +592,23 @@ class Queue {
 		this.currentIndex = 0;
 
 		this.schedulePush();
+	}
+
+	startPositionSave() {
+		this.stopPositionSave();
+		this.positionSaveInterval = window.setInterval(() => {
+			if (this.tracks.length > 0 && Math.abs(this.progressMs - this.lastSavedProgressMs) > 5000) {
+				this.lastSavedProgressMs = this.progressMs;
+				void this.pushQueue();
+			}
+		}, 30_000);
+	}
+
+	stopPositionSave() {
+		if (this.positionSaveInterval !== null) {
+			window.clearInterval(this.positionSaveInterval);
+			this.positionSaveInterval = null;
+		}
 	}
 
 	private createTabId(): string {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -93,6 +93,7 @@ export interface QueueState {
 	shuffle: boolean;
 	original_order_ids: string[];
 	auto_advance?: boolean;
+	progress_ms?: number;
 }
 
 export interface QueueResponse {

--- a/loq.toml
+++ b/loq.toml
@@ -123,11 +123,11 @@ max_lines = 622
 
 [[rules]]
 path = "frontend/src/lib/components/player/Player.svelte"
-max_lines = 566
+max_lines = 583
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"
-max_lines = 593
+max_lines = 627
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"


### PR DESCRIPTION
## Summary

- adds `progress_ms` to the `QueueState` JSON — **zero backend changes**, the backend stores and returns the dict verbatim
- Player continuously syncs `currentTime` → `queue.progressMs` via `$effect`
- on page close/hide, `flushSync()` pushes the current position with `keepalive: true` so the fetch survives page teardown
- on session restore, `loadeddata` handler seeks to saved position (skips if near end of track)
- 30s periodic save interval for crash resilience (browser/OS kill without `beforeunload`)

## Test plan

- [ ] play a track to ~1:00, reload → should restore at ~1:00 (paused)
- [ ] play a track, close tab, reopen → should restore position
- [ ] two tabs open, play in one → other tab shouldn't get disrupted
- [ ] skip to new track → position should be 0, no stale seek
- [ ] play track to near end, reload → should NOT seek to near-end (starts from 0)
- [ ] `just frontend check` passes
- [ ] `just backend test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)