### PR TITLE
fix(audio-replace): show useful context in current label

### DIFF
--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -1099,7 +1099,9 @@
 													</button>
 												{:else}
 													<div class="audio-current">
-														<span class="audio-current-label">current: {track.file_type}</span>
+														<span class="audio-current-label">
+															current: {track.file_type}{track.original_file_type && track.original_file_type !== track.file_type ? ` (transcoded from ${track.original_file_type})` : ''}{track.audio_storage === 'both' || track.audio_storage === 'pds' ? ' · stored on your PDS' : ' · stored on plyr.fm'}
+														</span>
 													</div>
 													<label class="audio-upload-btn">
 														<input

--- a/loq.toml
+++ b/loq.toml
@@ -156,7 +156,7 @@ max_lines = 2446
 
 [[rules]]
 path = "frontend/src/routes/portal/+page.svelte"
-max_lines = 3716
+max_lines = 3718
 
 [[rules]]
 path = "frontend/src/routes/settings/+page.svelte"


### PR DESCRIPTION
## Summary
Follow-up to #1312. \`current: m4a\` alone gave the user no sense of where the audio is stored or whether it was transcoded.

Now shows:
- \`current: m4a · stored on your PDS\`
- \`current: mp3 (transcoded from flac) · stored on plyr.fm\`

We don't have the original filename to show (it's content-hashed at upload), so format + transcode lineage + storage location is the most useful signal we can surface from the existing \`Track\` fields.

## Test plan
- [ ] check the audio replace section on a track stored only on plyr.fm
- [ ] check on a track stored on the PDS  
- [ ] check on a track that was transcoded (e.g. uploaded as flac → mp3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)