### PR TITLE
fix(images): consolidate two parallel image-upload paths

### DIFF
--- a/backend/src/backend/_internal/image_uploads.py
+++ b/backend/src/backend/_internal/image_uploads.py
@@ -22,6 +22,10 @@ MAX_IMAGE_SIZE_BYTES = 20 * 1024 * 1024  # 20MB
 COVER_EXTENSIONS = frozenset({".jpg", ".jpeg", ".png", ".webp"})
 
 
+class ImageUploadError(ValueError):
+    """validation or storage failure for an uploaded image."""
+
+
 @dataclass
 class ImageUploadResult:
     """result of processing an uploaded image."""
@@ -31,87 +35,49 @@ class ImageUploadResult:
     thumbnail_url: str | None
 
 
-async def process_image_upload(
-    image: UploadFile,
-    entity_type: str,
+async def save_image_with_thumbnail(
+    image_data: bytes,
+    filename: str,
     *,
+    entity_type: str,
+    content_type: str | None = None,
     allowed_extensions: frozenset[str] | None = None,
     scan_moderation: bool = True,
 ) -> ImageUploadResult:
-    """validate, store, thumbnail, and optionally moderate an uploaded image.
+    """validate format, normalize orientation, save to storage, generate thumbnail.
 
-    uses ImageFormat.validate_and_extract for validation, which prefers
-    content_type over filename extension (handles iOS HEIC→JPEG conversions).
-
-    args:
-        image: the uploaded file
-        entity_type: context label for thumbnails/moderation (e.g. "album", "playlist", "track")
-        allowed_extensions: if set, restrict accepted formats to these extensions
-            (e.g. COVER_EXTENSIONS for album/playlist covers). when None, accepts
-            all formats supported by ImageFormat (jpg, png, webp, gif).
-        scan_moderation: whether to run moderation scanning (default True)
-
-    returns:
-        ImageUploadResult with image_id, image_url, and optional thumbnail_url
-
-    raises:
-        HTTPException: on validation failure or storage error
+    raises ImageUploadError on validation failure. callers translate to
+    their context (HTTPException for sync routes, return-None for upload
+    background staging).
     """
-    if not image.filename:
-        raise HTTPException(status_code=400, detail="no filename provided")
+    image_format, is_valid = ImageFormat.validate_and_extract(filename, content_type)
+    if not is_valid or not image_format:
+        raise ImageUploadError("unsupported image type. supported: jpg, png, webp, gif")
 
-    image_format, is_valid = ImageFormat.validate_and_extract(
-        image.filename, image.content_type
-    )
-    if not is_valid:
-        raise HTTPException(
-            status_code=400,
-            detail="unsupported image type. supported: jpg, png, webp, gif",
-        )
-
-    # enforce narrower extension set when caller requires it (e.g. album/playlist covers)
-    if allowed_extensions and image_format:
+    if allowed_extensions:
         ext = f".{image_format.value}"
         if ext not in allowed_extensions:
             supported = ", ".join(sorted(e.lstrip(".") for e in allowed_extensions))
-            raise HTTPException(
-                status_code=400,
-                detail=f"unsupported image type for {entity_type}: .{image_format.value}. supported: {supported}",
+            raise ImageUploadError(
+                f"unsupported image type for {entity_type}: .{image_format.value}. supported: {supported}"
             )
 
-    # chunked read with size limit
-    image_data = bytearray()
-    while chunk := await image.read(CHUNK_SIZE):
-        if len(image_data) + len(chunk) > MAX_IMAGE_SIZE_BYTES:
-            raise HTTPException(
-                status_code=413,
-                detail="image too large (max 20MB)",
-            )
-        image_data.extend(chunk)
-
-    image_data = bytearray(normalize_orientation(bytes(image_data)))
-    image_obj = BytesIO(image_data)
-    image_id = await storage.save(image_obj, image.filename)
-    # use the actual filename extension — must match the key R2.save() stored
-    ext = PurePosixPath(image.filename).suffix.lower() or ".png"
+    image_data = normalize_orientation(image_data)
+    image_id = await storage.save(BytesIO(image_data), filename)
+    ext = PurePosixPath(filename).suffix.lower() or f".{image_format.value}"
     image_url = storage.build_image_url(image_id, ext)
-    thumbnail_url = await generate_and_save(bytes(image_data), image_id, entity_type)
+    thumbnail_url = await generate_and_save(image_data, image_id, entity_type)
 
-    # moderation scanning — dispatched as a docket background task so the
-    # HTTP response isn't blocked on the moderation service round trip
-    # (~3-6s for claude vision + possible cold-start penalty).  the scan
-    # only flags and notifies; it never gates the response.
     if scan_moderation and settings.moderation.image_moderation_enabled:
         try:
             from backend._internal.tasks.moderation import (
                 schedule_image_moderation_scan,
             )
 
-            content_type = image_format.media_type if image_format else "image/png"
             await schedule_image_moderation_scan(
                 image_id=image_id,
                 image_url=image_url,
-                content_type=content_type,
+                content_type=image_format.media_type,
                 entity_type=entity_type,
             )
         except Exception as e:
@@ -124,3 +90,39 @@ async def process_image_upload(
         image_url=image_url,
         thumbnail_url=thumbnail_url,
     )
+
+
+async def process_image_upload(
+    image: UploadFile,
+    entity_type: str,
+    *,
+    allowed_extensions: frozenset[str] | None = None,
+    scan_moderation: bool = True,
+) -> ImageUploadResult:
+    """chunked-read an UploadFile then save_image_with_thumbnail.
+
+    raises HTTPException on validation failure or oversize.
+    """
+    if not image.filename:
+        raise HTTPException(status_code=400, detail="no filename provided")
+
+    image_data = bytearray()
+    while chunk := await image.read(CHUNK_SIZE):
+        if len(image_data) + len(chunk) > MAX_IMAGE_SIZE_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail="image too large (max 20MB)",
+            )
+        image_data.extend(chunk)
+
+    try:
+        return await save_image_with_thumbnail(
+            bytes(image_data),
+            image.filename,
+            entity_type=entity_type,
+            content_type=image.content_type,
+            allowed_extensions=allowed_extensions,
+            scan_moderation=scan_moderation,
+        )
+    except ImageUploadError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -41,11 +41,13 @@ from backend._internal.atproto.handles import (
 from backend._internal.audio import AudioFormat
 from backend._internal.background import get_docket
 from backend._internal.clients.transcoder import get_transcoder_client
-from backend._internal.image import ImageFormat
+from backend._internal.image_uploads import (
+    ImageUploadError,
+    save_image_with_thumbnail,
+)
 from backend._internal.jobs import job_service
 from backend._internal.tasks import schedule_album_list_sync
 from backend._internal.tasks.hooks import run_post_track_create_hooks
-from backend._internal.thumbnails import generate_and_save
 from backend.config import settings
 from backend.models import Album, Artist, Track, UserPreferences
 from backend.models.job import JobStatus, JobType
@@ -214,26 +216,26 @@ async def stage_image_to_storage(
     image_filename: str,
     image_content_type: str | None,
 ) -> tuple[str | None, str | None, str | None]:
-    """save image bytes + thumbnail to object storage and return (image_id, image_url, thumbnail_url).
+    """save image bytes + thumbnail for the upload pipeline.
 
-    called from the HTTP handler. returns (None, None, None) if the image
-    format is unsupported or the save fails — the upload itself still
-    proceeds without an image rather than failing the whole track.
+    returns (None, None, None) if the image format is unsupported or the
+    save fails — the upload itself proceeds without an image rather than
+    failing the whole track.
     """
-    image_format, is_valid = ImageFormat.validate_and_extract(
-        image_filename, image_content_type
-    )
-    if not is_valid or not image_format:
-        logger.warning(f"unsupported image format: {image_filename}")
-        return None, None, None
-
     try:
-        image_id = await storage.save(BytesIO(image_data), f"images/{image_filename}")
-        image_url = await storage.get_url(image_id, file_type="image")
-        thumbnail_url = await generate_and_save(image_data, image_id, "track")
-        return image_id, image_url, thumbnail_url
+        result = await save_image_with_thumbnail(
+            image_data,
+            image_filename,
+            entity_type="track",
+            content_type=image_content_type,
+            scan_moderation=False,
+        )
+        return result.image_id, result.image_url, result.thumbnail_url
+    except ImageUploadError as e:
+        logger.warning("unsupported image format %s: %s", image_filename, e)
+        return None, None, None
     except Exception as e:
-        logger.warning(f"failed to save image: {e}", exc_info=True)
+        logger.warning("failed to save image: %s", e, exc_info=True)
         return None, None, None
 
 

--- a/loq.toml
+++ b/loq.toml
@@ -40,7 +40,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1505
+max_lines = 1507
 
 [[rules]]
 path = "backend/src/backend/config.py"


### PR DESCRIPTION
caught while smoke-testing #1364 on staging — uploaded a JPEG with EXIF Orientation=6, the saved bytes came back unchanged (200x100 with orientation tag still set). dug in:

- \`_internal/image_uploads.process_image_upload\` (used by edit paths: tracks PATCH, albums, playlists)
- \`api/tracks/uploads.stage_image_to_storage\` (used by the upload pipeline)

were two parallel functions doing the same job (validate, save to R2, generate thumbnail) with subtly different behavior. #1364's \`normalize_orientation\` only landed in the first one. same anti-pattern as #1363's resolver dup.

## what changes
- new \`save_image_with_thumbnail(image_data, filename, ...)\` core in \`image_uploads.py\` — the actual work (validate → normalize orientation → save → thumbnail → optional moderation), takes bytes
- \`process_image_upload\` becomes a thin wrapper: chunked-read UploadFile, then call the core, translating \`ImageUploadError\` to \`HTTPException(400)\`
- \`stage_image_to_storage\` becomes a thin wrapper: bytes already read, call the core, translate failures to \`return None, None, None\` (preserving current "upload proceeds without image rather than failing the whole track" semantics)
- new \`ImageUploadError\` exception so the core stays HTTP-agnostic

## also flags an existing inconsistency
\`stage_image_to_storage\` calls the core with \`scan_moderation=False\` to preserve current behavior — the upload path historically didn't moderate cover images while the edit path did. **probably a real bug, but not changing it here.** worth a separate ticket.

## test plan
- [x] \`just backend lint\` clean
- [x] tests pass locally
- [ ] CI passes
- [ ] re-run the staging smoke test from #1364 (upload sideways-tagged JPEG, verify saved bytes are upright)