### PR TITLE
fix: restore avatar on account reactivation, clear on deactivation

### DIFF
--- a/backend/src/backend/_internal/jetstream.py
+++ b/backend/src/backend/_internal/jetstream.py
@@ -25,6 +25,7 @@ from websockets.asyncio.client import ClientConnection
 
 from backend._internal.background import get_docket
 from backend._internal.tasks.ingest import (
+    ingest_account_status_change,
     ingest_comment_create,
     ingest_comment_delete,
     ingest_comment_update,
@@ -145,6 +146,23 @@ class JetstreamConsumer:
                     "jetstream dispatched identity update",
                     did=did,
                     handle=handle,
+                )
+            if time_us := event.get("time_us"):
+                self._cursor = time_us
+            return
+
+        if kind == "account":
+            did = event.get("did")
+            account = event.get("account") or {}
+            active = account.get("active", False)
+            if did and did in self._known_dids:
+                docket = get_docket()
+                await docket.add(ingest_account_status_change)(did=did, active=active)
+                logfire.info(
+                    "jetstream dispatched account status change",
+                    did=did,
+                    active=active,
+                    status=account.get("status"),
                 )
             if time_us := event.get("time_us"):
                 self._cursor = time_us

--- a/backend/src/backend/_internal/tasks/__init__.py
+++ b/backend/src/backend/_internal/tasks/__init__.py
@@ -30,6 +30,7 @@ from backend._internal.tasks.moderation import (
 )
 from backend._internal.tasks.ingest import (
     SubjectNotFoundError,
+    ingest_account_status_change,
     ingest_comment_create,
     ingest_comment_delete,
     ingest_comment_update,
@@ -108,6 +109,7 @@ def _build_background_tasks() -> list:
         ingest_list_update,
         ingest_list_delete,
         ingest_profile_update,
+        ingest_account_status_change,
         scan_image_moderation,
     ]
 
