### PR TITLE
feat: link app to docs.plyr.fm, add offboarding sections

### DIFF
--- a/docs/artists.md
+++ b/docs/artists.md
@@ -86,3 +86,7 @@ because tracks are ATProto records, you can:
 - **migrate** to a different PDS without losing anything
 
 your music lives in your repo under the `fm.plyr.track` collection. see the [lexicons overview](/lexicons/overview/) for the full schema.
+
+## leaving
+
+you can leave plyr.fm at any time. export your full catalog as a zip from the [portal](https://plyr.fm/portal), and your ATProto records remain on your PDS regardless. deleting your account removes all data from plyr.fm's infrastructure — for the full technical details, see the [offboarding documentation](https://github.com/zzstoatzz/plyr.fm/blob/main/docs-internal/offboarding.md).

--- a/docs/listeners.md
+++ b/docs/listeners.md
@@ -22,6 +22,10 @@ plyr.fm is an audio streaming platform built on [ATProto](https://atproto.com), 
 | `cmd+k` | search |
 | `m` | mute / unmute |
 
+## leaving
+
+your likes, comments, and playlists are ATProto records stored on your PDS — not locked into plyr.fm. you can leave at any time and your data stays with you. for the full technical details, see the [offboarding documentation](https://github.com/zzstoatzz/plyr.fm/blob/main/docs-internal/offboarding.md).
+
 ## start listening
 
 head to [plyr.fm](https://plyr.fm) and hit play.

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -983,7 +983,7 @@
 												</label>
 												{#if editSupportGate}
 													<p class="field-hint">
-														only users who support you via <a href="https://atprotofans.com" target="_blank" rel="noopener">atprotofans</a> can play this track
+														only users who support you via <a href="https://atprotofans.com" target="_blank" rel="noopener">atprotofans</a> can play this track. <a href="https://docs.plyr.fm/artists/#supporter-gated-tracks" target="_blank" rel="noopener">learn more</a>
 													</p>
 												{/if}
 											</div>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -399,7 +399,7 @@
 				</button>
 			</div>
 			<p class="token-overlay-hint">
-				use this token with the <a href="https://github.com/zzstoatzz/plyr-python-client" target="_blank" rel="noopener">python SDK</a> for programmatic API access
+				use this token with the <a href="https://docs.plyr.fm/developers/" target="_blank" rel="noopener">API or python SDK</a> for programmatic access
 			</p>
 			<button class="token-overlay-dismiss" onclick={dismissTokenOverlay}>
 				i've saved my token
@@ -641,7 +641,7 @@
 					<h3>developer tokens</h3>
 					<p>
 						create tokens for programmatic API access (uploads, track management).
-						use with the <a href="https://github.com/zzstoatzz/plyr-python-client" target="_blank" rel="noopener">python SDK</a>
+						use with the <a href="https://docs.plyr.fm/developers/" target="_blank" rel="noopener">API or python SDK</a>
 					</p>
 				</div>
 


### PR DESCRIPTION
## Summary

**app → docs links:**
- settings: developer token links now point to docs.plyr.fm/developers/ instead of raw GitHub repo
- portal: supporter gating hint adds "learn more" → docs.plyr.fm/artists/#supporter-gated-tracks

**offboarding sections:**
- listeners page: "leaving" section — your data stays on your PDS, links to detailed offboarding docs
- artists page: "leaving" section — export catalog, ATProto records persist, links to detailed offboarding docs

## Test plan

- [x] `bun run build` (docs) passes
- [x] `bun run check` (frontend) passes — 0 errors, 0 warnings
- [ ] verify links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)