### PR TITLE
[codex] remove live celestial logo

### DIFF
--- a/frontend/src/lib/ambient.svelte.ts
+++ b/frontend/src/lib/ambient.svelte.ts
@@ -23,15 +23,6 @@ interface AmbientLocation {
 	lon: number;
 }
 
-export interface CelestialState {
-	body: 'sun' | 'moon';
-	x: number;
-	y: number;
-	size: number;
-	opacity: number;
-	phase: number;
-}
-
 interface RGB {
 	r: number;
 	g: number;
@@ -61,74 +52,6 @@ const TINTED_VARS: [string, number][] = [
 	['--bg-tertiary', 0.07],
 	['--bg-hover', 0.08],
 ];
-
-const MS_PER_DAY = 86_400_000;
-const SYNODIC_MONTH_DAYS = 29.53058867;
-
-function toRadians(degrees: number): number {
-	return degrees * Math.PI / 180;
-}
-
-function toDegrees(radians: number): number {
-	return radians * 180 / Math.PI;
-}
-
-function clamp(min: number, max: number, value: number): number {
-	return Math.min(max, Math.max(min, value));
-}
-
-function getDayOfYear(date: Date): number {
-	const start = Date.UTC(date.getUTCFullYear(), 0, 0);
-	return Math.floor((date.getTime() - start) / MS_PER_DAY);
-}
-
-function getSolarTimeHours(date: Date, lon: number): number {
-	const day = getDayOfYear(date);
-	const utcHours = date.getUTCHours() + date.getUTCMinutes() / 60 + date.getUTCSeconds() / 3600;
-	const b = 2 * Math.PI * (day - 81) / 364;
-	const equationOfTimeMinutes = 9.87 * Math.sin(2 * b) - 7.53 * Math.cos(b) - 1.5 * Math.sin(b);
-	const hours = utcHours + lon / 15 + equationOfTimeMinutes / 60;
-	return ((hours % 24) + 24) % 24;
-}
-
-function getSolarAltitudeDegrees(date: Date, lat: number, lon: number): number {
-	const day = getDayOfYear(date);
-	const declination = toRadians(23.44 * Math.sin(2 * Math.PI * (day - 81) / 365));
-	const latitude = toRadians(lat);
-	const hourAngle = toRadians((getSolarTimeHours(date, lon) - 12) * 15);
-	const altitude = Math.asin(
-		Math.sin(latitude) * Math.sin(declination) +
-		Math.cos(latitude) * Math.cos(declination) * Math.cos(hourAngle)
-	);
-	return toDegrees(altitude);
-}
-
-function getMoonPhase(date: Date): number {
-	const knownNewMoon = Date.UTC(2000, 0, 6, 18, 14);
-	const daysSince = (date.getTime() - knownNewMoon) / MS_PER_DAY;
-	return ((daysSince / SYNODIC_MONTH_DAYS) % 1 + 1) % 1;
-}
-
-function computeCelestialState(location: AmbientLocation, weather: WeatherData, date: Date): CelestialState {
-	const solarHours = getSolarTimeHours(date, location.lon);
-	const solarAltitude = getSolarAltitudeDegrees(date, location.lat, location.lon);
-	const body = weather.is_day ? 'sun' : 'moon';
-	const phase = getMoonPhase(date);
-	const moonOffsetHours = phase * 24;
-	const bodyHours = body === 'sun' ? solarHours : (solarHours - moonOffsetHours + 24) % 24;
-	const hourAngle = ((bodyHours - 12) / 12);
-	const arcAltitude = body === 'sun'
-		? solarAltitude
-		: 56 * Math.cos(hourAngle * Math.PI) - 10;
-	const x = clamp(7, 93, 50 + hourAngle * 46);
-	const y = clamp(9, 46, 43 - ((arcAltitude + 8) / 82) * 34);
-	const size = clamp(74, 150, 86 + Math.max(0, arcAltitude) * 0.7);
-	const opacity = body === 'sun'
-		? clamp(0.22, 0.52, 0.26 + Math.max(0, solarAltitude) / 150)
-		: clamp(0.18, 0.38, 0.2 + Math.max(0, arcAltitude) / 260);
-
-	return { body, x, y, size, opacity, phase };
-}
 
 function getConditionLabel(code: number): string {
 	if (code <= 3) return 'clear';
@@ -295,11 +218,9 @@ class AmbientManager {
 	weather = $state<WeatherData | null>(null);
 	loading = $state(false);
 	error = $state<string | null>(null);
-	now = $state(new Date());
 	readonly temperatureUnit: TemperatureUnit = detectTemperatureUnit();
 
 	private fetchIntervalId: number | null = null;
-	private clockIntervalId: number | null = null;
 	private lastFetchTime = 0;
 	private readonly STALE_MS = 30 * 60 * 1000; // 30 minutes
 	private baseValues: Map<string, string> = new Map();
@@ -317,11 +238,6 @@ class AmbientManager {
 		const condition = getConditionLabel(w.weathercode);
 		const time = w.is_day ? 'day' : 'night';
 		return `${temp}°${unit} · ${condition} · ${time}`;
-	}
-
-	get celestial(): CelestialState | null {
-		if (!this.location || !this.weather) return null;
-		return computeCelestialState(this.location, this.weather, this.now);
 	}
 
 	/** activate ambient mode. returns false if geolocation denied or unavailable. */
@@ -400,10 +316,6 @@ class AmbientManager {
 		if (this.fetchIntervalId !== null) {
 			window.clearInterval(this.fetchIntervalId);
 			this.fetchIntervalId = null;
-		}
-		if (this.clockIntervalId !== null) {
-			window.clearInterval(this.clockIntervalId);
-			this.clockIntervalId = null;
 		}
 		document.removeEventListener('visibilitychange', this.handleVisibilityChange);
 
@@ -523,10 +435,6 @@ class AmbientManager {
 
 		// re-fetch every 30 minutes
 		this.fetchIntervalId = window.setInterval(() => this.fetchWeather(), this.STALE_MS);
-		this.now = new Date();
-		this.clockIntervalId = window.setInterval(() => {
-			this.now = new Date();
-		}, 60 * 1000);
 
 		// also re-fetch on tab re-focus if stale
 		if (browser) {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import logo from '$lib/assets/logo.png';
-	import logoMark from '$lib/assets/logo.svg';
 	import {
 		APP_NAME,
 		APP_TAGLINE,
@@ -20,7 +19,6 @@
 	import { auth } from '$lib/auth.svelte';
 	import { preferences } from '$lib/preferences.svelte';
 	import { ambient } from '$lib/ambient.svelte';
-	import type { CelestialState } from '$lib/ambient.svelte';
 	import { moderation } from '$lib/moderation.svelte';
 	import { player } from '$lib/player.svelte';
 	import { queue } from '$lib/queue.svelte';
@@ -47,23 +45,6 @@
 	);
 
 	let isEmbed = $derived($page.url.pathname.startsWith('/embed/'));
-	let celestial = $derived(ambient.celestial);
-	let showCelestialLogo = $derived(
-		!isEmbed &&
-		preferences.theme === 'live' &&
-		ambient.enabled &&
-		celestial !== null
-	);
-
-	function getCelestialStyle(state: CelestialState): string {
-		return [
-			`--celestial-x: ${state.x}%`,
-			`--celestial-y: ${state.y}%`,
-			`--celestial-size: ${state.size}px`,
-			`--celestial-opacity: ${state.opacity}`,
-			`--moon-shade-x: ${18 + state.phase * 64}%`
-		].join('; ');
-	}
 
 	// show terms overlay if authenticated and either never accepted or accepted before latest update
 	// exclude legal pages so users can read full terms/privacy/cookies
@@ -486,21 +467,6 @@
 	</script>
 </svelte:head>
 
-{#if showCelestialLogo && celestial}
-	<div
-		class="celestial-logo"
-		class:sun={celestial.body === 'sun'}
-		class:moon={celestial.body === 'moon'}
-		style={getCelestialStyle(celestial)}
-		aria-hidden="true"
-	>
-		<img src={logoMark} alt="" />
-		{#if celestial.body === 'moon'}
-			<span class="moon-shade"></span>
-		{/if}
-	</div>
-{/if}
-
 <div class="app-layout">
 	<main class="main-content" class:with-queue={showQueue && !isEmbed}>
 		{@render children?.()}
@@ -719,83 +685,6 @@
 		min-height: 100vh; /* fallback for browsers without dvh support */
 		width: 100%;
 		overflow-x: clip; /* clip instead of hidden to preserve position: sticky on descendants */
-		position: relative;
-		z-index: 1;
-	}
-
-	.celestial-logo {
-		position: fixed;
-		left: var(--celestial-x);
-		top: var(--celestial-y);
-		width: var(--celestial-size);
-		height: var(--celestial-size);
-		transform: translate(-50%, -50%);
-		opacity: var(--celestial-opacity);
-		pointer-events: none;
-		z-index: 0;
-		transition:
-			left 18s linear,
-			top 18s linear,
-			width 1.8s ease,
-			height 1.8s ease,
-			opacity 1.8s ease;
-	}
-
-	.celestial-logo img,
-	.moon-shade {
-		position: absolute;
-		inset: 0;
-		width: 100%;
-		height: 100%;
-		border-radius: var(--radius-full);
-	}
-
-	.celestial-logo img {
-		animation: celestial-breathe 10s ease-in-out infinite;
-	}
-
-	.celestial-logo.sun img {
-		filter:
-			sepia(1)
-			saturate(2.4)
-			hue-rotate(346deg)
-			brightness(1.4)
-			drop-shadow(0 0 18px rgba(255, 198, 82, 0.55))
-			drop-shadow(0 0 54px rgba(255, 145, 80, 0.28));
-	}
-
-	.celestial-logo.sun::before {
-		content: '';
-		position: absolute;
-		inset: -24%;
-		border-radius: var(--radius-full);
-		background: radial-gradient(circle, rgba(255, 202, 93, 0.22), transparent 66%);
-		animation: celestial-glow 12s ease-in-out infinite;
-	}
-
-	.celestial-logo.moon img {
-		filter:
-			grayscale(1)
-			brightness(1.85)
-			contrast(0.82)
-			drop-shadow(0 0 14px rgba(205, 222, 255, 0.38))
-			drop-shadow(0 0 42px rgba(138, 165, 220, 0.18));
-	}
-
-	.moon-shade {
-		background: radial-gradient(circle at var(--moon-shade-x) 48%, rgba(5, 8, 16, 0.78), rgba(5, 8, 16, 0.38) 43%, transparent 61%);
-		mix-blend-mode: multiply;
-		opacity: 0.62;
-	}
-
-	@keyframes celestial-breathe {
-		0%, 100% { transform: scale(1) rotate(0deg); }
-		50% { transform: scale(1.025) rotate(3deg); }
-	}
-
-	@keyframes celestial-glow {
-		0%, 100% { opacity: 0.65; transform: scale(1); }
-		50% { opacity: 1; transform: scale(1.08); }
 	}
 
 	@supports (min-height: 100dvh) {
@@ -875,18 +764,5 @@
 			bottom: calc(var(--player-height, 0px) + 20px + env(safe-area-inset-bottom, 0px));
 		}
 
-		.celestial-logo {
-			width: min(var(--celestial-size), 108px);
-			height: min(var(--celestial-size), 108px);
-		}
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.celestial-logo,
-		.celestial-logo img,
-		.celestial-logo.sun::before {
-			animation: none;
-			transition: opacity 0.2s ease;
-		}
 	}
 </style>

--- a/loq.toml
+++ b/loq.toml
@@ -132,7 +132,7 @@ max_lines = 738
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"
-max_lines = 893
+max_lines = 768
 
 [[rules]]
 path = "frontend/src/routes/costs/+page.svelte"
@@ -273,7 +273,3 @@ max_lines = 668
 [[rules]]
 path = "frontend/src/routes/embed/track/[[]id[]]/+page.svelte"
 max_lines = 623
-
-[[rules]]
-path = "frontend/src/lib/ambient.svelte.ts"
-max_lines = 546


### PR DESCRIPTION
## What changed

- Removes the live-theme celestial logo rendering from the root layout.
- Removes the sun/moon position and moon-phase calculations from the ambient theme store.
- Drops the line-count relaxation that was only needed by the removed ambient code, and reduces the layout line-count limit to the current file size via `just loq-relax`.

## Why

The logo-as-celestial-object experiment did not work well enough in staging and should be removed cleanly while keeping the rest of live theme intact.

## Validation

- `PUBLIC_API_URL=http://localhost:8001 just frontend check`
- commit hooks: loq, svelte check, eslint