@@ -135,6 +137,7 @@ __all__ = [
     "classify_genres",
     "consume_jetstream",
     "generate_embedding",
+    "ingest_account_status_change",
     "ingest_comment_create",
     "ingest_comment_delete",
     "ingest_comment_update",

--- a/backend/src/backend/_internal/tasks/ingest.py
+++ b/backend/src/backend/_internal/tasks/ingest.py
@@ -716,14 +716,16 @@ async def ingest_identity_update(
     did: str,
     handle: str,
 ) -> None:
-    """update artist handle and PDS URL when an identity event arrives.
+    """update artist handle, PDS URL, and avatar when an identity event arrives.
 
-    identity events fire on both handle changes and PDS migrations.
-    resolving the DID gives us the current PDS URL, so we update both
-    in one pass rather than lazily healing stale pds_url in every API
-    endpoint that fetches ATProto records.
+    identity events fire on handle changes, PDS migrations, and account
+    reactivation. resolving the DID gives us the current PDS URL, and
+    re-fetching the profile refreshes the avatar (which may have gone
+    stale during account deactivation).
     """
     from atproto_identity.did.resolver import AsyncDidResolver
+
+    from backend._internal.atproto.profile import fetch_user_avatar
 
     async with db_session() as db:
         artist = await db.get(Artist, did)
@@ -754,6 +756,17 @@ async def ingest_identity_update(
                 "ingest_identity_update: DID resolution failed for %s: %s", did, e
             )
 
+        # refresh avatar from Bluesky profile
+        try:
+            fresh_avatar = await fetch_user_avatar(did)
+            if fresh_avatar != artist.avatar_url:
+                changes["avatar_url"] = (artist.avatar_url, fresh_avatar)
+                artist.avatar_url = fresh_avatar
+        except Exception as e:
+            logger.warning(
+                "ingest_identity_update: avatar fetch failed for %s: %s", did, e
+            )
+
         if not changes:
             return
 
@@ -763,3 +776,49 @@ async def ingest_identity_update(
             did=did,
             changes={k: {"old": v[0], "new": v[1]} for k, v in changes.items()},
         )
+
+
+async def ingest_account_status_change(
+    did: str,
+    active: bool,
+) -> None:
+    """handle account activation/deactivation events.
+
+    on reactivation (active=True): re-fetch avatar from Bluesky since
+    the CDN URL goes dead during deactivation.
+
+    on deactivation (active=False): clear the avatar URL so the frontend
+    doesn't show a broken image pointing at a dead CDN URL.
+    """
+    from backend._internal.atproto.profile import fetch_user_avatar
+
+    async with db_session() as db:
+        artist = await db.get(Artist, did)
+        if not artist:
+            logger.debug("ingest_account_status_change: unknown artist %s", did)
+            return
+
+        if active:
+            # re-fetch avatar on reactivation
+            try:
+                fresh_avatar = await fetch_user_avatar(did)
+                if fresh_avatar != artist.avatar_url:
+                    artist.avatar_url = fresh_avatar
+                    await db.commit()
+                    logfire.info(
+                        "ingest: avatar restored on reactivation",
+                        did=did,
+                        avatar_url=fresh_avatar,
+                    )
+            except Exception as e:
+                logger.warning(
+                    "ingest_account_status_change: avatar fetch failed for %s: %s",
+                    did,
+                    e,
+                )
+        else:
+            # clear stale avatar on deactivation
+            if artist.avatar_url:
+                artist.avatar_url = None
+                await db.commit()
+                logfire.info("ingest: avatar cleared on deactivation", did=did)

--- a/backend/tests/test_jetstream.py
+++ b/backend/tests/test_jetstream.py
@@ -13,6 +13,7 @@ from backend._internal.jetstream import JetstreamConsumer, consume_jetstream
 from backend._internal.tasks.ingest import (
     SubjectNotFoundError,
     _write_tombstone,
+    ingest_account_status_change,
     ingest_comment_create,
     ingest_comment_delete,
     ingest_identity_update,
@@ -156,14 +157,59 @@ class TestJetstreamConsumer:
         await consumer._process_event(event)
         consumer._dispatch.assert_not_called()  # type: ignore[union-attr]
 
-    async def test_skips_non_commit_non_identity_events(self) -> None:
+    async def test_skips_non_commit_non_identity_non_account_events(self) -> None:
         consumer = JetstreamConsumer()
         consumer._known_dids = {"did:plc:jetstream_test"}
         consumer._dispatch = AsyncMock()  # type: ignore[method-assign]
 
-        event = {"kind": "account", "did": "did:plc:jetstream_test"}
+        event = {"kind": "info", "did": "did:plc:jetstream_test"}
         await consumer._process_event(event)
         consumer._dispatch.assert_not_called()  # type: ignore[union-attr]
+
+    async def test_dispatches_account_event(self) -> None:
+        consumer = JetstreamConsumer()
+        consumer._known_dids = {"did:plc:jetstream_test"}
+
+        mock_docket = MagicMock()
+        dispatched: list[dict] = []
+
+        async def capture(**kwargs: object) -> None:
+            dispatched.append(dict(kwargs))
+
+        mock_docket.add = MagicMock(return_value=capture)
+
+        event = {
+            "kind": "account",
+            "did": "did:plc:jetstream_test",
+            "time_us": 3000000,
+            "account": {"active": True, "status": "active"},
+        }
+
+        with patch("backend._internal.jetstream.get_docket", return_value=mock_docket):
+            await consumer._process_event(event)
+
+        assert len(dispatched) == 1
+        assert dispatched[0]["did"] == "did:plc:jetstream_test"
+        assert dispatched[0]["active"] is True
+        assert consumer._cursor == 3000000
+
+    async def test_account_event_skips_unknown_did(self) -> None:
+        consumer = JetstreamConsumer()
+        consumer._known_dids = {"did:plc:known"}
+
+        mock_docket = MagicMock()
+        mock_docket.add = MagicMock()
+
+        event = {
+            "kind": "account",
+            "did": "did:plc:unknown",
+            "account": {"active": False, "status": "deactivated"},
+        }
+
+        with patch("backend._internal.jetstream.get_docket", return_value=mock_docket):
+            await consumer._process_event(event)
+
+        mock_docket.add.assert_not_called()
 
     async def test_dispatches_identity_event(self) -> None:
         consumer = JetstreamConsumer()
@@ -1574,15 +1620,36 @@ def _mock_did_resolver(pds_url: str = "https://pds.example.com") -> AsyncMock:
     return mock_resolver
 
 
+def _patch_identity_update(
+    pds_url: str = "https://pds.example.com",
+    avatar_url: str | None = None,
+):
+    """context manager stack for patching DID resolution + avatar fetch."""
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    stack.enter_context(
+        patch(
+            "atproto_identity.did.resolver.AsyncDidResolver",
+            return_value=_mock_did_resolver(pds_url=pds_url),
+        )
+    )
+    stack.enter_context(
+        patch(
+            "backend._internal.atproto.profile.fetch_user_avatar",
+            new_callable=AsyncMock,
+            return_value=avatar_url,
+        )
+    )
+    return stack
+
+
 class TestIngestIdentityUpdate:
     async def test_updates_artist_handle(
         self, db_session: AsyncSession, artist: Artist
     ) -> None:
         new_handle = "updated.handle.example"
-        with patch(
-            "atproto_identity.did.resolver.AsyncDidResolver",
-            return_value=_mock_did_resolver(),
-        ):
+        with _patch_identity_update():
             await ingest_identity_update(did=artist.did, handle=new_handle)
 
         await db_session.refresh(artist)
@@ -1601,10 +1668,7 @@ class TestIngestIdentityUpdate:
         await db_session.commit()
 
         new_handle = "updated.handle.example"
-        with patch(
-            "atproto_identity.did.resolver.AsyncDidResolver",
-            return_value=_mock_did_resolver(),
-        ):
+        with _patch_identity_update():
             await ingest_identity_update(did=artist.did, handle=new_handle)
 
         await db_session.refresh(session)
@@ -1615,30 +1679,40 @@ class TestIngestIdentityUpdate:
     ) -> None:
         """PDS migration updates the cached pds_url via DID resolution."""
         new_pds = "https://new-pds.example.com"
-        with patch(
-            "atproto_identity.did.resolver.AsyncDidResolver",
-            return_value=_mock_did_resolver(pds_url=new_pds),
-        ):
+        with _patch_identity_update(pds_url=new_pds):
             await ingest_identity_update(did=artist.did, handle=artist.handle)
 
         await db_session.refresh(artist)
         assert artist.pds_url == new_pds
 
-    async def test_noop_when_handle_and_pds_unchanged(
+    async def test_updates_avatar(
+        self, db_session: AsyncSession, artist: Artist
+    ) -> None:
+        """identity event refreshes avatar from Bluesky profile."""
+        new_avatar = "https://cdn.bsky.app/img/avatar/plain/did:plc:test/newcid@jpeg"
+        with _patch_identity_update(avatar_url=new_avatar):
+            await ingest_identity_update(did=artist.did, handle=artist.handle)
+
+        await db_session.refresh(artist)
+        assert artist.avatar_url == new_avatar
+
+    async def test_noop_when_handle_pds_and_avatar_unchanged(
         self, db_session: AsyncSession, artist: Artist
     ) -> None:
         """no commit when nothing changed — idempotent."""
         original_handle = artist.handle
         original_pds = artist.pds_url
-        with patch(
-            "atproto_identity.did.resolver.AsyncDidResolver",
-            return_value=_mock_did_resolver(pds_url=original_pds or ""),
+        original_avatar = artist.avatar_url
+        with _patch_identity_update(
+            pds_url=original_pds or "",
+            avatar_url=original_avatar,
         ):
             await ingest_identity_update(did=artist.did, handle=original_handle)
 
         await db_session.refresh(artist)
         assert artist.handle == original_handle
         assert artist.pds_url == original_pds
+        assert artist.avatar_url == original_avatar
 
     async def test_noop_for_unknown_did(self, db_session: AsyncSession) -> None:
         """unknown DID is silently skipped (no DID resolution attempted)."""
@@ -1647,17 +1721,91 @@ class TestIngestIdentityUpdate:
     async def test_did_resolution_failure_still_updates_handle(
         self, db_session: AsyncSession, artist: Artist
     ) -> None:
-        """if DID resolution fails, handle is still updated."""
+        """if DID resolution fails, handle and avatar are still updated."""
         new_handle = "updated.handle.example"
         mock_resolver = AsyncMock()
         mock_resolver.resolve_atproto_data = AsyncMock(
             side_effect=Exception("resolution failed")
         )
-        with patch(
-            "atproto_identity.did.resolver.AsyncDidResolver",
-            return_value=mock_resolver,
+        with (
+            patch(
+                "atproto_identity.did.resolver.AsyncDidResolver",
+                return_value=mock_resolver,
+            ),
+            patch(
+                "backend._internal.atproto.profile.fetch_user_avatar",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
         ):
             await ingest_identity_update(did=artist.did, handle=new_handle)
 
         await db_session.refresh(artist)
         assert artist.handle == new_handle
+
+
+class TestIngestAccountStatusChange:
+    async def test_reactivation_restores_avatar(
+        self, db_session: AsyncSession, artist: Artist
+    ) -> None:
+        """reactivation fetches fresh avatar from Bluesky."""
+        artist.avatar_url = None
+        await db_session.commit()
+
+        new_avatar = "https://cdn.bsky.app/img/avatar/plain/did:plc:test/cid123@jpeg"
+        with patch(
+            "backend._internal.atproto.profile.fetch_user_avatar",
+            new_callable=AsyncMock,
+            return_value=new_avatar,
+        ):
+            await ingest_account_status_change(did=artist.did, active=True)
+
+        await db_session.refresh(artist)
+        assert artist.avatar_url == new_avatar
+
+    async def test_deactivation_clears_avatar(
+        self, db_session: AsyncSession, artist: Artist
+    ) -> None:
+        """deactivation clears avatar to avoid broken CDN URLs."""
+        artist.avatar_url = (
+            "https://cdn.bsky.app/img/avatar/plain/did:plc:test/old@jpeg"
+        )
+        await db_session.commit()
+
+        await ingest_account_status_change(did=artist.did, active=False)
+
+        await db_session.refresh(artist)
+        assert artist.avatar_url is None
+
+    async def test_deactivation_noop_when_no_avatar(
+        self, db_session: AsyncSession, artist: Artist
+    ) -> None:
+        """deactivation is a noop if avatar is already None."""
+        artist.avatar_url = None
+        await db_session.commit()
+
+        await ingest_account_status_change(did=artist.did, active=False)
+
+        await db_session.refresh(artist)
+        assert artist.avatar_url is None
+
+    async def test_unknown_did_is_skipped(self, db_session: AsyncSession) -> None:
+        """unknown DID is silently skipped."""
+        await ingest_account_status_change(did="did:plc:nonexistent", active=True)
+
+    async def test_avatar_fetch_failure_on_reactivation(
+        self, db_session: AsyncSession, artist: Artist
+    ) -> None:
+        """avatar fetch failure on reactivation doesn't raise."""
+        artist.avatar_url = None
+        await db_session.commit()
+
+        with patch(
+            "backend._internal.atproto.profile.fetch_user_avatar",
+            new_callable=AsyncMock,
+            side_effect=Exception("network error"),
+        ):
+            await ingest_account_status_change(did=artist.did, active=True)
+
+        await db_session.refresh(artist)
+        assert artist.avatar_url is None

--- a/loq.toml
+++ b/loq.toml
@@ -212,11 +212,11 @@ max_lines = 535
 
 [[rules]]
 path = "backend/src/backend/_internal/tasks/ingest.py"
-max_lines = 765
+max_lines = 824
 
 [[rules]]
 path = "backend/tests/test_jetstream.py"
-max_lines = 1663
+max_lines = 1811
 
 [[rules]]
 path = "frontend/src/lib/components/embed/CollectionEmbed.svelte"


### PR DESCRIPTION
## Summary

- **Handle `account` events in jetstream** — previously `kind=account` was silently skipped. Now dispatches `ingest_account_status_change` for known DIDs
- **On deactivation**: clears `avatar_url` so the frontend doesn't show a broken `cdn.bsky.app` image
- **On reactivation**: fetches fresh avatar from Bluesky profile and updates the DB
- **Avatar refresh in `ingest_identity_update`** — identity events (handle changes, PDS migrations, reactivation) now also re-fetch the avatar, not just handle + PDS URL

Triggered by a user deactivating then reactivating their ATProto account — avatar disappeared on deactivation (CDN URL went dead) and never came back.

## Test plan

- [x] Existing jetstream consumer tests updated (account events no longer skipped)
- [x] New `test_dispatches_account_event` / `test_account_event_skips_unknown_did` for jetstream dispatch
- [x] New `TestIngestAccountStatusChange` class: reactivation restores avatar, deactivation clears it, noop when no avatar, unknown DID skipped, fetch failure handled gracefully
- [x] `TestIngestIdentityUpdate` updated: new `test_updates_avatar` test, existing tests patched to mock avatar fetch
- [x] All pre-commit hooks pass (loq, ruff, ty, ruff-format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)