### PR TITLE
chore: pin atproto dependency to oauth-full branch

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "sqlalchemy>=2.0.36",
     "alembic>=1.14.0",
     "asyncpg>=0.30.0",
-    "atproto @ git+https://github.com/zzstoatzz/atproto@main",
+    "atproto @ git+https://github.com/zzstoatzz/atproto@oauth-full",
     "boto3>=1.37.0",
     "python-multipart>=0.0.20",
     "python-jose[cryptography]>=3.3.0",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -302,8 +302,8 @@ wheels = [
 
 [[package]]
 name = "atproto"
-version = "0.0.1.dev477"
-source = { git = "https://github.com/zzstoatzz/atproto?rev=main#14ed65941fa0dd5404dd5bdc22138142ce159bbf" }
+version = "0.0.2.dev1"
+source = { git = "https://github.com/zzstoatzz/atproto?rev=oauth-full#3459f9f696c0f32a81e2d6ae24a87cbcb2bf7d1f" }
 dependencies = [
     { name = "click" },
     { name = "cryptography" },
@@ -381,7 +381,7 @@ requires-dist = [
     { name = "aioboto3", specifier = ">=15.5.0" },
     { name = "alembic", specifier = ">=1.14.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
-    { name = "atproto", git = "https://github.com/zzstoatzz/atproto?rev=main" },
+    { name = "atproto", git = "https://github.com/zzstoatzz/atproto?rev=oauth-full" },
     { name = "beartype", specifier = ">=0.22.8" },
     { name = "boto3", specifier = ">=1.37.0" },
     { name = "cachetools", specifier = ">=6.2.1" },


### PR DESCRIPTION
## Summary

- pins `atproto` git dependency from `@main` to `@oauth-full`
- `main` was slimmed down for upstream PR (MarshalX/atproto#636) and no longer has the scopes library plyr.fm depends on
- also set `strict = false` in the fork's `poetry-dynamic-versioning` config so uv's shallow clones can build it

## Test plan

- [x] `uv lock` and `uv sync` succeed locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)