### PR TITLE
feat: XRPC mention search for Leaflet embeds

### DIFF
--- a/backend/src/backend/api/__init__.py
+++ b/backend/src/backend/api/__init__.py
@@ -20,6 +20,7 @@ from backend.api.search import router as search_router
 from backend.api.stats import router as stats_router
 from backend.api.tracks import router as tracks_router
 from backend.api.users import router as users_router
+from backend.api.xrpc import router as xrpc_router
 
 __all__ = [
     "account_router",
@@ -42,4 +43,5 @@ __all__ = [
     "stats_router",
     "tracks_router",
     "users_router",
+    "xrpc_router",
 ]

--- a/backend/src/backend/api/meta.py
+++ b/backend/src/backend/api/meta.py
@@ -93,6 +93,31 @@ async def jwks_endpoint() -> dict[str, Any]:
     return jwks
 
 
+@router.get("/.well-known/did.json")
+async def did_json() -> dict[str, Any]:
+    """serve DID document for did:web resolution.
+
+    enables ATProto apps to discover plyr.fm's XRPC services
+    (e.g. parts.page.mention.search for Leaflet embed integration).
+    """
+    client_uri = settings.atproto.client_id.replace("/oauth-client-metadata.json", "")
+    # did:web uses domain with colons for port in dev
+    domain = client_uri.replace("https://", "").replace("http://", "")
+    did = f"did:web:{domain}"
+
+    return {
+        "@context": ["https://www.w3.org/ns/did/v1"],
+        "id": did,
+        "service": [
+            {
+                "id": "#mention_search",
+                "type": "MentionSearchService",
+                "serviceEndpoint": client_uri,
+            },
+        ],
+    }
+
+
 @router.get("/robots.txt", include_in_schema=False)
 async def robots_txt():
     """serve robots.txt to tell crawlers this is an API, not a website."""

--- a/backend/src/backend/api/xrpc.py
+++ b/backend/src/backend/api/xrpc.py
@@ -1,0 +1,159 @@
+"""XRPC endpoints for cross-app interop.
+
+implements parts.page.mention.search for Leaflet embed integration.
+"""
+
+import logging
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.api.search import (
+    AlbumSearchResult,
+    ArtistSearchResult,
+    PlaylistSearchResult,
+    SearchResult,
+    TagSearchResult,
+    TrackSearchResult,
+    _search_albums,
+    _search_artists,
+    _search_playlists,
+    _search_tags,
+    _search_tracks,
+)
+from backend.config import settings
+from backend.models import get_db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/xrpc", tags=["xrpc"])
+
+# scope → search type mapping
+SCOPE_MAP: dict[str, str] = {
+    "tracks": "tracks",
+    "artists": "artists",
+    "albums": "albums",
+    "playlists": "playlists",
+    "tags": "tags",
+}
+
+ALL_TYPES = set(SCOPE_MAP.values())
+
+
+def _result_to_mention(result: SearchResult) -> dict[str, Any]:
+    """convert an internal search result to a parts.page.mention.search result."""
+    base_url = settings.frontend.url
+
+    match result:
+        case TrackSearchResult():
+            mention: dict[str, Any] = {
+                "uri": f"{base_url}/track/{result.id}",
+                "name": result.title,
+                "description": f"by {result.artist_display_name}",
+                "href": f"{base_url}/track/{result.id}",
+                "labels": [{"text": "track"}],
+                "embed": {
+                    "src": f"{base_url}/embed/track/{result.id}",
+                    "aspectRatio": {"width": 16, "height": 9},
+                },
+                "subscope": {"scope": "tracks", "label": "Tracks"},
+            }
+            if result.image_url:
+                mention["icon"] = result.image_url
+            return mention
+
+        case ArtistSearchResult():
+            mention = {
+                "uri": f"{base_url}/u/{result.handle}",
+                "name": result.display_name,
+                "description": f"@{result.handle}",
+                "href": f"{base_url}/u/{result.handle}",
+                "labels": [{"text": "artist"}],
+                "subscope": {"scope": "artists", "label": "Artists"},
+            }
+            if result.avatar_url:
+                mention["icon"] = result.avatar_url
+            return mention
+
+        case AlbumSearchResult():
+            mention = {
+                "uri": f"{base_url}/u/{result.artist_handle}/album/{result.slug}",
+                "name": result.title,
+                "description": f"by {result.artist_display_name}",
+                "href": f"{base_url}/u/{result.artist_handle}/album/{result.slug}",
+                "labels": [{"text": "album"}],
+                "embed": {
+                    "src": f"{base_url}/embed/album/{result.artist_handle}/{result.slug}",
+                    "aspectRatio": {"width": 16, "height": 9},
+                },
+                "subscope": {"scope": "albums", "label": "Albums"},
+            }
+            if result.image_url:
+                mention["icon"] = result.image_url
+            return mention
+
+        case PlaylistSearchResult():
+            mention = {
+                "uri": f"{base_url}/playlist/{result.id}",
+                "name": result.name,
+                "description": f"by {result.owner_display_name} · {result.track_count} tracks",
+                "href": f"{base_url}/playlist/{result.id}",
+                "labels": [{"text": "playlist"}],
+                "embed": {
+                    "src": f"{base_url}/embed/playlist/{result.id}",
+                    "aspectRatio": {"width": 16, "height": 9},
+                },
+                "subscope": {"scope": "playlists", "label": "Playlists"},
+            }
+            if result.image_url:
+                mention["icon"] = result.image_url
+            return mention
+
+        case TagSearchResult():
+            return {
+                "uri": f"{base_url}/tag/{result.name}",
+                "name": result.name,
+                "description": f"{result.track_count} tracks",
+                "href": f"{base_url}/tag/{result.name}",
+                "labels": [{"text": "tag"}],
+                "subscope": {"scope": "tags", "label": "Tags"},
+            }
+
+
+@router.get("/parts.page.mention.search")
+async def mention_search(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    service: str = Query(..., description="AT URI of the mention service record"),
+    search: str = Query(..., min_length=1, max_length=100, description="search query"),
+    scope: str | None = Query(None, description="scope to narrow results"),
+    limit: int = Query(20, ge=1, le=50, description="max results"),
+) -> dict[str, Any]:
+    """XRPC query: parts.page.mention.search
+
+    search plyr.fm tracks, artists, albums, playlists, and tags.
+    returns results formatted per the parts.page.mention.search lexicon
+    with embed info for Leaflet iframe integration.
+    """
+    if len(search) < 2:
+        return {"results": []}
+
+    types = {SCOPE_MAP[scope]} if scope and scope in SCOPE_MAP else ALL_TYPES
+
+    results: list[SearchResult] = []
+
+    if "tracks" in types:
+        results.extend(await _search_tracks(db, search, limit))
+    if "artists" in types:
+        results.extend(await _search_artists(db, search, limit))
+    if "albums" in types:
+        results.extend(await _search_albums(db, search, limit))
+    if "playlists" in types:
+        results.extend(await _search_playlists(db, search, limit))
+    if "tags" in types:
+        results.extend(await _search_tags(db, search, limit))
+
+    results.sort(key=lambda r: r.relevance, reverse=True)
+    results = results[:limit]
+
+    return {"results": [_result_to_mention(r) for r in results]}

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -37,6 +37,7 @@ from backend.api import (
     stats_router,
     tracks_router,
     users_router,
+    xrpc_router,
 )
 from backend.api.albums import router as albums_router
 from backend.api.lists import router as lists_router
@@ -161,3 +162,4 @@ app.include_router(oembed_router)
 app.include_router(stats_router)
 app.include_router(users_router)
 app.include_router(meta_router)
+app.include_router(xrpc_router)

--- a/backend/tests/api/test_xrpc.py
+++ b/backend/tests/api/test_xrpc.py
@@ -1,0 +1,155 @@
+"""tests for XRPC mention search endpoint."""
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.main import app
+from backend.models import Artist, Track
+
+
+@pytest.fixture
+async def search_fixtures(db_session: AsyncSession) -> dict[str, int]:
+    """create test data for mention search."""
+    artist = Artist(
+        did="did:plc:xrpc_test",
+        handle="stellz.test",
+        display_name="Stellz",
+    )
+    db_session.add(artist)
+    await db_session.flush()
+
+    track = Track(
+        title="banana mix",
+        artist_did=artist.did,
+        file_id="xrpc_test_123",
+        file_type="mp3",
+        r2_url="https://cdn.example.com/audio/banana.mp3",
+        image_url="https://cdn.example.com/images/banana.png",
+    )
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+
+    return {"track_id": track.id}
+
+
+@pytest.fixture
+def test_app(db_session: AsyncSession) -> FastAPI:
+    """get test app with db session dependency."""
+    _ = db_session
+    return app
+
+
+async def test_mention_search_returns_results(
+    test_app: FastAPI, search_fixtures: dict[str, int]
+) -> None:
+    """test that mention search returns formatted results."""
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/xrpc/parts.page.mention.search",
+            params={
+                "service": "at://did:plc:test/parts.page.mention.service/plyr",
+                "search": "banana",
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "results" in data
+    assert len(data["results"]) > 0
+
+    track_result = next(
+        (r for r in data["results"] if r["labels"][0]["text"] == "track"), None
+    )
+    assert track_result is not None
+    assert track_result["name"] == "banana mix"
+    assert "embed" in track_result
+    assert "/embed/track/" in track_result["embed"]["src"]
+    assert track_result["embed"]["aspectRatio"] == {"width": 16, "height": 9}
+    assert track_result["href"].endswith(f"/track/{search_fixtures['track_id']}")
+
+
+async def test_mention_search_scoped_to_tracks(
+    test_app: FastAPI, search_fixtures: dict[str, int]
+) -> None:
+    """test that scope=tracks only returns track results."""
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/xrpc/parts.page.mention.search",
+            params={
+                "service": "at://did:plc:test/parts.page.mention.service/plyr",
+                "search": "banana",
+                "scope": "tracks",
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    for result in data["results"]:
+        assert result["labels"][0]["text"] == "track"
+
+
+async def test_mention_search_artist_results(
+    test_app: FastAPI, search_fixtures: dict[str, int]
+) -> None:
+    """test that artist results have correct format (no embed)."""
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/xrpc/parts.page.mention.search",
+            params={
+                "service": "at://did:plc:test/parts.page.mention.service/plyr",
+                "search": "stellz",
+                "scope": "artists",
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["results"]) > 0
+
+    artist_result = data["results"][0]
+    assert artist_result["name"] == "Stellz"
+    assert "@stellz.test" in artist_result["description"]
+    assert "embed" not in artist_result
+
+
+async def test_mention_search_short_query(test_app: FastAPI) -> None:
+    """test that very short queries return empty results."""
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/xrpc/parts.page.mention.search",
+            params={
+                "service": "at://did:plc:test/parts.page.mention.service/plyr",
+                "search": "a",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"results": []}
+
+
+async def test_mention_search_no_results(test_app: FastAPI) -> None:
+    """test that unmatched queries return empty results."""
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/xrpc/parts.page.mention.search",
+            params={
+                "service": "at://did:plc:test/parts.page.mention.service/plyr",
+                "search": "xyznonexistent",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"results": []}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -177,6 +177,7 @@ async def _setup_template_database(template_url: str) -> None:
     engine = create_async_engine(template_url, echo=False)
     try:
         async with engine.begin() as conn:
+            await conn.execute(sa.text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
             await conn.run_sync(Base.metadata.create_all)
             await _truncate_tables(conn)
             await _create_clear_database_procedure(conn)


### PR DESCRIPTION

<img width="458" height="460" alt="image" src="https://github.com/user-attachments/assets/e9d2f1e9-00f8-45a4-9860-6cea14d33938" />


## Summary

Implements plyr.fm's side of the [Leaflet mention services](https://tangled.org/leaflet.pub/leaflet) integration — lets Leaflet users search for plyr.fm tracks, artists, albums, playlists, and tags inline while writing, and embed audio players directly in their publications.

**Two endpoints added:**

1. `GET /xrpc/parts.page.mention.search` — XRPC query per the `parts.page.mention.search` lexicon. Wraps our existing pg_trgm search. Returns results with:
   - **Tracks, albums, playlists**: embed info pointing to existing `/embed/*` pages
   - **Artists**: profile links (no embed surface yet)
   - **Tags**: tag page links
   - Subscope support for drilling into Tracks/Artists/Albums/etc.

2. `GET /.well-known/did.json` — DID document for `did:web:api.plyr.fm`. Declares a `#mention_search` service so ATProto apps can proxy XRPC calls to us without depending on a third-party feed service.

## How the production flow works

1. Leaflet user types `@` and selects plyr.fm as a mention service
2. Leaflet's `proxy_mention_search` sets `atproto-proxy: did:web:api.plyr.fm#mention_search`
3. User's PDS resolves `did:web:api.plyr.fm` via `https://api.plyr.fm/.well-known/did.json`
4. PDS proxies the XRPC call to `https://api.plyr.fm/xrpc/parts.page.mention.search`
5. Our endpoint returns results; if user selects a track, Leaflet renders our embed player in an iframe

## What's needed upstream (Leaflet side)

plyr.fm's endpoints are self-contained — no dependency on Leaflet's feed service. But for users to *discover* plyr.fm as a mention service, one of these needs to happen:

- **Option A (preferred)**: We open a PR to Leaflet adding plyr.fm as a built-in mention service — same pattern as Wikipedia and Pokemon. This is a ~30 line `mentions/services/plyr.ts` that calls our public search API. Already written and tested locally.
- **Option B**: A user creates a `parts.page.mention.service` PDS record pointing to `did:web:api.plyr.fm`, and Leaflet's appview indexes it. Other users can then enable it. No Leaflet code change needed, but requires manual setup.
- **Option C**: Jared adds it to a default/recommended services list in Leaflet's UI.

**Recommendation**: Option A first (PR to Leaflet), then Option B becomes the long-term pattern as the ecosystem matures.

## Tested locally

- Ran Leaflet (Next.js + Supabase) locally with plyr.fm mention service wired in
- Confirmed search returns results from production plyr.fm data
- Confirmed embed URLs resolve to working players
- Confirmed the full mention → embed flow works in the Leaflet editor

## Test plan

- [ ] CI passes (5 new tests)
- [ ] `curl "https://api.plyr.fm/.well-known/did.json"` returns valid DID document after deploy
- [ ] `curl "https://api.plyr.fm/xrpc/parts.page.mention.search?service=at://test&search=banana"` returns results
- [ ] embed URLs in results load working players

🤖 Generated with [Claude Code](https://claude.com/claude-code)