### PR TITLE
feat: jam output mode — one speaker vs everyone

### DIFF
--- a/backend/src/backend/_internal/jams.py
+++ b/backend/src/backend/_internal/jams.py
@@ -48,6 +48,7 @@ def _empty_state() -> dict[str, Any]:
         "server_time_ms": int(time.time() * 1000),
         "output_client_id": None,
         "output_did": None,
+        "output_mode": "one_speaker",
     }
 
 
@@ -342,6 +343,17 @@ class JamService:
                         return None
                 else:
                     return None
+            elif cmd_type == "set_mode":
+                # host-only
+                if did != jam.host_did:
+                    return None
+                new_mode = command.get("mode")
+                if new_mode not in ("one_speaker", "everyone"):
+                    return None
+                state["output_mode"] = new_mode
+                if new_mode == "everyone":
+                    state["output_client_id"] = None
+                    state["output_did"] = None
             else:
                 logger.warning("unknown jam command type: %s", cmd_type)
                 return None
@@ -447,6 +459,8 @@ class JamService:
             jam = await self._fetch_jam_by_id(db, jam_id)
             if not jam or not jam.is_active:
                 return
+            if jam.state.get("output_mode") == "everyone":
+                return  # no single output to clear
             if jam.state.get("output_client_id") != client_id:
                 return
             state = copy.deepcopy(jam.state)
@@ -503,6 +517,7 @@ class JamService:
                 if (
                     jam
                     and jam.is_active
+                    and jam.state.get("output_mode", "one_speaker") == "one_speaker"
                     and jam.state.get("output_client_id") is None
                     and did == jam.host_did
                 ):

--- a/backend/src/backend/api/jams.py
+++ b/backend/src/backend/api/jams.py
@@ -46,6 +46,7 @@ class CommandRequest(BaseModel):
     track_ids: list[str] | None = None
     current_index: int | None = None
     client_id: str | None = None
+    mode: str | None = None
 
 
 class JamResponse(BaseModel):
