### PR TITLE
feat: remove pds-audio-uploads feature flag

### DIFF
--- a/backend/src/backend/_internal/feature_flags.py
+++ b/backend/src/backend/_internal/feature_flags.py
@@ -13,7 +13,6 @@ from backend.models.feature_flag import FeatureFlag
 KNOWN_FLAGS = frozenset(
     {
         "lossless-uploads",  # enable AIFF/FLAC upload support
-        "pds-audio-uploads",  # enable PDS audio blob uploads
         "vibe-search",  # enable semantic vibe search in Cmd+K
     }
 )

--- a/backend/src/backend/api/pds_backfill.py
+++ b/backend/src/backend/api/pds_backfill.py
@@ -12,13 +12,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, require_auth
-from backend._internal.feature_flags import has_flag
 from backend._internal.jobs import job_service
 from backend._internal.pds_backfill_tasks import schedule_pds_backfill
 from backend.models import Track, get_db
 from backend.models.job import JobStatus, JobType
-
-PDS_AUDIO_UPLOADS_FLAG = "pds-audio-uploads"
 
 router = APIRouter(prefix="/pds-backfill", tags=["pds"])
 logger = logging.getLogger(__name__)
@@ -47,13 +44,9 @@ async def backfill_audio_to_pds(
 ) -> PdsBackfillStartResponse:
     """start backfill of existing tracks to the user's PDS.
 
-    requires the pds-audio-uploads feature flag.
     optionally accepts a list of track_ids to selectively backfill.
     returns a backfill_id for tracking progress via SSE.
     """
-    if not await has_flag(db, session.did, PDS_AUDIO_UPLOADS_FLAG):
-        raise HTTPException(status_code=403, detail="pds audio uploads not enabled")
-
     stmt = (
         select(Track.id)
         .where(

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -62,7 +62,6 @@ from .services import get_or_create_album
 
 logger = logging.getLogger(__name__)
 
-PDS_AUDIO_UPLOADS_FLAG = "pds-audio-uploads"
 PDS_AUDIO_UPLOADS_SETTING_KEY = "pds_audio_uploads_enabled"
 
 
@@ -305,9 +304,6 @@ async def _try_upload_to_pds(
 
 async def _should_upload_pds_blob(db: AsyncSession, user_did: str) -> bool:
     """check if PDS audio uploads are enabled for the user."""
-    if not await has_flag(db, user_did, PDS_AUDIO_UPLOADS_FLAG):
-        return False
-
     result = await db.execute(
         select(UserPreferences.ui_settings).where(UserPreferences.did == user_did)
     )

--- a/frontend/src/lib/components/PdsAudioUploadsToggle.svelte
+++ b/frontend/src/lib/components/PdsAudioUploadsToggle.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
-	import { auth } from '$lib/auth.svelte';
-	import { PDS_AUDIO_UPLOADS_FLAG } from '$lib/config';
 	import { preferences } from '$lib/preferences.svelte';
 	import { toast } from '$lib/toast.svelte';
 
-	let visible = $derived(auth.user?.enabled_flags?.includes(PDS_AUDIO_UPLOADS_FLAG) ?? false);
 	let enabled = $derived(preferences.uiSettings.pds_audio_uploads_enabled ?? false);
 
 	async function handleToggle(event: Event) {
@@ -19,18 +16,16 @@
 	}
 </script>
 
-{#if visible}
-	<div class="setting-row">
-		<div class="setting-info">
-			<h3>store audio on your pds</h3>
-			<p>store uploaded audio on your pds (falls back to plyr.fm storage if too large)</p>
-		</div>
-		<label class="toggle-switch">
-			<input type="checkbox" checked={enabled} onchange={handleToggle} />
-			<span class="toggle-slider"></span>
-		</label>
+<div class="setting-row">
+	<div class="setting-info">
+		<h3>store audio on your pds</h3>
+		<p>store uploaded audio on your pds (falls back to plyr.fm storage if too large)</p>
 	</div>
-{/if}
+	<label class="toggle-switch">
+		<input type="checkbox" checked={enabled} onchange={handleToggle} />
+		<span class="toggle-slider"></span>
+	</label>
+</div>
 
 <style>
 	.setting-row {

--- a/frontend/src/lib/components/PdsBackfillControl.svelte
+++ b/frontend/src/lib/components/PdsBackfillControl.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import PdsMigrationModal from './PdsMigrationModal.svelte';
-	import { API_URL, PDS_AUDIO_UPLOADS_FLAG } from '$lib/config';
-	import { auth } from '$lib/auth.svelte';
+	import { API_URL } from '$lib/config';
 	import { toast } from '$lib/toast.svelte';
 	import type { Track } from '$lib/types';
 
@@ -15,8 +14,6 @@
 
 	let showModal = $state(false);
 	let migrating = $state(false);
-
-	let hasFlag = $derived(auth.user?.enabled_flags?.includes(PDS_AUDIO_UPLOADS_FLAG) ?? false);
 
 	let backfillableTrackCount = $derived(
 		tracks.filter(
@@ -99,7 +96,7 @@
 	}
 </script>
 
-{#if hasFlag && backfillableTrackCount > 0}
+{#if backfillableTrackCount > 0}
 	<div class="data-control">
 		<div class="control-info">
 			<h3>migrate audio to your PDS</h3>

--- a/frontend/src/lib/components/PdsUploadNote.svelte
+++ b/frontend/src/lib/components/PdsUploadNote.svelte
@@ -1,17 +1,14 @@
 <script lang="ts">
-	import { auth } from "$lib/auth.svelte";
-	import { PDS_AUDIO_UPLOADS_FLAG } from "$lib/config";
 	import { preferences } from "$lib/preferences.svelte";
 
-	let hasFlag = $derived(auth.user?.enabled_flags?.includes(PDS_AUDIO_UPLOADS_FLAG) ?? false);
 	let enabled = $derived(preferences.uiSettings.pds_audio_uploads_enabled ?? false);
 </script>
 
-{#if hasFlag && !enabled}
+{#if !enabled}
 	<p class="pds-note">
 		pds audio uploads available in <a href="/settings">settings</a>
 	</p>
-{:else if hasFlag && enabled}
+{:else}
 	<p class="pds-note">uploads will be stored on your pds</p>
 {/if}
 

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -2,7 +2,6 @@ import { PUBLIC_API_URL } from '$env/static/public';
 
 export const API_URL = PUBLIC_API_URL || 'http://localhost:8001';
 
-export const PDS_AUDIO_UPLOADS_FLAG = 'pds-audio-uploads';
 export const VIBE_SEARCH_FLAG = 'vibe-search';
 
 /**


### PR DESCRIPTION
## Summary
- Remove `pds-audio-uploads` from `KNOWN_FLAGS` and all flag gate checks (backend + frontend)
- PDS audio upload toggle in settings is now visible to all users — the user preference still controls behavior
- Same pattern as jams flag removal (c6661b0)

## Test plan
- [x] `just backend test` — 514 passed
- [x] `just backend lint` — clean
- [x] `just frontend check` — 0 errors, 0 warnings
- [ ] Verify settings toggle visible for a non-flagged user on staging
- [ ] Verify PDS backfill control appears when user has eligible tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)