### PR TITLE
fix: short-circuit logfire proxy when browser_observability is disabled

### DIFF
--- a/backend/src/backend/api/meta.py
+++ b/backend/src/backend/api/meta.py
@@ -188,4 +188,6 @@ async def proxy_browser_telemetry(request: Request):
     stays server-side. protected by CORS (allowed origins only) and
     global rate limiting.
     """
+    if not settings.app.browser_observability:
+        return PlainTextResponse("browser observability disabled", status_code=204)
     return await logfire_proxy(request)


### PR DESCRIPTION
## Summary
- Backend proxy endpoint (`POST /logfire-proxy/{path}`) now returns 204 immediately when `BROWSER_OBSERVABILITY=false`
- Fixes: stale cached frontend clients bypass the frontend toggle from #1288 and keep hammering the proxy — 3,458 requests in 24 minutes, averaging 1.9s each, saturating the threadpool and causing `/tracks/top` to take 10-18s

## Test plan
- [ ] Deploy to staging, confirm proxy returns 204
- [ ] Verify `/tracks/top` latency drops to normal (<200ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)