### PR TITLE
fix: allow zzstoatzz.io custom domain in production CORS

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -223,7 +223,7 @@ class FrontendSettings(AppSettingsSection):
             return r"^(https://stg\.plyr\.fm|https://([a-z0-9]+\.)?relay-4i6\.pages\.dev|http://localhost:5173)$"
         elif hostname in ("plyr.fm", "www.plyr.fm"):
             # production: allow plyr.fm, www.plyr.fm, and embed consumers
-            return r"^(https://(www\.)?plyr\.fm|https://zzstoatzz\.github\.io|https://([a-z0-9]+\.)?relay-4i6\.pages\.dev|http://localhost:5173)$"
+            return r"^(https://(www\.)?plyr\.fm|https://zzstoatzz\.(github\.io|io)|https://([a-z0-9]+\.)?relay-4i6\.pages\.dev|http://localhost:5173)$"
         else:
             # local dev: allow localhost
             return r"^(http://localhost:5173)$"


### PR DESCRIPTION
## Summary
- `zzstoatzz.github.io` redirects to `zzstoatzz.io`, so the browser origin is the custom domain
- Updates regex from `zzstoatzz\.github\.io` to `zzstoatzz\.(github\.io|io)` to allow both

## Context
Follow-up to #994 — the previous PR allowed `zzstoatzz.github.io` but the site's custom domain redirect means the actual browser origin is `https://zzstoatzz.io`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)