### PR TITLE
fix: surface backend error detail on jam join failure

### DIFF
--- a/frontend/src/lib/jam.svelte.ts
+++ b/frontend/src/lib/jam.svelte.ts
@@ -93,8 +93,8 @@ class JamState {
 		}
 	}
 
-	async join(code: string): Promise<boolean> {
-		if (!browser) return false;
+	async join(code: string): Promise<string | true> {
+		if (!browser) return 'not available';
 
 		try {
 			const response = await fetch(`${API_URL}/jams/${code}/join`, {
@@ -102,7 +102,10 @@ class JamState {
 				credentials: 'include'
 			});
 
-			if (!response.ok) return false;
+			if (!response.ok) {
+				const body = await response.json().catch(() => null);
+				return body?.detail ?? 'could not join jam';
+			}
 
 			const data: JamInfo = await response.json();
 			this.applyJamData(data);
@@ -112,7 +115,7 @@ class JamState {
 			return true;
 		} catch (error) {
 			console.error('failed to join jam:', error);
-			return false;
+			return 'could not join jam';
 		}
 	}
 

--- a/frontend/src/routes/jam/[code]/+page.svelte
+++ b/frontend/src/routes/jam/[code]/+page.svelte
@@ -11,13 +11,13 @@
 	let error = $state<string | null>(null);
 
 	onMount(async () => {
-		const ok = await jam.join(data.code);
-		if (ok) {
+		const result = await jam.join(data.code);
+		if (result === true) {
 			// SvelteKit navigation preserves runtime — jam state survives
 			goto('/');
 		} else {
-			error = 'could not join jam — it may have ended or the code is invalid';
-			toast.error('failed to join jam');
+			error = result;
+			toast.error(result);
 		}
 	});
 </script>


### PR DESCRIPTION
## Summary
- `jam.join()` now returns the server's `detail` message instead of `false` on failure
- Join page and toast show the actual reason (e.g. "jams feature not enabled") instead of generic "failed to join jam"

## Test plan
- [ ] Visit `/jam/<code>` without the jams flag → should show "jams feature not enabled"
- [ ] Visit `/jam/<invalid>` → should show "jam not found or not active"

🤖 Generated with [Claude Code](https://claude.com/claude-code)