### PR TITLE
fix: fade transitions and reduced-motion across loading states

### DIFF
--- a/frontend/src/lib/components/CommentersTooltip.svelte
+++ b/frontend/src/lib/components/CommentersTooltip.svelte
@@ -6,6 +6,7 @@
 		triggerAvatarRefresh,
 		hasAttemptedRefresh
 	} from '$lib/avatar-refresh.svelte';
+	import { fade } from 'svelte/transition';
 	import SensitiveImage from './SensitiveImage.svelte';
 
 	interface Props {
@@ -126,43 +127,45 @@
 	onmouseenter={onMouseEnter}
 	onmouseleave={onMouseLeave}
 >
-	{#if loading}
-		<div class="loading">
-			<div class="loading-avatars">
-				{#each [1, 2, 3] as _}
-					<div class="avatar-skeleton"></div>
+	{#key loading}
+		{#if loading}
+			<div class="loading" transition:fade={{ duration: 200 }}>
+				<div class="loading-avatars">
+					{#each [1, 2, 3] as _}
+						<div class="avatar-skeleton"></div>
+					{/each}
+				</div>
+			</div>
+		{:else if error}
+			<div class="error" transition:fade={{ duration: 200 }}>{error}</div>
+		{:else if commenters.length > 0}
+			<div class="commenters-avatars" transition:fade={{ duration: 200 }}>
+				{#each commenters as commenter (commenter.did)}
+					{@const displayUrl = getDisplayUrl(commenter)}
+					{@const showFallback = shouldShowFallback(commenter)}
+					<a
+						href="/u/{commenter.handle}"
+						class="commenter-circle"
+						title="{commenter.display_name || commenter.handle} (@{commenter.handle})"
+					>
+						{#if displayUrl && !showFallback}
+							<SensitiveImage src={displayUrl} compact>
+								<img
+									src={displayUrl}
+									alt=""
+									onerror={() => handleAvatarError(commenter.did)}
+								/>
+							</SensitiveImage>
+						{:else}
+							<span>{(commenter.display_name || commenter.handle).charAt(0).toUpperCase()}</span>
+						{/if}
+					</a>
 				{/each}
 			</div>
-		</div>
-	{:else if error}
-		<div class="error">{error}</div>
-	{:else if commenters.length > 0}
-		<div class="commenters-avatars">
-			{#each commenters as commenter (commenter.did)}
-				{@const displayUrl = getDisplayUrl(commenter)}
-				{@const showFallback = shouldShowFallback(commenter)}
-				<a
-					href="/u/{commenter.handle}"
-					class="commenter-circle"
-					title="{commenter.display_name || commenter.handle} (@{commenter.handle})"
-				>
-					{#if displayUrl && !showFallback}
-						<SensitiveImage src={displayUrl} compact>
-							<img
-								src={displayUrl}
-								alt=""
-								onerror={() => handleAvatarError(commenter.did)}
-							/>
-						</SensitiveImage>
-					{:else}
-						<span>{(commenter.display_name || commenter.handle).charAt(0).toUpperCase()}</span>
-					{/if}
-				</a>
-			{/each}
-		</div>
-	{:else}
-		<div class="empty">no comments yet</div>
-	{/if}
+		{:else}
+			<div class="empty" transition:fade={{ duration: 200 }}>no comments yet</div>
+		{/if}
+	{/key}
 </div>
 
 <style>

--- a/frontend/src/lib/components/LikersTooltip.svelte
+++ b/frontend/src/lib/components/LikersTooltip.svelte
@@ -6,6 +6,7 @@
 		triggerAvatarRefresh,
 		hasAttemptedRefresh
 	} from '$lib/avatar-refresh.svelte';
+	import { fade } from 'svelte/transition';
 	import SensitiveImage from './SensitiveImage.svelte';
 
 	interface Props {
@@ -142,43 +143,45 @@
 	onmouseenter={onMouseEnter}
 	onmouseleave={onMouseLeave}
 >
-	{#if loading}
-		<div class="loading">
-			<div class="loading-avatars">
-				{#each [1, 2, 3] as _}
-					<div class="avatar-skeleton"></div>
+	{#key loading}
+		{#if loading}
+			<div class="loading" transition:fade={{ duration: 200 }}>
+				<div class="loading-avatars">
+					{#each [1, 2, 3] as _}
+						<div class="avatar-skeleton"></div>
+					{/each}
+				</div>
+			</div>
+		{:else if error}
+			<div class="error" transition:fade={{ duration: 200 }}>{error}</div>
+		{:else if likers.length > 0}
+			<div class="likers-avatars" transition:fade={{ duration: 200 }}>
+				{#each likers as liker (liker.did)}
+					{@const displayUrl = getDisplayUrl(liker)}
+					{@const showFallback = shouldShowFallback(liker)}
+					<a
+						href="/u/{liker.handle}/liked"
+						class="liker-circle"
+						title="{liker.display_name} (@{liker.handle}) • {formatTime(liker.liked_at)}"
+					>
+						{#if displayUrl && !showFallback}
+							<SensitiveImage src={displayUrl} compact>
+								<img
+									src={displayUrl}
+									alt=""
+									onerror={() => handleAvatarError(liker.did)}
+								/>
+							</SensitiveImage>
+						{:else}
+							<span>{(liker.display_name || liker.handle).charAt(0).toUpperCase()}</span>
+						{/if}
+					</a>
 				{/each}
 			</div>
-		</div>
-	{:else if error}
-		<div class="error">{error}</div>
-	{:else if likers.length > 0}
-		<div class="likers-avatars">
-			{#each likers as liker (liker.did)}
-				{@const displayUrl = getDisplayUrl(liker)}
-				{@const showFallback = shouldShowFallback(liker)}
-				<a
-					href="/u/{liker.handle}/liked"
-					class="liker-circle"
-					title="{liker.display_name} (@{liker.handle}) • {formatTime(liker.liked_at)}"
-				>
-					{#if displayUrl && !showFallback}
-						<SensitiveImage src={displayUrl} compact>
-							<img
-								src={displayUrl}
-								alt=""
-								onerror={() => handleAvatarError(liker.did)}
-							/>
-						</SensitiveImage>
-					{:else}
-						<span>{(liker.display_name || liker.handle).charAt(0).toUpperCase()}</span>
-					{/if}
-				</a>
-			{/each}
-		</div>
-	{:else}
-		<div class="empty">be the first to like this</div>
-	{/if}
+		{:else}
+			<div class="empty" transition:fade={{ duration: 200 }}>be the first to like this</div>
+		{/if}
+	{/key}
 </div>
 
 <style>

--- a/frontend/src/lib/components/PlatformStats.svelte
+++ b/frontend/src/lib/components/PlatformStats.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { fade } from 'svelte/transition';
 	import { statsCache, formatDuration } from '$lib/stats.svelte';
 
 	interface Props {
@@ -73,12 +74,13 @@
 			</svg>
 			<span>stats</span>
 		</div>
-		{#if loading}
-			<div class="stats-menu-loading">
-				<span class="skeleton-text"></span>
-			</div>
-		{:else if stats}
-			<div class="stats-menu-grid">
+		{#key loading}
+			{#if loading}
+				<div class="stats-menu-loading" transition:fade={{ duration: 200 }}>
+					<span class="skeleton-text"></span>
+				</div>
+			{:else if stats}
+				<div class="stats-menu-grid" transition:fade={{ duration: 200 }}>
 				<div class="stats-menu-item">
 					<svg class="menu-stat-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 						<polygon points="5 3 19 12 5 21 5 3"></polygon>
@@ -111,8 +113,9 @@
 					<span class="stats-menu-value">{formatDuration(stats.total_duration_seconds)}</span>
 					<span class="stats-menu-label">of audio</span>
 				</div>
-			</div>
-		{/if}
+				</div>
+			{/if}
+		{/key}
 	</div>
 {/if}
 

--- a/frontend/src/lib/components/WaveLoading.svelte
+++ b/frontend/src/lib/components/WaveLoading.svelte
@@ -70,4 +70,10 @@
 		font-size: var(--text-base);
 		text-align: center;
 	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.bar {
+			animation: none;
+		}
+	}
 </style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -11,6 +11,7 @@
 	import { tracksCache, fetchTopTracks } from '$lib/tracks.svelte';
 	import type { Track } from '$lib/types';
 	import { auth } from '$lib/auth.svelte';
+	import { fade } from 'svelte/transition';
 	import { APP_NAME, APP_TAGLINE, APP_CANONICAL_URL } from '$lib/branding';
 	import { API_URL } from '$lib/config';
 	import {
@@ -139,36 +140,38 @@
 
 <main>
 	<!-- top tracks section -->
-	{#if loadingTopTracks}
-		<section class="top-tracks">
-			<h2>
-				top tracks
-			</h2>
-			<div class="loading-container compact">
-				<WaveLoading size="sm" message="loading..." />
-			</div>
-		</section>
-	{:else if hasTopTracks}
-		<section class="top-tracks">
-			<h2>
-				top tracks
-			</h2>
-			<div class="top-tracks-grid">
-				{#each topTracks as track, i}
-					<TrackCard
-						{track}
-						index={i}
-						isPlaying={player.currentTrack?.id === track.id}
-						onPlay={(t) => queue.playNow(t)}
-					/>
-				{/each}
-			</div>
-		</section>
-	{/if}
+	{#key loadingTopTracks}
+		{#if loadingTopTracks}
+			<section class="top-tracks" transition:fade={{ duration: 200 }}>
+				<h2>
+					top tracks
+				</h2>
+				<div class="loading-container compact">
+					<WaveLoading size="sm" message="loading..." />
+				</div>
+			</section>
+		{:else if hasTopTracks}
+			<section class="top-tracks" transition:fade={{ duration: 200 }}>
+				<h2>
+					top tracks
+				</h2>
+				<div class="top-tracks-grid">
+					{#each topTracks as track, i}
+						<TrackCard
+							{track}
+							index={i}
+							isPlaying={player.currentTrack?.id === track.id}
+							onPlay={(t) => queue.playNow(t)}
+						/>
+					{/each}
+				</div>
+			</section>
+		{/if}
+	{/key}
 
 	<!-- artists from your bluesky network -->
 	{#if hasNetworkArtists}
-		<section class="network-artists">
+		<section class="network-artists" transition:fade={{ duration: 200 }}>
 			<h2>artists you know</h2>
 			<div class="artist-grid">
 				{#each networkArtists as artist}


### PR DESCRIPTION
## Summary

- **WaveLoading**: add `@media (prefers-reduced-motion: reduce)` to disable wave animation (accessibility fix)
- **CommentersTooltip / LikersTooltip**: wrap loading/loaded `{#if}` with `{#key loading}` + `transition:fade={{ duration: 200 }}` so shimmer→content fades smoothly instead of hard-cutting
- **PlatformStats** (menu variant): same `{#key}` + fade pattern for skeleton→stats grid
- **Homepage**: fade transitions on top tracks (loading→cards) and network artists sections

Matches the gold standard set by the artist detail page analytics section.

## Not changed

- **LikersSheet** — already has proper container transitions (backdrop fade, sheet slide-up)
- **Toast** — intentionally different timing (600ms) for notifications
- **Track detail page** — already uses `fade` from `svelte/transition`

## Test plan

- [ ] `just frontend check` passes (0 errors, 0 warnings)
- [ ] load homepage — top tracks fade in from loading state, network artists section fades in
- [ ] hover like/comment counts — tooltip content fades in from shimmer skeletons
- [ ] open mobile menu — platform stats fade in from skeleton
- [ ] enable `prefers-reduced-motion: reduce` in devtools — shimmer and wave animations stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)