### PR TITLE
fix: track embed clipping at short heights, guard collection WIDE query

### DIFF
--- a/frontend/src/lib/components/embed/CollectionEmbed.svelte
+++ b/frontend/src/lib/components/embed/CollectionEmbed.svelte
@@ -539,7 +539,7 @@
 	}
 
 	/* ===== WIDE (>= 500px): more room for artist column ===== */
-	@container (min-width: 500px) {
+	@container (min-width: 500px) and (aspect-ratio > 1.2) {
 		.track-artist { max-width: 40%; }
 	}
 </style>

--- a/frontend/src/routes/embed/track/[id]/+page.svelte
+++ b/frontend/src/routes/embed/track/[id]/+page.svelte
@@ -361,6 +361,12 @@
 		color: rgba(255, 255, 255, 0.5);
 	}
 
+	/* --- SHORT (height < 100px): hide progress bar --- */
+	@container (max-height: 99px) {
+		.player-controls { display: none; }
+		.content { justify-content: center; }
+	}
+
 	/* --- NARROW (width < 280px): blurred bg, compact controls --- */
 	@container (max-width: 279px) {
 		.bg-image,


### PR DESCRIPTION
## Summary
- Add SHORT container query (`max-height: 99px`) to track embed — hides player-controls when container is too short, preventing clipped progress bar and time labels
- Guard CollectionEmbed WIDE query with `aspect-ratio > 1.2` to prevent it from applying in portrait containers (same fix as #996 for track embed)

## Test plan
- [ ] Track embed at ~100px height: progress bar hidden, play button + title visible
- [ ] Track embed at ~130px height: full layout with progress bar (unchanged)
- [ ] Collection embed at 500px+ wide, portrait: WIDE query doesn't apply
- [ ] Collection embed at 500px+ wide, landscape: artist column gets 40% (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)