### PR TITLE
fix: surface atproto strongref fields in upload SSE stream

### DIFF
--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -1192,6 +1192,14 @@ async def upload_progress(upload_id: str) -> StreamingResponse:
                     payload["track_id"] = job.result["track_id"]
                 if job.result and "warnings" in job.result:
                     payload["warnings"] = job.result["warnings"]
+                # surface the PDS strongRef so album upload callers can build
+                # items[] arrays without a follow-up DB query (see #1260).
+                # background writes these to job.result in _process_upload_background;
+                # without this whitelist entry they never reach the SSE stream.
+                if job.result and "atproto_uri" in job.result:
+                    payload["atproto_uri"] = job.result["atproto_uri"]
+                if job.result and "atproto_cid" in job.result:
+                    payload["atproto_cid"] = job.result["atproto_cid"]
 
                 yield f"data: {json.dumps(payload)}\n\n"
 

--- a/backend/tests/api/test_upload_progress_sse.py
+++ b/backend/tests/api/test_upload_progress_sse.py
@@ -1,0 +1,135 @@
+"""unit tests for the SSE upload-progress endpoint field whitelist.
+
+regression coverage for the issue where atproto_uri and atproto_cid
+were written to job.result by the upload pipeline but never surfaced
+to the SSE stream because the endpoint whitelisted only track_id and
+warnings. caught by staging integration tests after #1260 merged.
+"""
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from backend.main import app
+from backend.models.job import Job, JobStatus, JobType
+
+
+def _make_completed_job(
+    *,
+    job_id: str = "test-upload-abc",
+    track_id: int = 42,
+    atproto_uri: str | None = "at://did:plc:test/fm.plyr.track/abc",
+    atproto_cid: str | None = "bafyTestCid",
+    warnings: list[str] | None = None,
+) -> Job:
+    """build a Job row with a completed upload and an arbitrary result dict."""
+    now = datetime.now(UTC)
+    result: dict = {"track_id": track_id}
+    if atproto_uri is not None:
+        result["atproto_uri"] = atproto_uri
+    if atproto_cid is not None:
+        result["atproto_cid"] = atproto_cid
+    if warnings:
+        result["warnings"] = warnings
+
+    job = Job(
+        id=job_id,
+        type=JobType.UPLOAD.value,
+        owner_did="did:plc:test",
+        status=JobStatus.COMPLETED.value,
+        message="upload completed successfully",
+        progress_pct=100.0,
+        phase="atproto",
+        result=result,
+        error=None,
+        created_at=now,
+        completed_at=now,
+    )
+    return job
+
+
+async def _read_first_completed_event(test_app: FastAPI, upload_id: str) -> dict:
+    """hit the SSE endpoint once, parse the first `data:` frame, return its JSON."""
+    async with (
+        AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client,
+        client.stream("GET", f"/tracks/uploads/{upload_id}/progress") as response,
+    ):
+        assert response.status_code == 200
+        async for line in response.aiter_lines():
+            if line.startswith("data: "):
+                return json.loads(line[6:])
+    raise AssertionError("SSE stream closed without emitting a data frame")
+
+
+@pytest.fixture
+def progress_app() -> FastAPI:
+    """the app under test doesn't require auth on the progress endpoint."""
+    return app
+
+
+async def test_sse_payload_surfaces_atproto_strongref(progress_app: FastAPI):
+    """atproto_uri and atproto_cid written to job.result MUST appear in the
+    SSE completion payload so album upload callers can build finalize
+    requests or any future consumer can grab the PDS strongRef without a
+    follow-up DB query.
+
+    regression: the endpoint previously whitelisted only track_id and
+    warnings, silently dropping the strongRef fields the upload pipeline
+    writes to job.result. the frontend UploadResult type and the docs
+    both promise these fields — the SSE handler has to deliver them.
+    """
+    job = _make_completed_job()
+
+    with patch(
+        "backend.api.tracks.uploads.job_service.get_job",
+        new=AsyncMock(return_value=job),
+    ):
+        payload = await _read_first_completed_event(progress_app, job.id)
+
+    assert payload["status"] == "completed"
+    assert payload["track_id"] == 42
+    assert payload["atproto_uri"] == "at://did:plc:test/fm.plyr.track/abc"
+    assert payload["atproto_cid"] == "bafyTestCid"
+
+
+async def test_sse_payload_omits_absent_strongref(progress_app: FastAPI):
+    """if the job.result doesn't have atproto_uri/atproto_cid (e.g. legacy
+    jobs or failures), the SSE payload must not invent them — absent keys
+    stay absent, no None pollution."""
+    job = _make_completed_job(atproto_uri=None, atproto_cid=None)
+
+    with patch(
+        "backend.api.tracks.uploads.job_service.get_job",
+        new=AsyncMock(return_value=job),
+    ):
+        payload = await _read_first_completed_event(progress_app, job.id)
+
+    assert payload["status"] == "completed"
+    assert payload["track_id"] == 42
+    assert "atproto_uri" not in payload
+    assert "atproto_cid" not in payload
+
+
+async def test_sse_payload_preserves_warnings_alongside_strongref(
+    progress_app: FastAPI,
+):
+    """both the warnings field and the strongRef fields must pass through
+    the whitelist together without interfering with each other."""
+    job = _make_completed_job(warnings=["pds blob upload timed out, used r2"])
+
+    with patch(
+        "backend.api.tracks.uploads.job_service.get_job",
+        new=AsyncMock(return_value=job),
+    ):
+        payload = await _read_first_completed_event(progress_app, job.id)
+
+    assert payload["track_id"] == 42
+    assert payload["atproto_uri"] == "at://did:plc:test/fm.plyr.track/abc"
+    assert payload["atproto_cid"] == "bafyTestCid"
+    assert payload["warnings"] == ["pds blob upload timed out, used r2"]

