### PR TITLE
fix(images): normalize iPhone MPO format + unwrap storage proxy in backfill

### DIFF
--- a/backend/src/backend/_internal/image.py
+++ b/backend/src/backend/_internal/image.py
@@ -11,13 +11,14 @@ from PIL import Image, ImageOps
 logger = logging.getLogger(__name__)
 
 
-# Pillow save-format names indexed by ImageFormat.value
+# Pillow save-format names indexed by Image.format. iPhone photos open as
+# "MPO" (Multi-Picture Object) but should be re-saved as plain JPEG.
 _PIL_SAVE_FORMAT = {
-    "jpg": "JPEG",
-    "jpeg": "JPEG",
-    "png": "PNG",
-    "webp": "WEBP",
-    "gif": "GIF",
+    "JPEG": "JPEG",
+    "MPO": "JPEG",
+    "PNG": "PNG",
+    "WEBP": "WEBP",
+    "GIF": "GIF",
 }
 
 # EXIF tag id for Orientation
@@ -42,8 +43,14 @@ def normalize_orientation(image_data: bytes) -> bytes:
     """
     try:
         img = Image.open(BytesIO(image_data))
-        save_format = _PIL_SAVE_FORMAT.get((img.format or "").lower())
-        if not save_format or not has_exif_rotation(image_data):
+        save_format = _PIL_SAVE_FORMAT.get(img.format or "")
+        if not save_format:
+            logger.warning(
+                "unrecognized image format %r — skipping orientation normalization",
+                img.format,
+            )
+            return image_data
+        if not has_exif_rotation(image_data):
             return image_data
         rotated = ImageOps.exif_transpose(img)
         buf = BytesIO()

--- a/backend/tests/_internal/test_image_orientation.py
+++ b/backend/tests/_internal/test_image_orientation.py
@@ -57,6 +57,33 @@ def test_normalize_orientation_returns_unchanged_when_orientation_is_identity() 
     assert normalize_orientation(original) is original
 
 
+def test_normalize_orientation_handles_mpo_format_as_jpeg(monkeypatch) -> None:
+    """iPhone photos open as MPO (Multi-Picture Object); save them back as JPEG.
+
+    if MPO isn't in the format map, normalize is a silent no-op — that's
+    how the album cover from track 923 ('day and age') escaped #1364's
+    fix on first pass.
+    """
+    src = _jpeg_with_orientation(6)
+    real_open = Image.open
+
+    def fake_open(fp, *args, **kwargs):
+        img = real_open(fp, *args, **kwargs)
+        img.format = "MPO"  # force the iPhone format
+        return img
+
+    monkeypatch.setattr("backend._internal.image.Image.open", fake_open, raising=True)
+
+    out_bytes = normalize_orientation(src)
+
+    # undo the patch BEFORE re-opening so we read the real format
+    monkeypatch.undo()
+    assert out_bytes != src, "MPO should be re-encoded with rotation applied"
+    out = Image.open(BytesIO(out_bytes))
+    assert out.format == "JPEG"
+    assert out.size == (100, 200)
+
+
 def test_generate_thumbnail_applies_exif_rotation() -> None:
     """sideways-tagged JPEG should produce an upright (square) thumbnail."""
     sideways = _jpeg_with_orientation(6)

--- a/scripts/backfill_image_orientation.py
+++ b/scripts/backfill_image_orientation.py
@@ -20,8 +20,7 @@ from backend._internal.image import has_exif_rotation, normalize_orientation
 from backend._internal.thumbnails import generate_thumbnail
 from backend.models import Album, Track
 from backend.models.playlist import Playlist
-from backend.storage import storage
-from backend.storage.r2 import R2Storage
+from backend.storage import _get_storage
 from backend.utilities.database import db_session
 
 logging.basicConfig(
@@ -33,13 +32,9 @@ logger = logging.getLogger(__name__)
 
 async def _overwrite_object(image_id: str, image_url: str, data: bytes) -> None:
     """upload `data` to R2 at the existing image's key, preserving image_id."""
-    if not isinstance(storage, R2Storage):
-        raise RuntimeError(
-            f"backfill requires R2 storage backend; got {type(storage).__name__}"
-        )
+    r2 = _get_storage()  # unwrap the lazy module-level proxy
     ext = PurePosixPath(image_url.split("?")[0]).suffix.lower() or ".jpg"
     key = f"images/{image_id}{ext}"
