### PR TITLE
fix(likers-sheet): make the drag handle actually swipe-to-dismiss

### DIFF
--- a/frontend/src/lib/components/LikersSheet.svelte
+++ b/frontend/src/lib/components/LikersSheet.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { likersSheet } from '$lib/likers-sheet.svelte';
 	import { getRefreshedAvatar, triggerAvatarRefresh, hasAttemptedRefresh } from '$lib/avatar-refresh.svelte';
+	import { swipeToDismiss } from '$lib/swipe-to-dismiss';
 	import SensitiveImage from './SensitiveImage.svelte';
 	import type { LikerData } from '$lib/tooltip-cache.svelte';
 
@@ -40,8 +41,16 @@
 	role="presentation"
 	onclick={handleBackdropClick}
 >
-	<div class="sheet" role="dialog" aria-modal="true" aria-label="liked by">
-		<div class="sheet-handle"></div>
+	<div
+		class="sheet"
+		role="dialog"
+		aria-modal="true"
+		aria-label="liked by"
+		{@attach swipeToDismiss(() => likersSheet.close())}
+	>
+		<div class="sheet-handle-area" data-sheet-handle role="presentation">
+			<div class="sheet-handle"></div>
+		</div>
 		<div class="sheet-header">
 			<span class="sheet-title">
 				{likersSheet.likeCount} {likersSheet.likeCount === 1 ? 'like' : 'likes'}
@@ -138,12 +147,30 @@
 		transform: translateY(0);
 	}
 
+	.sheet-handle-area {
+		/* expanded hit target (>= 44px tall) so a thumb-flick anywhere along the
+		   top strip triggers swipe-to-dismiss. visible handle stays small. */
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		padding: 0.75rem 1rem 0.5rem;
+		flex-shrink: 0;
+		cursor: grab;
+		/* prevent ios from interpreting the vertical drag as scroll */
+		touch-action: none;
+		-webkit-user-select: none;
+		user-select: none;
+	}
+
+	.sheet-handle-area:active {
+		cursor: grabbing;
+	}
+
 	.sheet-handle {
-		width: 32px;
+		width: 36px;
 		height: 4px;
 		background: var(--border-default);
 		border-radius: 2px;
-		margin: 0.75rem auto 0;
 		flex-shrink: 0;
 	}
 

