### PR TITLE
test(integration): use flat artist_handle field on track response

### DIFF
--- a/backend/tests/test_integration_upload.py
+++ b/backend/tests/test_integration_upload.py
@@ -142,7 +142,7 @@ async def test_upload_and_delete_track(test_audio_file: Path):
             f"track not found: {track_response.text}"
         )
         track = track_response.json()
-        print(f"track created: {track['title']} by {track['artist']['handle']}")
+        print(f"track created: {track['title']} by @{track['artist_handle']}")
 
         # 5. delete track
         delete_response = await client.delete(


### PR DESCRIPTION
## Summary
- one-line fix to `tests/test_integration_upload.py`: read `track['artist_handle']` instead of `track['artist']['handle']`

## Why
caught while smoke-testing the worker process split (#1359) on staging. the GET `/tracks/{id}` response is flat (artist + artist_handle + artist_did as sibling fields), not nested — so the test crashed on the print statement *after* the upload had already succeeded, and reported a fail despite the server-side path being entirely healthy.

verified locally against staging:
\`\`\`
upload started → processing → saving metadata → atproto → completed
track created: Integration Test Track (DELETE ME) by @zzstoatzz.io
track 2522 deleted successfully
verified track no longer exists
PASSED in 12.66s
\`\`\`

## Test plan
- [x] `uv run pytest tests/test_integration_upload.py -m integration -v` against staging passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)