### PR TITLE
fix: decouple for-you probe from cache, fix tag persistence

### DIFF
--- a/frontend/src/lib/for-you.svelte.ts
+++ b/frontend/src/lib/for-you.svelte.ts
@@ -8,6 +8,16 @@ interface ForYouApiResponse {
 	cold_start: boolean;
 }
 
+function loadSavedTags(): string[] {
+	if (typeof window === 'undefined') return [];
+	try {
+		const saved = localStorage.getItem('active_tags');
+		return saved ? JSON.parse(saved) : [];
+	} catch {
+		return [];
+	}
+}
+
 class ForYouCache {
 	tracks = $state<Track[]>([]);
 	loading = $state(false);
@@ -15,7 +25,7 @@ class ForYouCache {
 	nextCursor = $state<string | null>(null);
 	hasMore = $state(false);
 	coldStart = $state(false);
-	activeTags = $state<string[]>([]);
+	activeTags = $state<string[]>(loadSavedTags());
 
 	private buildUrl(): URL {
 		const url = new URL(`${API_URL}/for-you/`);

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -12,6 +12,7 @@
 	import { queue } from '$lib/queue.svelte';
 	import { tracksCache, fetchTopTracks } from '$lib/tracks.svelte';
 	import { forYouCache } from '$lib/for-you.svelte';
+	import { API_URL } from '$lib/config';
 	import { networkArtistsCache } from '$lib/network-artists.svelte';
 	import type { Track } from '$lib/types';
 	import { auth } from '$lib/auth.svelte';
@@ -38,6 +39,9 @@
 	let loadingMore = $derived(feedMode === 'for-you' ? forYouCache.loadingMore : tracksCache.loadingMore);
 	let hasMore = $derived(feedMode === 'for-you' ? forYouCache.hasMore : tracksCache.hasMore);
 	let hasTracks = $derived(tracks.length > 0);
+	let hasActiveTags = $derived(
+		feedMode === 'for-you' ? forYouCache.activeTags.length > 0 : tracksCache.activeTags.length > 0
+	);
 	let initialLoad = $state(true);
 
 	// top tracks (most liked)
@@ -140,26 +144,31 @@
 		}
 	});
 
-	// probe for-you feed availability when authenticated
+	// probe for-you availability — lightweight fetch decoupled from cache
+	// so tag filtering and cache state changes don't re-trigger this
 	$effect(() => {
 		if (auth.isAuthenticated) {
-			forYouCache.fetch().then(() => {
-				forYouAvailable = forYouCache.tracks.length > 0;
-				// if user had for-you selected but it's now empty, fall back to latest
-				if (feedMode === 'for-you' && !forYouAvailable) {
-					feedMode = 'latest';
-					if (typeof window !== 'undefined') {
+			fetch(`${API_URL}/for-you/?limit=1`, { credentials: 'include' })
+				.then((r) => (r.ok ? r.json() : null))
+				.then((data) => {
+					forYouAvailable = (data?.tracks?.length ?? 0) > 0;
+					if (!forYouAvailable && feedMode === 'for-you') {
+						feedMode = 'latest';
 						localStorage.setItem('feedMode', 'latest');
 					}
-				}
-			});
+					// if starting in for-you mode, populate the cache
+					if (forYouAvailable && feedMode === 'for-you') {
+						forYouCache.fetch();
+					}
+				})
+				.catch(() => {
+					forYouAvailable = false;
+				});
 		} else {
 			forYouAvailable = false;
 			if (feedMode === 'for-you') {
 				feedMode = 'latest';
-				if (typeof window !== 'undefined') {
-					localStorage.setItem('feedMode', 'latest');
-				}
+				localStorage.setItem('feedMode', 'latest');
 			}
 		}
 	});
@@ -210,16 +219,18 @@
 	}
 
 	function toggleFeed() {
+		// sync tags from the cache we're leaving to the one we're entering
+		const currentTags =
+			feedMode === 'latest' ? [...tracksCache.activeTags] : [...forYouCache.activeTags];
 		const next: FeedMode = feedMode === 'latest' ? 'for-you' : 'latest';
 		feedMode = next;
-		if (typeof window !== 'undefined') {
-			localStorage.setItem('feedMode', next);
-		}
-		// fetch if the target cache is empty
-		if (next === 'for-you' && forYouCache.tracks.length === 0) {
-			forYouCache.fetch();
-		} else if (next === 'latest' && tracksCache.tracks.length === 0) {
-			tracksCache.fetch();
+		localStorage.setItem('feedMode', next);
+
+		// setTags resets pagination and fetches with the synced tags
+		if (next === 'for-you') {
+			forYouCache.setTags(currentTags);
+		} else {
+			tracksCache.setTags(currentTags);
 		}
 	}
 
@@ -354,6 +365,12 @@
 					} else {
 						tracksCache.setTags(tags);
 					}
+					// persist tag selection regardless of feed mode
+					if (tags.length > 0) {
+						localStorage.setItem('active_tags', JSON.stringify(tags));
+					} else {
+						localStorage.removeItem('active_tags');
+					}
 				}}
 				hiddenTags={preferences.hiddenTags}
 			/>
@@ -364,7 +381,7 @@
 				<WaveLoading size="lg" message="loading tracks..." />
 			</div>
 		{:else if !hasTracks}
-			<p class="empty">no tracks yet</p>
+			<p class="empty">{hasActiveTags ? 'no tracks match these tags' : 'no tracks yet'}</p>
 		{:else}
 			<div class="track-list">
 				{#each tracks as track, i (track.id)}

--- a/loq.toml
+++ b/loq.toml
@@ -232,7 +232,7 @@ max_lines = 524
 
 [[rules]]
 path = "frontend/src/routes/+page.svelte"
-max_lines = 635
+max_lines = 652
 
 [[rules]]
 path = "frontend/src/lib/components/AlbumUploadForm.svelte"


### PR DESCRIPTION
## Summary
- **probe bug**: the `$effect` that checks for-you availability called `forYouCache.fetch()`, which synchronously reads `this.loading` (`$state`) — creating a reactive dependency. any cache state change (from `setTags` → `fetch`) re-triggered the probe, and if tag-filtered results were empty, the switcher disappeared. fixed by using a raw `fetch(limit=1)` with no reactive cache reads
- **tag persistence**: `ForYouCache` now initializes `activeTags` from `localStorage.active_tags` (same source as `TracksCache`). `toggleFeed` syncs tags from the outgoing cache to the incoming one. `onTagsChange` persists to localStorage regardless of which feed is active
- **empty state**: shows "no tracks match these tags" when active tag filters produce zero results, instead of "no tracks yet"

follow-up to #1282, #1283, #1284

## Test plan
- [ ] select a tag while in for-you mode — switcher stays visible even if results are empty
- [ ] switch feeds — tag selection carries over
- [ ] set tags in for-you mode, reload page — tags restored
- [ ] clear all tags — both feeds show unfiltered results
- [ ] empty state shows correct message based on whether tags are active

🤖 Generated with [Claude Code](https://claude.com/claude-code)