### PR TITLE
fix: handle include: scope expansion in check_scope_coverage

### DIFF
--- a/backend/src/backend/_internal/auth/__init__.py
+++ b/backend/src/backend/_internal/auth/__init__.py
@@ -46,9 +46,8 @@ from backend._internal.auth.oauth import (
     start_oauth_flow_with_scopes,
 )
 from backend._internal.auth.scopes import (
-    _check_scope_coverage,
-    _get_missing_scopes,
-    _parse_scopes,
+    check_scope_coverage,
+    get_missing_scopes,
 )
 from backend._internal.auth.session import (
     CONFIDENTIAL_REFRESH_TOKEN_DAYS,
@@ -72,12 +71,10 @@ __all__ = [
     "PendingDevTokenData",
     "PendingScopeUpgradeData",
     "Session",
-    "_check_scope_coverage",
     "_decrypt_data",
     "_encrypt_data",
-    "_get_missing_scopes",
-    "_parse_scopes",
     "check_artist_profile_exists",
+    "check_scope_coverage",
     "consume_exchange_token",
     "create_exchange_token",
     "create_session",
@@ -87,6 +84,7 @@ __all__ = [
     "delete_session",
     "ensure_artist_exists",
     "get_client_auth_method",
+    "get_missing_scopes",
     "get_oauth_client",
     "get_oauth_client_for_scope",
     "get_optional_session",

--- a/backend/src/backend/_internal/auth/dependencies.py
+++ b/backend/src/backend/_internal/auth/dependencies.py
@@ -6,7 +6,7 @@ from typing import Annotated
 from fastapi import Cookie, Header, HTTPException
 
 from backend._internal.auth.oauth import check_artist_profile_exists
-from backend._internal.auth.scopes import _check_scope_coverage, _get_missing_scopes
+from backend._internal.auth.scopes import check_scope_coverage, get_missing_scopes
 from backend._internal.auth.session import Session, get_session
 from backend.config import settings
 
@@ -50,8 +50,8 @@ async def require_auth(
     granted_scope = session.oauth_session.get("scope", "")
     required_scope = settings.atproto.resolved_scope
 
-    if not _check_scope_coverage(granted_scope, required_scope):
-        missing = _get_missing_scopes(granted_scope, required_scope)
+    if not check_scope_coverage(granted_scope, required_scope):
+        missing = get_missing_scopes(granted_scope, required_scope)
         logger.info(
             f"session {session.did} missing scopes: {missing}, prompting re-auth"
         )

--- a/backend/src/backend/_internal/auth/oauth.py
+++ b/backend/src/backend/_internal/auth/oauth.py
@@ -13,6 +13,7 @@ from atproto_oauth.client import (
 )
 from atproto_oauth.dpop import DPoPManager
 from atproto_oauth.pkce import PKCEManager
+from atproto_oauth.scopes import ScopesSet
 from atproto_oauth.stores.memory import MemorySessionStore
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
@@ -157,7 +158,10 @@ def get_oauth_client_for_scope(scope: str) -> OAuthClient:
 
     used during callback to match the scope that was used during authorization.
     """
-    include_teal = settings.teal.play_collection in scope
+    scopes = ScopesSet.from_string(scope)
+    include_teal = scopes.matches(
+        "repo", collection=settings.teal.play_collection, action="create"
+    )
     return get_oauth_client(include_teal=include_teal)
 
 

--- a/backend/src/backend/_internal/auth/scopes.py
+++ b/backend/src/backend/_internal/auth/scopes.py
@@ -1,6 +1,21 @@
 """OAuth scope parsing and validation using atproto_oauth.scopes."""
 
-from atproto_oauth.scopes import RepoPermission, ScopesSet
+from atproto_oauth.scopes import IncludeScope, RepoPermission, ScopesSet
+
+
+def _include_covered_by_granted(inc: IncludeScope, granted: ScopesSet) -> bool:
+    """check if an include: scope is covered by the granted set.
+
+    PDS servers expand ``include:ns.permSet`` into granular ``repo:``/``rpc:``
+    scopes, so the granted set will never contain the literal ``include:`` token.
+    instead, check that the granted set has at least one repo or rpc scope whose
+    collection/lxm is in the same namespace authority as the include scope.
+    """
+    for scope_str in granted:
+        if (rp := RepoPermission.from_string(scope_str)) is not None:
+            if any(inc.is_parent_authority_of(c) for c in rp.collection if c != "*"):
+                return True
+    return False
 
 
 def check_scope_coverage(granted_scope: str, required_scope: str) -> bool:
@@ -29,7 +44,16 @@ def check_scope_coverage(granted_scope: str, required_scope: str) -> bool:
                             return False
                 continue
 
-        # for other scopes (blob, include, transition, etc.), check exact presence
+        # include: scopes get expanded by the PDS into repo:/rpc: scopes,
+        # so the granted set won't contain the literal include: token.
+        # check namespace authority instead.
+        if token.startswith("include:"):
+            if (inc := IncludeScope.from_string(token)) is not None:
+                if _include_covered_by_granted(inc, granted):
+                    continue
+                return False
+
+        # for other scopes (blob, transition, etc.), check exact presence
         if not granted.has(token):
             return False
 
@@ -51,6 +75,12 @@ def get_missing_scopes(granted_scope: str, required_scope: str) -> set[str]:
                     for action in req.action:
                         if not granted.matches("repo", collection=coll, action=action):
                             missing.add(token)
+                continue
+
+        if token.startswith("include:"):
+            if (inc := IncludeScope.from_string(token)) is not None:
+                if not _include_covered_by_granted(inc, granted):
+                    missing.add(token)
                 continue
 
         if not granted.has(token):

--- a/backend/src/backend/_internal/auth/scopes.py
+++ b/backend/src/backend/_internal/auth/scopes.py
@@ -1,29 +1,74 @@
-"""OAuth scope parsing and validation."""
+"""OAuth scope parsing and validation using atproto_oauth.scopes."""
+
+from atproto_oauth.scopes import ScopesSet
 
 
-def _parse_scopes(scope_string: str) -> set[str]:
-    """parse an OAuth scope string into a set of individual scopes.
-
-    handles format like: "atproto repo:fm.plyr.track repo:fm.plyr.like"
-    returns: {"repo:fm.plyr.track", "repo:fm.plyr.like"}
-    """
-    parts = scope_string.split()
-    # filter out the "atproto" prefix and keep just the repo: scopes
-    return {p for p in parts if p.startswith("repo:")}
-
-
-def _check_scope_coverage(granted_scope: str, required_scope: str) -> bool:
+def check_scope_coverage(granted_scope: str, required_scope: str) -> bool:
     """check if granted scope covers all required scopes.
+
+    uses ScopesSet for spec-compliant matching: handles positional/query
+    format equivalence (``repo:nsid`` == ``repo?collection=nsid``),
+    wildcard matching, and action filtering.
 
     returns True if the session has all required permissions.
     """
-    granted = _parse_scopes(granted_scope)
-    required = _parse_scopes(required_scope)
-    return required.issubset(granted)
+    granted = ScopesSet.from_string(granted_scope)
+    required_tokens = required_scope.split()
+
+    for token in required_tokens:
+        # skip atproto prefix
+        if token == "atproto":
+            continue
+
+        # for repo scopes, parse and check semantic matching
+        if token.startswith("repo"):
+            from atproto_oauth.scopes import RepoPermission
+
+            if (req := RepoPermission.from_string(token)) is not None:
+                for coll in req.collection:
+                    for action in req.action:
+                        if not granted.matches("repo", collection=coll, action=action):
+                            return False
+                continue
+
+        # for blob scopes, check semantic matching
+        if token.startswith("blob"):
+            from atproto_oauth.scopes import BlobPermission
+
+            if (req := BlobPermission.from_string(token)) is not None:
+                # blob scopes don't have a clean "covers" semantic for patterns,
+                # so fall back to exact scope presence or string match
+                if granted.has(token) or granted.has(str(req)):
+                    continue
+                return False
+
+        # for other scopes, check exact presence
+        if not granted.has(token):
+            return False
+
+    return True
 
 
-def _get_missing_scopes(granted_scope: str, required_scope: str) -> set[str]:
+def get_missing_scopes(granted_scope: str, required_scope: str) -> set[str]:
     """get the scopes that are required but not granted."""
-    granted = _parse_scopes(granted_scope)
-    required = _parse_scopes(required_scope)
-    return required - granted
+    granted = ScopesSet.from_string(granted_scope)
+    missing: set[str] = set()
+
+    for token in required_scope.split():
+        if token == "atproto":
+            continue
+
+        if token.startswith("repo"):
+            from atproto_oauth.scopes import RepoPermission
+
+            if (req := RepoPermission.from_string(token)) is not None:
+                for coll in req.collection:
+                    for action in req.action:
+                        if not granted.matches("repo", collection=coll, action=action):
+                            missing.add(token)
+                continue
+
+        if not granted.has(token):
+            missing.add(token)
+
+    return missing

--- a/backend/src/backend/_internal/auth/scopes.py
+++ b/backend/src/backend/_internal/auth/scopes.py
@@ -1,6 +1,6 @@
 """OAuth scope parsing and validation using atproto_oauth.scopes."""
 
-from atproto_oauth.scopes import ScopesSet
+from atproto_oauth.scopes import RepoPermission, ScopesSet
 
 
 def check_scope_coverage(granted_scope: str, required_scope: str) -> bool:
@@ -22,8 +22,6 @@ def check_scope_coverage(granted_scope: str, required_scope: str) -> bool:
 
         # for repo scopes, parse and check semantic matching
         if token.startswith("repo"):
-            from atproto_oauth.scopes import RepoPermission
-
             if (req := RepoPermission.from_string(token)) is not None:
                 for coll in req.collection:
                     for action in req.action:
@@ -31,18 +29,7 @@ def check_scope_coverage(granted_scope: str, required_scope: str) -> bool:
                             return False
                 continue
 
-        # for blob scopes, check semantic matching
-        if token.startswith("blob"):
-            from atproto_oauth.scopes import BlobPermission
-
-            if (req := BlobPermission.from_string(token)) is not None:
-                # blob scopes don't have a clean "covers" semantic for patterns,
-                # so fall back to exact scope presence or string match
-                if granted.has(token) or granted.has(str(req)):
-                    continue
-                return False
-
-        # for other scopes, check exact presence
+        # for other scopes (blob, include, transition, etc.), check exact presence
         if not granted.has(token):
             return False
 
@@ -59,8 +46,6 @@ def get_missing_scopes(granted_scope: str, required_scope: str) -> set[str]:
             continue
 
         if token.startswith("repo"):
-            from atproto_oauth.scopes import RepoPermission
-
             if (req := RepoPermission.from_string(token)) is not None:
                 for coll in req.collection:
                     for action in req.action:

--- a/backend/src/backend/api/preferences.py
+++ b/backend/src/backend/api/preferences.py
@@ -69,8 +69,12 @@ def _has_teal_scope(session: Session) -> bool:
     """check if session has teal.fm scopes."""
     if not session.oauth_session:
         return False
-    scope = session.oauth_session.get("scope", "")
-    return settings.teal.play_collection in scope
+    from atproto_oauth.scopes import ScopesSet
+
+    scopes = ScopesSet.from_string(session.oauth_session.get("scope", ""))
+    return scopes.matches(
+        "repo", collection=settings.teal.play_collection, action="create"
+    )
 
 
 @router.get("/")

--- a/backend/src/backend/api/preferences.py
+++ b/backend/src/backend/api/preferences.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from typing import Annotated, Any
 
+from atproto_oauth.scopes import ScopesSet
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, field_validator
 from sqlalchemy import select
@@ -69,8 +70,6 @@ def _has_teal_scope(session: Session) -> bool:
     """check if session has teal.fm scopes."""
     if not session.oauth_session:
         return False
-    from atproto_oauth.scopes import ScopesSet
-
     scopes = ScopesSet.from_string(session.oauth_session.get("scope", ""))
     return scopes.matches(
         "repo", collection=settings.teal.play_collection, action="create"

--- a/backend/src/backend/api/tracks/playback.py
+++ b/backend/src/backend/api/tracks/playback.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from typing import Annotated
 
+from atproto_oauth.scopes import ScopesSet
 from fastapi import Body, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -127,8 +128,12 @@ async def increment_play_count(
         )
         if prefs and prefs.enable_teal_scrobbling:
             # check if session has teal scopes
-            scope = session.oauth_session.get("scope", "")
-            if settings.teal.play_collection in scope:
+            scopes = ScopesSet.from_string(session.oauth_session.get("scope", ""))
+            if scopes.matches(
+                "repo",
+                collection=settings.teal.play_collection,
+                action="create",
+            ):
                 await schedule_teal_scrobble(
                     session_id=session.session_id,
                     track_id=track_id,

--- a/backend/tests/_internal/test_auth_modules.py
+++ b/backend/tests/_internal/test_auth_modules.py
@@ -6,9 +6,8 @@ from backend._internal.auth.exchange import (
     create_exchange_token,
 )
 from backend._internal.auth.scopes import (
-    _check_scope_coverage,
-    _get_missing_scopes,
-    _parse_scopes,
+    check_scope_coverage,
+    get_missing_scopes,
 )
 from backend._internal.auth.session import (
     SESSION_CACHE_PREFIX,
@@ -18,13 +17,11 @@ from backend._internal.auth.session import (
 )
 
 
-def test_scopes_parse_roundtrip():
-    """parse and validate scope strings."""
+def test_scopes_coverage_roundtrip():
+    """scope coverage and missing scopes round-trip."""
     scope = "atproto repo:fm.plyr.track repo:fm.plyr.like"
-    parsed = _parse_scopes(scope)
-    assert parsed == {"repo:fm.plyr.track", "repo:fm.plyr.like"}
-    assert _check_scope_coverage(scope, scope) is True
-    assert _get_missing_scopes(scope, scope) == set()
+    assert check_scope_coverage(scope, scope) is True
+    assert get_missing_scopes(scope, scope) == set()
 
 
 def test_encryption_roundtrip():

--- a/backend/tests/test_scope_validation.py
+++ b/backend/tests/test_scope_validation.py
@@ -1,96 +1,81 @@
 """tests for OAuth scope validation functions."""
 
-from backend._internal.auth import (
-    _check_scope_coverage,
-    _get_missing_scopes,
-    _parse_scopes,
+from backend._internal.auth.scopes import (
+    check_scope_coverage,
+    get_missing_scopes,
 )
 
 
-class TestParseScopes:
-    """tests for _parse_scopes."""
-
-    def test_parses_standard_scope_string(self):
-        """should extract repo: scopes from atproto scope string."""
-        scope = "atproto repo:fm.plyr.track repo:fm.plyr.like"
-        result = _parse_scopes(scope)
-        assert result == {"repo:fm.plyr.track", "repo:fm.plyr.like"}
-
-    def test_ignores_atproto_prefix(self):
-        """should not include 'atproto' in parsed scopes."""
-        scope = "atproto repo:fm.plyr.track"
-        result = _parse_scopes(scope)
-        assert "atproto" not in result
-        assert result == {"repo:fm.plyr.track"}
-
-    def test_handles_empty_string(self):
-        """should return empty set for empty scope."""
-        result = _parse_scopes("")
-        assert result == set()
-
-    def test_handles_multiple_scopes(self):
-        """should handle three or more scopes."""
-        scope = "atproto repo:fm.plyr.track repo:fm.plyr.like repo:fm.plyr.comment"
-        result = _parse_scopes(scope)
-        assert result == {
-            "repo:fm.plyr.track",
-            "repo:fm.plyr.like",
-            "repo:fm.plyr.comment",
-        }
-
-
 class TestCheckScopeCoverage:
-    """tests for _check_scope_coverage."""
+    """tests for check_scope_coverage."""
 
     def test_returns_true_when_all_scopes_granted(self):
         """should return True when granted scope covers all required."""
         granted = "atproto repo:fm.plyr.track repo:fm.plyr.like repo:fm.plyr.comment"
         required = "atproto repo:fm.plyr.track repo:fm.plyr.like repo:fm.plyr.comment"
-        assert _check_scope_coverage(granted, required) is True
+        assert check_scope_coverage(granted, required) is True
 
     def test_returns_true_when_extra_scopes_granted(self):
         """should return True when granted has more than required."""
         granted = "atproto repo:fm.plyr.track repo:fm.plyr.like repo:fm.plyr.comment repo:fm.plyr.extra"
         required = "atproto repo:fm.plyr.track repo:fm.plyr.like"
-        assert _check_scope_coverage(granted, required) is True
+        assert check_scope_coverage(granted, required) is True
 
     def test_returns_false_when_missing_scope(self):
         """should return False when granted is missing required scope."""
         granted = "atproto repo:fm.plyr.track repo:fm.plyr.like"
         required = "atproto repo:fm.plyr.track repo:fm.plyr.like repo:fm.plyr.comment"
-        assert _check_scope_coverage(granted, required) is False
+        assert check_scope_coverage(granted, required) is False
 
     def test_returns_false_when_granted_empty(self):
         """should return False when granted scope is empty."""
         granted = ""
         required = "atproto repo:fm.plyr.track"
-        assert _check_scope_coverage(granted, required) is False
+        assert check_scope_coverage(granted, required) is False
 
     def test_returns_true_when_both_empty(self):
         """should return True when both are empty."""
-        assert _check_scope_coverage("", "") is True
+        assert check_scope_coverage("", "") is True
+
+    def test_wildcard_collection_covers_specific(self):
+        """repo:* should cover any specific collection."""
+        granted = "atproto repo:*"
+        required = "atproto repo:fm.plyr.track"
+        assert check_scope_coverage(granted, required) is True
+
+    def test_format_equivalence(self):
+        """repo:nsid == repo?collection=nsid."""
+        granted = "atproto repo?collection=fm.plyr.track"
+        required = "atproto repo:fm.plyr.track"
+        assert check_scope_coverage(granted, required) is True
+
+    def test_blob_scope_coverage(self):
+        """blob scopes should be checked."""
+        granted = "atproto blob:*/*"
+        required = "atproto blob:*/*"
+        assert check_scope_coverage(granted, required) is True
 
 
 class TestGetMissingScopes:
-    """tests for _get_missing_scopes."""
+    """tests for get_missing_scopes."""
 
     def test_returns_empty_when_all_covered(self):
         """should return empty set when all scopes are granted."""
         granted = "atproto repo:fm.plyr.track repo:fm.plyr.like repo:fm.plyr.comment"
         required = "atproto repo:fm.plyr.track repo:fm.plyr.like"
-        result = _get_missing_scopes(granted, required)
+        result = get_missing_scopes(granted, required)
         assert result == set()
 
     def test_returns_missing_scope(self):
         """should return the missing scope."""
         granted = "atproto repo:fm.plyr.track repo:fm.plyr.like"
         required = "atproto repo:fm.plyr.track repo:fm.plyr.like repo:fm.plyr.comment"
-        result = _get_missing_scopes(granted, required)
+        result = get_missing_scopes(granted, required)
         assert result == {"repo:fm.plyr.comment"}
 
     def test_returns_multiple_missing_scopes(self):
         """should return all missing scopes."""
         granted = "atproto repo:fm.plyr.track"
         required = "atproto repo:fm.plyr.track repo:fm.plyr.like repo:fm.plyr.comment"
-        result = _get_missing_scopes(granted, required)
+        result = get_missing_scopes(granted, required)
         assert result == {"repo:fm.plyr.like", "repo:fm.plyr.comment"}

--- a/backend/tests/test_scope_validation.py
+++ b/backend/tests/test_scope_validation.py
@@ -55,6 +55,25 @@ class TestCheckScopeCoverage:
         required = "atproto blob:*/*"
         assert check_scope_coverage(granted, required) is True
 
+    def test_include_covered_by_expanded_repo_scopes(self):
+        """PDS expands include: into repo: scopes — should still pass."""
+        granted = "atproto blob:*/* repo:fm.plyr.stg.track repo:fm.plyr.stg.like repo:fm.plyr.stg.comment repo:fm.plyr.stg.list repo:fm.plyr.stg.profile"
+        required = "atproto blob:*/* include:fm.plyr.stg.authFullApp"
+        assert check_scope_coverage(granted, required) is True
+
+    def test_include_not_covered_by_wrong_namespace(self):
+        """include: should fail if granted scopes are from a different namespace."""
+        granted = "atproto blob:*/* repo:fm.other.track"
+        required = "atproto blob:*/* include:fm.plyr.stg.authFullApp"
+        assert check_scope_coverage(granted, required) is False
+
+    def test_include_missing_shows_in_get_missing(self):
+        """get_missing_scopes should report include: as missing when not covered."""
+        granted = "atproto blob:*/* repo:fm.other.track"
+        required = "atproto blob:*/* include:fm.plyr.stg.authFullApp"
+        result = get_missing_scopes(granted, required)
+        assert result == {"include:fm.plyr.stg.authFullApp"}
+
 
 class TestGetMissingScopes:
     """tests for get_missing_scopes."""

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -302,8 +302,8 @@ wheels = [
 
 [[package]]
 name = "atproto"
-version = "0.0.1.dev476"
-source = { git = "https://github.com/zzstoatzz/atproto?rev=main#37e0e5c9a7bf5202e3e30ad686da2a18594cd126" }
+version = "0.0.1.dev477"
+source = { git = "https://github.com/zzstoatzz/atproto?rev=main#14ed65941fa0dd5404dd5bdc22138142ce159bbf" }
 dependencies = [
     { name = "click" },
     { name = "cryptography" },

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -302,8 +302,8 @@ wheels = [
 
 [[package]]
 name = "atproto"
-version = "0.0.1.dev474"
-source = { git = "https://github.com/zzstoatzz/atproto?rev=main#d3f6a3d2862f7916bf937547433ccab1b23a0007" }
+version = "0.0.1.dev476"
+source = { git = "https://github.com/zzstoatzz/atproto?rev=main#37e0e5c9a7bf5202e3e30ad686da2a18594cd126" }
 dependencies = [
     { name = "click" },
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

- PDS servers expand `include:ns.permSet` into granular `repo:`/`rpc:` scopes, so the granted scope never contains the literal `include:` token
- `check_scope_coverage` was doing exact string match for `include:` tokens, causing 403 `scope_upgrade_required` for all sessions on staging
- Fix: check namespace authority (via `IncludeScope.is_parent_authority_of`) instead of exact match

## Test plan

- [x] 3 new regression tests for include scope handling
- [x] 21 total scope tests pass
- [ ] Verify staging login works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)