### PR TITLE
fix: include alembic migrations in release change detection

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -67,7 +67,7 @@ def main() -> int:
 
         # check for backend changes since last release
         result = subprocess.run(
-            ["git", "log", f"{last_release}..HEAD", "--oneline", "--", "backend/src/backend/"],
+            ["git", "log", f"{last_release}..HEAD", "--oneline", "--", "backend/src/backend/", "backend/alembic/"],
             capture_output=True,
             text=True,
             check=True,


### PR DESCRIPTION
## Summary
- Release script only checked `backend/src/backend/` for changes since last release
- Migration-only commits (like the revision ID fix) were not detected, blocking `just release`
- Now also checks `backend/alembic/`

## Test plan
- [ ] `just release` succeeds after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)