### PR TITLE
perf: warm full connection pool at startup

### DIFF
--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -69,12 +69,30 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await queue_service.setup()
     await jam_service.setup()
 
-    # warm the database connection pool so the first request avoids cold connect
+    # warm the full database connection pool so deploy doesn't cause a
+    # connection storm — open pool_size connections concurrently, each
+    # executes SELECT 1 then returns to the pool ready for use.
     try:
         engine = get_engine()
-        async with engine.connect() as conn:
-            await conn.execute(text("SELECT 1"))
-        logger.info("database connection pool warmed")
+        pool_size = settings.database.pool_size
+
+        async def _warm_one() -> bool:
+            async with engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
+            return True
+
+        results = await asyncio.gather(
+            *[_warm_one() for _ in range(pool_size)],
+            return_exceptions=True,
+        )
+        warmed = sum(1 for r in results if r is True)
+        failed = pool_size - warmed
+        if failed:
+            logger.warning(
+                "warmed %d/%d pool connections (%d failed)", warmed, pool_size, failed
+            )
+        else:
+            logger.info("database connection pool warmed (%d connections)", warmed)
     except (OSError, SQLAlchemyError):
         logger.warning("failed to warm database connection pool")
 


### PR DESCRIPTION
## Summary
- pool warmup (#1025) only opened 1 connection — with pool_size=10, the other 9 still hit TCP+SSL setup on the first request burst after deploy
- logfire traces from today's deploy show 17 simultaneous `connect` spans (1.5-5.5s each), causing simple PK lookups to take 12s+ on `/tracks/top`
- fix: warm all `pool_size` connections concurrently via `asyncio.gather` at startup
- partial failures logged but don't block startup

## Test plan
- [ ] deploy to staging, check logfire for connection burst behavior
- [ ] verify `database connection pool warmed (10 connections)` in startup logs
- [ ] first request after deploy should not show slow connect spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)