--- a/loq.toml
+++ b/loq.toml
@@ -48,7 +48,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1215
+max_lines = 1223
 
 [[rules]]
 path = "backend/src/backend/config.py"


### PR DESCRIPTION
## Summary

Follow-up to #1260. Staging integration tests failed because the SSE endpoint whitelists which \`job.result\` fields are emitted, and the whitelist was \`track_id\` + \`warnings\` only — \`atproto_uri\` and \`atproto_cid\` were written to the job record by \`_process_upload_background\` but silently dropped on the way to the stream.

Docs, public API reference, and the frontend \`UploadResult\` type all promised these fields. The wire format didn't deliver them.

## What changed

\`backend/src/backend/api/tracks/uploads.py:upload_progress\` — conditionally copy \`atproto_uri\` and \`atproto_cid\` from \`job.result\` into the SSE payload, same mechanism as \`track_id\`/\`warnings\`.

## Why the miss wasn't caught earlier

Unit tests in \`test_albums.py\` mock \`upsert_album_list_record\` directly and never exercise the SSE endpoint. Integration tests that DO hit the SSE endpoint only run post-deploy (via \`workflow_run\` after \`deploy staging\`). Gap slipped through pre-merge CI and only surfaced when the staging deploy ran.

This PR adds pure unit coverage for the SSE whitelist so future regressions are caught on the PR.

## Regression tests

\`tests/api/test_upload_progress_sse.py\` — three cases mocking \`job_service.get_job\`:

- \`test_sse_payload_surfaces_atproto_strongref\` — the core fix
- \`test_sse_payload_omits_absent_strongref\` — legacy jobs (no strongref in \`result\`) produce a frame without the keys, not a frame with \`None\`
- \`test_sse_payload_preserves_warnings_alongside_strongref\` — warnings + strongref coexist

The existing \`tests/integration/test_album_upload.py\` will pass post-deploy once this lands.

## Functional note

Frontend \`uploader.svelte.ts\` collects these into \`UploadResult\` but doesn't read them — finalize sends \`track_ids\` and the backend resolves strongrefs from DB. Exposing on the wire still matches the stated design and keeps future client-side \`items[]\`-building flows unblocked (same pattern the album edit page reorder endpoint uses today).

## Test plan

- [x] \`just backend test tests/api/test_upload_progress_sse.py\` — 3 passed
- [x] \`just backend lint\` — clean
- [ ] post-merge: staging deploy → integration tests pass \`test_album_upload_preserves_finalize_order\` and \`test_album_finalize_preserves_existing_tracks_on_append\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)