### PR TITLE
feat: R2 CDN caching via custom domains + CacheControl headers

### DIFF
--- a/backend/src/backend/api/CLAUDE.md
+++ b/backend/src/backend/api/CLAUDE.md
@@ -12,7 +12,7 @@ resources:
 - **albums**: CRUD with cover art, track ordering, ATProto list records
 - **playlists**: CRUD with drag-and-drop reordering, ATProto list records
 - **artists**: profiles synced from ATProto identities, support links
-- **audio**: streaming via 307 redirects to R2 CDN
+- **audio**: streaming via 307 redirects to CDN
 - **queue**: server-authoritative with optimistic client updates
 - **preferences**: user settings (accent color, auto-play, teal scrobbling, sensitive artwork)
 - **exports**: media export with SSE progress tracking, concurrent downloads

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -561,12 +561,7 @@ async def get_my_file_sizes(
         r2 = cast("R2Storage", storage)
         async with semaphore:
             try:
-                async with r2.async_session.client(
-                    "s3",
-                    endpoint_url=r2.endpoint_url,
-                    aws_access_key_id=r2.aws_access_key_id,
-                    aws_secret_access_key=r2.aws_secret_access_key,
-                ) as client:
+                async with r2._s3_client() as client:
                     response = await client.head_object(
                         Bucket=storage.audio_bucket_name, Key=key
                     )

--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -3,7 +3,7 @@
 import time
 from collections.abc import Callable
 from io import BytesIO
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import BinaryIO
 
 import aioboto3
@@ -18,6 +18,9 @@ from backend._internal.image import ImageFormat
 from backend.config import settings
 from backend.utilities.database import db_session
 from backend.utilities.hashing import hash_file_chunked
+
+# content-hashed files never change — cache forever
+IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
 
 
 class UploadProgressTracker:
@@ -115,9 +118,18 @@ class R2Storage:
 
         # async session for read operations
         self.async_session = aioboto3.Session()
-        self.endpoint_url = settings.storage.r2_endpoint_url
-        self.aws_access_key_id = settings.storage.aws_access_key_id
-        self.aws_secret_access_key = settings.storage.aws_secret_access_key
+        self._s3_kwargs = {
+            "endpoint_url": settings.storage.r2_endpoint_url,
+            "aws_access_key_id": settings.storage.aws_access_key_id,
+            "aws_secret_access_key": settings.storage.aws_secret_access_key,
+        }
+
+    def _s3_client(self, **extra_kwargs):
+        """create an async S3 client context manager.
+
+        centralizes connection config so an S3/R2 swap is one-line.
+        """
+        return self.async_session.client("s3", **self._s3_kwargs, **extra_kwargs)
 
     async def save(
         self,
@@ -169,18 +181,16 @@ class R2Storage:
             )
 
             try:
-                async with self.async_session.client(
-                    "s3",
-                    endpoint_url=self.endpoint_url,
-                    aws_access_key_id=self.aws_access_key_id,
-                    aws_secret_access_key=self.aws_secret_access_key,
-                ) as client:
+                async with self._s3_client() as client:
                     # prepare upload arguments
                     upload_kwargs = {
                         "Fileobj": file,
                         "Bucket": bucket,
                         "Key": key,
-                        "ExtraArgs": {"ContentType": media_type},
+                        "ExtraArgs": {
+                            "ContentType": media_type,
+                            "CacheControl": IMMUTABLE_CACHE_CONTROL,
+                        },
                     }
 
                     # add progress callback if provided
@@ -224,12 +234,7 @@ class R2Storage:
         with logfire.span(
             "R2 get_url", file_id=file_id, file_type=file_type, extension=extension
         ):
-            async with self.async_session.client(
-                "s3",
-                endpoint_url=self.endpoint_url,
-                aws_access_key_id=self.aws_access_key_id,
-                aws_secret_access_key=self.aws_secret_access_key,
-            ) as client:
+            async with self._s3_client() as client:
                 # if file_type is "image", skip audio checks
                 if file_type != "image":
                     # if extension is provided, try single format
@@ -306,12 +311,7 @@ class R2Storage:
             file bytes if found, None otherwise
         """
         with logfire.span("R2 get_file_data", file_id=file_id, file_type=file_type):
-            async with self.async_session.client(
-                "s3",
-                endpoint_url=self.endpoint_url,
-                aws_access_key_id=self.aws_access_key_id,
-                aws_secret_access_key=self.aws_secret_access_key,
-            ) as client:
+            async with self._s3_client() as client:
                 # build key from file_id and file_type
                 audio_format = AudioFormat.from_extension(f".{file_type.lower()}")
                 if not audio_format:
@@ -393,12 +393,7 @@ class R2Storage:
             file_type=file_type,
         )
 
-        async with self.async_session.client(
-            "s3",
-            endpoint_url=self.endpoint_url,
-            aws_access_key_id=self.aws_access_key_id,
-            aws_secret_access_key=self.aws_secret_access_key,
-        ) as client:
+        async with self._s3_client() as client:
             # if file_type is provided, delete the exact key
             if file_type:
                 audio_format = AudioFormat.from_extension(f".{file_type.lower()}")
@@ -455,8 +450,6 @@ class R2Storage:
                     continue
 
             # try image formats
-            from backend._internal.image import ImageFormat
-
             for image_format in ImageFormat:
                 key = f"images/{file_id}.{image_format.value}"
 
@@ -498,8 +491,6 @@ class R2Storage:
         wasted round trips). the image URL already encodes the correct
         extension, so we can build the key directly.
         """
-        from pathlib import PurePosixPath
-
         # extract extension from URL: ".../images/abc123.png?..." → ".png"
         ext = PurePosixPath(image_url.split("?")[0]).suffix.lower()
         if not ext:
@@ -511,12 +502,7 @@ class R2Storage:
             return await self.delete(file_id)
 
         key = f"images/{file_id}{ext}"
-        async with self.async_session.client(
-            "s3",
-            endpoint_url=self.endpoint_url,
-            aws_access_key_id=self.aws_access_key_id,
-            aws_secret_access_key=self.aws_secret_access_key,
-        ) as client:
+        async with self._s3_client() as client:
             try:
                 await client.delete_object(Bucket=self.image_bucket_name, Key=key)
                 logfire.info(
@@ -575,17 +561,15 @@ class R2Storage:
             )
 
             try:
-                async with self.async_session.client(
-                    "s3",
-                    endpoint_url=self.endpoint_url,
-                    aws_access_key_id=self.aws_access_key_id,
-                    aws_secret_access_key=self.aws_secret_access_key,
-                ) as client:
+                async with self._s3_client() as client:
                     upload_kwargs = {
                         "Fileobj": file,
                         "Bucket": self.private_audio_bucket_name,
                         "Key": key,
-                        "ExtraArgs": {"ContentType": media_type},
+                        "ExtraArgs": {
+                            "ContentType": media_type,
+                            "CacheControl": IMMUTABLE_CACHE_CONTROL,
+                        },
                     }
 
                     if progress_callback and file_size > 0:
@@ -642,11 +626,7 @@ class R2Storage:
             key=key,
             expires_in=expiry,
         ):
