### PR TITLE
fix: histogram 500 — CAST() instead of :: to avoid SQLAlchemy bind collision

### DIFF
--- a/backend/src/backend/api/activity.py
+++ b/backend/src/backend/api/activity.py
@@ -249,10 +249,10 @@ async def get_activity_feed(
 
 
 _HISTOGRAM_QUERY = """
-    SELECT d::date AS bucket_date, COALESCE(c.total, 0) AS total
-    FROM generate_series(:start::date, :end_date::date, '1 day') d
+    SELECT CAST(d AS date) AS bucket_date, COALESCE(c.total, 0) AS total
+    FROM generate_series(CAST(:start AS date), CAST(:end_date AS date), '1 day') d
     LEFT JOIN (
-        SELECT created_at::date AS day, COUNT(*) AS total FROM (
+        SELECT CAST(created_at AS date) AS day, COUNT(*) AS total FROM (
             SELECT tl.created_at FROM track_likes tl WHERE tl.created_at >= :start
             UNION ALL
             SELECT t.created_at FROM tracks t WHERE t.created_at >= :start
@@ -262,7 +262,7 @@ _HISTOGRAM_QUERY = """
             SELECT a.created_at FROM artists a
                 WHERE a.handle != '' AND a.display_name != '' AND a.created_at >= :start
         ) events GROUP BY day
-    ) c ON c.day = d::date
+    ) c ON c.day = CAST(d AS date)
     ORDER BY bucket_date
 """
 


### PR DESCRIPTION
## Summary
- `/activity/histogram` has been 500ing on every request in production
- Root cause: `:start::date` in raw SQL is ambiguous for SQLAlchemy's `text()` parser — it consumes `:start` as a bind parameter, then `::date` becomes a syntax error
- Fix: use `CAST(:start AS date)` instead of `:start::date`
- Confirmed via Logfire: every histogram request returns 500 with `ProgrammingError: syntax error at or near ":"`

## Test plan
- [ ] `just backend test` passes (546 passed)
- [ ] `/activity/histogram?days=7` returns 200 with bucket data
- [ ] sparkline renders on the activity page

🤖 Generated with [Claude Code](https://claude.com/claude-code)