### PR TITLE
fix(upload): avoid session-state race in concurrent album creation

### DIFF
--- a/backend/src/backend/api/tracks/services.py
+++ b/backend/src/backend/api/tracks/services.py
@@ -1,7 +1,7 @@
 """shared helpers for track routes."""
 
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.models import Album, Artist
@@ -18,36 +18,36 @@ async def get_or_create_album(
     """Fetch or create an album for an artist.
 
     Returns (album, created) where created is True if a new album was made.
+
+    Uses INSERT ... ON CONFLICT DO NOTHING RETURNING so a race between
+    concurrent uploads to the same (artist_did, slug) does not have to
+    rollback a shared session. The old SELECT-then-INSERT-then-catch pattern
+    left the caller's AsyncSession in a fragile state under concurrent load
+    and caused pool-level MissingGreenlet errors mid-upload.
     """
     slug = slugify(title)
-    result = await db.execute(
+    stmt = (
+        pg_insert(Album)
+        .values(
+            artist_did=artist.did,
+            slug=slug,
+            title=title,
+            description=None,
+            image_id=image_id,
+            image_url=image_url,
+        )
+        .on_conflict_do_nothing(index_elements=["artist_did", "slug"])
+        .returning(Album)
+    )
+    result = await db.execute(stmt)
+    if album := result.scalar_one_or_none():
+        return album, True
+
+    # conflict — a concurrent task won the race. fetch the existing row.
+    existing = await db.execute(
         select(Album).where(Album.artist_did == artist.did, Album.slug == slug)
     )
-    if album := result.scalar_one_or_none():
-        return album, False
-
-    album = Album(
-        artist_did=artist.did,
-        slug=slug,
-        title=title,
-        description=None,
-        image_id=image_id,
-        image_url=image_url,
-    )
-    db.add(album)
-    try:
-        await db.flush()
-        return album, True
-    except IntegrityError:
-        # another request created this album concurrently
-        await db.rollback()
-        result = await db.execute(
-            select(Album).where(Album.artist_did == artist.did, Album.slug == slug)
-        )
-        album = result.scalar_one_or_none()
-        if not album:
-            raise
-        return album, False
+    return existing.scalar_one(), False
 
 
 __all__ = ["get_or_create_album"]

--- a/backend/tests/api/test_get_or_create_album.py
+++ b/backend/tests/api/test_get_or_create_album.py
@@ -1,0 +1,95 @@
+"""regression test for concurrent album creation race.
+
+history: the old SELECT-then-INSERT-then-catch-IntegrityError pattern in
+get_or_create_album left the caller's AsyncSession in a fragile state when
+multiple concurrent uploads raced to create the same (artist_did, slug) album.
+under load this surfaced as pool-level MissingGreenlet errors mid-upload (2 of
+12 concurrent uploads to the same album title failed on stg, 2026-04-24).
+
+the replacement uses INSERT ... ON CONFLICT DO NOTHING RETURNING so the race
+is resolved at the DB level — no rollback, no session state churn.
+"""
+
+import asyncio
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from backend.api.tracks.services import get_or_create_album
+from backend.models import Album, Artist
+
+from ..conftest import session_context
+
+
+async def _make_artist(db: AsyncSession, did: str = "did:plc:drone-test") -> Artist:
+    artist = Artist(
+        did=did,
+        handle="drone.test",
+        display_name="drone test",
+    )
+    db.add(artist)
+    await db.commit()
+    await db.refresh(artist)
+    return artist
+
+
+async def test_get_or_create_album_returns_existing(db_session: AsyncSession) -> None:
+    """second call with same (artist, title) returns existing album, created=False."""
+    artist = await _make_artist(db_session)
+
+    album_a, created_a = await get_or_create_album(
+        db_session, artist, "chromatic drones", image_id=None, image_url=None
+    )
+    await db_session.commit()
+
+    album_b, created_b = await get_or_create_album(
+        db_session, artist, "chromatic drones", image_id=None, image_url=None
+    )
+
+    assert created_a is True
+    assert created_b is False
+    assert album_a.id == album_b.id
+
+
+async def test_concurrent_get_or_create_album_same_title_no_duplicates(
+    _engine: AsyncEngine, _clear_db: None
+) -> None:
+    """12 concurrent tasks on SEPARATE sessions all trying to create the same
+    album must produce exactly one row, and all callers must agree on its id.
+
+    this mirrors the 12-chromatic-drone upload scenario that caused
+    MissingGreenlet failures in stg. each task uses its own AsyncSession —
+    sharing a single session across coroutines is separately broken and not
+    what happens in the real upload path (each upload task opens its own).
+    """
+    # seed artist on a dedicated session so the concurrent tasks can see it
+    async with session_context(engine=_engine) as seed_db:
+        artist = await _make_artist(seed_db, did="did:plc:drone-concurrent")
+        artist_did = artist.did
+
+    async def attempt() -> tuple[str, bool]:
+        async with session_context(engine=_engine) as db:
+            row = await db.execute(select(Artist).where(Artist.did == artist_did))
+            a = row.scalar_one()
+            album, created = await get_or_create_album(
+                db, a, "chromatic drones", image_id=None, image_url=None
+            )
+            await db.commit()
+            return album.id, created
+
+    results = await asyncio.gather(*(attempt() for _ in range(12)))
+
+    ids = {album_id for album_id, _ in results}
+    assert len(ids) == 1, f"expected 1 unique album id, got {ids}"
+
+    created_count = sum(1 for _, created in results if created)
+    assert created_count == 1, (
+        f"expected exactly 1 caller to see created=True, got {created_count}"
+    )
+
+    async with session_context(engine=_engine) as verify_db:
+        rows = await verify_db.execute(
+            select(Album).where(Album.artist_did == artist_did)
+        )
+        albums = rows.scalars().all()
+        assert len(albums) == 1, f"expected 1 album row, found {len(albums)}"


### PR DESCRIPTION
## Summary

During the 2026-04-24 12-chromatic-drone smoke test on stg, 2/12 concurrent uploads failed with `MissingGreenlet` at the pool level, roughly 300ms after `INSERT INTO albums`. After auditing the upload pipeline (no leaked sessions, all `async with`) and reading SQLAlchemy's 2.0.46 pool source, the proximate cause traces back to `get_or_create_album`:

```python
# before
try:
    await db.flush()           # race: multiple tasks INSERT same slug
    return album, True
except IntegrityError:
    await db.rollback()        # rolls back the CALLER'S session
    result = await db.execute(...)  # caller then keeps using this session
```

The caller (`_create_records`) keeps using `db` after `get_or_create_album` returns — adding a `CollectionEvent`, issuing `UPDATE tracks`, then `commit`. Under concurrent load, the rollback-on-shared-session path consistently triggered a pool-level `MissingGreenlet` on the next checkout.

Replaced SELECT-then-INSERT-then-catch with one statement:

```python
stmt = (
    pg_insert(Album)
    .values(...)
    .on_conflict_do_nothing(index_elements=["artist_did", "slug"])
    .returning(Album)
)
```

The unique index `uq_albums_artist_slug` already exists on both stg and prod (verified via Neon MCP).

## Test plan

- [x] New regression test `test_concurrent_get_or_create_album_same_title_no_duplicates` fires 12 concurrent tasks on separate sessions with the same title. Asserts exactly 1 row, exactly 1 `created=True`, all callers agree on the id. Passes locally.
- [x] `tests/api/test_albums.py`, `tests/api/test_upload_phases.py`, `tests/_internal/test_album_cache.py` (34 tests) still pass.
- [x] `just backend lint` clean.
- [ ] After merge + stg deploy: re-run the 12-chromatic-drone smoke test and confirm 12/12 succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)