### PR TITLE
docs: sync internal docs with worker process split + cyclopts CLI

### DIFF
--- a/docs/internal/backend/background-tasks.md
+++ b/docs/internal/backend/background-tasks.md
@@ -20,16 +20,28 @@ background tasks handle operations that shouldn't block the request/response cyc
 
 ## architecture
 
+in production and staging, the FastAPI process and the docket Worker run in **separate fly process groups** of the same `relay-api` app:
+
 ```
-┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│   FastAPI   │────▶│    Redis    │◀────│   Worker    │
-│   (add task)│     │  (queue)    │     │  (process)  │
-└─────────────┘     └─────────────┘     └─────────────┘
+fly app: relay-api
+┌────────────────────────────┐     ┌─────────────┐     ┌─────────────────────────────┐
+│  process group: app        │────▶│    Redis    │◀────│  process group: worker      │
+│  uvicorn → docket *client* │     │  (queue)    │     │  python -m backend.worker   │
+│  (no Worker, just enqueue) │     └─────────────┘     │  → docket Worker (consume)  │
+└────────────────────────────┘                          └─────────────────────────────┘
 ```
 
-- **docket** schedules tasks to Redis
-- **worker** runs in-process alongside FastAPI, processing tasks from the queue
-- tasks are durable - if the worker crashes, tasks are retried on restart
+- **app** group: serves HTTP. opens a Docket client via `docket_client_lifespan()` so request handlers can call `get_docket().add(task)(...)` to enqueue. does NOT run a Worker. sized for HTTP fan-out (1GB).
+- **worker** group: runs `python -m backend.worker`, which boots `notification_service.setup()` then enters `docket_worker_lifespan()` → docket `Worker.run_forever()`. no HTTP listener. sized for in-memory upload work (2GB).
+- **docket** schedules tasks to Redis; the `worker` process consumes them.
+- tasks are durable — if a worker machine dies, in-flight tasks redeliver to a sibling on restart.
+
+the split landed in zzstoatzz/plyr.fm#1359 after the 2026-04-30 incident
+(see [upload-oom-cycle runbook](/runbooks/upload-oom-cycle/)) where a single
+user's album upload OOM-killed uvicorn because Worker + uvicorn shared one
+process. the boundary now ensures worker memory pressure can't take down HTTP.
+
+in local development, both run in one process by default — see [local development](#local-development) below.
 
 ## configuration
 
@@ -73,6 +85,21 @@ just dev
 docker compose up -d  # starts redis on localhost:6379
 DOCKET_URL=redis://localhost:6379 just backend run
 ```
+
+`just backend run` starts uvicorn only — it opens a Docket *client* but
+does not run a Worker. for local dev this is usually fine: the API can
+enqueue tasks but they sit in Redis until consumed. options:
+
+- skip Redis entirely (omit `DOCKET_URL`) → tasks fall back to
+  `asyncio.create_task()` and run in-process (fire-and-forget, no retries).
+  this is the default when no Redis is configured — sufficient for most
+  feature work.
+- run a worker locally to mirror production:
+  ```bash
+  DOCKET_URL=redis://localhost:6379 uv run python -m backend.worker
+  ```
+  in a second terminal. this is the same entrypoint deployed to the
+  fly `worker` process group.
 
 ### production/staging
 

--- a/docs/internal/backend/streaming-uploads.md
+++ b/docs/internal/backend/streaming-uploads.md
@@ -7,7 +7,9 @@ title: "streaming uploads"
 
 ## overview
 
-plyr.fm uses streaming uploads for audio files to maintain constant memory usage regardless of file size. this prevents out-of-memory errors when handling large files on constrained environments (fly.io shared-cpu VMs with 256MB RAM).
+plyr.fm uses streaming uploads for audio files to maintain constant memory usage regardless of file size. this prevents out-of-memory errors when handling large files on constrained environments (fly.io shared-cpu VMs).
+
+note: this doc covers the **HTTP request → R2** path (handler-side, on the `app` process group). the **R2 → in-process consumer** path (worker-side, used during transcode + PDS upload) does *not* yet stream — `storage.get_file_data()` returns full bytes. that gap caused the 2026-04-30 OOM cycle and is tracked in zzstoatzz/plyr.fm#1357.
 
 ## problem (pre-implementation)
 
@@ -28,7 +30,7 @@ client.put_object(Body=content, ...)  # entire file in RAM
 ### memory profile
 - single 40MB upload: ~80-120MB peak memory
 - 3 concurrent uploads: ~240-360MB peak
-- fly.io shared-cpu VM: 256MB total RAM
+- fly.io shared-cpu VM at the time of writing: 256MB total RAM (since bumped — `app` is now 1GB, `worker` is 2GB; see [environments](/deployment/environments/))
 - **result**: OOM, worker restarts, service degradation
 
 ## solution: streaming approach (implemented)
@@ -277,7 +279,7 @@ successfully maintained during implementation:
 ### concurrent uploads
 - each upload uses independent chunk buffer
 - total memory = num_concurrent * CHUNK_SIZE
-- 5 concurrent @ 8MB chunks = 40MB total (well within 256MB limit)
+- 5 concurrent @ 8MB chunks = 40MB total (well within the `app` VM's 1GB)
 
 ## observability
 

--- a/docs/internal/deployment/environments.md
+++ b/docs/internal/deployment/environments.md
@@ -157,22 +157,30 @@ if a migration fails:
 ## monitoring
 
 **staging**:
-- logfire: environment filter `LOGFIRE_ENVIRONMENT=staging`
+- logfire: filter on `deployment_environment = 'staging'` (top-level column, not in attributes)
 - backend logs: `flyctl logs -a relay-api-staging`
+  - target a single process group: `flyctl logs -a relay-api-staging --process-group worker`
 
 **production**:
-- logfire: environment filter `LOGFIRE_ENVIRONMENT=production`
+- logfire: filter on `deployment_environment = 'production'`
 - backend logs: `flyctl logs -a relay-api`
+  - target a single process group: `flyctl logs -a relay-api --process-group worker`
+
+both environments split the backend into two fly process groups in the same app: `app` (uvicorn) and `worker` (docket consumer). see [background tasks](/backend/background-tasks/) for the architecture.
 
 ## costs
 
-**current**: ~$25-30/month
-- fly.io backend (production): ~$10/month (shared-cpu-1x, 256MB RAM)
-- fly.io backend (staging): ~$10/month (shared-cpu-1x, 256MB RAM)
-- fly.io transcoder: ~$0-5/month (auto-scales to zero when idle)
-- neon postgres: $5/month (starter plan)
+approximate monthly spend; check fly.io billing for current numbers.
+
+- fly.io backend (production): 2× `app` (shared-cpu-1x, 1GB) + 1× active `worker` (shared-cpu-1x, 2GB) + 1× standby `worker` (stopped, near-zero cost)
+- fly.io backend (staging): 1× `app` (shared-cpu-1x, 1GB) + 1× active `worker` (shared-cpu-1x, 1GB) + 1× standby
+- fly.io transcoder: auto-scales to zero when idle
+- fly.io self-hosted Redis: 1× shared-cpu-1x, 256MB per env
+- neon postgres: starter plan (3 environments)
 - cloudflare pages: free (frontend hosting)
 - cloudflare R2: ~$0.16/month (6 buckets across dev/staging/prod)
+
+note: prod's split sizing (`app=1GB`, `worker=2GB`) replaced the prior single 1GB process group after the 2026-04-30 OOM incident — see [upload-oom-cycle runbook](/runbooks/upload-oom-cycle/).
 
 ## workflow summary
 

--- a/docs/internal/local-development/setup.md
+++ b/docs/internal/local-development/setup.md
@@ -134,6 +134,22 @@ bun run dev -- --host
 
 frontend: http://localhost:5173
 
+### docket worker (optional)
+
+local dev usually doesn't need a separate worker — when `DOCKET_URL` is unset, scheduled tasks fall back to in-process `asyncio.create_task()` (fire-and-forget, no retries). that's enough for most feature work.
+
+if you want to mirror production's worker tier (separate process consuming from Redis):
+
+```bash
+# terminal: start redis if not already running
+just dev-services
+
+# terminal: start the worker (no HTTP, just consumes docket tasks)
+DOCKET_URL=redis://localhost:6379 uv run python -m backend.worker
+```
+
+this is the same entrypoint deployed to fly's `worker` process group. see [background tasks](/backend/background-tasks/) for the architecture.
+
 ### transcoder (optional)
 
 ```bash

--- a/docs/internal/tools/plyrfm.md
+++ b/docs/internal/tools/plyrfm.md
@@ -29,17 +29,28 @@ for authenticated operations:
 
 ## CLI
 
+the CLI is namespaced (`plyrfm tracks ...`, `plyrfm playlists ...`, etc.) — run `plyrfm --help` to see the full tree.
+
 ```bash
 # public (no auth)
-plyrfm list                        # list all tracks
+plyrfm tracks list                                  # list all tracks
+plyrfm tracks get 42                                # get one by ID
 
 # authenticated
-plyrfm my-tracks                   # list your tracks
-plyrfm upload track.mp3 "My Song"  # upload
-plyrfm download 42 -o song.mp3     # download
-plyrfm delete 42 -y                # delete
-plyrfm me                          # check auth
+plyrfm me                                           # check auth
+plyrfm tracks my                                    # list your tracks
+plyrfm tracks upload track.mp3 "My Song"            # upload
+plyrfm tracks upload track.mp3 "My Song" \
+    --album "My Album" \
+    --image cover.png \
+    --description "liner notes" \
+    --tag electronic --tag ambient \
+    --unlisted                                      # full metadata
+plyrfm tracks download 42 --output song.mp3        # download
+plyrfm tracks delete 42 --yes                      # delete (skip confirm)
 ```
+
+the `--unlisted` flag excludes the track from public discovery feeds (latest, top, for-you) but keeps it accessible by direct URL.
 
 use staging API:
 ```bash
@@ -48,24 +59,34 @@ PLYR_API_URL=https://api-stg.plyr.fm plyrfm list
 
 ## SDK
 
+the SDK is namespaced to mirror the CLI (`client.tracks`, `client.playlists`, ...).
+
 ```python
 from plyrfm import PlyrClient, AsyncPlyrClient
 
 # public operations (no auth)
 client = PlyrClient()
-tracks = client.list_tracks()
-track = client.get_track(42)
+tracks = client.tracks.list()
+track = client.tracks.get(42)
 
 # authenticated operations
 client = PlyrClient(token="your_token")  # or set PLYR_TOKEN
-my_tracks = client.my_tracks()
-result = client.upload("song.mp3", "My Song")
-client.delete(result.track_id)
+my_tracks = client.tracks.my()
+result = client.tracks.upload(
+    "song.mp3",
+    "My Song",
+    album="My Album",
+    image="cover.png",
+    description="liner notes",
+    tags={"electronic", "ambient"},
+    unlisted=True,
+)
+client.tracks.delete(result.track_id)
 ```
 
 async:
 ```python
 async with AsyncPlyrClient(token="your_token") as client:
-    tracks = await client.list_tracks()
-    await client.upload("song.mp3", "My Song")
+    tracks = await client.tracks.list()
+    await client.tracks.upload("song.mp3", "My Song")
 ```


### PR DESCRIPTION
## Summary
audit pass after #1359 (worker process split) and the SDK cyclopts migration that shipped in plyrfm 0.0.1a18. fixes the docs that still described the old single-process architecture, the old un-namespaced CLI, and stale memory numbers.

## Files changed
- **backend/background-tasks.md** — replace "worker runs in-process alongside FastAPI" diagram with the two-process-group reality (\`app\` + \`worker\`); document running the worker locally via \`python -m backend.worker\`
- **deployment/environments.md** — drop the wrong "shared-cpu-1x, 256MB RAM" cost table; reflect actual \`app=1GB\` + \`worker=2GB\` sizing; mention \`--process-group\` flag on \`flyctl logs\`
- **backend/streaming-uploads.md** — clarify this doc covers only the HTTP→R2 path; flag that R2→worker is NOT yet streaming (tracked in #1357); update stale 256MB references
- **local-development/setup.md** — add optional "docket worker" service alongside transcoder, with the \`python -m backend.worker\` command
- **tools/plyrfm.md** — replace pre-cyclopts CLI examples (\`plyrfm upload\`) with the namespaced ones (\`plyrfm tracks upload\`); add the new \`--image\` / \`--description\` / \`--unlisted\` flags; mirror SDK examples to \`client.tracks.upload(...)\` namespace

## Why
no aspirational changes — only fixes for things that were factually wrong as of \`main\`. caught while preparing the prod cutover and stress-test of the new worker tier.

## Test plan
- [ ] CI passes (path filter for \`docs/site/**\` won't trigger — only internal)
- [ ] visually skim rendered output in \`docs.plyr.fm\` once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)