### PR TITLE
refactor(features): consolidate two parallel resolvers + tighten module structure

### DIFF
--- a/backend/src/backend/_internal/atproto/handles.py
+++ b/backend/src/backend/_internal/atproto/handles.py
@@ -1,5 +1,20 @@
-"""ATProto handle resolution for featured artists."""
+"""ATProto handle resolution.
 
+handle → DID lookup (via the configured PDS-aware resolver) plus parsing
+of the user-supplied features-as-handles JSON into the canonical DB
+shape (`[{"did": "..."}]`).
+
+callers wanting the OPPOSITE direction (DID → fresh handle/displayName/
+avatar for rendering) should use `_internal.atproto.profiles.resolve_dids`.
+
+these are deliberately separate modules: handles.py is upstream of an
+upload (parse user input, validate, get DIDs); profiles.py is downstream
+of a read (hydrate stored DIDs for display). they don't overlap and
+shouldn't grow into each other.
+"""
+
+import asyncio
+import json
 import logging
 from typing import Any
 
@@ -10,6 +25,19 @@ logger = logging.getLogger(__name__)
 
 # shared resolver instance for DID/handle resolution
 _resolver = AsyncIdResolver()
+
+# upper bound on featured-artist count per track. the lexicon allows up
+# to 10 (`maxLength: 10`); we enforce a stricter app-level cap.
+MAX_FEATURES = 5
+
+
+class InvalidFeaturesError(ValueError):
+    """user-supplied featured-artists JSON is malformed or unresolvable.
+
+    callers translate to their context-appropriate error: HTTPException
+    in synchronous request handlers, UploadPhaseError in upload-pipeline
+    background tasks. the resolver itself stays HTTP-agnostic.
+    """
 
 
 async def resolve_handle(handle: str) -> dict[str, Any] | None:
@@ -71,52 +99,66 @@ async def resolve_handle(handle: str) -> dict[str, Any] | None:
 
 async def resolve_featured_artists(
     features_json: str | None,
+    *,
     exclude_handle: str,
-) -> list[dict]:
-    """resolve featured artist handles from JSON array.
+) -> list[dict[str, str]]:
+    """parse a user-supplied JSON handle list into the canonical DB shape.
 
     args:
