### PR TITLE
fix(copyright): suppress self-match flags before they reach UI/DM

### DIFF
--- a/backend/src/backend/_internal/moderation.py
+++ b/backend/src/backend/_internal/moderation.py
@@ -1,6 +1,7 @@
 """moderation service integration for copyright scanning."""
 
 import logging
+from collections import Counter
 from typing import Any
 
 import logfire
@@ -14,6 +15,54 @@ from backend.models import CopyrightScan, Track
 from backend.utilities.database import db_session
 
 logger = logging.getLogger(__name__)
+
+_SELF_MATCH_MIN_SLUG_LEN = 4
+
+
+def _slugify_artist(name: str) -> str:
+    """lowercase, alphanumeric-only — for fuzzy artist-name comparison."""
+    return "".join(c for c in name.lower() if c.isalnum())
+
+
+def _is_self_match(
+    match_artist: str, uploader_handle: str, uploader_display: str
+) -> bool:
+    """detect when a copyright match's artist is the uploader themselves.
+
+    AuDD frequently identifies an artist's own catalog uploads as
+    "violations" of their own published works elsewhere (e.g. dominant
+    match "Floby IV" on a track uploaded by handle "flo.by"). this is
+    a false positive — flagging it spams admin DMs and shows a red
+    badge to the artist on their own portal.
+
+    we compare slugified forms (lowercase, alphanumeric only) of the
+    match artist against the uploader's handle and display name. a
+    bidirectional substring check catches stage-name variants in
+    either direction (e.g. "flo.by" → "floby" is contained in
+    "Floby IV" → "flobyiv"). minimum length avoids accidental
+    matches on very short slugs.
+    """
+    m = _slugify_artist(match_artist)
+    if len(m) < _SELF_MATCH_MIN_SLUG_LEN:
+        return False
+    for candidate in (uploader_handle, uploader_display):
+        if not candidate:
+            continue
+        c = _slugify_artist(candidate)
+        if len(c) >= _SELF_MATCH_MIN_SLUG_LEN and (c in m or m in c):
+            return True
+    return False
+
+
+def _dominant_match_artist(matches: list[dict[str, Any]]) -> str | None:
+    """return the most frequent artist in scan matches, or None if empty."""
+    counts = Counter(
+        (m.get("artist") or "").strip() for m in matches if m.get("artist")
+    )
+    if not counts:
+        return None
+    artist, _ = counts.most_common(1)[0]
+    return artist or None
 
 
 async def scan_track_for_copyright(track_id: int, audio_url: str) -> None:
