### PR TITLE
fix: jam link previews showing generic branding

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -34,6 +34,7 @@
 		$page.url.pathname.startsWith('/playlist/') || // playlist detail
 		$page.url.pathname.startsWith('/tag/') || // tag detail
 		$page.url.pathname === '/liked' || // liked tracks
+		$page.url.pathname.startsWith('/jam/') || // jam invite
 		$page.url.pathname.match(/^\/u\/[^/]+$/) || // artist detail
 		$page.url.pathname.match(/^\/u\/[^/]+\/album\/[^/]+/) // album detail
 	);

--- a/frontend/src/routes/jam/[code]/+page.svelte
+++ b/frontend/src/routes/jam/[code]/+page.svelte
@@ -23,20 +23,39 @@
 </script>
 
 <svelte:head>
-	<title>joining jam - {APP_NAME}</title>
 	{#if data.preview}
 		{@const preview = data.preview}
 		{@const title = preview.name ?? `${preview.host_display_name}'s jam`}
 		{@const description =
 			preview.participant_count > 1
-				? `join ${preview.host_display_name} and ${preview.participant_count - 1} others on plyr.fm`
-				: `join ${preview.host_display_name} on plyr.fm`}
+				? `join ${preview.host_display_name} and ${preview.participant_count - 1} others on ${APP_NAME}`
+				: `${preview.host_display_name} is listening on ${APP_NAME} — join in`}
+		<title>{title} - {APP_NAME}</title>
+		<meta name="description" content={description} />
+
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
 		<meta property="og:title" content={title} />
 		<meta property="og:description" content={description} />
+		<meta property="og:url" content={`${APP_CANONICAL_URL}/jam/${preview.code}`} />
+		<meta property="og:site_name" content={APP_NAME} />
 		{#if preview.host_avatar_url}
 			<meta property="og:image" content={preview.host_avatar_url} />
+			<meta property="og:image:secure_url" content={preview.host_avatar_url} />
+			<meta property="og:image:width" content="400" />
+			<meta property="og:image:height" content="400" />
+			<meta property="og:image:alt" content="{preview.host_display_name}'s avatar" />
 		{/if}
-		<meta property="og:url" content={`${APP_CANONICAL_URL}/jam/${preview.code}`} />
+
+		<!-- Twitter -->
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content={title} />
+		<meta name="twitter:description" content={description} />
+		{#if preview.host_avatar_url}
+			<meta name="twitter:image" content={preview.host_avatar_url} />
+		{/if}
+	{:else}
+		<title>joining jam - {APP_NAME}</title>
 	{/if}
 </svelte:head>
 


### PR DESCRIPTION
## Summary
- Add `/jam/` to `hasPageMetadata` in root layout — default OG tags were rendering first, so crawlers saw the generic plyr.fm logo instead of jam-specific metadata
- Expand jam OG tags to match track/album quality: `og:type`, `og:site_name`, twitter card, image dimensions, better description copy

## Test plan
- Share a jam link in iMessage/Bluesky/Discord — should show host name + avatar instead of generic logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)