### PR TITLE
fix: feed mode not persisting across hard refresh

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -145,7 +145,10 @@
 	});
 
 	// probe for-you availability — lightweight fetch decoupled from cache
-	// so tag filtering and cache state changes don't re-trigger this
+	// so tag filtering and cache state changes don't re-trigger this.
+	// auth.loading starts true and flips false after /auth/me resolves —
+	// we must wait for that before reacting to isAuthenticated === false,
+	// otherwise the initial false state resets feedMode on every hard refresh.
 	$effect(() => {
 		if (auth.isAuthenticated) {
 			fetch(`${API_URL}/for-you/?limit=1`, { credentials: 'include' })
@@ -164,7 +167,8 @@
 				.catch(() => {
 					forYouAvailable = false;
 				});
-		} else {
+		} else if (!auth.loading) {
+			// auth finished loading and user is not authenticated
 			forYouAvailable = false;
 			if (feedMode === 'for-you') {
 				feedMode = 'latest';

--- a/loq.toml
+++ b/loq.toml
@@ -232,7 +232,7 @@ max_lines = 524
 
 [[rules]]
 path = "frontend/src/routes/+page.svelte"
-max_lines = 652
+max_lines = 656
 
 [[rules]]
 path = "frontend/src/lib/components/AlbumUploadForm.svelte"


### PR DESCRIPTION
## Summary
- `auth.isAuthenticated` starts `false` before `/auth/me` resolves — the probe effect's else branch fired immediately on mount, resetting `feedMode` to `'latest'` before auth had a chance to resolve
- fix: gate the else branch on `!auth.loading` so it only reacts after auth has finished loading

one-line fix, follow-up to #1285

## Test plan
- [ ] select "for you", hard refresh — stays on "for you"
- [ ] unauthenticated user — still sees "latest" only, no switcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)