### PR TITLE
refactor: use storage proxy in export_tasks

### DIFF
--- a/backend/src/backend/_internal/export_tasks.py
+++ b/backend/src/backend/_internal/export_tasks.py
@@ -256,7 +256,7 @@ async def process_export(export_id: str, artist_did: str) -> None:
                     with open(zip_path, "rb") as zip_file_obj:
                         await upload_client.upload_fileobj(
                             zip_file_obj,
-                            settings.storage.r2_bucket,
+                            storage.audio_bucket_name,
                             r2_key,
                             ExtraArgs={
                                 "ContentType": "application/zip",
@@ -279,7 +279,7 @@ async def process_export(export_id: str, artist_did: str) -> None:
                 raise
 
             # get download URL
-            download_url = f"{settings.storage.r2_public_bucket_url}/{r2_key}"
+            download_url = f"{storage.public_audio_bucket_url}/{r2_key}"
 
             # mark as completed
             await job_service.update_progress(


### PR DESCRIPTION
## Summary
- Replaces `settings.storage.r2_bucket` with `storage.audio_bucket_name` for export zip upload
- Replaces `settings.storage.r2_public_bucket_url` with `storage.public_audio_bucket_url` for download URL
- Reduces direct coupling to settings config, consistent with how the download path already uses `storage.audio_bucket_name`

Last item from the storage refactor plan (Parts 1-4 shipped in #976-978).

## Test plan
- [x] `just backend test` — 533 passed
- [x] `just frontend check` — 0 errors
- [x] pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)