### PR TITLE
feat: artist embed page for Leaflet integration

### DIFF
--- a/backend/src/backend/api/xrpc.py
+++ b/backend/src/backend/api/xrpc.py
@@ -70,6 +70,10 @@ def _result_to_mention(result: SearchResult) -> dict[str, Any]:
                 "description": f"@{result.handle}",
                 "href": f"{base_url}/u/{result.handle}",
                 "labels": [{"text": "artist"}],
+                "embed": {
+                    "src": f"{base_url}/embed/u/{result.handle}",
+                    "aspectRatio": {"width": 16, "height": 9},
+                },
                 "subscope": {"scope": "artists", "label": "Artists"},
             }
             if result.avatar_url:

--- a/backend/tests/api/test_xrpc.py
+++ b/backend/tests/api/test_xrpc.py
@@ -98,7 +98,7 @@ async def test_mention_search_scoped_to_tracks(
 async def test_mention_search_artist_results(
     test_app: FastAPI, search_fixtures: dict[str, int]
 ) -> None:
-    """test that artist results have correct format (no embed)."""
+    """test that artist results have correct format with embed."""
     async with AsyncClient(
         transport=ASGITransport(app=test_app), base_url="http://test"
     ) as client:
@@ -118,7 +118,8 @@ async def test_mention_search_artist_results(
     artist_result = data["results"][0]
     assert artist_result["name"] == "Stellz"
     assert "@stellz.test" in artist_result["description"]
-    assert "embed" not in artist_result
+    assert "embed" in artist_result
+    assert "/embed/u/stellz.test" in artist_result["embed"]["src"]
 
 
 async def test_mention_search_short_query(test_app: FastAPI) -> None:

--- a/frontend/src/lib/components/embed/CollectionEmbed.svelte
+++ b/frontend/src/lib/components/embed/CollectionEmbed.svelte
@@ -2,16 +2,7 @@
 	import { page } from '$app/stores';
 	import { onMount, tick } from 'svelte';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
-	import type { Track } from '$lib/types';
-
-	interface CollectionData {
-		title: string;
-		subtitle: string;
-		subtitleUrl: string;
-		collectionUrl: string;
-		imageUrl: string | null;
-		tracks: Track[];
-	}
+	import type { CollectionData } from '$lib/types';
 
 	let { collection }: { collection: CollectionData } = $props();
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -220,3 +220,12 @@ export interface JamPlaybackState {
 	output_mode?: 'one_speaker' | 'everyone';
 }
 
+export interface CollectionData {
+	title: string;
+	subtitle: string;
+	subtitleUrl: string;
+	collectionUrl: string;
+	imageUrl: string | null;
+	tracks: Track[];
+}
+

--- a/frontend/src/routes/embed/album/[handle]/[slug]/+page.server.ts
+++ b/frontend/src/routes/embed/album/[handle]/[slug]/+page.server.ts
@@ -1,16 +1,7 @@
 import { API_URL } from '$lib/config';
-import type { AlbumResponse, Track } from '$lib/types';
+import type { AlbumResponse, CollectionData } from '$lib/types';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-
-export interface CollectionData {
-	title: string;
-	subtitle: string;
-	subtitleUrl: string;
-	collectionUrl: string;
-	imageUrl: string | null;
-	tracks: Track[];
-}
 
 export const load: PageServerLoad = async ({ params, fetch }) => {
 	try {

--- a/frontend/src/routes/embed/playlist/[id]/+page.server.ts
+++ b/frontend/src/routes/embed/playlist/[id]/+page.server.ts
@@ -1,5 +1,5 @@
 import { API_URL } from '$lib/config';
-import type { Track } from '$lib/types';
+import type { CollectionData, Track } from '$lib/types';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -8,15 +8,6 @@ interface PlaylistResponse {
 	name: string;
 	owner_handle: string;
 	image_url?: string;
-	tracks: Track[];
-}
-
-export interface CollectionData {
-	title: string;
-	subtitle: string;
-	subtitleUrl: string;
-	collectionUrl: string;
-	imageUrl: string | null;
 	tracks: Track[];
 }
 

--- a/frontend/src/routes/embed/u/[handle]/+page.server.ts
+++ b/frontend/src/routes/embed/u/[handle]/+page.server.ts
@@ -1,0 +1,45 @@
+import { API_URL } from '$lib/config';
+import type { Artist, Track } from '$lib/types';
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import type { CollectionData } from '../../album/[handle]/[slug]/+page.server';
+
+export const load: PageServerLoad = async ({ params, fetch }) => {
+	try {
+		const isDid = params.handle.startsWith('did:');
+		const artistUrl = isDid
+			? `${API_URL}/artists/${params.handle}`
+			: `${API_URL}/artists/by-handle/${params.handle}`;
+		const artistResponse = await fetch(artistUrl);
+
+		if (!artistResponse.ok) {
+			throw error(404, 'artist not found');
+		}
+
+		const artist: Artist = await artistResponse.json();
+
+		const tracksResponse = await fetch(
+			`${API_URL}/tracks/?artist_did=${artist.did}&limit=10`
+		);
+		let tracks: Track[] = [];
+
+		if (tracksResponse.ok) {
+			const data = await tracksResponse.json();
+			tracks = data.tracks || [];
+		}
+
+		return {
+			collection: {
+				title: artist.display_name,
+				subtitle: `@${artist.handle}`,
+				subtitleUrl: `https://plyr.fm/u/${artist.handle}`,
+				collectionUrl: `https://plyr.fm/u/${artist.handle}`,
+				imageUrl: artist.avatar_url ?? null,
+				tracks
+			} satisfies CollectionData
+		};
+	} catch (e) {
+		console.error('failed to load artist:', e);
+		throw error(404, 'artist not found');
+	}
+};

--- a/frontend/src/routes/embed/u/[handle]/+page.server.ts
+++ b/frontend/src/routes/embed/u/[handle]/+page.server.ts
@@ -1,8 +1,7 @@
 import { API_URL } from '$lib/config';
-import type { Artist, Track } from '$lib/types';
+import type { Artist, CollectionData, Track } from '$lib/types';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-import type { CollectionData } from '../../album/[handle]/[slug]/+page.server';
 
 export const load: PageServerLoad = async ({ params, fetch }) => {
 	try {

--- a/frontend/src/routes/embed/u/[handle]/+page.svelte
+++ b/frontend/src/routes/embed/u/[handle]/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import CollectionEmbed from '$lib/components/embed/CollectionEmbed.svelte';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+</script>
+
+<CollectionEmbed collection={data.collection} />


### PR DESCRIPTION
## Summary

- New `/embed/u/[handle]` route — artist embed showing their recent tracks, reuses `CollectionEmbed` (same component as album/playlist embeds)
- XRPC mention search now returns `embed` info for artist results, enabling the "Embed >" option in Leaflet's mention UI
- Deduplicated `CollectionData` interface into `$lib/types.ts` — was defined in 4 places (album, playlist, artist routes, and the component itself)

## Test plan

- [ ] CI passes
- [ ] `/embed/u/piss.beauty` loads stellz's tracks in the collection player
- [ ] XRPC artist results include `embed.src` → `/embed/u/{handle}`
- [ ] In Leaflet, artist results show "Embed >" option

🤖 Generated with [Claude Code](https://claude.com/claude-code)