### PR TITLE
fix: migrate rate limiting from in-memory to Redis

### DIFF
--- a/backend/src/backend/utilities/rate_limit.py
+++ b/backend/src/backend/utilities/rate_limit.py
@@ -9,5 +9,5 @@ limiter = Limiter(
     key_func=get_remote_address,
     enabled=settings.rate_limit.enabled,
     default_limits=[settings.rate_limit.default_limit],
-    storage_uri="memory://",
+    storage_uri=settings.docket.url or "memory://",
 )

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,35 @@
+"""Tests for rate limiting configuration."""
+
+from unittest.mock import patch
+
+from backend.config import settings
+
+
+def test_limiter_uses_redis_when_docket_url_set() -> None:
+    """limiter should use docket Redis URL for storage when available."""
+    with patch.object(settings.docket, "url", "redis://localhost:6379/0"):
+        # re-import to pick up patched settings
+        import importlib
+
+        import backend.utilities.rate_limit as rl_module
+
+        importlib.reload(rl_module)
+
+        assert rl_module.limiter._storage_uri == "redis://localhost:6379/0"
+
+    # reload again to restore original state
+    importlib.reload(rl_module)
+
+
+def test_limiter_falls_back_to_memory_when_no_docket_url() -> None:
+    """limiter should fall back to in-memory storage when DOCKET_URL is empty."""
+    with patch.object(settings.docket, "url", ""):
+        import importlib
+
+        import backend.utilities.rate_limit as rl_module
+
+        importlib.reload(rl_module)
+
+        assert rl_module.limiter._storage_uri == "memory://"
+
+    importlib.reload(rl_module)

--- a/docs-internal/rate-limiting.md
+++ b/docs-internal/rate-limiting.md
@@ -13,22 +13,15 @@ Rate limits are configured via environment variables. Defaults are set in `src/b
 | `RATE_LIMIT_ENABLED` | `true` | Enable/disable rate limiting globally. |
 | `RATE_LIMIT_DEFAULT_LIMIT` | `100/minute` | Global limit applied to all endpoints by default. |
 | `RATE_LIMIT_AUTH_LIMIT` | `10/minute` | Strict limit for auth endpoints (`/auth/start`, `/auth/exchange`). |
-| `RATE_LIMIT_UPLOAD_LIMIT` | `5/minute` | Strict limit for file uploads (`/tracks/`). |
+| `RATE_LIMIT_UPLOAD_LIMIT` | `20/minute` | Strict limit for file uploads (`/tracks/`). |
 
 ## Architecture
 
-The current implementation uses **in-memory storage**.
+The implementation uses **Redis-backed storage** via the existing docket Redis instance (`DOCKET_URL`).
 
-*   **Per-Instance:** Limits are tracked per application instance (Fly Machine).
-*   **Scaling:** With multiple replicas (e.g., 2 machines), the **effective global limit** scales linearly.
-    *   Example: A limit of `100/minute` with 2 machines results in a total capacity of roughly `200/minute`.
+*   **Global Counters:** Limits are shared across all application instances (Fly Machines). A `100/minute` limit means 100 requests total, regardless of which machine handles them.
 *   **Keying:** Limits are applied by **IP address** (`get_remote_address`).
-
-### Why in-memory?
-For our current scale, in-memory is sufficient and avoids the complexity/cost of a dedicated Redis cluster. This provides effective protection against single-source flooding (DDoS/brute-force) directed at any specific instance.
-
-### Future State (Redis)
-If strict global synchronization or complex tier-based limiting is required in the future, we will migrate to a Redis-backed limiter. `slowapi` supports Redis out of the box, which would allow maintaining shared counters across all application instances.
+*   **Fallback:** When `DOCKET_URL` is not set (e.g., local dev without Redis), falls back to in-memory storage automatically.
 
 ## Adding Limits to Endpoints
 


### PR DESCRIPTION
## Summary
- rate limits were per-instance (each Fly Machine tracked independently), so 2 machines = 2x configured limit
- switch `storage_uri` to use existing docket Redis (`settings.docket.url`) for global counters across all instances
- falls back to `memory://` when `DOCKET_URL` is not set (local dev)
- update `docs-internal/rate-limiting.md` to reflect Redis-backed architecture, fix stale `upload_limit` default (was `5/minute` in docs, `20/minute` in code)

closes #1043

## Test plan
- [x] added regression tests: limiter uses Redis URL when available, falls back to memory when not
- [x] `just backend lint` passes
- [ ] after deploy: confirm 429s in Logfire are global (not per-instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)