### PR TITLE
fix: feed switcher UX — segmented control

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -322,22 +322,29 @@
 					type="button"
 					class="clickable-heading"
 					onclick={refreshFeed}
-					onkeydown={(event) => {
-						if (event.key === 'Enter' || event.key === ' ') {
-							event.preventDefault();
-							refreshFeed();
-						}
-					}}
 					title="click to refresh"
 				>
-					{feedMode === 'for-you' ? 'for you' : 'latest tracks'}
+					tracks
 				</button>
-				{#if auth.isAuthenticated && forYouAvailable}
-					<button class="feed-toggle" onclick={toggleFeed}>
-						{feedMode === 'for-you' ? 'latest' : 'for you'}
-					</button>
-				{/if}
 			</h2>
+			{#if auth.isAuthenticated && forYouAvailable}
+				<div class="feed-switcher" role="tablist" aria-label="feed type">
+					<button
+						class="feed-tab"
+						class:active={feedMode === 'latest'}
+						role="tab"
+						aria-selected={feedMode === 'latest'}
+						onclick={() => { if (feedMode !== 'latest') toggleFeed(); }}
+					>latest</button>
+					<button
+						class="feed-tab"
+						class:active={feedMode === 'for-you'}
+						role="tab"
+						aria-selected={feedMode === 'for-you'}
+						onclick={() => { if (feedMode !== 'for-you') toggleFeed(); }}
+					>for you</button>
+				</div>
+			{/if}
 		</div>
 		{#if feedMode === 'latest'}
 			<div class="filter-row">
@@ -417,21 +424,38 @@
 		opacity: 0.7;
 	}
 
-	.feed-toggle {
-		background: transparent;
-		border: none;
-		padding: 0;
-		font: inherit;
-		font-size: var(--text-base);
-		font-weight: 400;
-		color: var(--accent);
-		cursor: pointer;
-		transition: opacity 0.15s;
-		user-select: none;
+	.feed-switcher {
+		display: flex;
+		gap: 0.25rem;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-xl);
+		padding: 0.2rem;
 	}
 
-	.feed-toggle:hover {
-		opacity: 0.7;
+	.feed-tab {
+		background: transparent;
+		border: 1px solid transparent;
+		border-radius: var(--radius-xl);
+		padding: 0.35rem 0.85rem;
+		font: inherit;
+		font-size: var(--text-sm);
+		color: var(--text-tertiary);
+		cursor: pointer;
+		transition: all 0.15s;
+		user-select: none;
+		white-space: nowrap;
+	}
+
+	.feed-tab:hover:not(.active) {
+		color: var(--text-secondary);
+	}
+
+	.feed-tab.active {
+		background: color-mix(in srgb, var(--accent) 15%, transparent);
+		border-color: var(--accent);
+		color: var(--accent);
+		font-weight: 600;
 	}
 
 	.top-tracks-grid {

--- a/loq.toml
+++ b/loq.toml
@@ -232,7 +232,7 @@ max_lines = 524
 
 [[rules]]
 path = "frontend/src/routes/+page.svelte"
-max_lines = 606
+max_lines = 630
 
 [[rules]]
 path = "frontend/src/lib/components/AlbumUploadForm.svelte"


### PR DESCRIPTION
## Summary
- replaces the confusing inline text toggle ("latest tracks _for you_") with a proper segmented control
- two pill buttons with clear active/inactive states — active gets accent-tinted background + accent border, matching the theme button pattern from settings
- heading simplified to "tracks" with the switcher sitting alongside in the section header
- only renders for authenticated users with for-you data (unchanged behavior)

follow-up to #1282

## Test plan
- [ ] segmented control renders with clear active/inactive distinction
- [ ] clicking inactive tab switches feed
- [ ] visually consistent with theme buttons in settings and tag filter pills
- [ ] unauthenticated: no switcher shown, heading says "tracks"

🤖 Generated with [Claude Code](https://claude.com/claude-code)