### PR TITLE
fix(jam): toast on deep-link join so users know they're in

### DIFF
--- a/frontend/src/routes/jam/[code]/+page.svelte
+++ b/frontend/src/routes/jam/[code]/+page.svelte
@@ -27,6 +27,8 @@
 		// authenticated — proceed with join
 		const result = await jam.join(data.code);
 		if (result === true) {
+			const hostName = data.preview?.host_display_name;
+			toast.success(hostName ? `joined ${hostName}'s jam` : 'joined jam');
 			goto('/');
 		} else {
 			error = result;


### PR DESCRIPTION
## Summary

- reported by @hipstersmoothie.com on bsky: deep-linked to a jam, signed in, ended up on the homepage with no signal that the join actually worked
- `frontend/src/routes/jam/[code]/+page.svelte` has no UI for authed users — just \`<p class=\"joining\">joining jam...</p>\` before \`goto('/')\` runs. the jam UI lives in the global queue panel which auto-opens on \`jam.active\`, but the transition can be easy to miss
- minimal fix: fire a \`toast.success\` naming the host so the join is acknowledged

## Investigation

logfire spans confirmed the intent-preservation cookie from #993 worked end-to-end (he reached \`/jam/0toyxh1w\`, joined, was bounced to home by the pre-existing \`goto('/')\` from #949). he then re-hit \`/jam/0toyxh1w\` twice more — most likely re-tapping the share link to retry, since the home landing didn't acknowledge the join.

## Test plan

- [ ] log out, click a \`/jam/[code]\` share link, sign in to join → toast reads \"joined {host}'s jam\" and queue is open on home
- [ ] reload from a non-jam page while in an active jam → no spurious toast (layout auto-rejoin doesn't route through this page)
- [ ] join a jam without a preview (cold link, preview fetch failed) → falls back to \"joined jam\"