### PR TITLE
feat(font): switch default font from mono to georgia

### DIFF
--- a/docs/site/src/styles/custom.css
+++ b/docs/site/src/styles/custom.css
@@ -18,9 +18,8 @@
   --sl-color-gray-6: #141414;
   --sl-color-black: #0a0a0a;
 
-  /* monospace font stack from plyr.fm */
-  --sl-font: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', 'Consolas',
-    monospace;
+  /* body font stack from plyr.fm — code blocks keep monospace via --sl-font-system-mono */
+  --sl-font: 'Georgia', 'Times New Roman', serif;
   --sl-font-system-mono: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code',
     'Consolas', monospace;
 }

--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -9,15 +9,15 @@ export type Theme = 'dark' | 'light' | 'system' | 'live';
 export type FontFamily = 'mono' | 'geist' | 'inter' | 'comic-sans' | 'georgia' | 'system-ui';
 
 export const FONT_OPTIONS: { value: FontFamily; label: string; stack: string }[] = [
+	{ value: 'georgia', label: 'georgia', stack: "'Georgia', 'Times New Roman', serif" },
 	{ value: 'mono', label: 'mono', stack: "'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', 'Consolas', monospace" },
 	{ value: 'geist', label: 'geist', stack: "'Geist', 'Inter', system-ui, sans-serif" },
 	{ value: 'inter', label: 'inter', stack: "'Inter', system-ui, sans-serif" },
 	{ value: 'system-ui', label: 'system', stack: "system-ui, -apple-system, 'Segoe UI', sans-serif" },
-	{ value: 'georgia', label: 'georgia', stack: "'Georgia', 'Times New Roman', serif" },
 	{ value: 'comic-sans', label: 'comic sans', stack: "'Comic Sans MS', 'Comic Sans', cursive" },
 ];
 
-export const DEFAULT_FONT: FontFamily = 'mono';
+export const DEFAULT_FONT: FontFamily = 'georgia';
 
 export interface UiSettings {
 	background_image_url?: string;

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -637,7 +637,7 @@
 	:global(body) {
 		margin: 0;
 		padding: 0;
-		font-family: var(--font-family, 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', 'Consolas', monospace);
+		font-family: var(--font-family, 'Georgia', 'Times New Roman', serif);
 		background-color: var(--bg-primary);
 		color: var(--text-primary);
 		-webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## Summary

Result of an informal poll. Default font flips from `mono` to `georgia` across the app and docs site. Users who explicitly chose a font keep their choice — only never-set users get the new default.

## Why this is safe

`preferences.ui_settings.font_family` is absent from the JSONB until the user explicitly picks one. The `?? DEFAULT_FONT` fall-through only fires when the key is missing, so:

| user state | server JSONB | result |
|---|---|---|
| never touched selector | `font_family` absent | gets georgia ✅ |
| explicitly picked mono | `font_family: 'mono'` | stays mono ✅ |
| explicitly picked anything else | `font_family: X` | stays X ✅ |

## Changes

- `DEFAULT_FONT: 'mono' → 'georgia'` (`preferences.svelte.ts:20`)
- `FONT_OPTIONS` reordered to lead with georgia
- body CSS fallback in `+layout.svelte:640` updated to Georgia stack (covers the moment before JS sets `--font-family`)
- docs site `--sl-font` switched to Georgia. `--sl-font-system-mono` kept for code blocks (`docs/site/src/styles/custom.css`)

## Caveat — one-frame flash

Users with `localStorage['fontFamily'] === 'mono'` (written from the resolved default, not raw `font_family`) will see one frame of mono on first post-deploy load before `preferences.fetch()` resolves to georgia and overwrites the cache. Accepted as not worth a version-bump migration.

## Test plan

- [x] `bun run check` — 0 errors, 0 warnings
- [ ] visual: app loads in georgia for a never-set test account
- [ ] visual: app loads in mono for an account that explicitly set mono
- [ ] visual: docs site renders in georgia, code blocks stay monospace