### PR TITLE
fix: regenerate migration with proper alembic revision ID

### DIFF
--- a/backend/alembic/versions/2026_02_26_085017_97e520a2e2fa_fix_jsonb_null_in_support_gate.py
+++ b/backend/alembic/versions/2026_02_26_085017_97e520a2e2fa_fix_jsonb_null_in_support_gate.py
@@ -1,8 +1,8 @@
-"""fix JSONB null in support_gate — convert to SQL NULL
+"""fix jsonb null in support_gate
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: 97e520a2e2fa
 Revises: f4ff6ce7d78b
-Create Date: 2026-02-26 00:00:00.000000
+Create Date: 2026-02-26 08:50:17.916457
 
 """
 
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "a1b2c3d4e5f6"
+revision: str = "97e520a2e2fa"
 down_revision: str | Sequence[str] | None = "f4ff6ce7d78b"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None


### PR DESCRIPTION
## Summary

- Previous migration (#966) used a hand-written placeholder revision ID that caused alembic cycle detection during staging deploy
- Deleted the hand-written file and regenerated with `alembic revision -m "..."` for a proper ID
- Same data fix: converts JSONB `null` → SQL `NULL` in `tracks.support_gate` and `jobs.result`

## Test plan

- [x] `alembic heads` → single head `97e520a2e2fa`, no cycle
- [ ] Staging deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)