### PR TITLE
feat: embed glow bar + share button

### DIFF
--- a/frontend/src/lib/components/embed/CollectionEmbed.svelte
+++ b/frontend/src/lib/components/embed/CollectionEmbed.svelte
@@ -23,6 +23,15 @@
 
 	let currentTrack = $derived(collection.tracks[currentIndex]);
 	let isPlayable = $derived(currentTrack?.r2_url && !currentTrack?.gated);
+	let showCopied = $state(false);
+
+	async function copyShareLink() {
+		const url = collection.collectionUrl;
+		try { await navigator.clipboard.writeText(url); }
+		catch { if (navigator.share) { try { await navigator.share({ url }); } catch { /* dismissed */ } } return; }
+		showCopied = true;
+		setTimeout(() => { showCopied = false; }, 2000);
+	}
 
 	function togglePlay() {
 		if (!isPlayable) return;
@@ -119,7 +128,16 @@
 				<span class="meta-sep">&middot;</span>
 				<a href={collection.subtitleUrl} target="_blank" rel="noopener noreferrer" class="subtitle">{collection.subtitle}</a>
 			</div>
+			<div class="actions">
+			<button class="share-btn" onclick={copyShareLink} title="copy link">
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" class="share-icon">
+					<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+					<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+				</svg>
+				{#if showCopied}<span class="copied">copied!</span>{/if}
+			</button>
 			<a href="https://plyr.fm" target="_blank" rel="noopener noreferrer" class="logo">plyr.fm</a>
+		</div>
 		</div>
 
 		<div class="track-list">
@@ -146,7 +164,7 @@
 			{/if}
 		</div>
 
-		<div class="player-bar">
+		<div class="player-bar" class:is-playing={!paused}>
 			<div class="now-playing">
 				{#if currentTrack?.image_url}
 					<img class="np-art" src={currentTrack.image_url} alt="" />
@@ -352,6 +370,13 @@
 	}
 	.logo:hover { color: var(--c-logo-hover); }
 
+	.actions { display: flex; align-items: center; gap: clamp(4px, 1.5cqi, 8px); flex-shrink: 0; }
+	.share-btn { background: none; border: none; color: var(--text-tertiary); cursor: pointer; padding: 2px; display: flex; align-items: center; position: relative; }
+	.share-btn:hover { color: var(--text-primary); }
+	.share-icon { width: var(--logo-size); height: var(--logo-size); }
+	.copied { position: absolute; top: -1.5rem; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.8); color: #fff; padding: 2px 8px; border-radius: 4px; font-size: 10px; white-space: nowrap; pointer-events: none; animation: fadeIn 0.15s ease-in; }
+	@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
 	.track-list {
 		flex: 1; overflow-y: auto; min-height: 0;
 		scrollbar-width: thin;
@@ -400,9 +425,12 @@
 		display: flex;
 		flex-direction: column;
 		gap: 4px;
-		border-top: 1px solid var(--c-progress-bg);
 		padding-top: var(--gap);
+		position: relative;
 	}
+
+	.player-bar::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 1px; background: #6a9fff; opacity: 0.32; filter: saturate(0.9) brightness(0.75); box-shadow: 0 0 0 transparent; transition: opacity 0.15s ease-out, filter 0.15s ease-out, box-shadow 0.2s ease-out; pointer-events: none; z-index: 2; }
+	.player-bar.is-playing::before { opacity: 0.95; filter: saturate(1.25) brightness(1.28); box-shadow: 0 0 6px color-mix(in srgb, #6a9fff 65%, transparent), 0 0 14px color-mix(in srgb, #6a9fff 45%, transparent); }
 
 	.now-playing {
 		display: flex;
@@ -505,6 +533,8 @@
 		}
 		.bg-image, .bg-overlay { display: block; }
 		.art-container, .track-list { display: none; }
+		.share-btn { color: rgba(255,255,255,0.5); }
+		.share-btn:hover { color: rgba(255,255,255,0.75); }
 		.np-art, .np-art-placeholder { display: none; }
 		.content { justify-content: center; gap: clamp(4px, 1.5cqi, 8px); }
 		.collection-header { flex-direction: column; gap: 0; }
@@ -518,7 +548,7 @@
 
 	/* ===== MICRO (< 200px): hide times, logo, np-meta ===== */
 	@container (max-width: 199px) {
-		.time, .logo, .np-meta { display: none; }
+		.time, .logo, .np-meta, .share-btn { display: none; }
 	}
 
 	/* ===== TALL (aspect-ratio <= 1.2, >= 200px, >= 300px height): blurred bg, vertical ===== */
@@ -536,6 +566,8 @@
 		.art-container { display: none; }
 		.content { flex: 1; }
 		.title { text-shadow: 0 1px 4px rgba(0,0,0,0.6); }
+		.share-btn { color: rgba(255,255,255,0.5); }
+		.share-btn:hover { color: rgba(255,255,255,0.75); }
 	}
 
 	/* ===== WIDE (>= 500px): more room for artist column ===== */

--- a/frontend/src/routes/embed/track/[id]/+page.svelte
+++ b/frontend/src/routes/embed/track/[id]/+page.svelte
@@ -11,6 +11,15 @@
 	let paused = $state(true);
 	let currentTime = $state(0);
 	let duration = $state(0);
+	let showCopied = $state(false);
+
+	async function copyShareLink() {
+		const url = `https://plyr.fm/track/${track.id}`;
+		try { await navigator.clipboard.writeText(url); }
+		catch { if (navigator.share) { try { await navigator.share({ url }); } catch { /* dismissed */ } } return; }
+		showCopied = true;
+		setTimeout(() => { showCopied = false; }, 2000);
+	}
 
 	function togglePlay() {
 		if (audio.paused) {
@@ -45,7 +54,7 @@
 	});
 </script>
 
-<div class="embed-container">
+<div class="embed-container" class:is-playing={!paused}>
 	<!-- background image for mobile layout -->
 	{#if track.image_url}
 		<SensitiveImage src={track.image_url}>
@@ -95,9 +104,16 @@
 				<a href="https://plyr.fm/u/{track.artist_handle}" target="_blank" rel="noopener noreferrer" class="artist">{track.artist}</a>
 			</div>
 
-			<a href="https://plyr.fm" target="_blank" rel="noopener noreferrer" class="logo">
-				plyr.fm
-			</a>
+			<div class="actions">
+				<button class="share-btn" onclick={copyShareLink} title="copy link">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" class="share-icon">
+						<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+						<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+					</svg>
+					{#if showCopied}<span class="copied">copied!</span>{/if}
+				</button>
+				<a href="https://plyr.fm" target="_blank" rel="noopener noreferrer" class="logo">plyr.fm</a>
+			</div>
 		</div>
 
 		<div class="player-controls">
@@ -148,6 +164,9 @@
 		--time-size: clamp(10px, 3cqi, 12px);
 		--logo-size: clamp(8px, 2.5cqi, 12px);
 	}
+
+	.embed-container::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 1px; background: #6a9fff; opacity: 0.32; filter: saturate(0.9) brightness(0.75); box-shadow: 0 0 0 transparent; transition: opacity 0.15s ease-out, filter 0.15s ease-out, box-shadow 0.2s ease-out; pointer-events: none; z-index: 2; }
+	.embed-container.is-playing::before { opacity: 0.95; filter: saturate(1.25) brightness(1.28); box-shadow: 0 0 6px color-mix(in srgb, #6a9fff 65%, transparent), 0 0 14px color-mix(in srgb, #6a9fff 45%, transparent); }
 
 	.bg-image {
 		display: none;
@@ -292,6 +311,13 @@
 		color: var(--text-muted);
 	}
 
+	.actions { display: flex; align-items: center; gap: clamp(4px, 1.5cqi, 8px); flex-shrink: 0; }
+	.share-btn { background: none; border: none; color: var(--text-tertiary); cursor: pointer; padding: 2px; display: flex; align-items: center; position: relative; }
+	.share-btn:hover { color: var(--text-primary); }
+	.share-icon { width: var(--logo-size); height: var(--logo-size); }
+	.copied { position: absolute; top: -1.5rem; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.8); color: #fff; padding: 2px 8px; border-radius: 4px; font-size: 10px; white-space: nowrap; pointer-events: none; animation: fadeIn 0.15s ease-in; }
+	@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
 	.player-controls {
 		display: flex;
 		align-items: center;
@@ -401,6 +427,9 @@
 			color: rgba(255, 255, 255, 0.75);
 		}
 
+		.share-btn { color: rgba(255, 255, 255, 0.5); }
+		.share-btn:hover { color: rgba(255, 255, 255, 0.75); }
+
 		.time {
 			color: rgba(255, 255, 255, 0.6);
 		}
@@ -416,7 +445,7 @@
 
 	/* --- MICRO (width < 200px): hide time labels, minimal UI --- */
 	@container (max-width: 199px) {
-		.time {
+		.time, .share-btn {
 			display: none;
 		}
 
@@ -484,6 +513,9 @@
 		.logo:hover {
 			color: rgba(255, 255, 255, 0.75);
 		}
+
+		.share-btn { color: rgba(255, 255, 255, 0.5); }
+		.share-btn:hover { color: rgba(255, 255, 255, 0.75); }
 
 		.time {
 			color: rgba(255, 255, 255, 0.6);

--- a/loq.toml
+++ b/loq.toml
@@ -147,7 +147,7 @@ max_lines = 724
 
 [[rules]]
 path = "frontend/src/routes/embed/track/\\[id\\]/+page.svelte"
-max_lines = 522
+max_lines = 555
 
 [[rules]]
 path = "frontend/src/routes/library/+page.svelte"
@@ -219,4 +219,4 @@ max_lines = 535
 
 [[rules]]
 path = "frontend/src/lib/components/embed/CollectionEmbed.svelte"
-max_lines = 550
+max_lines = 580


### PR DESCRIPTION
## Summary
- Adds a 1px accent-colored glow bar to track and collection embeds that lights up on playback and dims on pause (matching main Player `::before` style)
- Adds an inline share button (link icon) that copies the plyr.fm page URL with "copied!" tooltip feedback — no auth dependency
- Container-query-aware: hidden in MICRO, white-themed in blurred-bg modes (NARROW, SQUARE/TALL)

## Test plan
- [ ] Wide: glow bar at top, share + logo in header, progress bar visible
- [ ] Square/Tall: glow bar on blurred bg, share visible with white theme
- [ ] Narrow: glow bar, share matches white theme
- [ ] Micro: share hidden, glow bar still visible
- [ ] Short: glow bar visible, share visible, no progress bar
- [ ] Collection: glow above player-bar, share next to logo
- [ ] Click share → "copied!" tooltip appears, URL is the plyr.fm page URL (not embed URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)