### PR TITLE
fix(restore): preserve PDS blob ref on restored track record

### DIFF
--- a/backend/src/backend/api/tracks/revisions.py
+++ b/backend/src/backend/api/tracks/revisions.py
@@ -29,6 +29,7 @@ from sqlalchemy.orm import selectinload
 from backend._internal import Session as AuthSession
 from backend._internal import require_auth
 from backend._internal.atproto.records import build_track_record, update_record
+from backend._internal.audio import AudioFormat
 from backend._internal.track_revisions import prune_revisions
 from backend.api.albums import invalidate_album_cache_by_id
 from backend.config import settings
@@ -196,6 +197,23 @@ async def restore_track_revision(
 
     # build + publish the updated PDS record FIRST, mirroring the replace flow.
     # if this fails, we abort before touching the DB.
+    #
+    # if the revision carried a PDS blob ref, include it in the new record so
+    # the user's PDS keeps its canonical copy of the audio. the blob itself is
+    # NOT re-uploaded — we trust that PDS still has it (blobs are only GC'd
+    # after a grace period post-dereference). if the blob has already been
+    # GC'd by the user's PDS, this record is still valid; playback falls back
+    # to audio_url (R2).
+    audio_blob: dict | None = None
+    if revision.pds_blob_cid:
+        audio_format = AudioFormat.from_extension(f".{revision.file_type}")
+        audio_blob = {
+            "$type": "blob",
+            "ref": {"$link": revision.pds_blob_cid},
+            "mimeType": audio_format.media_type if audio_format else "audio/mpeg",
+            "size": revision.pds_blob_size or 0,
+        }
+
     new_record = build_track_record(
         title=track.title,
         artist=track.artist.display_name,
@@ -206,7 +224,7 @@ async def restore_track_revision(
         features=list(track.features) if track.features else None,
         image_url=await track.get_image_url(),
         support_gate=dict(track.support_gate) if track.support_gate else None,
-        audio_blob=None,  # PDS blob not re-uploaded on restore (see note below)
+        audio_blob=audio_blob,
         description=track.description,
     )
     try:

--- a/backend/tests/api/track_audio_replace/test_revisions.py
+++ b/backend/tests/api/track_audio_replace/test_revisions.py
@@ -16,7 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal.track_revisions import prune_revisions
-from backend.models import MAX_REVISIONS_PER_TRACK, Artist, TrackRevision
+from backend.models import MAX_REVISIONS_PER_TRACK, Artist, Track, TrackRevision
 
 from ._helpers import OWNER_DID, TRACK_URI, make_track
 
@@ -324,6 +324,79 @@ class TestRestoreEndpoint:
         assert len(revisions_after) == 1
         assert revisions_after[0].file_id == "CURRENT"
         assert revisions_after[0].duration == 200
+
+    async def test_restore_preserves_pds_blob_on_live_track(
+        self,
+        test_app_owner: FastAPI,
+        db_session: AsyncSession,
+        owner: Artist,
+    ) -> None:
+        """regression for staging smoke: if the revision was audio_storage='both'
+        with a PDS blob cid, the restored live track must KEEP audio_storage='both'
+        and the pds_blob_cid, not silently drop back to 'r2' with null blob."""
+        track = make_track(file_id="CURRENT-NEW", duration=200)
+        # simulate the post-replace state: track has 'both' storage with a new blob
+        track.audio_storage = "both"
+        track.pds_blob_cid = "bafkreiNEWBLOB"
+        track.pds_blob_size = 9999
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+
+        # revision row captures the pre-replace 'both' state with the ORIGINAL blob
+        revision = TrackRevision(
+            track_id=track.id,
+            file_id="ORIGINAL",
+            file_type="wav",
+            original_file_id=None,
+            original_file_type=None,
+            audio_storage="both",
+            audio_url="https://audio.example/ORIGINAL.wav",
+            pds_blob_cid="bafkreiORIGINALBLOB",
+            pds_blob_size=4096,
+            duration=120,
+            was_gated=False,
+        )
+        db_session.add(revision)
+        await db_session.commit()
+        await db_session.refresh(revision)
+        original_revision_id = revision.id
+        track_id = track.id
+
+        with patch(
+            "backend.api.tracks.revisions.update_record",
+            AsyncMock(return_value=(TRACK_URI, "bafyRESTORED")),
+        ) as mock_update:
+            async with AsyncClient(
+                transport=ASGITransport(app=test_app_owner), base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    f"/tracks/{track_id}/revisions/{original_revision_id}/restore"
+                )
+
+        assert resp.status_code == 200
+
+        # the PDS record MUST have been rebuilt with the original blob ref —
+        # dropping it silently would desync PDS from DB and lose the user's
+        # PDS-hosted copy of the audio.
+        assert mock_update.call_count == 1
+        published_record = mock_update.call_args.kwargs["record"]
+        assert published_record.get("audioBlob") is not None, (
+            "restore built a record without audioBlob, losing the user's PDS blob ref"
+        )
+        assert published_record["audioBlob"]["ref"]["$link"] == "bafkreiORIGINALBLOB"
+
+        # the DB track row must reflect the revision's storage state
+        db_session.expire_all()
+        refreshed = await db_session.get(Track, track_id)
+        assert refreshed is not None
+        assert refreshed.file_id == "ORIGINAL"
+        assert refreshed.audio_storage == "both", (
+            f"expected audio_storage='both' after restoring a 'both' revision, "
+            f"got {refreshed.audio_storage!r}"
+        )
+        assert refreshed.pds_blob_cid == "bafkreiORIGINALBLOB"
+        assert refreshed.pds_blob_size == 4096
 
     async def test_409_when_gating_mismatches(
         self,


### PR DESCRIPTION
## Summary

Caught by manual staging smoke against #1318. When restoring a revision that had `audio_storage=\"both\"` with a PDS blob ref, the restored PDS record was being published WITHOUT an `audioBlob` field — silently dropping the user's PDS-hosted copy of the audio.

## Root cause

The restore code explicitly passed `audio_blob=None` to `build_track_record` with a misleading comment claiming \"PDS blob not re-uploaded on restore\". The comment was right about the blob *bytes* (they're already on PDS — no re-upload needed), but the blob *ref* must still be included in the new record. ATProto records can reference pre-uploaded blobs; the ref is what makes the PDS serve that binary content.

## Fix

If the revision carries a `pds_blob_cid`, construct a BlobRef (using the stored size + the file_type's mime type) and pass it to `build_track_record`.

## Regression test

Sets up the exact scenario the smoke hit:
- track in `audio_storage=\"both\"` with a new blob (post-replace state)
- revision captures the pre-replace `\"both\"` state with the original blob ref
- after restore: assert the published record contains `audioBlob` pointing at the original ref; assert the live track row keeps `audio_storage=\"both\"` and the correct `pds_blob_cid` / `pds_blob_size`

## Followup note

If the user's PDS has already GC'd the old blob (happens after a grace period once nothing references it), the record is still valid — playback falls back to `audio_url` (R2 CDN). We don't re-upload the blob as part of restore; that would require hauling bytes through the backend and is out of scope for v1.

## Test plan

- [x] new regression test passes
- [x] all existing audio-replace tests still pass (34/34)
- [x] lint + types clean
- [ ] after merge + staging deploy, re-run manual smoke: upload → replace → verify history → restore → verify PDS record has `audioBlob`, DB has `audio_storage=\"both\"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)