### PR TITLE
fix: glass styling for feed switcher + tag filtering on for-you

### DIFF
--- a/backend/src/backend/api/for_you.py
+++ b/backend/src/backend/api/for_you.py
@@ -274,6 +274,7 @@ async def get_for_you_feed(
     auth_session: AuthSession = Depends(require_auth),
     cursor: str | None = Query(None),
     limit: int = Query(30, ge=1, le=50),
+    tags: list[str] | None = Query(None),
 ) -> ForYouResponse:
     """Personalized feed for the authenticated user.
 
@@ -341,6 +342,19 @@ async def get_for_you_feed(
         hidden_set = {r.track_id for r in hidden_rows}
         if hidden_set:
             track_ids = [tid for tid in track_ids if tid not in hidden_set]
+
+    # apply active tag filter (inclusive — keep only tracks with at least one matching tag)
+    if tags and track_ids:
+        tagged_rows = (
+            await db.execute(
+                select(TrackTag.track_id)
+                .join(Tag, TrackTag.tag_id == Tag.id)
+                .where(Tag.name.in_(tags))
+                .where(TrackTag.track_id.in_(track_ids))
+            )
+        ).all()
+        tagged_set = {r.track_id for r in tagged_rows}
+        track_ids = [tid for tid in track_ids if tid in tagged_set]
 
     # page window
     page_ids = track_ids[offset : offset + limit]

--- a/frontend/src/lib/for-you.svelte.ts
+++ b/frontend/src/lib/for-you.svelte.ts
@@ -15,13 +15,22 @@ class ForYouCache {
 	nextCursor = $state<string | null>(null);
 	hasMore = $state(false);
 	coldStart = $state(false);
+	activeTags = $state<string[]>([]);
+
+	private buildUrl(): URL {
+		const url = new URL(`${API_URL}/for-you/`);
+		for (const tag of this.activeTags) {
+			url.searchParams.append('tags', tag);
+		}
+		return url;
+	}
 
 	async fetch(force = false): Promise<void> {
 		if (!force && this.loading) return;
 
 		this.loading = true;
 		try {
-			const response = await fetch(`${API_URL}/for-you/`, {
+			const response = await fetch(this.buildUrl().toString(), {
 				credentials: 'include'
 			});
 			if (!response.ok) {
@@ -48,7 +57,7 @@ class ForYouCache {
 
 		this.loadingMore = true;
 		try {
-			const url = new URL(`${API_URL}/for-you/`);
+			const url = this.buildUrl();
 			url.searchParams.set('cursor', this.nextCursor);
 
 			const response = await fetch(url.toString(), {
@@ -72,6 +81,13 @@ class ForYouCache {
 		this.nextCursor = null;
 		this.hasMore = false;
 		this.coldStart = false;
+	}
+
+	setTags(tags: string[]): void {
+		this.activeTags = tags;
+		this.nextCursor = null;
+		this.hasMore = false;
+		this.fetch(true);
 	}
 }
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -346,15 +346,19 @@
 				</div>
 			{/if}
 		</div>
-		{#if feedMode === 'latest'}
-			<div class="filter-row">
-				<TagFilter
-					onTagsChange={(tags) => tracksCache.setTags(tags)}
-					hiddenTags={preferences.hiddenTags}
-				/>
-				<HiddenTagsFilter />
-			</div>
-		{/if}
+		<div class="filter-row">
+			<TagFilter
+				onTagsChange={(tags) => {
+					if (feedMode === 'for-you') {
+						forYouCache.setTags(tags);
+					} else {
+						tracksCache.setTags(tags);
+					}
+				}}
+				hiddenTags={preferences.hiddenTags}
+			/>
+			<HiddenTagsFilter />
+		</div>
 		{#if showLoading}
 			<div class="loading-container">
 				<WaveLoading size="lg" message="loading tracks..." />
@@ -427,17 +431,17 @@
 	.feed-switcher {
 		display: flex;
 		gap: 0.25rem;
-		background: var(--bg-secondary);
-		border: 1px solid var(--border-subtle);
-		border-radius: var(--radius-xl);
+		background: var(--track-bg, var(--bg-secondary));
+		border: 1px solid var(--track-border, var(--border-subtle));
+		border-radius: var(--radius-md);
 		padding: 0.2rem;
 	}
 
 	.feed-tab {
 		background: transparent;
 		border: 1px solid transparent;
-		border-radius: var(--radius-xl);
-		padding: 0.35rem 0.85rem;
+		border-radius: var(--radius-sm);
+		padding: 0.3rem 0.75rem;
 		font: inherit;
 		font-size: var(--text-sm);
 		color: var(--text-tertiary);
@@ -449,11 +453,12 @@
 
 	.feed-tab:hover:not(.active) {
 		color: var(--text-secondary);
+		background: var(--track-border, rgba(255, 255, 255, 0.06));
 	}
 
 	.feed-tab.active {
-		background: color-mix(in srgb, var(--accent) 15%, transparent);
-		border-color: var(--accent);
+		background: color-mix(in srgb, var(--accent) 12%, var(--track-bg, transparent));
+		border-color: color-mix(in srgb, var(--accent) 20%, var(--track-border, transparent));
 		color: var(--accent);
 		font-weight: 600;
 	}

--- a/loq.toml
+++ b/loq.toml
@@ -232,7 +232,7 @@ max_lines = 524
 
 [[rules]]
 path = "frontend/src/routes/+page.svelte"
-max_lines = 630
+max_lines = 635
 
 [[rules]]
 path = "frontend/src/lib/components/AlbumUploadForm.svelte"


### PR DESCRIPTION
## Summary
- segmented control now uses `--track-bg`/`--track-border`/`--radius-md` to match track items and cards (was using opaque `--bg-secondary` + `--radius-xl`)
- active tab uses `color-mix` with `--track-bg` base instead of bare `transparent` — blends naturally
- hover state on inactive tab uses `--track-border` opacity
- tag filters now shown for both feed modes — added `tags` query param to `GET /for-you/` that filters candidates to tracks with at least one matching tag (same inclusive semantics as `/tracks/`)
- `ForYouCache` gains `setTags()` matching `TracksCache` interface

follow-up to #1282, #1283

## Test plan
- [ ] segmented control visually matches track item styling (glass bg, subtle borders, matching radii)
- [ ] tag filter works on for-you feed — selecting a tag narrows results
- [ ] tag filter still works on latest feed
- [ ] switching feeds with tags active routes to correct cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)