-        features_json: JSON array string of handles, e.g., '["user1.bsky.social"]'
-        exclude_handle: handle to exclude (typically the uploading artist)
+        features_json: JSON array of handle strings, e.g.,
+            `'["user.bsky.social", "@other.user"]'`. None or empty is
+            valid and returns `[]`.
+        exclude_handle: the uploading artist's handle. self-features
+            are silently dropped (they're not an error — just no-ops).
 
     returns:
-        list of resolved artist dicts, excluding failures and the uploader
+        canonical DB shape: `[{"did": "did:plc:..."}, ...]`. handle and
+        display_name are NOT stored; the API hydrates them per-request
+        via `_internal.atproto.profiles.resolve_dids` so they stay
+        current with the featured artist's profile (see #1355).
+
+    raises:
+        InvalidFeaturesError: if the JSON is malformed, not a list, has
+            non-string entries, exceeds MAX_FEATURES, or any handle
+            fails to resolve. callers translate to their context-
+            appropriate error type.
     """
     if not features_json:
         return []
 
-    import asyncio
-    import json
-
     try:
         handles_list = json.loads(features_json)
-    except json.JSONDecodeError:
-        logger.warning(
-            "malformed features JSON, ignoring", extra={"raw": features_json}
-        )
-        return []
+    except json.JSONDecodeError as exc:
+        raise InvalidFeaturesError(f"invalid JSON in features: {exc}") from exc
 
     if not isinstance(handles_list, list):
-        return []
+        raise InvalidFeaturesError("features must be a JSON array of handles")
 
-    # filter valid handles, excluding the uploading artist
-    valid_handles = [
-        handle
-        for handle in handles_list
-        if isinstance(handle, str) and handle.lstrip("@") != exclude_handle
-    ]
+    if len(handles_list) > MAX_FEATURES:
+        raise InvalidFeaturesError(f"maximum {MAX_FEATURES} featured artists allowed")
+
+    valid_handles: list[str] = []
+    for handle in handles_list:
+        if not isinstance(handle, str):
+            raise InvalidFeaturesError("each feature must be a string handle")
+        # silently drop self-features — common when re-submitting an edit
+        # form that pre-populates the artist's own handle
+        if handle.lstrip("@") == exclude_handle:
+            continue
+        valid_handles.append(handle)
 
     if not valid_handles:
         return []
 
-    # resolve concurrently
     resolved = await asyncio.gather(
         *[resolve_handle(h) for h in valid_handles],
         return_exceptions=True,
     )
 
-    # store only the canonical DID. handle/display_name are mutable
-    # snapshots that the API hydrates fresh per-request via
-    # `_internal.atproto.profiles.resolve_dids`. keeping them here would
-    # re-introduce the drift bug fixed by #1355.
-    return [{"did": r["did"]} for r in resolved if isinstance(r, dict) and r.get("did")]
+    out: list[dict[str, str]] = []
+    for handle, r in zip(valid_handles, resolved, strict=False):
+        if isinstance(r, Exception) or not isinstance(r, dict) or not r.get("did"):
+            raise InvalidFeaturesError(f"failed to resolve handle: {handle}")
+        out.append({"did": r["did"]})
+
+    return out

--- a/backend/src/backend/_internal/atproto/handles.py
+++ b/backend/src/backend/_internal/atproto/handles.py
@@ -1,17 +1,4 @@
-"""ATProto handle resolution.
-
-handle → DID lookup (via the configured PDS-aware resolver) plus parsing
-of the user-supplied features-as-handles JSON into the canonical DB
-shape (`[{"did": "..."}]`).
-
-callers wanting the OPPOSITE direction (DID → fresh handle/displayName/
-avatar for rendering) should use `_internal.atproto.profiles.resolve_dids`.
-
-these are deliberately separate modules: handles.py is upstream of an
-upload (parse user input, validate, get DIDs); profiles.py is downstream
-of a read (hydrate stored DIDs for display). they don't overlap and
-shouldn't grow into each other.
-"""
+"""ATProto handle → DID resolution and featured-artist input parsing."""
 
 import asyncio
 import json
@@ -32,12 +19,7 @@ MAX_FEATURES = 5
 
 
 class InvalidFeaturesError(ValueError):
-    """user-supplied featured-artists JSON is malformed or unresolvable.
-
-    callers translate to their context-appropriate error: HTTPException
-    in synchronous request handlers, UploadPhaseError in upload-pipeline
-    background tasks. the resolver itself stays HTTP-agnostic.
-    """
+    """user-supplied featured-artists JSON is malformed or unresolvable."""
 
 
 async def resolve_handle(handle: str) -> dict[str, Any] | None:
@@ -102,26 +84,19 @@ async def resolve_featured_artists(
     *,
     exclude_handle: str,
 ) -> list[dict[str, str]]:
-    """parse a user-supplied JSON handle list into the canonical DB shape.
+    """parse a JSON handle list and resolve each to a DID.
 
     args:
         features_json: JSON array of handle strings, e.g.,
-            `'["user.bsky.social", "@other.user"]'`. None or empty is
-            valid and returns `[]`.
-        exclude_handle: the uploading artist's handle. self-features
-            are silently dropped (they're not an error — just no-ops).
+            `'["user.bsky.social", "@other.user"]'`. empty or None → `[]`.
+        exclude_handle: handle to drop from the result (the uploading artist).
 
     returns:
-        canonical DB shape: `[{"did": "did:plc:..."}, ...]`. handle and
-        display_name are NOT stored; the API hydrates them per-request
-        via `_internal.atproto.profiles.resolve_dids` so they stay
-        current with the featured artist's profile (see #1355).
+        `[{"did": "did:plc:..."}, ...]`.
 
     raises:
-        InvalidFeaturesError: if the JSON is malformed, not a list, has
-            non-string entries, exceeds MAX_FEATURES, or any handle
-            fails to resolve. callers translate to their context-
-            appropriate error type.
+        InvalidFeaturesError: malformed JSON, non-list, non-string entries,
+            over MAX_FEATURES, or any handle fails to resolve.
     """
     if not features_json:
         return []
@@ -141,8 +116,6 @@ async def resolve_featured_artists(
     for handle in handles_list:
         if not isinstance(handle, str):
             raise InvalidFeaturesError("each feature must be a string handle")
-        # silently drop self-features — common when re-submitting an edit
-        # form that pre-populates the artist's own handle
         if handle.lstrip("@") == exclude_handle:
             continue
         valid_handles.append(handle)

--- a/backend/src/backend/_internal/atproto/handles.py
+++ b/backend/src/backend/_internal/atproto/handles.py
@@ -115,5 +115,8 @@ async def resolve_featured_artists(
         return_exceptions=True,
     )
 
-    # filter out exceptions and None values
-    return [r for r in resolved if isinstance(r, dict) and r is not None]
+    # store only the canonical DID. handle/display_name are mutable
+    # snapshots that the API hydrates fresh per-request via
+    # `_internal.atproto.profiles.resolve_dids`. keeping them here would
+    # re-introduce the drift bug fixed by #1355.
+    return [{"did": r["did"]} for r in resolved if isinstance(r, dict) and r.get("did")]

--- a/backend/src/backend/_internal/atproto/profiles.py
+++ b/backend/src/backend/_internal/atproto/profiles.py
@@ -1,25 +1,8 @@
-"""DID-keyed profile resolver with caching.
+"""DID → profile resolver.
 
-featured artists (and any other place that needs to render an identity)
-are stored as DIDs only — the canonical, immutable identifier. handle,
-display_name, and avatar_url are mutable properties of the profile that
-should be resolved fresh at read time rather than snapshotted into the
-record.
-
-resolution order, cheapest-first:
-1. local `artists` table — covers every plyr.fm user. one SQL hit, batched.
-2. in-process LRU cache — for DIDs we've seen recently but aren't plyr.fm users.
-3. live bsky `app.bsky.actor.getProfile` — fallback for cold cache misses.
-
-use `resolve_dids()` for any number of DIDs — it issues at most one SQL
-query for the artists JOIN and parallelizes bsky fallbacks for cold
-cache misses.
-
-DIDs that cannot be resolved (network failure, bsky returns non-200, no
-profile exists) are simply omitted from the result. callers must not
-assume `len(out) == len(input)`. for the featured-artist render path
-this is the right shape: a featured artist whose profile we can't load
-is better not shown than shown as a placeholder DID string.
+resolution order: local `artists` table, then in-process TTL cache,
+then `app.bsky.actor.getProfile`. unresolvable DIDs are dropped from
+the output (so `len(out) <= len(input)`).
 """
 
 import asyncio
@@ -39,18 +22,15 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True, slots=True)
 class ResolvedProfile:
-    """current profile snapshot for a DID, hydrated at resolve time."""
-
     did: str
     handle: str
     display_name: str
     avatar_url: str | None
 
 
-# in-process cache for non-plyr.fm DIDs. plyr.fm users come from the
-# artists table on every call (cheap JOIN), so caching them risks
-# serving stale display_name/avatar after a profile update.
-_CACHE_TTL_SECONDS = 300  # 5 minutes
+# only caches non-artist-table DIDs; artist-table rows go through the
+# JOIN every call so they reflect any profile update immediately.
+_CACHE_TTL_SECONDS = 300
 _CACHE_MAX_SIZE = 2048
 
 _cache: dict[str, tuple[float, ResolvedProfile]] = {}

--- a/backend/src/backend/_internal/atproto/records/fm_plyr/track.py
+++ b/backend/src/backend/_internal/atproto/records/fm_plyr/track.py
@@ -41,11 +41,8 @@ async def build_track_record(
         audio_url: optional R2 URL for audio file (omit when audioBlob is present)
         album: optional album name
         duration: optional duration in seconds
-        features: optional list of featured artists. each entry must contain
-            `did`; handle/displayName are resolved fresh at write time so the
-            published record's snapshot matches the artist's identity *as of
-            publish*. callers may pass `[{"did": "..."}]` (canonical DB shape)
-            or any legacy shape that includes `did` — extra fields are ignored.
+        features: list of `{"did": "..."}` entries. handle/displayName for
+            the lexicon snapshot are resolved fresh from the DID.
         image_url: optional cover art image URL
         support_gate: optional gating config (e.g., {"type": "any"})
         audio_blob: optional blob reference from PDS upload (canonical source when present)
@@ -72,11 +69,6 @@ async def build_track_record(
     if duration:
         record["duration"] = duration
     if features:
-        # resolve DIDs to fresh handle/displayName so the published snapshot
-        # reflects the featured artist's identity at publish time.
-        # `featuredArtist.handle` and `displayName` are deprecated in the
-        # lexicon (see lexicons/track.json) but still emitted for compat
-        # with readers that haven't migrated to resolving from did.
         dids = [did for f in features if isinstance(f, dict) and (did := f.get("did"))]
         if dids:
             profiles = await resolve_dids(dids)
@@ -132,9 +124,7 @@ async def create_track_record(
         audio_url: optional R2 URL for audio file (omit when audioBlob is present)
         album: optional album name
         duration: optional duration in seconds
-        features: optional list of featured artists; entries must contain
-            `did`. extra fields (handle, display_name, avatar_url) are
-            ignored — the lexicon snapshot is resolved fresh inside
+        features: list of `{"did": "..."}` entries; passed through to
             `build_track_record`.
         image_url: optional cover art image URL
         support_gate: optional gating config (e.g., {"type": "any"})

--- a/backend/src/backend/_internal/tasks/ingest.py
+++ b/backend/src/backend/_internal/tasks/ingest.py
@@ -37,18 +37,7 @@ class SubjectNotFoundError(Exception):
 
 
 def _features_to_did_list(features: list | None) -> list[dict[str, str]]:
-    """extract canonical DIDs from any historical feature shape.
-
-    accepts:
-    - new shape: `[{"did": "did:plc:..."}]`
-    - legacy lexicon shape: `[{"did": "...", "handle": "...", "displayName": "..."}]`
-    - already-flat: `["did:plc:...", "did:plc:..."]`
-
-    returns the canonical DB shape: `[{"did": "did:plc:..."}]`. handle and
-    displayName fields from the PDS record are intentionally discarded —
-    they're stale snapshots that we resolve fresh at API-read time via
-    `_internal.atproto.profiles.resolve_dids`.
-    """
+    """extract DIDs from any feature shape into `[{"did": "..."}]`."""
     if not features:
         return []
     out: list[dict[str, str]] = []
@@ -380,9 +369,6 @@ async def ingest_track_update(
         if "supportGate" in record:
             track.support_gate = record["supportGate"]
 
-        # features — store only the canonical DID. handle/displayName in the
-        # PDS record are denormalized snapshots that drift; we resolve them
-        # fresh at read time via _internal.atproto.profiles.
         if (features := record.get("features")) is not None:
             track.features = _features_to_did_list(features)
 

--- a/backend/src/backend/api/tracks/constants.py
+++ b/backend/src/backend/api/tracks/constants.py
@@ -1,6 +1,4 @@
 """constants for track endpoints."""
 
-MAX_FEATURES = 5
-
 DISCOVERY_CACHE_KEY = "plyr:tracks:discovery"
 DISCOVERY_CACHE_TTL_SECONDS = 60

--- a/backend/src/backend/api/tracks/metadata_service.py
+++ b/backend/src/backend/api/tracks/metadata_service.py
@@ -1,14 +1,4 @@
-"""Track metadata mutations that need DB-side bookkeeping.
-
-scope is deliberately narrow: anything that requires looking up or
-mutating related rows (e.g., create-or-attach an album, sync the
-`track.extra['album']` flag in lockstep with `track.album_id`).
-
-handle/profile resolution lives in `_internal/atproto/handles.py` —
-do not add a parallel resolver here. image upload lives in
-`_internal/image_uploads.py` — call `process_image_upload` directly
-rather than re-wrapping it.
-"""
+"""Track metadata mutations that need cross-table bookkeeping."""
 
 import logging
 

--- a/backend/src/backend/api/tracks/metadata_service.py
+++ b/backend/src/backend/api/tracks/metadata_service.py
@@ -1,82 +1,25 @@
-"""Helpers for track metadata updates."""
+"""Track metadata mutations that need DB-side bookkeeping.
 
-import asyncio
-import json
+scope is deliberately narrow: anything that requires looking up or
+mutating related rows (e.g., create-or-attach an album, sync the
+`track.extra['album']` flag in lockstep with `track.album_id`).
+
+handle/profile resolution lives in `_internal/atproto/handles.py` —
+do not add a parallel resolver here. image upload lives in
+`_internal/image_uploads.py` — call `process_image_upload` directly
+rather than re-wrapping it.
+"""
+
 import logging
-from typing import TYPE_CHECKING, Any
 
-from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import attributes
-from starlette.datastructures import UploadFile
 
-from backend._internal.atproto.handles import resolve_handle
-from backend._internal.image_uploads import process_image_upload
 from backend.models import Track
 
-from .constants import MAX_FEATURES
 from .services import get_or_create_album
 
 logger = logging.getLogger(__name__)
-
-
-async def resolve_feature_handles(
-    features_json: str, *, artist_handle: str
-) -> list[dict[str, Any]]:
-    """Parse and resolve feature handles from JSON."""
-    try:
-        handles_list = json.loads(features_json)
-    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
-        raise HTTPException(
-            status_code=400, detail=f"invalid JSON in features: {exc}"
-        ) from exc
-
-    if not isinstance(handles_list, list):
-        raise HTTPException(
-            status_code=400, detail="features must be a JSON array of handles"
-        )
-
-    if len(handles_list) > MAX_FEATURES:
-        raise HTTPException(
-            status_code=400,
-            detail=f"maximum {MAX_FEATURES} featured artists allowed",
-        )
-
-    valid_handles: list[str] = []
-    for handle in handles_list:
-        if not isinstance(handle, str):
-            raise HTTPException(
-                status_code=400, detail="each feature must be a string handle"
-            )
-        # prevent self-featuring
-        if handle.lstrip("@") == artist_handle:
-            continue
-        valid_handles.append(handle)
-
-    if not valid_handles:
-        return []
-
-    resolved_artists = await asyncio.gather(
-        *[resolve_handle(h) for h in valid_handles],
-        return_exceptions=True,
-    )
-
-    features: list[dict[str, Any]] = []
-    for handle, resolved in zip(valid_handles, resolved_artists, strict=False):
-        if isinstance(resolved, Exception) or not resolved:
-            raise HTTPException(
-                status_code=400,
-                detail=f"failed to resolve handle: {handle}",
-            )
-        if TYPE_CHECKING:
-            assert isinstance(resolved, dict)
-        # store only the canonical DID. handle/displayName are mutable
-        # snapshots that the API hydrates fresh per-request via
-        # `_internal.atproto.profiles.resolve_dids`. keeping them here
-        # would re-introduce the drift bug fixed by #1355.
-        features.append({"did": resolved["did"]})
-
-    return features
 
 
 async def apply_album_update(
@@ -119,11 +62,3 @@ async def apply_album_update(
         track.album_id = None
 
     return True
-
-
-async def upload_track_image(
-    image: UploadFile,
-) -> tuple[str, str | None, str | None]:
-    """Persist a track image and return (image_id, public_url, thumbnail_url)."""
-    uploaded = await process_image_upload(image, "track")
-    return uploaded.image_id, uploaded.image_url, uploaded.thumbnail_url

--- a/backend/src/backend/api/tracks/mutations.py
+++ b/backend/src/backend/api/tracks/mutations.py
@@ -21,12 +21,17 @@ from backend._internal.atproto import (
     upload_blob,
 )
 from backend._internal.atproto.client import make_pds_request
+from backend._internal.atproto.handles import (
+    InvalidFeaturesError,
+    resolve_featured_artists,
+)
 from backend._internal.atproto.records import (
     build_track_record,
     update_record,
 )
 from backend._internal.atproto.tid import datetime_to_tid
 from backend._internal.audio import AudioFormat
+from backend._internal.image_uploads import process_image_upload
 from backend._internal.tasks import (
     schedule_album_list_sync,
     schedule_move_track_audio,
@@ -39,11 +44,7 @@ from backend.schemas import MessageResponse, TrackResponse
 from backend.storage import storage
 from backend.utilities.tags import get_or_create_tag, parse_tags_json
 
-from .metadata_service import (
-    apply_album_update,
-    resolve_feature_handles,
-    upload_track_image,
-)
+from .metadata_service import apply_album_update
 from .router import router
 
 logger = logging.getLogger(__name__)
@@ -251,9 +252,12 @@ async def update_track_metadata(
     album_changed = old_album_id != new_album_id
 
     if features is not None:
-        track.features = await resolve_feature_handles(
-            features, artist_handle=track.artist.handle
-        )
+        try:
+            track.features = await resolve_featured_artists(
+                features, exclude_handle=track.artist.handle
+            )
+        except InvalidFeaturesError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     image_changed = False
     image_url = None
@@ -276,7 +280,12 @@ async def update_track_metadata(
         image_changed = True
     elif image and image.filename:
         # handle image upload/replacement
-        image_id, image_url, thumbnail_url = await upload_track_image(image)
+        uploaded = await process_image_upload(image, "track")
+        image_id, image_url, thumbnail_url = (
+            uploaded.image_id,
+            uploaded.image_url,
+            uploaded.thumbnail_url,
+        )
 
         if track.image_id and track.image_id != image_id:
             # only delete old image from R2 if album doesn't share it

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -34,7 +34,10 @@ from backend._internal.atproto import (
     create_track_record,
     upload_blob,
 )
-from backend._internal.atproto.handles import resolve_featured_artists
+from backend._internal.atproto.handles import (
+    InvalidFeaturesError,
+    resolve_featured_artists,
+)
 from backend._internal.audio import AudioFormat
 from backend._internal.background import get_docket
 from backend._internal.clients.transcoder import get_transcoder_client
@@ -704,9 +707,12 @@ async def _create_records(
                 "resolving featured artists...",
                 phase="metadata",
             )
-            featured_artists = await resolve_featured_artists(
-                ctx.features_json, artist.handle
-            )
+            try:
+                featured_artists = await resolve_featured_artists(
+                    ctx.features_json, exclude_handle=artist.handle
+                )
+            except InvalidFeaturesError as exc:
+                raise UploadPhaseError(str(exc)) from exc
 
         # if an explicit album_id was passed, resolve the album up front so the
         # ATProto track record includes the correct album title and the row is

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -77,12 +77,7 @@ class AlbumSummary(BaseModel):
 
 
 class FeaturedArtist(BaseModel):
-    """featured artist metadata, hydrated from the artist's DID at read time.
-
-    `track.features` in the DB stores only DIDs; this view shape is built by
-    `_internal.atproto.profiles.resolve_dids()` on every API response so
-    handle/display_name/avatar_url are always fresh.
-    """
+    """featured artist view, hydrated from a DID."""
 
     did: str
     handle: str
@@ -91,12 +86,7 @@ class FeaturedArtist(BaseModel):
 
 
 async def _hydrate_features(stored: list | None) -> list[FeaturedArtist]:
-    """build FeaturedArtist views from `track.features` (a list of `{did}` dicts).
-
-    tolerates legacy shapes (`[{did, handle, displayName}]` or
-    `[{did, handle, display_name}]`) by extracting only the DID — drift
-    in the snapshot fields is irrelevant because we resolve fresh below.
-    """
+    """build FeaturedArtist views from `track.features`."""
     if not stored:
         return []
     dids: list[str] = []

--- a/backend/tests/api/test_track_deletion.py
+++ b/backend/tests/api/test_track_deletion.py
@@ -485,14 +485,16 @@ async def test_edit_same_image_does_not_delete(
         delete_calls.append(file_id)
         return True
 
+    from backend._internal.image_uploads import ImageUploadResult
+
     with (
         patch(
-            "backend.api.tracks.mutations.upload_track_image",
+            "backend.api.tracks.mutations.process_image_upload",
             new_callable=AsyncMock,
-            return_value=(
-                same_image_id,
-                f"https://example.com/images/{same_image_id}.png",
-                f"https://example.com/images/{same_image_id}_thumb.webp",
+            return_value=ImageUploadResult(
+                image_id=same_image_id,
+                image_url=f"https://example.com/images/{same_image_id}.png",
+                thumbnail_url=f"https://example.com/images/{same_image_id}_thumb.webp",
             ),
         ),
         patch(

--- a/loq.toml
+++ b/loq.toml
@@ -40,7 +40,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1500
+max_lines = 1505
 
 [[rules]]
 path = "backend/src/backend/config.py"

--- a/loq.toml
+++ b/loq.toml
@@ -224,7 +224,7 @@ max_lines = 643
 
 [[rules]]
 path = "backend/tests/api/test_track_deletion.py"
-max_lines = 519
+max_lines = 521
 
 [[rules]]
 path = "backend/tests/api/test_top_tracks.py"


### PR DESCRIPTION
caught while smoke-testing #1362 on staging that there were **two parallel** features-from-handles resolvers, drifted apart in error semantics. that's a structural smell — fixing it properly instead of just patching the second one.

## the duplication

| function | location | called by | semantics |
|---|---|---|---|
| `resolve_featured_artists` | `_internal/atproto/handles.py` | upload (`uploads.py:707`) | lenient — silently drops unresolvable handles |
| `resolve_feature_handles`  | `api/tracks/metadata_service.py` | edit (`mutations.py:254`) | strict — raises `HTTPException(400)` on resolve failure |

Same job, two implementations, two slightly different names, two different error paths. Classic accidentally-parallel evolution.

## changes

- **single resolver** in `_internal/atproto/handles.py:resolve_featured_artists` with strict semantics (raises `InvalidFeaturesError` on malformed JSON / non-list / non-string entries / over-cap / unresolvable handle)
- both call sites translate `InvalidFeaturesError` → context-appropriate error: `HTTPException(400)` in `mutations.py` (sync request), `UploadPhaseError` in `uploads.py` (background task → SSE progress channel)
- **promotes upload semantics from "lenient" to "strict"**: silently dropping unresolvable handles meant a user thought their featured artist stuck when it didn't. failing the upload with a clear "failed to resolve handle: ..." is better UX
- moves `MAX_FEATURES` from `api/tracks/constants.py` to `handles.py` so the resolver owns its own cap (otherwise `_internal/` would back-import from `api/`, an anti-pattern)
- **inlines** `metadata_service.upload_track_image` — it was a 2-line passthrough around `process_image_upload`, called from exactly one place. Per CLAUDE.md "Don't create helpers, utilities, or abstractions for one-time operations"
- **shrinks `metadata_service.py`** to just `apply_album_update` (the one thing in there doing real DB-side bookkeeping). Adds a module docstring explicitly forbidding re-introducing parallel resolvers

## broader audit (separate concerns I noticed but did NOT change here)

Surveyed everything in `src/backend` named `resolve_*`:

| function | location | role | status |
|---|---|---|---|
| `resolve_handle` | `_internal/atproto/handles.py` | handle → profile | kept (used by oauth + features) |
| `resolve_featured_artists` | `_internal/atproto/handles.py` | features JSON → DIDs | **kept (canonical)** |
| `resolve_feature_handles` | `api/tracks/metadata_service.py` | features JSON → DIDs (dup) | **deleted** |
| `resolve_dids` | `_internal/atproto/profiles.py` | DIDs → fresh profiles | kept (display-time hydration, added by #1362) |
| `_resolve_handle_from_pds` | `_internal/auth/oauth.py` | DID → handle from describeRepo | kept (oauth callback fallback, different job) |
| `resolve_audio_url` | `_internal/tasks/hooks.py` | track_id → audio URL | kept (different job) |
| `resolve_list_by_uri` | `api/lists/resolver.py` | at-uri → list record | kept (different job) |

Only one true dup — addressed here. The rest are doing genuinely different jobs.

## structural smell flagged for follow-up (not addressed in this PR)

`api/tracks/metadata_service.py` was a "service" module under `api/` containing business logic that overlapped `_internal/`. After this PR it's a single function (`apply_album_update`) — but the broader pattern (api-layer "service" wrappers around `_internal/` helpers) is worth a deliberate audit. Should probably be a tracking issue.

## test plan
- [x] `just backend lint` clean
- [ ] CI passes
- [ ] re-upload a featured track on staging, confirm DB row is `[{"did": "..."}]` (this was the original validation that caught the bug)
- [ ] try uploading with a deliberately-invalid handle, confirm the upload SSE progress reports the failure clearly (no longer silently drops)