### PR TITLE
feat: cache bluesky follow graph in Redis

### DIFF
--- a/backend/src/backend/_internal/follow_graph.py
+++ b/backend/src/backend/_internal/follow_graph.py
@@ -1,0 +1,118 @@
+"""bluesky follow graph with Redis read-through caching."""
+
+import json
+import logging
+from dataclasses import asdict, dataclass
+
+import httpx
+import logfire
+
+from backend._internal.atproto.profile import BSKY_API_BASE, normalize_avatar_url
+from backend.utilities.redis import get_async_redis_client
+
+logger = logging.getLogger(__name__)
+
+FOLLOWS_CACHE_PREFIX = "plyr:follows:"
+FOLLOWS_CACHE_TTL_SECONDS = 600  # 10 minutes
+
+
+@dataclass(frozen=True, slots=True)
+class FollowInfo:
+    """metadata about a follow relationship from bluesky."""
+
+    index: int  # enumeration position (0 = most recent, higher = older)
+    avatar_url: str | None  # avatar from bluesky profile
+
+
+async def get_follows(did: str) -> dict[str, FollowInfo]:
+    """get all DIDs a user follows on bluesky, with Redis read-through cache.
+
+    checks Redis first, falls back to live Bluesky API on miss,
+    then writes back to cache. fails silently on Redis errors.
+    """
+    cache_key = f"{FOLLOWS_CACHE_PREFIX}{did}"
+
+    # try cache
+    try:
+        redis = get_async_redis_client()
+        if cached := await redis.get(cache_key):
+            return _deserialize_follows(cached)
+    except Exception:
+        logger.debug("redis cache read failed for follows %s", did)
+
+    # cache miss — fetch live
+    follows = await _fetch_follows_from_bsky(did)
+
+    # write back
+    try:
+        redis = get_async_redis_client()
+        await redis.set(
+            cache_key, _serialize_follows(follows), ex=FOLLOWS_CACHE_TTL_SECONDS
+        )
+    except Exception:
+        logger.debug("redis cache write failed for follows %s", did)
+
+    return follows
+
+
+async def warm_follows_cache(did: str) -> None:
+    """always fetch from bluesky and write to Redis. called from background task."""
+    follows = await _fetch_follows_from_bsky(did)
+    cache_key = f"{FOLLOWS_CACHE_PREFIX}{did}"
+    try:
+        redis = get_async_redis_client()
+        await redis.set(
+            cache_key, _serialize_follows(follows), ex=FOLLOWS_CACHE_TTL_SECONDS
+        )
+        logfire.info("warmed follows cache", did=did, count=len(follows))
+    except Exception:
+        logger.debug("redis cache write failed warming follows for %s", did)
+
+
+async def _fetch_follows_from_bsky(did: str) -> dict[str, FollowInfo]:
+    """fetch all DIDs a user follows on bluesky with profile metadata.
+
+    returns a mapping of DID -> FollowInfo. enumeration order approximates
+    follow age (0 = most recently followed) since the API paginates by TID.
+    """
+    follows: dict[str, FollowInfo] = {}
+    cursor: str | None = None
+    index = 0
+
+    async with httpx.AsyncClient() as client:
+        while True:
+            params: dict[str, str | int] = {"actor": did, "limit": 100}
+            if cursor:
+                params["cursor"] = cursor
+
+            resp = await client.get(
+                f"{BSKY_API_BASE}/app.bsky.graph.getFollows",
+                params=params,
+                timeout=10.0,
+            )
+            if resp.status_code != 200:
+                logger.warning("getFollows failed for %s: %s", did, resp.status_code)
+                break
+
+            data = resp.json()
+            for f in data.get("follows", []):
+                follows[f["did"]] = FollowInfo(
+                    index=index,
+                    avatar_url=normalize_avatar_url(f.get("avatar")),
+                )
+                index += 1
+
+            if not (cursor := data.get("cursor")):
+                break
+
+    return follows
+
+
+def _serialize_follows(follows: dict[str, FollowInfo]) -> str:
+    """serialize follow map to JSON for Redis storage."""
+    return json.dumps({did: asdict(info) for did, info in follows.items()})
+
+
+def _deserialize_follows(raw: str) -> dict[str, FollowInfo]:
+    """deserialize follow map from Redis JSON."""
+    return {did: FollowInfo(**info) for did, info in json.loads(raw).items()}

