### PR TITLE
feat: BROWSER_OBSERVABILITY toggle for browser telemetry proxy

### DIFF
--- a/backend/src/backend/api/meta.py
+++ b/backend/src/backend/api/meta.py
@@ -29,6 +29,7 @@ async def get_public_config() -> dict[str, int | str | list[str]]:
     return {
         "max_upload_size_mb": settings.storage.max_upload_size_mb,
         "max_image_size_mb": 20,  # hardcoded limit for cover art
+        "browser_observability": settings.app.browser_observability,
         "default_hidden_tags": DEFAULT_HIDDEN_TAGS,
         "bufo_exclude_patterns": list(settings.bufo.exclude_patterns),
         "bufo_include_patterns": list(settings.bufo.include_patterns),

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -123,6 +123,11 @@ class AppSettings(AppSettingsSection):
         default=60,
         description="Interval for background tasks in seconds",
     )
+    browser_observability: bool = Field(
+        default=True,
+        validation_alias="BROWSER_OBSERVABILITY",
+        description="Enable browser telemetry proxy (logfire-proxy endpoint). Disable to reduce backend load from browser trace forwarding.",
+    )
     broadcast_channel_prefix: str = Field(
         default="plyr",
         description="Prefix used for browser BroadcastChannel identifiers",

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -16,6 +16,7 @@ export function getAtprotofansSupportUrl(did: string): string {
 interface ServerConfig {
 	max_upload_size_mb: number;
 	max_image_size_mb: number;
+	browser_observability: boolean;
 	default_hidden_tags: string[];
 	bufo_exclude_patterns: string[];
 	bufo_include_patterns: string[];

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -26,6 +26,7 @@
 	import { search } from '$lib/search.svelte';
 	import { browser } from '$app/environment';
 	import { initObservability } from '$lib/observability';
+	import { getServerConfig } from '$lib/config';
 	let { children } = $props<{ children: any }>();
 	let showQueue = $state(false);
 
@@ -59,8 +60,12 @@
 	// initialize auth and preferences once on mount (not on every navigation)
 	// this prevents repeated /auth/me calls for unauthenticated users
 	onMount(async () => {
-		// set up browser observability before any fetch calls
-		initObservability();
+		// set up browser observability if enabled by backend config
+		getServerConfig()
+			.then((config) => {
+				if (config.browser_observability) initObservability();
+			})
+			.catch(() => {});
 
 		// fetch sensitive images client-side (small payload, fast)
 		moderation.initialize();

--- a/loq.toml
+++ b/loq.toml
@@ -132,7 +132,7 @@ max_lines = 738
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"
-max_lines = 749
+max_lines = 750
 
 [[rules]]
 path = "frontend/src/routes/costs/+page.svelte"


### PR DESCRIPTION
## Summary
- browser SDK proxies all trace data through `POST /logfire-proxy/v1/traces` on the backend (required by Logfire — can't expose write token in browser)
- `logfire_proxy()` uses `run_in_threadpool` for a synchronous HTTP forwarding call — under load this saturates the threadpool and starves async DB handlers
- logfire data showed 694 proxy requests in 10 minutes (vs ~50 actual API requests), each taking 3+ seconds — this was the root cause of the prod slowness at 22:49-23:20 UTC
- adds `BROWSER_OBSERVABILITY` env var (default: `true`) exposed via `GET /config`
- frontend gates `initObservability()` on this flag
- set `BROWSER_OBSERVABILITY=false` to disable and eliminate proxy load

## Test plan
- [ ] default (no env var): browser telemetry works as before
- [ ] `BROWSER_OBSERVABILITY=false`: no `/logfire-proxy` requests from browser, backend load drops
- [ ] `/config` endpoint includes `browser_observability` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)