### PR TITLE
fix: align action icon with header avatar horizontally

### DIFF
--- a/frontend/src/routes/activity/+page.svelte
+++ b/frontend/src/routes/activity/+page.svelte
@@ -425,7 +425,10 @@
 		font-size: var(--text-sm); color: var(--text-tertiary); margin: 0;
 		line-height: 1.2; display: flex; align-items: center; gap: 0.375rem;
 	}
-	.action-icon { flex-shrink: 0; opacity: 0.6; color: var(--type-color); line-height: 0; }
+	.action-icon {
+		flex-shrink: 0; opacity: 0.6; color: var(--type-color); line-height: 0;
+		margin: 0 3px; /* center 14px icon in 20px space to align with header avatar */
+	}
 	.verb {
 		font-size: var(--text-xs);
 		color: color-mix(in srgb, var(--text-tertiary) 70%, var(--accent));


### PR DESCRIPTION
## Summary
- header avatar is 20px, action icon SVG is 14px — text on each line started at different horizontal positions (6px offset)
- added 3px horizontal margin on action icon to center it in 20px space, matching the avatar width
- "liked" / "uploaded" / "commented on" now aligns with the display name above

## Test plan
- [ ] verb text ("liked", "uploaded") aligns horizontally with display name
- [ ] icons visually centered under the header avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)