### PR TITLE
feat(playlists): private<->public visibility toggle

### DIFF
--- a/backend/src/backend/api/lists/playlists.py
+++ b/backend/src/backend/api/lists/playlists.py
@@ -152,22 +152,19 @@ async def _snapshot_pds_items(
     ]
 
 
-async def _make_playlist_public(session: AuthSession, playlist: Playlist) -> None:
-    """transition private → public.
+async def _publish_items_to_pds(
+    session: AuthSession, items: list[dict[str, str]], name: str
+) -> tuple[str, str]:
+    """write items as a new public ATProto list record on the user's PDS.
 
-    1. write items_json to a new ATProto list record on the user's PDS
-    2. update the row to reference the new record, clear items_json,
-       set is_private=false, and reset show_on_profile=false (visibility
-       changed; the user opts back in if they want it on their profile)
-
-    raises if the PDS write fails — the row stays private, no detritus.
+    returns ``(uri, cid)``. raises HTTPException(500) on PDS failure so
+    the caller can abort the transition without partial state.
     """
-    items = list(playlist.items_json or [])
     try:
-        uri, cid = await create_list_record(
+        return await create_list_record(
             auth_session=session,
             items=items,
-            name=playlist.name,
+            name=name,
             list_type="playlist",
         )
     except Exception as e:
@@ -175,42 +172,25 @@ async def _make_playlist_public(session: AuthSession, playlist: Playlist) -> Non
             status_code=500, detail=f"failed to publish playlist: {e}"
         ) from e
 
-    playlist.atproto_record_uri = uri
-    playlist.atproto_record_cid = cid
-    playlist.items_json = None
-    playlist.is_private = False
-    playlist.show_on_profile = False
-    playlist.track_count = len(items)
 
+async def _delete_pds_list_record_best_effort(
+    session: AuthSession, uri: str, playlist_id: str
+) -> None:
+    """log-and-continue delete of a public list record.
 
-async def _make_playlist_private(session: AuthSession, playlist: Playlist) -> None:
-    """transition public → private.
-
-    1. snapshot current PDS items into items_json (preserves ordering + cids)
-    2. flip the row to private and clear the PDS-record fields
-    3. best-effort delete the PDS record (logged-and-continue if it fails;
-       user-facing state is already correct, the public record is detritus)
+    used after flipping a playlist to private. the user-facing state is
+    already correct by the time we get here; the public record is
+    recoverable detritus, not a hard error.
     """
