### PR TITLE
docs: overhaul contributing page, add contribute skill

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,51 +2,81 @@
 title: "contributing"
 ---
 
-plyr.fm is open source on [tangled.org](https://tangled.org/zzstoatzz.io/plyr.fm). contributions welcome.
+plyr.fm is open source. development happens on [GitHub](https://github.com/zzstoatzz/plyr.fm) (mirrored to [tangled.org](https://tangled.org/zzstoatzz.io/plyr.fm)). contributions welcome — fork the repo and open a PR.
+
+## using a coding assistant?
+
+if you're using Claude Code, Cursor, Codex, or similar — copy the prompt below into your assistant to get oriented:
+
+```
+i want to contribute to plyr.fm. the repo is at https://github.com/zzstoatzz/plyr.fm
+
+read the CLAUDE.md at the repo root for project context, then read STATUS.md
+for active tasks. fork the repo, make your change on a branch, run linting
+(just backend lint / just frontend check), add tests for bug fixes, and open a PR.
+
+the stack is FastAPI + SvelteKit + Postgres + Redis. use `uv` for Python, `bun`
+for frontend, and `just` as the task runner. see backend/.env.example for all
+environment variables.
+```
+
+or install the [contribute skill](https://github.com/zzstoatzz/plyr.fm/tree/main/skills/contribute) for richer agent context.
 
 ## prerequisites
 
 - [uv](https://docs.astral.sh/uv/) (Python 3.11+)
 - [bun](https://bun.sh/) (frontend)
 - [just](https://just.systems/) (task runner)
+- [docker](https://www.docker.com/) (for Redis and test databases)
 
 ## quickstart
 
 ```bash
-gh repo clone zzstoatzz/plyr.fm
+# fork on github, then clone your fork
+gh repo fork zzstoatzz/plyr.fm --clone
 cd plyr.fm
 
+# install dependencies
 uv sync
 cd frontend && bun install && cd ..
 
-cp .env.example .env
-# edit .env with your credentials
+# configure environment
+cp backend/.env.example backend/.env
+# edit backend/.env — see the setup guide linked below for details
+```
 
-# terminal 1
+### running the stack
+
+```bash
+# start redis (required for background tasks)
+just dev-services
+
+# terminal 1 — backend (port 8001, hot reloads)
 just backend run
 
-# terminal 2
+# terminal 2 — frontend (port 5173, hot reloads)
 just frontend run
 ```
 
-visit http://localhost:5173 to see the app.
+the backend needs a Postgres connection. you can use the [Neon](https://neon.tech) dev instance or a local Postgres — set `DATABASE_URL` in your `.env`. see [`backend/.env.example`](https://github.com/zzstoatzz/plyr.fm/blob/main/backend/.env.example) for all configuration options and the [local development setup guide](https://github.com/zzstoatzz/plyr.fm/blob/main/docs-internal/local-development/setup.md) for detailed walkthrough.
 
 ## workflow
 
 1. check [`STATUS.md`](https://github.com/zzstoatzz/plyr.fm/blob/main/STATUS.md) for active tasks
 2. [open an issue](https://github.com/zzstoatzz/plyr.fm/issues) describing the change
-3. branch from `main`, make your changes
-4. open a PR — never push directly to main
+3. fork the repo, branch from `main`, make your changes
+4. open a PR from your fork
 
 ## useful commands
 
 ```bash
 just backend run          # start backend
 just frontend run         # start frontend
-just backend test         # run tests (from repo root)
-just backend lint         # lint python (ruff)
-just frontend check       # lint svelte
-just backend migrate-up   # apply migrations
+just dev-services         # start redis
+just backend test         # run tests (spins up isolated postgres + redis)
+just backend lint         # type check + ruff
+just frontend check       # svelte type check
+just backend migrate-up   # apply database migrations
 ```
 
 ## conventions
@@ -56,5 +86,6 @@ just backend migrate-up   # apply migrations
 - **lowercase aesthetic** in naming, docs, and commits
 - SvelteKit with **Svelte 5 Runes** (`$state`, `$derived`, `$effect`)
 - use `uv` for Python (never `pip`)
+- add regression tests when fixing bugs
 
-detailed internal documentation (environment setup, deployment, architecture) is available to active contributors in the `docs-internal/` directory.
+detailed internal documentation (environment setup, deployment, architecture) is in [`docs-internal/`](https://github.com/zzstoatzz/plyr.fm/tree/main/docs-internal).

--- a/skills/contribute/SKILL.md
+++ b/skills/contribute/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: contribute
+description: Contributing to plyr.fm — an audio streaming app built on ATProto. Use when making changes to the plyr.fm codebase, fixing bugs, adding features, or opening pull requests.
+metadata:
+  author: zzstoatzz
+  repo: https://github.com/zzstoatzz/plyr.fm
+---
+
+# contributing to plyr.fm
+
+## orientation
+
+1. read `CLAUDE.md` at the repo root — it has project structure, stack details, and rules
+2. read `STATUS.md` for active tasks and known issues
+3. check [open issues](https://github.com/zzstoatzz/plyr.fm/issues) for things to work on
+
+## stack
+
+- **backend**: FastAPI, SQLAlchemy, Neon Postgres, Cloudflare R2 — in `backend/`
+- **frontend**: SvelteKit (Svelte 5 Runes), Bun — in `frontend/`
+- **task runner**: `just` (justfiles at root, `backend/`, `frontend/`, etc.)
+- **python**: always use `uv`, never `pip`
+- **services**: Redis (via `just dev-services`), transcoder (Rust), moderation (Rust)
+
+## making changes
+
+1. fork `zzstoatzz/plyr.fm` on GitHub
+2. branch from `main`
+3. make your changes
+4. run linting before committing:
+   - `just backend lint` — python type checking + ruff
+   - `just frontend check` — svelte type check
+5. add regression tests for bug fixes (`just backend test` runs them)
+6. open a PR from your fork — describe what changed and why
+
+## key rules
+
+- type hints required everywhere (Python and TypeScript)
+- async everywhere — never block the event loop (`anyio`/`aiofiles`)
+- lowercase aesthetic in naming, docs, commits
+- imports at the top of files — only defer to break circular deps
+- never hardcode ATProto NSIDs — they're environment-aware via settings
+- session IDs in HttpOnly cookies — never use localStorage for auth
+
+## running locally
+
+```bash
+uv sync && cd frontend && bun install && cd ..
+cp backend/.env.example backend/.env
+# edit backend/.env — needs DATABASE_URL at minimum
+
+just dev-services    # redis
+just backend run     # port 8001
+just frontend run    # port 5173
+```
+
+see `backend/.env.example` for all env vars. see `docs-internal/local-development/setup.md` for detailed walkthrough.
+
+## environment variables
+
+the backend requires a `.env` file. key vars:
+
+- `DATABASE_URL` — postgres connection (Neon dev instance or local)
+- `ATPROTO_CLIENT_ID`, `ATPROTO_CLIENT_SECRET`, `ATPROTO_REDIRECT_URI` — OAuth config
+- `STORAGE_BACKEND` — "filesystem" for local dev (no R2 needed)
+- `DOCKET_URL` — redis URL for background tasks (optional, falls back to asyncio)
+
+## useful commands
+
+```
+just backend run          # start backend (hot reload)
+just frontend run         # start frontend (hot reload)
+just dev-services         # start redis
+just backend test         # run tests (isolated postgres + redis via docker)
+just backend lint         # type check + ruff
+just frontend check       # svelte type check
+just backend migrate-up   # apply migrations
+just backend migrate "msg" # create migration
+```
+
+## project structure
+
+```
+backend/src/backend/
+├── api/          # public endpoints
+├── _internal/    # auth, PDS, uploads
+├── models/       # SQLAlchemy schemas
+├── storage/      # R2 and filesystem
+└── utilities/    # config, helpers
+
+frontend/src/
+├── routes/       # pages (+page.svelte, +page.server.ts)
+└── lib/          # components & state (.svelte.ts)
+```
+
+## further reading
+
+- `docs-internal/` — detailed architecture, deployment, testing docs
+- `docs/lexicons/overview.md` — ATProto record schemas
+- `backend/.env.example` — all configuration options


### PR DESCRIPTION
## Summary

- **contributing page rewrite**: GitHub is primary remote (tangled.org is mirror), fork-based workflow, Redis/Postgres requirements documented, links to `.env.example` and internal setup guide
- **coding assistant prompt**: copy-pasteable prompt at the top of the page for Claude Code / Cursor / Codex users
- **contribute skill**: `skills/contribute/SKILL.md` following the [agentskills.io](https://agentskills.io) spec — gives coding assistants project context, stack details, key rules, and local dev setup

## Test plan

- [ ] `cd docs-site && bun run build` passes
- [ ] contributing page: mentions GitHub as primary, fork workflow, Redis, Postgres, .env.example link
- [ ] skill file validates against agentskills spec (name matches dir, frontmatter present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)