### PR TITLE
fix(restore): re-upload blob to PDS when it's been GC'd

### DIFF
--- a/backend/src/backend/api/tracks/revisions.py
+++ b/backend/src/backend/api/tracks/revisions.py
@@ -28,12 +28,14 @@ from sqlalchemy.orm import selectinload
 
 from backend._internal import Session as AuthSession
 from backend._internal import require_auth
+from backend._internal.atproto import PayloadTooLargeError, upload_blob
 from backend._internal.atproto.records import build_track_record, update_record
 from backend._internal.audio import AudioFormat
 from backend._internal.track_revisions import prune_revisions
 from backend.api.albums import invalidate_album_cache_by_id
 from backend.config import settings
 from backend.models import Track, TrackRevision
+from backend.storage import storage
 from backend.utilities.database import db_session
 
 from .router import router
@@ -199,18 +201,20 @@ async def restore_track_revision(
     # if this fails, we abort before touching the DB.
     #
     # if the revision carried a PDS blob ref, include it in the new record so
-    # the user's PDS keeps its canonical copy of the audio. the blob itself is
-    # NOT re-uploaded — we trust that PDS still has it (blobs are only GC'd
-    # after a grace period post-dereference). if the blob has already been
-    # GC'd by the user's PDS, this record is still valid; playback falls back
-    # to audio_url (R2).
+    # the user's PDS keeps its canonical copy of the audio. we first try the
+    # revision's original CID — if PDS still has it, zero extra cost. if PDS
+    # has GC'd the blob (normal after audio was replaced), we re-upload the
+    # bytes from R2 to mint a fresh CID. the core promise of plyr.fm is that
+    # users own their audio on their PDS; losing the blob ref on restore
+    # would silently break that promise.
+    audio_format = AudioFormat.from_extension(f".{revision.file_type}")
+    content_type = audio_format.media_type if audio_format else "audio/mpeg"
     audio_blob: dict | None = None
     if revision.pds_blob_cid:
-        audio_format = AudioFormat.from_extension(f".{revision.file_type}")
         audio_blob = {
             "$type": "blob",
             "ref": {"$link": revision.pds_blob_cid},
-            "mimeType": audio_format.media_type if audio_format else "audio/mpeg",
+            "mimeType": content_type,
             "size": revision.pds_blob_size or 0,
         }
 
@@ -227,10 +231,12 @@ async def restore_track_revision(
         audio_blob=audio_blob,
         description=track.description,
     )
-    # `pds_blob_lost` tracks whether we had to drop the blob ref because the
-    # user's PDS no longer has it. when True, we downgrade the restored track
-    # to audio_storage="r2" with null pds_blob_cid on commit — R2 playback
-    # still works, but the PDS-hosted copy is genuinely gone.
+    # track the effective PDS blob state that will land on the DB row:
+    # - if the initial update_record succeeds: revision's own ref (no change)
+    # - if we had to re-upload: the newly-minted ref from the retry
+    # - if re-upload also fails: None → downgrade track to audio_storage="r2"
+    effective_blob_cid: str | None = revision.pds_blob_cid
+    effective_blob_size: int | None = revision.pds_blob_size
     pds_blob_lost = False
     try:
         _, new_cid = await update_record(
@@ -241,19 +247,54 @@ async def restore_track_revision(
     except Exception as exc:
         # PDSes GC unreferenced blobs after a short grace period. when a user
         # replaces audio and then later restores, the old blob may already be
-        # gone. retry without the blob ref so the restore still succeeds —
-        # the audio remains available via R2 (audio_url).
+        # gone. re-upload the R2 bytes to PDS to mint a fresh CID so the
+        # restored record still references a first-class PDS blob.
         if audio_blob is not None and "BlobNotFound" in str(exc):
             logfire.info(
-                "restore: PDS lost the old blob; publishing without audioBlob",
+                "restore: PDS lost the old blob; re-uploading bytes from R2",
                 track_id=track_id,
                 revision_id=revision_id,
-                blob_cid=revision.pds_blob_cid,
+                old_blob_cid=revision.pds_blob_cid,
             )
-            # build a fresh dict for the retry — never mutate `new_record`
-            # in place so callers / tests can inspect the original payload
-            retry_record = {k: v for k, v in new_record.items() if k != "audioBlob"}
-            pds_blob_lost = True
+            reupload_blob_ref: dict | None = None
+            try:
+                audio_data = await storage.get_file_data(
+                    revision.file_id, revision.file_type
+                )
+                if audio_data:
+                    reupload_blob_ref = await upload_blob(
+                        auth_session, audio_data, content_type
+                    )
+            except PayloadTooLargeError:
+                logfire.info(
+                    "restore: re-upload skipped (PDS payload too large)",
+                    track_id=track_id,
+                    revision_id=revision_id,
+                )
+            except Exception:
+                logfire.exception(
+                    "restore: re-upload failed; falling back to r2-only",
+                    track_id=track_id,
+                    revision_id=revision_id,
+                )
+
+            if reupload_blob_ref is not None:
+                # success path: replace the audioBlob in the record with the
+                # fresh ref and retry publishing. build a fresh dict rather
+                # than mutating the original new_record.
+                retry_record = dict(new_record)
+                retry_record["audioBlob"] = reupload_blob_ref
+                effective_blob_cid = reupload_blob_ref.get("ref", {}).get("$link")
+                effective_blob_size = reupload_blob_ref.get("size")
+            else:
+                # could not re-upload (R2 miss / oversize / transient failure)
+                # — fall back to the old drop-the-ref behavior so the restore
+                # still completes, and mark the track r2-only on commit.
+                retry_record = {k: v for k, v in new_record.items() if k != "audioBlob"}
+                effective_blob_cid = None
+                effective_blob_size = None
+                pds_blob_lost = True
+
             try:
                 _, new_cid = await update_record(
                     auth_session=auth_session,
@@ -262,7 +303,7 @@ async def restore_track_revision(
                 )
             except Exception as exc2:
                 logfire.exception(
-                    "restore: failed to update ATProto record (retry without blob)",
+                    "restore: failed to update ATProto record (retry)",
                     track_id=track_id,
                     revision_id=revision_id,
                 )
@@ -311,17 +352,25 @@ async def restore_track_revision(
         live_track.r2_url = revision.audio_url
         live_track.atproto_record_cid = new_cid
 
-        # if the PDS lost the blob between replace and restore, downgrade the
-        # track's recorded storage state so it matches the published record
-        # (no audioBlob). otherwise copy through the revision's state.
+        # if the PDS lost the blob AND we couldn't re-upload it, downgrade the
+        # track's recorded storage state to match the published record (no
+        # audioBlob). otherwise record the effective blob ref on the track —
+        # this is the revision's original CID if PDS still had it, or a fresh
+        # CID minted by the re-upload path.
         if pds_blob_lost:
             live_track.audio_storage = "r2"
             live_track.pds_blob_cid = None
             live_track.pds_blob_size = None
         else:
-            live_track.audio_storage = revision.audio_storage
-            live_track.pds_blob_cid = revision.pds_blob_cid
-            live_track.pds_blob_size = revision.pds_blob_size
+            # if the original had no PDS blob (audio_storage="r2"), preserve
+            # that; otherwise we successfully have a blob on PDS (either the
+            # original one or a re-uploaded one) so ensure storage reflects it.
+            if effective_blob_cid is not None:
+                live_track.audio_storage = "both"
+            else:
+                live_track.audio_storage = revision.audio_storage
+            live_track.pds_blob_cid = effective_blob_cid
+            live_track.pds_blob_size = effective_blob_size
 
         # update duration in extra; clear stale genre-prediction provenance so
         # a future re-classification doesn't get short-circuited.

--- a/backend/tests/api/track_audio_replace/test_revisions.py
+++ b/backend/tests/api/track_audio_replace/test_revisions.py
@@ -398,17 +398,17 @@ class TestRestoreEndpoint:
         assert refreshed.pds_blob_cid == "bafkreiORIGINALBLOB"
         assert refreshed.pds_blob_size == 4096
 
-    async def test_restore_falls_back_when_pds_blob_gc(
+    async def test_restore_reuploads_blob_when_pds_gc(
         self,
         test_app_owner: FastAPI,
         db_session: AsyncSession,
         owner: Artist,
     ) -> None:
-        """if the user's PDS has already GC'd the old blob, restore must not
-        fail. it should retry publishing WITHOUT audioBlob and downgrade the
-        track to audio_storage='r2' so DB + PDS stay consistent. R2 playback
-        still works — only the PDS-hosted copy is lost, which is expected
-        after GC."""
+        """if the user's PDS has GC'd the old blob, restore re-uploads the
+        R2 bytes to PDS to mint a fresh CID and republishes the record with
+        the new ref. the core plyr.fm promise is that users own their audio
+        on their PDS — dropping the ref silently would break that.
+        """
         track = make_track(file_id="CURRENT-NEW", duration=200)
         track.audio_storage = "both"
         track.pds_blob_cid = "bafkreiNEWBLOB"
@@ -443,10 +443,27 @@ class TestRestoreEndpoint:
                 RuntimeError(
                     'PDS request failed: 400 {"error":"BlobNotFound","message":"Could not find blob: bafkreiGCdBLOB"}'
                 ),
-                (TRACK_URI, "bafyRESTOREDNOBBLOB"),
+                (TRACK_URI, "bafyRESTOREDWITHFRESHBLOB"),
             ]
         )
-        with patch("backend.api.tracks.revisions.update_record", update_record_mock):
+        # storage returns the R2 bytes, upload_blob mints a fresh CID
+        reupload_ref = {
+            "$type": "blob",
+            "ref": {"$link": "bafkreiFRESH"},
+            "mimeType": "audio/wav",
+            "size": 4096,
+        }
+        get_file_data_mock = AsyncMock(return_value=b"fake-audio-bytes")
+        upload_blob_mock = AsyncMock(return_value=reupload_ref)
+
+        with (
+            patch("backend.api.tracks.revisions.update_record", update_record_mock),
+            patch(
+                "backend.api.tracks.revisions.storage.get_file_data",
+                get_file_data_mock,
+            ),
+            patch("backend.api.tracks.revisions.upload_blob", upload_blob_mock),
+        ):
             async with AsyncClient(
                 transport=ASGITransport(app=test_app_owner), base_url="http://test"
             ) as client:
@@ -455,15 +472,105 @@ class TestRestoreEndpoint:
                 )
 
         assert resp.status_code == 200
-        # first attempt included audioBlob; retry dropped it
+        # first attempt used the revision's original (GC'd) CID; retry used
+        # the freshly re-uploaded blob ref — NOT a record with audioBlob dropped
         assert update_record_mock.call_count == 2
         first_record = update_record_mock.call_args_list[0].kwargs["record"]
         second_record = update_record_mock.call_args_list[1].kwargs["record"]
-        assert first_record.get("audioBlob") is not None
-        assert second_record.get("audioBlob") is None
+        assert first_record["audioBlob"]["ref"]["$link"] == "bafkreiGCdBLOB"
+        assert second_record["audioBlob"]["ref"]["$link"] == "bafkreiFRESH"
 
-        # DB now reflects the downgraded state — track's published record has
-        # no audioBlob, so audio_storage must be 'r2' and pds_blob_cid null
+        # re-upload happened with the R2 bytes
+        get_file_data_mock.assert_awaited_once_with("ORIGINAL", "wav")
+        upload_blob_mock.assert_awaited_once()
+        assert upload_blob_mock.call_args.args[1] == b"fake-audio-bytes"
+        assert upload_blob_mock.call_args.args[2] == "audio/wav"
+
+        # DB reflects the fresh blob — audio_storage stays "both", pds_blob_cid
+        # is the re-uploaded CID (not the original GC'd one, not null)
+        db_session.expire_all()
+        refreshed = await db_session.get(Track, track_id)
+        assert refreshed is not None
+        assert refreshed.file_id == "ORIGINAL"
+        assert refreshed.audio_storage == "both"
+        assert refreshed.pds_blob_cid == "bafkreiFRESH"
+        assert refreshed.pds_blob_size == 4096
+        assert refreshed.atproto_record_cid == "bafyRESTOREDWITHFRESHBLOB"
+
+    async def test_restore_falls_back_to_r2_when_reupload_also_fails(
+        self,
+        test_app_owner: FastAPI,
+        db_session: AsyncSession,
+        owner: Artist,
+    ) -> None:
+        """if the PDS GC'd the blob AND re-upload also fails (R2 miss,
+        PDS oversize, transient error), restore still completes by
+        dropping the blob ref and downgrading the track to r2-only.
+        playback keeps working via audio_url; only the PDS-hosted copy
+        is genuinely gone."""
+        track = make_track(file_id="CURRENT-NEW", duration=200)
+        track.audio_storage = "both"
+        track.pds_blob_cid = "bafkreiNEWBLOB"
+        track.pds_blob_size = 9999
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+
+        revision = TrackRevision(
+            track_id=track.id,
+            file_id="ORIGINAL",
+            file_type="wav",
+            original_file_id=None,
+            original_file_type=None,
+            audio_storage="both",
+            audio_url="https://audio.example/ORIGINAL.wav",
+            pds_blob_cid="bafkreiGCdBLOB",
+            pds_blob_size=4096,
+            duration=120,
+            was_gated=False,
+        )
+        db_session.add(revision)
+        await db_session.commit()
+        await db_session.refresh(revision)
+        revision_id = revision.id
+        track_id = track.id
+
+        update_record_mock = AsyncMock(
+            side_effect=[
+                RuntimeError(
+                    'PDS request failed: 400 {"error":"BlobNotFound","message":"Could not find blob: bafkreiGCdBLOB"}'
+                ),
+                (TRACK_URI, "bafyRESTOREDNOBBLOB"),
+            ]
+        )
+        # R2 returns None (bytes genuinely unrecoverable), so re-upload
+        # is impossible and we fall back to publishing without audioBlob
+        get_file_data_mock = AsyncMock(return_value=None)
+        upload_blob_mock = AsyncMock()
+
+        with (
+            patch("backend.api.tracks.revisions.update_record", update_record_mock),
+            patch(
+                "backend.api.tracks.revisions.storage.get_file_data",
+                get_file_data_mock,
+            ),
+            patch("backend.api.tracks.revisions.upload_blob", upload_blob_mock),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=test_app_owner), base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    f"/tracks/{track_id}/revisions/{revision_id}/restore"
+                )
+
+        assert resp.status_code == 200
+        # upload_blob was not called because there were no bytes
+        upload_blob_mock.assert_not_awaited()
+        # retry record has audioBlob dropped (fallback path)
+        second_record = update_record_mock.call_args_list[1].kwargs["record"]
+        assert "audioBlob" not in second_record
+
+        # DB downgraded to r2-only
         db_session.expire_all()
         refreshed = await db_session.get(Track, track_id)
         assert refreshed is not None

--- a/loq.toml
+++ b/loq.toml
@@ -268,4 +268,4 @@ max_lines = 512
 
 [[rules]]
 path = "backend/tests/api/track_audio_replace/test_revisions.py"
-max_lines = 561
+max_lines = 668


### PR DESCRIPTION
## Summary
plyr.fm's core promise is that users own their audio on their PDS. the restore-audio-revision path silently broke that promise when the PDS had already garbage-collected the old blob (which it does within seconds of the blob becoming unreferenced). this PR changes the behavior so restore re-uploads the R2 bytes to the user's PDS to mint a fresh blob CID, instead of publishing a record with no \`audioBlob\` at all.

## How I found it
Smoke-tested \`audio-replace\` + \`revisions\` end-to-end on \`stg.plyr.fm\`. after a replace, I restored the original revision via \`POST /tracks/{id}/revisions/{revision_id}/restore\`. result:

- ✅ DB pointed at the old R2 file_id; audioUrl played back byte-for-byte v1
- ❌ PDS record had **no \`audioBlob\` field at all**
- ❌ DB had \`audio_storage = \"r2\"\`, \`pds_blob_cid = null\`

external atproto clients reading the track record would see no blob — track effectively downgraded from \"first-class PDS asset\" to \"plyr.fm-hosted only\". the old restore code had an explicit comment:
> the blob itself is NOT re-uploaded — we trust that PDS still has it (blobs are only GC'd after a grace period post-dereference).

in practice on current PDS implementations, the \"grace period\" is often zero — the blob is gone before the user gets a chance to restore.

## What changes

\`backend/src/backend/api/tracks/revisions.py\` — \`restore_track_revision\`:

when \`update_record\` fails with \`BlobNotFound\`:
1. \`storage.get_file_data(revision.file_id, revision.file_type)\` → fetches bytes from R2
2. \`upload_blob(auth_session, bytes, content_type)\` → mints a fresh blob CID on the user's PDS
3. retry \`update_record\` with the new blob ref
4. commit the track with \`audio_storage=\"both\"\` and the new CID

fallback chain (rare): if R2 is missing the bytes, or PDS rejects the re-upload (\`PayloadTooLargeError\`, transient error), the old drop-the-ref behavior kicks in and the track is downgraded to r2-only. restore still completes so the user isn't stuck; playback keeps working.

## Tests

\`backend/tests/api/track_audio_replace/test_revisions.py\`:
- **rewrote** \`test_restore_falls_back_when_pds_blob_gc\` → \`test_restore_reuploads_blob_when_pds_gc\` — asserts the retry record carries the re-uploaded ref (\`bafkreiFRESH\`), \`upload_blob\` was called with the R2 bytes, and the DB commits \`audio_storage=\"both\"\` + the new CID.
- **added** \`test_restore_falls_back_to_r2_when_reupload_also_fails\` — covers the R2-miss path (storage returns None): \`upload_blob\` is not called, retry record drops \`audioBlob\`, DB downgrades to r2-only.

all 14 tests in \`test_revisions.py\` pass. \`just backend lint\` clean.

## Test plan
- [x] unit tests pass
- [x] verified live on stg.plyr.fm: smoke-tested audio-replace flow today; observed the missing audioBlob on restored records (before this PR)
- [ ] after merge: re-run the smoke test on \`stg.plyr.fm\` to confirm the restored PDS record includes a fresh \`audioBlob\` ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)