### PR TITLE
feat: default new uploads to user's PDS

### DIFF
--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -310,12 +310,12 @@ async def _try_upload_to_pds(
 
 
 async def _should_upload_pds_blob(db: AsyncSession, user_did: str) -> bool:
-    """check if PDS audio uploads are enabled for the user."""
+    """check if PDS audio uploads are enabled for the user (default: on)."""
     result = await db.execute(
         select(UserPreferences.ui_settings).where(UserPreferences.did == user_did)
     )
     ui_settings = result.scalar_one_or_none() or {}
-    return bool(ui_settings.get(PDS_AUDIO_UPLOADS_SETTING_KEY))
+    return ui_settings.get(PDS_AUDIO_UPLOADS_SETTING_KEY, True) is not False
 
 
 async def _transcode_audio(

--- a/frontend/src/lib/components/PdsAudioUploadsToggle.svelte
+++ b/frontend/src/lib/components/PdsAudioUploadsToggle.svelte
@@ -2,7 +2,7 @@
 	import { preferences } from '$lib/preferences.svelte';
 	import { toast } from '$lib/toast.svelte';
 
-	let enabled = $derived(preferences.uiSettings.pds_audio_uploads_enabled ?? false);
+	let enabled = $derived(preferences.uiSettings.pds_audio_uploads_enabled ?? true);
 
 	async function handleToggle(event: Event) {
 		const input = event.target as HTMLInputElement;
@@ -19,7 +19,7 @@
 <div class="setting-row">
 	<div class="setting-info">
 		<h3>store audio on your pds</h3>
-		<p>store uploaded audio on your pds (falls back to plyr.fm storage if too large)</p>
+		<p>new uploads are stored on your pds by default (falls back to plyr.fm storage if too large)</p>
 	</div>
 	<label class="toggle-switch">
 		<input type="checkbox" checked={enabled} onchange={handleToggle} />


### PR DESCRIPTION
## Summary
- flip PDS audio upload default from opt-in to opt-out
- users who never touched the setting now get PDS uploads automatically
- users who explicitly disabled it stay opted out (`is not False` check)
- fallback to R2-only on `PayloadTooLargeError` (413) unchanged
- update frontend toggle copy to reflect new default

## Test plan
- [ ] upload a track with a fresh account (no preference set) — should attempt PDS upload
- [ ] upload a track with `pds_audio_uploads_enabled: false` — should skip PDS upload
- [ ] upload a file larger than PDS limit — should fall back to R2 gracefully
- [ ] verify toggle shows enabled by default in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)