### PR TITLE
docs: center embeds, fix stat card heights, add contact

### DIFF
--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -107,6 +107,7 @@
 /* trending tracks */
 .trending-section {
   max-width: 32rem;
+  margin: 0 auto;
 }
 
 .trending-container {
@@ -141,7 +142,7 @@
 /* stats cards */
 .stats-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  grid-template-columns: repeat(4, 1fr);
   gap: 1rem;
 }
 
@@ -170,6 +171,7 @@
 /* track search */
 .search-section {
   max-width: 32rem;
+  margin: 0 auto;
 }
 
 #track-search-input {

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -88,3 +88,9 @@ import HeroWaveform from '../../components/HeroWaveform.astro';
     the API is public. build your own player, analytics, or recommendation engine — the data is open.
   </p>
 </div>
+
+<div class="landing-section" style="text-align: center; margin-top: 4rem;">
+  <p style="color: var(--sl-color-gray-3); font-size: 0.8rem;">
+    questions? <a href="mailto:plyrdotfm@proton.me" style="color: var(--sl-color-accent);">plyrdotfm@proton.me</a>
+  </p>
+</div>


### PR DESCRIPTION
## Summary

- **center embeds on desktop**: trending tracks and search sections now use `margin: 0 auto` so they're centered instead of left-aligned
- **fix stat card heights**: stats grid uses `repeat(4, 1fr)` instead of `auto-fit` — the tracks card was rendering taller than the others
- **add contact email**: `plyrdotfm@proton.me` at the bottom of the landing page

## Test plan

- [ ] `cd docs-site && bun run build` passes
- [ ] desktop: embeds and search centered in the content area
- [ ] all four stat cards render at equal height
- [ ] contact email visible at bottom of landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)