### PR TITLE
fix: jam stripe pill z-index and transparency

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -682,9 +682,8 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.3rem;
-		z-index: 1;
-		backdrop-filter: var(--glass-blur, none);
-		-webkit-backdrop-filter: var(--glass-blur, none);
+		z-index: 3;
+		background: var(--bg-tertiary);
 	}
 
 	.jam-stripe-label .muted {


### PR DESCRIPTION
## Summary
- Bump `.jam-stripe-label` z-index from 1 to 3 (glow bar `::before` is z-index 2)
- Replace semi-transparent glass background with solid `--bg-tertiary` so glow doesn't bleed through

## Test plan
- Join a jam as non-output device — "playing here" pill should sit cleanly above the glow bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)