### PR TITLE
fix: CORS regex rejects plyr.fm subdomains

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -219,11 +219,11 @@ class FrontendSettings(AppSettingsSection):
         hostname = parsed.hostname or "localhost"
 
         if hostname == "stg.plyr.fm":
-            # staging: allow stg.plyr.fm
-            return r"^(https://stg\.plyr\.fm|https://([a-z0-9]+\.)?relay-4i6\.pages\.dev|http://localhost:5173)$"
+            # staging: allow stg.plyr.fm and *.stg.plyr.fm subdomains
+            return r"^(https://([a-z0-9-]+\.)?stg\.plyr\.fm|https://([a-z0-9]+\.)?relay-4i6\.pages\.dev|http://localhost:5173)$"
         elif hostname in ("plyr.fm", "www.plyr.fm"):
-            # production: allow plyr.fm, www.plyr.fm, and embed consumers
-            return r"^(https://(www\.)?plyr\.fm|https://zzstoatzz\.(github\.io|io)|https://([a-z0-9]+\.)?relay-4i6\.pages\.dev|http://localhost:5173)$"
+            # production: allow plyr.fm, *.plyr.fm subdomains, and embed consumers
+            return r"^(https://([a-z0-9-]+\.)?plyr\.fm|https://zzstoatzz\.(github\.io|io)|https://([a-z0-9]+\.)?relay-4i6\.pages\.dev|http://localhost:5173)$"
         else:
             # local dev: allow localhost
             return r"^(http://localhost:5173)$"

--- a/backend/tests/test_cors_origins.py
+++ b/backend/tests/test_cors_origins.py
@@ -1,0 +1,98 @@
+import os
+import re
+
+import pytest
+
+from backend.config import FrontendSettings
+
+
+def _make_settings(frontend_url: str) -> FrontendSettings:
+    """create FrontendSettings with the given FRONTEND_URL."""
+    env = os.environ.copy()
+    os.environ["FRONTEND_URL"] = frontend_url
+    try:
+        return FrontendSettings()
+    finally:
+        os.environ.clear()
+        os.environ.update(env)
+
+
+def _matches(pattern: str, origin: str) -> bool:
+    return re.match(pattern, origin) is not None
+
+
+class TestProductionCorsOrigins:
+    """CORS regex for production (FRONTEND_URL=https://plyr.fm)."""
+
+    @pytest.fixture
+    def regex(self) -> str:
+        return _make_settings("https://plyr.fm").resolved_cors_origin_regex
+
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "https://plyr.fm",
+            "https://www.plyr.fm",
+            "https://docs.plyr.fm",
+            "https://stg.plyr.fm",
+            "https://zzstoatzz.github.io",
+            "https://zzstoatzz.io",
+            "http://localhost:5173",
+        ],
+    )
+    def test_allowed(self, regex: str, origin: str) -> None:
+        assert _matches(regex, origin), f"{origin} should be allowed"
+
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "https://evil-plyr.fm",
+            "https://notplyr.fm",
+            "http://plyr.fm",
+        ],
+    )
+    def test_rejected(self, regex: str, origin: str) -> None:
+        assert not _matches(regex, origin), f"{origin} should be rejected"
+
+
+class TestStagingCorsOrigins:
+    """CORS regex for staging (FRONTEND_URL=https://stg.plyr.fm)."""
+
+    @pytest.fixture
+    def regex(self) -> str:
+        return _make_settings("https://stg.plyr.fm").resolved_cors_origin_regex
+
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "https://stg.plyr.fm",
+            "https://docs.stg.plyr.fm",
+            "http://localhost:5173",
+        ],
+    )
+    def test_allowed(self, regex: str, origin: str) -> None:
+        assert _matches(regex, origin), f"{origin} should be allowed"
+
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "https://plyr.fm",
+            "https://evil-stg.plyr.fm",
+        ],
+    )
+    def test_rejected(self, regex: str, origin: str) -> None:
+        assert not _matches(regex, origin), f"{origin} should be rejected"
+
+
+class TestLocalDevCorsOrigins:
+    """CORS regex for local dev (FRONTEND_URL=http://localhost:5173)."""
+
+    @pytest.fixture
+    def regex(self) -> str:
+        return _make_settings("http://localhost:5173").resolved_cors_origin_regex
+
+    def test_allows_localhost(self, regex: str) -> None:
+        assert _matches(regex, "http://localhost:5173")
+
+    def test_rejects_remote(self, regex: str) -> None:
+        assert not _matches(regex, "https://plyr.fm")


### PR DESCRIPTION
## Summary
- widen CORS origin regex to allow all `*.plyr.fm` subdomains (was only `plyr.fm` + `www.plyr.fm`)
- same fix for staging (`*.stg.plyr.fm`)
- `docs.plyr.fm` landing page stats/search were blocked by this

## Test plan
- [x] 17 new regression tests in `test_cors_origins.py` — all pass
- [ ] after deploy, verify `docs.plyr.fm` stats and search work (no CORS errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)