### PR TITLE
revert(test): remove the "flakiness" retry-poll on test_cross_user_like

### DIFF
--- a/backend/tests/integration/test_interactions.py
+++ b/backend/tests/integration/test_interactions.py
@@ -59,21 +59,10 @@ async def test_cross_user_like(
         track = await client1.get_track(track_id)
         assert track.like_count == initial_likes
 
-        # verify track no longer in user2's liked tracks. the liked list can
-        # lag a beat after unlike (cache / read-replica propagation), so
-        # retry-poll before asserting — matches test_upload_searchable's
-        # pattern for eventually-consistent reads.
-        import asyncio
-
-        for _ in range(5):
-            liked = await client2.liked_tracks(limit=100)
-            liked_ids = [t.id for t in liked]
-            if track_id not in liked_ids:
-                break
-            await asyncio.sleep(1)
-        assert track_id not in liked_ids, (
-            f"track {track_id} still in user2's liked after unlike + 5s poll"
-        )
+        # verify track no longer in user2's liked tracks
+        liked = await client2.liked_tracks(limit=100)
+        liked_ids = [t.id for t in liked]
+        assert track_id not in liked_ids
 
     finally:
         await client1.delete(track_id)


### PR DESCRIPTION
## Summary

Reverting the retry-poll I added in #1320 on `test_cross_user_like`. I called the failing test "flaky" without investigating. It isn't — it exposed a real race condition in the like → pds_create → jetstream ingest pipeline. Full analysis + fix directions in #1321.

The retry-poll was hiding a bug. Removing it so future failures stay visible until #1321 is fixed at the source.

## Test plan

- [x] audio revisions tests still pass
- [ ] note that `test_cross_user_like` may start failing intermittently again — that's the point. #1321 tracks the underlying fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)