@@ -191,6 +192,8 @@ async def jam_command(
         command["current_index"] = body.current_index
     if body.client_id is not None:
         command["client_id"] = body.client_id
+    if body.mode is not None:
+        command["mode"] = body.mode
 
     result = await jam_service.handle_command(jam["id"], session.did, command)
     if not result:

--- a/backend/tests/api/test_jams.py
+++ b/backend/tests/api/test_jams.py
@@ -1163,3 +1163,197 @@ async def test_update_queue_clamps_index(
         r = await _update_queue(client, code, [], 0)
         assert r["state"]["current_index"] == 0
         assert r["state"]["current_track_id"] is None
+
+
+# ── output mode tests ──────────────────────────────────────────────
+
+
+async def test_set_mode_host_only(
+    test_app: FastAPI, db_session: AsyncSession, second_user: str
+) -> None:
+    """test that only the host can set output mode."""
+    from backend._internal import require_auth
+
+    # create jam as host
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        create_response = await client.post("/jams/", json={"track_ids": ["t1"]})
+        code = create_response.json()["code"]
+
+    # switch to second user
+    async def mock_joiner_auth() -> Session:
+        return MockSession(did=second_user)
+
+    app.dependency_overrides[require_auth] = mock_joiner_auth
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        await client.post(f"/jams/{code}/join")
+
+        # non-host tries to set mode — should fail
+        response = await client.post(
+            f"/jams/{code}/command",
+            json={"type": "set_mode", "mode": "everyone"},
+        )
+
+    assert response.status_code == 400
+
+
+async def test_set_mode_everyone(test_app: FastAPI, db_session: AsyncSession) -> None:
+    """test that host can set mode to everyone and output fields are cleared."""
+    from starlette.websockets import WebSocket
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        create_response = await client.post("/jams/", json={"track_ids": ["t1"]})
+        code = create_response.json()["code"]
+        jam_id = create_response.json()["id"]
+
+    # set up host as output device first
+    ws = AsyncMock(spec=WebSocket)
+    await jam_service.connect_ws(jam_id, ws, "did:test:host")
+    jam_service._ws_client_ids[ws] = "host-client"
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        await client.post(
+            f"/jams/{code}/command",
+            json={"type": "set_output", "client_id": "host-client"},
+        )
+
+        # switch to everyone mode
+        response = await client.post(
+            f"/jams/{code}/command",
+            json={"type": "set_mode", "mode": "everyone"},
+        )
+
+    assert response.status_code == 200
+    state = response.json()["state"]
+    assert state["output_mode"] == "everyone"
+    assert state["output_client_id"] is None
+    assert state["output_did"] is None
+
+    await jam_service.disconnect_ws(jam_id, ws)
+
+
+async def test_set_mode_back_to_one_speaker(
+    test_app: FastAPI, db_session: AsyncSession
+) -> None:
+    """test round-trip: one_speaker → everyone → one_speaker."""
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        create_response = await client.post("/jams/", json={"track_ids": ["t1"]})
+        code = create_response.json()["code"]
+        assert create_response.json()["state"]["output_mode"] == "one_speaker"
+
+        # switch to everyone
+        r1 = await client.post(
+            f"/jams/{code}/command",
+            json={"type": "set_mode", "mode": "everyone"},
+        )
+        assert r1.json()["state"]["output_mode"] == "everyone"
+
+        # switch back to one_speaker
+        r2 = await client.post(
+            f"/jams/{code}/command",
+            json={"type": "set_mode", "mode": "one_speaker"},
+        )
+        assert r2.json()["state"]["output_mode"] == "one_speaker"
+
+
+async def test_everyone_mode_skips_output_disconnect_pause(
+    test_app: FastAPI, db_session: AsyncSession
+) -> None:
+    """test that in everyone mode, disconnecting a WS does NOT pause playback."""
+    from starlette.websockets import WebSocket
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        create_response = await client.post(
+            "/jams/", json={"track_ids": ["t1"], "is_playing": True}
+        )
+        code = create_response.json()["code"]
+        jam_id = create_response.json()["id"]
+
+        # switch to everyone mode
+        await client.post(
+            f"/jams/{code}/command",
+            json={"type": "set_mode", "mode": "everyone"},
+        )
+
+    # connect a WS and then disconnect it
+    ws = AsyncMock(spec=WebSocket)
+    await jam_service.connect_ws(jam_id, ws, "did:test:host")
+    jam_service._ws_client_ids[ws] = "host-client"
+    await jam_service.disconnect_ws(jam_id, ws)
+
+    # jam should still be playing
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        get_response = await client.get(f"/jams/{code}")
+        state = get_response.json()["state"]
+        assert state["is_playing"] is True
+        assert state["output_mode"] == "everyone"
+
+
+async def test_everyone_mode_skips_auto_output(
+    test_app: FastAPI, db_session: AsyncSession
+) -> None:
+    """test that in everyone mode, host sync does NOT auto-assign output."""
+    from starlette.websockets import WebSocket
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        create_response = await client.post("/jams/", json={"track_ids": ["t1"]})
+        code = create_response.json()["code"]
+        jam_id = create_response.json()["id"]
+
+        # switch to everyone mode
+        await client.post(
+            f"/jams/{code}/command",
+            json={"type": "set_mode", "mode": "everyone"},
+        )
+
+    # host connects and sends sync
+    ws = AsyncMock(spec=WebSocket)
+    await jam_service.connect_ws(jam_id, ws, "did:test:host")
+    await jam_service._handle_sync(
+        jam_id, "did:test:host", {"client_id": "host-abc", "last_id": None}, ws
+    )
+
+    # output_client_id should remain None (not auto-set)
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        get_response = await client.get(f"/jams/{code}")
+        state = get_response.json()["state"]
+        assert state["output_client_id"] is None
+        assert state["output_mode"] == "everyone"
+
+    await jam_service.disconnect_ws(jam_id, ws)
+
+
+async def test_set_mode_invalid_value(
+    test_app: FastAPI, db_session: AsyncSession
+) -> None:
+    """test that an invalid mode value is rejected."""
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        create_response = await client.post("/jams/", json={"track_ids": ["t1"]})
+        code = create_response.json()["code"]
+
+        response = await client.post(
+            f"/jams/{code}/command",
+            json={"type": "set_mode", "mode": "invalid_mode"},
+        )
+
+    assert response.status_code == 400

--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -167,7 +167,9 @@
 					<div class="jam-meta">
 						<span class="connection-dot" class:connected={jam.connected} class:reconnecting={jam.reconnecting}></span>
 						<span class="jam-code">{jam.code}</span>
-						{#if jam.outputClientId}
+						{#if jam.outputMode === 'everyone'}
+							<span class="output-status">everyone plays</span>
+						{:else if jam.outputClientId}
 							<span class="output-status">
 								{#if jam.isOutputDevice}
 									<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon><path d="M19.07 4.93a10 10 0 0 1 0 14.14"></path><path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path></svg>
@@ -183,7 +185,12 @@
 					</div>
 				</div>
 				<div class="queue-actions">
-					{#if !jam.isOutputDevice}
+					{#if jam.isHost}
+						<button class="mode-toggle" onclick={() => jam.setMode(jam.outputMode === 'everyone' ? 'one_speaker' : 'everyone')} title={jam.outputMode === 'everyone' ? 'switch to one speaker' : 'let everyone play'}>
+							{jam.outputMode === 'everyone' ? 'one speaker' : 'everyone'}
+						</button>
+					{/if}
+					{#if jam.outputMode !== 'everyone' && !jam.isOutputDevice}
 						<button class="output-btn" onclick={() => jam.setOutput()} title="play audio on this device">
 							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 								<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
@@ -265,7 +272,7 @@
 		{#if jam.active && jam.participants.length > 0}
 			<div class="participants-strip">
 				{#each jam.participants as participant (participant.did)}
-					<div class="participant-chip" class:is-output={participant.did === jam.outputDid} title={participant.display_name ?? participant.handle}>
+					<div class="participant-chip" class:is-output={jam.outputMode !== 'everyone' && participant.did === jam.outputDid} title={participant.display_name ?? participant.handle}>
 						{#if participant.avatar_url}
 							<img src={participant.avatar_url} alt="" class="participant-avatar" />
 						{:else}
@@ -276,7 +283,7 @@
 								</svg>
 							</div>
 						{/if}
-						{#if participant.did === jam.outputDid}
+						{#if jam.outputMode !== 'everyone' && participant.did === jam.outputDid}
 							<div class="speaker-badge">
 								<svg width="8" height="8" viewBox="0 0 24 24" fill="currentColor" stroke="none">
 									<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
@@ -888,6 +895,23 @@
 
 	.output-status.no-output {
 		color: var(--text-muted);
+	}
+
+	.mode-toggle {
+		padding: 0.125rem 0.5rem;
+		font-size: var(--text-xs);
+		font-family: inherit;
+		background: transparent;
+		border: 1px solid var(--border-subtle);
+		color: var(--text-tertiary);
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+
+	.mode-toggle:hover {
+		color: var(--accent);
+		border-color: var(--accent);
 	}
 
 	.output-btn {

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -605,7 +605,9 @@
 		{#if jam.active}
 			<div class="jam-stripe-label">
 				<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>{#if jam.isOutputDevice}<path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>{/if}</svg>
-				{#if jam.isOutputDevice}
+				{#if jam.outputMode === 'everyone'}
+					<span class="muted">everyone plays</span>
+				{:else if jam.isOutputDevice}
 					playing here
 				{:else if jam.outputClientId}
 					playing elsewhere

--- a/frontend/src/lib/jam.svelte.ts
+++ b/frontend/src/lib/jam.svelte.ts
@@ -1,5 +1,6 @@
 import { browser } from '$app/environment';
 import { API_URL } from './config';
+import { auth } from '$lib/auth.svelte';
 import { queue, type JamBridge } from './queue.svelte';
 import type { JamInfo, JamParticipant, JamPlaybackState, Track } from './types';
 
@@ -21,6 +22,7 @@ class JamState {
 	clientId = $state<string>('');
 	outputClientId = $state<string | null>(null);
 	outputDid = $state<string | null>(null);
+	outputMode = $state<'one_speaker' | 'everyone'>('one_speaker');
 
 	private ws: WebSocket | null = null;
 	private lastStreamId: string | null = null;
@@ -52,7 +54,12 @@ class JamState {
 	}
 
 	get isOutputDevice(): boolean {
+		if (this.outputMode === 'everyone') return true;
 		return this.clientId !== '' && this.clientId === this.outputClientId;
+	}
+
+	get isHost(): boolean {
+		return !!this.jam && this.jam.host_did === auth.user?.did;
 	}
 
 	private createBridge(): JamBridge {
@@ -187,6 +194,10 @@ class JamState {
 
 	setOutput(): void {
 		this.sendCommand({ type: 'set_output', client_id: this.clientId });
+	}
+
+	setMode(mode: 'one_speaker' | 'everyone'): void {
+		this.sendCommand({ type: 'set_mode', mode });
 	}
 
 	private sendCommand(payload: Record<string, unknown>): void {
@@ -333,6 +344,7 @@ class JamState {
 		this.serverTimeMs = state.server_time_ms;
 		this.outputClientId = state.output_client_id ?? null;
 		this.outputDid = state.output_did ?? null;
+		this.outputMode = state.output_mode ?? 'one_speaker';
 
 		if (data.tracks_changed && Array.isArray(data.tracks)) {
 			this.tracks = data.tracks as Track[];
@@ -370,6 +382,7 @@ class JamState {
 		this.serverTimeMs = state.server_time_ms;
 		this.outputClientId = state.output_client_id ?? null;
 		this.outputDid = state.output_did ?? null;
+		this.outputMode = state.output_mode ?? 'one_speaker';
 
 		this.syncToQueue();
 	}
@@ -393,6 +406,7 @@ class JamState {
 		this.lastStreamId = null;
 		this.outputClientId = null;
 		this.outputDid = null;
+		this.outputMode = 'one_speaker';
 	}
 
 	destroy(): void {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -172,5 +172,6 @@ export interface JamPlaybackState {
 	server_time_ms: number;
 	output_client_id?: string | null;
 	output_did?: string | null;
+	output_mode?: 'one_speaker' | 'everyone';
 }
 

--- a/loq.toml
+++ b/loq.toml
@@ -71,7 +71,7 @@ max_lines = 554
 
 [[rules]]
 path = "backend/tests/api/test_jams.py"
-max_lines = 1181
+max_lines = 1359
 
 [[rules]]
 path = "backend/tests/api/test_track_comments.py"
@@ -111,7 +111,7 @@ max_lines = 1087
 
 [[rules]]
 path = "frontend/src/lib/components/Queue.svelte"
-max_lines = 929
+max_lines = 952
 
 [[rules]]
 path = "frontend/src/lib/components/SearchModal.svelte"
@@ -131,7 +131,7 @@ max_lines = 622
 
 [[rules]]
 path = "frontend/src/lib/components/player/Player.svelte"
-max_lines = 725
+max_lines = 727
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"


### PR DESCRIPTION
## Summary

- Adds `output_mode` (`"one_speaker"` | `"everyone"`) to jam state, defaulting to current single-speaker behavior
- Host can toggle mid-jam via new `set_mode` command — non-hosts are rejected
- In "everyone" mode: all clients play audio, output device tracking is skipped, WS disconnect doesn't pause playback
- Frontend shows mode-aware status labels, host-only toggle button, hides "play here" and speaker badges when irrelevant

## Test plan

- [x] 6 new backend tests covering host-only gating, mode switch, round-trip, skip-disconnect-pause, skip-auto-output, invalid value rejection
- [x] Full backend suite passes (509 passed)
- [x] `svelte-check` passes (0 errors, 0 warnings)
- [ ] Manual: create jam → default "one speaker" works as before
- [ ] Manual: host toggles "everyone" → all participants hear audio
- [ ] Manual: toggle back → single output resumes, "play here" reappears
- [ ] Manual: non-host cannot see toggle button
- [ ] Manual: in "everyone" mode, participant disconnect does NOT pause

🤖 Generated with [Claude Code](https://claude.com/claude-code)