### PR TITLE
fix: clamp long track titles in analytics cards

### DIFF
--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -1072,7 +1072,12 @@ $effect(() => {
 		color: var(--text-primary);
 		margin: 0.5rem 0;
 		font-weight: 500;
-		line-height: 1;
+		line-height: 1.3;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
 	}
 
 	.top-item-plays {


### PR DESCRIPTION
## Summary

Long track titles overflow the \"most played\" / \"most liked\" analytics cards on artist profile pages, pushing content past card boundaries.

Clamp \`.top-item-title\` to 2 lines with ellipsis. Bump \`line-height\` from 1 to 1.3 for readable two-line spacing.

## Test plan

- [x] \`just frontend check\` — 0 errors, 0 warnings
- [ ] check artist profile with the long-titled track — title truncates at 2 lines with \"...\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)