### PR TITLE
chore: remove dead osprey reference and duplicate loq rule

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -329,7 +329,7 @@ Leaflet mention service is live (#1271-1273) — plyr.fm is one of the first ATP
 - Jetstream audit trail / activity feed integration — persistent log of firehose events, toggle for visibility
 - share to bluesky (#334)
 - lyrics and annotations (#373)
-- configurable rules engine for moderation (Osprey rules engine PR #958 — on hold pending infrastructure consolidation, see #907)
+- configurable rules engine for moderation (#958)
 - infrastructure consolidation — audit and migrate from Fly.io sprawl to Helm/K8s pattern (#907, reference: `../relay`)
 - time-release gating (#642)
 - social activity feed (#971)

--- a/loq.toml
+++ b/loq.toml
@@ -243,10 +243,6 @@ path = "frontend/src/routes/+page.svelte"
 max_lines = 528
 
 [[rules]]
-path = "frontend/src/routes/u/[[]handle[]]/+page.svelte"
-max_lines = 1468
-
-[[rules]]
 path = "frontend/src/lib/components/AlbumUploadForm.svelte"
 max_lines = 823
 


### PR DESCRIPTION
## Summary
- Remove stale Osprey rules engine reference from STATUS.md backlog — `services/osprey/` was never committed (only contained `__pycache__` artifacts from a since-abandoned PR #958)
- Remove duplicate loq override for `u/[handle]/+page.svelte` that used `[[]handle[]]` glob syntax while the canonical entry uses `\\[handle\\]`

## Test plan
- [x] `uvx loq check` passes (717 files ok)
- [x] pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)