### PR TITLE
fix: correct leaving docs on ATProto record deletion

### DIFF
--- a/docs/artists.md
+++ b/docs/artists.md
@@ -89,4 +89,4 @@ your music lives in your repo under the `fm.plyr.track` collection. see the [lex
 
 ## leaving
 
-you can leave plyr.fm at any time. export your full catalog as a zip from the [portal](https://plyr.fm/portal), and your ATProto records remain on your PDS regardless. deleting your account removes all data from plyr.fm's infrastructure — for the full technical details, see the [offboarding documentation](https://github.com/zzstoatzz/plyr.fm/blob/main/docs-internal/offboarding.md).
+you can leave plyr.fm at any time. export your full catalog as a zip from the [portal](https://plyr.fm/portal). deleting your account removes all data from plyr.fm's infrastructure — your ATProto records stay on your PDS by default, but you can choose to delete those too. for the full technical details, see the [offboarding documentation](https://github.com/zzstoatzz/plyr.fm/blob/main/docs-internal/offboarding.md).

--- a/docs/listeners.md
+++ b/docs/listeners.md
@@ -24,7 +24,7 @@ plyr.fm is an audio streaming platform built on [ATProto](https://atproto.com), 
 
 ## leaving
 
-your likes, comments, and playlists are ATProto records stored on your PDS — not locked into plyr.fm. you can leave at any time and your data stays with you. for the full technical details, see the [offboarding documentation](https://github.com/zzstoatzz/plyr.fm/blob/main/docs-internal/offboarding.md).
+your likes, comments, and playlists are ATProto records stored on your PDS — not locked into plyr.fm. you can leave at any time — your ATProto records stay on your PDS by default, but you can choose to delete those too. for the full technical details, see the [offboarding documentation](https://github.com/zzstoatzz/plyr.fm/blob/main/docs-internal/offboarding.md).
 
 ## start listening
 


### PR DESCRIPTION
## Summary
- the "leaving" sections on artists and listeners pages claimed ATProto records unconditionally remain on the user's PDS after account deletion
- in reality, `DELETE /account/` accepts `delete_atproto_records: bool` — users can choose to delete them
- updated both pages to say records stay by default but can be deleted

## Test plan
- [x] read the actual deletion code (`backend/src/backend/api/account.py`)
- [ ] verify docs build: `cd docs-site && bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)