### PR TITLE
docs: add supporter-gated tracks section to artists page

### DIFF
--- a/docs/artists.md
+++ b/docs/artists.md
@@ -54,6 +54,30 @@ https://api.plyr.fm/oembed?url=https://plyr.fm/track/{track_id}
 
 paste a plyr.fm track link into any oEmbed-compatible platform and it will render a player automatically.
 
+## supporter-gated tracks
+
+:::caution[experimental]
+this feature is early and has limitations — see below.
+:::
+
+plyr.fm integrates with [ATProtoFans](https://atprotofans.com) to let artists gate tracks behind supporter status. when a listener tries to play a gated track, plyr.fm checks whether they support the artist — if they do, they get access; if not, the track is locked.
+
+today this is a **binary check**: a listener either supports you or they don't. there are no tiers, amounts, or expiration windows — any active support relationship grants access to all your gated tracks.
+
+### how it works
+
+1. upload a track and toggle **supporter-gated** in the track editor
+2. when a listener hits play, plyr.fm checks their support status via ATProtoFans
+3. supporters get access; everyone else sees a lock
+
+### what's next
+
+because ATProto doesn't yet have a permissioned data primitive, gated audio currently lives in plyr.fm-managed storage rather than on your PDS. this is the one exception to the "your music, your data" promise — and we want to fix it.
+
+the ATProto team is [exploring permissioned data](https://dholms.leaflet.pub/3mfrsbcn2gk2a) through concepts like **buckets** — named containers with access control lists that could let private blobs live on your own PDS. once that ships, gated tracks could move back to artist-controlled storage while still enforcing access rules at the protocol level.
+
+we'd also like to support more expressive gating — tiers, time-limited early access, per-track pricing — as the ecosystem matures.
+
 ## your data
 
 because tracks are ATProto records, you can:


### PR DESCRIPTION
## Summary

- add "supporter-gated tracks" section to the artists page with experimental caution admonition
- explain the binary ATProtoFans support check and its limitations
- link to dholms' permissioned data proposal as the future path for artist-controlled gated storage
- remove transcoding claim (feature-flagged)

## Test plan

- [x] `bun run build` passes
- [ ] review section reads well for non-technical artists

🤖 Generated with [Claude Code](https://claude.com/claude-code)