### PR TITLE
fix(images): apply EXIF orientation on upload + thumbnail; backfill

### DIFF
--- a/backend/src/backend/_internal/image.py
+++ b/backend/src/backend/_internal/image.py
@@ -2,7 +2,57 @@
 
 from __future__ import annotations
 
+import logging
 from enum import Enum
+from io import BytesIO
+
+from PIL import Image, ImageOps
+
+logger = logging.getLogger(__name__)
+
+
+# Pillow save-format names indexed by ImageFormat.value
+_PIL_SAVE_FORMAT = {
+    "jpg": "JPEG",
+    "jpeg": "JPEG",
+    "png": "PNG",
+    "webp": "WEBP",
+    "gif": "GIF",
+}
+
+# EXIF tag id for Orientation
+_EXIF_ORIENTATION_TAG = 0x0112
+
+
+def has_exif_rotation(image_data: bytes) -> bool:
+    """true iff the image has a non-trivial EXIF Orientation tag."""
+    try:
+        return (
+            Image.open(BytesIO(image_data)).getexif().get(_EXIF_ORIENTATION_TAG, 1) != 1
+        )
+    except Exception:
+        return False
+
+
+def normalize_orientation(image_data: bytes) -> bytes:
+    """rotate `image_data` upright per its EXIF Orientation tag.
+
+    returns the input unchanged if there's no rotation needed or the
+    image format isn't recognized.
+    """
+    try:
+        img = Image.open(BytesIO(image_data))
+        save_format = _PIL_SAVE_FORMAT.get((img.format or "").lower())
+        if not save_format or not has_exif_rotation(image_data):
+            return image_data
+        rotated = ImageOps.exif_transpose(img)
+        buf = BytesIO()
+        save_kwargs = {"quality": 95} if save_format == "JPEG" else {}
+        rotated.save(buf, format=save_format, **save_kwargs)
+        return buf.getvalue()
+    except Exception as exc:
+        logger.warning("failed to normalize image orientation: %s", exc)
+        return image_data
 
 
 class ImageFormat(str, Enum):

--- a/backend/src/backend/_internal/image_uploads.py
+++ b/backend/src/backend/_internal/image_uploads.py
@@ -8,7 +8,7 @@ from pathlib import PurePosixPath
 from fastapi import HTTPException
 from starlette.datastructures import UploadFile
 
-from backend._internal.image import ImageFormat
+from backend._internal.image import ImageFormat, normalize_orientation
 from backend._internal.thumbnails import generate_and_save
 from backend.config import settings
 from backend.storage import storage
@@ -89,6 +89,7 @@ async def process_image_upload(
             )
         image_data.extend(chunk)
 
+    image_data = bytearray(normalize_orientation(bytes(image_data)))
     image_obj = BytesIO(image_data)
     image_id = await storage.save(image_obj, image.filename)
     # use the actual filename extension — must match the key R2.save() stored

--- a/backend/src/backend/_internal/thumbnails.py
+++ b/backend/src/backend/_internal/thumbnails.py
@@ -3,7 +3,7 @@
 import logging
 from io import BytesIO
 
