### PR TITLE
fix: newline before 'here's the latest one'

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -61,7 +61,8 @@ import HeroWaveform from '../../components/HeroWaveform.astro';
 <div class="landing-section">
   <h2>your music, your data</h2>
   <p style="color: var(--sl-color-gray-2); font-size: 0.9rem; margin-bottom: 1rem;">
-    every track on plyr.fm is an ATProto record in the artist's personal data repo — including <a href="https://plyr.fm/u/plyr.fm" style="color: var(--sl-color-accent);">plyr.fm's own dev podcasts</a>. here's the latest one:
+    every track on plyr.fm is an ATProto record in the artist's personal data repo — including <a href="https://plyr.fm/u/plyr.fm" style="color: var(--sl-color-accent);">plyr.fm's own dev podcasts</a>.
+    <br />here's the latest one:
   </p>
   <div class="record-example">
 


### PR DESCRIPTION
## Summary

- break "here's the latest one:" onto its own line in the homepage record section

🤖 Generated with [Claude Code](https://claude.com/claude-code)