-    # infer media type from extension
     media_type = {
         ".jpg": "image/jpeg",
         ".jpeg": "image/jpeg",
@@ -47,9 +42,9 @@ async def _overwrite_object(image_id: str, image_url: str, data: bytes) -> None:
         ".webp": "image/webp",
         ".gif": "image/gif",
     }.get(ext, "application/octet-stream")
-    async with storage._s3_client() as client:
+    async with r2._s3_client() as client:
         await client.put_object(
-            Bucket=storage.image_bucket_name,
+            Bucket=r2.image_bucket_name,
             Key=key,
             Body=data,
             ContentType=media_type,
@@ -104,7 +99,7 @@ async def _process_one(
 
             await _overwrite_object(row["image_id"], row["image_url"], normalized)
             thumb_data = generate_thumbnail(normalized)
-            await storage.save_thumbnail(thumb_data, row["image_id"])
+            await _get_storage().save_thumbnail(thumb_data, row["image_id"])
             counter["fixed"] += 1
             logger.info(
                 "[%d/%d] %s: rewrote (%d → %d bytes) + regenerated thumbnail",


### PR DESCRIPTION
caught while running the orientation backfill on prod after #1364 — the album cover for "fort knox 04/24/26" (the one making @incognitothief / @zzstoatzz.io's "day and age" thumbnail look sideways) wasn't being rewritten despite having EXIF Orientation=6. dug in: 13 of 20 affected prod images were silently being skipped.

## what + why

**MPO format**. iPhone JPEGs are recognized by Pillow as `MPO` (Multi-Picture Object), not `JPEG`. My `_PIL_SAVE_FORMAT` mapping in #1364 only had jpg/png/webp/gif keyed by lowercased ImageFormat values. `'mpo'` fell through, `save_format` was None, `normalize_orientation` returned the input unchanged. The dry-run reported these images as "already upright" misleadingly because `has_exif_rotation` correctly returned True but the rewrite was a no-op — which counted as "upright" via the `normalized == original` short-circuit in the script.

- restructure `_PIL_SAVE_FORMAT` to be keyed by `Image.format` directly (uppercase: "JPEG", "MPO", etc) — both map to "JPEG" output
- log a warning when an unrecognized format is encountered instead of silently no-op'ing
- new regression test that patches `Image.open` to return an MPO-flagged image and asserts the result is rewritten as upright JPEG

**Storage proxy**. `backend.storage.storage` is a `_StorageProxy` that forwards attribute access via `__getattr__`. The backfill script's `isinstance(storage, R2Storage)` was always False, so the put_object path crashed with "backfill requires R2 storage backend". Unwrap with `backend.storage._get_storage()` directly.

## how this slipped past

- my MPO test fixture in #1364 used PIL-generated JPEGs, which Pillow always tags as "JPEG". Real iPhone bytes (with the multi-picture container header) get tagged "MPO". The new test monkeypatches the format to simulate it
- the backfill script was tested locally on synthetic data; `_StorageProxy` only matters with the real lazy-init storage, which isn't exercised in unit tests

## what's already deployed
nothing from this PR yet. but the BYTES on prod R2 are already corrected — I ran the backfill locally using the fixed code (which uses local backend imports), then manually purged 29 stale CDN URLs from Cloudflare. Visually verified via Chrome DevTools MCP that the user's specific track ("day and age") now renders upright.

## what this PR ships
- the code fix so future iPhone uploads get normalized at upload time (not just via post-hoc backfill)
- the regression test
- the script fix so anyone running the backfill again doesn't hit the proxy bug

## follow-ups (not in this PR)

- **auto-purge backend on image rewrite**: every time we overwrite an existing R2 object at the same key, the CF edge keeps serving the stale bytes for up to 1 year (the cache rule's `max-age=31536000, immutable` override). A new fly secret with `Zone.Cache Purge` permission + a small purge call from the backend/script would close this loop. Worth its own PR.
- **track 891 orphan**: pre-existing data integrity issue — `image_id=c9a281a37d8bc943` on the track but the R2 object is gone. Backfill reports it as a 404 failure on every run. Either null out the orphan reference or have backfill self-heal.
- **separate prefix patterns in R2**: noticed track 50's `image_url` is `images.plyr.fm/<id>.jpg` (no `images/` prefix) while everyone else's is `images.plyr.fm/images/<id>.jpg` — historical artifact from earlier upload code. Cosmetic; doesn't affect anything user-visible.

## test plan
- [x] `just backend lint` clean
- [x] new MPO test passes locally
- [ ] CI passes
- [ ] re-deploy → upload an iPhone JPEG to staging → confirm saved bytes are upright (no MPO leak through)