### PR TITLE
feat(backend): replace audio on existing track

### DIFF
--- a/backend/src/backend/_internal/tasks/hooks.py
+++ b/backend/src/backend/_internal/tasks/hooks.py
@@ -8,7 +8,7 @@ import logging
 
 import logfire
 from redis.exceptions import RedisError
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.orm import joinedload
 
 from backend._internal.atproto.client import pds_blob_url
@@ -18,7 +18,7 @@ from backend._internal.tasks.ml import (
     schedule_genre_classification,
 )
 from backend.config import settings
-from backend.models import Artist, Track
+from backend.models import Artist, CopyrightScan, Track
 from backend.utilities.database import db_session
 from backend.utilities.redis import get_async_redis_client
 
@@ -107,6 +107,63 @@ async def run_post_track_create_hooks(
 
     logfire.info(
         "post-create hooks completed",
+        track_id=track_id,
+        has_audio_url=audio_url is not None,
+    )
+
+
+async def run_post_track_audio_replace_hooks(
+    track_id: int,
+    *,
+    audio_url: str | None = None,
+) -> None:
+    """post-replace side effects for tracks — fired when audio bytes change.
+
+    differences from `run_post_track_create_hooks`:
+    - never sends a creation notification (followers were notified at upload time)
+    - invalidates stale CopyrightScan rows before re-scheduling a fresh scan
+    - re-runs CLAP embedding (turbopuffer upsert overwrites by track_id)
+    - re-runs genre classification only when the upload originally opted in
+      via `extra.auto_tag` (we don't want to clobber manual tags)
+
+    note: a labeler label attached to the (stable) track URI from the OLD audio
+    is NOT auto-dismissed here. that's a moderation decision — left for manual
+    review via the admin tooling.
+    """
+    if audio_url is None:
+        audio_url = await resolve_audio_url(track_id)
+
+    # 1. invalidate stale copyright scan rows so the new scan replaces them
+    async with db_session() as db:
+        await db.execute(
+            delete(CopyrightScan).where(CopyrightScan.track_id == track_id)
+        )
+        await db.commit()
+
+    # 2. re-trigger copyright scan against the new audio bytes
+    if audio_url:
+        await schedule_copyright_scan(track_id, audio_url)
+
+    # 3. re-trigger CLAP embedding (turbopuffer upsert overwrites)
+    if audio_url and settings.modal.enabled and settings.turbopuffer.enabled:
+        await schedule_embedding_generation(track_id, audio_url)
+
+    # 4. re-trigger genre classification only if the original upload opted in.
+    # the classify_genres task tracks `extra.genre_predictions_file_id` so it
+    # already knows when a re-classification is needed, but we only want auto-tag
+    # to fire again if the user originally requested it.
+    if audio_url and settings.replicate.enabled:
+        async with db_session() as db:
+            track = await db.get(Track, track_id)
+            should_reclassify = bool(track and track.extra.get("auto_tag"))
+        if should_reclassify:
+            await schedule_genre_classification(track_id, audio_url)
+
+    # 5. discovery cache invalidation (in case "for-you" used stale embedding)
+    await invalidate_tracks_discovery_cache()
+
+    logfire.info(
+        "post-replace hooks completed",
         track_id=track_id,
         has_audio_url=audio_url is not None,
     )

--- a/backend/src/backend/api/tracks/__init__.py
+++ b/backend/src/backend/api/tracks/__init__.py
@@ -14,6 +14,7 @@ from . import (
 from . import uploads as _uploads  # /, /uploads/{upload_id}/progress
 from . import comments as _comments  # /{track_id}/comments, /comments/{comment_id}
 from . import mutations as _mutations  # /{track_id}, /{track_id}/restore-record
+from . import audio_replace as _audio_replace  # /{track_id}/audio
 from . import playback as _playback  # /{track_id}, /{track_id}/play
 
 __all__ = ["router"]

--- a/backend/src/backend/api/tracks/audio_replace.py
+++ b/backend/src/backend/api/tracks/audio_replace.py
@@ -50,6 +50,7 @@ from backend._internal.tasks.hooks import (
     invalidate_tracks_discovery_cache,
     run_post_track_audio_replace_hooks,
 )
+from backend.api.albums import invalidate_album_cache_by_id
 from backend.api.tracks.uploads import (
     AudioInfo,
     PdsBlobResult,
@@ -295,12 +296,24 @@ async def _commit_db_swap(
 async def _cleanup_old_files(state: TrackAudioState, sr: StorageResult) -> None:
     """delete the old R2 audio object(s) after a successful swap.
 
-    skips deletion when the new file_id matches the old one (identical bytes —
-    nothing to clean up), and silently swallows already-gone errors.
+    routes to `delete_gated` when the track was supporter-gated (private bucket);
+    otherwise uses the public-bucket `delete`. skips deletion when the new
+    file_id matches the old one (identical bytes — nothing to clean up), and
+    silently swallows already-gone errors.
+
+    note: the gated/non-gated decision uses the OLD `support_gate` because the
+    file we're cleaning up is the OLD audio. if a future endpoint flips gating
+    *and* replaces audio in the same call, this needs to take the OLD vs NEW
+    bucket destination separately.
     """
+    delete_fn = (
+        storage.delete_gated if state.support_gate is not None else storage.delete
+    )
     if state.old_file_id != sr.file_id:
         with contextlib.suppress(Exception):
-            await storage.delete(state.old_file_id, state.old_file_type)
+            await delete_fn(state.old_file_id, state.old_file_type)
+    # transcode originals always go to the public bucket regardless of gating
+    # (gated tracks can't be lossless yet — see _store_audio in uploads.py)
     if state.old_original_file_id and state.old_original_file_id != sr.original_file_id:
         with contextlib.suppress(Exception):
             await storage.delete(
@@ -313,8 +326,6 @@ async def _maybe_resync_album_list(track: Track, auth_session: AuthSession) -> N
     embedded strongRef carries the new track CID."""
     if track.album_id:
         await schedule_album_list_sync(auth_session.session_id, track.album_id)
-        from backend.api.albums import invalidate_album_cache_by_id
-
         async with db_session() as db:
             await invalidate_album_cache_by_id(db, track.album_id)
 
@@ -322,20 +333,30 @@ async def _maybe_resync_album_list(track: Track, auth_session: AuthSession) -> N
 async def _process_replace_background(ctx: ReplaceContext) -> None:
     """orchestrate the audio replace pipeline.
 
-    ordering is critical for atomicity:
+    the pipeline is split into two halves around the DB swap:
+
+    pre-commit (rollback applies — failure deletes the new R2 file):
         1. load + authorize
         2. validate new bytes
         3. store new bytes (R2 + transcode if needed)
         4. upload to PDS (best-effort)
-        5. publish updated ATProto record   ← if this fails, rollback by deleting new R2 file
-        6. swap DB row in a single transaction
-        7. delete old R2 file (success-only side effect)
+        5. publish updated ATProto record (PUT)
+        6. atomically swap the DB row
+
+    post-commit (NO rollback — the track is replaced; failures are logged):
+        7. delete old R2 file
         8. fire post-replace hooks (rescan, re-embed, re-classify)
-        9. invalidate caches + maybe resync album list record
+        9. resync album list record
+        10. invalidate discovery cache
+
+    the split is critical: once `_commit_db_swap` returns, the track row points
+    at the new file and the ATProto record is published. tearing down the new
+    R2 object at that point would leave production looking at a broken track.
     """
     new_file_id_for_rollback: str | None = None
     new_original_file_id_for_rollback: str | None = None
     new_original_file_type_for_rollback: str | None = None
+    rollback_gated: bool = False
 
     with logfire.span(
         "process audio replace background",
@@ -343,12 +364,14 @@ async def _process_replace_background(ctx: ReplaceContext) -> None:
         track_id=ctx.track_id,
         filename=ctx.filename,
     ):
+        # ---- pre-commit (rollback applies) ----
         try:
             await job_service.update_progress(
                 ctx.job_id, JobStatus.PROCESSING, "preparing audio replace..."
             )
 
             state = await _load_and_authorize(ctx.track_id, ctx.auth_session)
+            rollback_gated = state.support_gate is not None
             phase_ctx = _build_upload_context_for_phases(ctx, state)
 
             audio_info = await _validate_audio(phase_ctx)
@@ -366,50 +389,36 @@ async def _process_replace_background(ctx: ReplaceContext) -> None:
             ):
                 ctx.auth_session = refreshed
 
+            # defensive re-load: a concurrent PATCH may have updated title /
+            # album / features / image / description / support_gate / unlisted
+            # while we were uploading. publish with the freshest non-audio
+            # metadata so we don't roll the user's edit back on PDS.
+            state = await _refresh_metadata_state(state)
+
             new_cid = await _publish_record_update(
                 ctx, state, audio_info, sr, pds_result
             )
 
             track = await _commit_db_swap(state, audio_info, sr, pds_result, new_cid)
 
-            # success — clean up the old R2 object(s)
-            await _cleanup_old_files(state, sr)
-
-            # fire post-replace hooks (rescan/re-embed/maybe re-classify)
-            await run_post_track_audio_replace_hooks(track.id, audio_url=sr.r2_url)
-
-            # if the track is part of an album, refresh the album list record
-            # so its strongRef points at the new CID
-            await _maybe_resync_album_list(track, ctx.auth_session)
-
-            await invalidate_tracks_discovery_cache()
-
-            await job_service.update_progress(
-                ctx.job_id,
-                JobStatus.COMPLETED,
-                "audio replaced",
-                result={
-                    "track_id": track.id,
-                    "atproto_uri": track.atproto_record_uri,
-                    "atproto_cid": track.atproto_record_cid,
-                },
-            )
-
         except UploadPhaseError as e:
-            # rollback: drop the just-written R2 file(s) so we don't strand orphans
             await _rollback_new_files(
                 new_file_id_for_rollback,
                 new_original_file_id_for_rollback,
                 new_original_file_type_for_rollback,
+                gated=rollback_gated,
             )
             await job_service.update_progress(
                 ctx.job_id, JobStatus.FAILED, "audio replace failed", error=e.error
             )
+            _unlink_temp(ctx.file_path)
+            return
         except Exception as e:
             await _rollback_new_files(
                 new_file_id_for_rollback,
                 new_original_file_id_for_rollback,
                 new_original_file_type_for_rollback,
+                gated=rollback_gated,
             )
             logger.exception(
                 "audio replace job %s failed with unexpected error", ctx.job_id
@@ -420,20 +429,112 @@ async def _process_replace_background(ctx: ReplaceContext) -> None:
                 "audio replace failed",
                 error=f"unexpected error: {e!s}",
             )
-        finally:
-            with contextlib.suppress(Exception):
-                Path(ctx.file_path).unlink(missing_ok=True)
+            _unlink_temp(ctx.file_path)
+            return
+
+        # ---- post-commit (NO rollback — the swap is committed) ----
+        # each side effect is best-effort. if any fails we log and keep going;
+        # the track is already pointing at the new audio.
+        try:
+            await _cleanup_old_files(state, sr)
+        except Exception:
+            logger.exception(
+                "audio replace: old-file cleanup failed (track is replaced; "
+                "old R2 object may be orphaned)",
+            )
+
+        try:
+            await run_post_track_audio_replace_hooks(track.id, audio_url=sr.r2_url)
+        except Exception:
+            logger.exception(
+                "audio replace: post-replace hooks failed (track is replaced; "
+                "copyright/embedding/genre re-runs may not have been scheduled)",
+            )
+
+        try:
+            await _maybe_resync_album_list(track, ctx.auth_session)
+        except Exception:
+            logger.exception(
+                "audio replace: album list resync failed (track is replaced; "
+                "album record's strongRef may carry a stale CID until next edit)",
+            )
+
+        with contextlib.suppress(Exception):
+            await invalidate_tracks_discovery_cache()
+
+        await job_service.update_progress(
+            ctx.job_id,
+            JobStatus.COMPLETED,
+            "audio replaced",
+            result={
+                "track_id": track.id,
+                "atproto_uri": track.atproto_record_uri,
+                "atproto_cid": track.atproto_record_cid,
+            },
+        )
+        _unlink_temp(ctx.file_path)
+
+
+def _unlink_temp(file_path: str) -> None:
+    """remove the temp upload file (suppress all errors)."""
+    with contextlib.suppress(Exception):
+        Path(file_path).unlink(missing_ok=True)
+
+
+async def _refresh_metadata_state(state: TrackAudioState) -> TrackAudioState:
+    """reload non-audio fields right before publishing the ATProto record.
+
+    minimizes the window in which a concurrent `PATCH /tracks/{id}` (title,
+    description, image, features, support_gate) gets clobbered by the stale
+    metadata we captured at `_load_and_authorize` time.
+    """
+    async with db_session() as db:
+        result = await db.execute(
+            select(Track)
+            .options(selectinload(Track.artist))
+            .where(Track.id == state.track_id)
+        )
+        track = result.scalar_one_or_none()
+        if not track:
+            # row vanished between authorize and publish; let the caller
+            # raise the same UploadPhaseError it would have on _commit_db_swap.
+            raise UploadPhaseError("track was deleted during replace")
+        return TrackAudioState(
+            track_id=track.id,
+            artist_did=track.artist_did,
+            artist_display_name=track.artist.display_name,
+            atproto_record_uri=track.atproto_record_uri or state.atproto_record_uri,
+            old_file_id=state.old_file_id,
+            old_file_type=state.old_file_type,
+            old_original_file_id=state.old_original_file_id,
+            old_original_file_type=state.old_original_file_type,
+            title=track.title,
+            album=track.album,
+            duration=track.duration,
+            features=list(track.features) if track.features else [],
+            image_url=await track.get_image_url(),
+            description=track.description,
+            support_gate=dict(track.support_gate) if track.support_gate else None,
+        )
 
 
 async def _rollback_new_files(
     new_file_id: str | None,
     new_original_file_id: str | None,
     new_original_file_type: str | None,
+    *,
+    gated: bool,
 ) -> None:
-    """delete any new R2 object we wrote before discovering the operation must abort."""
+    """delete any new R2 object we wrote before discovering the operation must abort.
+
+    `gated=True` routes the playable-file delete to the private bucket. transcode
+    originals always live in the public bucket (gated tracks can't be lossless),
+    so the original delete uses the public path unconditionally.
+    """
     if new_file_id:
+        delete_fn = storage.delete_gated if gated else storage.delete
         with contextlib.suppress(Exception):
-            await storage.delete(new_file_id)
+            await delete_fn(new_file_id)
     if new_original_file_id:
         with contextlib.suppress(Exception):
             await storage.delete(new_original_file_id, new_original_file_type)

--- a/backend/src/backend/api/tracks/audio_replace.py
+++ b/backend/src/backend/api/tracks/audio_replace.py
@@ -1,0 +1,550 @@
+"""replace the audio file backing an existing track.
+
+PUT /tracks/{track_id}/audio uploads new audio bytes for an existing track,
+keeping the track's stable identity (id, atproto URI, likes, comments, plays)
+while atomically swapping the underlying file in R2 and on the user's PDS.
+
+design notes:
+- the track URI never changes, so likes/playlists/comments keep working.
+- the track record CID does change (new audioUrl/audioBlob/duration). this is
+  the same CID-churn behavior as PATCH /tracks/{id} today, which the rest of
+  the system already tolerates.
+- a labeler label that was attached to the old audio stays attached to the
+  (URI-stable) track. operators must dismiss it manually if the new audio is
+  clean. this is intentional — automatically dismissing copyright labels would
+  be a moderation hole.
+- the old R2 object is deleted only after the PDS write succeeds; the old PDS
+  blob is left to PDS garbage collection.
+"""
+
+import contextlib
+import logging
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated
+from urllib.parse import urljoin
+
+import logfire
+from fastapi import (
+    BackgroundTasks,
+    Depends,
+    File,
+    HTTPException,
+    Request,
+    UploadFile,
+)
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from backend._internal import Session as AuthSession
+from backend._internal import get_session, require_auth
+from backend._internal.atproto.records import (
+    build_track_record,
+    update_record,
+)
+from backend._internal.audio import AudioFormat
+from backend._internal.jobs import job_service
+from backend._internal.tasks import schedule_album_list_sync
+from backend._internal.tasks.hooks import (
+    invalidate_tracks_discovery_cache,
+    run_post_track_audio_replace_hooks,
+)
+from backend.api.tracks.uploads import (
+    AudioInfo,
+    PdsBlobResult,
+    StorageResult,
+    UploadContext,
+    UploadPhaseError,
+    UploadStartResponse,
+    _store_audio,
+    _upload_to_pds,
+    _validate_audio,
+)
+from backend.config import settings
+from backend.models import Track
+from backend.models.job import JobStatus, JobType
+from backend.storage import storage
+from backend.utilities.database import db_session
+from backend.utilities.hashing import CHUNK_SIZE
+from backend.utilities.rate_limit import limiter
+
+from .router import router
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TrackAudioState:
+    """snapshot of a track's audio fields, captured before replacement.
+
+    used for both rebuilding the track ATProto record (preserving non-audio
+    metadata like title/album/features/image) and for cleanup of the old R2
+    object after the new record publishes successfully.
+    """
+
+    track_id: int
+    artist_did: str
+    artist_display_name: str
+    atproto_record_uri: str
+
+    # current audio state (for rollback / cleanup)
+    old_file_id: str
+    old_file_type: str
+    old_original_file_id: str | None
+    old_original_file_type: str | None
+
+    # non-audio metadata (preserved across the rebuild)
+    title: str
+    album: str | None
+    duration: int | None  # current duration; replaced with new duration in new record
+    features: list[dict]
+    image_url: str | None
+    description: str | None
+    support_gate: dict | None
+
+
+@dataclass
+class ReplaceContext:
+    """all data needed to process an audio replace in the background."""
+
+    job_id: str
+    auth_session: AuthSession
+    track_id: int
+    file_path: str
+    filename: str
+
+
+async def _load_and_authorize(
+    track_id: int, auth_session: AuthSession
+) -> TrackAudioState:
+    """phase 1: load the track, verify ownership, snapshot current audio state."""
+    async with db_session() as db:
+        result = await db.execute(
+            select(Track)
+            .options(selectinload(Track.artist))
+            .where(Track.id == track_id)
+        )
+        track = result.scalar_one_or_none()
+
+        if not track:
+            raise UploadPhaseError("track not found")
+        if track.artist_did != auth_session.did:
+            raise UploadPhaseError("you can only replace audio on your own tracks")
+        if not track.atproto_record_uri:
+            raise UploadPhaseError(
+                "this track has no ATProto record — restore it before replacing audio"
+            )
+
+        return TrackAudioState(
+            track_id=track.id,
+            artist_did=track.artist_did,
+            artist_display_name=track.artist.display_name,
+            atproto_record_uri=track.atproto_record_uri,
+            old_file_id=track.file_id,
+            old_file_type=track.file_type,
+            old_original_file_id=track.original_file_id,
+            old_original_file_type=track.original_file_type,
+            title=track.title,
+            album=track.album,
+            duration=track.duration,
+            features=list(track.features) if track.features else [],
+            image_url=await track.get_image_url(),
+            description=track.description,
+            support_gate=dict(track.support_gate) if track.support_gate else None,
+        )
+
+
+def _build_upload_context_for_phases(
+    ctx: ReplaceContext, state: TrackAudioState
+) -> UploadContext:
+    """build a stub UploadContext so the existing phase helpers work unchanged.
+
+    only the audio-related fields matter to `_validate_audio`, `_store_audio`,
+    `_upload_to_pds`. the rest are filled with sensible defaults that the
+    helpers don't read (we never call `_create_records`).
+    """
+    return UploadContext(
+        upload_id=ctx.job_id,
+        auth_session=ctx.auth_session,
+        file_path=ctx.file_path,
+        filename=ctx.filename,
+        title=state.title,
+        artist_did=state.artist_did,
+        album=state.album,
+        album_id=None,
+        features_json=None,
+        tags=[],
+        support_gate=state.support_gate,
+    )
+
+
+def _audio_url_for_record(state: TrackAudioState, sr: StorageResult) -> str:
+    """compute the audioUrl field for the new ATProto record.
+
+    gated tracks point at the auth-protected backend endpoint; public tracks
+    point at the R2 custom domain URL.
+    """
+    if state.support_gate is not None:
+        backend_url = settings.atproto.redirect_uri.rsplit("/", 2)[0]
+        return urljoin(backend_url + "/", f"audio/{sr.file_id}")
+    assert sr.r2_url is not None  # public tracks always have an r2_url
+    return sr.r2_url
+
+
+async def _publish_record_update(
+    ctx: ReplaceContext,
+    state: TrackAudioState,
+    audio_info: AudioInfo,
+    sr: StorageResult,
+    pds_result: PdsBlobResult | None,
+) -> str:
+    """phase 5: rebuild the track ATProto record with new audio fields.
+
+    raises UploadPhaseError on failure. the new R2 file is cleaned up by the
+    orchestrator on rollback.
+
+    returns the new record CID.
+    """
+    playable_file_type = (
+        sr.playable_format.value
+        if sr.playable_format
+        else Path(ctx.filename).suffix.lower().lstrip(".")
+    )
+
+    new_record = build_track_record(
+        title=state.title,
+        artist=state.artist_display_name,
+        audio_url=_audio_url_for_record(state, sr),
+        file_type=playable_file_type,
+        album=state.album,
+        duration=audio_info.duration,
+        features=state.features or None,
+        image_url=state.image_url,
+        support_gate=state.support_gate,
+        audio_blob=pds_result.blob_ref if pds_result else None,
+        description=state.description,
+    )
+
+    try:
+        _, new_cid = await update_record(
+            auth_session=ctx.auth_session,
+            record_uri=state.atproto_record_uri,
+            record=new_record,
+        )
+    except Exception as exc:
+        logfire.exception(
+            "audio replace: failed to update ATProto record",
+            track_id=state.track_id,
+            record_uri=state.atproto_record_uri,
+        )
+        raise UploadPhaseError(f"failed to publish updated record: {exc}") from exc
+
+    return new_cid
+
+
+async def _commit_db_swap(
+    state: TrackAudioState,
+    audio_info: AudioInfo,
+    sr: StorageResult,
+    pds_result: PdsBlobResult | None,
+    new_record_cid: str,
+) -> Track:
+    """phase 6: atomically swap track audio fields in a single transaction.
+
+    clears the auto_tag flag and stale genre prediction provenance so the
+    post-replace hooks make a clean re-classification decision.
+    """
+    playable_file_type = (
+        sr.playable_format.value
+        if sr.playable_format
+        else state.old_file_type  # transcode shouldn't have run if web-playable; safe fallback
+    )
+    has_pds_blob = bool(pds_result and pds_result.cid)
+
+    async with db_session() as db:
+        track = await db.get(Track, state.track_id)
+        if not track:
+            # extremely unlikely race: track deleted between authorize and commit
+            raise UploadPhaseError("track was deleted during replace")
+
+        track.file_id = sr.file_id
+        track.file_type = playable_file_type
+        track.original_file_id = sr.original_file_id
+        track.original_file_type = sr.original_file_type
+        track.r2_url = sr.r2_url
+        track.audio_storage = "both" if has_pds_blob else "r2"
+        track.pds_blob_cid = pds_result.cid if pds_result else None
+        track.pds_blob_size = pds_result.size if pds_result else None
+        track.atproto_record_cid = new_record_cid
+
+        # update duration; clear stale genre-prediction provenance so a future
+        # re-classification doesn't get short-circuited as "already done".
+        extra = dict(track.extra) if track.extra else {}
+        if audio_info.duration is not None:
+            extra["duration"] = audio_info.duration
+        extra.pop("genre_predictions", None)
+        extra.pop("genre_predictions_file_id", None)
+        track.extra = extra
+
+        await db.commit()
+        await db.refresh(track)
+        return track
+
+
+async def _cleanup_old_files(state: TrackAudioState, sr: StorageResult) -> None:
+    """delete the old R2 audio object(s) after a successful swap.
+
+    skips deletion when the new file_id matches the old one (identical bytes —
+    nothing to clean up), and silently swallows already-gone errors.
+    """
+    if state.old_file_id != sr.file_id:
+        with contextlib.suppress(Exception):
+            await storage.delete(state.old_file_id, state.old_file_type)
+    if state.old_original_file_id and state.old_original_file_id != sr.original_file_id:
+        with contextlib.suppress(Exception):
+            await storage.delete(
+                state.old_original_file_id, state.old_original_file_type
+            )
+
+
+async def _maybe_resync_album_list(track: Track, auth_session: AuthSession) -> None:
+    """if the track is in an album, refresh the album list record so its
+    embedded strongRef carries the new track CID."""
+    if track.album_id:
+        await schedule_album_list_sync(auth_session.session_id, track.album_id)
+        from backend.api.albums import invalidate_album_cache_by_id
+
+        async with db_session() as db:
+            await invalidate_album_cache_by_id(db, track.album_id)
+
+
+async def _process_replace_background(ctx: ReplaceContext) -> None:
+    """orchestrate the audio replace pipeline.
+
+    ordering is critical for atomicity:
+        1. load + authorize
+        2. validate new bytes
+        3. store new bytes (R2 + transcode if needed)
+        4. upload to PDS (best-effort)
+        5. publish updated ATProto record   ← if this fails, rollback by deleting new R2 file
+        6. swap DB row in a single transaction
+        7. delete old R2 file (success-only side effect)
+        8. fire post-replace hooks (rescan, re-embed, re-classify)
+        9. invalidate caches + maybe resync album list record
+    """
+    new_file_id_for_rollback: str | None = None
+    new_original_file_id_for_rollback: str | None = None
+    new_original_file_type_for_rollback: str | None = None
+
+    with logfire.span(
+        "process audio replace background",
+        job_id=ctx.job_id,
+        track_id=ctx.track_id,
+        filename=ctx.filename,
+    ):
+        try:
+            await job_service.update_progress(
+                ctx.job_id, JobStatus.PROCESSING, "preparing audio replace..."
+            )
+
+            state = await _load_and_authorize(ctx.track_id, ctx.auth_session)
+            phase_ctx = _build_upload_context_for_phases(ctx, state)
+
+            audio_info = await _validate_audio(phase_ctx)
+            sr = await _store_audio(phase_ctx, audio_info)
+            new_file_id_for_rollback = sr.file_id
+            new_original_file_id_for_rollback = sr.original_file_id
+            new_original_file_type_for_rollback = sr.original_file_type
+
+            pds_result = await _upload_to_pds(phase_ctx, audio_info, sr)
+
+            # the PDS upload may have refreshed the OAuth token in-place; pull
+            # the freshest session for the upcoming putRecord call.
+            if pds_result and (
+                refreshed := await get_session(ctx.auth_session.session_id)
+            ):
+                ctx.auth_session = refreshed
+
+            new_cid = await _publish_record_update(
+                ctx, state, audio_info, sr, pds_result
+            )
+
+            track = await _commit_db_swap(state, audio_info, sr, pds_result, new_cid)
+
+            # success — clean up the old R2 object(s)
+            await _cleanup_old_files(state, sr)
+
+            # fire post-replace hooks (rescan/re-embed/maybe re-classify)
+            await run_post_track_audio_replace_hooks(track.id, audio_url=sr.r2_url)
+
+            # if the track is part of an album, refresh the album list record
+            # so its strongRef points at the new CID
+            await _maybe_resync_album_list(track, ctx.auth_session)
+
+            await invalidate_tracks_discovery_cache()
+
+            await job_service.update_progress(
+                ctx.job_id,
+                JobStatus.COMPLETED,
+                "audio replaced",
+                result={
+                    "track_id": track.id,
+                    "atproto_uri": track.atproto_record_uri,
+                    "atproto_cid": track.atproto_record_cid,
+                },
+            )
+
+        except UploadPhaseError as e:
+            # rollback: drop the just-written R2 file(s) so we don't strand orphans
+            await _rollback_new_files(
+                new_file_id_for_rollback,
+                new_original_file_id_for_rollback,
+                new_original_file_type_for_rollback,
+            )
+            await job_service.update_progress(
+                ctx.job_id, JobStatus.FAILED, "audio replace failed", error=e.error
+            )
+        except Exception as e:
+            await _rollback_new_files(
+                new_file_id_for_rollback,
+                new_original_file_id_for_rollback,
+                new_original_file_type_for_rollback,
+            )
+            logger.exception(
+                "audio replace job %s failed with unexpected error", ctx.job_id
+            )
+            await job_service.update_progress(
+                ctx.job_id,
+                JobStatus.FAILED,
+                "audio replace failed",
+                error=f"unexpected error: {e!s}",
+            )
+        finally:
+            with contextlib.suppress(Exception):
+                Path(ctx.file_path).unlink(missing_ok=True)
+
+
+async def _rollback_new_files(
+    new_file_id: str | None,
+    new_original_file_id: str | None,
+    new_original_file_type: str | None,
+) -> None:
+    """delete any new R2 object we wrote before discovering the operation must abort."""
+    if new_file_id:
+        with contextlib.suppress(Exception):
+            await storage.delete(new_file_id)
+    if new_original_file_id:
+        with contextlib.suppress(Exception):
+            await storage.delete(new_original_file_id, new_original_file_type)
+
+
+# -- HTTP surface ----------------------------------------------------------------
+
+
+@router.put("/{track_id}/audio")
+@limiter.limit(settings.rate_limit.upload_limit)
+async def replace_track_audio(
+    request: Request,
+    track_id: int,
+    background_tasks: BackgroundTasks,
+    auth_session: Annotated[AuthSession, Depends(require_auth)],
+    file: UploadFile = File(...),
+) -> UploadStartResponse:
+    """Replace the audio file backing an existing track (owner only).
+
+    The track id, ATProto URI, likes, comments, plays, tags, and album linkage
+    all carry over. Only the audio bytes (and derived fields: duration,
+    fingerprint, embedding) are replaced.
+
+    Returns the same `UploadStartResponse` shape as `POST /tracks/`, so callers
+    can reuse the existing `GET /tracks/uploads/{upload_id}/progress` SSE
+    endpoint to follow progress.
+    """
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="no filename provided")
+
+    ext = Path(file.filename).suffix.lower()
+    if not (audio_format := AudioFormat.from_extension(ext)):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"unsupported file type: {ext}. "
+                f"supported: {AudioFormat.supported_extensions_str()}"
+            ),
+        )
+    del audio_format  # validated; the background pipeline re-derives it
+
+    # cheap pre-check so we 404/403 before streaming a multi-MB body to disk
+    async with db_session() as db:
+        result = await db.execute(
+            select(Track.artist_did, Track.atproto_record_uri).where(
+                Track.id == track_id
+            )
+        )
+        row = result.first()
+        if not row:
+            raise HTTPException(status_code=404, detail="track not found")
+        artist_did, atproto_uri = row
+        if artist_did != auth_session.did:
+            raise HTTPException(
+                status_code=403,
+                detail="you can only replace audio on your own tracks",
+            )
+        if not atproto_uri:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "this track has no ATProto record — restore it before "
+                    "replacing audio"
+                ),
+            )
+
+    # stream the body to a temp file (constant memory, enforce max size)
+    file_path: str | None = None
+    try:
+        max_size = settings.storage.max_upload_size_mb * 1024 * 1024
+        bytes_read = 0
+        with tempfile.NamedTemporaryFile(delete=False, suffix=ext) as tmp:
+            file_path = tmp.name
+            while chunk := await file.read(CHUNK_SIZE):
+                bytes_read += len(chunk)
+                if bytes_read > max_size:
+                    tmp.close()
+                    Path(file_path).unlink(missing_ok=True)
+                    raise HTTPException(
+                        status_code=413,
+                        detail=(
+                            f"file too large (max "
+                            f"{settings.storage.max_upload_size_mb}MB)"
+                        ),
+                    )
+                tmp.write(chunk)
+
+        job_id = await job_service.create_job(
+            JobType.UPLOAD,
+            auth_session.did,
+            "audio replace queued for processing",
+        )
+
+        background_tasks.add_task(
+            _process_replace_background,
+            ReplaceContext(
+                job_id=job_id,
+                auth_session=auth_session,
+                track_id=track_id,
+                file_path=file_path,
+                filename=file.filename,
+            ),
+        )
+    except Exception:
+        if file_path:
+            with contextlib.suppress(Exception):
+                Path(file_path).unlink(missing_ok=True)
+        raise
+
+    return UploadStartResponse(
+        upload_id=job_id,
+        status="pending",
+        message="audio replace queued for processing",
+    )

--- a/backend/src/backend/storage/protocol.py
+++ b/backend/src/backend/storage/protocol.py
@@ -46,6 +46,10 @@ class StorageProtocol(Protocol):
         progress_callback: Callable[[float], None] | None = None,
     ) -> str: ...
 
+    async def delete_gated(
+        self, file_id: str, file_type: str | None = None
+    ) -> bool: ...
+
     async def generate_presigned_url(
         self,
         file_id: str,

--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -16,6 +16,7 @@ from sqlalchemy import func, select
 from backend._internal.audio import AudioFormat
 from backend._internal.image import ImageFormat
 from backend.config import settings
+from backend.models.track import Track
 from backend.utilities.database import db_session
 from backend.utilities.hashing import hash_file_chunked
 
@@ -362,8 +363,6 @@ class R2Storage:
                       if None, falls back to trying all formats (legacy/images).
         """
         # check refcount before deleting
-        from backend.models.track import Track
-
         async with db_session() as db:
             stmt = (
                 select(func.count()).select_from(Track).where(Track.file_id == file_id)
@@ -589,6 +588,94 @@ class R2Storage:
 
             logfire.info("R2 gated upload complete", file_id=file_id, key=key)
             return file_id
+
+    async def delete_gated(self, file_id: str, file_type: str | None = None) -> bool:
+        """delete a gated audio file from the private R2 bucket.
+
+        mirrors `delete()` (refcount check then key probe) but targets
+        `private_audio_bucket_name`. needed because gated audio lives in a
+        separate bucket and the public-bucket-only `delete()` would silently
+        no-op on it.
+        """
+        if not self.private_audio_bucket_name:
+            logfire.warning(
+                "delete_gated: R2_PRIVATE_BUCKET not configured, skipping",
+                file_id=file_id,
+            )
+            return False
+
+        # refcount check — same guard as `delete()` so a duplicate gated row
+        # doesn't pull the file out from under another track.
+        async with db_session() as db:
+            stmt = (
+                select(func.count()).select_from(Track).where(Track.file_id == file_id)
+            )
+            result = await db.execute(stmt)
+            refcount = result.scalar_one()
+
+            if refcount > 1:
+                logfire.info(
+                    "skipping R2 gated delete, file still referenced",
+                    file_id=file_id,
+                    refcount=refcount,
+                )
+                return False
+
+        async with self._s3_client() as client:
+            if file_type:
+                audio_format = AudioFormat.from_extension(f".{file_type.lower()}")
+                if audio_format:
+                    key = f"audio/{file_id}{audio_format.extension}"
+                    try:
+                        await client.head_object(
+                            Bucket=self.private_audio_bucket_name, Key=key
+                        )
+                        await client.delete_object(
+                            Bucket=self.private_audio_bucket_name, Key=key
+                        )
+                        logfire.info(
+                            "R2 gated file deleted",
+                            file_id=file_id,
+                            key=key,
+                            bucket=self.private_audio_bucket_name,
+                        )
+                        return True
+                    except client.exceptions.ClientError as e:
+                        logfire.warning(
+                            "R2 gated delete failed for known file_type",
+                            file_id=file_id,
+                            key=key,
+                            file_type=file_type,
+                            error=str(e),
+                        )
+                        return False
+
+            # fallback: try every audio format
+            for audio_format in AudioFormat:
+                key = f"audio/{file_id}{audio_format.extension}"
+                try:
+                    await client.head_object(
+                        Bucket=self.private_audio_bucket_name, Key=key
+                    )
+                    await client.delete_object(
+                        Bucket=self.private_audio_bucket_name, Key=key
+                    )
+                    logfire.info(
+                        "R2 gated file deleted (fallback)",
+                        file_id=file_id,
+                        key=key,
+                        bucket=self.private_audio_bucket_name,
+                    )
+                    return True
+                except client.exceptions.ClientError:
+                    continue
+
+            logfire.warning(
+                "R2 gated delete: no matching file in private bucket",
+                file_id=file_id,
+                bucket=self.private_audio_bucket_name,
+            )
+            return False
 
     async def generate_presigned_url(
         self,

--- a/backend/tests/api/track_audio_replace/_helpers.py
+++ b/backend/tests/api/track_audio_replace/_helpers.py
@@ -178,6 +178,10 @@ def patched_replace_pipeline(
             AsyncMock(**storage_delete_kwargs),
         ) as mock_storage_delete,
         patch(
+            "backend.api.tracks.audio_replace.storage.delete_gated",
+            AsyncMock(return_value=True),
+        ) as mock_storage_delete_gated,
+        patch(
             "backend.api.tracks.audio_replace.run_post_track_audio_replace_hooks",
             new_callable=AsyncMock,
         ) as mock_hooks,
@@ -203,6 +207,7 @@ def patched_replace_pipeline(
         yield {
             "update_record": mock_update_record,
             "storage_delete": mock_storage_delete,
+            "storage_delete_gated": mock_storage_delete_gated,
             "post_hooks": mock_hooks,
             "schedule_album_sync": mock_album_sync,
         }

--- a/backend/tests/api/track_audio_replace/_helpers.py
+++ b/backend/tests/api/track_audio_replace/_helpers.py
@@ -1,0 +1,208 @@
+"""shared helpers (non-fixture) for the audio-replace test suite.
+
+pytest fixtures live in `conftest.py`; everything in this file is plain
+imports — call them as functions.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, patch
+
+from backend._internal import Session
+from backend._internal.audio import AudioFormat
+from backend.api.tracks.audio_replace import ReplaceContext
+from backend.api.tracks.uploads import (
+    AudioInfo,
+    PdsBlobResult,
+    StorageResult,
+)
+from backend.models import Track
+
+OWNER_DID = "did:plc:owner"
+OTHER_DID = "did:plc:someone-else"
+TRACK_URI = f"at://{OWNER_DID}/fm.plyr.track/3kabcdefghi23"
+
+
+class MockSession(Session):
+    """drop-in for require_auth that doesn't touch encryption."""
+
+    def __init__(self, did: str = OWNER_DID):
+        self.did = did
+        self.handle = "owner.bsky.social"
+        self.session_id = "session-id"
+        self.access_token = "tok"
+        self.refresh_token = "ref"
+        self.oauth_session = {
+            "did": did,
+            "handle": "owner.bsky.social",
+            "pds_url": "https://test.pds",
+            "authserver_iss": "https://auth.test",
+            "scope": "atproto transition:generic",
+            "access_token": "tok",
+            "refresh_token": "ref",
+            "dpop_private_key_pem": "fake_key",
+            "dpop_authserver_nonce": "",
+            "dpop_pds_nonce": "",
+        }
+
+
+def make_track(
+    *,
+    artist_did: str = OWNER_DID,
+    file_id: str = "old-file-id",
+    file_type: str = "mp3",
+    record_uri: str | None = TRACK_URI,
+    record_cid: str | None = "bafyOLD",
+    duration: int | None = 120,
+    album_id: str | None = None,
+    support_gate: dict | None = None,
+    auto_tag: bool = False,
+) -> Track:
+    extra: dict = {}
+    if duration is not None:
+        extra["duration"] = duration
+    if auto_tag:
+        extra["auto_tag"] = True
+    return Track(
+        title="My Song",
+        artist_did=artist_did,
+        file_id=file_id,
+        file_type=file_type,
+        original_file_id=None,
+        original_file_type=None,
+        extra=extra,
+        atproto_record_uri=record_uri,
+        atproto_record_cid=record_cid,
+        r2_url=f"https://audio.example/{file_id}.{file_type}",
+        audio_storage="r2",
+        pds_blob_cid=None,
+        notification_sent=True,
+        album_id=album_id,
+        support_gate=support_gate,
+    )
+
+
+def replace_ctx(track_id: int = 1) -> ReplaceContext:
+    return ReplaceContext(
+        job_id="job-1",
+        auth_session=MockSession(OWNER_DID),
+        track_id=track_id,
+        file_path="/tmp/fake-replacement.mp3",
+        filename="replacement.mp3",
+    )
+
+
+def audio_info(duration: int = 200, is_gated: bool = False) -> AudioInfo:
+    """default duration differs from `make_track` to verify the swap took."""
+    return AudioInfo(format=AudioFormat.MP3, duration=duration, is_gated=is_gated)
+
+
+def storage_result(
+    *,
+    file_id: str = "new-file-id",
+    original_file_id: str | None = None,
+    original_file_type: str | None = None,
+    r2_url: str | None = "https://audio.example/new-file-id.mp3",
+) -> StorageResult:
+    return StorageResult(
+        file_id=file_id,
+        original_file_id=original_file_id,
+        original_file_type=original_file_type,
+        playable_format=AudioFormat.MP3,
+        r2_url=r2_url,
+        transcode_info=None,
+    )
+
+
+def pds_result(
+    *, cid: str | None = "bafyNEWBLOB", size: int | None = 4096
+) -> PdsBlobResult:
+    return PdsBlobResult(
+        blob_ref={"$type": "blob", "ref": {"$link": cid}, "size": size}
+        if cid
+        else None,
+        cid=cid,
+        size=size,
+    )
+
+
+@contextlib.contextmanager
+def patched_replace_pipeline(
+    *,
+    validate: AudioInfo | None = None,
+    store: StorageResult | None = None,
+    pds: PdsBlobResult | None = None,
+    update_record_return: tuple[str, str] = (TRACK_URI, "bafyNEWREC"),
+    update_record_side_effect: object = None,
+    storage_delete_side_effect: object = None,
+    refreshed_session: Session | None = None,
+) -> Iterator[dict]:
+    """patch every external dependency of `_process_replace_background`.
+
+    yields a dict of the mocks (`update_record`, `storage_delete`, `post_hooks`,
+    `schedule_album_sync`) so tests can assert on them. lets each test focus
+    on the one or two things it actually verifies.
+    """
+    update_record_kwargs: dict = (
+        {"side_effect": update_record_side_effect}
+        if update_record_side_effect is not None
+        else {"return_value": update_record_return}
+    )
+    storage_delete_kwargs: dict = (
+        {"side_effect": storage_delete_side_effect}
+        if storage_delete_side_effect is not None
+        else {"return_value": True}
+    )
+
+    with (
+        patch(
+            "backend.api.tracks.audio_replace._validate_audio",
+            AsyncMock(return_value=validate or audio_info()),
+        ),
+        patch(
+            "backend.api.tracks.audio_replace._store_audio",
+            AsyncMock(return_value=store or storage_result()),
+        ),
+        patch(
+            "backend.api.tracks.audio_replace._upload_to_pds",
+            AsyncMock(return_value=pds if pds is not None else pds_result()),
+        ),
+        patch(
+            "backend.api.tracks.audio_replace.update_record",
+            AsyncMock(**update_record_kwargs),
+        ) as mock_update_record,
+        patch(
+            "backend.api.tracks.audio_replace.storage.delete",
+            AsyncMock(**storage_delete_kwargs),
+        ) as mock_storage_delete,
+        patch(
+            "backend.api.tracks.audio_replace.run_post_track_audio_replace_hooks",
+            new_callable=AsyncMock,
+        ) as mock_hooks,
+        patch(
+            "backend.api.tracks.audio_replace.schedule_album_list_sync",
+            new_callable=AsyncMock,
+        ) as mock_album_sync,
+        patch(
+            "backend.api.albums.invalidate_album_cache_by_id",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "backend.api.tracks.audio_replace.invalidate_tracks_discovery_cache",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "backend.api.tracks.audio_replace.get_session",
+            AsyncMock(return_value=refreshed_session),
+        ),
+        patch("backend.api.tracks.audio_replace.job_service", AsyncMock()),
+        patch("pathlib.Path.unlink"),
+    ):
+        yield {
+            "update_record": mock_update_record,
+            "storage_delete": mock_storage_delete,
+            "post_hooks": mock_hooks,
+            "schedule_album_sync": mock_album_sync,
+        }

--- a/backend/tests/api/track_audio_replace/conftest.py
+++ b/backend/tests/api/track_audio_replace/conftest.py
@@ -1,0 +1,60 @@
+"""pytest fixtures shared across the audio-replace test suite.
+
+scoped to this directory only — no side effects on other tests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+from fastapi import FastAPI
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import Session, require_auth
+from backend.main import app
+from backend.models import Artist
+
+from ._helpers import OTHER_DID, OWNER_DID, MockSession
+
+
+@pytest.fixture
+async def owner(db_session: AsyncSession) -> Artist:
+    artist = Artist(did=OWNER_DID, handle="owner.bsky.social", display_name="Owner")
+    db_session.add(artist)
+    await db_session.commit()
+    await db_session.refresh(artist)
+    return artist
+
+
+@pytest.fixture
+async def other_artist(db_session: AsyncSession) -> Artist:
+    artist = Artist(did=OTHER_DID, handle="other.bsky.social", display_name="Other")
+    db_session.add(artist)
+    await db_session.commit()
+    await db_session.refresh(artist)
+    return artist
+
+
+@pytest.fixture
+def test_app_owner() -> Generator[FastAPI, None, None]:
+    """app with require_auth overridden to return the OWNER session."""
+
+    async def _auth() -> Session:
+        return MockSession(OWNER_DID)
+
+    app.dependency_overrides[require_auth] = _auth
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def test_app_other() -> Generator[FastAPI, None, None]:
+    """app with require_auth overridden to return a non-owner session."""
+
+    async def _auth() -> Session:
+        return MockSession(OTHER_DID)
+
+    app.dependency_overrides[require_auth] = _auth
+    yield app
+    app.dependency_overrides.clear()

--- a/backend/tests/api/track_audio_replace/test_endpoint.py
+++ b/backend/tests/api/track_audio_replace/test_endpoint.py
@@ -1,0 +1,123 @@
+"""HTTP-layer tests for `PUT /tracks/{track_id}/audio`.
+
+these are the fast, "before the upload even gets queued" checks: auth,
+ownership, format validation, and the basic schedule-and-return contract.
+the actual background pipeline lives in `test_pipeline.py`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.models import Artist
+
+from ._helpers import make_track
+
+
+class TestEndpointAuthAndValidation:
+    """fast checks that don't exercise the background pipeline."""
+
+    async def test_404_when_track_missing(
+        self, test_app_owner: FastAPI, owner: Artist
+    ) -> None:
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app_owner), base_url="http://test"
+        ) as client:
+            resp = await client.put(
+                "/tracks/999999/audio",
+                files={"file": ("new.mp3", b"\x00" * 32, "audio/mpeg")},
+            )
+        assert resp.status_code == 404
+
+    async def test_403_when_not_owner(
+        self,
+        test_app_other: FastAPI,
+        db_session: AsyncSession,
+        owner: Artist,
+        other_artist: Artist,
+    ) -> None:
+        track = make_track()
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app_other), base_url="http://test"
+        ) as client:
+            resp = await client.put(
+                f"/tracks/{track.id}/audio",
+                files={"file": ("new.mp3", b"\x00" * 32, "audio/mpeg")},
+            )
+        assert resp.status_code == 403
+
+    async def test_400_when_unsupported_format(
+        self, test_app_owner: FastAPI, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        track = make_track()
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app_owner), base_url="http://test"
+        ) as client:
+            resp = await client.put(
+                f"/tracks/{track.id}/audio",
+                files={
+                    "file": (
+                        "evil.exe",
+                        b"MZ\x00\x00",
+                        "application/octet-stream",
+                    )
+                },
+            )
+        assert resp.status_code == 400
+        assert "unsupported" in resp.json()["detail"].lower()
+
+    async def test_400_when_track_has_no_atproto_record(
+        self, test_app_owner: FastAPI, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        """can't replace audio on a track whose ATProto record was lost."""
+        track = make_track(record_uri=None, record_cid=None)
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app_owner), base_url="http://test"
+        ) as client:
+            resp = await client.put(
+                f"/tracks/{track.id}/audio",
+                files={"file": ("new.mp3", b"\x00" * 32, "audio/mpeg")},
+            )
+        assert resp.status_code == 400
+
+    async def test_returns_upload_id_and_schedules_background(
+        self, test_app_owner: FastAPI, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        """successful enqueue returns the SSE-pollable upload_id."""
+        track = make_track()
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+
+        # patch the background hook so the queued task is a no-op
+        with patch(
+            "backend.api.tracks.audio_replace._process_replace_background",
+            new_callable=AsyncMock,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=test_app_owner), base_url="http://test"
+            ) as client:
+                resp = await client.put(
+                    f"/tracks/{track.id}/audio",
+                    files={"file": ("new.mp3", b"\x00" * 32, "audio/mpeg")},
+                )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "pending"
+        assert body["upload_id"]

--- a/backend/tests/api/track_audio_replace/test_hooks.py
+++ b/backend/tests/api/track_audio_replace/test_hooks.py
@@ -1,0 +1,144 @@
+"""tests for `run_post_track_audio_replace_hooks`.
+
+verifies the hook invalidates stale CopyrightScan rows, re-fires copyright/
+embedding/genre tasks against the new audio bytes, and respects the auto-tag
+opt-in for genre re-classification.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal.tasks.hooks import run_post_track_audio_replace_hooks
+from backend.models import Artist, CopyrightScan
+
+from ._helpers import make_track
+
+
+class TestPostReplaceHooks:
+    async def test_invalidates_old_copyright_scan_rows_and_reschedules(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        track = make_track(file_id="NEW")
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+
+        # an old scan that should be invalidated by the replace hook
+        db_session.add(
+            CopyrightScan(track_id=track.id, is_flagged=False, highest_score=10)
+        )
+        await db_session.commit()
+
+        with (
+            patch(
+                "backend._internal.tasks.hooks.schedule_copyright_scan",
+                new_callable=AsyncMock,
+            ) as mock_scan,
+            patch(
+                "backend._internal.tasks.hooks.schedule_embedding_generation",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "backend._internal.tasks.hooks.schedule_genre_classification",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "backend._internal.tasks.hooks.invalidate_tracks_discovery_cache",
+                new_callable=AsyncMock,
+            ),
+            patch("backend._internal.tasks.hooks.settings") as mock_settings,
+        ):
+            mock_settings.modal.enabled = False
+            mock_settings.turbopuffer.enabled = False
+            mock_settings.replicate.enabled = False
+            await run_post_track_audio_replace_hooks(
+                track.id, audio_url="https://audio.example/NEW.mp3"
+            )
+
+        # old scan was deleted
+        remaining = await db_session.execute(
+            select(CopyrightScan).where(CopyrightScan.track_id == track.id)
+        )
+        assert remaining.scalars().all() == []
+
+        # new scan was scheduled
+        mock_scan.assert_called_once_with(track.id, "https://audio.example/NEW.mp3")
+
+    async def test_only_reclassifies_genres_when_auto_tag_was_set(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        """auto-tag was a per-upload opt-in. don't re-fire it on a manual
+        replace if the user never asked for it — they may have hand-tagged."""
+        # track WITHOUT auto_tag flag
+        track = make_track(file_id="NEW", auto_tag=False)
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+
+        with (
+            patch(
+                "backend._internal.tasks.hooks.schedule_copyright_scan",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "backend._internal.tasks.hooks.schedule_embedding_generation",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "backend._internal.tasks.hooks.schedule_genre_classification",
+                new_callable=AsyncMock,
+            ) as mock_genre,
+            patch(
+                "backend._internal.tasks.hooks.invalidate_tracks_discovery_cache",
+                new_callable=AsyncMock,
+            ),
+            patch("backend._internal.tasks.hooks.settings") as mock_settings,
+        ):
+            mock_settings.modal.enabled = False
+            mock_settings.turbopuffer.enabled = False
+            mock_settings.replicate.enabled = True
+            await run_post_track_audio_replace_hooks(
+                track.id, audio_url="https://audio.example/NEW.mp3"
+            )
+
+        mock_genre.assert_not_called()
+
+    async def test_reclassifies_genres_when_auto_tag_present(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        track = make_track(file_id="NEW", auto_tag=True)
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+
+        with (
+            patch(
+                "backend._internal.tasks.hooks.schedule_copyright_scan",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "backend._internal.tasks.hooks.schedule_embedding_generation",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "backend._internal.tasks.hooks.schedule_genre_classification",
+                new_callable=AsyncMock,
+            ) as mock_genre,
+            patch(
+                "backend._internal.tasks.hooks.invalidate_tracks_discovery_cache",
+                new_callable=AsyncMock,
+            ),
+            patch("backend._internal.tasks.hooks.settings") as mock_settings,
+        ):
+            mock_settings.modal.enabled = False
+            mock_settings.turbopuffer.enabled = False
+            mock_settings.replicate.enabled = True
+            await run_post_track_audio_replace_hooks(
+                track.id, audio_url="https://audio.example/NEW.mp3"
+            )
+
+        mock_genre.assert_called_once_with(track.id, "https://audio.example/NEW.mp3")

--- a/backend/tests/api/track_audio_replace/test_pipeline.py
+++ b/backend/tests/api/track_audio_replace/test_pipeline.py
@@ -6,13 +6,17 @@ verifying the swap is atomic, rollback works, and the right hooks fire.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.api.tracks.audio_replace import (
     TrackAudioState,
     _process_replace_background,
 )
-from backend.models import Album, Artist
+from backend.models import Album, Artist, Track
+from backend.utilities.database import db_session as _db_session
 
 from ._helpers import (
     OWNER_DID,
@@ -272,6 +276,175 @@ class TestReplaceOrchestration:
             await _process_replace_background(replace_ctx(track_id=track_id))
 
         assert captured_session["token"] == "REFRESHED-TOKEN"
+
+
+class TestPostCommitFailureIsolation:
+    """regression for review feedback: post-commit failures must NOT roll back
+    the new audio. once `_commit_db_swap` returns, the track is replaced —
+    deleting the new R2 file at that point would leave production broken."""
+
+    async def test_post_replace_hooks_failure_does_not_rollback(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        track = make_track(file_id="OLD")
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+        track_id = track.id
+
+        deleted_keys: list[str] = []
+
+        async def fake_delete(file_id: str, file_type: str | None = None) -> bool:
+            deleted_keys.append(file_id)
+            return True
+
+        with patched_replace_pipeline(
+            store=storage_result(file_id="NEW"),
+            storage_delete_side_effect=fake_delete,
+        ) as mocks:
+            # post-commit hook blows up
+            mocks["post_hooks"].side_effect = RuntimeError("docket exploded")
+            await _process_replace_background(replace_ctx(track_id=track_id))
+
+        # track row IS replaced — no rollback
+        await db_session.refresh(track)
+        assert track.file_id == "NEW"
+        assert track.atproto_record_cid == "bafyNEWREC"
+
+        # the NEW R2 file must NOT have been deleted
+        assert "NEW" not in deleted_keys
+        # the OLD R2 file should have been cleaned up before the hooks ran
+        assert "OLD" in deleted_keys
+
+    async def test_album_resync_failure_does_not_rollback(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        album = Album(artist_did=OWNER_DID, slug="my-album", title="My Album")
+        db_session.add(album)
+        await db_session.flush()
+        track = make_track(album_id=album.id, file_id="OLD")
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+        track_id = track.id
+
+        with patched_replace_pipeline(
+            store=storage_result(file_id="NEW"),
+        ) as mocks:
+            mocks["schedule_album_sync"].side_effect = RuntimeError("docket down")
+            await _process_replace_background(replace_ctx(track_id=track_id))
+
+        # row is committed despite the schedule_album_list_sync failure
+        await db_session.refresh(track)
+        assert track.file_id == "NEW"
+        assert track.atproto_record_cid == "bafyNEWREC"
+
+
+class TestGatedAudioCleanup:
+    """regression for review feedback: gated tracks live in the private R2
+    bucket. cleanup and rollback must use `delete_gated`, not `delete`."""
+
+    async def test_old_gated_audio_uses_delete_gated_on_success(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        track = make_track(file_id="OLD", support_gate={"type": "any"})
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+        track_id = track.id
+
+        with patched_replace_pipeline(
+            validate=audio_info(is_gated=True),
+            store=storage_result(file_id="NEW", r2_url=None),
+            pds=None,  # gated tracks skip PDS upload
+        ) as mocks:
+            await _process_replace_background(replace_ctx(track_id=track_id))
+
+        # the OLD gated file was deleted via delete_gated, NOT delete
+        mocks["storage_delete_gated"].assert_called_once()
+        assert mocks["storage_delete_gated"].call_args.args[0] == "OLD"
+        # delete (public bucket) must not have been used for the gated file_id
+        for call in mocks["storage_delete"].call_args_list:
+            assert call.args[0] != "OLD"
+
+    async def test_rollback_for_gated_track_uses_delete_gated(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        track = make_track(file_id="OLD", support_gate={"type": "any"})
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+        track_id = track.id
+
+        with patched_replace_pipeline(
+            validate=audio_info(is_gated=True),
+            store=storage_result(file_id="NEW", r2_url=None),
+            pds=None,
+            update_record_side_effect=RuntimeError("PDS exploded"),
+        ) as mocks:
+            await _process_replace_background(replace_ctx(track_id=track_id))
+
+        # rollback deletes the NEW file from the PRIVATE bucket
+        mocks["storage_delete_gated"].assert_called_once()
+        assert mocks["storage_delete_gated"].call_args.args[0] == "NEW"
+
+        # track row is unchanged
+        await db_session.refresh(track)
+        assert track.file_id == "OLD"
+
+
+class TestConcurrentMetadataPatch:
+    """regression: minimize the window where a concurrent PATCH /tracks/{id}
+    title (or other metadata) gets clobbered by a stale snapshot taken at
+    `_load_and_authorize` time."""
+
+    async def test_publishes_freshly_loaded_title(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        track = make_track(file_id="OLD")
+        track.title = "Original Title"
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+        track_id = track.id
+
+        captured_record: dict = {}
+
+        async def fake_update_record(
+            *, auth_session, record_uri: str, record: dict
+        ) -> tuple[str, str]:
+            captured_record.update(record)
+            return record_uri, "bafyNEWREC"
+
+        # simulate a concurrent PATCH that lands AFTER _load_and_authorize but
+        # BEFORE _publish_record_update by mutating the row mid-pipeline — the
+        # mutation runs in the side_effect of `_store_audio`, which fires
+        # between authorize and publish.
+        async def store_then_patch(*_args, **_kwargs):
+            async with _db_session() as session:
+                await session.execute(
+                    update(Track)
+                    .where(Track.id == track_id)
+                    .values(title="Patched Title")
+                )
+                await session.commit()
+            return storage_result(file_id="NEW")
+
+        with (
+            patched_replace_pipeline(
+                store=storage_result(file_id="NEW"),
+                update_record_side_effect=fake_update_record,
+            ),
+            patch(
+                "backend.api.tracks.audio_replace._store_audio",
+                AsyncMock(side_effect=store_then_patch),
+            ),
+        ):
+            await _process_replace_background(replace_ctx(track_id=track_id))
+
+        # the published record reflects the PATCH'd title because we re-fetched
+        # state right before publishing
+        assert captured_record["title"] == "Patched Title"
 
 
 def test_track_audio_state_dataclass() -> None:

--- a/backend/tests/api/track_audio_replace/test_pipeline.py
+++ b/backend/tests/api/track_audio_replace/test_pipeline.py
@@ -1,0 +1,297 @@
+"""orchestration tests for `_process_replace_background`.
+
+these run the background pipeline end-to-end with the I/O phases mocked,
+verifying the swap is atomic, rollback works, and the right hooks fire.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.api.tracks.audio_replace import (
+    TrackAudioState,
+    _process_replace_background,
+)
+from backend.models import Album, Artist
+
+from ._helpers import (
+    OWNER_DID,
+    TRACK_URI,
+    MockSession,
+    audio_info,
+    make_track,
+    patched_replace_pipeline,
+    pds_result,
+    replace_ctx,
+    storage_result,
+)
+
+
+class TestReplaceOrchestration:
+    """exercise `_process_replace_background` end-to-end with mocked phases."""
+
+    async def test_happy_path_swaps_audio_and_updates_record(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        """on success: file_id/r2_url/atproto_record_cid/duration update,
+        old R2 file is deleted, post-replace hooks fire, no notification fires."""
+        track = make_track(file_id="OLD", duration=120)
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+        track_id = track.id
+
+        deleted_keys: list[str] = []
+
+        async def fake_delete(file_id: str, file_type: str | None = None) -> bool:
+            deleted_keys.append(file_id)
+            return True
+
+        with patched_replace_pipeline(
+            store=storage_result(file_id="NEW"),
+            storage_delete_side_effect=fake_delete,
+        ) as mocks:
+            await _process_replace_background(replace_ctx(track_id=track_id))
+
+        # DB row was atomically swapped
+        await db_session.refresh(track)
+        assert track.file_id == "NEW"
+        assert track.r2_url == "https://audio.example/new-file-id.mp3"
+        assert track.atproto_record_cid == "bafyNEWREC"
+        assert track.atproto_record_uri == TRACK_URI  # URI is stable
+        assert track.extra["duration"] == 200  # new duration
+        assert track.audio_storage == "both"
+        assert track.pds_blob_cid == "bafyNEWBLOB"
+        assert track.notification_sent is True  # never re-fires
+
+        # old R2 file was deleted
+        assert "OLD" in deleted_keys
+
+        # post-replace hooks were scheduled with the new audio URL
+        mocks["post_hooks"].assert_called_once()
+        call = mocks["post_hooks"].call_args
+        assert call.args[0] == track_id
+        assert call.kwargs["audio_url"] == "https://audio.example/new-file-id.mp3"
+
+    async def test_rollback_when_pds_record_update_fails(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        """if `update_record` raises, we delete the new R2 file and leave the
+        track row pointing at the OLD file_id/cid — no orphan, no broken state."""
+        track = make_track(file_id="OLD", record_cid="bafyOLD", duration=120)
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+        track_id = track.id
+
+        deleted_keys: list[str] = []
+
+        async def fake_delete(file_id: str, file_type: str | None = None) -> bool:
+            deleted_keys.append(file_id)
+            return True
+
+        with patched_replace_pipeline(
+            store=storage_result(file_id="NEW"),
+            update_record_side_effect=RuntimeError("PDS exploded"),
+            storage_delete_side_effect=fake_delete,
+        ) as mocks:
+            await _process_replace_background(replace_ctx(track_id=track_id))
+
+        # track row is unchanged
+        await db_session.refresh(track)
+        assert track.file_id == "OLD"
+        assert track.atproto_record_cid == "bafyOLD"
+        assert track.extra["duration"] == 120  # never updated
+
+        # the new R2 file we just wrote was deleted (no orphan)
+        assert "NEW" in deleted_keys
+        # the old R2 file was NOT deleted
+        assert "OLD" not in deleted_keys
+
+        # post-replace hooks must not have fired
+        mocks["post_hooks"].assert_not_called()
+
+    async def test_pds_blob_too_large_fallback_keeps_r2_only(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        """when PDS upload returns a None-cid result (too large / failed), the
+        track is recorded as r2-only and pds_blob_cid is cleared."""
+        track = make_track(file_id="OLD")
+        # simulate that the previous audio had a PDS blob
+        track.pds_blob_cid = "bafyOLDBLOB"
+        track.pds_blob_size = 9999
+        track.audio_storage = "both"
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+        track_id = track.id
+
+        with patched_replace_pipeline(
+            store=storage_result(file_id="NEW"),
+            pds=pds_result(cid=None, size=None),
+        ):
+            await _process_replace_background(replace_ctx(track_id=track_id))
+
+        await db_session.refresh(track)
+        assert track.audio_storage == "r2"
+        assert track.pds_blob_cid is None
+        assert track.pds_blob_size is None
+
+    async def test_album_list_resync_scheduled_when_track_in_album(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        """tracks in an album must trigger a list-record resync so the album's
+        embedded strongRef carries the new track CID."""
+        album = Album(artist_did=OWNER_DID, slug="my-album", title="My Album")
+        db_session.add(album)
+        await db_session.flush()
+        track = make_track(album_id=album.id)
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+        track_id = track.id
+        album_id = album.id
+
+        with patched_replace_pipeline(
+            store=storage_result(file_id="NEW"),
+        ) as mocks:
+            await _process_replace_background(replace_ctx(track_id=track_id))
+
+        mocks["schedule_album_sync"].assert_called_once()
+        # second positional arg is album_id (after session_id)
+        assert mocks["schedule_album_sync"].call_args.args[1] == album_id
+
+    async def test_gated_track_record_uses_backend_audio_url(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        """gated tracks must not write a public R2 URL into the ATProto record;
+        they need the auth-protected `/audio/{file_id}` redirect endpoint."""
+        track = make_track(support_gate={"type": "any"})
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+        track_id = track.id
+
+        captured_record: dict = {}
+
+        async def fake_update_record(
+            *, auth_session, record_uri: str, record: dict
+        ) -> tuple[str, str]:
+            captured_record.update(record)
+            return record_uri, "bafyNEWREC"
+
+        with patched_replace_pipeline(
+            validate=audio_info(is_gated=True),
+            store=storage_result(file_id="NEW", r2_url=None),  # gated → r2_url=None
+            pds=None,  # gated tracks skip PDS upload
+            update_record_side_effect=fake_update_record,
+        ):
+            await _process_replace_background(replace_ctx(track_id=track_id))
+
+        # the recorded audioUrl points at /audio/{file_id}, not at R2
+        assert captured_record["audioUrl"].endswith("/audio/NEW")
+        assert "supportGate" in captured_record
+        assert captured_record["supportGate"] == {"type": "any"}
+
+    async def test_lossless_replace_records_original_file_id(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        """a lossless (FLAC) replacement should store both transcoded mp3 and
+        the original file id on the row."""
+        track = make_track(file_id="OLD")
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+        track_id = track.id
+
+        with patched_replace_pipeline(
+            store=storage_result(
+                file_id="NEW_MP3",
+                original_file_id="NEW_FLAC",
+                original_file_type="flac",
+            ),
+        ):
+            await _process_replace_background(replace_ctx(track_id=track_id))
+
+        await db_session.refresh(track)
+        assert track.file_id == "NEW_MP3"
+        assert track.original_file_id == "NEW_FLAC"
+        assert track.original_file_type == "flac"
+
+    async def test_db_swap_clears_stale_genre_predictions(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        """stale genre_predictions / genre_predictions_file_id must be cleared
+        on a successful audio swap so a future re-classification doesn't get
+        short-circuited as 'already done'."""
+        track = make_track(file_id="OLD")
+        track.extra = {
+            **track.extra,
+            "genre_predictions": [{"name": "ambient", "confidence": 0.9}],
+            "genre_predictions_file_id": "OLD",
+        }
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+        track_id = track.id
+
+        with patched_replace_pipeline(store=storage_result(file_id="NEW")):
+            await _process_replace_background(replace_ctx(track_id=track_id))
+
+        await db_session.refresh(track)
+        assert "genre_predictions" not in track.extra
+        assert "genre_predictions_file_id" not in track.extra
+
+    async def test_session_reloaded_after_pds_upload(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        """if PDS upload refreshed the OAuth token, the new session is used for
+        the subsequent putRecord call (mirrors the upload-pipeline regression)."""
+        track = make_track(file_id="OLD")
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+        track_id = track.id
+
+        refreshed = MockSession(OWNER_DID)
+        refreshed.oauth_session["access_token"] = "REFRESHED-TOKEN"
+
+        captured_session: dict = {}
+
+        async def fake_update_record(
+            *, auth_session, record_uri: str, record: dict
+        ) -> tuple[str, str]:
+            captured_session["token"] = auth_session.oauth_session["access_token"]
+            return record_uri, "bafyNEWREC"
+
+        with patched_replace_pipeline(
+            store=storage_result(file_id="NEW"),
+            update_record_side_effect=fake_update_record,
+            refreshed_session=refreshed,
+        ):
+            await _process_replace_background(replace_ctx(track_id=track_id))
+
+        assert captured_session["token"] == "REFRESHED-TOKEN"
+
+
+def test_track_audio_state_dataclass() -> None:
+    """sanity check the snapshot dataclass."""
+    state = TrackAudioState(
+        track_id=1,
+        artist_did=OWNER_DID,
+        artist_display_name="Owner",
+        atproto_record_uri=TRACK_URI,
+        old_file_id="OLD",
+        old_file_type="mp3",
+        old_original_file_id=None,
+        old_original_file_type=None,
+        title="My Song",
+        album=None,
+        duration=120,
+        features=[],
+        image_url=None,
+        description=None,
+        support_gate=None,
+    )
+    assert state.track_id == 1
+    assert state.support_gate is None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -60,6 +60,19 @@ class MockStorage(R2Storage):
         """Mock delete."""
         return True
 
+    async def delete_gated(self, file_id: str, file_type: str | None = None) -> bool:
+        """Mock delete_gated."""
+        return True
+
+    async def save_gated(
+        self,
+        file: BinaryIO | BytesIO,
+        filename: str,
+        progress_callback: Callable[[float], None] | None = None,
+    ) -> str:
+        """Mock save_gated."""
+        return "mock_gated_file_id_456"
+
 
 def pytest_configure(config):
     """Set mock storage before any test modules are imported."""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -310,6 +310,7 @@ async def _setup_database_direct(database_url: str) -> None:
     engine = create_async_engine(database_url, echo=False)
     try:
         async with engine.begin() as conn:
+            await conn.execute(sa.text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
             await conn.run_sync(Base.metadata.create_all)
             await _truncate_tables(conn)
             await _create_clear_database_procedure(conn)

--- a/backend/tests/test_moderation.py
+++ b/backend/tests/test_moderation.py
@@ -532,12 +532,19 @@ class MockReportSession(Session):
 
 @pytest.fixture
 def report_test_app() -> Generator[FastAPI, None, None]:
-    """create test app with mocked auth for report tests."""
+    """create test app with mocked auth for report tests.
+
+    also resets the slowapi rate-limiter so per-IP budgets from earlier tests
+    in the same session don't bleed into this one (causes spurious 429s under
+    parallel xdist runs).
+    """
+    from backend.utilities.rate_limit import limiter
 
     async def mock_require_auth() -> Session:
         return MockReportSession()
 
     app.dependency_overrides[require_auth] = mock_require_auth
+    limiter.reset()
 
     yield app
 

--- a/loq.toml
+++ b/loq.toml
@@ -76,7 +76,7 @@ max_lines = 569
 
 [[rules]]
 path = "backend/tests/test_moderation.py"
-max_lines = 715
+max_lines = 718
 
 [[rules]]
 path = "docs/internal/authentication.md"
@@ -253,3 +253,7 @@ max_lines = 574
 [[rules]]
 path = "backend/src/backend/api/lists/playlists.py"
 max_lines = 952
+
+[[rules]]
+path = "backend/src/backend/api/tracks/audio_replace.py"
+max_lines = 552

--- a/loq.toml
+++ b/loq.toml
@@ -48,7 +48,7 @@ max_lines = 1000
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
-max_lines = 766
+max_lines = 828
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"
@@ -256,4 +256,8 @@ max_lines = 952
 
 [[rules]]
 path = "backend/src/backend/api/tracks/audio_replace.py"
-max_lines = 552
+max_lines = 651
+
+[[rules]]
+path = "backend/tests/conftest.py"
+max_lines = 515


### PR DESCRIPTION
## Summary
Adds `PUT /tracks/{track_id}/audio` so artists can swap the audio file backing an existing track without losing likes, comments, plays, the track URI, or the track ID.

Backend-only — frontend is a follow-up.

## Why now
Logfire spans show `darkhart.bsky.social` deleted + re-uploaded the same track 3× in ~65 minutes today (885 → 886 → 887 → 888). Each cycle wastes an R2 upload, a PDS blob upload, an ATProto `createRecord`, a `deleteRecord`, and silently nukes any likes / playlist refs / comments / play counts the track had accumulated.

## How it works

The track's identity is its `atproto_record_uri` (stable). What this endpoint changes:
- **R2 audio object**: new content-hashed file, old object deleted on success
- **PDS audio blob**: new blob upload (best-effort; falls back to r2-only on size limit)
- **ATProto track record**: PUT to existing rkey — `audioUrl` / `audioBlob` / `fileType` / `duration` updated, new record CID
- **DB row**: atomic swap of `file_id`, `file_type`, `r2_url`, `pds_blob_*`, `audio_storage`, `atproto_record_cid`, `extra.duration`. Stale `genre_predictions` / `genre_predictions_file_id` cleared.

What stays the same: track id, URI, likes, comments, plays, tags, album linkage, image, support_gate, `notification_sent`.

### Pipeline ordering (atomic with rollback)
1. Load + authorize (ownership, has-record check)
2. Validate new audio (format, duration)
3. Store new audio (R2; transcode if lossless)
4. Upload to PDS (best-effort)
5. PUT updated ATProto record ← if this fails, **rollback**: delete the new R2 file, leave the track row untouched
6. Atomic DB row swap
7. Delete old R2 object (success-only side effect)
8. `run_post_track_audio_replace_hooks` — invalidate stale `CopyrightScan` rows, re-fire copyright scan / CLAP embedding / genre classification (only if `auto_tag` was set)
9. Schedule album list resync if track is in an album so the album's strongRef carries the new track CID
10. Invalidate discovery cache

### Reuse, not duplication
The new orchestrator imports `_validate_audio`, `_store_audio`, `_upload_to_pds` from `uploads.py` so transcoding, PDS-blob fallback, and gated-bucket logic stay in one place.

## Intentional non-changes (worth flagging for review)

- **Labeler labels are NOT auto-dismissed.** A label attached to the (URI-stable) track record from the OLD audio stays attached after replace. Auto-dismissing copyright labels would be a moderation hole — left for manual review via existing tools.
- **Likes / playlists / comments retain stale strongRef CIDs** in the embedded `(uri, cid)` references. This is the same CID-churn behavior `PATCH /tracks/{id}` produces today; the rest of the system already tolerates it.
- **Old PDS blob is left to PDS garbage collection** — no explicit unreferenceing call.
- **Old R2 object is deleted immediately on success** — clients that loaded the old `audio_url` mid-stream may 404. Acceptable for now (the `<audio>` element handles the playback gracefully); could add a brief grace period later if it shows up in support.

## Test coverage

`backend/tests/api/track_audio_replace/` — 17 tests across 3 files:

**`test_endpoint.py`** (HTTP layer)
- 404 on missing track
- 403 on non-owner
- 400 on unsupported format
- 400 when track has no ATProto record
- 200 schedules background and returns SSE-pollable upload_id

**`test_pipeline.py`** (orchestration end-to-end with mocked I/O phases)
- happy path: file_id/r2_url/atproto_record_cid/duration all swap, old R2 file deleted, post-replace hooks fire, no notification re-fires
- **rollback** when `update_record` fails: new R2 file deleted, track row unchanged, hooks NOT fired
- PDS blob too large → falls back to r2-only, clears `pds_blob_cid`
- track in album → `schedule_album_list_sync` fires
- gated track writes `/audio/{file_id}` (not R2 URL) into the record + preserves `supportGate`
- lossless replace (FLAC) records both transcoded mp3 and original
- `genre_predictions` / `genre_predictions_file_id` cleared from `extra`
- session reload after PDS-upload token refresh (mirrors the upload-pipeline regression)

**`test_hooks.py`** (`run_post_track_audio_replace_hooks`)
- old `CopyrightScan` rows deleted, new scan scheduled
- genre re-classification skipped when `auto_tag` was not set (don't clobber manual tags)
- genre re-classification fires when `auto_tag` was set

## Drive-by fixes (uncovered while building this)

Two pre-existing test failures that the hard rule "no failing tests" required fixing:
- `tests/conftest.py` — `pg_trgm` extension was only created in the xdist template-DB path, so single-worker mode failed `test_xrpc.py::test_mention_search_returns_results`
- `tests/test_moderation.py` — slowapi rate-limit budget leaked between tests in the same session, causing 429s under `-n auto`. `report_test_app` fixture now resets the limiter.

## Test plan

- [x] `just backend test` — 810 pass, 17 skipped (sequential)
- [x] `pytest -n auto` — 810 pass under parallel xdist
- [x] `just backend lint` — ruff + ty clean
- [ ] manual smoke against staging once frontend lands
- [ ] verify in production: pick a real track, replace its audio, confirm likes/comments/plays/album linkage all survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)