@@ -63,15 +112,50 @@ async def _store_scan_result(track_id: int, result: Any) -> None:
         result: ScanResult from moderation client
     """
     async with db_session() as db:
+        # decide effective is_flagged BEFORE the row is written so the
+        # transient flag never reaches the UI / DM path. self-matches
+        # (uploader is the dominant match artist) get demoted to clear.
+        is_flagged = result.is_flagged
+        suppressed_self_match: str | None = None
+
+        if is_flagged:
+            track = await db.scalar(
+                select(Track)
+                .options(joinedload(Track.artist))
+                .where(Track.id == track_id)
+            )
+            dominant = _dominant_match_artist(result.matches)
+            if (
+                track
+                and track.artist
+                and dominant
+                and _is_self_match(
+                    dominant, track.artist.handle, track.artist.display_name or ""
+                )
+            ):
+                is_flagged = False
+                suppressed_self_match = dominant
+        else:
+            track = None
+
         scan = CopyrightScan(
             track_id=track_id,
-            is_flagged=result.is_flagged,
+            is_flagged=is_flagged,
             highest_score=result.highest_score,
             matches=result.matches,
             raw_response=result.raw_response,
         )
         db.add(scan)
         await db.commit()
+
+        if suppressed_self_match:
+            logfire.info(
+                "copyright self-match suppressed",
+                track_id=track_id,
+                dominant_artist=suppressed_self_match,
+                uploader_handle=track.artist.handle if track and track.artist else None,
+            )
+            return
 
         logfire.info(
             "copyright scan stored",
@@ -82,19 +166,13 @@ async def _store_scan_result(track_id: int, result: Any) -> None:
         )
 
         # notify admin only — never DM the artist
-        if result.is_flagged:
-            track = await db.scalar(
-                select(Track)
-                .options(joinedload(Track.artist))
-                .where(Track.id == track_id)
+        if is_flagged and track and track.artist:
+            await notification_service.send_copyright_flag_notification(
+                track_id=track_id,
+                track_title=track.title,
+                artist_handle=track.artist.handle,
+                matches=scan.matches,
             )
-            if track and track.artist:
-                await notification_service.send_copyright_flag_notification(
-                    track_id=track_id,
-                    track_title=track.title,
-                    artist_handle=track.artist.handle,
-                    matches=scan.matches,
-                )
 
 
 async def _store_scan_error(track_id: int, error: str) -> None:

--- a/backend/tests/_internal/test_copyright_self_match.py
+++ b/backend/tests/_internal/test_copyright_self_match.py
@@ -1,0 +1,232 @@
+"""regression: self-match copyright flags must not surface to UI or DMs.
+
+history: 2026-04-25 — flo.by uploaded a batch of his own catalog. AuDD
+identified each track's dominant match as "Floby IV" (his stage name),
+so every scan came back is_flagged=true. that path:
+  - wrote `copyright_scans.is_flagged=true` (visible to creator on /portal)
+  - fired admin DM "copyright flag on plyr.fm / primary: X by Floby IV"
+
+the artist saw red badges on his own tracks and reached out; the admin
+got 30 DM spams in an hour. the perpetual sync flipped is_flagged=false
+within 5min, but only after the damage was done.
+
+fix: detect self-match by comparing slugified dominant artist vs uploader
+handle/display_name. demote is_flagged to false at write time so the UI
+flag and the DM never fire.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal.moderation import (
+    _dominant_match_artist,
+    _is_self_match,
+    _store_scan_result,
+)
+from backend.models import Artist, CopyrightScan, Track
+
+
+@dataclass
+class _FakeScanResult:
+    is_flagged: bool
+    highest_score: int
+    matches: list[dict[str, Any]]
+    raw_response: dict[str, Any]
+
+
+def _matches(*pairs: tuple[str, str]) -> list[dict[str, Any]]:
+    return [{"artist": a, "title": t, "score": 0} for a, t in pairs]
+
+
+# --- unit: _is_self_match ---
+
+
+class TestIsSelfMatch:
+    def test_floby_iv_matches_flo_by_handle(self) -> None:
+        # the actual case that triggered this fix
+        assert _is_self_match("Floby IV", "flo.by", "flo.by") is True
+
+    def test_exact_handle_match(self) -> None:
+        assert _is_self_match("knock2one", "knock2one.bsky.social", "knock2one") is True
+
+    def test_display_name_substring(self) -> None:
+        assert _is_self_match("Mister X", "msx.bsky.social", "Mister") is True
+
+    def test_unrelated_artist_is_not_self_match(self) -> None:
+        # j4ck.xyz uploaded a Conan Gray cover — should NOT be suppressed
+        assert _is_self_match("Conan Gray", "j4ck.xyz", "j4ck.xyz") is False
+
+    def test_unrelated_artist_zedd(self) -> None:
+        # natalie.sh's "mid 123" matched "Zedd" — should NOT be suppressed
+        assert _is_self_match("Zedd", "natalie.sh", "natalie.sh") is False
+
+    def test_short_match_artist_not_suppressed(self) -> None:
+        # 3-char artist would otherwise over-match; require min slug length
+        assert _is_self_match("DJ", "djsomething.bsky.social", "DJ Some") is False
+
+    def test_empty_uploader_display_safe(self) -> None:
+        assert _is_self_match("Floby IV", "flo.by", "") is True
+
+    def test_empty_match_returns_false(self) -> None:
+        assert _is_self_match("", "flo.by", "flo.by") is False
+
+
+# --- unit: _dominant_match_artist ---
+
+
+class TestDominantMatchArtist:
+    def test_picks_most_frequent(self) -> None:
+        ms = _matches(
+            ("Floby IV", "Summer Heat"),
+            ("Floby IV", "Summer Heat"),
+            ("Other", "song"),
+        )
+        assert _dominant_match_artist(ms) == "Floby IV"
+
+    def test_empty_returns_none(self) -> None:
+        assert _dominant_match_artist([]) is None
+
+    def test_skips_blank_artists(self) -> None:
+        ms = [{"artist": "", "title": "x"}, {"artist": "Real", "title": "y"}]
+        assert _dominant_match_artist(ms) == "Real"
+
+
+# --- integration: _store_scan_result demotes self-matches ---
+
+
+async def _make_artist_and_track(
+    db: AsyncSession,
+    *,
+    handle: str = "flo.by",
+    display_name: str = "flo.by",
+    did: str = "did:plc:test-flo",
+    title: str = "Summer Heat",
+) -> Track:
+    artist = Artist(did=did, handle=handle, display_name=display_name)
+    db.add(artist)
+    await db.commit()
+    track = Track(
+        title=title,
+        file_id="abc123",
+        file_type="mp3",
+        artist_did=did,
+        r2_url="https://audio.plyr.fm/audio/abc123.mp3",
+    )
+    db.add(track)
+    await db.commit()
+    await db.refresh(track)
+    return track
+
+
+async def test_store_scan_result_suppresses_self_match(
+    db_session: AsyncSession,
+) -> None:
+    track = await _make_artist_and_track(db_session)
+    scan_result = _FakeScanResult(
+        is_flagged=True,
+        highest_score=0,
+        matches=_matches(
+            ("Floby IV", "Summer Heat"),
+            ("Floby IV", "Summer Heat"),
+            ("Floby IV", "Summer Heat"),
+        ),
+        raw_response={},
+    )
+
+    with patch(
+        "backend._internal.moderation.notification_service.send_copyright_flag_notification",
+        new_callable=AsyncMock,
+    ) as mock_dm:
+        await _store_scan_result(track.id, scan_result)
+
+    # row was written with is_flagged=false (no UI flag)
+    rows = (
+        (
+            await db_session.execute(
+                select(CopyrightScan).where(CopyrightScan.track_id == track.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].is_flagged is False
+    # admin DM NEVER fires for self-matches
+    mock_dm.assert_not_called()
+
+
+async def test_store_scan_result_real_violation_still_flags(
+    db_session: AsyncSession,
+) -> None:
+    track = await _make_artist_and_track(
+        db_session,
+        handle="j4ck.xyz",
+        display_name="j4ck.xyz",
+        did="did:plc:test-j4ck",
+        title="acoustic guitar cover of vodka cranberry",
+    )
+    scan_result = _FakeScanResult(
+        is_flagged=True,
+        highest_score=0,
+        matches=_matches(
+            ("Conan Gray", "Vodka Cranberry"),
+            ("Conan Gray", "Vodka Cranberry"),
+            ("Conan Gray", "Vodka Cranberry"),
+        ),
+        raw_response={},
+    )
+
+    with patch(
+        "backend._internal.moderation.notification_service.send_copyright_flag_notification",
+        new_callable=AsyncMock,
+    ) as mock_dm:
+        await _store_scan_result(track.id, scan_result)
+
+    rows = (
+        (
+            await db_session.execute(
+                select(CopyrightScan).where(CopyrightScan.track_id == track.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    # genuine non-self-match: flag stays true and admin gets DM
+    assert rows[0].is_flagged is True
+    mock_dm.assert_awaited_once()
+
+
+async def test_store_scan_result_clear_path_unchanged(
+    db_session: AsyncSession,
+) -> None:
+    track = await _make_artist_and_track(db_session, did="did:plc:test-clear")
+    scan_result = _FakeScanResult(
+        is_flagged=False,
+        highest_score=0,
+        matches=[],
+        raw_response={},
+    )
+
+    with patch(
+        "backend._internal.moderation.notification_service.send_copyright_flag_notification",
+        new_callable=AsyncMock,
+    ) as mock_dm:
+        await _store_scan_result(track.id, scan_result)
+
+    rows = (
+        (
+            await db_session.execute(
+                select(CopyrightScan).where(CopyrightScan.track_id == track.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].is_flagged is False
+    mock_dm.assert_not_called()


### PR DESCRIPTION
## Summary

flo.by uploaded his catalog today; AuDD identified each track's dominant match as **Floby IV** (his stage name elsewhere). Every scan returned `is_flagged=true`, which:

- showed a red \"potential copyright violation\" badge to the artist on his own \`/portal\` page
- fired an admin DM \"copyright flag on plyr.fm / primary: X by Floby IV\" — admin received ~30 DMs in one session

\`sync_copyright_resolutions\` flipped \`is_flagged=false\` within 5 min, but only after the artist had already seen the flag and the DM spam had landed.

## Fix

In \`_store_scan_result\`, when AuDD returns \`is_flagged=true\`:
1. Look up the uploader's artist record
2. Compute the dominant match artist (most frequent in matches)
3. Compare slugified forms (lowercase, alphanumeric only) — bidirectional substring check, min length 4
4. On self-match → demote to \`is_flagged=false\` **before** writing the row, **before** the DM call

Logs \`copyright self-match suppressed\` for observability.

## What this does NOT fix

\`sync_copyright_resolutions\` (\`backend/src/backend/_internal/tasks/copyright.py:80-83\`) still silently flips \`is_flagged=false\` for any flagged scan whose URI isn't in the moderation service's active labels — including URIs where a label was *never* emitted (the scan flow doesn't call \`/emit-label\`). That's a separate semantic bug. Tracking it as a follow-up.

## Test plan

- [x] 14 new tests covering self-match detection unit logic + 3 integration cases through \`_store_scan_result\`
- [x] confirms real cross-artist matches (Conan Gray on j4ck.xyz, Zedd on natalie.sh) still flag normally
- [x] \`just backend test\` for related suites: 46/46 passing
- [x] \`just backend lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)