### PR TITLE
fix: network artists not loading on initial page load

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -47,14 +47,18 @@
 	let sentinelElement = $state<HTMLDivElement | null>(null);
 
 	onMount(async () => {
-		const [topResult] = await Promise.all([
-			fetchTopTracks(10),
-			tracksCache.fetch(),
-			auth.isAuthenticated ? networkArtistsCache.fetch() : Promise.resolve()
-		]);
+		const [topResult] = await Promise.all([fetchTopTracks(10), tracksCache.fetch()]);
 		topTracks = topResult;
 		loadingTopTracks = false;
 		initialLoad = false;
+	});
+
+	// fetch network artists reactively — auth.isAuthenticated is false on
+	// initial load and flips to true after the async /auth/me call resolves
+	$effect(() => {
+		if (auth.isAuthenticated) {
+			networkArtistsCache.fetch();
+		}
 	});
 
 	// set up IntersectionObserver for infinite scroll


### PR DESCRIPTION
## Summary

- `auth.isAuthenticated` starts as `false` and flips to `true` after an async `/auth/me` call in the root layout
- The homepage `onMount` checked `auth.isAuthenticated` synchronously — on a fresh page load it was still `false`, so the network artists fetch was skipped entirely
- Replaced the one-shot `onMount` check with a reactive `$effect` that triggers the fetch when `auth.isAuthenticated` becomes `true`
- The cache's TTL guard prevents redundant fetches on subsequent navigations

## Test plan

- [ ] `just frontend check` passes
- [ ] hard refresh the homepage while logged in — "artists you know" should appear on first load
- [ ] navigate away and back — section appears instantly from cache (no re-fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)