### PR TITLE
fix: use proper alembic revision ID for migration

### DIFF
--- a/backend/alembic/versions/2026_02_26_000000_fix_jsonb_null_support_gate.py
+++ b/backend/alembic/versions/2026_02_26_000000_fix_jsonb_null_support_gate.py
@@ -1,6 +1,6 @@
 """fix JSONB null in support_gate — convert to SQL NULL
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: d20b713cd31b
 Revises: f4ff6ce7d78b
 Create Date: 2026-02-26 00:00:00.000000
 
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "a1b2c3d4e5f6"
+revision: str = "d20b713cd31b"
 down_revision: str | Sequence[str] | None = "f4ff6ce7d78b"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None


### PR DESCRIPTION
## Summary

- The placeholder revision ID `a1b2c3d4e5f6` in the support_gate migration caused alembic to detect a cycle during staging deploy
- Replaced with a properly generated unique ID `d20b713cd31b`
- Verified: `alembic heads` shows single head, no cycle

## Test plan

- [x] `alembic heads` resolves to single head
- [ ] Staging deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)