-from PIL import Image
+from PIL import Image, ImageOps
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +22,7 @@ def generate_thumbnail(image_data: bytes, size: int = 96, quality: int = 80) -> 
         WebP-encoded thumbnail bytes
     """
     img = Image.open(BytesIO(image_data))
+    img = ImageOps.exif_transpose(img)
 
     # convert to RGB (handles RGBA, palette, etc.)
     if img.mode not in ("RGB", "L"):

--- a/backend/tests/_internal/test_image_orientation.py
+++ b/backend/tests/_internal/test_image_orientation.py
@@ -1,0 +1,68 @@
+"""regression tests for EXIF orientation normalization on uploads + thumbnails."""
+
+from io import BytesIO
+
+from PIL import Image
+
+from backend._internal.image import has_exif_rotation, normalize_orientation
+from backend._internal.thumbnails import generate_thumbnail
+
+
+def _jpeg_with_orientation(orientation: int) -> bytes:
+    """build a 200x100 landscape JPEG with the given EXIF Orientation tag."""
+    img = Image.new("RGB", (200, 100), color="red")
+    exif = img.getexif()
+    exif[0x0112] = orientation
+    buf = BytesIO()
+    img.save(buf, format="JPEG", exif=exif)
+    return buf.getvalue()
+
+
+def _plain_jpeg() -> bytes:
+    img = Image.new("RGB", (200, 100), color="blue")
+    buf = BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def test_has_exif_rotation_detects_non_identity_orientation() -> None:
+    assert has_exif_rotation(_jpeg_with_orientation(6)) is True
+    assert has_exif_rotation(_jpeg_with_orientation(8)) is True
+    assert has_exif_rotation(_jpeg_with_orientation(3)) is True
+
+
+def test_has_exif_rotation_ignores_identity_and_missing() -> None:
+    assert has_exif_rotation(_jpeg_with_orientation(1)) is False
+    assert has_exif_rotation(_plain_jpeg()) is False
+
+
+def test_normalize_orientation_rotates_landscape_to_portrait_for_orientation_6() -> (
+    None
+):
+    """orientation=6 means rotate 90° CW → 200x100 sensor becomes 100x200 upright."""
+    rotated = normalize_orientation(_jpeg_with_orientation(6))
+    img = Image.open(BytesIO(rotated))
+    assert img.size == (100, 200)
+    # the new image should have no rotation tag (or identity)
+    assert img.getexif().get(0x0112, 1) in (0, 1)
+
+
+def test_normalize_orientation_returns_unchanged_when_no_rotation() -> None:
+    original = _plain_jpeg()
+    assert normalize_orientation(original) is original
+
+
+def test_normalize_orientation_returns_unchanged_when_orientation_is_identity() -> None:
+    original = _jpeg_with_orientation(1)
+    assert normalize_orientation(original) is original
+
+
+def test_generate_thumbnail_applies_exif_rotation() -> None:
+    """sideways-tagged JPEG should produce an upright (square) thumbnail."""
+    sideways = _jpeg_with_orientation(6)
+    thumb = generate_thumbnail(sideways, size=64)
+    img = Image.open(BytesIO(thumb))
+    assert img.size == (64, 64)
+    # no good way to assert color from a single-color test image post-crop,
+    # but at minimum we can verify it didn't crash and is a valid square WebP
+    assert img.format == "WEBP"

--- a/scripts/backfill_image_orientation.py
+++ b/scripts/backfill_image_orientation.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env -S uv run --script --quiet
+"""rewrite track/album/playlist images to bake EXIF Orientation into pixels.
+
+usage:
+    uv run scripts/backfill_image_orientation.py --dry-run
+    uv run scripts/backfill_image_orientation.py --limit 5
+    uv run scripts/backfill_image_orientation.py --concurrency 10
+"""
+
+import argparse
+import asyncio
+import logging
+import time
+from pathlib import PurePosixPath
+
+import httpx
+from sqlalchemy import select
+
+from backend._internal.image import has_exif_rotation, normalize_orientation
+from backend._internal.thumbnails import generate_thumbnail
+from backend.models import Album, Track
+from backend.models.playlist import Playlist
+from backend.storage import storage
+from backend.storage.r2 import R2Storage
+from backend.utilities.database import db_session
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+async def _overwrite_object(image_id: str, image_url: str, data: bytes) -> None:
+    """upload `data` to R2 at the existing image's key, preserving image_id."""
+    if not isinstance(storage, R2Storage):
+        raise RuntimeError(
+            f"backfill requires R2 storage backend; got {type(storage).__name__}"
+        )
+    ext = PurePosixPath(image_url.split("?")[0]).suffix.lower() or ".jpg"
+    key = f"images/{image_id}{ext}"
+    # infer media type from extension
+    media_type = {
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".png": "image/png",
+        ".webp": "image/webp",
+        ".gif": "image/gif",
+    }.get(ext, "application/octet-stream")
+    async with storage._s3_client() as client:
+        await client.put_object(
+            Bucket=storage.image_bucket_name,
+            Key=key,
+            Body=data,
+            ContentType=media_type,
+        )
+
+
+async def _process_one(
+    row: dict,
+    http: httpx.AsyncClient,
+    sem: asyncio.Semaphore,
+    counter: dict[str, int],
+    total: int,
+    dry_run: bool,
+) -> None:
+    async with sem:
+        idx = counter["started"] + 1
+        counter["started"] += 1
+        label = f"{row['table']} {row['id']} (image_id={row['image_id']})"
+
+        try:
+            resp = await http.get(row["image_url"])
+            resp.raise_for_status()
+            original = resp.content
+
+            if not has_exif_rotation(original):
+                counter["upright"] += 1
+                logger.info("[%d/%d] %s: already upright", idx, total, label)
+                return
+
+            normalized = normalize_orientation(original)
+            if normalized == original:
+                counter["upright"] += 1
+                logger.info(
+                    "[%d/%d] %s: orientation tag present but normalize was a no-op",
+                    idx,
+                    total,
+                    label,
+                )
+                return
+
+            if dry_run:
+                counter["would_fix"] += 1
+                logger.info(
+                    "[%d/%d] %s: would rewrite (%d → %d bytes) + regen thumbnail",
+                    idx,
+                    total,
+                    label,
+                    len(original),
+                    len(normalized),
+                )
+                return
+
+            await _overwrite_object(row["image_id"], row["image_url"], normalized)
+            thumb_data = generate_thumbnail(normalized)
+            await storage.save_thumbnail(thumb_data, row["image_id"])
+            counter["fixed"] += 1
+            logger.info(
+                "[%d/%d] %s: rewrote (%d → %d bytes) + regenerated thumbnail",
+                idx,
+                total,
+                label,
+                len(original),
+                len(normalized),
+            )
+        except Exception:
+            logger.exception("failed for %s", label)
+            counter["failed"] += 1
+
+
+async def _gather_rows(limit: int | None) -> list[dict]:
+    rows: list[dict] = []
+    async with db_session() as db:
+        for table_name, model in (
+            ("track", Track),
+            ("album", Album),
+            ("playlist", Playlist),
+        ):
+            remaining = (limit - len(rows)) if limit else None
+            if limit and remaining is not None and remaining <= 0:
+                break
+            stmt = (
+                select(model)
+                .where(model.image_id.isnot(None), model.image_url.isnot(None))
+                .order_by(model.id)
+            )
+            if remaining:
+                stmt = stmt.limit(remaining)
+            result = await db.execute(stmt)
+            for entity in result.scalars():
+                rows.append(
+                    {
+                        "table": table_name,
+                        "id": entity.id,
+                        "image_id": entity.image_id,
+                        "image_url": entity.image_url,
+                    }
+                )
+    return rows
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would change without writing to R2",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None, help="cap on number of rows to process"
+    )
+    parser.add_argument(
+        "--concurrency", type=int, default=8, help="parallel workers (default 8)"
+    )
+    args = parser.parse_args()
+
+    rows = await _gather_rows(args.limit)
+    if not rows:
+        logger.info("no rows with images found")
+        return
+
+    logger.info(
+        "checking %d images (concurrency=%d, dry_run=%s)",
+        len(rows),
+        args.concurrency,
+        args.dry_run,
+    )
+
+    sem = asyncio.Semaphore(args.concurrency)
+    counter = {"started": 0, "upright": 0, "would_fix": 0, "fixed": 0, "failed": 0}
+    t0 = time.monotonic()
+
+    async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as http:
+        await asyncio.gather(
+            *[
+                _process_one(row, http, sem, counter, len(rows), args.dry_run)
+                for row in rows
+            ]
+        )
+
+    elapsed = time.monotonic() - t0
+    logger.info(
+        "done in %.0fs: upright=%d, would_fix=%d, fixed=%d, failed=%d (total=%d)",
+        elapsed,
+        counter["upright"],
+        counter["would_fix"],
+        counter["fixed"],
+        counter["failed"],
+        len(rows),
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## what + why
phone JPEGs typically store the sensor in landscape with an EXIF `Orientation` tag asking viewers to rotate at display time. browsers honor it; PIL's `Image.open` does not. so the saved-verbatim full image rendered correctly in browsers but the cropped/resized WebP thumbnail came out sideways for any track whose source had a non-identity tag.

list views (`TrackItem`, etc.) prefer `thumbnail_url` → sideways. detail page reads `image_url` → upright. that's the symptom.

## changes
- **`thumbnails.generate_thumbnail`**: `ImageOps.exif_transpose` before crop
- **`image_uploads.process_image_upload`**: bake rotation into the saved bytes too (browsers stop being the only thing that renders these correctly)
- **new `image.normalize_orientation` helper**: only re-encodes when there's actual rotation to apply (no quality loss for the already-upright common case)
- **`scripts/backfill_image_orientation.py`**: walks every track/album/playlist with an image, rewrites both the full image (overwriting at the same R2 key, preserving `image_id`) and the thumbnail when the source has non-trivial orientation
- 6 regression tests covering both helpers + the thumbnail pipeline (passing locally with `PYTHONMALLOC=malloc` to dodge the unrelated 3.14 segfault)

## rollout
1. merge → staging deploy
2. `uv run scripts/backfill_image_orientation.py --dry-run` against staging — see how many rows are affected
3. drop `--dry-run`
4. spot-check a few list views
5. `just release` to prod
6. same backfill against prod

## test plan
- [x] `just backend lint` clean
- [x] new tests pass locally
- [ ] CI passes
- [ ] dry-run on staging reports a sensible count of affected rows
- [ ] post-backfill, sideways thumbnails on staging are upright