### PR TITLE
feat: unlisted tracks — exclude from discovery feeds

### DIFF
--- a/backend/alembic/versions/2026_04_10_104404_9eda586624d0_add_unlisted_column_to_tracks.py
+++ b/backend/alembic/versions/2026_04_10_104404_9eda586624d0_add_unlisted_column_to_tracks.py
@@ -1,0 +1,30 @@
+"""add unlisted column to tracks
+
+Revision ID: 9eda586624d0
+Revises: 4e5638f6576a
+Create Date: 2026-04-10 10:44:04.227029
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "9eda586624d0"
+down_revision: str | None = "4e5638f6576a"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    """Add unlisted boolean column to tracks table."""
+    op.add_column(
+        "tracks",
+        sa.Column("unlisted", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+
+def downgrade() -> None:
+    """Remove unlisted column from tracks table."""
+    op.drop_column("tracks", "unlisted")

--- a/backend/src/backend/api/for_you.py
+++ b/backend/src/backend/api/for_you.py
@@ -308,7 +308,10 @@ async def get_for_you_feed(
         top_ids = [tid for tid, _ in top_slice]
         artist_rows = (
             await db.execute(
-                select(Track.id, Track.artist_did).where(Track.id.in_(top_ids))
+                select(Track.id, Track.artist_did).where(
+                    Track.id.in_(top_ids),
+                    Track.unlisted == False,  # noqa: E712
+                )
             )
         ).all()
         artist_by_track = {row.id: row.artist_did for row in artist_rows}

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -137,6 +137,9 @@ async def list_tracks(
     # filter by artist if provided
     if artist_did:
         stmt = stmt.where(Track.artist_did == artist_did)
+    else:
+        # discovery feed: exclude unlisted tracks (artist pages show all)
+        stmt = stmt.where(Track.unlisted == False)  # noqa: E712
 
     # filter out tracks with hidden tags
     # when filter_hidden_tags is None (default), auto-decide:
@@ -361,17 +364,17 @@ async def list_top_tracks(
 
     top_track_ids = [tid for tid, _ in top_tracks_with_counts]
 
-    # fetch tracks with relationships
+    # fetch tracks with relationships, excluding unlisted
     stmt = (
         select(Track)
         .join(Artist)
         .options(selectinload(Track.artist), selectinload(Track.album_rel))
-        .where(Track.id.in_(top_track_ids))
+        .where(Track.id.in_(top_track_ids), Track.unlisted == False)  # noqa: E712
     )
     result = await db.execute(stmt)
     tracks_by_id = {track.id: track for track in result.scalars().all()}
 
-    # preserve order from top_track_ids
+    # preserve order from top_track_ids (unlisted tracks silently dropped)
     tracks = [tracks_by_id[tid] for tid in top_track_ids if tid in tracks_by_id]
 
     # get authenticated user's liked tracks (scoped to current track IDs only)

--- a/backend/src/backend/api/tracks/mutations.py
+++ b/backend/src/backend/api/tracks/mutations.py
@@ -174,6 +174,10 @@ async def update_track_metadata(
         str | None,
         Form(description="Set to 'true' to remove artwork"),
     ] = None,
+    unlisted: Annotated[
+        str | None,
+        Form(description="Set to 'true' to exclude from feeds, 'false' to include"),
+    ] = None,
 ) -> TrackResponse:
     """Update track metadata (only by owner)."""
     result = await db.execute(
@@ -235,6 +239,10 @@ async def update_track_metadata(
                 ) from e
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e)) from e
+
+    # handle unlisted toggle
+    if unlisted is not None:
+        track.unlisted = unlisted.lower() == "true"
 
     # track album changes for list sync
     old_album_id = track.album_id

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -103,6 +103,9 @@ class UploadContext:
     # auto-apply recommended genre tags after classification
     auto_tag: bool = False
 
+    # visibility: unlisted tracks don't appear in discovery feeds
+    unlisted: bool = False
+
 
 @dataclass
 class AudioInfo:
@@ -719,6 +722,7 @@ async def _create_records(
             image_url=image_url,
             thumbnail_url=thumbnail_url,
             support_gate=ctx.support_gate,
+            unlisted=ctx.unlisted,
             audio_storage=audio_storage,
             pds_blob_cid=pds_result.cid if pds_result else None,
             pds_blob_size=pds_result.size if pds_result else None,
@@ -996,6 +1000,12 @@ async def upload_track(
         str | None,
         Form(description="auto-apply recommended genre tags after classification"),
     ] = None,
+    unlisted: Annotated[
+        str | None,
+        Form(
+            description="set to 'true' to exclude from discovery feeds (latest, top, for-you)"
+        ),
+    ] = None,
     file: UploadFile = File(...),
     image: UploadFile | None = File(None),
 ) -> UploadStartResponse:
@@ -1140,6 +1150,7 @@ async def upload_track(
             image_content_type=image_content_type,
             support_gate=parsed_support_gate,
             auto_tag=auto_tag == "true",
+            unlisted=unlisted == "true",
         )
         background_tasks.add_task(_process_upload_background, ctx)
     except Exception:

--- a/backend/src/backend/models/track.py
+++ b/backend/src/backend/models/track.py
@@ -101,6 +101,13 @@ class Track(Base):
     image_url: Mapped[str | None] = mapped_column(String, nullable=True)
     thumbnail_url: Mapped[str | None] = mapped_column(String, nullable=True)
 
+    # visibility — unlisted tracks don't appear in discovery feeds (latest,
+    # top, for-you) but are still accessible via direct link, artist profile,
+    # album pages, playlists, and search
+    unlisted: Mapped[bool] = mapped_column(
+        nullable=False, default=False, server_default="false"
+    )
+
     # notification tracking
     notification_sent: Mapped[bool] = mapped_column(
         nullable=False, default=False, server_default="false"

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -122,6 +122,7 @@ class TrackResponse(BaseModel):
     description: str | None = None  # track description (liner notes, show notes)
     audio_storage: str = "r2"  # "r2" | "pds" | "both"
     pds_blob_cid: str | None = None  # CID if stored on user's PDS
+    unlisted: bool = False  # excluded from discovery feeds
 
     @classmethod
     async def from_track(
@@ -233,4 +234,5 @@ class TrackResponse(BaseModel):
             original_file_type=track.original_file_type,
             audio_storage=track.audio_storage,
             pds_blob_cid=track.pds_blob_cid,
+            unlisted=track.unlisted,
         )

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -64,6 +64,7 @@ export interface Track {
 	description?: string | null; // track description (liner notes, show notes)
 	audio_storage?: 'r2' | 'pds' | 'both'; // where audio is stored
 	pds_blob_cid?: string | null; // CID if stored on user's PDS
+	unlisted?: boolean; // excluded from discovery feeds
 }
 
 export interface LinkedAccount {

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -81,7 +81,8 @@ class UploaderState {
 		onSuccess?: (_result?: UploadResult) => void,
 		callbacks?: UploadProgressCallback,
 		label?: string,
-		albumId?: string
+		albumId?: string,
+		unlisted?: boolean
 	): void {
 		const taskId = crypto.randomUUID();
 		const fileSizeMB = file.size / 1024 / 1024;
@@ -129,6 +130,9 @@ class UploaderState {
 		}
 		if (description) {
 			formData.append('description', description);
+		}
+		if (unlisted) {
+			formData.append('unlisted', 'true');
 		}
 
 		const xhr = new XMLHttpRequest();

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -35,6 +35,7 @@
 	let editImagePreviewUrl = $state<string | null>(null);
 	let editRemoveImage = $state(false);
 	let editSupportGate = $state(false);
+	let editUnlisted = $state(false);
 	let hasUnresolvedEditFeaturesInput = $state(false);
 	let recommendedTags = $state<{name: string; score: number}[]>([]);
 	let loadingRecommendedTags = $state(false);
@@ -405,6 +406,7 @@
 		editFeaturedArtists = track.features || [];
 		editTags = track.tags || [];
 		editSupportGate = track.support_gate !== null && track.support_gate !== undefined;
+		editUnlisted = track.unlisted ?? false;
 		fetchRecommendedTags(track.id);
 	}
 
@@ -443,6 +445,7 @@
 		editImagePreviewUrl = null;
 		editRemoveImage = false;
 		editSupportGate = false;
+		editUnlisted = false;
 		recommendedTags = [];
 		loadingRecommendedTags = false;
 		recommendedTagsTrackId = null;
@@ -469,6 +472,7 @@
 		} else {
 			formData.append('support_gate', 'null');
 		}
+		formData.append('unlisted', editUnlisted ? 'true' : 'false');
 		// handle artwork: remove, replace, or leave unchanged
 		if (editRemoveImage) {
 			formData.append('remove_image', 'true');
@@ -1017,6 +1021,21 @@
 												{/if}
 											</div>
 										{/if}
+										<div class="edit-field-group">
+											<span class="edit-label">visibility</span>
+											<label class="toggle-row">
+												<input
+													type="checkbox"
+													bind:checked={editUnlisted}
+												/>
+												<span>unlisted — won't appear in feeds</span>
+											</label>
+											{#if editUnlisted}
+												<p class="field-hint">
+													this track won't show up in the latest, top, or for-you feeds. it's still accessible via direct link, your profile, albums, playlists, and search.
+												</p>
+											{/if}
+										</div>
 									</div>
 									<div class="edit-actions">
 										<button

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -61,6 +61,7 @@
 	let attestedRights = $state(false);
 	let supportGated = $state(false);
 	let autoTag = $state(false);
+	let trackUnlisted = $state(false);
 
 	// albums for selection
 	let albums = $state<AlbumSummary[]>([]);
@@ -125,6 +126,7 @@
 		const isGated = supportGated;
 		const shouldAutoTag = autoTag;
 		const uploadDescription = description;
+		const isUnlisted = trackUnlisted;
 
 		const clearForm = () => {
 			title = "";
@@ -137,6 +139,7 @@
 			attestedRights = false;
 			supportGated = false;
 			autoTag = false;
+			trackUnlisted = false;
 
 			const fileInput = document.getElementById(
 				"file-input",
@@ -167,6 +170,9 @@
 				},
 				onError: () => {},
 			},
+			undefined, // label
+			undefined, // albumId
+			isUnlisted,
 		);
 	}
 
@@ -407,6 +413,21 @@
 							want to offer exclusive tracks to supporters? <a href="https://atprotofans.com" target="_blank" rel="noopener">set up atprotofans</a>, then enable it in your <a href="/portal">portal</a>
 						</span>
 					</div>
+				{/if}
+			</div>
+
+			<div class="form-group">
+				<label class="checkbox-label">
+					<input
+						type="checkbox"
+						bind:checked={trackUnlisted}
+					/>
+					<span class="checkbox-text">unlisted — won't appear in feeds</span>
+				</label>
+				{#if trackUnlisted}
+					<p class="field-hint">
+						this track won't show up in the latest, top, or for-you feeds. it's still accessible via direct link, your profile, albums, playlists, and search.
+					</p>
 				{/if}
 			</div>
 

--- a/loq.toml
+++ b/loq.toml
@@ -40,7 +40,7 @@ max_lines = 1149
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
-max_lines = 581
+max_lines = 584
 
 [[rules]]
 path = "backend/src/backend/api/tracks/mutations.py"
@@ -48,7 +48,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1223
+max_lines = 1234
 
 [[rules]]
 path = "backend/src/backend/config.py"
@@ -164,7 +164,7 @@ max_lines = 2446
 
 [[rules]]
 path = "frontend/src/routes/portal/+page.svelte"
-max_lines = 3470
+max_lines = 3489
 
 [[rules]]
 path = "frontend/src/routes/settings/+page.svelte"
@@ -184,7 +184,7 @@ max_lines = 1299
 
 [[rules]]
 path = "frontend/src/routes/upload/+page.svelte"
-max_lines = 798
+max_lines = 819
 
 [[rules]]
 path = "services/moderation/src/admin.rs"


### PR DESCRIPTION
## Summary

Adds an \`unlisted\` boolean to Track (default false) that lets artists opt specific tracks out of the latest, top, and for-you feeds while keeping them accessible everywhere else.

## Where unlisted tracks are filtered

| surface | filtered? | why |
|---------|-----------|-----|
| \`GET /tracks/\` (latest feed) | yes (when no \`artist_did\`) | discovery feed shouldn't push unlisted content |
| \`GET /tracks/top\` | yes | public leaderboard |
| \`GET /for-you/\` | yes | personalized feed |
| \`GET /tracks/?artist_did=...\` (artist profile) | **no** | artist chose to publish, just not in feeds |
| \`GET /tracks/{id}\` (direct link) | **no** | always accessible |
| album tracks | **no** | album context is explicit |
| playlist tracks | **no** | curator chose to include it |
| search | **no** | if someone searches for it, they should find it |
| \`GET /tracks/me\` (portal) | **no** | owner's view |

## What changed

**Backend**
- Migration: \`unlisted\` boolean column, NOT NULL, DEFAULT false
- \`listing.py\`: discovery feed filters \`WHERE unlisted = false\`; artist profile pages don't
- \`listing.py\`: top tracks excludes unlisted at fetch
- \`for_you.py\`: excludes unlisted from candidate pool
- \`uploads.py\`: new \`unlisted\` form field on upload
- \`mutations.py\`: new \`unlisted\` form field on edit
- \`schemas.py\`: \`unlisted\` in TrackResponse

**Frontend**
- \`types.ts\`: \`unlisted?: boolean\` on Track
- \`uploader.svelte.ts\`: new \`unlisted\` param → FormData
- Upload page: checkbox with hint text
- Portal track editor: checkbox pre-filled from current state

## Test plan

- [ ] CI passes
- [ ] upload a track with unlisted checked → doesn't appear on homepage latest feed
- [ ] same track appears on artist profile page
- [ ] same track accessible via direct link
- [ ] edit track in portal → toggle unlisted off → appears in feeds again
- [ ] top tracks and for-you feeds respect the filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)