### PR TITLE
fix: reduce ambient gradient banding with more stops and calmer animation

### DIFF
--- a/frontend/src/lib/ambient.svelte.ts
+++ b/frontend/src/lib/ambient.svelte.ts
@@ -68,17 +68,17 @@ function computeWarmth(temperature: number, unit: TemperatureUnit): number {
 	return Math.min(1, Math.max(0, (temperature - cold) / (hot - cold)));
 }
 
-/** interpolate 3 color stops into 7 for smoother gradients (reduces banding) */
+/** interpolate 3 color stops into 16 for smoother gradients (reduces banding) */
 function smoothGradient(c1: RGB, c2: RGB, c3: RGB): string {
 	const lerp = (a: number, b: number, t: number) => Math.round(a + (b - a) * t);
 	const stops: string[] = [];
-	// 4 stops from c1→c2, 4 stops from c2→c3 (c2 shared = 7 total)
-	for (let i = 0; i <= 3; i++) {
-		const t = i / 3;
+	const HALF = 8; // 8 stops per segment, shared midpoint = 15 total
+	for (let i = 0; i <= HALF; i++) {
+		const t = i / HALF;
 		stops.push(`rgb(${lerp(c1.r, c2.r, t)}, ${lerp(c1.g, c2.g, t)}, ${lerp(c1.b, c2.b, t)})`);
 	}
-	for (let i = 1; i <= 3; i++) {
-		const t = i / 3;
+	for (let i = 1; i <= HALF - 1; i++) {
+		const t = i / (HALF - 1);
 		stops.push(`rgb(${lerp(c2.r, c3.r, t)}, ${lerp(c2.g, c3.g, t)}, ${lerp(c2.b, c3.b, t)})`);
 	}
 	return `linear-gradient(135deg, ${stops.join(', ')})`;

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -644,8 +644,8 @@
 	}
 
 	@keyframes -global-ambient-drift {
-		0%, 100% { opacity: 0.35; filter: brightness(1); }
-		50% { opacity: 0.5; filter: brightness(1.08); }
+		0%, 100% { opacity: 0.35; }
+		50% { opacity: 0.45; }
 	}
 
 	/* background image with blur effect */


### PR DESCRIPTION
## Summary
- increased gradient interpolation from 7 to 16 color stops for finer color transitions
- removed `brightness(1.08)` from breathing animation — it amplified banding at step boundaries
- tightened opacity range (0.35→0.45 instead of 0.35→0.5) for subtler breathing

no SVG noise filters — [that approach failed twice](#1159, #1298).

## Test plan
- [ ] enable live theme, check if diagonal banding is reduced
- [ ] verify breathing animation still looks smooth
- [ ] check both day and night weather palettes

🤖 Generated with [Claude Code](https://claude.com/claude-code)