### PR TITLE
fix: center-align action icons with header avatar

### DIFF
--- a/frontend/src/routes/activity/+page.svelte
+++ b/frontend/src/routes/activity/+page.svelte
@@ -209,7 +209,7 @@
 						</div>
 						{#if event.type === 'like' && event.track}
 							<p class="event-action">
-								<svg class="action-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+								<span class="icon-slot"><svg class="action-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></span>
 								<span class="verb">liked</span> <a href="/track/{event.track.id}" class="track-link">{event.track.title}</a>
 								{#if event.track.artist_handle && !isSelfAction}
 									<span class="by-artist">by</span>
@@ -228,12 +228,12 @@
 							</p>
 						{:else if event.type === 'track' && event.track}
 							<p class="event-action">
-								<svg class="action-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+								<span class="icon-slot"><svg class="action-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg></span>
 								<span class="verb">uploaded</span> <a href="/track/{event.track.id}" class="track-link">{event.track.title}</a>
 							</p>
 						{:else if event.type === 'comment' && event.track}
 							<p class="event-action">
-								<svg class="action-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+								<span class="icon-slot"><svg class="action-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
 								<span class="verb">commented on</span> <a href="/track/{event.track.id}" class="track-link">{event.track.title}</a>
 								{#if event.track.artist_handle && !isSelfAction}
 									<span class="by-artist">by</span>
@@ -252,7 +252,7 @@
 							</p>
 						{:else if event.type === 'join'}
 							<p class="event-action">
-								<svg class="action-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg>
+								<span class="icon-slot"><svg class="action-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg></span>
 								<span class="verb">joined</span> plyr.fm
 							</p>
 						{/if}
@@ -425,10 +425,11 @@
 		font-size: var(--text-sm); color: var(--text-tertiary); margin: 0;
 		line-height: 1.2; display: flex; align-items: center; gap: 0.375rem;
 	}
-	.action-icon {
-		flex-shrink: 0; opacity: 0.6; color: var(--type-color); line-height: 0;
-		margin: 0 3px; /* center 14px icon in 20px space to align with header avatar */
+	.icon-slot {
+		width: 20px; flex-shrink: 0;
+		display: flex; align-items: center; justify-content: center;
 	}
+	.action-icon { opacity: 0.6; color: var(--type-color); }
 	.verb {
 		font-size: var(--text-xs);
 		color: color-mix(in srgb, var(--text-tertiary) 70%, var(--accent));


### PR DESCRIPTION
## Summary
- wraps each action SVG in a 20px-wide flex container (`icon-slot`) with `justify-content: center`
- the 14px icon is now centered within the same 20px width as the header avatar
- the geometric centers of avatar and icon sit on the same vertical axis

reverts the margin approach from #1014 which didn't address the actual centering issue.

## Test plan
- [ ] draw a vertical line through the center of the header avatar — it passes through the center of the action icon below

🤖 Generated with [Claude Code](https://claude.com/claude-code)