### PR TITLE
fix: correct plyr.fm profile link to /u/plyr.fm

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -64,7 +64,7 @@ import HeroWaveform from '../../components/HeroWaveform.astro';
 <div class="landing-section">
   <h2>your music, your data</h2>
   <p style="color: var(--sl-color-gray-2); font-size: 0.9rem; margin-bottom: 1rem;">
-    every track on plyr.fm is an ATProto record in the artist's personal data repo — including <a href="https://plyr.fm/plyr.fm" style="color: var(--sl-color-accent);">plyr.fm's own dev podcasts</a>. here's the latest one:
+    every track on plyr.fm is an ATProto record in the artist's personal data repo — including <a href="https://plyr.fm/u/plyr.fm" style="color: var(--sl-color-accent);">plyr.fm's own dev podcasts</a>. here's the latest one:
   </p>
   <div class="record-example">
 


### PR DESCRIPTION
## Summary

- fix 404 on dev podcast link: `plyr.fm/plyr.fm` → `plyr.fm/u/plyr.fm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)