### PR TITLE
docs: replace user-facing "handle" with "account"

### DIFF
--- a/docs/public/artists.md
+++ b/docs/public/artists.md
@@ -6,14 +6,14 @@ description: "upload, manage, and distribute your audio"
 you make sound! let's get it out there!
 
 :::caution[🚦]
-you _don't_ have a handle? head to [plyr.fm/login](https://plyr.fm/login) to create an account.
+you _don't_ have an account? head to [plyr.fm/login](https://plyr.fm/login) to create one.
 :::
 
 on plyr.fm, you can share **music**, **podcasts**, **sound art**, **ASMR**, and anything else that makes noise — no distribution fees, no gatekeepers.
 
 when you upload a track:
 - it's stored in [a place you control](https://at-me.zzstoatzz.io/view/?handle=zzstoatzz.io), tied to your identity
-- share your track with anyone, even if they don't have a handle
+- share your track with anyone, even if they don't have an account
 - you can [embed a player](#embeds) on your website or blog
 - you can [gate tracks](#supporter-gated-tracks) behind supporter status
 

--- a/docs/public/listeners.md
+++ b/docs/public/listeners.md
@@ -3,10 +3,10 @@ title: "for listeners"
 description: "discover and stream audio on plyr.fm"
 ---
 
-you have a handle! you like _sound_! let's go!
+you have an account! you like _sound_! let's go!
 
 :::caution[🚦]
-you _don't_ have a handle? head to [plyr.fm/login](https://plyr.fm/login) to create an account.
+you _don't_ have an account? head to [plyr.fm/login](https://plyr.fm/login) to create one.
 
 if you don't want to create an account, you can still queue and listen to audio on plyr.fm. you just won't be able to like, comment, build playlists, support creators, or save your preferences.
 :::


### PR DESCRIPTION
## Summary

- listeners page: "you have a handle" → "you have an account", "don't have a handle" → "don't have an account"
- artists page: "don't have a handle" → "don't have an account", "even if they don't have a handle" → "even if they don't have an account"

Follow-up to #1268.

## Test plan

- [ ] verify docs site renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)