### PR TITLE
fix: cache network artists across navigations

### DIFF
--- a/frontend/src/lib/network-artists.svelte.ts
+++ b/frontend/src/lib/network-artists.svelte.ts
@@ -1,0 +1,50 @@
+// network artists cache - prevents refetching on navigation
+import { browser } from '$app/environment';
+import { API_URL } from '$lib/config';
+
+export interface NetworkArtist {
+	did: string;
+	handle: string;
+	display_name: string;
+	avatar_url: string | null;
+	track_count: number;
+}
+
+class NetworkArtistsCache {
+	artists = $state<NetworkArtist[]>([]);
+	loading = $state(false);
+	private lastFetch = 0;
+	private readonly CACHE_DURATION = 300_000; // 5 minutes
+
+	get hasArtists(): boolean {
+		return this.artists.length > 0;
+	}
+
+	async fetch(force = false): Promise<void> {
+		if (!browser) return;
+
+		const now = Date.now();
+		const isCacheValid =
+			this.artists.length > 0 && now - this.lastFetch < this.CACHE_DURATION;
+
+		if (!force && isCacheValid) return;
+		if (this.loading) return;
+
+		this.loading = true;
+		try {
+			const response = await fetch(`${API_URL}/discover/network`, {
+				credentials: 'include'
+			});
+			if (response.ok) {
+				this.artists = await response.json();
+				this.lastFetch = now;
+			}
+		} catch (e) {
+			console.error('failed to load network artists:', e);
+		} finally {
+			this.loading = false;
+		}
+	}
+}
+
+export const networkArtistsCache = new NetworkArtistsCache();

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -9,24 +9,16 @@
 	import { player } from '$lib/player.svelte';
 	import { queue } from '$lib/queue.svelte';
 	import { tracksCache, fetchTopTracks } from '$lib/tracks.svelte';
+	import { networkArtistsCache } from '$lib/network-artists.svelte';
 	import type { Track } from '$lib/types';
 	import { auth } from '$lib/auth.svelte';
 	import { fade } from 'svelte/transition';
 	import { APP_NAME, APP_TAGLINE, APP_CANONICAL_URL } from '$lib/branding';
-	import { API_URL } from '$lib/config';
 	import {
 		getRefreshedAvatar,
 		triggerAvatarRefresh,
 		hasAttemptedRefresh
 	} from '$lib/avatar-refresh.svelte';
-
-	interface NetworkArtist {
-		did: string;
-		handle: string;
-		display_name: string;
-		avatar_url: string | null;
-		track_count: number;
-	}
 
 	// use cached tracks
 	let tracks = $derived(tracksCache.tracks);
@@ -42,8 +34,8 @@
 	let hasTopTracks = $derived(topTracks.length > 0);
 
 	// network artists (people you follow on bluesky who have music here)
-	let networkArtists = $state<NetworkArtist[]>([]);
-	let hasNetworkArtists = $derived(networkArtists.length > 0);
+	let networkArtists = $derived(networkArtistsCache.artists);
+	let hasNetworkArtists = $derived(networkArtistsCache.hasArtists);
 
 	// show loading during initial load or when actively loading with no cached data
 	let showLoading = $derived((initialLoad && !hasTracks) || (loadingTracks && !hasTracks));
@@ -55,17 +47,10 @@
 	let sentinelElement = $state<HTMLDivElement | null>(null);
 
 	onMount(async () => {
-		const networkPromise = auth.isAuthenticated
-			? fetch(`${API_URL}/discover/network`, { credentials: 'include' })
-					.then((r) => (r.ok ? r.json() : []))
-					.then((artists: NetworkArtist[]) => (networkArtists = artists))
-					.catch(() => {})
-			: Promise.resolve();
-
 		const [topResult] = await Promise.all([
 			fetchTopTracks(10),
 			tracksCache.fetch(),
-			networkPromise
+			auth.isAuthenticated ? networkArtistsCache.fetch() : Promise.resolve()
 		]);
 		topTracks = topResult;
 		loadingTopTracks = false;


### PR DESCRIPTION
## Summary

- `networkArtists` was component-local `$state` in `+page.svelte` — destroyed every time you navigated away, re-fetched every time you came back
- Created `network-artists.svelte.ts` with a module-level singleton cache (same pattern as `tracksCache`, `statsCache`)
- 5-minute TTL, deduplicates concurrent requests, survives route changes
- On return visits to the homepage, the "artists you know" section appears instantly from cache

## Test plan

- [ ] `just frontend check` passes
- [ ] load homepage while authenticated — "artists you know" appears
- [ ] navigate to an artist page, then back to homepage — section is already there, no re-fetch
- [ ] wait 5+ minutes, navigate back — re-fetches fresh data

🤖 Generated with [Claude Code](https://claude.com/claude-code)