### PR TITLE
fix: restore glass blur on stripe pill with readable text

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -672,7 +672,7 @@
 		top: 0;
 		left: 50%;
 		transform: translate(-50%, -50%);
-		background: var(--glass-bg, var(--bg-tertiary));
+		background: color-mix(in srgb, var(--bg-tertiary) 95%, transparent);
 		border: 1px solid var(--border-subtle);
 		border-radius: var(--radius-full);
 		padding: 0.1rem 0.5rem;
@@ -683,7 +683,8 @@
 		align-items: center;
 		gap: 0.3rem;
 		z-index: 3;
-		background: var(--bg-tertiary);
+		backdrop-filter: blur(8px);
+		-webkit-backdrop-filter: blur(8px);
 	}
 
 	.jam-stripe-label .muted {


### PR DESCRIPTION
## Summary
- Restore backdrop blur on jam stripe pill (was removed in #991)
- Use 95% opacity `bg-tertiary` via `color-mix` — enough to block the glow bar from bleeding through while keeping the frosted glass look

## Test plan
- Jam stripe pill should have subtle glass effect but text remains fully readable over the glow bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)