### PR TITLE
fix: JSONB null vs SQL NULL on support_gate

### DIFF
--- a/backend/alembic/versions/2026_02_26_000000_fix_jsonb_null_support_gate.py
+++ b/backend/alembic/versions/2026_02_26_000000_fix_jsonb_null_support_gate.py
@@ -1,0 +1,33 @@
+"""fix JSONB null in support_gate — convert to SQL NULL
+
+Revision ID: a1b2c3d4e5f6
+Revises: f4ff6ce7d78b
+Create Date: 2026-02-26 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = "f4ff6ce7d78b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Convert JSONB literal null to SQL NULL in support_gate and job result."""
+    op.execute(
+        sa.text(
+            "UPDATE tracks SET support_gate = NULL WHERE support_gate::text = 'null'"
+        )
+    )
+    op.execute(sa.text("UPDATE jobs SET result = NULL WHERE result::text = 'null'"))
+
+
+def downgrade() -> None:
+    """No-op — cannot distinguish original JSONB nulls from SQL NULLs."""

--- a/backend/src/backend/models/job.py
+++ b/backend/src/backend/models/job.py
@@ -49,7 +49,9 @@ class Job(Base):
     phase: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # Result/Error
-    result: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    result: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB(none_as_null=True), nullable=True
+    )
     error: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # Metadata

--- a/backend/src/backend/models/track.py
+++ b/backend/src/backend/models/track.py
@@ -100,7 +100,7 @@ class Track(Base):
 
     # supporter-gated content (e.g., {"type": "any"} requires any atprotofans support)
     support_gate: Mapped[dict | None] = mapped_column(
-        JSONB, nullable=True, default=None
+        JSONB(none_as_null=True), nullable=True, default=None
     )
 
     @property

--- a/backend/tests/models/test_support_gate_null.py
+++ b/backend/tests/models/test_support_gate_null.py
@@ -1,0 +1,113 @@
+"""regression test: support_gate = None must produce SQL NULL, not JSONB null."""
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.models import Artist, Track
+
+
+async def test_support_gate_none_is_sql_null(db_session: AsyncSession) -> None:
+    """setting support_gate = None must store SQL NULL so IS NULL queries match."""
+    artist = Artist(
+        did="did:plc:nullgate",
+        handle="nullgate.bsky.social",
+        display_name="Null Gate Artist",
+    )
+    db_session.add(artist)
+    await db_session.flush()
+
+    track = Track(
+        title="Ungated Track",
+        artist_did=artist.did,
+        file_id="ungated-test",
+        file_type="mp3",
+        support_gate=None,
+    )
+    db_session.add(track)
+    await db_session.commit()
+
+    # raw SQL: support_gate should be SQL NULL, not JSONB literal 'null'
+    row = (
+        await db_session.execute(
+            sa.text(
+                "SELECT support_gate IS NULL AS is_null, "
+                "support_gate::text "
+                "FROM tracks WHERE id = :id"
+            ),
+            {"id": track.id},
+        )
+    ).one()
+    assert row.is_null is True, (
+        f"expected SQL NULL but got JSONB value: {row.support_gate!r}"
+    )
+
+
+async def test_support_gate_none_found_by_is_null_filter(
+    db_session: AsyncSession,
+) -> None:
+    """track with support_gate=None must be found by ORM .is_(None) filter."""
+    artist = Artist(
+        did="did:plc:backfillgate",
+        handle="backfillgate.bsky.social",
+        display_name="Backfill Gate Artist",
+    )
+    db_session.add(artist)
+    await db_session.flush()
+
+    track = Track(
+        title="Backfillable Track",
+        artist_did=artist.did,
+        file_id="backfillable-test",
+        file_type="mp3",
+        support_gate=None,
+    )
+    db_session.add(track)
+    await db_session.commit()
+
+    # the backfill query pattern: Track.support_gate.is_(None)
+    result = await db_session.execute(
+        sa.select(Track.id).where(
+            Track.artist_did == artist.did,
+            Track.support_gate.is_(None),
+        )
+    )
+    found_ids = [row[0] for row in result.all()]
+    assert track.id in found_ids, "track with support_gate=None not found by IS NULL"
+
+
+async def test_support_gate_cleared_becomes_sql_null(
+    db_session: AsyncSession,
+) -> None:
+    """clearing support_gate from a dict to None must produce SQL NULL."""
+    artist = Artist(
+        did="did:plc:cleargate",
+        handle="cleargate.bsky.social",
+        display_name="Clear Gate Artist",
+    )
+    db_session.add(artist)
+    await db_session.flush()
+
+    track = Track(
+        title="Was Gated Track",
+        artist_did=artist.did,
+        file_id="was-gated-test",
+        file_type="mp3",
+        support_gate={"type": "any"},
+    )
+    db_session.add(track)
+    await db_session.commit()
+
+    # clear the gate
+    track.support_gate = None
+    await db_session.commit()
+
+    # verify SQL NULL via raw query
+    row = (
+        await db_session.execute(
+            sa.text(
+                "SELECT support_gate IS NULL AS is_null FROM tracks WHERE id = :id"
+            ),
+            {"id": track.id},
+        )
+    ).one()
+    assert row.is_null is True, "clearing support_gate did not produce SQL NULL"

--- a/frontend/src/lib/components/PdsBackfillControl.svelte
+++ b/frontend/src/lib/components/PdsBackfillControl.svelte
@@ -40,9 +40,10 @@
 			});
 
 			if (!res.ok) {
+				const err = await res.json().catch(() => null);
 				migrating = false;
 				toast.dismiss(toastId);
-				toast.error('failed to start migration');
+				toast.error(err?.detail || 'failed to start migration');
 				return;
 			}
 


### PR DESCRIPTION
## Summary

- SQLAlchemy JSONB default (`none_as_null=False`) stores Python `None` as JSON literal `null` instead of SQL `NULL` — this made ungated tracks invisible to the PDS backfill query (`support_gate IS NULL`) after any portal edit
- Added `none_as_null=True` to `track.support_gate` and `job.result` JSONB columns
- Migration fixes 6 affected production rows by converting JSONB `null` → SQL `NULL`
- PdsBackfillControl now shows actual API error detail instead of generic toast

## Test plan

- [x] 3 regression tests: NULL roundtrip, ORM `is_(None)` filter, clear-from-gated
- [x] Full suite: 514 passed, 13 skipped
- [x] Lint clean (ruff, ty, svelte-check, eslint)
- [ ] After deploy to staging: `SELECT count(*) FROM tracks WHERE support_gate::text = 'null'` returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)