### PR TITLE
docs: clarify PDS audio storage default in artists page

### DIFF
--- a/docs/artists.md
+++ b/docs/artists.md
@@ -10,7 +10,7 @@ plyr.fm gives artists a place to share music where **you own your data**. every 
 1. sign in at [plyr.fm](https://plyr.fm) with your [Atmosphere](https://atproto.com) account (Bluesky, BlackSky, etc.)
 2. click **upload** and drop your audio files
 3. add a title, tags, and optional cover art
-4. your track is live — stored in your PDS and indexed by plyr.fm
+4. your track is live — the audio and metadata are stored on your PDS and indexed by plyr.fm (falls back to plyr.fm storage if your PDS can't accept the file)
 
 supported formats: MP3, WAV, FLAC, AAC, OGG.
 


### PR DESCRIPTION
## Summary
- update uploading step 4 to reflect that audio + metadata are now stored on the user's PDS by default
- mention graceful fallback to plyr.fm storage

follows #1060

## Test plan
- [x] verify wording is accurate against upload code

🤖 Generated with [Claude Code](https://claude.com/claude-code)