### PR TITLE
fix: move image moderation to background task + eliminate R2 delete spray

### DIFF
--- a/backend/src/backend/_internal/image_uploads.py
+++ b/backend/src/backend/_internal/image_uploads.py
@@ -8,9 +8,7 @@ from pathlib import PurePosixPath
 from fastapi import HTTPException
 from starlette.datastructures import UploadFile
 
-from backend._internal.clients.moderation import get_moderation_client
 from backend._internal.image import ImageFormat
-from backend._internal.notifications import notification_service
 from backend._internal.thumbnails import generate_and_save
 from backend.config import settings
 from backend.storage import storage
@@ -98,21 +96,27 @@ async def process_image_upload(
     image_url = storage.build_image_url(image_id, ext)
     thumbnail_url = await generate_and_save(bytes(image_data), image_id, entity_type)
 
-    # moderation scanning (non-blocking — flags but doesn't reject)
+    # moderation scanning — dispatched as a docket background task so the
+    # HTTP response isn't blocked on the moderation service round trip
+    # (~3-6s for claude vision + possible cold-start penalty).  the scan
+    # only flags and notifies; it never gates the response.
     if scan_moderation and settings.moderation.image_moderation_enabled:
         try:
-            client = get_moderation_client()
+            from backend._internal.tasks.moderation import (
+                schedule_image_moderation_scan,
+            )
+
             content_type = image_format.media_type if image_format else "image/png"
-            result = await client.scan_image(bytes(image_data), image_id, content_type)
-            if not result.is_safe:
-                await notification_service.send_image_flag_notification(
-                    image_id=image_id,
-                    severity=result.severity,
-                    categories=result.violated_categories,
-                    context=f"{entity_type} cover",
-                )
+            await schedule_image_moderation_scan(
+                image_id=image_id,
+                image_url=image_url,
+                content_type=content_type,
+                entity_type=entity_type,
+            )
         except Exception as e:
-            logger.warning("image moderation failed for %s: %s", image_id, e)
+            logger.warning(
+                "failed to schedule image moderation for %s: %s", image_id, e
+            )
 
     return ImageUploadResult(
         image_id=image_id,

--- a/backend/src/backend/_internal/tasks/__init__.py
+++ b/backend/src/backend/_internal/tasks/__init__.py
@@ -24,6 +24,10 @@ from backend._internal.tasks.hooks import (
     invalidate_tracks_discovery_cache,
     run_post_track_create_hooks,
 )
+from backend._internal.tasks.moderation import (
+    scan_image_moderation,
+    schedule_image_moderation_scan,
+)
 from backend._internal.tasks.ingest import (
     SubjectNotFoundError,
     ingest_comment_create,
@@ -104,6 +108,7 @@ def _build_background_tasks() -> list:
         ingest_list_update,
         ingest_list_delete,
         ingest_profile_update,
+        scan_image_moderation,
     ]
 
 
@@ -151,6 +156,7 @@ __all__ = [
     "pds_update_comment",
     "run_post_track_create_hooks",
     "scan_copyright",
+    "scan_image_moderation",
     "schedule_album_list_sync",
     "schedule_atproto_sync",
     "schedule_copyright_resolution_sync",
@@ -158,6 +164,7 @@ __all__ = [
     "schedule_embedding_generation",
     "schedule_follow_graph_warm",
     "schedule_genre_classification",
+    "schedule_image_moderation_scan",
     "schedule_move_track_audio",
     "schedule_pds_create_comment",
     "schedule_pds_create_like",

--- a/backend/src/backend/_internal/tasks/moderation.py
+++ b/backend/src/backend/_internal/tasks/moderation.py
@@ -1,0 +1,75 @@
+"""background tasks for image moderation.
+
+image moderation was previously awaited inline during track/album PATCH
+requests, blocking the HTTP response for ~3-6s while the moderation
+service ran claude vision. moving to a docket task makes the response
+instantaneous while still flagging unsafe images.
+"""
+
+import logging
+
+import httpx
+import logfire
+
+from backend._internal.background import get_docket
+from backend._internal.clients.moderation import get_moderation_client
+from backend._internal.notifications import notification_service
+
+logger = logging.getLogger(__name__)
+
+
+async def scan_image_moderation(
+    image_id: str,
+    image_url: str,
+    content_type: str,
+    entity_type: str,
+) -> None:
+    """download the image from R2 and scan it for policy violations.
+
+    called as a docket background task after the image has been stored.
+    fetches the image bytes from its public URL (already on R2 CDN) and
+    sends them to the moderation service. if the image is flagged, fires
+    a notification — same behavior as the old inline path, just not
+    blocking the user's request.
+    """
+    try:
+        # fetch the image bytes from R2 (public URL, no auth needed)
+        async with httpx.AsyncClient(timeout=httpx.Timeout(15.0)) as http:
+            response = await http.get(image_url)
+            response.raise_for_status()
+            image_bytes = response.content
+
+        client = get_moderation_client()
+        result = await client.scan_image(image_bytes, image_id, content_type)
+
+        if not result.is_safe:
+            await notification_service.send_image_flag_notification(
+                image_id=image_id,
+                severity=result.severity,
+                categories=result.violated_categories,
+                context=f"{entity_type} cover",
+            )
+
+        logfire.info(
+            "background image moderation complete",
+            image_id=image_id,
+            is_safe=result.is_safe,
+            severity=result.severity,
+        )
+    except Exception as e:
+        logger.warning("background image moderation failed for %s: %s", image_id, e)
+
+
+async def schedule_image_moderation_scan(
+    *,
+    image_id: str,
+    image_url: str,
+    content_type: str,
+    entity_type: str,
+) -> None:
+    """schedule an image moderation scan via docket."""
+    docket = get_docket()
+    await docket.add(scan_image_moderation)(
+        image_id, image_url, content_type, entity_type
+    )
+    logfire.info("scheduled image moderation scan", image_id=image_id)

--- a/backend/src/backend/api/albums.py
+++ b/backend/src/backend/api/albums.py
@@ -551,7 +551,10 @@ async def upload_album_cover(
         # delete old image if exists (prevent R2 object leaks)
         if album.image_id and album.image_id != uploaded.image_id:
             with contextlib.suppress(Exception):
-                await storage.delete(album.image_id)
+                if album.image_url:
+                    await storage.delete_image(album.image_id, album.image_url)
+                else:
+                    await storage.delete(album.image_id)
 
         # update album with new image
         album.image_id = uploaded.image_id
@@ -974,7 +977,10 @@ async def delete_album(
     # delete cover image from storage if exists
     if album.image_id:
         with contextlib.suppress(Exception):
-            await storage.delete(album.image_id)
+            if album.image_url:
+                await storage.delete_image(album.image_id, album.image_url)
+            else:
+                await storage.delete(album.image_id)
 
     # capture slug before deletion
     album_slug = album.slug

--- a/backend/src/backend/api/lists.py
+++ b/backend/src/backend/api/lists.py
@@ -885,7 +885,10 @@ async def upload_playlist_cover(
         # delete old image if exists (prevent R2 object leaks)
         if playlist.image_id and playlist.image_id != uploaded.image_id:
             with contextlib.suppress(Exception):
-                await storage.delete(playlist.image_id)
+                if playlist.image_url:
+                    await storage.delete_image(playlist.image_id, playlist.image_url)
+                else:
+                    await storage.delete(playlist.image_id)
 
         # update playlist with new image
         playlist.image_id = uploaded.image_id

--- a/backend/src/backend/api/tracks/mutations.py
+++ b/backend/src/backend/api/tracks/mutations.py
@@ -114,7 +114,10 @@ async def delete_track(
         )
         if not album_shares_image:
             try:
-                await storage.delete(track.image_id)
+                if track.image_url:
+                    await storage.delete_image(track.image_id, track.image_url)
+                else:
+                    await storage.delete(track.image_id)
             except Exception as e:
                 logger.warning(
                     f"failed to delete image {track.image_id}: {e}", exc_info=True
@@ -255,7 +258,10 @@ async def update_track_metadata(
         )
         if not album_shares_image:
             with contextlib.suppress(Exception):
-                await storage.delete(track.image_id)
+                if track.image_url:
+                    await storage.delete_image(track.image_id, track.image_url)
+                else:
+                    await storage.delete(track.image_id)
         track.image_id = None
         track.image_url = None
         track.thumbnail_url = None
@@ -272,7 +278,10 @@ async def update_track_metadata(
             )
             if not album_shares_image:
                 with contextlib.suppress(Exception):
-                    await storage.delete(track.image_id)
+                    if track.image_url:
+                        await storage.delete_image(track.image_id, track.image_url)
+                    else:
+                        await storage.delete(track.image_id)
 
         track.image_id = image_id
         track.image_url = image_url

--- a/backend/src/backend/storage/protocol.py
+++ b/backend/src/backend/storage/protocol.py
@@ -37,6 +37,8 @@ class StorageProtocol(Protocol):
 
     async def delete(self, file_id: str, file_type: str | None = None) -> bool: ...
 
+    async def delete_image(self, file_id: str, image_url: str) -> bool: ...
+
     async def save_gated(
         self,
         file: BinaryIO | BytesIO,

--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -490,6 +490,51 @@ class R2Storage:
             )
             return False
 
+    async def delete_image(self, file_id: str, image_url: str) -> bool:
+        """delete an image from R2 using its known URL to derive the exact key.
+
+        avoids the format-spray fallback in delete() which tries every audio
+        format then every image format via sequential HEAD requests (~1.3s of
+        wasted round trips). the image URL already encodes the correct
+        extension, so we can build the key directly.
+        """
+        from pathlib import PurePosixPath
+
+        # extract extension from URL: ".../images/abc123.png?..." → ".png"
+        ext = PurePosixPath(image_url.split("?")[0]).suffix.lower()
+        if not ext:
+            logfire.warning(
+                "delete_image: could not extract extension from URL, falling back",
+                file_id=file_id,
+                image_url=image_url,
+            )
+            return await self.delete(file_id)
+
+        key = f"images/{file_id}{ext}"
+        async with self.async_session.client(
+            "s3",
+            endpoint_url=self.endpoint_url,
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+        ) as client:
+            try:
+                await client.delete_object(Bucket=self.image_bucket_name, Key=key)
+                logfire.info(
+                    "R2 image deleted (direct)",
+                    file_id=file_id,
+                    key=key,
+                    bucket=self.image_bucket_name,
+                )
+                return True
+            except client.exceptions.ClientError as e:
+                logfire.warning(
+                    "R2 delete_image failed, falling back to format scan",
+                    file_id=file_id,
+                    key=key,
+                    error=str(e),
+                )
+                return await self.delete(file_id)
+
     async def save_gated(
         self,
         file: BinaryIO | BytesIO,

--- a/backend/tests/api/test_track_deletion.py
+++ b/backend/tests/api/test_track_deletion.py
@@ -312,10 +312,17 @@ async def test_track_deletion_preserves_shared_album_image(
     async def mock_delete(file_id: str, file_type: str | None = None):
         delete_calls.append(file_id)
 
+    async def mock_delete_image(file_id: str, image_url: str):
+        delete_calls.append(file_id)
+
     with (
         patch(
             "backend.api.tracks.mutations.storage.delete",
             side_effect=mock_delete,
+        ),
+        patch(
+            "backend.api.tracks.mutations.storage.delete_image",
+            side_effect=mock_delete_image,
         ),
         patch(
             "backend.api.tracks.mutations.schedule_album_list_sync",
@@ -370,10 +377,17 @@ async def test_track_deletion_deletes_unshared_image(
     async def mock_delete(file_id: str, file_type: str | None = None):
         delete_calls.append(file_id)
 
+    async def mock_delete_image(file_id: str, image_url: str):
+        delete_calls.append(file_id)
+
     with (
         patch(
             "backend.api.tracks.mutations.storage.delete",
             side_effect=mock_delete,
+        ),
+        patch(
+            "backend.api.tracks.mutations.storage.delete_image",
+            side_effect=mock_delete_image,
         ),
         patch(
             "backend.api.tracks.mutations.schedule_album_list_sync",

--- a/loq.toml
+++ b/loq.toml
@@ -232,7 +232,7 @@ max_lines = 580
 
 [[rules]]
 path = "backend/tests/api/test_track_deletion.py"
-max_lines = 505
+max_lines = 519
 
 [[rules]]
 path = "backend/tests/api/test_top_tracks.py"

--- a/loq.toml
+++ b/loq.toml
@@ -28,7 +28,7 @@ max_lines = 896
 
 [[rules]]
 path = "backend/src/backend/api/albums.py"
-max_lines = 989
+max_lines = 995
 
 [[rules]]
 path = "backend/src/backend/api/auth.py"
@@ -36,7 +36,7 @@ max_lines = 807
 
 [[rules]]
 path = "backend/src/backend/api/lists.py"
-max_lines = 1146
+max_lines = 1149
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
@@ -56,7 +56,7 @@ max_lines = 1000
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
-max_lines = 725
+max_lines = 766
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"


### PR DESCRIPTION
## Summary

Two perf fixes for track/album image edits. Observed via Logfire traces on a real user session (`annamist.com` editing track 862) — a single PATCH was taking **8.9 seconds**.

### 1. Image moderation → docket background task (~6s saved)

The moderation service (Claude Vision on Fly.io) was `await`ed inline during `PATCH /tracks/{id}`. The scan only flags and notifies — it never gates the response — so blocking on it was pure waste. Moved to a new `scan_image_moderation` docket task that fetches the image from its R2 URL and scans async, matching how copyright audio scans already work.

### 2. R2 image delete → direct key lookup (~1.3s saved)

`storage.delete()` with no `file_type` tries every `AudioFormat` extension (7-8 HEAD requests) then every `ImageFormat` extension (5 HEAD requests) sequentially before finding the right one. New `delete_image(file_id, image_url)` method parses the extension from the URL and hits the correct key on the first try. Falls back to the spray only if URL parsing fails.

### Combined impact

Track image edit: **8.9s → ~1s** (R2 upload + thumbnail + DB + ATProto sync).

## Files changed

- `backend/src/backend/_internal/image_uploads.py` — replaced inline `await client.scan_image()` with `schedule_image_moderation_scan()`
- `backend/src/backend/_internal/tasks/moderation.py` — new docket task `scan_image_moderation` + scheduler
- `backend/src/backend/_internal/tasks/__init__.py` — register the new task
- `backend/src/backend/storage/r2.py` — new `delete_image()` method
- `backend/src/backend/storage/protocol.py` — add `delete_image` to protocol
- `backend/src/backend/api/albums.py` — use `delete_image` for cover art cleanup
- `backend/src/backend/api/tracks/mutations.py` — use `delete_image` for track art cleanup
- `backend/src/backend/api/lists.py` — use `delete_image` for playlist cover cleanup

## Test plan

- [x] `just backend lint` — clean
- [ ] CI tests pass
- [ ] post-deploy: edit a track's cover art on staging, verify PATCH completes in ~1s instead of ~9s via Logfire
- [ ] post-deploy: verify image moderation scan fires as a background task (check Logfire for `background image moderation complete` span)

🤖 Generated with [Claude Code](https://claude.com/claude-code)