### PR TITLE
fix: split search into explicit keyword/mood modes

### DIFF
--- a/frontend/src/lib/components/SearchModal.svelte
+++ b/frontend/src/lib/components/SearchModal.svelte
@@ -12,7 +12,12 @@
 
 	// sync semantic search availability from user flags
 	$effect(() => {
-		search.semanticEnabled = auth.user?.enabled_flags?.includes(VIBE_SEARCH_FLAG) ?? false;
+		const enabled = auth.user?.enabled_flags?.includes(VIBE_SEARCH_FLAG) ?? false;
+		search.semanticEnabled = enabled;
+		// clamp mode back to keyword when the flag flips off
+		if (!enabled && search.mode === 'semantic') {
+			search.setMode('keyword');
+		}
 	});
 
 	// detect mobile on mount
@@ -155,7 +160,9 @@
 				bind:this={inputRef}
 				type="text"
 				class="search-input"
-				placeholder="search tracks, artists, albums, playlists..."
+				placeholder={search.semanticEnabled && search.mode === 'semantic'
+					? 'describe a mood or vibe...'
+					: 'search tracks, artists, albums, playlists...'}
 				value={search.query}
 				oninput={(e) => search.setQuery(e.currentTarget.value)}
 				maxlength="100"
@@ -170,6 +177,31 @@
 				<kbd class="search-shortcut">{getShortcutHint()}</kbd>
 			{/if}
 		</div>