--- a/backend/src/backend/_internal/tasks/__init__.py
+++ b/backend/src/backend/_internal/tasks/__init__.py
@@ -39,10 +39,12 @@ from backend._internal.tasks.storage import (
 from backend._internal.tasks.sync import (
     schedule_album_list_sync,
     schedule_atproto_sync,
+    schedule_follow_graph_warm,
     schedule_teal_scrobble,
     scrobble_to_teal,
     sync_album_list,
     sync_atproto,
+    warm_follow_graph,
 )
 
 # collection of all background task functions for docket registration
@@ -62,6 +64,7 @@ background_tasks = [
     move_track_audio,
     generate_embedding,
     classify_genres,
+    warm_follow_graph,
 ]
 
 __all__ = [
@@ -80,6 +83,7 @@ __all__ = [
     "schedule_copyright_resolution_sync",
     "schedule_copyright_scan",
     "schedule_embedding_generation",
+    "schedule_follow_graph_warm",
     "schedule_genre_classification",
     "schedule_move_track_audio",
     "schedule_pds_create_comment",
@@ -92,4 +96,5 @@ __all__ = [
     "sync_album_list",
     "sync_atproto",
     "sync_copyright_resolutions",
+    "warm_follow_graph",
 ]

--- a/backend/src/backend/_internal/tasks/sync.py
+++ b/backend/src/backend/_internal/tasks/sync.py
@@ -6,6 +6,7 @@ import logfire
 from sqlalchemy import select
 
 from backend._internal.background import get_docket
+from backend._internal.follow_graph import warm_follows_cache
 
 logger = logging.getLogger(__name__)
 
@@ -195,3 +196,22 @@ async def schedule_album_list_sync(session_id: str, album_id: str) -> None:
     docket = get_docket()
     await docket.add(sync_album_list)(session_id, album_id)
     logfire.info("scheduled album list sync", album_id=album_id)
+
+
+async def warm_follow_graph(user_did: str) -> None:
+    """warm the bluesky follow graph cache for a user.
+
+    fetches follows from bluesky and writes to Redis so that
+    subsequent requests to /discover/network are fast.
+
+    args:
+        user_did: the user's DID
+    """
+    await warm_follows_cache(user_did)
+
+
+async def schedule_follow_graph_warm(user_did: str) -> None:
+    """schedule a follow graph cache warm via docket."""
+    docket = get_docket()
+    await docket.add(warm_follow_graph)(user_did)
+    logfire.info("scheduled follow graph warm", user_did=user_did)

--- a/backend/src/backend/api/auth.py
+++ b/backend/src/backend/api/auth.py
@@ -39,7 +39,7 @@ from backend._internal import (
     switch_active_account,
 )
 from backend._internal.auth import get_refresh_token_lifetime_days
-from backend._internal.tasks import schedule_atproto_sync
+from backend._internal.tasks import schedule_atproto_sync, schedule_follow_graph_warm
 from backend.config import settings
 from backend.models import Artist, get_db
 from backend.utilities.rate_limit import limiter
@@ -249,6 +249,7 @@ async def oauth_callback(
 
         # schedule ATProto sync (via docket if enabled, else asyncio)
         await schedule_atproto_sync(session_id, did)
+        await schedule_follow_graph_warm(did)
 
         return RedirectResponse(
             url=f"{settings.frontend.url}/settings?exchange_token={exchange_token}&scope_upgraded=true",
@@ -275,6 +276,7 @@ async def oauth_callback(
 
         # schedule ATProto sync
         await schedule_atproto_sync(session_id, did)
+        await schedule_follow_graph_warm(did)
 
         return RedirectResponse(
             url=f"{settings.frontend.url}/portal?exchange_token={exchange_token}&account_added=true",
@@ -292,6 +294,7 @@ async def oauth_callback(
 
     # schedule ATProto sync (via docket if enabled, else asyncio)
     await schedule_atproto_sync(session_id, did)
+    await schedule_follow_graph_warm(did)
 
     # redirect to profile setup if needed, otherwise to portal
     redirect_path = "/portal" if has_profile else "/profile/setup"

--- a/backend/src/backend/api/discover.py
+++ b/backend/src/backend/api/discover.py
@@ -1,17 +1,16 @@
 """discovery endpoints — social graph powered artist discovery."""
 
 import logging
-from dataclasses import dataclass
 from typing import Annotated
 
-import httpx
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, field_validator
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, require_auth
-from backend._internal.atproto.profile import BSKY_API_BASE, normalize_avatar_url
+from backend._internal.atproto.profile import normalize_avatar_url
+from backend._internal.follow_graph import get_follows
 from backend.models import Artist, Track, get_db
 
 logger = logging.getLogger(__name__)
@@ -34,60 +33,13 @@ class NetworkArtistResponse(BaseModel):
         return normalize_avatar_url(v)
 
 
-@dataclass(frozen=True, slots=True)
-class FollowInfo:
-    """metadata about a follow relationship from bluesky."""
-
-    index: int  # enumeration position (0 = most recent, higher = older)
-    avatar_url: str | None  # avatar from bluesky profile
-
-
-async def _get_follows(did: str) -> dict[str, FollowInfo]:
-    """fetch all DIDs a user follows on bluesky with profile metadata.
-
-    returns a mapping of DID -> FollowInfo. enumeration order approximates
-    follow age (0 = most recently followed) since the API paginates by TID.
-    """
-    follows: dict[str, FollowInfo] = {}
-    cursor: str | None = None
-    index = 0
-
-    async with httpx.AsyncClient() as client:
-        while True:
-            params: dict[str, str | int] = {"actor": did, "limit": 100}
-            if cursor:
-                params["cursor"] = cursor
-
-            resp = await client.get(
-                f"{BSKY_API_BASE}/app.bsky.graph.getFollows",
-                params=params,
-                timeout=10.0,
-            )
-            if resp.status_code != 200:
-                logger.warning(f"getFollows failed for {did}: {resp.status_code}")
-                break
-
-            data = resp.json()
-            for f in data.get("follows", []):
-                follows[f["did"]] = FollowInfo(
-                    index=index,
-                    avatar_url=normalize_avatar_url(f.get("avatar")),
-                )
-                index += 1
-
-            if not (cursor := data.get("cursor")):
-                break
-
-    return follows
-
-
 @router.get("/network")
 async def get_network_artists(
     db: Annotated[AsyncSession, Depends(get_db)],
     auth_session: Session = Depends(require_auth),
 ) -> list[NetworkArtistResponse]:
     """discover artists on plyr.fm that you follow on bluesky."""
-    follow_dids = await _get_follows(auth_session.did)
+    follow_dids = await get_follows(auth_session.did)
     if not follow_dids:
         return []
 

--- a/backend/tests/_internal/test_follow_graph.py
+++ b/backend/tests/_internal/test_follow_graph.py
@@ -1,0 +1,139 @@
+"""tests for bluesky follow graph caching."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend._internal.follow_graph import (
+    FOLLOWS_CACHE_PREFIX,
+    FOLLOWS_CACHE_TTL_SECONDS,
+    FollowInfo,
+    _deserialize_follows,
+    _serialize_follows,
+    get_follows,
+    warm_follows_cache,
+)
+
+SAMPLE_FOLLOWS: dict[str, FollowInfo] = {
+    "did:plc:alice": FollowInfo(index=0, avatar_url="https://cdn.bsky.app/alice.jpg"),
+    "did:plc:bob": FollowInfo(index=1, avatar_url=None),
+}
+
+
+def test_serialization_roundtrip() -> None:
+    """serialize -> deserialize preserves data."""
+    result = _deserialize_follows(_serialize_follows(SAMPLE_FOLLOWS))
+    assert result == SAMPLE_FOLLOWS
+
+
+def test_serialization_empty() -> None:
+    """empty dict roundtrips correctly."""
+    result = _deserialize_follows(_serialize_follows({}))
+    assert result == {}
+
+
+@pytest.fixture
+def mock_redis() -> AsyncMock:
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value=None)
+    redis.set = AsyncMock()
+    return redis
+
+
+@pytest.fixture
+def mock_fetch() -> AsyncMock:
+    return AsyncMock(return_value=SAMPLE_FOLLOWS)
+
+
+async def test_cache_hit(mock_redis: AsyncMock) -> None:
+    """returns cached data without calling bluesky."""
+    mock_redis.get.return_value = _serialize_follows(SAMPLE_FOLLOWS)
+
+    with (
+        patch(
+            "backend._internal.follow_graph.get_async_redis_client",
+            return_value=mock_redis,
+        ),
+        patch(
+            "backend._internal.follow_graph._fetch_follows_from_bsky",
+        ) as mock_fetch,
+    ):
+        result = await get_follows("did:plc:test")
+
+    assert result == SAMPLE_FOLLOWS
+    mock_fetch.assert_not_called()
+
+
+async def test_cache_miss_fetches_and_writes(
+    mock_redis: AsyncMock, mock_fetch: AsyncMock
+) -> None:
+    """on miss, fetches from bluesky and writes back to redis."""
+    with (
+        patch(
+            "backend._internal.follow_graph.get_async_redis_client",
+            return_value=mock_redis,
+        ),
+        patch(
+            "backend._internal.follow_graph._fetch_follows_from_bsky",
+            mock_fetch,
+        ),
+    ):
+        result = await get_follows("did:plc:test")
+
+    assert result == SAMPLE_FOLLOWS
+    mock_fetch.assert_awaited_once_with("did:plc:test")
+
+    # verify cache write
+    mock_redis.set.assert_awaited_once()
+    call_args = mock_redis.set.call_args
+    assert call_args[0][0] == f"{FOLLOWS_CACHE_PREFIX}did:plc:test"
+    assert call_args[1]["ex"] == FOLLOWS_CACHE_TTL_SECONDS
+
+    # verify written data roundtrips
+    written = _deserialize_follows(call_args[0][1])
+    assert written == SAMPLE_FOLLOWS
+
+
+async def test_redis_error_falls_back_to_live(mock_fetch: AsyncMock) -> None:
+    """redis errors fall back to live fetch without raising."""
+    broken_redis = AsyncMock()
+    broken_redis.get.side_effect = ConnectionError("redis down")
+    broken_redis.set.side_effect = ConnectionError("redis down")
+
+    with (
+        patch(
+            "backend._internal.follow_graph.get_async_redis_client",
+            return_value=broken_redis,
+        ),
+        patch(
+            "backend._internal.follow_graph._fetch_follows_from_bsky",
+            mock_fetch,
+        ),
+    ):
+        result = await get_follows("did:plc:test")
+
+    assert result == SAMPLE_FOLLOWS
+    mock_fetch.assert_awaited_once()
+
+
+async def test_warm_writes_to_redis(
+    mock_redis: AsyncMock, mock_fetch: AsyncMock
+) -> None:
+    """warm_follows_cache always fetches and writes to redis."""
+    with (
+        patch(
+            "backend._internal.follow_graph.get_async_redis_client",
+            return_value=mock_redis,
+        ),
+        patch(
+            "backend._internal.follow_graph._fetch_follows_from_bsky",
+            mock_fetch,
+        ),
+    ):
+        await warm_follows_cache("did:plc:test")
+
+    mock_fetch.assert_awaited_once_with("did:plc:test")
+    mock_redis.set.assert_awaited_once()
+    call_args = mock_redis.set.call_args
+    assert call_args[0][0] == f"{FOLLOWS_CACHE_PREFIX}did:plc:test"
+    assert call_args[1]["ex"] == FOLLOWS_CACHE_TTL_SECONDS

--- a/backend/tests/api/test_discover.py
+++ b/backend/tests/api/test_discover.py
@@ -9,7 +9,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, require_auth
-from backend.api.discover import FollowInfo
+from backend._internal.follow_graph import FollowInfo
 from backend.main import app
 from backend.models import Artist, Track
 
@@ -98,7 +98,7 @@ async def test_network_excludes_artists_with_zero_tracks(
     tracks should be returned.
     """
     with patch(
-        "backend.api.discover._get_follows",
+        "backend.api.discover.get_follows",
         new_callable=AsyncMock,
         return_value={
             artist_with_tracks.did: FollowInfo(index=0, avatar_url=None),
@@ -123,7 +123,7 @@ async def test_network_returns_empty_when_no_follows_are_artists(
 ) -> None:
     """returns empty list when none of the user's follows are on plyr.fm."""
     with patch(
-        "backend.api.discover._get_follows",
+        "backend.api.discover.get_follows",
         new_callable=AsyncMock,
         return_value={
             "did:plc:stranger1": FollowInfo(index=0, avatar_url=None),
@@ -145,7 +145,7 @@ async def test_network_returns_empty_when_no_follows(
 ) -> None:
     """returns empty list when user follows nobody."""
     with patch(
-        "backend.api.discover._get_follows",
+        "backend.api.discover.get_follows",
         new_callable=AsyncMock,
         return_value={},
     ):
@@ -168,7 +168,7 @@ async def test_network_avatar_fallback_from_bluesky(
 
     bsky_avatar = "https://cdn.bsky.app/img/avatar/did:plc:has_tracks/abc@jpeg"
     with patch(
-        "backend.api.discover._get_follows",
+        "backend.api.discover.get_follows",
         new_callable=AsyncMock,
         return_value={
             artist_with_tracks.did: FollowInfo(index=0, avatar_url=bsky_avatar),
@@ -208,7 +208,7 @@ async def test_network_ordered_by_follow_age(
     await db_session.commit()
 
     with patch(
-        "backend.api.discover._get_follows",
+        "backend.api.discover.get_follows",
         new_callable=AsyncMock,
         return_value={
             "did:plc:recent": FollowInfo(index=0, avatar_url=None),  # most recent

--- a/backend/tests/api/test_list_record_sync.py
+++ b/backend/tests/api/test_list_record_sync.py
@@ -528,9 +528,9 @@ async def test_login_callback_triggers_background_sync(
             return_value=True,
         ),
         patch(
-            "backend.api.auth.schedule_atproto_sync",
-            new_callable=AsyncMock,
+            "backend.api.auth.schedule_atproto_sync", new_callable=AsyncMock
         ) as mock_schedule_sync,
+        patch("backend.api.auth.schedule_follow_graph_warm", new_callable=AsyncMock),
     ):
         async with AsyncClient(
             transport=ASGITransport(app=test_app), base_url="http://test"


### PR DESCRIPTION
## Summary
- Extract follow graph logic from `discover.py` into shared `_internal/follow_graph.py` with Redis read-through caching (600s TTL)
- Warm the cache on login via a docket background task so the first `/discover/network` request is fast
- `GET /discover/network` should drop from ~2s to <100ms on cache hit (the DB query itself is only 16ms)

## Changes
- **NEW** `_internal/follow_graph.py` — `FollowInfo`, `get_follows()` (read-through cache), `warm_follows_cache()`, Bluesky pagination logic
- **MODIFIED** `api/discover.py` — imports from `follow_graph` instead of inlining the logic
- **MODIFIED** `_internal/tasks/sync.py` + `__init__.py` — `warm_follow_graph` background task
- **MODIFIED** `api/auth.py` — `schedule_follow_graph_warm(did)` alongside all 3 existing `schedule_atproto_sync` calls
- **NEW** `tests/_internal/test_follow_graph.py` — 6 unit tests (serialization, cache hit/miss, Redis error fallback, warm)
- **MODIFIED** `tests/api/test_discover.py` — updated import path and mock targets
- **MODIFIED** `tests/api/test_list_record_sync.py` — added mock for new scheduler call

## Test plan
- [x] `just backend test` — 520 passed, 13 skipped
- [x] `just backend lint` — clean
- [ ] Check Logfire after deploy: `GET /discover/network` latency on cache hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)