### PR TITLE
[codex] add live logo celestial theme

### DIFF
--- a/frontend/src/lib/ambient.svelte.ts
+++ b/frontend/src/lib/ambient.svelte.ts
@@ -23,6 +23,15 @@ interface AmbientLocation {
 	lon: number;
 }
 
+export interface CelestialState {
+	body: 'sun' | 'moon';
+	x: number;
+	y: number;
+	size: number;
+	opacity: number;
+	phase: number;
+}
+
 interface RGB {
 	r: number;
 	g: number;
@@ -52,6 +61,74 @@ const TINTED_VARS: [string, number][] = [
 	['--bg-tertiary', 0.07],
 	['--bg-hover', 0.08],
 ];
+
+const MS_PER_DAY = 86_400_000;
+const SYNODIC_MONTH_DAYS = 29.53058867;
+
+function toRadians(degrees: number): number {
+	return degrees * Math.PI / 180;
+}
+
+function toDegrees(radians: number): number {
+	return radians * 180 / Math.PI;
+}
+
+function clamp(min: number, max: number, value: number): number {
+	return Math.min(max, Math.max(min, value));
+}
+
+function getDayOfYear(date: Date): number {
+	const start = Date.UTC(date.getUTCFullYear(), 0, 0);
+	return Math.floor((date.getTime() - start) / MS_PER_DAY);
+}
+
+function getSolarTimeHours(date: Date, lon: number): number {
+	const day = getDayOfYear(date);
+	const utcHours = date.getUTCHours() + date.getUTCMinutes() / 60 + date.getUTCSeconds() / 3600;
+	const b = 2 * Math.PI * (day - 81) / 364;
+	const equationOfTimeMinutes = 9.87 * Math.sin(2 * b) - 7.53 * Math.cos(b) - 1.5 * Math.sin(b);
+	const hours = utcHours + lon / 15 + equationOfTimeMinutes / 60;
+	return ((hours % 24) + 24) % 24;
+}
+
+function getSolarAltitudeDegrees(date: Date, lat: number, lon: number): number {
+	const day = getDayOfYear(date);
+	const declination = toRadians(23.44 * Math.sin(2 * Math.PI * (day - 81) / 365));
+	const latitude = toRadians(lat);
+	const hourAngle = toRadians((getSolarTimeHours(date, lon) - 12) * 15);
+	const altitude = Math.asin(
+		Math.sin(latitude) * Math.sin(declination) +
+		Math.cos(latitude) * Math.cos(declination) * Math.cos(hourAngle)
+	);
+	return toDegrees(altitude);
+}
+
+function getMoonPhase(date: Date): number {
+	const knownNewMoon = Date.UTC(2000, 0, 6, 18, 14);
+	const daysSince = (date.getTime() - knownNewMoon) / MS_PER_DAY;
+	return ((daysSince / SYNODIC_MONTH_DAYS) % 1 + 1) % 1;
+}
+
+function computeCelestialState(location: AmbientLocation, weather: WeatherData, date: Date): CelestialState {
+	const solarHours = getSolarTimeHours(date, location.lon);
+	const solarAltitude = getSolarAltitudeDegrees(date, location.lat, location.lon);
+	const body = weather.is_day ? 'sun' : 'moon';
+	const phase = getMoonPhase(date);
+	const moonOffsetHours = phase * 24;
+	const bodyHours = body === 'sun' ? solarHours : (solarHours - moonOffsetHours + 24) % 24;
+	const hourAngle = ((bodyHours - 12) / 12);
+	const arcAltitude = body === 'sun'
+		? solarAltitude
+		: 56 * Math.cos(hourAngle * Math.PI) - 10;
+	const x = clamp(7, 93, 50 + hourAngle * 46);
+	const y = clamp(9, 46, 43 - ((arcAltitude + 8) / 82) * 34);
+	const size = clamp(74, 150, 86 + Math.max(0, arcAltitude) * 0.7);
+	const opacity = body === 'sun'
+		? clamp(0.22, 0.52, 0.26 + Math.max(0, solarAltitude) / 150)
+		: clamp(0.18, 0.38, 0.2 + Math.max(0, arcAltitude) / 260);
+
+	return { body, x, y, size, opacity, phase };
+}
 
 function getConditionLabel(code: number): string {
 	if (code <= 3) return 'clear';
@@ -218,9 +295,11 @@ class AmbientManager {
 	weather = $state<WeatherData | null>(null);
 	loading = $state(false);
 	error = $state<string | null>(null);
+	now = $state(new Date());
 	readonly temperatureUnit: TemperatureUnit = detectTemperatureUnit();
 
 	private fetchIntervalId: number | null = null;
+	private clockIntervalId: number | null = null;
 	private lastFetchTime = 0;
 	private readonly STALE_MS = 30 * 60 * 1000; // 30 minutes
 	private baseValues: Map<string, string> = new Map();
@@ -238,6 +317,11 @@ class AmbientManager {
 		const condition = getConditionLabel(w.weathercode);
 		const time = w.is_day ? 'day' : 'night';
 		return `${temp}°${unit} · ${condition} · ${time}`;
+	}
+
+	get celestial(): CelestialState | null {
+		if (!this.location || !this.weather) return null;
+		return computeCelestialState(this.location, this.weather, this.now);
 	}
 
 	/** activate ambient mode. returns false if geolocation denied or unavailable. */
@@ -317,6 +401,11 @@ class AmbientManager {
 			window.clearInterval(this.fetchIntervalId);
 			this.fetchIntervalId = null;
 		}
+		if (this.clockIntervalId !== null) {
+			window.clearInterval(this.clockIntervalId);
+			this.clockIntervalId = null;
+		}
+		document.removeEventListener('visibilitychange', this.handleVisibilityChange);
 
 		this.clearFromDOM();
 
@@ -434,6 +523,10 @@ class AmbientManager {
 
 		// re-fetch every 30 minutes
 		this.fetchIntervalId = window.setInterval(() => this.fetchWeather(), this.STALE_MS);
+		this.now = new Date();
+		this.clockIntervalId = window.setInterval(() => {
+			this.now = new Date();
+		}, 60 * 1000);
 
 		// also re-fetch on tab re-focus if stale
 		if (browser) {

--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -23,6 +23,7 @@ export interface UiSettings {
 	background_image_url?: string;
 	background_tile?: boolean;
 	use_playing_artwork_as_background?: boolean;
+	live_logo_celestial_enabled?: boolean;
 	pds_audio_uploads_enabled?: boolean;
 	font_family?: FontFamily;
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import logo from '$lib/assets/logo.png';
+	import logoMark from '$lib/assets/logo.svg';
 	import {
 		APP_NAME,
 		APP_TAGLINE,
@@ -19,6 +20,7 @@
 	import { auth } from '$lib/auth.svelte';
 	import { preferences } from '$lib/preferences.svelte';
 	import { ambient } from '$lib/ambient.svelte';
+	import type { CelestialState } from '$lib/ambient.svelte';
 	import { moderation } from '$lib/moderation.svelte';
 	import { player } from '$lib/player.svelte';
 	import { queue } from '$lib/queue.svelte';
@@ -45,6 +47,24 @@
 	);
 
 	let isEmbed = $derived($page.url.pathname.startsWith('/embed/'));
+	let celestial = $derived(ambient.celestial);
+	let showCelestialLogo = $derived(
+		!isEmbed &&
+		preferences.theme === 'live' &&
+		ambient.enabled &&
+		(preferences.uiSettings.live_logo_celestial_enabled ?? false) &&
+		celestial !== null
+	);
+
+	function getCelestialStyle(state: CelestialState): string {
+		return [
+			`--celestial-x: ${state.x}%`,
+			`--celestial-y: ${state.y}%`,
+			`--celestial-size: ${state.size}px`,
+			`--celestial-opacity: ${state.opacity}`,
+			`--moon-shade-x: ${18 + state.phase * 64}%`
+		].join('; ');
+	}
 
 	// show terms overlay if authenticated and either never accepted or accepted before latest update
 	// exclude legal pages so users can read full terms/privacy/cookies
@@ -467,6 +487,21 @@
 	</script>
 </svelte:head>
 
+{#if showCelestialLogo && celestial}
+	<div
+		class="celestial-logo"
+		class:sun={celestial.body === 'sun'}
+		class:moon={celestial.body === 'moon'}
+		style={getCelestialStyle(celestial)}
+		aria-hidden="true"
+	>
+		<img src={logoMark} alt="" />
+		{#if celestial.body === 'moon'}
+			<span class="moon-shade"></span>
+		{/if}
+	</div>
+{/if}
+
 <div class="app-layout">
 	<main class="main-content" class:with-queue={showQueue && !isEmbed}>
 		{@render children?.()}
@@ -685,6 +720,83 @@
 		min-height: 100vh; /* fallback for browsers without dvh support */
 		width: 100%;
 		overflow-x: clip; /* clip instead of hidden to preserve position: sticky on descendants */
+		position: relative;
+		z-index: 1;
+	}
+
+	.celestial-logo {
+		position: fixed;
+		left: var(--celestial-x);
+		top: var(--celestial-y);
+		width: var(--celestial-size);
+		height: var(--celestial-size);
+		transform: translate(-50%, -50%);
+		opacity: var(--celestial-opacity);
+		pointer-events: none;
+		z-index: 0;
+		transition:
+			left 18s linear,
+			top 18s linear,
+			width 1.8s ease,
+			height 1.8s ease,
+			opacity 1.8s ease;
+	}
+
+	.celestial-logo img,
+	.moon-shade {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		border-radius: var(--radius-full);
+	}
+
+	.celestial-logo img {
+		animation: celestial-breathe 10s ease-in-out infinite;
+	}
+
+	.celestial-logo.sun img {
+		filter:
+			sepia(1)
+			saturate(2.4)
+			hue-rotate(346deg)
+			brightness(1.4)
+			drop-shadow(0 0 18px rgba(255, 198, 82, 0.55))
+			drop-shadow(0 0 54px rgba(255, 145, 80, 0.28));
+	}
+
+	.celestial-logo.sun::before {
+		content: '';
+		position: absolute;
+		inset: -24%;
+		border-radius: var(--radius-full);
+		background: radial-gradient(circle, rgba(255, 202, 93, 0.22), transparent 66%);
+		animation: celestial-glow 12s ease-in-out infinite;
+	}
+
+	.celestial-logo.moon img {
+		filter:
+			grayscale(1)
+			brightness(1.85)
+			contrast(0.82)
+			drop-shadow(0 0 14px rgba(205, 222, 255, 0.38))
+			drop-shadow(0 0 42px rgba(138, 165, 220, 0.18));
+	}
+
+	.moon-shade {
+		background: radial-gradient(circle at var(--moon-shade-x) 48%, rgba(5, 8, 16, 0.78), rgba(5, 8, 16, 0.38) 43%, transparent 61%);
+		mix-blend-mode: multiply;
+		opacity: 0.62;
+	}
+
+	@keyframes celestial-breathe {
+		0%, 100% { transform: scale(1) rotate(0deg); }
+		50% { transform: scale(1.025) rotate(3deg); }
+	}
+
+	@keyframes celestial-glow {
+		0%, 100% { opacity: 0.65; transform: scale(1); }
+		50% { opacity: 1; transform: scale(1.08); }
 	}
 
 	@supports (min-height: 100dvh) {
@@ -762,6 +874,20 @@
 
 		.queue-toggle {
 			bottom: calc(var(--player-height, 0px) + 20px + env(safe-area-inset-bottom, 0px));
+		}
+
+		.celestial-logo {
+			width: min(var(--celestial-size), 108px);
+			height: min(var(--celestial-size), 108px);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.celestial-logo,
+		.celestial-logo img,
+		.celestial-logo.sun::before {
+			animation: none;
+			transition: opacity 0.2s ease;
 		}
 	}
 </style>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -26,6 +26,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 	let backgroundImageUrl = $derived(preferences.uiSettings.background_image_url ?? '');
 	let backgroundTile = $derived(preferences.uiSettings.background_tile ?? false);
 	let usePlayingArtwork = $derived(preferences.uiSettings.use_playing_artwork_as_background ?? false);
+	let liveLogoCelestialEnabled = $derived(preferences.uiSettings.live_logo_celestial_enabled ?? false);
 	let autoDownloadLiked = $derived(preferences.autoDownloadLiked);
 	// developer token state
 	let creatingToken = $state(false);
@@ -194,6 +195,11 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 	async function saveUsePlayingArtwork(enabled: boolean) {
 		await preferences.updateUiSettings({ use_playing_artwork_as_background: enabled });
 		toast.success(enabled ? 'playing artwork background enabled' : 'playing artwork background disabled');
+	}
+
+	async function saveLiveLogoCelestial(enabled: boolean) {
+		await preferences.updateUiSettings({ live_logo_celestial_enabled: enabled });
+		toast.success(enabled ? 'live sky logo enabled' : 'live sky logo disabled');
 	}
 
 	function selectTheme(theme: Theme) {
@@ -489,6 +495,21 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 						<span>{ambientError}</span>
 					</div>
 				{/if}
+
+				<div class="setting-row">
+					<div class="setting-info">
+						<h3>live sky logo</h3>
+						<p>use the plyr.fm mark as a sun or moon while live theme is active</p>
+					</div>
+					<label class="toggle-switch" title={currentTheme === 'live' ? ambientCondition ?? 'live sky logo' : 'enable live theme to see it'}>
+						<input
+							type="checkbox"
+							checked={liveLogoCelestialEnabled}
+							onchange={(e) => saveLiveLogoCelestial((e.target as HTMLInputElement).checked)}
+						/>
+						<span class="toggle-slider"></span>
+					</label>
+				</div>
 
 				<div class="setting-row">
 					<div class="setting-info">

--- a/loq.toml
+++ b/loq.toml
@@ -132,7 +132,7 @@ max_lines = 738
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"
-max_lines = 767
+max_lines = 893
 
 [[rules]]
 path = "frontend/src/routes/costs/+page.svelte"
@@ -273,3 +273,7 @@ max_lines = 668
 [[rules]]
 path = "frontend/src/routes/embed/track/[[]id[]]/+page.svelte"
 max_lines = 623
+
+[[rules]]
+path = "frontend/src/lib/ambient.svelte.ts"
+max_lines = 546


### PR DESCRIPTION
## What changed

- Adds a `live_logo_celestial_enabled` UI setting for the live theme.
- Renders the plyr.fm SVG mark as a subtle sun or moon layer only when live theme is active and the new setting is enabled.
- Extends the ambient live-theme manager with location/time-aware celestial positioning and moon phase styling.
- Uses `just loq-relax` for the files whose line counts increased.

## Why

The live theme already uses session location and current weather to tune the app. This builds on that by letting the logo become a quiet celestial object that reflects the listener's local day or night without touching auth/session storage or backend APIs.

## Validation

- `PUBLIC_API_URL=http://localhost:8001 just frontend check`
- commit hooks: loq, svelte check, eslint
