### PR TITLE
docs(deployment): correct frontend Pages build config

### DIFF
--- a/docs/internal/deployment/environments.md
+++ b/docs/internal/deployment/environments.md
@@ -97,18 +97,18 @@ this will:
 
 **plyr-fm** (production):
 - framework: sveltekit
-- build command: `cd frontend && bun run build`
-- build output: `frontend/build`
+- build command: `cd frontend && bun install && bun run build`
+- build output: `frontend/.svelte-kit/cloudflare`
 - production branch: `production-fe`
-- production environment: `PUBLIC_API_URL=https://api.plyr.fm`
-- custom domain: `plyr.fm`
+- production environment: `PUBLIC_API_URL=https://api.plyr.fm`, `SKIP_DEPENDENCY_INSTALL=1`
+- custom domain: `plyr.fm` (also `www.plyr.fm`)
 
 **plyr-fm-stg** (staging):
 - framework: sveltekit
-- build command: `cd frontend && bun run build`
-- build output: `frontend/build`
+- build command: `cd frontend && bun install && bun run build`
+- build output: `frontend/.svelte-kit/cloudflare`
 - production branch: `main`
-- production environment: `PUBLIC_API_URL=https://api-stg.plyr.fm`
+- production environment: `PUBLIC_API_URL=https://api-stg.plyr.fm`, `SKIP_DEPENDENCY_INSTALL=1`
 - custom domain: `stg.plyr.fm`
 
 ### docs


### PR DESCRIPTION
## Summary
`docs/internal/deployment/environments.md` described the frontend Pages build config incorrectly. Verified against the live project config on both `plyr-fm` and `plyr-fm-stg` today during the CF-account-migration recovery — the actual values on CF are:

| field | was documented as | actual |
|---|---|---|
| build command | `cd frontend && bun run build` | `cd frontend && bun install && bun run build` |
| build output | `frontend/build` | `frontend/.svelte-kit/cloudflare` |
| env vars | only `PUBLIC_API_URL` | also `SKIP_DEPENDENCY_INSTALL=1` |
| prod domain | `plyr.fm` | `plyr.fm` + `www.plyr.fm` |

`SKIP_DEPENDENCY_INSTALL=1` tells CF's build runner to skip its automatic install step, so the build command has to run `bun install` itself. `frontend/.svelte-kit/cloudflare` matches `pages_build_output_dir` in `frontend/wrangler.toml`.

Same fixes applied to both prod and staging subsections.

## Test plan
- [x] config values match the live CF Pages projects (verified via API against both `plyr-fm` and `plyr-fm-stg` on the N8@zzstoatzz.io account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)