### PR TITLE
fix(embed): wire MediaSession metadata + action handlers on embed surfaces

### DIFF
--- a/frontend/src/lib/components/embed/CollectionEmbed.svelte
+++ b/frontend/src/lib/components/embed/CollectionEmbed.svelte
@@ -2,6 +2,14 @@
 	import { page } from '$app/stores';
 	import { onMount, tick } from 'svelte';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
+	import {
+		clearMediaSessionMetadata,
+		setMediaSessionActionHandlers,
+		setMediaSessionMetadata,
+		setMediaSessionPlaybackState,
+		setMediaSessionPositionState
+	} from '$lib/media-session';
+	import { trackCoverUrl } from '$lib/track-cover';
 	import type { CollectionData } from '$lib/types';
 
 	let { collection }: { collection: CollectionData } = $props();
@@ -91,6 +99,73 @@
 		if ($page.url.searchParams.get('autoplay') === '1' && isPlayable) {
 			audio.play().catch(() => { paused = true; });
 		}
+
+		// route OS-level lock-screen / system-media controls to the embed's
+		// own playback functions. without these, the lock-screen control
+		// only knew that an `<audio>` element was playing — no title, no
+		// artwork, and the next/previous buttons were ignored.
+		setMediaSessionActionHandlers({
+			play: () => { audio?.play().catch(() => {}); },
+			pause: () => { audio?.pause(); },
+			previoustrack: () => { void skipPrev(); },
+			nexttrack: () => { void skipNext(); },
+			seekto: (details) => {
+				if (audio && details.seekTime !== undefined) {
+					audio.currentTime = details.seekTime;
+				}
+			},
+			seekbackward: (details) => {
+				if (!audio) return;
+				audio.currentTime = Math.max(
+					0,
+					audio.currentTime - (details.seekOffset ?? 10)
+				);
+			},
+			seekforward: (details) => {
+				if (!audio) return;
+				audio.currentTime = Math.min(
+					duration,
+					audio.currentTime + (details.seekOffset ?? 10)
+				);
+			}
+		});
+
+		return () => {
+			// clear metadata when the component unmounts so a stale embed
+			// doesn't leave its title/cover hanging on the OS controls
+			// after navigation away.
+			clearMediaSessionMetadata();
+			setMediaSessionPlaybackState('none');
+			setMediaSessionActionHandlers({
+				play: null,
+				pause: null,
+				previoustrack: null,
+				nexttrack: null,
+				seekto: null,
+				seekbackward: null,
+				seekforward: null
+			});
+		};
+	});
+
+	// keep the OS-level lock-screen metadata in sync with the current track
+	$effect(() => {
+		if (!currentTrack) return;
+		setMediaSessionMetadata({
+			title: currentTrack.title,
+			artist: currentTrack.artist,
+			album: collection.title,
+			artworkUrl: trackCoverUrl(currentTrack),
+			artworkFallbackUrl: collection.imageUrl
+		});
+	});
+
+	$effect(() => {
+		setMediaSessionPlaybackState(paused ? 'paused' : 'playing');
+	});
+
+	$effect(() => {
+		setMediaSessionPositionState({ duration, position: currentTime });
 	});
 </script>
 

