### PR TITLE
fix(likes): tombstone cancelled URIs to prevent like resurrection race

### DIFF
--- a/backend/src/backend/_internal/tasks/ingest.py
+++ b/backend/src/backend/_internal/tasks/ingest.py
@@ -21,6 +21,7 @@ from backend._internal.tasks.origin_trust import (
     is_trusted_audio_origin,
     is_trusted_image_origin,
 )
+from backend._internal.tasks.pds import is_like_uri_cancelled
 from backend.config import settings
 from backend.models import Artist, Playlist, Track, TrackComment, TrackLike
 from backend.models.session import UserSession
@@ -415,6 +416,20 @@ async def ingest_like_create(
     """create a like from a Jetstream event."""
     if errors := validate_record("fm.plyr.like", record):
         logfire.warn("ingest: invalid like record, skipping", uri=uri, errors=errors)
+        return
+
+    # `pds_create_like` tombstones URIs whose owning row was unliked while
+    # the PDS create was still in flight. Jetstream may emit the create
+    # event for that URI before our orphan-cleanup PDS delete propagates;
+    # without this guard, we'd insert a row the user already cancelled
+    # (the "like resurrects after unlike" race surfaced by
+    # `test_cross_user_like` in integration tests).
+    if await is_like_uri_cancelled(uri):
+        logfire.info(
+            "ingest: skipping cancelled like create event",
+            uri=uri,
+            user_did=did,
+        )
         return
 
     subject = record.get("subject", {})

--- a/backend/src/backend/_internal/tasks/pds.py
+++ b/backend/src/backend/_internal/tasks/pds.py
@@ -4,6 +4,7 @@ import logging
 from datetime import UTC, datetime
 
 import logfire
+from redis.exceptions import RedisError
 from sqlalchemy import select
 
 from backend._internal.atproto.records import (
@@ -16,8 +17,62 @@ from backend._internal.auth import get_session
 from backend._internal.background import get_docket
 from backend.models import TrackComment, TrackLike
 from backend.utilities.database import db_session
+from backend.utilities.redis import get_async_redis_client
 
 logger = logging.getLogger(__name__)
+
+
+# When `pds_create_like` discovers that the user already unliked before the
+# PDS record could be written, we tombstone the URI in Redis so the matching
+# Jetstream `app.bsky.feed.like` create event — which arrives after our local
+# delete and would otherwise resurrect the row in `ingest_like_create` —
+# is recognized as already-cancelled and skipped. the TTL only needs to
+# cover Jetstream propagation; 5 minutes is comfortably above observed
+# end-to-end latency. expiry is harmless: by then the matching delete event
+# (from our orphan-cleanup) will have arrived and any stray row would be
+# cleaned up via `ingest_like_delete` shortly thereafter.
+LIKE_CANCELLED_TOMBSTONE_PREFIX = "like_cancelled:"
+LIKE_CANCELLED_TOMBSTONE_TTL_SECONDS = 300
+
+
+async def mark_like_uri_cancelled(like_uri: str) -> None:
+    """tombstone a like URI so a still-in-flight Jetstream create event
+    for it is treated as already-cancelled and dropped before it can
+    re-insert the row that the user just unliked.
+
+    suppressed on Redis errors — the tombstone is an optimization to
+    close a race window, and a missed tombstone falls back to the
+    natural Jetstream-delete-event eventually clearing the resurrected
+    row. don't fail the cancellation on a transient Redis blip.
+    """
+    try:
+        redis = get_async_redis_client()
+        await redis.set(
+            f"{LIKE_CANCELLED_TOMBSTONE_PREFIX}{like_uri}",
+            "1",
+            ex=LIKE_CANCELLED_TOMBSTONE_TTL_SECONDS,
+        )
+    except RedisError as e:
+        logger.warning(
+            "failed to write like-cancelled tombstone for %s: %s", like_uri, e
+        )
+
+
+async def is_like_uri_cancelled(like_uri: str) -> bool:
+    """check whether a like URI has been tombstoned by `pds_create_like`.
+
+    suppressed on Redis errors — returning False on Redis trouble means
+    the ingest path falls through to its normal behavior; the
+    eventually-arriving delete event still cleans up.
+    """
+    try:
+        redis = get_async_redis_client()
+        return await redis.exists(f"{LIKE_CANCELLED_TOMBSTONE_PREFIX}{like_uri}") > 0
+    except RedisError as e:
+        logger.warning(
+            "failed to read like-cancelled tombstone for %s: %s", like_uri, e
+        )
+        return False
 
 
 async def pds_create_like(
@@ -57,8 +112,17 @@ async def pds_create_like(
                 await session.commit()
                 logger.info(f"pds_create_like: created like record {like_uri}")
             else:
-                # like was deleted before we could update it - clean up orphan
+                # the user unliked before we could write the PDS record. we
+                # already created it on PDS in `create_like_record` above,
+                # so we now have to delete it. but Jetstream has likely
+                # already emitted a `like` create event for the URI we just
+                # wrote — if it lands in `ingest_like_create` before our
+                # PDS delete propagates, the row gets resurrected (no local
+                # row exists for the existing-row dedup branch to catch).
+                # tombstone the URI in Redis BEFORE the PDS delete so the
+                # ingest path can recognize and drop the create event.
                 logger.warning(f"pds_create_like: like {like_id} no longer exists")
+                await mark_like_uri_cancelled(like_uri)
                 await delete_record_by_uri(auth_session, like_uri)
 
     except Exception as e:

--- a/backend/tests/test_jetstream.py
+++ b/backend/tests/test_jetstream.py
@@ -1100,6 +1100,62 @@ class TestIngestLikeCreate:
                 uri="at://did:plc:jetstream_test/fm.plyr.like/like2",
             )
 
+    async def test_skips_create_for_cancelled_uri(
+        self, db_session: AsyncSession, artist: Artist, track: Track
+    ) -> None:
+        """regression for the like-resurrection race surfaced by
+        `test_cross_user_like` in the staging integration suite.
+
+        sequence: user clicks like (DB INSERT, atproto_like_uri=NULL),
+        then unlikes before `pds_create_like` finishes writing to PDS
+        (DB row deleted, no PDS URI to schedule a delete for). then
+        `pds_create_like` completes — PDS record IS written, but the
+        local row is gone, so it tombstones the URI and schedules an
+        orphan PDS delete. before that delete propagates through
+        Jetstream, the matching `app.bsky.feed.like` create event
+        arrives. without the tombstone check this re-inserts the row
+        the user already cancelled; with it, the event is dropped.
+        """
+        from backend._internal.tasks.pds import LIKE_CANCELLED_TOMBSTONE_PREFIX
+
+        cancelled_uri = "at://did:plc:jetstream_test/fm.plyr.like/cancelled"
+        store: dict[str, str] = {
+            f"{LIKE_CANCELLED_TOMBSTONE_PREFIX}{cancelled_uri}": "1"
+        }
+
+        async def fake_exists(key: str) -> int:
+            return 1 if key in store else 0
+
+        mock_redis = AsyncMock()
+        mock_redis.exists = AsyncMock(side_effect=fake_exists)
+
+        record = {
+            "subject": {
+                "uri": track.atproto_record_uri,
+                "cid": track.atproto_record_cid,
+            },
+            "createdAt": _recent_ts(),
+        }
+        with patch(
+            "backend._internal.tasks.pds.get_async_redis_client",
+            return_value=mock_redis,
+        ):
+            await ingest_like_create(
+                did=artist.did,
+                rkey="cancelled",
+                record=record,
+                uri=cancelled_uri,
+            )
+
+        result = await db_session.execute(
+            select(TrackLike).where(TrackLike.atproto_like_uri == cancelled_uri)
+        )
+        assert result.scalar_one_or_none() is None, (
+            "ingest_like_create must drop the create event when the URI is "
+            "tombstoned by pds_create_like's orphan-cleanup path; otherwise "
+            "the unlike-while-pending race resurrects the row."
+        )
+
 
 class TestIngestLikeDelete:
     async def test_deletes_by_uri(

--- a/backend/tests/test_pds_create_like_tombstone.py
+++ b/backend/tests/test_pds_create_like_tombstone.py
@@ -1,0 +1,187 @@
+"""regression: pds_create_like writes a tombstone when its row was unliked.
+
+paired with `TestIngestLikeCreate.test_skips_create_for_cancelled_uri` —
+together they cover both halves of the unlike-while-pending race fix:
+
+- this file: tombstone IS written by `pds_create_like` when the optimistic
+  TrackLike row no longer exists at the time the PDS create completes
+  (i.e. the user unliked between handler-return and worker-execution).
+- ingest test: `ingest_like_create` reads the tombstone and drops the
+  matching create event so the row is not resurrected.
+
+without both halves, the race in `test_cross_user_like` (integration
+suite) returns: PDS-create completes, Jetstream emits a create event,
+ingest re-inserts the row that the user already cancelled.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal.tasks.pds import (
+    LIKE_CANCELLED_TOMBSTONE_PREFIX,
+    LIKE_CANCELLED_TOMBSTONE_TTL_SECONDS,
+    pds_create_like,
+)
+from backend.models import Artist, Track
+
+
+@pytest.fixture
+async def artist(db_session: AsyncSession) -> Artist:
+    """test artist with a unique DID (xdist-safe)."""
+    a = Artist(
+        did=f"did:plc:liketomb_{uuid.uuid4().hex[:12]}",
+        handle="liketomb.test",
+        display_name="Like Tombstone Test",
+        pds_url="https://bsky.social",
+    )
+    db_session.add(a)
+    await db_session.commit()
+    return a
+
+
+@pytest.fixture
+async def track(db_session: AsyncSession, artist: Artist) -> Track:
+    """test track owned by `artist`."""
+    t = Track(
+        title="liketomb track",
+        file_id=f"file_{uuid.uuid4().hex[:12]}",
+        file_type="mp3",
+        artist_did=artist.did,
+        r2_url="https://r2.example.com/liketomb.mp3",
+        atproto_record_uri=f"at://{artist.did}/fm.plyr.track/liketomb",
+        atproto_record_cid="bafyliketomb",
+        audio_storage="r2",
+    )
+    db_session.add(t)
+    await db_session.commit()
+    return t
+
+
+def _mock_redis() -> tuple[AsyncMock, dict[str, str]]:
+    """in-memory redis double that records SETs so we can assert TTL + ordering."""
+    store: dict[str, str] = {}
+    set_calls: list[tuple[str, str, int | None]] = []
+
+    async def fake_set(key: str, value: str, ex: int | None = None) -> None:
+        store[key] = value
+        set_calls.append((key, value, ex))
+
+    async def fake_exists(key: str) -> int:
+        return 1 if key in store else 0
+
+    mock = AsyncMock()
+    mock.set = AsyncMock(side_effect=fake_set)
+    mock.exists = AsyncMock(side_effect=fake_exists)
+    mock._set_calls = set_calls
+    return mock, store
+
+
+class TestPdsCreateLikeTombstones:
+    """`pds_create_like` writes a tombstone before issuing the orphan PDS
+    delete, so a still-in-flight Jetstream create event for the same URI
+    is recognized as already-cancelled in `ingest_like_create`."""
+
+    async def test_writes_tombstone_when_local_row_already_unliked(
+        self, db_session: AsyncSession, artist: Artist, track: Track
+    ) -> None:
+        """if the optimistic TrackLike row is gone by the time PDS create
+        returns, tombstone the URI BEFORE calling delete_record_by_uri."""
+        # no row in the DB — user already unliked.
+        nonexistent_like_id = 99999999
+        created_uri = "at://did:plc:test/fm.plyr.like/cancelled-uri"
+
+        mock_redis, store = _mock_redis()
+        delete_call_args: list[str] = []
+
+        async def fake_delete_by_uri(_session: object, uri: str) -> None:
+            delete_call_args.append(uri)
+
+        with (
+            patch(
+                "backend._internal.tasks.pds.get_session",
+                return_value=AsyncMock(did=artist.did),
+            ),
+            patch(
+                "backend._internal.tasks.pds.create_like_record",
+                return_value=created_uri,
+            ),
+            patch(
+                "backend._internal.tasks.pds.delete_record_by_uri",
+                side_effect=fake_delete_by_uri,
+            ),
+            patch(
+                "backend._internal.tasks.pds.get_async_redis_client",
+                return_value=mock_redis,
+            ),
+        ):
+            await pds_create_like(
+                session_id="any-session",
+                like_id=nonexistent_like_id,
+                subject_uri=track.atproto_record_uri or "at://did/track/1",
+                subject_cid=track.atproto_record_cid or "bafy",
+            )
+
+        # tombstone is keyed by URI under the documented prefix, with the
+        # documented TTL — these constants are the contract `ingest.py`
+        # imports against, so a future drift breaks both halves at once.
+        tombstone_key = f"{LIKE_CANCELLED_TOMBSTONE_PREFIX}{created_uri}"
+        assert tombstone_key in store
+        ((called_key, _, ttl),) = mock_redis._set_calls
+        assert called_key == tombstone_key
+        assert ttl == LIKE_CANCELLED_TOMBSTONE_TTL_SECONDS
+
+        # and the orphan PDS delete still fires (the tombstone closes the
+        # ingest race; the actual PDS record still has to be removed).
+        assert delete_call_args == [created_uri]
+
+    async def test_no_tombstone_on_happy_path(
+        self, db_session: AsyncSession, artist: Artist, track: Track
+    ) -> None:
+        """the tombstone path is *only* for the orphan-cleanup branch; a
+        normal PDS create that finds its local row should not pollute
+        Redis with a tombstone (which would suppress the user's own
+        Jetstream create event and stall the like indefinitely)."""
+        from backend.models import TrackLike
+
+        like = TrackLike(track_id=track.id, user_did=artist.did, atproto_like_uri=None)
+        db_session.add(like)
+        await db_session.commit()
+        await db_session.refresh(like)
+
+        mock_redis, store = _mock_redis()
+
+        with (
+            patch(
+                "backend._internal.tasks.pds.get_session",
+                return_value=AsyncMock(did=artist.did),
+            ),
+            patch(
+                "backend._internal.tasks.pds.create_like_record",
+                return_value="at://did:plc:test/fm.plyr.like/happy",
+            ),
+            patch(
+                "backend._internal.tasks.pds.delete_record_by_uri",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+            patch(
+                "backend._internal.tasks.pds.get_async_redis_client",
+                return_value=mock_redis,
+            ),
+        ):
+            await pds_create_like(
+                session_id="any-session",
+                like_id=like.id,
+                subject_uri=track.atproto_record_uri or "at://did/track/1",
+                subject_cid=track.atproto_record_cid or "bafy",
+            )
+
+        assert store == {}, (
+            "happy-path PDS create must not write a tombstone "
+            "(would suppress the user's own Jetstream create event)"
+        )
+        mock_delete.assert_not_called()

--- a/loq.toml
+++ b/loq.toml
@@ -212,11 +212,11 @@ max_lines = 535
 
 [[rules]]
 path = "backend/src/backend/_internal/tasks/ingest.py"
-max_lines = 824
+max_lines = 839
 
 [[rules]]
 path = "backend/tests/test_jetstream.py"
-max_lines = 1811
+max_lines = 1867
 
 [[rules]]
 path = "frontend/src/lib/components/embed/CollectionEmbed.svelte"


### PR DESCRIPTION
## Summary

`test_cross_user_like` flakes intermittently in the staging integration suite (failed runs 2026-04-20, 2026-04-25). Verified mechanism — real race, not "flakiness":

```
1. user clicks LIKE  → DB INSERT row R (atproto_like_uri=NULL),
                       schedule pds_create_like(R.id)
2. user clicks UNLIKE before pds_create_like runs. uri is NULL,
                       so handler just DELETEs R. no PDS-delete
                       is scheduled (no URI yet).
3. pds_create_like(R.id) runs:
     a. PDS create returns URI X
     b. SELECT R.id → row gone → orphan-cleanup branch
     c. delete_record_by_uri(X) scheduled
4. Jetstream emits the like-create event for X BEFORE the matching
   delete event from (3c) propagates.
5. ingest_like_create finds no existing row for (track, user)
   → INSERTS fresh row with URI X. **the unlike just got undone.**
6. eventually the delete event arrives, ingest_like_delete clears
   the resurrected row — but in the gap, the user sees their
   unlike reverted.
```

## Fix

Tombstone the URI in Redis at step (3c), keyed `like_cancelled:<uri>` with a 5-minute TTL. `ingest_like_create` checks the tombstone in step (5) and drops the create event. TTL only needs to cover Jetstream propagation; expiry is harmless because the delete event from (3c) clears any stray row shortly after.

## Why Redis tombstone over a `cancelled_at` schema column

A tombstone column would be more "complete" but requires:
- Alembic migration on prod
- `WHERE cancelled_at IS NULL` filter on ~15 read-path call sites (`get_like_counts`, `list_liked_tracks`, `is_liked` checks across multiple endpoints, the activity feed, the for-you feed, etc.)
- Updated dedup logic in `like_track` for re-like-after-cancel
- Periodic GC

The race is a transient write-side race; the data model doesn't need to change to model it. A scoped Redis tombstone fixes the bug in the two files that own the race, doesn't touch read paths, and falls back gracefully on Redis trouble (the existing Jetstream-delete cleanup still applies).

## Mirrors the existing track-tombstone pattern

`ingest.py` already uses Redis tombstones to prevent ghost tracks from Jetstream cursor rewind. This PR introduces the equivalent for likes — same primitive, different prefix (`like_cancelled:` vs `plyr:tombstone:`) reflecting the different concern (write race vs replay race).

## Tests

- `tests/test_pds_create_like_tombstone.py` — `pds_create_like` writes the tombstone in the orphan branch, and crucially does NOT write one on the happy path (would otherwise suppress the user's own legitimate Jetstream create event and stall the like indefinitely).
- `tests/test_jetstream.py::TestIngestLikeCreate::test_skips_create_for_cancelled_uri` — `ingest_like_create` drops the create event when the URI is tombstoned.

## Validation

- `just backend lint`: ruff + ty clean.
- 447/447 backend tests pass locally (full `tests/api/` + jetstream + pds suites).

## Test plan

- [x] New regression tests pass.
- [x] Existing 84 jetstream + 13 track-likes API tests still pass.
- [ ] After merge + staging deploy: the integration `test_cross_user_like` should stop flaking. Watch the next 3-5 main-merge runs.

## Not in this PR

- A schema-level tombstone redesign. If the resurrection race recurs in a way Redis can't catch (e.g. multi-region Redis split-brain), the cancelled_at column is the next escalation; for now scoped Redis is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)