### PR TITLE
docs: link docs.plyr.fm from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ live dashboard: https://plyr.fm/costs
 
 ## links
 
+- **docs**: https://docs.plyr.fm
 - **production**: https://plyr.fm
 - **staging**: https://stg.plyr.fm
 - **API docs**: https://api.plyr.fm/docs
 - **python SDK / MCP server**: [plyrfm](https://github.com/zzstoatzz/plyr-python-client) ([PyPI](https://pypi.org/project/plyrfm/))
-- **documentation**: [docs/README.md](docs/README.md)
 - **status**: [STATUS.md](STATUS.md)
 
 ### mirrors


### PR DESCRIPTION
## Summary

- replace `docs/README.md` link with `docs.plyr.fm` in the links section
- move docs to top of links list

🤖 Generated with [Claude Code](https://claude.com/claude-code)