### PR TITLE
fix: remove redundant developer link from hero

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -9,9 +9,6 @@ hero:
     - text: start listening
       link: https://plyr.fm
       icon: right-arrow
-    - text: for developers
-      link: /developers/
-      variant: minimal
 ---
 
 import Stats from '../../components/Stats.astro';


### PR DESCRIPTION
## Summary

- remove "for developers" hero action — the audience grid cards already cover all four audiences

🤖 Generated with [Claude Code](https://claude.com/claude-code)