-            async with self.async_session.client(
-                "s3",
-                endpoint_url=self.endpoint_url,
-                aws_access_key_id=self.aws_access_key_id,
-                aws_secret_access_key=self.aws_secret_access_key,
+            async with self._s3_client(
                 config=Config(signature_version="s3v4"),
             ) as client:
                 url = await client.generate_presigned_url(
@@ -672,17 +652,15 @@ class R2Storage:
         """save a WebP thumbnail alongside the original image in R2."""
         key = f"images/{image_id}_thumb.webp"
         with logfire.span("R2 save_thumbnail", image_id=image_id, key=key):
-            async with self.async_session.client(
-                "s3",
-                endpoint_url=self.endpoint_url,
-                aws_access_key_id=self.aws_access_key_id,
-                aws_secret_access_key=self.aws_secret_access_key,
-            ) as client:
+            async with self._s3_client() as client:
                 await client.upload_fileobj(
                     BytesIO(thumbnail_data),
                     self.image_bucket_name,
                     key,
-                    ExtraArgs={"ContentType": "image/webp"},
+                    ExtraArgs={
+                        "ContentType": "image/webp",
+                        "CacheControl": IMMUTABLE_CACHE_CONTROL,
+                    },
                 )
             return f"{self.public_image_bucket_url}/{key}"
 
@@ -728,12 +706,7 @@ class R2Storage:
             to_private=to_private,
         ):
             try:
-                async with self.async_session.client(
-                    "s3",
-                    endpoint_url=self.endpoint_url,
-                    aws_access_key_id=self.aws_access_key_id,
-                    aws_secret_access_key=self.aws_secret_access_key,
-                ) as client:
+                async with self._s3_client() as client:
                     # copy to destination
                     await client.copy_object(
                         CopySource={"Bucket": src_bucket, "Key": key},

--- a/backend/tests/test_storage_types.py
+++ b/backend/tests/test_storage_types.py
@@ -18,9 +18,11 @@ def _mock_r2_storage() -> tuple[R2Storage, AsyncMock]:
         s.public_audio_bucket_url = "https://audio.test.dev"
         s.public_image_bucket_url = "https://images.test.dev"
         s.presigned_url_expiry = 3600
-        s.endpoint_url = "https://test.r2.dev"
-        s.aws_access_key_id = "test"
-        s.aws_secret_access_key = "test"
+        s._s3_kwargs = {
+            "endpoint_url": "https://test.r2.dev",
+            "aws_access_key_id": "test",
+            "aws_secret_access_key": "test",
+        }
 
         mock_client = AsyncMock()
         mock_client.upload_fileobj = AsyncMock()

--- a/docs/internal/backend/configuration.md
+++ b/docs/internal/backend/configuration.md
@@ -90,8 +90,8 @@ R2_BUCKET=your-audio-bucket
 R2_PRIVATE_BUCKET=your-private-audio-bucket  # for supporter-gated content
 R2_IMAGE_BUCKET=your-image-bucket
 R2_ENDPOINT_URL=https://xxx.r2.cloudflarestorage.com
-R2_PUBLIC_BUCKET_URL=https://pub-xxx.r2.dev  # for audio files
-R2_PUBLIC_IMAGE_BUCKET_URL=https://pub-xxx.r2.dev  # for image files
+R2_PUBLIC_BUCKET_URL=https://audio.plyr.fm  # audio files (custom domain for CDN caching)
+R2_PUBLIC_IMAGE_BUCKET_URL=https://images.plyr.fm  # image files (custom domain for CDN caching)
 AWS_ACCESS_KEY_ID=your-r2-access-key
 AWS_SECRET_ACCESS_KEY=your-r2-secret
 ```

--- a/docs/internal/local-development/setup.md
+++ b/docs/internal/local-development/setup.md
@@ -58,8 +58,8 @@ R2_BUCKET=audio-dev
 R2_PRIVATE_BUCKET=audio-private-dev  # for supporter-gated content
 R2_IMAGE_BUCKET=images-dev
 R2_ENDPOINT_URL=<your-r2-endpoint>
-R2_PUBLIC_BUCKET_URL=<your-r2-public-url>
-R2_PUBLIC_IMAGE_BUCKET_URL=<your-r2-image-public-url>
+R2_PUBLIC_BUCKET_URL=<your-r2-public-url>  # local dev can use r2.dev URLs; production uses audio.plyr.fm
+R2_PUBLIC_IMAGE_BUCKET_URL=<your-r2-image-public-url>  # local dev can use r2.dev URLs; production uses images.plyr.fm
 AWS_ACCESS_KEY_ID=<your-r2-access-key>
 AWS_SECRET_ACCESS_KEY=<your-r2-secret>
 

--- a/docs/internal/moderation/sensitive-content.md
+++ b/docs/internal/moderation/sensitive-content.md
@@ -158,7 +158,7 @@ future work might include:
 ### example: flagging an R2 image
 
 ```sql
--- image URL: https://pub-xxx.r2.dev/images/abc123.jpg
+-- image URL: https://images.plyr.fm/images/abc123.jpg
 INSERT INTO sensitive_images (image_id, reason, flagged_by)
 VALUES ('abc123', 'nudity', 'admin');
 ```

--- a/docs/internal/security.md
+++ b/docs/internal/security.md
@@ -67,7 +67,7 @@ presigned URLs are time-limited (5 minutes) and grant direct R2 access. security
 ### ATProto Record Behavior
 
 when a track is gated, the ATProto `fm.plyr.track` record's `audioUrl` changes:
-- **public**: points to R2 CDN URL (e.g., `https://cdn.plyr.fm/audio/abc123.mp3`)
+- **public**: points to CDN URL (e.g., `https://audio.plyr.fm/audio/abc123.mp3`)
 - **gated**: points to API endpoint (e.g., `https://api.plyr.fm/audio/abc123`)
 
 this means ATProto clients cannot stream gated content without authentication through plyr.fm's API.

--- a/docs/public/developers/api-reference/audio.md
+++ b/docs/public/developers/api-reference/audio.md
@@ -17,9 +17,9 @@ stream_audio(file_id: str, request: Request, session: Session | None = Depends(g
 ```
 
 
-stream audio file by redirecting to R2 CDN URL.
+stream audio file by redirecting to CDN URL.
 
-for public tracks: redirects to R2 CDN URL.
+for public tracks: redirects to CDN URL.
 for gated tracks: validates supporter status and returns presigned URL.
 
 HEAD requests are used for pre-flight auth checks - they return
@@ -38,7 +38,7 @@ get_audio_url(file_id: str, session: Session | None = Depends(get_optional_sessi
 
 return direct URL for audio file.
 
-for public tracks: returns R2 CDN URL for offline caching.
+for public tracks: returns CDN URL for offline caching.
 for gated tracks: returns presigned URL after supporter validation.
 
 used for offline mode - frontend fetches and caches locally.

--- a/docs/public/index.mdx
+++ b/docs/public/index.mdx
@@ -74,7 +74,7 @@ import HeroWaveform from '../../components/HeroWaveform.astro';
   "album": "2026",
   "title": "plyr.fm update - February 27, 2026",
   "artist": "plyr.fm",
-  "audioUrl": "https://pub-d4ed8a1e39d44dac85263d86ad5676fd.r2.dev/audio/ada9cadc63efd822.wav",
+  "audioUrl": "https://audio.plyr.fm/audio/ada9cadc63efd822.wav",
   "duration": 265,
   "fileType": "wav",
   "audioBlob": {

--- a/docs/public/lexicons/overview.md
+++ b/docs/public/lexicons/overview.md
@@ -46,7 +46,7 @@ example record from the network:
   "title": "plyr.fm update - February 27, 2026",
   "artist": "plyr.fm",
   "album": "2026",
-  "audioUrl": "https://pub-d4ed8a1e39d44dac85263d86ad5676fd.r2.dev/audio/ada9cadc63efd822.wav",
+  "audioUrl": "https://audio.plyr.fm/audio/ada9cadc63efd822.wav",
   "audioBlob": {
     "$type": "blob",
     "ref": { "$link": "bafkreifnvhfnyy7p3ara2gdyv6krztsd26luv2mi45j7hw3sreq7xjpd24" },


### PR DESCRIPTION
## Summary
- Set `Cache-Control: public, max-age=31536000, immutable` on all R2 uploads (audio, images, thumbnails) — objects are content-hashed, so this is safe
- Consolidate 9 identical S3 client connection blocks into `_s3_client()` helper — makes an S3/R2 swap a one-line change
- Hoist 2 deferred imports to top-level (`ImageFormat` was already imported, `PurePosixPath` is stdlib)
- Fix external code in `tracks/listing.py` that reached into R2Storage internals for S3 credentials

## Infrastructure (already done)
Custom domains provisioned via Cloudflare API (both SSL + ownership active):
- `audio.plyr.fm` → `audio-prod` bucket
- `images.plyr.fm` → `images-prod` bucket

### Remaining dashboard steps (after merge)
1. **Enable Smart Tiered Cache** on `plyr.fm` zone — auto-optimizes R2 caching topology
2. **Create "Cache Everything" cache rule** for `audio.plyr.fm` and `images.plyr.fm` subdomains — some audio extensions aren't in default cached list
3. **Swap env vars** on Fly.io:
   - `R2_PUBLIC_BUCKET_URL` → `https://audio.plyr.fm`
   - `R2_PUBLIC_IMAGE_BUCKET_URL` → `https://images.plyr.fm`
4. **Backfill DB URLs** — update `r2_url` and `image_url` columns from r2.dev → custom domain

Old `r2.dev` URLs continue to work — they just bypass CDN caching.

## Test plan
- [x] All pre-commit hooks pass
- [ ] CI test suite
- [x] Custom domains verified serving (200 for both audio and images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)