### PR TITLE
fix: eliminate jam no-output state + restructure header

### DIFF
--- a/backend/src/backend/_internal/jams.py
+++ b/backend/src/backend/_internal/jams.py
@@ -453,8 +453,27 @@ class JamService:
         with contextlib.suppress(Exception):
             await old_ws.close(code=4010, reason="replaced by new connection")
 
+    def _find_fallback_output(
+        self, jam_id: str, host_did: str, *, exclude_client_ids: set[str] | None = None
+    ) -> tuple[str, str] | None:
+        """find a connected client to be fallback output. returns (did, client_id) or None. prefers host."""
+        fallback: tuple[str, str] | None = None
+        for ws in self._connections.get(jam_id, set()):
+            if not (client_id := self._ws_client_ids.get(ws)):
+                continue
+            if exclude_client_ids and client_id in exclude_client_ids:
+                continue
+            for did, (jid, w) in self._ws_by_did.items():
+                if jid == jam_id and w is ws:
+                    if did == host_did:
+                        return (did, client_id)  # host preferred
+                    if fallback is None:
+                        fallback = (did, client_id)
+                    break
+        return fallback
+
     async def _clear_output_if_matches(self, jam_id: str, client_id: str) -> None:
-        """clear output_client_id and pause if it matches the given client_id."""
+        """clear output_client_id if it matches the given client_id. tries fallback before pausing."""
         async with db_session() as db:
             jam = await self._fetch_jam_by_id(db, jam_id)
             if not jam or not jam.is_active:
@@ -463,10 +482,23 @@ class JamService:
                 return  # no single output to clear
             if jam.state.get("output_client_id") != client_id:
                 return
+
             state = copy.deepcopy(jam.state)
-            state["output_client_id"] = None
-            state["output_did"] = None
-            state["is_playing"] = False
+
+            # try to find a fallback output device
+            if fallback := self._find_fallback_output(
+                jam_id, jam.host_did, exclude_client_ids={client_id}
+            ):
+                fallback_did, fallback_client_id = fallback
+                state["output_client_id"] = fallback_client_id
+                state["output_did"] = fallback_did
+                actor_type = "output_fallback"
+            else:
+                state["output_client_id"] = None
+                state["output_did"] = None
+                state["is_playing"] = False
+                actor_type = "output_disconnected"
+
             jam.state = state
             jam.revision += 1
             jam.updated_at = datetime.now(UTC)
@@ -479,7 +511,7 @@ class JamService:
                     "revision": jam.revision,
                     "state": state,
                     "tracks_changed": False,
-                    "actor": {"did": "system", "type": "output_disconnected"},
+                    "actor": {"did": "system", "type": actor_type},
                 },
             )
 
@@ -511,7 +543,7 @@ class JamService:
         if client_id := message.get("client_id"):
             self._ws_client_ids[ws] = client_id
 
-            # auto-set output to host on first connect if no output set
+            # auto-set output on connect if no output set (any client, not just host)
             async with db_session() as db:
                 jam = await self._fetch_jam_by_id(db, jam_id)
                 if (
@@ -519,7 +551,6 @@ class JamService:
                     and jam.is_active
                     and jam.state.get("output_mode", "one_speaker") == "one_speaker"
                     and jam.state.get("output_client_id") is None
-                    and did == jam.host_did
                 ):
                     state = copy.deepcopy(jam.state)
                     state["output_client_id"] = client_id

