### PR TITLE
fix: deduplicate pulse icon — new status page icon

### DIFF
--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -39,7 +39,8 @@
 			title="view status page"
 		>
 			<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-				<polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+				<rect x="6" y="14" width="4" height="6" rx="1"></rect>
+				<rect x="14" y="8" width="4" height="12" rx="1"></rect>
 			</svg>
 		</a>
 		<a


### PR DESCRIPTION
## Summary
- Swaps the status page link icon from pulse (heartbeat) to ascending bars
- Pulse icon is now exclusively used for the activity link on the homepage
- No more duplicate icons

## Test plan
- [ ] Status page link in left margin shows bar chart icon, not pulse
- [ ] Activity link on homepage still shows pulse icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)