### PR TITLE
fix: auto-claim jam output when nobody has it

### DIFF
--- a/frontend/src/lib/jam.svelte.ts
+++ b/frontend/src/lib/jam.svelte.ts
@@ -355,6 +355,15 @@ class JamState {
 		}
 
 		this.syncToQueue();
+
+		// auto-claim output if nobody has it — "no output" should never be a visible state
+		if (
+			this.outputMode === 'one_speaker' &&
+			this.outputClientId === null &&
+			this.ws?.readyState === WebSocket.OPEN
+		) {
+			this.setOutput();
+		}
 	}
 
 	private async handleParticipantMessage(_data: Record<string, unknown>): Promise<void> {


### PR DESCRIPTION
## Summary
- When a state update arrives with `one_speaker` mode and `output_client_id === null`, the client immediately sends `set_output` to claim it
- First connected client to do this wins (server validates the client_id), rest get the state update
- Eliminates the "both clients show playing elsewhere" state entirely

Previous PR (#963) added backend fallback on disconnect, but the client could still land in no-output if the auto-output event was missed (race between sync snapshot and stream events). This is the client-side safety net.

## Test plan
- [x] `just frontend check` — 0 errors
- [ ] manual: two clients in jam, both should never show "playing elsewhere" simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)