### PR TITLE
fix: unique alembic revision ID for thumbnail migration

### DIFF
--- a/backend/alembic/versions/2026_02_27_120000_add_thumbnail_url_column.py
+++ b/backend/alembic/versions/2026_02_27_120000_add_thumbnail_url_column.py
@@ -1,6 +1,6 @@
 """add thumbnail_url column
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: 75e853113f1b
 Revises: 97e520a2e2fa
 Create Date: 2026-02-27 12:00:00.000000
 
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "a1b2c3d4e5f6"
+revision: str = "75e853113f1b"
 down_revision: str | Sequence[str] | None = "97e520a2e2fa"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None


### PR DESCRIPTION
## Summary
- The thumbnail migration reused revision ID `a1b2c3d4e5f6` which already belongs to `add_ui_settings_jsonb`
- This caused alembic cycle detection failure, blocking both staging and prod deploys
- Assigns a unique revision ID `75e853113f1b`

## Test plan
- [ ] CI deploy succeeds (staging + prod)
- [ ] `thumbnail_url` columns exist after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)