### PR TITLE
feat(tags): default-hide suno + use 'voice memo' tag for /record

### DIFF
--- a/backend/src/backend/utilities/tags.py
+++ b/backend/src/backend/utilities/tags.py
@@ -11,7 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 # tags that are hidden by default for new users
-DEFAULT_HIDDEN_TAGS: list[str] = ["ai", "ai-slop"]
+DEFAULT_HIDDEN_TAGS: list[str] = ["ai", "ai-slop", "suno"]
 
 # tag validation constraints
 MAX_TAG_LENGTH = 50

--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -47,7 +47,7 @@ const DEFAULT_PREFERENCES: Preferences = {
 	accent_color: null,
 	auto_advance: true,
 	allow_comments: true,
-	hidden_tags: ['ai', 'ai-slop'],
+	hidden_tags: ['ai', 'ai-slop', 'suno'],
 	theme: 'dark',
 	enable_teal_scrobbling: false,
 	teal_needs_reauth: false,

--- a/frontend/src/routes/record/+page.svelte
+++ b/frontend/src/routes/record/+page.svelte
@@ -194,7 +194,7 @@
 		const now = new Date();
 		const pad = (n: number) => String(n).padStart(2, '0');
 		title = `recording ${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}`;
-		tags = ['voice-memo'];
+		tags = ['voice memo'];
 		uiState = 'preview';
 	}
 


### PR DESCRIPTION
## Summary
- adds `suno` to `DEFAULT_HIDDEN_TAGS` (backend `utilities/tags.py` + frontend `preferences.svelte.ts`) so new users default to hiding it alongside `ai` / `ai-slop`
- `/record` now tags voice captures with `voice memo` (space, matches normalized form) instead of `voice-memo`

note: `DEFAULT_HIDDEN_TAGS` only applies to fresh preference rows — existing users keep whatever they already have. they can add `suno` manually from the tag filter UI.

## Test plan
- [ ] new account: tag filter shows `ai`, `ai-slop`, `suno` hidden by default
- [ ] existing account: hidden tags unchanged
- [ ] record a voice memo at `/record` → resulting track has `voice memo` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)