### PR TITLE
fix: stop liker strip clicks from triggering track playback

### DIFF
--- a/frontend/src/lib/components/LikersStrip.svelte
+++ b/frontend/src/lib/components/LikersStrip.svelte
@@ -110,12 +110,18 @@
 	}
 </script>
 
+<!-- stop clicks and keyboard activations from bubbling to an enclosing
+     interactive surface (e.g. the TrackItem play button). otherwise clicking
+     +N or × would also trigger track playback. -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <span
 	class="likers-strip"
 	class:expanded
 	class:loading
 	bind:this={container}
 	aria-live="polite"
+	onclick={(e) => e.stopPropagation()}
+	onkeydown={(e) => e.stopPropagation()}
 >
 	<AvatarStack
 		users={usersForStack}


### PR DESCRIPTION
Clicking +N or × on the inline liker strip inside a TrackItem was bubbling to the outer play button and starting playback before the expand/collapse could land. Stopped click+keydown propagation at LikersStrip's root so all strip interactions stay contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)