### PR TITLE
docs: fix casing, links, and inaccuracies in public pages

### DIFF
--- a/docs/artists.md
+++ b/docs/artists.md
@@ -1,18 +1,18 @@
 ---
 title: "for artists"
-description: "upload, manage, and distribute your music on ATProto"
+description: "upload, manage, and distribute your music on atproto"
 ---
 
-plyr.fm gives artists a place to share music where **you own your data**. every track you upload is an [ATProto](https://atproto.com) record stored in your personal data server — portable, verifiable, and yours.
+plyr.fm gives artists a place to share music where **you own your data**. every track you upload is an [atproto](https://atproto.com) record stored in your [PDS](https://atproto.com/guides/self-hosting#pds) — the metadata record and the audio blob itself — portable, verifiable, and yours.
 
 ## uploading
 
-1. sign in at [plyr.fm](https://plyr.fm) with your [Atmosphere](https://atproto.com) account (Bluesky, BlackSky, etc.)
+1. sign in at [plyr.fm](https://plyr.fm) with your [atproto](https://atproto.com/specs/account) account (Bluesky, BlackSky, etc.)
 2. click **upload** and drop your audio files
 3. add a title, tags, and optional cover art
 4. your track is live — the audio and metadata are stored on your PDS and indexed by plyr.fm (falls back to plyr.fm storage if your PDS can't accept the file)
 
-supported formats: MP3, WAV, FLAC, AAC, OGG.
+supported formats: MP3, WAV, M4A.
 
 ## embeds
 
@@ -72,15 +72,15 @@ today this is a **binary check**: a listener either supports you or they don't. 
 
 ### what's next
 
-because ATProto doesn't yet have a permissioned data primitive, gated audio currently lives in plyr.fm-managed storage rather than on your PDS. this is the one exception to the "your music, your data" promise — and we want to fix it.
+because atproto doesn't yet have permissioned data, gated audio currently lives in plyr.fm-managed storage (public blob). this is the one exception to the "your music, your data" promise — and we want to fix it.
 
-the ATProto team is [exploring permissioned data](https://dholms.leaflet.pub/3mfrsbcn2gk2a) through concepts like **buckets** — named containers with access control lists that could let private blobs live on your own PDS. once that ships, gated tracks could move back to artist-controlled storage while still enforcing access rules at the protocol level.
+the atproto team is [exploring permissioned data](https://dholms.leaflet.pub/3mfrsbcn2gk2a) through concepts like **buckets** — named containers with access control lists that could let private blobs live on your own PDS. once that ships, gated tracks could move back to artist-controlled storage while still enforcing access rules at the protocol level.
 
 we'd also like to support more expressive gating — tiers, time-limited early access, per-track pricing — as the ecosystem matures.
 
 ## your data
 
-because tracks are ATProto records, you can:
+because tracks are atproto records, you can:
 
 - **[export](https://plyr.fm/portal)** your entire catalog from your PDS at any time
 - **migrate** to a different PDS without losing anything
@@ -89,4 +89,4 @@ your music lives in your repo under the `fm.plyr.track` collection. see the [lex
 
 ## leaving
 
-you can leave plyr.fm at any time. export your full catalog as a zip from the [portal](https://plyr.fm/portal). deleting your account removes all data from plyr.fm's infrastructure — your ATProto records stay on your PDS by default, but you can choose to delete those too. for the full technical details, see the [offboarding documentation](https://github.com/zzstoatzz/plyr.fm/blob/main/docs-internal/offboarding.md).
+you can leave plyr.fm at any time. export your full catalog as a zip from the [portal](https://plyr.fm/portal). deleting your account removes all data from plyr.fm's infrastructure — your atproto records stay on your PDS by default, but you can choose to delete those too. for the full technical details, see the [offboarding documentation](https://github.com/zzstoatzz/plyr.fm/blob/main/docs-internal/offboarding.md).

--- a/docs/listeners.md
+++ b/docs/listeners.md
@@ -3,12 +3,12 @@ title: "for listeners"
 description: "discover and stream music on plyr.fm"
 ---
 
-plyr.fm is an audio streaming platform built on [ATProto](https://atproto.com), the open protocol behind [Bluesky](https://bsky.app) and [BlackSky](https://blacksky.community). sign in with your [Atmosphere](https://atproto.com) account and start listening — if you have a Bluesky handle, you're already in.
+plyr.fm is an audio streaming platform built on [atproto](https://atproto.com), the open protocol behind [Bluesky](https://bsky.app) and [BlackSky](https://blacksky.community). sign in with your [atproto](https://atproto.com/specs/account) account and start listening — if you have a Bluesky handle, you're already in.
 
 ## what you get
 
 - **stream music** from independent artists who own their data
-- **like, comment, and build playlists** — all stored in your personal data repo
+- **like, comment, and build playlists** — all stored in your [PDS](https://atproto.com/guides/self-hosting#pds)
 - **timed comments** — leave reactions at specific moments in a track
 
 ## keyboard shortcuts
@@ -24,7 +24,7 @@ plyr.fm is an audio streaming platform built on [ATProto](https://atproto.com), 
 
 ## leaving
 
-your likes, comments, and playlists are ATProto records stored on your PDS — not locked into plyr.fm. you can leave at any time — your ATProto records stay on your PDS by default, but you can choose to delete those too. for the full technical details, see the [offboarding documentation](https://github.com/zzstoatzz/plyr.fm/blob/main/docs-internal/offboarding.md).
+you can leave plyr.fm at any time. your atproto records stay on your PDS by default, but you can choose to delete those too. for the full technical details, see the [offboarding documentation](https://github.com/zzstoatzz/plyr.fm/blob/main/docs-internal/offboarding.md).
 
 ## start listening
 


### PR DESCRIPTION
## Summary
- lowercase "ATProto" → "atproto" throughout `listeners.md` and `artists.md`
- link "Atmosphere" references to atproto account spec, "personal data repo/server" to PDS self-hosting docs
- mention audio blob alongside metadata record in artists intro
- correct supported formats to MP3, WAV, M4A (FLAC/AIFF are behind feature flag; AAC/OGG not in AudioFormat enum)
- simplify gated audio and leaving section copy, remove redundant lede in listeners leaving section

## Test plan
- [ ] visual review of rendered markdown on docs.plyr.fm preview
- [ ] confirm no remaining uppercase "ATProto" in these two files (ATProtoFans is intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)