### PR TITLE
fix: don't render dead-end "+1" / "+2" tiles in avatar stacks

### DIFF
--- a/backend/src/backend/utilities/aggregations.py
+++ b/backend/src/backend/utilities/aggregations.py
@@ -77,7 +77,7 @@ async def get_like_counts(db: AsyncSession, track_ids: list[int]) -> dict[int, i
 async def get_top_likers(
     db: AsyncSession,
     track_ids: list[int],
-    limit: int = 3,
+    limit: int = 5,
 ) -> dict[int, list[LikerPreview]]:
     """get the N most recent likers per track in a single batched query.
 
@@ -90,7 +90,11 @@ async def get_top_likers(
     args:
         db: database session
         track_ids: list of track IDs to get likers for
-        limit: max likers per track (default 3)
+        limit: max likers per track. default 5 — the frontend displays 3
+            inline but only shows a "+N" expand tile when the overflow is
+            meaningful (3+). returning 5 means tracks with 4 or 5 total
+            likes can render everyone inline without the dead-end "+1"/"+2"
+            affordance.
 
     returns:
         dict mapping track_id -> list of LikerPreview, most recent first.

--- a/backend/tests/utilities/test_aggregations.py
+++ b/backend/tests/utilities/test_aggregations.py
@@ -296,19 +296,25 @@ async def test_get_top_likers_empty_list(db_session: AsyncSession):
     assert result == {}
 
 
-async def test_get_top_likers_limits_to_three_by_default(
+async def test_get_top_likers_default_limit(
     db_session: AsyncSession, test_tracks_with_liker_artists: list[Track]
 ):
-    """default limit=3 returns at most 3 likers per track, most recent first."""
+    """default limit=5 returns at most 5 likers per track, most recent first.
+
+    the frontend displays 3 inline but the backend returns 5 so tracks with
+    4 or 5 total likes can render everyone without a dead-end "+1"/"+2" tile.
+    """
     tracks = test_tracks_with_liker_artists
     result = await get_top_likers(db_session, [t.id for t in tracks])
 
-    # track 0 has 5 likes → returns 3 most recent (liker5, liker4, liker3)
-    assert len(result[tracks[0].id]) == 3
+    # track 0 has exactly 5 likes → returns all 5 most recent
+    assert len(result[tracks[0].id]) == 5
     assert [liker.handle for liker in result[tracks[0].id]] == [
         "liker5.bsky.social",
         "liker4.bsky.social",
         "liker3.bsky.social",
+        "liker2.bsky.social",
+        "liker1.bsky.social",
     ]
 
     # track 1 has 2 likes → returns both (liker2, liker1)

--- a/frontend/src/lib/components/AvatarStack.svelte
+++ b/frontend/src/lib/components/AvatarStack.svelte
@@ -8,6 +8,11 @@
 		total: number;
 		/** max avatars to render before overflowing to "+N". default 3. */
 		maxVisible?: number;
+		/** minimum overflow size that justifies a "+N" tile. if the overflow
+		 *  would be smaller than this, just render everyone inline — clicking
+		 *  "+1" to reveal a single extra avatar is ridiculous and expanding
+		 *  scrolls nowhere. default 3. */
+		minOverflow?: number;
 		/** avatar diameter in pixels. default 24. */
 		size?: number;
 		/** CSS color for the hairline ring separating stacked avatars.
@@ -45,6 +50,7 @@
 		users,
 		total,
 		maxVisible = 3,
+		minOverflow = 3,
 		size = 24,
 		borderColor = 'var(--bg-secondary)',
 		moreHref,
@@ -64,7 +70,19 @@
 		return u.display_name || u.handle;
 	}
 
-	let visible = $derived(users.slice(0, maxVisible));
+	// if the overflow would be tiny, show everyone — "+1" (or "+2") next to
+	// three avatars is a dead-end affordance: clicking it scrolls nowhere.
+	// only skip the +N tile when we actually have enough users loaded to
+	// fill in the overflow; otherwise we'd render 3 and pretend that's all.
+	let effectiveMaxVisible = $derived.by(() => {
+		const wouldOverflow = Math.max(0, total - maxVisible);
+		const haveEveryone = users.length >= total;
+		if (wouldOverflow > 0 && wouldOverflow < minOverflow && haveEveryone) {
+			return total;
+		}
+		return maxVisible;
+	});
+	let visible = $derived(users.slice(0, effectiveMaxVisible));
 	let overflow = $derived(Math.max(0, total - visible.length));
 	// overlap grows with size so the visual density stays consistent.
 	let overlap = $derived(Math.round(size / 4));


### PR DESCRIPTION
Expanding "+1" to see one more avatar scrolled nowhere — pointless affordance.

- backend get_top_likers default limit 3→5 so tracks with 4–5 total likes ship everyone in the preview
- AvatarStack minOverflow prop (default 3) — only skip "+N" when overflow is small AND we have everyone loaded

Behavior: total ≤ 5 shows everyone inline, total ≥ 6 shows 3 + "+N≥3".

🤖 Generated with [Claude Code](https://claude.com/claude-code)