### PR TITLE
[codex] make live logo celestial inherent

### DIFF
--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -23,7 +23,6 @@ export interface UiSettings {
 	background_image_url?: string;
 	background_tile?: boolean;
 	use_playing_artwork_as_background?: boolean;
-	live_logo_celestial_enabled?: boolean;
 	pds_audio_uploads_enabled?: boolean;
 	font_family?: FontFamily;
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -52,7 +52,6 @@
 		!isEmbed &&
 		preferences.theme === 'live' &&
 		ambient.enabled &&
-		(preferences.uiSettings.live_logo_celestial_enabled ?? false) &&
 		celestial !== null
 	);
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -26,7 +26,6 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 	let backgroundImageUrl = $derived(preferences.uiSettings.background_image_url ?? '');
 	let backgroundTile = $derived(preferences.uiSettings.background_tile ?? false);
 	let usePlayingArtwork = $derived(preferences.uiSettings.use_playing_artwork_as_background ?? false);
-	let liveLogoCelestialEnabled = $derived(preferences.uiSettings.live_logo_celestial_enabled ?? false);
 	let autoDownloadLiked = $derived(preferences.autoDownloadLiked);
 	// developer token state
 	let creatingToken = $state(false);
@@ -195,11 +194,6 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 	async function saveUsePlayingArtwork(enabled: boolean) {
 		await preferences.updateUiSettings({ use_playing_artwork_as_background: enabled });
 		toast.success(enabled ? 'playing artwork background enabled' : 'playing artwork background disabled');
-	}
-
-	async function saveLiveLogoCelestial(enabled: boolean) {
-		await preferences.updateUiSettings({ live_logo_celestial_enabled: enabled });
-		toast.success(enabled ? 'live sky logo enabled' : 'live sky logo disabled');
 	}
 
 	function selectTheme(theme: Theme) {
@@ -495,21 +489,6 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 						<span>{ambientError}</span>
 					</div>
 				{/if}
-
-				<div class="setting-row">
-					<div class="setting-info">
-						<h3>live sky logo</h3>
-						<p>use the plyr.fm mark as a sun or moon while live theme is active</p>
-					</div>
-					<label class="toggle-switch" title={currentTheme === 'live' ? ambientCondition ?? 'live sky logo' : 'enable live theme to see it'}>
-						<input
-							type="checkbox"
-							checked={liveLogoCelestialEnabled}
-							onchange={(e) => saveLiveLogoCelestial((e.target as HTMLInputElement).checked)}
-						/>
-						<span class="toggle-slider"></span>
-					</label>
-				</div>
 
 				<div class="setting-row">
 					<div class="setting-info">


### PR DESCRIPTION
## What changed

- Removes the separate live sky logo setting from the settings page.
- Removes the persisted `live_logo_celestial_enabled` UI setting type.
- Makes the celestial logo layer an inherent part of live theme whenever ambient location/weather is active.

## Why

The logo sky should behave as an extension of live theme, not as a second opt-in preference. The only remaining gates are live theme, non-embed pages, and available ambient sky data.

## Validation

- `PUBLIC_API_URL=http://localhost:8001 just frontend check`
- commit hooks: loq, svelte check, eslint