--- a/frontend/src/lib/media-session.ts
+++ b/frontend/src/lib/media-session.ts
@@ -1,0 +1,111 @@
+/**
+ * Helpers for keeping `navigator.mediaSession` populated.
+ *
+ * Use from any component that owns an `<audio>` element and wants the OS
+ * lock-screen / system-media controls to show track title / artist /
+ * artwork and route play/pause/next/prev to the right handlers.
+ *
+ * The main app player has its own (older) inline implementation in
+ * `Player.svelte`; that's untouched here. These helpers exist so the
+ * embed surfaces (which today set NO MediaSession state, leaving lock
+ * screens with a placeholder) can match.
+ *
+ * All functions are no-ops on platforms / contexts where the API isn't
+ * available (e.g. SSR, very old browsers).
+ */
+
+export interface MediaMetadataInput {
+	title: string;
+	artist: string;
+	album?: string;
+	/**
+	 * Preferred artwork URL (per-track image). When absent, the helper
+	 * falls back to `artworkFallbackUrl` (typically the collection /
+	 * album cover); when both are absent it leaves artwork empty so
+	 * the OS shows whatever it would by default.
+	 */
+	artworkUrl?: string | null;
+	artworkFallbackUrl?: string | null;
+}
+
+function hasMediaSession(): boolean {
+	return typeof navigator !== 'undefined' && 'mediaSession' in navigator;
+}
+
+function buildArtwork(input: MediaMetadataInput): MediaImage[] {
+	const url = input.artworkUrl ?? input.artworkFallbackUrl;
+	if (!url) return [];
+	// Single 512×512 entry is the documented well-supported shape across
+	// Chrome / Safari / Firefox; multiple sizes are nice-to-have but the
+	// OS scales as needed.
+	return [{ src: url, sizes: '512x512', type: 'image/jpeg' }];
+}
+
+export function setMediaSessionMetadata(input: MediaMetadataInput): void {
+	if (!hasMediaSession()) return;
+	navigator.mediaSession.metadata = new MediaMetadata({
+		title: input.title,
+		artist: input.artist,
+		album: input.album ?? '',
+		artwork: buildArtwork(input)
+	});
+}
+
+export function clearMediaSessionMetadata(): void {
+	if (!hasMediaSession()) return;
+	navigator.mediaSession.metadata = null;
+}
+
+export function setMediaSessionPlaybackState(
+	state: 'playing' | 'paused' | 'none'
+): void {
+	if (!hasMediaSession()) return;
+	navigator.mediaSession.playbackState = state;
+}
+
+export function setMediaSessionPositionState(opts: {
+	duration: number;
+	position: number;
+	playbackRate?: number;
+}): void {
+	if (!hasMediaSession()) return;
+	if (!opts.duration || opts.duration <= 0) return;
+	// `setPositionState` throws on bad input (e.g. position > duration);
+	// the OS-level position display is purely cosmetic, so swallow.
+	try {
+		navigator.mediaSession.setPositionState({
+			duration: opts.duration,
+			position: Math.max(0, Math.min(opts.position, opts.duration)),
+			playbackRate: opts.playbackRate ?? 1
+		});
+	} catch {
+		// no-op: stale duration/position during track transitions can fail
+	}
+}
+
+export type MediaSessionHandlers = Partial<
+	Record<MediaSessionAction, MediaSessionActionHandler | null>
+>;
+
+/**
+ * Apply (or clear, by passing `null`) a set of action handlers. Pass
+ * `null` for an action to remove its handler — useful when a context
+ * doesn't support that action (e.g. single-track embeds have no
+ * `nexttrack`/`previoustrack`, so passing `null` for those tells the
+ * OS to grey them out instead of inheriting a stale handler from a
+ * prior page.
+ */
+export function setMediaSessionActionHandlers(
+	handlers: MediaSessionHandlers
+): void {
+	if (!hasMediaSession()) return;
+	for (const [action, handler] of Object.entries(handlers) as Array<
+		[MediaSessionAction, MediaSessionActionHandler | null]
+	>) {
+		try {
+			navigator.mediaSession.setActionHandler(action, handler);
+		} catch {
+			// some browsers throw on unsupported actions; leave them be
+		}
+	}
+}

--- a/frontend/src/routes/embed/track/[id]/+page.svelte
+++ b/frontend/src/routes/embed/track/[id]/+page.svelte
@@ -2,6 +2,13 @@
 	import { page } from '$app/stores';
 	import { onMount } from 'svelte';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
+	import {
+		clearMediaSessionMetadata,
+		setMediaSessionActionHandlers,
+		setMediaSessionMetadata,
+		setMediaSessionPlaybackState,
+		setMediaSessionPositionState
+	} from '$lib/media-session';
 	import { trackCoverUrl } from '$lib/track-cover';
 	import type { PageData } from './$types';
 
@@ -53,6 +60,66 @@
 				paused = true;
 			});
 		}
