### PR TITLE
refactor: drop vestigial mid-page progress block on album upload

### DIFF
--- a/frontend/src/lib/components/AlbumUploadForm.svelte
+++ b/frontend/src/lib/components/AlbumUploadForm.svelte
@@ -35,8 +35,6 @@
 			albums.some((a) => a.title.toLowerCase() === albumTitle.trim().toLowerCase()),
 	);
 
-	let completedCount = $derived(tracks.filter((t) => t.status === 'completed').length);
-	let activeUploadCount = $derived(tracks.filter((t) => t.status === 'uploading' || t.status === 'processing').length);
 	let hasUnresolvedFeatures = $derived(tracks.some((t) => t.hasUnresolvedFeaturesInput));
 
 	let canSubmit = $derived(
@@ -483,26 +481,6 @@
 		/>
 	</div>
 
-	{#if uploading}
-		<div class="upload-progress">
-			{#if activeUploadCount > 0}
-				<p class="progress-text">
-					{completedCount} of {tracks.length} completed, {activeUploadCount} uploading...
-				</p>
-			{:else}
-				<p class="progress-text">
-					{completedCount} of {tracks.length} track{tracks.length > 1 ? 's' : ''} completed
-				</p>
-			{/if}
-			<div class="progress-bar-bg">
-				<div
-					class="progress-bar-fill"
-					style="width: {(completedCount / tracks.length) * 100}%"
-				></div>
-			</div>
-		</div>
-	{/if}
-
 	<div class="form-group attestation">
 		<label class="checkbox-label">
 			<input
@@ -691,35 +669,6 @@
 		clip: rect(0, 0, 0, 0);
 		white-space: nowrap;
 		border: 0;
-	}
-
-	.upload-progress {
-		margin-bottom: 1.5rem;
-		padding: 1rem;
-		background: var(--bg-primary);
-		border-radius: var(--radius-sm);
-		border: 1px solid var(--border-default);
-	}
-
-	.progress-text {
-		font-size: var(--text-sm);
-		color: var(--text-secondary);
-		margin-bottom: 0.5rem;
-	}
-
-	.progress-bar-bg {
-		width: 100%;
-		height: 4px;
-		background: var(--border-subtle);
-		border-radius: 2px;
-		overflow: hidden;
-	}
-
-	.progress-bar-fill {
-		height: 100%;
-		background: var(--accent);
-		border-radius: 2px;
-		transition: width 0.3s ease;
 	}
 
 	.attestation {


### PR DESCRIPTION
## Summary

Since #1238 added per-track toasts and `TrackEntryCard` renders a `uploading | processing | completed | failed` pill on each card, the mid-page aggregate progress block was showing the same information a third time. Dropped it.

## What changed

- Removed the `{#if uploading}` block rendering `"N of M completed, K uploading..."` + progress bar in `AlbumUploadForm.svelte`
- Removed the `completedCount` / `activeUploadCount` derived state that only fed the block
- Removed `.upload-progress` / `.progress-text` / `.progress-bar-bg` / `.progress-bar-fill` CSS

Net: 51 lines deleted, no functional change.

## What you see now during album upload

1. **Per-track toast (bottom-left)** — one toast per track with title, live XHR upload %, then SSE phase messages (\"creating atproto record...\", etc.), ending in a success or error toast
2. **Per-card status pill on each `TrackEntryCard`** — inline status indicator next to the track title inside the form
3. ~~Mid-page aggregate counter + progress bar~~ (removed)

## Known trade-off (deliberately deferred)

A very large album (e.g. 20+ tracks) stacks a lot of toasts. If that becomes a real annoyance we can reintroduce a centralized summary or change the toast strategy. For now the concern is theoretical — leaving this to find out from real usage.

## Test plan

- [x] \`just frontend check\` — 0 errors, 0 warnings
- [ ] manual: upload a 3-track album on staging — toasts fire per track, per-card status pills update, no mid-page block
- [ ] manual: single-track upload on \`/upload\` still works (untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)