### PR TITLE
fix: eliminate jam WS send-after-close race condition

### DIFF
--- a/backend/src/backend/_internal/jams.py
+++ b/backend/src/backend/_internal/jams.py
@@ -412,6 +412,11 @@ class JamService:
 
     async def disconnect_ws(self, jam_id: str, ws: WebSocket) -> None:
         """unregister a WebSocket connection."""
+        # remove from connections FIRST so _fan_out won't send to this ws
+        # while _clear_output_if_matches publishes events
+        if jam_id in self._connections:
+            self._connections[jam_id].discard(ws)
+
         # check if disconnecting WS was the output device
         disconnecting_client_id = self._ws_client_ids.pop(ws, None)
         if disconnecting_client_id:
@@ -426,17 +431,15 @@ class JamService:
         for did in dids_to_remove:
             del self._ws_by_did[did]
 
-        if jam_id in self._connections:
-            self._connections[jam_id].discard(ws)
-            if not self._connections[jam_id]:
-                del self._connections[jam_id]
-                # cancel reader if no more connections
-                if jam_id in self._reader_tasks:
-                    self._reader_tasks[jam_id].cancel()
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await self._reader_tasks[jam_id]
-                    del self._reader_tasks[jam_id]
-                    logger.info("stopped stream reader for jam %s", jam_id)
+        if jam_id in self._connections and not self._connections[jam_id]:
+            del self._connections[jam_id]
+            # cancel reader if no more connections
+            if jam_id in self._reader_tasks:
+                self._reader_tasks[jam_id].cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._reader_tasks[jam_id]
+                del self._reader_tasks[jam_id]
+                logger.info("stopped stream reader for jam %s", jam_id)
 
     async def _close_ws_for_did(self, did: str) -> None:
         """close any existing WebSocket for this DID."""


### PR DESCRIPTION
## Summary

- `disconnect_ws` called `_clear_output_if_matches` (publishes to Redis) while the closing WS was still in `self._connections`
- `_stream_reader` background task could pick up the event and `_fan_out` would send to the already-closed WS
- fix: `discard(ws)` before `_clear_output_if_matches`, matching the pattern in `_close_ws_for_did`
- also improves `_find_fallback_output` — won't consider the departing WS as a fallback candidate

## Test plan

- [x] all 52 jam tests pass
- [ ] monitor logfire for `Cannot call "send" once a close message has been sent` after deploy


🤖 Generated with [Claude Code](https://claude.com/claude-code)