### PR TITLE
fix: update status icon in mobile LinksMenu

### DIFF
--- a/frontend/src/lib/components/LinksMenu.svelte
+++ b/frontend/src/lib/components/LinksMenu.svelte
@@ -97,8 +97,8 @@
 						stroke-linecap="round"
 						stroke-linejoin="round"
 					>
-						<polyline points="22 12 18 12 15 21 9 3 6 12 2 12"
-						></polyline>
+						<rect x="6" y="14" width="4" height="6" rx="1"></rect>
+						<rect x="14" y="8" width="4" height="12" rx="1"></rect>
 					</svg>
 					<div class="link-info">
 						<span class="link-title">status page</span>


### PR DESCRIPTION
## Summary
- Updates the status page icon in LinksMenu (mobile) to ascending bars, matching the desktop header change from #1018

## Test plan
- [ ] Mobile links menu shows bar chart icon for status page

🤖 Generated with [Claude Code](https://claude.com/claude-code)