### PR TITLE
fix(confirm-dialog): stack above other modals

### DIFF
--- a/frontend/src/lib/components/ConfirmDialog.svelte
+++ b/frontend/src/lib/components/ConfirmDialog.svelte
@@ -100,7 +100,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		z-index: 1000;
+		z-index: 10000;
 		padding: 1rem;
 	}
 


### PR DESCRIPTION
## Summary
\`ConfirmDialog\` had \`z-index: 1000\` while every other sheet / modal in the codebase uses \`z-index: 9999\` (AudioRevisionsSheet, LikersSheet, LogoutModal, SearchModal, PdsMigrationModal, FeedbackModal, Toast, TermsOverlay). opening a confirm from *inside* one of those sheets — specifically "restore" inside the audio version-history sheet — rendered the confirm dialog **behind** the sheet, forcing the user to dismiss the sheet before they could click confirm. confusing and broken.

bumping to \`z-index: 10000\` so confirm dialogs always stack on top. a confirm is by definition the top-level decision point, so it should own the highest layer.

## Test plan
- [x] prettier + svelte-check + eslint pass (pre-commit)
- [ ] after deploy: open a track's version history → click restore on a revision → confirm dialog renders on top of the sheet, clickable without dismissing the sheet first

🤖 Generated with [Claude Code](https://claude.com/claude-code)