### PR TITLE
fix: playcount lock not reactive — plays silently lost

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -374,10 +374,7 @@
 						currentBlobUrl = src;
 					}
 
-					player.audioElement.src = src;
-					player.audioElement.load();
-
-					// wait for audio to be ready before allowing playback
+					// attach listener BEFORE load() to avoid race with cached audio
 					player.audioElement.addEventListener(
 						'loadeddata',
 						() => {
@@ -397,6 +394,9 @@
 						},
 						{ once: true }
 					);
+
+					player.audioElement.src = src;
+					player.audioElement.load();
 				})
 				.catch((err) => {
 					isLoadingTrack = false;

--- a/frontend/src/lib/player.svelte.ts
+++ b/frontend/src/lib/player.svelte.ts
@@ -22,7 +22,7 @@ class PlayerState {
 
 	// lock play counting during track transitions to prevent spurious fires
 	// from stale currentTime/duration values before new audio loads
-	private _playCountLocked = false;
+	private _playCountLocked = $state(false);
 
 	setRef(code: string | null, trackId: number | null = null) {
 		this.ref = code;


### PR DESCRIPTION
## Summary

- `_playCountLocked` was a plain class field, not `$state()`. The `$effect` calling `incrementPlayCount()` never re-evaluated when the lock was released after `loadeddata`, so **zero play counts fired after the first track transition**
- Moved `loadeddata` listener attachment before `.load()` to prevent race with cached audio

## Root cause

Introduced in #1024 (scrobble dedup). The lock mechanism worked correctly in isolation, but because the field wasn't reactive, Svelte's effect system couldn't track it as a dependency.

## Test plan

- [ ] Play a track past 30s threshold — play count should increment
- [ ] Switch tracks, play past threshold — second track should also count
- [ ] Verify in logfire: `POST /tracks/{id}/play` requests appearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)