### PR TITLE
fix(portal): audio-clear-btn inherits global font for consistency

### DIFF
--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -2829,6 +2829,7 @@
 		background: transparent;
 		border: none;
 		color: var(--accent);
+		font-family: inherit;
 		opacity: 0.7;
 		cursor: pointer;
 		transition: opacity 0.15s;

--- a/loq.toml
+++ b/loq.toml
@@ -156,7 +156,7 @@ max_lines = 2446
 
 [[rules]]
 path = "frontend/src/routes/portal/+page.svelte"
-max_lines = 3881
+max_lines = 3882
 
 [[rules]]
 path = "frontend/src/routes/settings/+page.svelte"


### PR DESCRIPTION
## Summary
follow-up to #1326 — the × button that clears a selected file in the audio-replace row is the only remaining \`<button>\` in that group that lacked \`font-family: inherit\`. currently only renders an SVG icon so there's no visible font today, but matching the sibling buttons keeps the group consistent and future-proofs against any later text-label additions.

## Also this PR serves as a webhook-reconnect verification
after reconnecting the GitHub App → plyr.fm repo integration today, this is the first push to \`main\` — we're watching whether CF Pages auto-builds on staging (and later on prod via \`just release-frontend-only\`).

## Test plan
- [x] prettier + svelte-check + eslint pass (pre-commit)
- [ ] after merge: confirm CF Pages auto-triggers a staging build on \`main\` push
- [ ] after release-frontend-only: confirm CF Pages auto-triggers a prod build on \`production-fe\` push
- [ ] post-deploy: verify \`/track/[id]\`, \`/u/[handle]\`, \`/search\`, \`/tags\`, \`/artists\` all 200 on both envs (SSR routes that need \`PUBLIC_API_URL\` baked in by CF's own builder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)