### PR TITLE
fix(font): comic sans now actually renders as comic sans on mobile

### DIFF
--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -14,7 +14,7 @@ export const FONT_OPTIONS: { value: FontFamily; label: string; stack: string }[]
 	{ value: 'geist', label: 'geist', stack: "'Geist', 'Inter', system-ui, sans-serif" },
 	{ value: 'inter', label: 'inter', stack: "'Inter', system-ui, sans-serif" },
 	{ value: 'system-ui', label: 'system', stack: "system-ui, -apple-system, 'Segoe UI', sans-serif" },
-	{ value: 'comic-sans', label: 'comic sans', stack: "'Comic Sans MS', 'Comic Sans', cursive" },
+	{ value: 'comic-sans', label: 'comic sans', stack: "'Comic Sans MS', 'Comic Sans', 'Comic Neue', cursive" },
 ];
 
 export const DEFAULT_FONT: FontFamily = 'georgia';

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -408,7 +408,7 @@
 	<meta name="theme-color" content="#0a0a0a" />
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-	<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..900&family=Inter:wght@300..900&display=swap" rel="stylesheet" />
+	<link href="https://fonts.googleapis.com/css2?family=Comic+Neue:wght@400;700&family=Geist:wght@300..900&family=Inter:wght@300..900&display=swap" rel="stylesheet" />
 
 	{#if !hasPageMetadata}
 		<!-- default meta tags for pages without specific metadata -->
@@ -466,7 +466,7 @@
 						'inter': "'Inter', system-ui, sans-serif",
 						'system-ui': "system-ui, -apple-system, 'Segoe UI', sans-serif",
 						'georgia': "'Georgia', 'Times New Roman', serif",
-						'comic-sans': "'Comic Sans MS', 'Comic Sans', cursive",
+						'comic-sans': "'Comic Sans MS', 'Comic Sans', 'Comic Neue', cursive",
 					};
 					if (fonts[savedFont]) root.style.setProperty('--font-family', fonts[savedFont]);
 				}


### PR DESCRIPTION
## Summary
- the \"comic sans\" font option was rendering as Snell Roundhand on iOS (and a generic system cursive on Android) because mobile OSes don't ship `Comic Sans MS` — the stack fell through to the generic `cursive` keyword
- desktop masked the bug: macOS/Windows usually have Comic Sans MS preinstalled, so the first stack entry resolved
- fix: add **Comic Neue** (free, open-source Comic Sans clone — already on Google Fonts) to the preload `<link>` and to the font stack as a pre-cursive fallback
- new stack: `'Comic Sans MS', 'Comic Sans', 'Comic Neue', cursive` — desktop with local Comic Sans MS keeps using the local font (no extra fetch), mobile gets Comic Neue, anything weirder still falls through to `cursive`
- updated in three places: `preferences.svelte.ts` (canonical FONT_OPTIONS), `+layout.svelte` flash-prevention inline script (must mirror), and the Google Fonts URL on the same file

## Test plan
- [ ] open settings on mobile, switch to comic sans, confirm renders as Comic Sans not script/cursive
- [ ] confirm desktop with Comic Sans MS installed still uses the local font (no Comic Neue request in devtools)
- [ ] confirm desktop without Comic Sans MS (e.g. linux) falls through to Comic Neue
- [ ] confirm no flash-of-wrong-font on first load after preference set

🤖 Generated with [Claude Code](https://claude.com/claude-code)