--- a/backend/tests/api/test_jams.py
+++ b/backend/tests/api/test_jams.py
@@ -760,10 +760,10 @@ async def test_set_output_validates_client_id(
     await jam_service.disconnect_ws(jam_id, ws)
 
 
-async def test_output_clears_on_disconnect(
+async def test_output_disconnect_no_remaining_pauses(
     test_app: FastAPI, db_session: AsyncSession
 ) -> None:
-    """test that output_client_id clears and playback pauses when output WS disconnects."""
+    """test that output clears and playback pauses when the only client disconnects (no fallback)."""
     from starlette.websockets import WebSocket
 
     # create jam and set output via API
@@ -789,7 +789,7 @@ async def test_output_clears_on_disconnect(
             json={"type": "set_output", "client_id": "host-output-client"},
         )
 
-    # disconnect output device
+    # disconnect output device (no other clients connected)
     await jam_service.disconnect_ws(jam_id, ws)
 
     # verify DB state: output cleared, playback paused
@@ -1357,3 +1357,209 @@ async def test_set_mode_invalid_value(
         )
 
     assert response.status_code == 400
+
+
+# ── output fallback tests ──────────────────────────────────────────
+
+
+async def test_output_fallback_on_disconnect(
+    test_app: FastAPI, db_session: AsyncSession, second_user: str
+) -> None:
+    """test that output reassigns to remaining client when output WS disconnects."""
+    from starlette.websockets import WebSocket
+
+    from backend._internal import require_auth
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        create_response = await client.post(
+            "/jams/", json={"track_ids": ["t1"], "is_playing": True}
+        )
+        code = create_response.json()["code"]
+        jam_id = create_response.json()["id"]
+
+    # second user joins
+    async def mock_joiner_auth() -> Session:
+        return MockSession(did=second_user)
+
+    app.dependency_overrides[require_auth] = mock_joiner_auth
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        await client.post(f"/jams/{code}/join")
+
+    # restore host auth
+    async def mock_host_auth() -> Session:
+        return MockSession(did="did:test:host")
+
+    app.dependency_overrides[require_auth] = mock_host_auth
+
+    # connect both WSs
+    ws_host = AsyncMock(spec=WebSocket)
+    ws_joiner = AsyncMock(spec=WebSocket)
+    await jam_service.connect_ws(jam_id, ws_host, "did:test:host")
+    jam_service._ws_client_ids[ws_host] = "host-client"
+    await jam_service.connect_ws(jam_id, ws_joiner, second_user)
+    jam_service._ws_client_ids[ws_joiner] = "joiner-client"
+
+    # set joiner as output device
+    app.dependency_overrides[require_auth] = mock_joiner_auth
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        await client.post(
+            f"/jams/{code}/command",
+            json={"type": "set_output", "client_id": "joiner-client"},
+        )
+
+    # disconnect the output device (joiner)
+    await jam_service.disconnect_ws(jam_id, ws_joiner)
+
+    # output should have fallen back to host, playback should NOT be paused
+    app.dependency_overrides[require_auth] = mock_host_auth
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        get_response = await client.get(f"/jams/{code}")
+        state = get_response.json()["state"]
+        assert state["output_client_id"] == "host-client"
+        assert state["output_did"] == "did:test:host"
+        assert state["is_playing"] is True
+
+    await jam_service.disconnect_ws(jam_id, ws_host)
+
+
+async def test_output_fallback_prefers_host(
+    test_app: FastAPI, db_session: AsyncSession, second_user: str
+) -> None:
+    """test that fallback prefers host over other connected clients."""
+    from starlette.websockets import WebSocket
+
+    from backend._internal import require_auth
+
+    # create a third user
+    third_did = "did:test:third"
+    third_artist = Artist(
+        did=third_did,
+        handle="test.third",
+        display_name="Test Third",
+    )
+    db_session.add(third_artist)
+    await enable_flag(db_session, third_did, "jams")
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        create_response = await client.post(
+            "/jams/", json={"track_ids": ["t1"], "is_playing": True}
+        )
+        code = create_response.json()["code"]
+        jam_id = create_response.json()["id"]
+
+    # join second and third users
+    for did in [second_user, third_did]:
+
+        async def _auth(did: str = did) -> Session:
+            return MockSession(did=did)
+
+        app.dependency_overrides[require_auth] = _auth
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            await client.post(f"/jams/{code}/join")
+
+    # connect all three WSs
+    ws_host = AsyncMock(spec=WebSocket)
+    ws_joiner = AsyncMock(spec=WebSocket)
+    ws_third = AsyncMock(spec=WebSocket)
+    await jam_service.connect_ws(jam_id, ws_host, "did:test:host")
+    jam_service._ws_client_ids[ws_host] = "host-client"
+    await jam_service.connect_ws(jam_id, ws_joiner, second_user)
+    jam_service._ws_client_ids[ws_joiner] = "joiner-client"
+    await jam_service.connect_ws(jam_id, ws_third, third_did)
+    jam_service._ws_client_ids[ws_third] = "third-client"
+
+    # set third user as output
+    async def mock_third_auth() -> Session:
+        return MockSession(did=third_did)
+
+    app.dependency_overrides[require_auth] = mock_third_auth
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        await client.post(
+            f"/jams/{code}/command",
+            json={"type": "set_output", "client_id": "third-client"},
+        )
+
+    # disconnect the output (third user)
+    await jam_service.disconnect_ws(jam_id, ws_third)
+
+    # fallback should prefer host over joiner
+    async def mock_host_auth() -> Session:
+        return MockSession(did="did:test:host")
+
+    app.dependency_overrides[require_auth] = mock_host_auth
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        get_response = await client.get(f"/jams/{code}")
+        state = get_response.json()["state"]
+        assert state["output_client_id"] == "host-client"
+        assert state["output_did"] == "did:test:host"
+        assert state["is_playing"] is True
+
+    await jam_service.disconnect_ws(jam_id, ws_host)
+    await jam_service.disconnect_ws(jam_id, ws_joiner)
+
+
+async def test_non_host_auto_output_on_sync(
+    test_app: FastAPI, db_session: AsyncSession, second_user: str
+) -> None:
+    """test that a non-host gets auto-assigned as output when no output is set."""
+    from starlette.websockets import WebSocket
+
+    from backend._internal import require_auth
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        create_response = await client.post("/jams/", json={"track_ids": ["t1"]})
+        code = create_response.json()["code"]
+        jam_id = create_response.json()["id"]
+        assert create_response.json()["state"]["output_client_id"] is None
+
+    # join as second user
+    async def mock_joiner_auth() -> Session:
+        return MockSession(did=second_user)
+
+    app.dependency_overrides[require_auth] = mock_joiner_auth
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        await client.post(f"/jams/{code}/join")
+
+    # connect joiner WS and send sync with client_id (no host WS connected)
+    ws = AsyncMock(spec=WebSocket)
+    await jam_service.connect_ws(jam_id, ws, second_user)
+    await jam_service._handle_sync(
+        jam_id, second_user, {"client_id": "joiner-abc-123", "last_id": None}, ws
+    )
+
+    # verify non-host was auto-assigned as output
+    async def mock_host_auth() -> Session:
+        return MockSession(did="did:test:host")
+
+    app.dependency_overrides[require_auth] = mock_host_auth
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        get_response = await client.get(f"/jams/{code}")
+        state = get_response.json()["state"]
+        assert state["output_client_id"] == "joiner-abc-123"
+        assert state["output_did"] == second_user
+
+    await jam_service.disconnect_ws(jam_id, ws)

--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -162,68 +162,59 @@
 	<div class="queue" class:jam-mode={jam.active}>
 		<div class="queue-header">
 			{#if jam.active}
-				<div class="jam-info">
-					<span class="jam-name">{jam.jam?.name ?? 'jam'}</span>
-					<div class="jam-meta">
+				<div class="jam-header-row">
+					<div class="jam-identity">
 						<span class="connection-dot" class:connected={jam.connected} class:reconnecting={jam.reconnecting}></span>
+						<span class="jam-name">{jam.jam?.name ?? 'jam'}</span>
 						<span class="jam-code">{jam.code}</span>
-						{#if jam.outputMode === 'everyone'}
-							<span class="output-status">everyone plays</span>
-						{:else if jam.outputClientId}
-							<span class="output-status">
-								{#if jam.isOutputDevice}
-									<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon><path d="M19.07 4.93a10 10 0 0 1 0 14.14"></path><path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path></svg>
-									playing here
-								{:else}
-									<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon><path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path></svg>
-									{outputParticipant ? `playing on ${outputParticipant.display_name ?? outputParticipant.handle}` : 'playing elsewhere'}
-								{/if}
-							</span>
-						{:else}
-							<span class="output-status no-output">no output</span>
+					</div>
+					<div class="queue-actions">
+						{#if upcoming.length > 0}
+							<button
+								class="clear-btn"
+								onclick={() => queue.clearUpNext()}
+								title="clear upcoming tracks"
+							>
+								clear
+							</button>
 						{/if}
+						<button class="share-btn" onclick={shareJam} title="share jam link">
+							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+								<circle cx="18" cy="5" r="3"></circle>
+								<circle cx="6" cy="12" r="3"></circle>
+								<circle cx="18" cy="19" r="3"></circle>
+								<line x1="8.59" y1="13.51" x2="15.42" y2="17.49"></line>
+								<line x1="15.41" y1="6.51" x2="8.59" y2="10.49"></line>
+							</svg>
+						</button>
+						<button class="leave-btn" onclick={leaveJam} title="leave jam">
+							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+								<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path>
+								<polyline points="16 17 21 12 16 7"></polyline>
+								<line x1="21" y1="12" x2="9" y2="12"></line>
+							</svg>
+						</button>
 					</div>
 				</div>
-				<div class="queue-actions">
+				<div class="jam-output-row">
+					<span class="output-status">
+						{#if jam.outputMode === 'everyone'}
+							<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon><path d="M19.07 4.93a10 10 0 0 1 0 14.14"></path><path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path></svg>
+							everyone plays
+						{:else if jam.isOutputDevice}
+							<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon><path d="M19.07 4.93a10 10 0 0 1 0 14.14"></path><path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path></svg>
+							playing here
+						{:else}
+							<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon><path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path></svg>
+							<span class="output-name">{outputParticipant ? (outputParticipant.display_name ?? outputParticipant.handle) : 'elsewhere'}</span>
+							<button class="pill-btn" onclick={() => jam.setOutput()}>play here</button>
+						{/if}
+					</span>
 					{#if jam.isHost}
-						<button class="mode-toggle" onclick={() => jam.setMode(jam.outputMode === 'everyone' ? 'one_speaker' : 'everyone')} title={jam.outputMode === 'everyone' ? 'switch to one speaker' : 'let everyone play'}>
+						<button class="pill-btn" onclick={() => jam.setMode(jam.outputMode === 'everyone' ? 'one_speaker' : 'everyone')} title={jam.outputMode === 'everyone' ? 'switch to one speaker' : 'let everyone play'}>
 							{jam.outputMode === 'everyone' ? 'one speaker' : 'everyone'}
 						</button>
 					{/if}
-					{#if jam.outputMode !== 'everyone' && !jam.isOutputDevice}
-						<button class="output-btn" onclick={() => jam.setOutput()} title="play audio on this device">
-							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
-								<path d="M19.07 4.93a10 10 0 0 1 0 14.14"></path>
-								<path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>
-							</svg>
-						</button>
-					{/if}
-					{#if upcoming.length > 0}
-						<button
-							class="clear-btn"
-							onclick={() => queue.clearUpNext()}
-							title="clear upcoming tracks"
-						>
-							clear
-						</button>
-					{/if}
-					<button class="share-btn" onclick={shareJam} title="share jam link">
-						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-							<circle cx="18" cy="5" r="3"></circle>
-							<circle cx="6" cy="12" r="3"></circle>
-							<circle cx="18" cy="19" r="3"></circle>
-							<line x1="8.59" y1="13.51" x2="15.42" y2="17.49"></line>
-							<line x1="15.41" y1="6.51" x2="8.59" y2="10.49"></line>
-						</svg>
-					</button>
-					<button class="leave-btn" onclick={leaveJam} title="leave jam">
-						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-							<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path>
-							<polyline points="16 17 21 12 16 7"></polyline>
-							<line x1="21" y1="12" x2="9" y2="12"></line>
-						</svg>
-					</button>
 				</div>
 			{:else}
 				<h2>queue</h2>
@@ -422,11 +413,52 @@
 		border-image: linear-gradient(90deg, #ff6b6b, #ffd93d, #6bcb77, #4d96ff, #9b59b6, #ff6b6b) 1;
 	}
 
-	.jam-info {
+	.jam-header-row {
 		display: flex;
-		flex-direction: column;
-		gap: 0.2rem;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.jam-identity {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
 		min-width: 0;
+		overflow: hidden;
+	}
+
+	.jam-output-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.output-name {
+		max-width: 140px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		display: inline-block;
+		vertical-align: bottom;
+	}
+
+	.pill-btn {
+		padding: 0.125rem 0.5rem;
+		font-size: var(--text-xs);
+		font-family: inherit;
+		background: transparent;
+		border: 1px solid var(--border-subtle);
+		color: var(--text-tertiary);
+		border-radius: var(--radius-full);
+		cursor: pointer;
+		transition: all 0.15s ease;
+		white-space: nowrap;
+	}
+
+	.pill-btn:hover {
+		color: var(--accent);
+		border-color: var(--accent);
 	}
 
 	.jam-name {
@@ -437,12 +469,8 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
-	}
-
-	.jam-meta {
-		display: flex;
-		align-items: center;
-		gap: 0.375rem;
+		min-width: 0;
+		flex-shrink: 1;
 	}
 
 	.connection-dot {
@@ -472,6 +500,7 @@
 		font-size: var(--text-xs);
 		color: var(--text-tertiary);
 		font-family: monospace;
+		flex-shrink: 0;
 	}
 
 	.share-btn,
@@ -542,6 +571,12 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+	}
+
+	.jam-mode .queue-header {
+		flex-direction: column;
+		align-items: stretch;
+		gap: 0.375rem;
 	}
 
 	.queue-actions {
@@ -891,48 +926,8 @@
 		gap: 0.25rem;
 		font-size: var(--text-xs);
 		color: var(--text-tertiary);
-	}
-
-	.output-status.no-output {
-		color: var(--text-muted);
-	}
-
-	.mode-toggle {
-		padding: 0.125rem 0.5rem;
-		font-size: var(--text-xs);
-		font-family: inherit;
-		background: transparent;
-		border: 1px solid var(--border-subtle);
-		color: var(--text-tertiary);
-		border-radius: var(--radius-sm);
-		cursor: pointer;
-		transition: all 0.15s ease;
-	}
-
-	.mode-toggle:hover {
-		color: var(--accent);
-		border-color: var(--accent);
-	}
-
-	.output-btn {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 32px;
-		height: 32px;
-		padding: 0;
-		background: transparent;
-		border: 1px solid var(--border-subtle);
-		color: var(--text-tertiary);
-		border-radius: var(--radius-sm);
-		cursor: pointer;
-		transition: all 0.15s ease;
-	}
-
-	.output-btn:hover {
-		color: var(--accent);
-		border-color: var(--accent);
-		background: color-mix(in srgb, var(--accent) 10%, transparent);
+		min-width: 0;
+		overflow: hidden;
 	}
 
 	.speaker-badge {

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -609,11 +609,8 @@
 					<span class="muted">everyone plays</span>
 				{:else if jam.isOutputDevice}
 					playing here
-				{:else if jam.outputClientId}
-					playing elsewhere
-					<button class="play-here-pill" onclick={() => jam.setOutput()}>play here</button>
 				{:else}
-					<span class="muted">no output</span>
+					playing elsewhere
 					<button class="play-here-pill" onclick={() => jam.setOutput()}>play here</button>
 				{/if}
 			</div>

--- a/loq.toml
+++ b/loq.toml
@@ -71,7 +71,7 @@ max_lines = 554
 
 [[rules]]
 path = "backend/tests/api/test_jams.py"
-max_lines = 1359
+max_lines = 1565
 
 [[rules]]
 path = "backend/tests/api/test_track_comments.py"


### PR DESCRIPTION
## Summary
- **backend**: output device disconnecting now falls back to another connected client (prefers host) instead of leaving "no output". auto-output on sync broadened to any client, not just host.
- **frontend**: jam header split into two rows — identity+actions on top, output routing+mode toggle below. "no output" UI branch removed. defensive mobile overflow CSS added.
- **tests**: 3 new tests (fallback on disconnect, fallback prefers host, non-host auto-output), 1 renamed for clarity.

## Test plan
- [x] `just backend test tests/api/test_jams.py -v` — 51 passed
- [x] `just backend test` — 512 passed, 13 skipped
- [x] `just frontend check` — 0 errors, 0 warnings
- [x] `just backend lint` — all passed
- [ ] manual: check jam header layout on mobile (320px–414px)
- [ ] manual: disconnect output device with another client connected → verify fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)