### PR TITLE
feat(ci): workflow_dispatch deploy triggers for frontend + backend prod

### DIFF
--- a/.github/workflows/deploy-frontend-prod.yml
+++ b/.github/workflows/deploy-frontend-prod.yml
@@ -1,0 +1,42 @@
+name: deploy frontend prod
+
+# manual-dispatch fallback for the Cloudflare Pages GitHub integration.
+# CF Pages' git webhook has silently dropped pushes before (Apr 2026 —
+# production-fe advanced through #1311/#1312/#1313 without CF rebuilding).
+# this gives us a CI-side lever to force a production deploy.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "ref to build & deploy (default: production-fe tip)"
+        required: false
+        default: production-fe
+
+jobs:
+  deploy:
+    name: deploy frontend prod
+    runs-on: ubuntu-latest
+    concurrency: deploy-frontend-production
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: install deps
+        working-directory: frontend
+        run: bun install --frozen-lockfile
+
+      - name: build
+        working-directory: frontend
+        run: bun run build
+
+      - name: deploy to cloudflare pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: frontend
+          command: pages deploy .svelte-kit/cloudflare --project-name=plyr-fm --branch=production-fe --commit-dirty=true

--- a/.github/workflows/deploy-frontend-staging.yml
+++ b/.github/workflows/deploy-frontend-staging.yml
@@ -1,0 +1,41 @@
+name: deploy frontend staging
+
+# manual-dispatch fallback for the Cloudflare Pages GitHub integration on
+# the staging project (plyr-fm-stg). primary path is still CF's git webhook
+# on pushes to main — this is here for parity with prod and for recovery.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "ref to build & deploy (default: main tip)"
+        required: false
+        default: main
+
+jobs:
+  deploy:
+    name: deploy frontend staging
+    runs-on: ubuntu-latest
+    concurrency: deploy-frontend-staging
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: install deps
+        working-directory: frontend
+        run: bun install --frozen-lockfile
+
+      - name: build
+        working-directory: frontend
+        run: bun run build
+
+      - name: deploy to cloudflare pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: frontend
+          command: pages deploy .svelte-kit/cloudflare --project-name=plyr-fm-stg --branch=main --commit-dirty=true

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -3,6 +3,7 @@ name: deploy prod
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
Adds a CI-side lever to redeploy when the Cloudflare Pages GitHub integration silently drops a push.

## Why now
On 2026-04-19, `production-fe` advanced through #1311 → #1312 → #1313 (the audio-replace feature) via `just release-frontend-only`, but Cloudflare Pages never rebuilt. The `plyr-fm` Pages project has exactly **one** production deployment in history — commit `a4977bc2` (#1310) from Apr 19 05:42 UTC. Zero failed deployments, zero preview builds, no sign of the webhook firing for the later pushes.

Result: the "replace audio file" UI has been invisible on `plyr.fm` for 3 days despite being on the `production-fe` branch the whole time. There was no GitHub Actions lever to re-fire the deploy — the only paths were another `git push`, clicking Retry in the CF dashboard, or calling the CF API by hand.

Also: the existing backend `deploy-prod.yml` only triggers on `release: published`. If a release-triggered deploy fails there's no re-run button either.

## What this adds

| file | trigger | target |
|---|---|---|
| `deploy-frontend-prod.yml` (new) | `workflow_dispatch` only | builds + uploads via `wrangler pages deploy` to the `plyr-fm` CF Pages project. Defaults to the `production-fe` ref; overridable from the GH UI. |
| `deploy-frontend-staging.yml` (new) | `workflow_dispatch` only | same shape against `plyr-fm-stg`, defaults to `main`. Parity so recovery works on both environments. |
| `deploy-prod.yml` (+1 line) | `release: published` **or** `workflow_dispatch` | backend prod — now re-fireable without cutting a new release tag. |

Uses the existing `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` secrets (same ones the CDN provisioning work in #1278 used).

## Scope decisions
- **workflow_dispatch only** (no push triggers on the frontend workflows). The Cloudflare Pages git integration stays as the primary path — this is a fallback lever, not a migration. Adding a push trigger here would race with CF's own webhook-driven build and double-deploy on every push.
- **Builds in CI via wrangler**, not a CF API re-trigger. Using `wrangler pages deploy` makes the build auditable in GitHub Actions and eliminates dependency on CF's git webhook path (which is exactly what broke). `.svelte-kit/cloudflare` is uploaded directly.
- **Not migrating away from `production-fe`.** The branch + `just release-frontend-only` flow stays; this PR just gives us a CI-side way to re-run a build against whatever ref is currently on that branch.

## Out of scope (intentionally)
- A follow-up could migrate the frontend entirely to CI-only deploys (disable CF's git integration, promote via `workflow_dispatch` or tags). That's a bigger decision — logging it here so it's on record.
- Doesn't fix the underlying "why did CF's webhook stop firing" question. Worth a brief investigation, but unrelated to having a recovery lever.

## Test plan
- [ ] merge, then fire `deploy frontend prod` from Actions → confirm it builds from `production-fe` tip and the live `plyr.fm` bundle contains `audio-replace-editor`
- [ ] fire `deploy frontend staging` → confirm `stg.plyr.fm` rebuilds from `main`
- [ ] fire `deploy prod` (backend) without a release → confirm it deploys HEAD of main to `relay-api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)