### PR TITLE
fix: handle include: scope expansion in check_scope_coverage

### DIFF
--- a/backend/src/backend/_internal/auth/scopes.py
+++ b/backend/src/backend/_internal/auth/scopes.py
@@ -1,6 +1,21 @@
 """OAuth scope parsing and validation using atproto_oauth.scopes."""
 
-from atproto_oauth.scopes import RepoPermission, ScopesSet
+from atproto_oauth.scopes import IncludeScope, RepoPermission, ScopesSet
+
+
+def _include_covered_by_granted(inc: IncludeScope, granted: ScopesSet) -> bool:
+    """check if an include: scope is covered by the granted set.
+
+    PDS servers expand ``include:ns.permSet`` into granular ``repo:``/``rpc:``
+    scopes, so the granted set will never contain the literal ``include:`` token.
+    instead, check that the granted set has at least one repo scope whose
+    collection is in the same namespace authority as the include scope.
+    """
+    for scope_str in granted:
+        if (rp := RepoPermission.from_string(scope_str)) is not None:
+            if any(inc.is_parent_authority_of(c) for c in rp.collection if c != "*"):
+                return True
+    return False
 
 
 def check_scope_coverage(granted_scope: str, required_scope: str) -> bool:
@@ -29,7 +44,16 @@ def check_scope_coverage(granted_scope: str, required_scope: str) -> bool:
                             return False
                 continue
 
-        # for other scopes (blob, include, transition, etc.), check exact presence
+        # include: scopes get expanded by the PDS into repo:/rpc: scopes,
+        # so the granted set won't contain the literal include: token.
+        # check namespace authority instead.
+        if token.startswith("include:"):
+            if (inc := IncludeScope.from_string(token)) is not None:
+                if _include_covered_by_granted(inc, granted):
+                    continue
+                return False
+
+        # for other scopes (blob, transition, etc.), check exact presence
         if not granted.has(token):
             return False
 
@@ -51,6 +75,12 @@ def get_missing_scopes(granted_scope: str, required_scope: str) -> set[str]:
                     for action in req.action:
                         if not granted.matches("repo", collection=coll, action=action):
                             missing.add(token)
+                continue
+
+        if token.startswith("include:"):
+            if (inc := IncludeScope.from_string(token)) is not None:
+                if not _include_covered_by_granted(inc, granted):
+                    missing.add(token)
                 continue
 
         if not granted.has(token):

--- a/backend/tests/test_scope_validation.py
+++ b/backend/tests/test_scope_validation.py
@@ -55,6 +55,25 @@ class TestCheckScopeCoverage:
         required = "atproto blob:*/*"
         assert check_scope_coverage(granted, required) is True
 
+    def test_include_covered_by_expanded_repo_scopes(self):
+        """PDS expands include: into repo: scopes — should still pass."""
+        granted = "atproto blob:*/* repo:fm.plyr.stg.track repo:fm.plyr.stg.like repo:fm.plyr.stg.comment"
+        required = "atproto blob:*/* include:fm.plyr.stg.authFullApp"
+        assert check_scope_coverage(granted, required) is True
+
+    def test_include_not_covered_by_wrong_namespace(self):
+        """include: should fail if granted scopes are from a different namespace."""
+        granted = "atproto blob:*/* repo:fm.other.track"
+        required = "atproto blob:*/* include:fm.plyr.stg.authFullApp"
+        assert check_scope_coverage(granted, required) is False
+
+    def test_include_missing_shows_in_get_missing(self):
+        """get_missing_scopes should report include: as missing when not covered."""
+        granted = "atproto blob:*/* repo:fm.other.track"
+        required = "atproto blob:*/* include:fm.plyr.stg.authFullApp"
+        result = get_missing_scopes(granted, required)
+        assert result == {"include:fm.plyr.stg.authFullApp"}
+
 
 class TestGetMissingScopes:
     """tests for get_missing_scopes."""


### PR DESCRIPTION
## Summary

- PDS servers expand `include:ns.permSet` into granular `repo:`/`rpc:` scopes, so the granted scope never contains the literal `include:` token
- `check_scope_coverage` was doing exact string match for `include:` tokens, causing 403 `scope_upgrade_required` for **all sessions** on staging
- Fix: check namespace authority (via `IncludeScope.is_parent_authority_of`) instead of exact match

## Test plan

- [x] 3 new regression tests for include scope handling
- [x] 21 total scope tests pass
- [x] Lint clean
- [ ] Verify staging login works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)