+
+		{#if search.semanticEnabled}
+			<div class="search-mode-toggle" role="tablist" aria-label="search mode">
+				<button
+					type="button"
+					role="tab"
+					aria-selected={search.mode === 'keyword'}
+					class="mode-chip"
+					class:active={search.mode === 'keyword'}
+					onclick={() => search.setMode('keyword')}
+				>
+					keyword
+				</button>
+				<button
+					type="button"
+					role="tab"
+					aria-selected={search.mode === 'semantic'}
+					class="mode-chip"
+					class:active={search.mode === 'semantic'}
+					onclick={() => search.setMode('semantic')}
+				>
+					mood
+				</button>
+			</div>
+		{/if}
 
 		<div class="search-body">
 		{#if search.activeResults.length > 0}
@@ -223,28 +255,14 @@
 							<span class="result-title">{getResultTitle(result)}</span>
 							<span class="result-subtitle">{getResultSubtitle(result)}</span>
 						</div>
-						{#if result.type === 'track' && search.semanticResultIds.has(result.id)}
-							{@const pct = Math.round((search.semanticSimilarityMap.get(result.id) ?? 0) * 100)}
+						{#if search.mode === 'semantic' && result.type === 'track' && 'similarity' in result}
+							{@const pct = Math.round(result.similarity * 100)}
 							<span class="result-type mood">{pct}%</span>
 						{:else}
 							<span class="result-type">{result.type}</span>
 						{/if}
 					</button>
 				{/each}
-				{#if search.semanticLoading}
-					<div class="semantic-loading">
-						<div class="search-spinner-small"></div>
-						<span>searching by mood...</span>
-					</div>
-				{/if}
-			</div>
-		{:else if search.query.length >= 2 && !search.loading && search.semanticLoading}
-			<div class="search-results">
-				<div class="search-empty">no matches by name</div>
-				<div class="semantic-loading">
-					<div class="search-spinner-small"></div>
-					<span>searching by mood...</span>
-				</div>
 			</div>
 		{:else if search.query.length >= 2 && !search.loading && !search.semanticLoading && search.activeResults.length === 0}
 			<div class="search-empty">
@@ -356,6 +374,39 @@
 		border-top-color: var(--accent);
 		border-radius: var(--radius-full);
 		animation: spin 0.6s linear infinite;
+	}
+
+	.search-mode-toggle {
+		display: flex;
+		gap: 0.375rem;
+		padding: 0.5rem 1.25rem;
+		border-bottom: 1px solid var(--border-subtle);
+		background: color-mix(in srgb, var(--bg-tertiary) 30%, transparent);
+	}
+
+	.mode-chip {
+		font-family: inherit;
+		font-size: 11px;
+		text-transform: lowercase;
+		letter-spacing: 0.02em;
+		padding: 0.25rem 0.6rem;
+		background: var(--bg-tertiary);
+		color: var(--text-muted);
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+		transition: background 0.1s, color 0.1s, border-color 0.1s;
+	}
+
+	.mode-chip:hover {
+		background: var(--bg-hover);
+		color: var(--text-secondary);
+	}
+
+	.mode-chip.active {
+		color: var(--accent);
+		background: color-mix(in srgb, var(--accent) 10%, transparent);
+		border-color: color-mix(in srgb, var(--accent) 35%, transparent);
 	}
 
 	@keyframes spin {
@@ -490,25 +541,6 @@
 		background: color-mix(in srgb, var(--accent) 10%, transparent);
 	}
 
-	.semantic-loading {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: 0.5rem;
-		padding: 0.75rem;
-		color: var(--text-muted);
-		font-size: var(--text-xs);
-	}
-
-	.search-spinner-small {
-		width: 12px;
-		height: 12px;
-		border: 1.5px solid var(--border-default);
-		border-top-color: var(--accent);
-		border-radius: var(--radius-full);
-		animation: spin 0.6s linear infinite;
-	}
-
 	.search-empty {
 		padding: 2rem;
 		text-align: center;
@@ -588,8 +620,7 @@
 
 	/* respect reduced motion */
 	@media (prefers-reduced-motion: reduce) {
-		.search-spinner,
-		.search-spinner-small {
+		.search-spinner {
 			animation: none;
 		}
 	}

--- a/frontend/src/lib/search.svelte.ts
+++ b/frontend/src/lib/search.svelte.ts
@@ -2,6 +2,7 @@
 import { API_URL } from '$lib/config';
 
 export type SearchResultType = 'track' | 'artist' | 'album' | 'tag' | 'playlist';
+export type SearchMode = 'keyword' | 'semantic';
 
 export interface TrackSearchResult {
 	type: 'track';
@@ -87,12 +88,19 @@ export interface SearchResponse {
 }
 
 const MAX_QUERY_LENGTH = 100;
+const EMPTY_COUNTS: SearchResponse['counts'] = {
+	tracks: 0,
+	artists: 0,
+	albums: 0,
+	tags: 0,
+	playlists: 0
+};
 
 class SearchState {
 	isOpen = $state(false);
 	query = $state('');
 	results = $state<SearchResult[]>([]);
-	counts = $state<SearchResponse['counts']>({ tracks: 0, artists: 0, albums: 0, tags: 0, playlists: 0 });
+	counts = $state<SearchResponse['counts']>({ ...EMPTY_COUNTS });
 	loading = $state(false);
 	error = $state<string | null>(null);
 	selectedIndex = $state(0);
@@ -102,6 +110,9 @@ class SearchState {
 	semanticLoading = $state(false);
 	semanticAvailable = $state(true);
 	semanticResults = $state<SemanticSearchResult[]>([]);
+
+	// mode toggle — only exposed to users with the vibe-search flag
+	mode = $state<SearchMode>('keyword');
 
 	// reference to input element for direct focus (mobile keyboard workaround)
 	inputRef: HTMLInputElement | null = null;
@@ -124,7 +135,7 @@ class SearchState {
 		this.query = '';
 		this.results = [];
 		this.semanticResults = [];
-		this.counts = { tracks: 0, artists: 0, albums: 0, tags: 0, playlists: 0 };
+		this.counts = { ...EMPTY_COUNTS };
 		this.error = null;
 		this.selectedIndex = 0;
 	}
@@ -135,6 +146,7 @@ class SearchState {
 		this.results = [];
 		this.semanticResults = [];
 		this.error = null;
+		this.mode = 'keyword';
 		if (this.keywordTimeout) {
 			clearTimeout(this.keywordTimeout);
 			this.keywordTimeout = null;
@@ -157,12 +169,14 @@ class SearchState {
 		this.query = value;
 		this.selectedIndex = 0;
 
-		// clear previous timeouts
+		// always clear both timers — we never want a stale fetch racing the active mode
 		if (this.keywordTimeout) {
 			clearTimeout(this.keywordTimeout);
+			this.keywordTimeout = null;
 		}
 		if (this.semanticTimeout) {
 			clearTimeout(this.semanticTimeout);
+			this.semanticTimeout = null;
 		}
 
 		// validate length
@@ -170,41 +184,59 @@ class SearchState {
 			this.error = `query too long (max ${MAX_QUERY_LENGTH} characters)`;
 			this.results = [];
 			this.semanticResults = [];
-			this.counts = { tracks: 0, artists: 0, albums: 0, tags: 0, playlists: 0 };
+			this.counts = { ...EMPTY_COUNTS };
 			return;
 		}
 
 		this.error = null;
 
-		// keyword search: 150ms debounce, min 2 chars
-		// set loading=true immediately so the body doesn't flash "no results for X"
-		// during the debounce window before the fetch actually fires
-		if (value.length >= 2) {
-			this.loading = true;
-			this.keywordTimeout = setTimeout(() => {
-				void this.search(value);
-			}, 150);
-		} else {
-			this.loading = false;
-			this.results = [];
-			this.counts = { tracks: 0, artists: 0, albums: 0, tags: 0, playlists: 0 };
-		}
-
-		// semantic search: 500ms debounce, min 3 chars, only if enabled
-		if (this.semanticEnabled && value.length >= 3) {
-			this.semanticLoading = true;
-			this.semanticTimeout = setTimeout(() => {
-				void this.searchSemantic(value);
-			}, 500);
-		} else {
-			this.semanticLoading = false;
+		if (this.mode === 'keyword') {
+			// fire keyword search only; clear any semantic state
 			this.semanticResults = [];
+			this.semanticLoading = false;
+			if (value.length >= 2) {
+				this.loading = true;
+				this.keywordTimeout = setTimeout(() => {
+					void this.search(value);
+				}, 150);
+			} else {
+				this.loading = false;
+				this.results = [];
+				this.counts = { ...EMPTY_COUNTS };
+			}
+		} else {
+			// fire semantic search only; clear any keyword state
+			this.results = [];
+			this.counts = { ...EMPTY_COUNTS };
+			this.loading = false;
+			if (value.length >= 3) {
+				this.semanticLoading = true;
+				this.semanticTimeout = setTimeout(() => {
+					void this.searchSemantic(value);
+				}, 500);
+			} else {
+				this.semanticLoading = false;
+				this.semanticResults = [];
+			}
+		}
+	}
+
+	setMode(next: SearchMode) {
+		if (next === this.mode) return;
+		this.mode = next;
+		this.results = [];
+		this.semanticResults = [];
+		this.counts = { ...EMPTY_COUNTS };
+		this.selectedIndex = 0;
+		if (this.query.length >= 2) {
+			this.setQuery(this.query);
 		}
 	}
 
 	async search(query: string): Promise<void> {
 		if (query.length < 2) return;
 
+		const modeAtStart = this.mode;
 		this.loading = true;
 		this.error = null;
 
@@ -219,25 +251,28 @@ class SearchState {
 
 			const data: SearchResponse = await response.json();
 
-			// stale query guard
-			if (this.query !== query) return;
+			// stale query or stale mode guard
+			if (this.query !== query || this.mode !== modeAtStart) return;
 
 			this.results = data.results;
 			this.counts = data.counts;
 			this.selectedIndex = 0;
 		} catch (e) {
-			if (this.query !== query) return;
+			if (this.query !== query || this.mode !== modeAtStart) return;
 			console.error('search error:', e);
 			this.error = e instanceof Error ? e.message : 'search failed';
 			this.results = [];
 		} finally {
-			this.loading = false;
+			if (this.mode === modeAtStart && this.query === query) {
+				this.loading = false;
+			}
 		}
 	}
 
 	async searchSemantic(query: string): Promise<void> {
 		if (query.length < 3) return;
 
+		const modeAtStart = this.mode;
 		this.semanticLoading = true;
 
 		try {
@@ -247,58 +282,34 @@ class SearchState {
 
 			if (!response.ok) {
 				// non-ok but not a structured response — silently degrade
-				this.semanticResults = [];
-				this.semanticAvailable = false;
+				if (this.query === query && this.mode === modeAtStart) {
+					this.semanticResults = [];
+					this.semanticAvailable = false;
+				}
 				return;
 			}
 
 			const data: SemanticSearchResponse = await response.json();
 
-			// stale query guard
-			if (this.query !== query) return;
+			// stale query or stale mode guard
+			if (this.query !== query || this.mode !== modeAtStart) return;
 
 			this.semanticAvailable = data.available;
 			this.semanticResults = data.available ? data.results : [];
 			this.selectedIndex = 0;
 		} catch (e) {
-			if (this.query !== query) return;
+			if (this.query !== query || this.mode !== modeAtStart) return;
 			console.error('semantic search error:', e);
 			this.semanticResults = [];
 		} finally {
-			this.semanticLoading = false;
+			if (this.mode === modeAtStart && this.query === query) {
+				this.semanticLoading = false;
+			}
 		}
 	}
 
-	/** semantic results with keyword track IDs filtered out */
-	get dedupedSemanticResults(): SemanticSearchResult[] {
-		const keywordTrackIds = new Set(
-			this.results.filter((r) => r.type === 'track').map((r) => (r as TrackSearchResult).id)
-		);
-		return this.semanticResults.filter((r) => !keywordTrackIds.has(r.id));
-	}
-
-	/** IDs of results that came from semantic search (for badge rendering) */
-	get semanticResultIds(): Set<number> {
-		return new Set(this.dedupedSemanticResults.map((r) => r.id));
-	}
-
-	/** similarity scores keyed by track ID for badge display */
-	get semanticSimilarityMap(): Map<number, number> {
-		return new Map(this.dedupedSemanticResults.map((r) => [r.id, r.similarity]));
-	}
-
 	get activeResults(): (SearchResult | SemanticSearchResult)[] {
-		const keyword = this.results;
-		const semantic = this.dedupedSemanticResults;
-
-		if (semantic.length === 0) return keyword;
-		if (keyword.length === 0) return semantic;
-
-		// merge by score — both relevance and similarity are 0-1
-		const score = (r: SearchResult | SemanticSearchResult): number =>
-			'similarity' in r ? r.similarity : r.relevance;
-
-		return [...keyword, ...semantic].sort((a, b) => score(b) - score(a));
+		return this.mode === 'keyword' ? this.results : this.semanticResults;
 	}
 
 	selectNext() {

--- a/loq.toml
+++ b/loq.toml
@@ -108,7 +108,7 @@ max_lines = 980
 
 [[rules]]
 path = "frontend/src/lib/components/SearchModal.svelte"
-max_lines = 596
+max_lines = 627
 
 [[rules]]
 path = "frontend/src/lib/components/TrackActionsMenu.svelte"


### PR DESCRIPTION
## summary

reverts the Cmd+K modal back to an explicit mode toggle so mood (semantic) search stops interleaving with keyword search. keyword stays the default; flagged users get a chip toggle to opt into mood. non-flagged users see zero change.

## why

the search modal's been through three iterations:

1. **#848 (Feb 4)** — vibe search MVP shipped *with* a keyword/mood toggle, gated behind `vibe-search`
2. **#851** — removed the toggle in favor of parallel fire + "sounds like" separator
3. **#858** — merged both lists by score so semantic tracks wouldn't bunch at the bottom

step 3 is the one that hurts. BM25 relevance and cosine similarity are both 0–1 but measure different things — sorting a mixed list by that joint score produces jarring interleaves where a mediocre semantic match outranks a solid keyword hit. since only i have the flag on, no one else is exposed, but the UX has to be nailed before we'd ever consider rolling mood search out more broadly.

reference pattern: the leaflet-search frontend (`../leaflet-search/site/index.html:1366-1399`) — explicit mode chips, default to keyword, filters adapt to mode. we stay simpler here: just two modes, no hybrid.

## changes

- `search.svelte.ts` — add `mode: SearchMode` state, `setMode()`, and stale-mode guards on in-flight fetches. `activeResults` returns only the active mode's list. dropped `dedupedSemanticResults` / `semanticResultIds` / `semanticSimilarityMap`.
- `SearchModal.svelte` — small keyword/mood chip toggle below the input, rendered only when `search.semanticEnabled`. placeholder copy follows the active mode. similarity % badge only renders in semantic mode.
- `loq.toml` — relaxed SearchModal line limit (toggle markup + styles are real new UI, not golf-target growth)

## test plan

- [ ] open Cmd+K as a flagged user → toggle appears below the input, defaults to `keyword`
- [ ] type in keyword mode → keyword results only, no mood % badges
- [ ] flip to mood → keyword results clear, mood results show with % badges, placeholder switches to "describe a mood or vibe..."
- [ ] flip back to keyword → mood results clear
- [ ] open Cmd+K as a non-flagged user → no toggle, keyword-only behavior unchanged
- [ ] keyboard nav (↑/↓/Enter/Esc) works in both modes
- [ ] close and reopen → mode resets to keyword

🤖 Generated with [Claude Code](https://claude.com/claude-code)