-    items = await _snapshot_pds_items(session, playlist)
-    public_uri = playlist.atproto_record_uri
-
-    playlist.items_json = items
-    playlist.is_private = True
-    playlist.atproto_record_uri = None
-    playlist.atproto_record_cid = None
-    playlist.show_on_profile = False
-    playlist.track_count = len(items)
-
-    if public_uri:
-        try:
-            await delete_record_by_uri(session, public_uri)
-        except Exception as e:
-            logger.warning(
-                "made playlist %s private but failed to delete PDS record %s: %s",
-                playlist.id,
-                public_uri,
-                e,
-            )
+    try:
+        await delete_record_by_uri(session, uri)
+    except Exception as e:
+        logger.warning(
+            "made playlist %s private but failed to delete PDS record %s: %s",
+            playlist_id,
+            uri,
+            e,
+        )
 
 
 async def _read_playlist_items(
@@ -838,12 +818,36 @@ async def update_playlist(
     _assert_can_mutate(session, playlist)
 
     # privacy transition runs first — it can reset show_on_profile, which
-    # the explicit show_on_profile arg below should then override if given
+    # the explicit show_on_profile arg below should then override if given.
+    # state assignment is done inline so the full transition is readable in
+    # one place; the helpers do only the I/O.
     if is_private is not None and is_private != playlist.is_private:
         if is_private:
-            await _make_playlist_private(session, playlist)
+            # public → private: snapshot PDS items, flip the row, then
+            # best-effort delete the now-orphan PDS record
+            items = await _snapshot_pds_items(session, playlist)
+            public_uri = playlist.atproto_record_uri
+            playlist.items_json = items
+            playlist.is_private = True
+            playlist.atproto_record_uri = None
+            playlist.atproto_record_cid = None
+            playlist.show_on_profile = False
+            playlist.track_count = len(items)
+            if public_uri:
+                await _delete_pds_list_record_best_effort(
+                    session, public_uri, playlist.id
+                )
         else:
-            await _make_playlist_public(session, playlist)
+            # private → public: write the items to a new PDS list record,
+            # then point the row at it and clear the local item store
+            items = list(playlist.items_json or [])
+            uri, cid = await _publish_items_to_pds(session, items, playlist.name)
+            playlist.atproto_record_uri = uri
+            playlist.atproto_record_cid = cid
+            playlist.items_json = None
+            playlist.is_private = False
+            playlist.show_on_profile = False
+            playlist.track_count = len(items)
 
     if show_on_profile is not None:
         playlist.show_on_profile = show_on_profile

--- a/backend/src/backend/api/lists/playlists.py
+++ b/backend/src/backend/api/lists/playlists.py
@@ -117,21 +117,19 @@ def _can_view(session_did: str | None, playlist: Playlist) -> bool:
 
 
 async def _snapshot_pds_items(
-    session: AuthSession, playlist: Playlist
+    session: AuthSession, atproto_record_uri: str
 ) -> list[dict[str, str]]:
-    """fetch the playlist's current items from the PDS list record as
-    `[{uri, cid}, ...]`. used when transitioning public → private to
-    preserve item ordering + cids in `items_json`.
-    """
-    if not playlist.atproto_record_uri:
-        return []
+    """fetch a list record's current items from the PDS as `[{uri, cid}, ...]`.
 
+    pure I/O — takes only what it needs. used when transitioning public →
+    private to preserve item ordering + cids before flipping local state.
+    """
     oauth_data = session.oauth_session
     if not oauth_data or "access_token" not in oauth_data:
         raise HTTPException(status_code=401, detail="invalid session")
 
     oauth_session = _reconstruct_oauth_session(oauth_data)
-    repo, collection, rkey = parse_at_uri(playlist.atproto_record_uri)
+    repo, collection, rkey = parse_at_uri(atproto_record_uri)
     url = f"{oauth_data['pds_url']}/xrpc/com.atproto.repo.getRecord"
     response = await get_oauth_client().make_authenticated_request(
         session=oauth_session,
@@ -817,15 +815,25 @@ async def update_playlist(
 
     _assert_can_mutate(session, playlist)
 
-    # privacy transition runs first — it can reset show_on_profile, which
-    # the explicit show_on_profile arg below should then override if given.
-    # state assignment is done inline so the full transition is readable in
-    # one place; the helpers do only the I/O.
+    # apply name first so a privacy transition that writes a PDS record
+    # uses the new name, avoiding a wasted second PDS write to rename
+    # immediately after publishing
+    name_changed = False
+    if name is not None and name.strip():
+        new_name = name.strip()
+        name_changed = new_name != playlist.name
+        playlist.name = new_name
+
+    # privacy transition — it can reset show_on_profile, which the explicit
+    # show_on_profile arg below should then override if given. state
+    # assignment is inline so the full transition is readable in one place;
+    # the helpers do only the I/O.
     if is_private is not None and is_private != playlist.is_private:
         if is_private:
             # public → private: snapshot PDS items, flip the row, then
             # best-effort delete the now-orphan PDS record
-            items = await _snapshot_pds_items(session, playlist)
+            assert playlist.atproto_record_uri is not None
+            items = await _snapshot_pds_items(session, playlist.atproto_record_uri)
             public_uri = playlist.atproto_record_uri
             playlist.items_json = items
             playlist.is_private = True
@@ -833,13 +841,13 @@ async def update_playlist(
             playlist.atproto_record_cid = None
             playlist.show_on_profile = False
             playlist.track_count = len(items)
-            if public_uri:
-                await _delete_pds_list_record_best_effort(
-                    session, public_uri, playlist.id
-                )
+            await _delete_pds_list_record_best_effort(session, public_uri, playlist.id)
+            # the name update path below would no-op anyway (private playlist
+            # has no PDS record to also rename), so nothing else to do
+            name_changed = False
         else:
-            # private → public: write the items to a new PDS list record,
-            # then point the row at it and clear the local item store
+            # private → public: write the items to a new PDS list record
+            # using the (possibly updated) name, then point the row at it
             items = list(playlist.items_json or [])
             uri, cid = await _publish_items_to_pds(session, items, playlist.name)
             playlist.atproto_record_uri = uri
@@ -848,14 +856,16 @@ async def update_playlist(
             playlist.is_private = False
             playlist.show_on_profile = False
             playlist.track_count = len(items)
+            # the name was baked into the PDS record we just created; no need
+            # for the rename path below to re-write it
+            name_changed = False
 
     if show_on_profile is not None:
         playlist.show_on_profile = show_on_profile
 
-    # update name if provided
-    if name is not None and name.strip():
-        playlist.name = name.strip()
-
+    # rename the PDS record only when the name changed AND we didn't just
+    # create/destroy the PDS record via a privacy transition
+    if name_changed:
         if not playlist.is_private and playlist.atproto_record_uri:
             # public playlists: also update the ATProto record's name field
             try:

--- a/backend/src/backend/api/lists/playlists.py
+++ b/backend/src/backend/api/lists/playlists.py
@@ -116,6 +116,103 @@ def _can_view(session_did: str | None, playlist: Playlist) -> bool:
     return not playlist.is_private or session_did == playlist.owner_did
 
 
+async def _snapshot_pds_items(
+    session: AuthSession, playlist: Playlist
+) -> list[dict[str, str]]:
+    """fetch the playlist's current items from the PDS list record as
+    `[{uri, cid}, ...]`. used when transitioning public → private to
+    preserve item ordering + cids in `items_json`.
+    """
+    if not playlist.atproto_record_uri:
+        return []
+
+    oauth_data = session.oauth_session
+    if not oauth_data or "access_token" not in oauth_data:
+        raise HTTPException(status_code=401, detail="invalid session")
+
+    oauth_session = _reconstruct_oauth_session(oauth_data)
+    repo, collection, rkey = parse_at_uri(playlist.atproto_record_uri)
+    url = f"{oauth_data['pds_url']}/xrpc/com.atproto.repo.getRecord"
+    response = await get_oauth_client().make_authenticated_request(
+        session=oauth_session,
+        method="GET",
+        url=url,
+        params={"repo": repo, "collection": collection, "rkey": rkey},
+    )
+    if response.status_code != 200:
+        raise HTTPException(
+            status_code=502, detail="failed to read playlist record from PDS"
+        )
+
+    items = response.json().get("value", {}).get("items", [])
+    return [
+        {"uri": item["subject"]["uri"], "cid": item["subject"]["cid"]}
+        for item in items
+        if item.get("subject", {}).get("uri")
+    ]
+
+
+async def _make_playlist_public(session: AuthSession, playlist: Playlist) -> None:
+    """transition private → public.
+
+    1. write items_json to a new ATProto list record on the user's PDS
+    2. update the row to reference the new record, clear items_json,
+       set is_private=false, and reset show_on_profile=false (visibility
+       changed; the user opts back in if they want it on their profile)
+
+    raises if the PDS write fails — the row stays private, no detritus.
+    """
+    items = list(playlist.items_json or [])
+    try:
+        uri, cid = await create_list_record(
+            auth_session=session,
+            items=items,
+            name=playlist.name,
+            list_type="playlist",
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"failed to publish playlist: {e}"
+        ) from e
+
+    playlist.atproto_record_uri = uri
+    playlist.atproto_record_cid = cid
+    playlist.items_json = None
+    playlist.is_private = False
+    playlist.show_on_profile = False
+    playlist.track_count = len(items)
+
+
+async def _make_playlist_private(session: AuthSession, playlist: Playlist) -> None:
+    """transition public → private.
+
+    1. snapshot current PDS items into items_json (preserves ordering + cids)
+    2. flip the row to private and clear the PDS-record fields
+    3. best-effort delete the PDS record (logged-and-continue if it fails;
+       user-facing state is already correct, the public record is detritus)
+    """
+    items = await _snapshot_pds_items(session, playlist)
+    public_uri = playlist.atproto_record_uri
+
+    playlist.items_json = items
+    playlist.is_private = True
+    playlist.atproto_record_uri = None
+    playlist.atproto_record_cid = None
+    playlist.show_on_profile = False
+    playlist.track_count = len(items)
+
+    if public_uri:
+        try:
+            await delete_record_by_uri(session, public_uri)
+        except Exception as e:
+            logger.warning(
+                "made playlist %s private but failed to delete PDS record %s: %s",
+                playlist.id,
+                public_uri,
+                e,
+            )
+
+
 async def _read_playlist_items(
     playlist: Playlist, artist: Artist
 ) -> list[dict[str, str]]:
@@ -712,14 +809,20 @@ async def update_playlist(
     playlist_id: str,
     name: Annotated[str | None, Form()] = None,
     show_on_profile: Annotated[bool | None, Form()] = None,
+    is_private: Annotated[bool | None, Form()] = None,
     session: AuthSession = Depends(require_auth),
     db: AsyncSession = Depends(get_db),
 ) -> PlaylistResponse:
-    """update playlist metadata (name, show_on_profile).
+    """update playlist metadata (name, show_on_profile, is_private).
 
     use POST /playlists/{id}/cover to update cover art separately.
+
+    toggling `is_private` runs a transition: private → public publishes
+    a new ATProto list record on the user's PDS; public → private
+    snapshots the PDS items into local storage and removes the PDS
+    record. show_on_profile resets to false on either transition so the
+    user opts back in for profile visibility after a privacy change.
     """
-    # verify playlist exists and belongs to the authenticated user
     result = await db.execute(
         select(Playlist, Artist)
         .join(Artist, Playlist.owner_did == Artist.did)
@@ -734,7 +837,14 @@ async def update_playlist(
 
     _assert_can_mutate(session, playlist)
 
-    # update show_on_profile if provided
+    # privacy transition runs first — it can reset show_on_profile, which
+    # the explicit show_on_profile arg below should then override if given
+    if is_private is not None and is_private != playlist.is_private:
+        if is_private:
+            await _make_playlist_private(session, playlist)
+        else:
+            await _make_playlist_public(session, playlist)
+
     if show_on_profile is not None:
         playlist.show_on_profile = show_on_profile
 

--- a/backend/tests/api/test_private_playlists.py
+++ b/backend/tests/api/test_private_playlists.py
@@ -461,3 +461,152 @@ async def test_private_playlist_not_in_activity_feed(
             assert collection.get("name") != "secret", (
                 "private playlist leaked into activity feed"
             )
+
+
+# ---------------------------------------------------------------------------
+# visibility toggle (private <-> public)
+# ---------------------------------------------------------------------------
+
+
+from unittest.mock import AsyncMock, patch  # noqa: E402
+
+
+async def test_make_private_playlist_public(
+    app_as_owner: FastAPI, db_session: AsyncSession, owner: Artist
+) -> None:
+    """private → public publishes a PDS list record and clears items_json."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app_as_owner), base_url="http://test"
+    ) as client:
+        playlist = await _create_private_playlist(client, "going public")
+        # seed an item so we exercise the items copy
+        await client.post(
+            f"/lists/playlists/{playlist['id']}/tracks",
+            json={"track_uri": "at://did:plc:x/c/r1", "track_cid": "bafy1"},
+        )
+
+        # also flip show_on_profile=true to verify the toggle resets it
+        await client.patch(
+            f"/lists/playlists/{playlist['id']}",
+            data={"show_on_profile": "true"},
+        )
+
+        with patch(
+            "backend.api.lists.playlists.create_list_record",
+            new_callable=AsyncMock,
+            return_value=("at://did:plc:owner/fm.plyr.list/abc123", "bafyrec"),
+        ) as mock_create:
+            resp = await client.patch(
+                f"/lists/playlists/{playlist['id']}",
+                data={"is_private": "false"},
+            )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["is_private"] is False
+    assert body["atproto_record_uri"] == "at://did:plc:owner/fm.plyr.list/abc123"
+    assert body["show_on_profile"] is False  # reset on transition
+
+    # the PDS write got the snapshotted items
+    mock_create.assert_awaited_once()
+    await_args = mock_create.await_args
+    assert await_args is not None
+    assert await_args.kwargs["items"] == [
+        {"uri": "at://did:plc:x/c/r1", "cid": "bafy1"}
+    ]
+    assert await_args.kwargs["name"] == "going public"
+
+    db_row = (
+        await db_session.execute(select(Playlist).where(Playlist.id == playlist["id"]))
+    ).scalar_one()
+    assert db_row.items_json is None
+    assert db_row.is_private is False
+
+
+async def test_make_public_playlist_private(
+    app_as_owner: FastAPI, db_session: AsyncSession, owner: Artist
+) -> None:
+    """public → private snapshots PDS items into items_json and best-effort
+    deletes the PDS record."""
+
+    # create a public playlist via direct DB insert (avoid mocking the
+    # public create path which involves the real OAuth client)
+    public = Playlist(
+        owner_did=owner.did,
+        name="going private",
+        atproto_record_uri="at://did:plc:owner/fm.plyr.list/pub1",
+        atproto_record_cid="bafypub1",
+        is_private=False,
+        show_on_profile=True,
+        track_count=2,
+    )
+    db_session.add(public)
+    await db_session.commit()
+    await db_session.refresh(public)
+
+    snapshot_items = [
+        {"uri": "at://did:plc:x/c/r1", "cid": "bafy1"},
+        {"uri": "at://did:plc:x/c/r2", "cid": "bafy2"},
+    ]
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_as_owner), base_url="http://test"
+    ) as client:
+        with (
+            patch(
+                "backend.api.lists.playlists._snapshot_pds_items",
+                new_callable=AsyncMock,
+                return_value=snapshot_items,
+            ),
+            patch(
+                "backend.api.lists.playlists.delete_record_by_uri",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            resp = await client.patch(
+                f"/lists/playlists/{public.id}",
+                data={"is_private": "true"},
+            )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["is_private"] is True
+    assert body["atproto_record_uri"] is None
+    assert body["show_on_profile"] is False
+
+    await db_session.refresh(public)
+    db_row = public
+    assert db_row.is_private is True
+    assert db_row.atproto_record_uri is None
+    assert db_row.atproto_record_cid is None
+    assert db_row.items_json == [
+        {"uri": "at://did:plc:x/c/r1", "cid": "bafy1"},
+        {"uri": "at://did:plc:x/c/r2", "cid": "bafy2"},
+    ]
+    assert db_row.track_count == 2
+
+    mock_delete.assert_awaited_once()
+
+
+async def test_visibility_unchanged_is_a_noop(
+    app_as_owner: FastAPI, owner: Artist
+) -> None:
+    """passing is_private equal to the current value doesn't trigger the
+    transition (no PDS calls, no show_on_profile reset)."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app_as_owner), base_url="http://test"
+    ) as client:
+        playlist = await _create_private_playlist(client, "stay private")
+
+        with patch(
+            "backend.api.lists.playlists.create_list_record",
+            new_callable=AsyncMock,
+        ) as mock_create:
+            resp = await client.patch(
+                f"/lists/playlists/{playlist['id']}",
+                data={"is_private": "true"},
+            )
+
+    assert resp.status_code == 200
+    assert resp.json()["is_private"] is True
+    mock_create.assert_not_awaited()

--- a/backend/tests/api/test_private_playlists.py
+++ b/backend/tests/api/test_private_playlists.py
@@ -588,6 +588,46 @@ async def test_make_public_playlist_private(
     mock_delete.assert_awaited_once()
 
 
+async def test_make_public_with_name_uses_new_name_in_one_pds_write(
+    app_as_owner: FastAPI, owner: Artist
+) -> None:
+    """when PATCH carries both name and is_private=false, the new PDS
+    record is created with the new name in a single write — no follow-up
+    rename round-trip."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app_as_owner), base_url="http://test"
+    ) as client:
+        playlist = await _create_private_playlist(client, "old name")
+
+        with (
+            patch(
+                "backend.api.lists.playlists.create_list_record",
+                new_callable=AsyncMock,
+                return_value=("at://did:plc:owner/fm.plyr.list/abc", "bafycid"),
+            ) as mock_create,
+            patch(
+                "backend.api.lists.playlists.update_list_record",
+                new_callable=AsyncMock,
+            ) as mock_update,
+        ):
+            resp = await client.patch(
+                f"/lists/playlists/{playlist['id']}",
+                data={"name": "new name", "is_private": "false"},
+            )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "new name"
+    assert body["is_private"] is False
+
+    # one write to publish, zero to rename
+    mock_create.assert_awaited_once()
+    create_args = mock_create.await_args
+    assert create_args is not None
+    assert create_args.kwargs["name"] == "new name"
+    mock_update.assert_not_awaited()
+
+
 async def test_visibility_unchanged_is_a_noop(
     app_as_owner: FastAPI, owner: Artist
 ) -> None:

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -266,8 +266,6 @@
 						<span class="visibility-sublabel">only you can see it</span>
 					</button>
 				</div>
-				<p class="visibility-note">can't be changed after creating.</p>
-
 				{#if error}
 					<p class="error">{error}</p>
 				{/if}
@@ -628,13 +626,6 @@
 		font-size: var(--text-xs);
 		color: var(--text-tertiary);
 		line-height: 1.3;
-	}
-
-	.visibility-note {
-		margin: 0.5rem 0 0 0;
-		font-size: var(--text-xs);
-		color: var(--text-muted);
-		line-height: 1.4;
 	}
 
 	.modal-footer {

--- a/frontend/src/routes/playlist/[id]/+page.svelte
+++ b/frontend/src/routes/playlist/[id]/+page.svelte
@@ -409,6 +409,13 @@
 		togglingVisibility = true;
 		const goingPrivate = !playlist.is_private;
 		try {
+			// flush any pending edit-mode changes (reorder, name edit) before
+			// the privacy transition so the publish/snapshot sees the latest
+			// state instead of silently dropping unsaved edits
+			if (isEditMode) {
+				await saveAllChanges();
+			}
+
 			const formData = new FormData();
 			formData.append("is_private", String(goingPrivate));
 			const response = await fetch(

--- a/frontend/src/routes/playlist/[id]/+page.svelte
+++ b/frontend/src/routes/playlist/[id]/+page.svelte
@@ -402,6 +402,49 @@
 		}
 	}
 
+	let showVisibilityConfirm = $state(false);
+	let togglingVisibility = $state(false);
+
+	async function toggleVisibility() {
+		togglingVisibility = true;
+		const goingPrivate = !playlist.is_private;
+		try {
+			const formData = new FormData();
+			formData.append("is_private", String(goingPrivate));
+			const response = await fetch(
+				`${API_URL}/lists/playlists/${playlist.id}`,
+				{
+					method: "PATCH",
+					credentials: "include",
+					body: formData,
+				},
+			);
+			if (!response.ok) {
+				const err = await response
+					.json()
+					.catch(() => ({ detail: "unknown error" }));
+				throw new Error(err.detail || "failed to change visibility");
+			}
+			const updated = await response.json();
+			playlist.is_private = updated.is_private;
+			playlist.atproto_record_uri = updated.atproto_record_uri;
+			playlist.show_on_profile = updated.show_on_profile;
+			editShowOnProfile = updated.show_on_profile;
+			toast.success(
+				goingPrivate
+					? "playlist is now private"
+					: "playlist is now public",
+			);
+			showVisibilityConfirm = false;
+		} catch (e) {
+			toast.error(
+				e instanceof Error ? e.message : "failed to change visibility",
+			);
+		} finally {
+			togglingVisibility = false;
+		}
+	}
+
 	function handleCoverSelect(event: Event) {
 		const input = event.target as HTMLInputElement;
 		const file = input.files?.[0];
@@ -841,6 +884,16 @@
 							/>
 							<span class="toggle-label">show on profile</span>
 						</label>
+					{/if}
+					{#if isEditMode && isOwner}
+						<button
+							type="button"
+							class="visibility-toggle-btn"
+							onclick={() => (showVisibilityConfirm = true)}
+							disabled={togglingVisibility}
+						>
+							{playlist.is_private ? "make public" : "make private"}
+						</button>
 					{/if}
 				</div>
 
@@ -1384,6 +1437,62 @@
 	</div>
 {/if}
 
+{#if showVisibilityConfirm}
+	<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+	<div
+		class="modal-overlay"
+		role="presentation"
+		onclick={() => (showVisibilityConfirm = false)}
+	>
+		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+		<div
+			class="modal"
+			role="alertdialog"
+			aria-modal="true"
+			aria-labelledby="visibility-confirm-title"
+			tabindex="-1"
+			onclick={(e) => e.stopPropagation()}
+		>
+			<div class="modal-header">
+				<h3 id="visibility-confirm-title">
+					{playlist.is_private ? "make this playlist public?" : "make this playlist private?"}
+				</h3>
+			</div>
+			<div class="modal-body">
+				<p>
+					{#if playlist.is_private}
+						"{playlist.name}" will be published to your PDS as a public list record. anyone with the link will be able to see it.
+					{:else}
+						"{playlist.name}" will be removed from your PDS and only you will be able to see it. it won't appear in search, on your profile, or in the activity feed.
+					{/if}
+				</p>
+			</div>
+			<div class="modal-footer">
+				<button
+					class="cancel-btn"
+					onclick={() => (showVisibilityConfirm = false)}
+					disabled={togglingVisibility}
+				>
+					cancel
+				</button>
+				<button
+					class="confirm-btn"
+					onclick={toggleVisibility}
+					disabled={togglingVisibility}
+				>
+					{#if togglingVisibility}
+						working...
+					{:else if playlist.is_private}
+						make public
+					{:else}
+						make private
+					{/if}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
 {#if showDeleteConfirm}
 	<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 	<div
@@ -1630,6 +1739,30 @@
 
 	.show-on-profile-toggle:hover .toggle-label {
 		color: var(--text-primary);
+	}
+
+	.visibility-toggle-btn {
+		display: inline-block;
+		margin-top: 0.75rem;
+		padding: 0.4rem 0.85rem;
+		background: transparent;
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-md);
+		font-family: inherit;
+		font-size: var(--text-sm);
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: border-color 0.15s, color 0.15s;
+	}
+
+	.visibility-toggle-btn:hover:not(:disabled) {
+		border-color: var(--accent);
+		color: var(--text-primary);
+	}
+
+	.visibility-toggle-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 
 	.icon-btn {

--- a/loq.toml
+++ b/loq.toml
@@ -252,7 +252,7 @@ max_lines = 574
 
 [[rules]]
 path = "backend/src/backend/api/lists/playlists.py"
-max_lines = 952
+max_lines = 1036
 
 [[rules]]
 path = "backend/src/backend/api/tracks/audio_replace.py"
@@ -273,3 +273,11 @@ max_lines = 668
 [[rules]]
 path = "frontend/src/routes/embed/track/[[]id[]]/+page.svelte"
 max_lines = 623
+
+[[rules]]
+path = "backend/tests/api/test_private_playlists.py"
+max_lines = 612
+
+[[rules]]
+path = "frontend/src/routes/playlist/[[]id[]]/+page.svelte"
+max_lines = 2577

--- a/loq.toml
+++ b/loq.toml
@@ -252,7 +252,7 @@ max_lines = 574
 
 [[rules]]
 path = "backend/src/backend/api/lists/playlists.py"
-max_lines = 1036
+max_lines = 1040
 
 [[rules]]
 path = "backend/src/backend/api/tracks/audio_replace.py"

--- a/loq.toml
+++ b/loq.toml
@@ -252,7 +252,7 @@ max_lines = 574
 
 [[rules]]
 path = "backend/src/backend/api/lists/playlists.py"
-max_lines = 1040
+max_lines = 1050
 
 [[rules]]
 path = "backend/src/backend/api/tracks/audio_replace.py"
@@ -276,8 +276,8 @@ max_lines = 623
 
 [[rules]]
 path = "backend/tests/api/test_private_playlists.py"
-max_lines = 612
+max_lines = 652
 
 [[rules]]
 path = "frontend/src/routes/playlist/[[]id[]]/+page.svelte"
-max_lines = 2577
+max_lines = 2584


### PR DESCRIPTION
## what it does

makes playlist visibility togglable after creation. private playlists become public (published to your PDS); public playlists become private (snapshotted into local storage, removed from your PDS). matches what every other playlist app does.

## what to feel

1. open a private playlist → click edit → "make public" → confirm dialog → playlist gets published, share button reappears, "show on profile" toggle becomes available
2. open a public playlist → click edit → "make private" → confirm dialog → playlist disappears from your profile, share button hides, type label becomes "private playlist"
3. the create modal no longer says "can't be changed after creating"

## backend

extends \`PATCH /lists/playlists/{id}\` with an \`is_private\` parameter. toggling runs a transition:

- **private → public**: writes \`items_json\` to a new ATProto list record on the user's PDS, updates the row, clears \`items_json\`, resets \`show_on_profile=false\`
- **public → private**: snapshots the current PDS items into \`items_json\` (preserving order + cids), flips the row to private, resets \`show_on_profile=false\`, best-effort deletes the PDS record

ordering rule: persist the new state first, update the row, then clean up the old state. failures during the new-state write abort the transition; failures during cleanup are logged and tolerated.

\`show_on_profile\` resets to false on either transition — visibility changed, the user opts back in if they want it surfaced on their profile.

## frontend

- drop "can't be changed after creating" from the create modal
- add a "make public" / "make private" button to the playlist detail page edit panel
- confirmation dialog explains what happens to the PDS record in each direction

## tests

- private → public: PDS write called with the snapshotted items; \`items_json\` cleared; \`show_on_profile\` reset; \`is_private=false\`
- public → private: \`items_json\` populated from the PDS snapshot; PDS delete called; row flipped private
- visibility-unchanged is a no-op (no PDS calls, no field resets)