### PR TITLE
fix(uploads): migrate track upload + audio replace to docket

### DIFF
--- a/backend/src/backend/_internal/tasks/__init__.py
+++ b/backend/src/backend/_internal/tasks/__init__.py
@@ -76,8 +76,15 @@ def _build_background_tasks() -> list:
     """build the task list, deferring jetstream import to break circular dep.
 
     cycle: jetstream.py → tasks.ingest → tasks/__init__.py → jetstream.py
+
+    the upload / audio-replace tasks are also imported lazily because their
+    modules (`api.tracks.uploads`, `api.tracks.audio_replace`) pull in the
+    FastAPI router infrastructure, which we don't want to touch at task-module
+    import time.
     """
     from backend._internal.jetstream import consume_jetstream
+    from backend.api.tracks.audio_replace import run_track_audio_replace
+    from backend.api.tracks.uploads import run_track_upload
 
     return [
         consume_jetstream,
@@ -111,6 +118,8 @@ def _build_background_tasks() -> list:
         ingest_profile_update,
         ingest_account_status_change,
         scan_image_moderation,
+        run_track_upload,
+        run_track_audio_replace,
     ]
 
 

--- a/backend/src/backend/api/tracks/audio_replace.py
+++ b/backend/src/backend/api/tracks/audio_replace.py
@@ -30,7 +30,6 @@ from urllib.parse import urljoin
 
 import logfire
 from fastapi import (
-    BackgroundTasks,
     Depends,
     File,
     HTTPException,
@@ -47,6 +46,7 @@ from backend._internal.atproto.records import (
     update_record,
 )
 from backend._internal.audio import AudioFormat
+from backend._internal.background import get_docket
 from backend._internal.jobs import job_service
 from backend._internal.tasks import schedule_album_list_sync
 from backend._internal.tasks.hooks import (
@@ -539,6 +539,62 @@ async def _rollback_new_files(
             await storage.delete(new_original_file_id, new_original_file_type)
 
 
+# -- background task registration -----------------------------------------------
+
+
+async def run_track_audio_replace(
+    job_id: str,
+    session_id: str,
+    track_id: int,
+    file_path: str,
+    filename: str,
+) -> None:
+    """docket task entry point for audio replace.
+
+    takes primitive args (everything that survives Redis serialization),
+    rehydrates the auth session from the stored session_id, constructs a
+    ReplaceContext, and delegates to the phase orchestrator
+    (`_process_replace_background`). this is the function registered with
+    docket; the HTTP handler enqueues it via `schedule_track_audio_replace`.
+    """
+    auth_session = await get_session(session_id)
+    if auth_session is None:
+        await job_service.update_progress(
+            job_id,
+            JobStatus.FAILED,
+            "audio replace failed",
+            error="authentication session expired before processing could begin",
+        )
+        _unlink_temp(file_path)
+        return
+
+    ctx = ReplaceContext(
+        job_id=job_id,
+        auth_session=auth_session,
+        track_id=track_id,
+        file_path=file_path,
+        filename=filename,
+    )
+    await _process_replace_background(ctx)
+
+
+async def schedule_track_audio_replace(ctx: ReplaceContext) -> None:
+    """enqueue an audio replace as a docket task.
+
+    the HTTP handler should return to the client as soon as this call
+    resolves; the actual R2/PDS/ATProto work runs on a docket worker with
+    bounded concurrency so concurrent replaces can't saturate the DB pool.
+    """
+    docket = get_docket()
+    await docket.add(run_track_audio_replace)(
+        job_id=ctx.job_id,
+        session_id=ctx.auth_session.session_id,
+        track_id=ctx.track_id,
+        file_path=ctx.file_path,
+        filename=ctx.filename,
+    )
+
+
 # -- HTTP surface ----------------------------------------------------------------
 
 
@@ -547,7 +603,6 @@ async def _rollback_new_files(
 async def replace_track_audio(
     request: Request,
     track_id: int,
-    background_tasks: BackgroundTasks,
     auth_session: Annotated[AuthSession, Depends(require_auth)],
     file: UploadFile = File(...),
 ) -> UploadStartResponse:
@@ -627,8 +682,7 @@ async def replace_track_audio(
             "audio replace queued for processing",
         )
 
-        background_tasks.add_task(
-            _process_replace_background,
+        await schedule_track_audio_replace(
             ReplaceContext(
                 job_id=job_id,
                 auth_session=auth_session,

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -13,7 +13,6 @@ from typing import Annotated, Any
 import aiofiles
 import logfire
 from fastapi import (
-    BackgroundTasks,
     Depends,
     File,
     Form,
@@ -28,7 +27,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session as AuthSession
-from backend._internal import require_artist_profile
+from backend._internal import get_session, require_artist_profile
 from backend._internal.atproto import (
     BlobRef,
     PayloadTooLargeError,
@@ -37,6 +36,7 @@ from backend._internal.atproto import (
 )
 from backend._internal.atproto.handles import resolve_featured_artists
 from backend._internal.audio import AudioFormat
+from backend._internal.background import get_docket
 from backend._internal.clients.transcoder import get_transcoder_client
 from backend._internal.image import ImageFormat
 from backend._internal.jobs import job_service
@@ -972,12 +972,112 @@ async def _process_upload_background(ctx: UploadContext) -> None:
                     Path(ctx.image_path).unlink(missing_ok=True)
 
 
+async def run_track_upload(
+    upload_id: str,
+    session_id: str,
+    file_path: str,
+    filename: str,
+    title: str,
+    artist_did: str,
+    album: str | None,
+    album_id: str | None,
+    features_json: str | None,
+    tags: list[str],
+    description: str | None,
+    image_path: str | None,
+    image_filename: str | None,
+    image_content_type: str | None,
+    support_gate: dict | None,
+    auto_tag: bool,
+    unlisted: bool,
+) -> None:
+    """docket task entry point for track uploads.
+
+    takes primitive args (everything that survives Redis serialization),
+    rehydrates the auth session from the stored session_id, constructs an
+    UploadContext, and delegates to the phase orchestrator
+    (`_process_upload_background`). this is the function registered with
+    docket; the HTTP handler enqueues it via `schedule_track_upload`.
+
+    rehydrating the session at task start rather than passing the cached
+    AuthSession over the wire means we pick up any token refresh that
+    happened between the HTTP request and the worker picking up the task.
+    """
+    auth_session = await get_session(session_id)
+    if auth_session is None:
+        # session expired or was revoked between HTTP request and task start.
+        # no way to publish to the user's PDS without it — fail the job and
+        # clean up the temp files we staged.
+        await job_service.update_progress(
+            upload_id,
+            JobStatus.FAILED,
+            "upload failed",
+            error="authentication session expired before processing could begin",
+        )
+        with contextlib.suppress(Exception):
+            Path(file_path).unlink(missing_ok=True)
+        if image_path:
+            with contextlib.suppress(Exception):
+                Path(image_path).unlink(missing_ok=True)
+        return
+
+    ctx = UploadContext(
+        upload_id=upload_id,
+        auth_session=auth_session,
+        file_path=file_path,
+        filename=filename,
+        title=title,
+        artist_did=artist_did,
+        album=album,
+        album_id=album_id,
+        features_json=features_json,
+        tags=tags,
+        description=description,
+        image_path=image_path,
+        image_filename=image_filename,
+        image_content_type=image_content_type,
+        support_gate=support_gate,
+        auto_tag=auto_tag,
+        unlisted=unlisted,
+    )
+    await _process_upload_background(ctx)
+
+
+async def schedule_track_upload(ctx: UploadContext) -> None:
+    """enqueue a track upload as a docket task.
+
+    the HTTP handler should return to the client as soon as this call
+    resolves; the actual R2/PDS/ATProto work runs on a docket worker with
+    bounded concurrency (`settings.docket.worker_concurrency`), which
+    prevents a burst of simultaneous uploads from saturating the DB pool.
+    """
+    docket = get_docket()
+    await docket.add(run_track_upload)(
+        upload_id=ctx.upload_id,
+        session_id=ctx.auth_session.session_id,
+        file_path=ctx.file_path,
+        filename=ctx.filename,
+        title=ctx.title,
+        artist_did=ctx.artist_did,
+        album=ctx.album,
+        album_id=ctx.album_id,
+        features_json=ctx.features_json,
+        tags=ctx.tags,
+        description=ctx.description,
+        image_path=ctx.image_path,
+        image_filename=ctx.image_filename,
+        image_content_type=ctx.image_content_type,
+        support_gate=ctx.support_gate,
+        auto_tag=ctx.auto_tag,
+        unlisted=ctx.unlisted,
+    )
+
+
 @router.post("/")
 @limiter.limit(settings.rate_limit.upload_limit)
 async def upload_track(
     request: Request,
     title: Annotated[str, Form()],
-    background_tasks: BackgroundTasks,
     auth_session: AuthSession = Depends(require_artist_profile),
     album: Annotated[str | None, Form()] = None,
     album_id: Annotated[
@@ -1021,7 +1121,6 @@ async def upload_track(
             Example: {"type": "any"} - requires any atprotofans support.
         file: Audio file to upload (required).
         image: Optional image file for track artwork.
-        background_tasks: FastAPI background-task runner.
         auth_session: Authenticated artist session (dependency-injected).
 
     Returns:
@@ -1152,7 +1251,7 @@ async def upload_track(
             auto_tag=auto_tag == "true",
             unlisted=unlisted == "true",
         )
-        background_tasks.add_task(_process_upload_background, ctx)
+        await schedule_track_upload(ctx)
     except Exception:
         if file_path:
             with contextlib.suppress(Exception):

--- a/backend/tests/api/track_audio_replace/test_endpoint.py
+++ b/backend/tests/api/track_audio_replace/test_endpoint.py
@@ -105,9 +105,9 @@ class TestEndpointAuthAndValidation:
         await db_session.commit()
         await db_session.refresh(track)
 
-        # patch the background hook so the queued task is a no-op
+        # patch the docket scheduler so the queued task is a no-op
         with patch(
-            "backend.api.tracks.audio_replace._process_replace_background",
+            "backend.api.tracks.audio_replace.schedule_track_audio_replace",
             new_callable=AsyncMock,
         ):
             async with AsyncClient(

--- a/backend/tests/integration/test_album_upload.py
+++ b/backend/tests/integration/test_album_upload.py
@@ -11,16 +11,19 @@ or the atproto_uri/atproto_cid SSE completion fields.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from .utils.audio import save_drone
+
 if TYPE_CHECKING:
     from plyrfm import AsyncPlyrClient
 
-pytestmark = [pytest.mark.integration, pytest.mark.timeout(180)]
+pytestmark = [pytest.mark.integration, pytest.mark.timeout(300)]
 
 
 async def _create_album(
@@ -302,6 +305,101 @@ async def test_album_finalize_preserves_existing_tracks_on_append(
         assert returned_ids.index(track_a) < returned_ids.index(track_c), (
             f"preserved tracks must appear before newly-appended tracks, "
             f"got {returned_ids}"
+        )
+    finally:
+        if album_id:
+            await _delete_album_cascade(client, album_id=album_id)
+
+
+async def test_album_upload_10_tracks_concurrently(
+    user1_client: AsyncPlyrClient,
+    tmp_path: Path,
+) -> None:
+    """upload 10 tracks to an album concurrently and verify every one completes.
+
+    regression for the 2026-04-24 pool-pressure incident. the upload pipeline
+    used to run on `fastapi.BackgroundTasks`, which tied the HTTP request
+    lifecycle to the entire upload duration and held a request-scoped DB
+    connection the whole time. 6 concurrent uploads from a single album
+    create saturated the pool and starved unrelated routes.
+
+    this test exercises 10 concurrent uploads against the real backend. for
+    it to pass on the docket-based flow:
+      1. every HTTP POST /tracks/ must return promptly (the handler just
+         enqueues a docket task, so response time is bounded by validation +
+         streaming-to-disk, not by R2 + PDS + ATProto record creation)
+      2. every queued task must complete (no worker starvation, no task lost)
+      3. the album's list record must contain all 10 track IDs
+      4. all 10 SSE streams must report a `completed` event with a real
+         track_id + atproto_uri + atproto_cid
+    """
+    client = user1_client
+    album_id: str | None = None
+    n_tracks = 10
+    # pick 10 distinct pitches so each generated audio file has a different
+    # hash; the upload path rejects duplicate file_ids with 409.
+    notes = ["C3", "D3", "E3", "F3", "G3", "A3", "B3", "C4", "D4", "E4"]
+    assert len(notes) == n_tracks
+
+    try:
+        # step 1: create album shell
+        album = await _create_album(
+            client,
+            title="Integration Test Album (10 Concurrent Uploads)",
+            description=(
+                "regression for upload-on-docket migration; verifies 10 "
+                "concurrent uploads all complete"
+            ),
+        )
+        album_id = album["id"]
+        assert album_id is not None
+
+        # step 2: generate 10 unique audio files up front (file-hash-distinct
+        # so duplicate detection doesn't short-circuit)
+        files: list[Path] = []
+        for i, note in enumerate(notes):
+            path = tmp_path / f"concurrent_{i:02d}_{note}.wav"
+            # slightly different durations as extra hash entropy
+            save_drone(path, note, duration_sec=2.0 + (i * 0.1))
+            files.append(path)
+
+        # step 3: fire all 10 uploads concurrently and collect track_ids
+        uploads = [
+            _upload_track_with_album_id(
+                client,
+                file=path,
+                title=f"Concurrent Upload {i:02d} - {notes[i]}",
+                album_id=album_id,
+                tags={"integration-test", "concurrent-upload"},
+            )
+            for i, path in enumerate(files)
+        ]
+        track_ids = await asyncio.gather(*uploads)
+        assert len(track_ids) == n_tracks
+        assert len(set(track_ids)) == n_tracks, (
+            f"expected {n_tracks} distinct track ids, got duplicates: {track_ids}"
+        )
+
+        # step 4: finalize in upload order and verify the list record has all N
+        finalized = await _finalize_album(
+            client, album_id=album_id, track_ids=list(track_ids)
+        )
+        assert finalized["list_uri"] is not None
+        assert finalized["track_count"] == n_tracks
+
+        artist_handle = finalized["artist_handle"]
+        slug = finalized["slug"]
+        detail_response = await client._client.get(
+            client._url(f"/albums/{artist_handle}/{slug}"),
+            headers=client._auth_headers,
+        )
+        detail_response.raise_for_status()
+        detail = detail_response.json()
+
+        returned_ids = [t["id"] for t in detail["tracks"]]
+        assert sorted(returned_ids) == sorted(track_ids), (
+            f"album must contain all {n_tracks} uploaded tracks; "
+            f"expected {sorted(track_ids)}, got {sorted(returned_ids)}"
         )
     finally:
         if album_id:

--- a/loq.toml
+++ b/loq.toml
@@ -40,7 +40,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1234
+max_lines = 1333
 
 [[rules]]
 path = "backend/src/backend/config.py"
@@ -256,7 +256,7 @@ max_lines = 952
 
 [[rules]]
 path = "backend/src/backend/api/tracks/audio_replace.py"
-max_lines = 651
+max_lines = 704
 
 [[rules]]
 path = "backend/tests/conftest.py"


### PR DESCRIPTION
## Summary
\`POST /tracks/\` and \`PUT /tracks/{id}/audio\` were on \`fastapi.BackgroundTasks.add_task\`, which runs the task inside the ASGI request lifecycle **after** the response is sent. consequence: any request-scoped DB session stays checked out of the pool until the task finishes (20–100s per upload), and nothing bounds concurrency.

today flo.by uploaded 6 tracks in a single album-create fan-out. six concurrent uploads held six of the 10 pool slots for over a minute and starved every other request (\`/auth/me\` p95 hit 9.7s, \`/health\` 3s).

this PR moves both handlers to docket. there's an integration test covering 10 concurrent uploads so the scenario is locked in going forward.

## Why it was broken

the pattern was in place from the very first streaming-uploads commit (\`26a48c75\`, Nov 2025). docket landed a month later (Dec 2025) and all post-upload tasks were migrated piecemeal — copyright, embedding, genre, image moderation, ATProto sync, teal scrobble, media export, PDS backfill, album list sync. **but the upload orchestration itself never was.** audio replace (#1311, Apr 2026) copied the same \`BackgroundTasks\` pattern, inheriting the gap.

## Changes

| file | change |
|---|---|
| \`uploads.py\` | add \`run_track_upload\` (docket task) + \`schedule_track_upload\` helper |
| \`audio_replace.py\` | add \`run_track_audio_replace\` + \`schedule_track_audio_replace\` |
| both handlers | drop \`background_tasks: BackgroundTasks\` param, call \`await schedule_*\` |
| \`_internal/tasks/__init__.py\` | register both tasks in \`_build_background_tasks\` |
| \`test_endpoint.py\` | patch the scheduler helper rather than the orchestrator |
| \`tests/integration/test_album_upload.py\` | new test: \`test_album_upload_10_tracks_concurrently\` fires 10 concurrent uploads and asserts all complete |
| \`loq.toml\` | relax limits on \`uploads.py\` + \`audio_replace.py\` for the new wrapper functions |

## Design choices (deliberate)

- **primitives, not the dataclass, over the Redis wire.** matches every other docket task (\`process_export\`, \`scan_copyright\`, \`generate_embedding\` all take ids/scalars). avoids serializing \`AuthSession\` with its encrypted OAuth tokens.
- **session rehydration at task start.** if the OAuth token refreshed between queue and execution, we pick up the fresh session. the orchestrator already had mid-task recovery logic; this just makes start-of-task fresh too.
- **orchestrator signatures unchanged.** \`_process_upload_background(ctx)\` / \`_process_replace_background(ctx)\` keep working. the new docket entry points (\`run_*\`) wrap them — rehydrate session, build ctx, delegate. \`test_upload_session_reload.py\` and \`track_audio_replace/test_pipeline.py\` continue driving orchestrators directly, unchanged.
- **no schema change.** no new tables, no jobs-row metadata blob. 17 upload args are ugly but one-shot, and match the precedent.

## What this PR does not do

- not migrating *all* \`BackgroundTasks\` usages across the codebase. scoped to the two verified-broken handlers.
- not touching \`worker_concurrency\`. default 10 is already better than today's unbounded.
- not moving orchestrators out of \`uploads.py\` / \`audio_replace.py\`. natural home is still alongside the handlers and pipeline helpers.

## Impact once deployed

- HTTP handler returns in <1s; request-scoped DB session released on response
- per-op DB sessions inside the task instead of one held across 100s
- concurrent uploads queue in Redis past \`worker_concurrency\`, instead of saturating the pool
- cleaner Logfire traces: HTTP span ~1s, separate task span visible

## Test plan

- [x] \`just backend lint\`: ruff + ty clean
- [x] \`test_upload_session_reload.py\` (orchestrator-direct): passes unchanged
- [x] \`track_audio_replace/\` suite: 38/38 passing
- [x] CI: pre_commit + test-backend + build backend image
- [ ] integration: run \`test_album_upload_10_tracks_concurrently\` against staging after deploy
- [ ] stg smoke: upload a single track, observe HTTP span <1s + separate docket task span in Logfire
- [ ] prod smoke post-release: same; also try a 10-track album upload to verify the pool doesn't spike

## Related
- retros: [2025-11-17 connection pool outage](../sandbox/retrospectives/2025-11-17-connection-pool-outage.md), [2025-12-02 recurrence](../sandbox/retrospectives/2025-12-02-connection-pool-outage-recurrence.md)
- docs: \`docs/internal/backend/database/connection-pooling.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)