### PR TITLE
fix: update plyrfm CLI calls for v0.0.1a16 namespace restructure

### DIFF
--- a/.github/workflows/status-maintenance.yml
+++ b/.github/workflows/status-maintenance.yml
@@ -280,7 +280,7 @@ jobs:
           fi
 
           # check existing tracks to determine episode number
-          EXISTING=$(uv run --with plyrfm -- plyrfm my-tracks --limit 50 2>/dev/null || echo "")
+          EXISTING=$(uv run --with plyrfm -- plyrfm tracks my --limit 50 2>/dev/null || echo "")
           TODAY=$(date +'%B %d, %Y')
           YEAR=$(date +%Y)
 
@@ -298,6 +298,6 @@ jobs:
           fi
 
           echo "Uploading as: $TITLE"
-          uv run --with plyrfm -- plyrfm upload update.wav "$TITLE" --album "$YEAR" -t "ai"
+          uv run --with plyrfm -- plyrfm tracks upload update.wav "$TITLE" --album "$YEAR" -t "ai"
         env:
           PLYR_TOKEN: ${{ secrets.PLYR_BOT_TOKEN }}

--- a/.github/workflows/upload-audio.yml
+++ b/.github/workflows/upload-audio.yml
@@ -42,7 +42,7 @@ jobs:
         if: inputs.delete_track_id != ''
         run: |
           echo "Deleting track ${{ inputs.delete_track_id }}..."
-          uv run --with plyrfm -- plyrfm delete "${{ inputs.delete_track_id }}" --yes
+          uv run --with plyrfm -- plyrfm tracks delete "${{ inputs.delete_track_id }}" --yes
         env:
           PLYR_TOKEN: ${{ secrets.PLYR_BOT_TOKEN }}
 
@@ -69,6 +69,6 @@ jobs:
           echo "Album: $ALBUM"
           echo "Tags: $TAGS"
 
-          eval uv run --with plyrfm -- plyrfm upload update.wav '"${{ inputs.title }}"' --album '"$ALBUM"' $TAG_ARGS
+          eval uv run --with plyrfm -- plyrfm tracks upload update.wav '"${{ inputs.title }}"' --album '"$ALBUM"' $TAG_ARGS
         env:
           PLYR_TOKEN: ${{ secrets.PLYR_BOT_TOKEN }}

--- a/docs/site/public/llms-full.txt
+++ b/docs/site/public/llms-full.txt
@@ -32,18 +32,17 @@ from plyrfm import PlyrClient
 client = PlyrClient()
 
 # search for tracks
-results = client.search("ambient")
-for track in results:
-    print(f"{track.title} by {track.artist}")
-    print(f"  stream: {track.stream_url}")
+results = client.discover.search("ambient")
+for r in results.results:
+    print(f"{r.title} ({r.type})")
 
 # get top tracks
-for track in client.top_tracks(limit=5):
+for track in client.discover.top_tracks(limit=5):
     print(f"{track.title} — {track.play_count} plays")
 
 # authenticated: like a track (requires developer token)
 authed = PlyrClient(token="your_token_from_plyr.fm/portal")
-authed.like(track_id=42)
+authed.tracks.like(42)
 ```
 
 ## MCP server (for AI assistants)
@@ -52,7 +51,7 @@ authed.like(track_id=42)
 claude mcp add plyr-fm -- uvx plyrfm-mcp
 ```
 
-Tools: search, list_tracks, top_tracks, tracks_by_tag, get_track, liked_tracks, my_tracks.
+Tools: search, list_tracks, top_tracks, tracks_by_tag, get_track, liked_tracks, my_tracks, list_playlists, get_playlist, playlists_by_artist, playlist_recommendations.
 
 ---
 


### PR DESCRIPTION
## Summary

- update workflow CLI invocations for plyrfm v0.0.1a16 which moved from flat commands to noun-first subcommands
- update SDK examples in `llms-full.txt` for the new namespace API
- add new playlist MCP tools to the tools list

### workflow changes

| before | after |
|---|---|
| `plyrfm delete <id> --yes` | `plyrfm tracks delete <id> --yes` |
| `plyrfm upload file "title" ...` | `plyrfm tracks upload file "title" ...` |
| `plyrfm my-tracks --limit 50` | `plyrfm tracks my --limit 50` |

### SDK examples updated

| before | after |
|---|---|
| `client.search("ambient")` | `client.discover.search("ambient")` |
| `client.top_tracks(limit=5)` | `client.discover.top_tracks(limit=5)` |
| `authed.like(track_id=42)` | `authed.tracks.like(42)` |

## Test plan

- [x] no code changes — only workflow scripts and docs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)