### PR TITLE
fix: prevent personal queue fetch from overwriting jam state

### DIFF
--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -178,6 +178,7 @@ class Queue {
 	async fetchQueue(force = false) {
 		if (!browser) return;
 		if (!this.isAuthenticated()) return; // skip if not authenticated
+		if (this.jamBridge) return; // jam owns the queue state
 
 		// while we have unsent or in-flight local changes, skip non-forced fetches
 		if (
@@ -215,6 +216,9 @@ class Queue {
 			if (this.revision !== null && data.revision < this.revision) {
 				return;
 			}
+
+			// jam may have activated while fetch was in flight
+			if (this.jamBridge) return;
 
 			this.revision = data.revision;
 			this.etag = newEtag;
@@ -333,6 +337,7 @@ class Queue {
 	async pushQueue(): Promise<boolean> {
 		if (!browser) return false;
 		if (!this.isAuthenticated()) return false; // skip if not authenticated
+		if (this.jamBridge) return false; // jam owns the queue state
 
 		if (this.syncInProgress) {
 			this.pendingSync = true;

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -61,19 +61,22 @@
 		// check auth status once
 		await auth.initialize();
 
-		// if authenticated, fetch preferences and queue
+		// if authenticated, fetch preferences and reconnect to active jam or personal queue
 		if (auth.isAuthenticated) {
 			await preferences.initialize();
-			if (queue.revision === null) {
-				void queue.fetchQueue();
-			}
 
-			// reconnect to active jam on page load/refresh
+			// check for active jam first — if rejoining, jam owns the queue state
+			let joinedJam = false;
 			if (!jam.active && auth.user?.enabled_flags?.includes(JAMS_FLAG)) {
 				const activeJam = await jam.fetchActive();
 				if (activeJam) {
 					await jam.join(activeJam.code);
+					joinedJam = true;
 				}
+			}
+
+			if (!joinedJam && queue.revision === null) {
+				void queue.fetchQueue();
 			}
 		}
 	});


### PR DESCRIPTION
## Summary
- `fetchQueue()` fired as fire-and-forget during layout init, racing with `jam.join()` — when its response arrived after `syncToQueue()`, `applySnapshot()` overwrote `queue.tracks` with the personal queue, disabling next/previous buttons
- Added 3 guards in `queue.svelte.ts`: skip fetch/push when jam bridge is active, including a mid-flight check before `applySnapshot()`
- Reordered layout init to check for active jam first, skipping `fetchQueue()` entirely when rejoining

## Test plan
- [x] `just frontend check` — 0 errors
- [x] `just backend test tests/api/test_jams.py` — 23/23 pass
- [ ] Start jam, add tracks, verify next/previous buttons work
- [ ] Refresh page during active jam, verify queue state preserved
- [ ] Leave jam, verify personal queue restores correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)