--- a/frontend/src/lib/swipe-to-dismiss.ts
+++ b/frontend/src/lib/swipe-to-dismiss.ts
@@ -1,0 +1,111 @@
+// swipe-to-dismiss attachment for bottom sheets.
+//
+// the visual handle on a bottom sheet is a near-universal mobile affordance
+// (iOS sheets, android bottom sheets) that signals "drag me down to close".
+// without this attachment the affordance lies — the handle is decorative and
+// the only dismiss is tapping a small × or the backdrop.
+//
+// usage:
+//   <div class="sheet" {@attach swipeToDismiss(() => sheet.close())}>
+//     <div class="sheet-handle-area" data-sheet-handle>
+//       <div class="sheet-handle"></div>
+//     </div>
+//     ...
+//   </div>
+//
+// the attachment is applied to the sheet element. it locates its handle by
+// `[data-sheet-handle]` and binds pointer listeners there. drag updates the
+// sheet's inline transform; release either dismisses (call `onDismiss`) past
+// the threshold/velocity, or snaps back by clearing the inline transform.
+
+import type { Attachment } from 'svelte/attachments';
+
+interface SwipeToDismissOptions {
+	/** css selector for the drag handle within the sheet (default: `[data-sheet-handle]`) */
+	handleSelector?: string;
+	/** distance in px past which release dismisses (default: 80) */
+	dismissDeltaPx?: number;
+	/** downward velocity in px/ms past which release dismisses (default: 0.5) */
+	dismissVelocityPxPerMs?: number;
+	/** ms to wait before clearing the inline dismiss transform (default: 250, matches sheet transition) */
+	dismissResetMs?: number;
+}
+
+export function swipeToDismiss(
+	onDismiss: () => void,
+	options: SwipeToDismissOptions = {}
+): Attachment<HTMLElement> {
+	const {
+		handleSelector = '[data-sheet-handle]',
+		dismissDeltaPx = 80,
+		dismissVelocityPxPerMs = 0.5,
+		dismissResetMs = 250
+	} = options;
+
+	return (sheet) => {
+		const handle = sheet.querySelector<HTMLElement>(handleSelector);
+		if (!handle) return;
+
+		let dragging = false;
+		let startY = 0;
+		let delta = 0;
+		let lastY = 0;
+		let lastT = 0;
+		let velocity = 0;
+
+		function down(event: PointerEvent) {
+			dragging = true;
+			startY = event.clientY;
+			lastY = event.clientY;
+			lastT = event.timeStamp;
+			delta = 0;
+			velocity = 0;
+			handle!.setPointerCapture(event.pointerId);
+			sheet.style.transition = 'none';
+		}
+
+		function move(event: PointerEvent) {
+			if (!dragging) return;
+			const d = Math.max(0, event.clientY - startY);
+			const dt = event.timeStamp - lastT;
+			if (dt > 0) velocity = (event.clientY - lastY) / dt;
+			lastY = event.clientY;
+			lastT = event.timeStamp;
+			delta = d;
+			sheet.style.transform = `translateY(${d}px)`;
+		}
+
+		function up() {
+			if (!dragging) return;
+			dragging = false;
+			// restore the css transition so snap-back / dismiss animate
+			sheet.style.transition = '';
+			const shouldDismiss = delta > dismissDeltaPx || velocity > dismissVelocityPxPerMs;
+			if (shouldDismiss) {
+				// drive the dismiss animation explicitly so it flows from the
+				// dragged position out of view, regardless of when the parent's
+				// open class flips.
+				sheet.style.transform = 'translateY(100%)';
+				onDismiss();
+				setTimeout(() => {
+					sheet.style.transform = '';
+				}, dismissResetMs);
+			} else {
+				// snap back: clear inline transform so the open css rule wins
+				sheet.style.transform = '';
+			}
+		}
+
+		handle.addEventListener('pointerdown', down);
+		handle.addEventListener('pointermove', move);
+		handle.addEventListener('pointerup', up);
+		handle.addEventListener('pointercancel', up);
+
+		return () => {
+			handle.removeEventListener('pointerdown', down);
+			handle.removeEventListener('pointermove', move);
+			handle.removeEventListener('pointerup', up);
+			handle.removeEventListener('pointercancel', up);
+		};
+	};
+}


### PR DESCRIPTION
## Why

The handle on the likers sheet was decorative — visually a near-universal "drag-me-down to close" affordance (iOS sheets, Android bottom sheets), but with no event handlers. The only working dismiss paths were a small × in the top-right and a backdrop tap. That's a bad fit for one-thumb use, and the lying affordance actively obscures the real dismiss paths.

This is the first step toward broader UX accessibility work (e.g. queueing tracks one-thumb while on a bike). Bigger changes are scoped separately.

## What

- new `swipeToDismiss` Svelte 5 attachment in `frontend/src/lib/swipe-to-dismiss.ts` — applied to a sheet element, locates a `[data-sheet-handle]` child, drives the sheet's transform during drag, and calls `onDismiss()` past either an 80px delta or 0.5 px/ms downward velocity
- `LikersSheet` adopts the attachment; the visible handle is unchanged but its parent now provides a >=44px hit-target (`touch-action: none` to prevent iOS scroll hijacking)
- snap-back when the user releases under threshold; explicit `translateY(100%)` on dismiss so the slide-out animates from the dragged position regardless of when the parent's `.open` class flips
- backdrop-tap and × button kept as alternative dismiss paths

## Scope

Just `LikersSheet` for this PR — proving ground for the pattern. The same attachment can be dropped onto `AudioRevisionsSheet`, `Queue`, and the route sheets in `playlist/[id]`, `u/[handle]/album/[slug]`, and `liked` in a follow-up.

## Test plan
- [ ] open the likers sheet on mobile (touch); flick the handle down → sheet dismisses with the slide animation
- [ ] open the sheet, drag the handle a small amount and release → sheet snaps back into place
- [ ] tap the × button → still closes
- [ ] tap the backdrop → still closes
- [ ] desktop with mouse: click + drag the handle area → same behavior
- [ ] dragging upward on the handle has no effect (delta clamps at 0)
- [ ] inner list scrolls normally (handle area only is draggable; list is independent)
- [ ] reduced-motion users: drag still works, snap-back is instant (no transition), unchanged from current

🤖 Generated with [Claude Code](https://claude.com/claude-code)