### PR TITLE
fix: improve header icons for devlog and source

### DIFF
--- a/docs-site/src/components/SocialIcons.astro
+++ b/docs-site/src/components/SocialIcons.astro
@@ -25,8 +25,8 @@
     class="social-link"
   >
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-      <path d="M12 20h9"></path>
-      <path d="M16.376 3.622a1 1 0 0 1 3.002 3.002L7.368 18.635a2 2 0 0 1-.855.506l-2.872.838a.5.5 0 0 1-.62-.62l.838-2.872a2 2 0 0 1 .506-.855z"></path>
+      <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path>
+      <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path>
     </svg>
   </a>
   <a
@@ -38,8 +38,8 @@
     class="social-link"
   >
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+      <polyline points="16 18 22 12 16 6"></polyline>
+      <polyline points="8 6 2 12 8 18"></polyline>
     </svg>
   </a>
 </div>


### PR DESCRIPTION
## Summary

- devlog: pencil → open book (reads as blog/journal, not edit button)
- source: chain link → code brackets `</>` (universally recognized for source code)

## Test plan

- [x] `bun run build` passes
- [ ] verify icons render correctly in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)