### PR TITLE
fix: docs light mode text unreadable

### DIFF
--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -32,7 +32,7 @@
   --sl-color-accent-high: #1a3a6a;
   --sl-color-text-accent: #4a7ddd;
 
-  --sl-color-white: #fafafa;
+  --sl-color-white: #171717;
   --sl-color-gray-1: #171717;
   --sl-color-gray-2: #525252;
   --sl-color-gray-3: #737373;


### PR DESCRIPTION
## Summary

- `--sl-color-white` was set to `#fafafa` in light mode, but Starlight uses this variable as the highest-contrast foreground color (titles, input text, search results). It needs to flip dark in light mode, just like Starlight's own defaults do.
- Fixed to `#171717` — the rest of the gray scale was already correctly inverted.

## Test plan

- [ ] Open [docs.plyr.fm](https://docs.plyr.fm) in light mode
- [ ] Verify audience card titles, search input text, and search result titles are readable
- [ ] Verify dark mode is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)