### PR TITLE
fix: embed sizing — pixel dimensions instead of aspectRatio

### DIFF
--- a/backend/src/backend/api/xrpc.py
+++ b/backend/src/backend/api/xrpc.py
@@ -55,7 +55,8 @@ def _result_to_mention(result: SearchResult) -> dict[str, Any]:
                 "labels": [{"text": "track"}],
                 "embed": {
                     "src": f"{base_url}/embed/track/{result.id}",
-                    "aspectRatio": {"width": 16, "height": 9},
+                    "width": 600,
+                    "height": 160,
                 },
                 "subscope": {"scope": "tracks", "label": "Tracks"},
             }
@@ -72,7 +73,8 @@ def _result_to_mention(result: SearchResult) -> dict[str, Any]:
                 "labels": [{"text": "artist"}],
                 "embed": {
                     "src": f"{base_url}/embed/u/{result.handle}",
-                    "aspectRatio": {"width": 16, "height": 9},
+                    "width": 600,
+                    "height": 400,
                 },
                 "subscope": {"scope": "artists", "label": "Artists"},
             }
@@ -89,7 +91,8 @@ def _result_to_mention(result: SearchResult) -> dict[str, Any]:
                 "labels": [{"text": "album"}],
                 "embed": {
                     "src": f"{base_url}/embed/album/{result.artist_handle}/{result.slug}",
-                    "aspectRatio": {"width": 16, "height": 9},
+                    "width": 600,
+                    "height": 400,
                 },
                 "subscope": {"scope": "albums", "label": "Albums"},
             }
@@ -106,7 +109,8 @@ def _result_to_mention(result: SearchResult) -> dict[str, Any]:
                 "labels": [{"text": "playlist"}],
                 "embed": {
                     "src": f"{base_url}/embed/playlist/{result.id}",
-                    "aspectRatio": {"width": 16, "height": 9},
+                    "width": 600,
+                    "height": 400,
                 },
                 "subscope": {"scope": "playlists", "label": "Playlists"},
             }

--- a/backend/tests/api/test_xrpc.py
+++ b/backend/tests/api/test_xrpc.py
@@ -69,7 +69,8 @@ async def test_mention_search_returns_results(
     assert track_result["name"] == "banana mix"
     assert "embed" in track_result
     assert "/embed/track/" in track_result["embed"]["src"]
-    assert track_result["embed"]["aspectRatio"] == {"width": 16, "height": 9}
+    assert track_result["embed"]["width"] == 600
+    assert track_result["embed"]["height"] == 160
     assert track_result["href"].endswith(f"/track/{search_fixtures['track_id']}")
 
 


### PR DESCRIPTION
## Summary

16:9 aspectRatio made collection embeds way too tall in Leaflet. Switch to fixed width/height defaults so Leaflet uses pixel sizing with a draggable resize handle:

- Tracks: 600x160 (compact player bar)
- Artists/albums/playlists: 600x400 (room for track list)

These are defaults — users can resize after insertion.

## Test plan

- [ ] CI passes
- [ ] track embeds render compact in Leaflet
- [ ] collection embeds show track list without excess blank space

🤖 Generated with [Claude Code](https://claude.com/claude-code)