### PR TITLE
fix: show "liked N ago" in liker stack avatar tooltips

### DIFF
--- a/backend/src/backend/utilities/aggregations.py
+++ b/backend/src/backend/utilities/aggregations.py
@@ -36,8 +36,8 @@ class LikerPreview(BaseModel):
     """lightweight liker preview embedded in track responses.
 
     used to render the overlapping avatar stack next to a track's like count
-    without a follow-up request. the full `LikerInfo` (with `liked_at`) is
-    still served by `GET /tracks/{id}/likes` for the detail tooltip/sheet.
+    without a follow-up request. includes `liked_at` so the per-avatar hover
+    tooltip can show "display name · 2h ago" without a follow-up fetch.
 
     defined here (alongside aggregation helpers) rather than in `schemas.py`
     to avoid a circular import: `schemas.py` imports from `aggregations.py`.
@@ -47,6 +47,7 @@ class LikerPreview(BaseModel):
     handle: str
     display_name: str | None
     avatar_url: str | None
+    liked_at: str
 
 
 async def get_like_counts(db: AsyncSession, track_ids: list[int]) -> dict[int, int]:
@@ -114,6 +115,7 @@ async def get_top_likers(
             Artist.display_name.label("display_name"),
             Artist.avatar_url.label("avatar_url"),
             TrackLike.track_id.label("track_id"),
+            TrackLike.created_at.label("liked_at"),
             rn,
         )
         .join(Artist, Artist.did == TrackLike.user_did)
@@ -128,6 +130,7 @@ async def get_top_likers(
             ranked.c.display_name,
             ranked.c.avatar_url,
             ranked.c.track_id,
+            ranked.c.liked_at,
         )
         .where(ranked.c.rn <= limit)
         .order_by(ranked.c.track_id, ranked.c.rn)
@@ -135,13 +138,14 @@ async def get_top_likers(
 
     result = await db.execute(stmt)
     out: dict[int, list[LikerPreview]] = defaultdict(list)
-    for did, handle, display_name, avatar_url, track_id in result.all():
+    for did, handle, display_name, avatar_url, track_id, liked_at in result.all():
         out[track_id].append(
             LikerPreview(
                 did=did,
                 handle=handle,
                 display_name=display_name,
                 avatar_url=avatar_url,
+                liked_at=liked_at.isoformat(),
             )
         )
     return dict(out)

--- a/backend/tests/utilities/test_aggregations.py
+++ b/backend/tests/utilities/test_aggregations.py
@@ -325,7 +325,7 @@ async def test_get_top_likers_limits_to_three_by_default(
 async def test_get_top_likers_preview_fields(
     db_session: AsyncSession, test_tracks_with_liker_artists: list[Track]
 ):
-    """LikerPreview has did, handle, display_name, avatar_url — and no liked_at."""
+    """LikerPreview has did, handle, display_name, avatar_url, liked_at."""
     tracks = test_tracks_with_liker_artists
     result = await get_top_likers(db_session, [tracks[0].id])
 
@@ -334,9 +334,10 @@ async def test_get_top_likers_preview_fields(
     assert liker.handle.endswith(".bsky.social")
     assert liker.display_name is not None
     assert liker.avatar_url is not None
-    # LikerPreview is deliberately lighter than the tooltip's LikerInfo — no
-    # liked_at field, since the inline stack doesn't render timestamps
-    assert not hasattr(liker, "liked_at")
+    # liked_at is included so the hover tooltip can show "name · 2h ago"
+    # without a follow-up fetch
+    assert liker.liked_at  # ISO-formatted timestamp string
+    assert "T" in liker.liked_at  # crude format check
 
 
 async def test_get_top_likers_respects_custom_limit(

--- a/frontend/src/lib/components/AvatarStack.svelte
+++ b/frontend/src/lib/components/AvatarStack.svelte
@@ -24,6 +24,10 @@
 		avatarHref?: (u: UserPreview) => string;
 		/** handler for clicks on individual avatars (e.g. stop propagation). */
 		onAvatarClick?: (u: UserPreview, e: MouseEvent) => void;
+		/** build the hover/focus title shown for each avatar. defaults to
+		 *  `display_name || handle`. likers surfaces pass a formatter that
+		 *  appends the relative `liked_at` timestamp. */
+		avatarTitle?: (u: UserPreview) => string;
 		/** accessible label for the strip (e.g. "21 likes"). */
 		ariaLabel?: string;
 		/** extra class on the container, for site-specific tweaks. */
@@ -48,11 +52,17 @@
 		onMoreClick,
 		avatarHref,
 		onAvatarClick,
+		avatarTitle,
 		ariaLabel,
 		class: klass = '',
 		scrollable = false,
 		maxScrollWidth = '20rem'
 	}: Props = $props();
+
+	function resolveTitle(u: UserPreview): string {
+		if (avatarTitle) return avatarTitle(u);
+		return u.display_name || u.handle;
+	}
 
 	let visible = $derived(users.slice(0, maxVisible));
 	let overflow = $derived(Math.max(0, total - visible.length));
@@ -79,7 +89,7 @@
 	style="--stack-size: {size}px; --stack-overlap: {overlap}px; --stack-border: {borderColor}; --stack-max-width: {maxScrollWidth};"
 >
 	{#each visible as user (user.did)}
-		{@const title = user.display_name || user.handle}
+		{@const title = resolveTitle(user)}
 		{#if avatarHref}
 			<a
 				class="avatar"

--- a/frontend/src/lib/components/LikersStrip.svelte
+++ b/frontend/src/lib/components/LikersStrip.svelte
@@ -94,6 +94,20 @@
 	});
 
 	let likeWord = $derived(likeCount === 1 ? 'like' : 'likes');
+
+	function formatRelativeTime(iso: string): string {
+		const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
+		if (seconds < 60) return 'just now';
+		if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+		if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+		if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`;
+		return `${Math.floor(seconds / 604800)}w ago`;
+	}
+
+	function avatarTitle(u: UserPreview): string {
+		const name = u.display_name || u.handle;
+		return u.liked_at ? `${name} · liked ${formatRelativeTime(u.liked_at)}` : name;
+	}
 </script>
 
 <span
@@ -113,6 +127,7 @@
 		scrollable={expanded}
 		onMoreClick={expanded ? undefined : handleMoreClick}
 		avatarHref={(u) => `/u/${u.handle}`}
+		{avatarTitle}
 		ariaLabel={`${likeCount} ${likeWord}`}
 	/>
 	{#if expanded}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -42,6 +42,9 @@ export interface UserPreview {
 	handle: string;
 	display_name?: string | null;
 	avatar_url?: string | null;
+	/** ISO timestamp — only set for likers (from backend LikerPreview).
+	 *  supporters from atprotofans don't carry a timestamp. */
+	liked_at?: string;
 }
 
 export interface Track {


### PR DESCRIPTION
Hover tooltip lost timestamp info in the last cut — only display name showed. Adds it back without reintroducing a popover.

- Backend: `LikerPreview.liked_at` (ISO) pulled from `track_likes.created_at` in the existing window-function query.
- Frontend: `AvatarStack` gets optional `avatarTitle(user)` formatter prop. `LikersStrip` passes one that renders \"display name · liked 2h ago\". Supporters pass nothing and keep their existing name-only tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)