### PR TITLE
docs: full-width embeds, fix stats single row

### DIFF
--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -106,8 +106,6 @@
 
 /* trending tracks */
 .trending-section {
-  max-width: 32rem;
-  margin: 0 auto;
 }
 
 .trending-container {
@@ -141,19 +139,20 @@
 
 /* stats cards */
 .stats-grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  display: flex;
   gap: 1rem;
 }
 
 .stat-card {
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1.25rem 1rem;
+  padding: 1.25rem 0.5rem;
   border: 1px solid var(--sl-color-gray-4);
   border-radius: 0.5rem;
   background: var(--sl-color-gray-6);
+  min-width: 0;
 }
 
 .stat-value {
@@ -166,12 +165,11 @@
   font-size: 0.8rem;
   color: var(--sl-color-gray-2);
   margin-top: 0.25rem;
+  white-space: nowrap;
 }
 
 /* track search */
 .search-section {
-  max-width: 32rem;
-  margin: 0 auto;
 }
 
 #track-search-input {
@@ -278,26 +276,16 @@
   }
 
   .stats-grid {
-    grid-template-columns: repeat(2, 1fr);
+    flex-wrap: wrap;
     gap: 0.75rem;
   }
 
   .stat-card {
-    padding: 1rem 0.75rem;
+    flex: 1 1 calc(50% - 0.75rem);
+    padding: 1rem 0.5rem;
   }
 
   .stat-value {
     font-size: 1.5rem;
-  }
-
-  .trending-section,
-  .search-section {
-    max-width: 100%;
-  }
-}
-
-@media (max-width: 480px) {
-  .stats-grid {
-    grid-template-columns: 1fr 1fr;
   }
 }


### PR DESCRIPTION
## Summary

- **embeds + search fill page width**: removed `max-width: 32rem` from trending tracks and search sections — they now fill the `landing-section` width (48rem, centered) naturally. no more left-aligned awkwardness with "hear it" heading.
- **stats cards in a single row**: switched from CSS grid (`repeat(4, 1fr)` which was wrapping to 2x2) to flexbox with `flex: 1` and no wrapping. all 4 cards stay in one row on desktop, equal height. wraps to 2x2 on mobile (768px breakpoint).

## Test plan

- [ ] `cd docs-site && bun run build` passes
- [ ] desktop: embeds fill page width, "hear it" heading aligned with embeds
- [ ] desktop: all 4 stat cards in a single row, same height
- [ ] mobile: stats wrap to 2x2, embeds stack vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)