### PR TITLE
docs: adopt "atmosphere account" terminology

### DIFF
--- a/.github/workflows/status-maintenance.yml
+++ b/.github/workflows/status-maintenance.yml
@@ -213,7 +213,7 @@ jobs:
             ### terminology
 
             plyr.fm is built on **ATProto** (the protocol), not Bluesky (the app).
-            say "ATProto identities" or just "identities" - never "Bluesky accounts".
+            say "atmosphere accounts" or just "accounts" - never "Bluesky accounts".
 
             ### identifying what actually shipped
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ just dev-services-down
 - teal.fm scrobbling and now-playing reporting
 
 ### creating
-- OAuth authentication via ATProto (bluesky accounts), multi-account support
+- OAuth authentication via ATProto (atmosphere accounts), multi-account support
 - upload tracks with title, artwork, tags, and featured artists
 - lossless audio support (AIFF/FLAC) with automatic MP3 transcoding for universal playback
 - auto-tagging via ML genre classification

--- a/docs/internal/tools/status-maintenance.md
+++ b/docs/internal/tools/status-maintenance.md
@@ -75,10 +75,10 @@ the project name is pronounced "player FM". in scripts, write:
 ### terminology
 
 plyr.fm operates at the ATProto protocol layer:
-- say "ATProto identities" or "identities"
+- say "atmosphere accounts" or just "accounts"
 - never "Bluesky accounts"
 
-Bluesky is one application on ATProto, like plyr.fm is another.
+Bluesky is one application on the Atmosphere, like plyr.fm is another.
 
 ### tone
 
@@ -135,7 +135,7 @@ if a reverted PR is polluting the results, add a temporary exclusion.
 ### audio has wrong terminology
 
 check the terminology section in the workflow prompt. common mistakes:
-- "Bluesky accounts" should be "ATProto identities"
+- "Bluesky accounts" should be "atmosphere accounts"
 - "plyr" should be "player FM" (phonetic)
 
 ### STATUS.md over 500 lines

--- a/docs/public/artists.md
+++ b/docs/public/artists.md
@@ -21,9 +21,9 @@ your catalog isn't trapped here — other apps can access your tracks without pl
 
 ## your first upload
 
-1. **sign in** at [plyr.fm](https://plyr.fm) with your handle (e.g. `you.bsky.social`)
+1. **sign in** at [plyr.fm](https://plyr.fm) with your atmosphere account (e.g. `you.bsky.social`)
 
-   ![plyr.fm sign-in page — enter your handle to get started](/screenshots/login-page.png)
+   ![plyr.fm sign-in page — enter your atmosphere account to get started](/screenshots/login-page.png)
 
 2. **upload** — click the upload button and drop your audio file (MP3, WAV, or M4A)
 

--- a/docs/public/glossary.md
+++ b/docs/public/glossary.md
@@ -21,9 +21,13 @@ a named group of records in a user's data repo, identified by an [NSID](#nsid). 
 
 see: [atproto.com/specs/did](https://atproto.com/specs/did)
 
-### handle (atproto handle)
+### atmosphere account
 
-a human-readable identifier for an atproto account, formatted as a domain name (e.g. `artist.bsky.social` or `yourname.com`). sometimes called an [internet handle](https://internethandle.org). handles can change — DIDs are the stable identifier underneath.
+an account on the [Atmosphere](https://atproto.com) — the open network of apps and services built on the AT Protocol. your atmosphere account is portable: you can use it to sign in to plyr.fm, Bluesky, and any other atproto app. accounts are hosted by a [PDS](#pds) provider (like `bsky.social`).
+
+### handle
+
+a human-readable identifier for an atmosphere account, formatted as a domain name (e.g. `artist.bsky.social` or `yourname.com`). handles can change — [DIDs](#did) are the stable identifier underneath.
 
 ### Jetstream
 

--- a/docs/public/listeners.md
+++ b/docs/public/listeners.md
@@ -25,9 +25,9 @@ even today, other apps (like [aetheros.computer](https://aetheros.computer)) alr
 
 ## your first 5 minutes
 
-1. **sign in** — go to [plyr.fm](https://plyr.fm) and enter your handle (e.g. `you.bsky.social`)
+1. **sign in** — go to [plyr.fm](https://plyr.fm) and enter your atmosphere account (e.g. `you.bsky.social`)
 
-   ![plyr.fm sign-in page — enter your handle to get started](/screenshots/login-page.png)
+   ![plyr.fm sign-in — enter your atmosphere account to get started](/screenshots/login-page.png)
 
 2. **find a track** — browse the feed to see what's playing
 

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -121,7 +121,7 @@
 			{#if mode === 'signin'}
 				<div class="input-group">
 					<label for="handle">
-						<a href="https://internethandle.org" target="_blank" rel="noopener" class="handle-label-link">internet handle</a>
+						<a href="https://atproto.com/guides/glossary#handle" target="_blank" rel="noopener" class="handle-label-link">atmosphere account</a>
 					</label>
 					<HandleAutocomplete
 						bind:value={handle}


### PR DESCRIPTION
## Summary

- login page label: "internet handle" → "atmosphere account" (links to atproto.com/guides/glossary#handle)
- glossary: split "handle (atproto handle)" into separate "atmosphere account" and "handle" entries
- docs (listeners, artists): updated sign-in instructions to say "atmosphere account"
- README: "bluesky accounts" → "atmosphere accounts"
- status-maintenance workflow + docs: "ATProto identities" → "atmosphere accounts"

ref: [Sri's article on Atmosphere terminology](https://sri.leaflet.pub/3maltcnnbqs2n) — accounts, not handles.

## Follow-up

Screenshots in `docs/site/public/screenshots/login-page.png` will be outdated after this merges. Will capture fresh screenshots against prod in a follow-up PR.

## Test plan

- [ ] verify login page label reads "atmosphere account" and links to atproto glossary
- [ ] verify docs site glossary renders both new entries correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)