### PR TITLE
fix: deepcopy jam state to prevent shallow-copy clobber

### DIFF
--- a/backend/src/backend/_internal/jams.py
+++ b/backend/src/backend/_internal/jams.py
@@ -6,6 +6,7 @@ for real-time playback sync across participants.
 
 import asyncio
 import contextlib
+import copy
 import json
 import logging
 import secrets
@@ -287,7 +288,7 @@ class JamService:
             if not participant.scalar_one_or_none():
                 return None
 
-            state = dict(jam.state)
+            state = copy.deepcopy(jam.state)
             cmd_type = command.get("type")
             now_ms = int(time.time() * 1000)
 
@@ -490,7 +491,7 @@ class JamService:
                 return
             if jam.state.get("output_client_id") != client_id:
                 return
-            state = dict(jam.state)
+            state = copy.deepcopy(jam.state)
             state["output_client_id"] = None
             state["output_did"] = None
             state["is_playing"] = False
@@ -547,7 +548,7 @@ class JamService:
                     and jam.state.get("output_client_id") is None
                     and did == jam.host_did
                 ):
-                    state = dict(jam.state)
+                    state = copy.deepcopy(jam.state)
                     state["output_client_id"] = client_id
                     state["output_did"] = did
                     jam.state = state

--- a/backend/tests/api/test_jams.py
+++ b/backend/tests/api/test_jams.py
@@ -340,6 +340,32 @@ async def test_command_add_tracks(test_app: FastAPI, db_session: AsyncSession) -
     assert response.json()["tracks_changed"] is True
 
 
+async def test_next_after_add_tracks(
+    test_app: FastAPI, db_session: AsyncSession
+) -> None:
+    """next after add_tracks must advance — regression for shallow-copy bug."""
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        create_response = await client.post("/jams/", json={"track_ids": ["t1"]})
+        code = create_response.json()["code"]
+
+        await client.post(
+            f"/jams/{code}/command",
+            json={"type": "add_tracks", "track_ids": ["t2", "t3"]},
+        )
+
+        next_response = await client.post(
+            f"/jams/{code}/command",
+            json={"type": "next"},
+        )
+
+    state = next_response.json()["state"]
+    assert state["track_ids"] == ["t1", "t2", "t3"]
+    assert state["current_index"] == 1
+    assert state["current_track_id"] == "t2"
+
+
 async def test_command_remove_track(
     test_app: FastAPI, db_session: AsyncSession
 ) -> None:

--- a/loq.toml
+++ b/loq.toml
@@ -23,7 +23,7 @@ max_lines = 612
 
 [[rules]]
 path = "backend/src/backend/_internal/jams.py"
-max_lines = 820
+max_lines = 822
 
 [[rules]]
 path = "backend/src/backend/api/albums.py"
@@ -71,7 +71,7 @@ max_lines = 554
 
 [[rules]]
 path = "backend/tests/api/test_jams.py"
-max_lines = 1057
+max_lines = 1084
 
 [[rules]]
 path = "backend/tests/api/test_track_comments.py"


### PR DESCRIPTION
## Summary
- `dict(jam.state)` creates a shallow copy where nested lists (`track_ids`) are shared references — in-place mutations via `.extend()` mutate both copies, so SQLAlchemy doesn't detect changes on reassignment
- Replaced all 3 `dict(jam.state)` calls with `copy.deepcopy(jam.state)`: `handle_command`, `_clear_output_if_matches`, `_handle_sync` auto-output
- Added regression test: `test_next_after_add_tracks` verifies next advances after add_tracks

## Test plan
- [x] All 36 jam tests pass locally
- [ ] CI passes
- [ ] Verify next button works in a jam on staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)