### PR TITLE
fix(album-upload): use canonical album route in success toast

### DIFF
--- a/frontend/src/lib/components/AlbumUploadForm.svelte
+++ b/frontend/src/lib/components/AlbumUploadForm.svelte
@@ -380,13 +380,18 @@
 		await onAlbumsReload();
 
 		if (completed > 0) {
+			// only offer the "view album" action when we know the artist handle —
+			// the canonical album route is `/u/[handle]/album/[slug]`, so without
+			// a handle the link would 404. artistProfile is loaded on mount but
+			// may be null if the profile fetch failed.
+			const artistHandle = artistProfile?.handle;
 			toast.success(
 				`${completed} of ${tracks.length} track${tracks.length > 1 ? 's' : ''} uploaded`,
 				5000,
-				albumSlug
+				albumSlug && artistHandle
 					? {
 							label: 'view album',
-							href: `/album/${albumSlug}`,
+							href: `/u/${artistHandle}/album/${albumSlug}`,
 						}
 					: undefined,
 			);


### PR DESCRIPTION
## Why
After a successful album upload, the "view album" action in the toast linked to \`/album/\${albumSlug}\`, but no such route exists — the actual album route is \`/u/[handle]/album/[slug]\`. Tapping the action 404s right after a successful publish.

This was the only outlier — every other album link in the codebase (sitemap, search, feedback service, AT-URI redirect, activity feed, oembed) already uses the \`/u/[handle]/album/[slug]\` shape.

## What
- include \`artistProfile?.handle\` (already loaded on mount) in the link
- if the profile fetch failed and we don't have a handle, omit the action entirely rather than offering a guaranteed-404

## Test plan
- [ ] upload an album → success toast appears with "view album" action
- [ ] tap the action → lands on the album page (not a 404)
- [ ] mock or simulate an artistProfile fetch failure → success toast appears without a "view album" action (instead of with a broken one)

closes #1343

🤖 Generated with [Claude Code](https://claude.com/claude-code)