### PR TITLE
feat: allow zzstoatzz.github.io in production CORS

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -222,8 +222,8 @@ class FrontendSettings(AppSettingsSection):
             # staging: allow stg.plyr.fm
             return r"^(https://stg\.plyr\.fm|https://([a-z0-9]+\.)?relay-4i6\.pages\.dev|http://localhost:5173)$"
         elif hostname in ("plyr.fm", "www.plyr.fm"):
-            # production: allow plyr.fm and www.plyr.fm
-            return r"^(https://(www\.)?plyr\.fm|https://([a-z0-9]+\.)?relay-4i6\.pages\.dev|http://localhost:5173)$"
+            # production: allow plyr.fm, www.plyr.fm, and embed consumers
+            return r"^(https://(www\.)?plyr\.fm|https://zzstoatzz\.github\.io|https://([a-z0-9]+\.)?relay-4i6\.pages\.dev|http://localhost:5173)$"
         else:
             # local dev: allow localhost
             return r"^(http://localhost:5173)$"


### PR DESCRIPTION
## Summary
- Adds `https://zzstoatzz.github.io` to the production CORS origin allowlist
- Enables the personal site's embedded plyr.fm player to use the search API

## Context
The personal site at zzstoatzz.github.io is replacing its SoundCloud widget with a plyr.fm player that includes search. The search fetches from `api.plyr.fm/search/` which currently only allows `plyr.fm` origins.

## Test plan
- [ ] Verify existing CORS behavior unchanged for plyr.fm / www.plyr.fm
- [ ] Verify `https://zzstoatzz.github.io` can fetch from the search endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)