+
+		// route OS-level lock-screen / system-media controls. single-track
+		// embed has no next/previous, so we explicitly null those handlers
+		// — that tells the OS to grey them out instead of inheriting a
+		// stale handler from a prior page.
+		setMediaSessionActionHandlers({
+			play: () => { audio?.play().catch(() => {}); },
+			pause: () => { audio?.pause(); },
+			previoustrack: null,
+			nexttrack: null,
+			seekto: (details) => {
+				if (audio && details.seekTime !== undefined) {
+					audio.currentTime = details.seekTime;
+				}
+			},
+			seekbackward: (details) => {
+				if (!audio) return;
+				audio.currentTime = Math.max(
+					0,
+					audio.currentTime - (details.seekOffset ?? 10)
+				);
+			},
+			seekforward: (details) => {
+				if (!audio) return;
+				audio.currentTime = Math.min(
+					duration,
+					audio.currentTime + (details.seekOffset ?? 10)
+				);
+			}
+		});
+
+		return () => {
+			clearMediaSessionMetadata();
+			setMediaSessionPlaybackState('none');
+			setMediaSessionActionHandlers({
+				play: null,
+				pause: null,
+				seekto: null,
+				seekbackward: null,
+				seekforward: null
+			});
+		};
+	});
+
+	$effect(() => {
+		if (!track) return;
+		setMediaSessionMetadata({
+			title: track.title,
+			artist: track.artist,
+			album: track.album?.title,
+			artworkUrl: coverUrl
+		});
+	});
+
+	$effect(() => {
+		setMediaSessionPlaybackState(paused ? 'paused' : 'playing');
+	});
+
+	$effect(() => {
+		setMediaSessionPositionState({ duration, position: currentTime });
 	});
 </script>
 

--- a/loq.toml
+++ b/loq.toml
@@ -220,7 +220,7 @@ max_lines = 1867
 
 [[rules]]
 path = "frontend/src/lib/components/embed/CollectionEmbed.svelte"
-max_lines = 580
+max_lines = 643
 
 [[rules]]
 path = "backend/tests/api/test_track_deletion.py"
@@ -272,4 +272,4 @@ max_lines = 668
 
 [[rules]]
 path = "frontend/src/routes/embed/track/[[]id[]]/+page.svelte"
-max_lines = 556
+max_lines = 623


### PR DESCRIPTION
## Summary

Empirical finding from iOS lock-screen testing today: the embed surfaces set NOTHING on `navigator.mediaSession`. Lock-screen controls show generic placeholders — no title, no cover art, and next/previous either grey or stale-handlered. The main app's `Player.svelte` has correct MediaSession setup; the embeds just never got it.

## Changes

- **`lib/media-session.ts`** (new): tiny helper module wrapping the four MediaSession APIs we use (metadata / playbackState / positionState / action handlers) with no-op fallbacks on platforms without the API. `setPositionState` is wrapped in try/catch because it throws on stale duration/position during track transitions.
- **`CollectionEmbed.svelte`** (album/playlist embed): metadata effect (track change), playbackState effect (paused change), positionState effect (time/duration change), action handlers registered once on mount with cleanup on unmount. Artwork fallback chain: per-track image → collection image.
- **`embed/track/[id]/+page.svelte`** (single-track embed): same shape, but explicitly nulls `previoustrack`/`nexttrack` so the OS greys them out instead of inheriting stale handlers from a prior page.

Cleanup-on-unmount clears metadata, sets `playbackState = 'none'`, nulls all action handlers — prevents stale lock-screen entries when the user navigates away from an embed mid-playback.

## What this PR does NOT do

Doesn't touch `Player.svelte`. It has its own (older, inline) MediaSession setup that works. Refactoring it to use these helpers is a separate dedup concern; the goal here is to close the embed gap without risking the main app player.

## Validation

- `just frontend check`: 0 errors / 0 warnings.
- Reviewed via `svelte:svelte-file-editor` agent. Confirmed:
  - Reactivity correct — each `\$effect` reads only its declared deps, no spurious re-runs.
  - SvelteKit's onMount cleanup return fires on navigation; no stale handlers leak across pages.
  - `\$state` closures inside the action handlers read the **current** value at handler-call time (Svelte 5 compiles them to live signal-store reads, not mount-time snapshots) — so `seekforward` reading `duration` 30 seconds later gets the right value.
  - No conflict with `Player.svelte`'s inline impl (different routes, single `navigator.mediaSession` per document, last-write-wins; embed routes don't mount the main player).

## Context

This came out of empirical iOS lock-screen testing for the auto-advance issue (zzstoatzz.io/plyr.fm#1). While testing, the user noticed the embed lock-screen showed no title/artwork. Auto-advance itself works gaplessly on iOS Safari for both embed AND main app post-#1339 — so this PR is purely a separate UX fix, not part of the auto-advance investigation. The auto-advance work continues separately and is now Android-Chrome-specific.

## Test plan

- [x] svelte-check clean.
- [ ] After deploy: open an embed (e.g. via Tangled, or directly /embed/album/...) on iPhone, lock screen, confirm title/cover show on the lock-screen control and play/pause/next/prev work.
- [ ] Same on Android Chrome.
- [ ] Confirm the main app player's lock-screen behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)