### PR TITLE
fix(uploads): stream audio end-to-end so worker doesn't OOM on long-form audio

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,7 +28,10 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
-    timeout-minutes: 15
+    # 30 min accommodates the long-form regression test (a ~150 MB 60 min
+    # WAV upload + transcode + PDS upload + scanners). short-form tests
+    # finish in seconds; the cap is sized for the worst case.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/backend/src/backend/_internal/atproto/client.py
+++ b/backend/src/backend/_internal/atproto/client.py
@@ -10,6 +10,7 @@ import httpcore
 import httpx
 from atproto import AtUri
 from atproto_oauth.models import OAuthSession
+from atproto_oauth.security import is_safe_url
 from cachetools import LRUCache
 
 from backend._internal import Session as AuthSession
@@ -363,7 +364,15 @@ async def _signed_streaming_post(
     retry submits an empty body. for streaming uploads we must call the
     factory anew per attempt, so this helper reimplements just the DPoP
     signing + nonce-retry shape.
+
+    `is_safe_url` is mirrored from `make_authenticated_request` so that
+    PDS URLs from session storage cannot be redirected to a private
+    address by a malicious or malformed session record before we stream
+    user audio bytes to them.
     """
+    if not is_safe_url(url):
+        raise ValueError(f"Unsafe URL: {url}")
+
     client_obj = get_oauth_client()
     # OAuthClient does not expose its DPoP helper on the public surface, but
     # the alternative is reimplementing DPoP proof creation here. an upstream

--- a/backend/src/backend/_internal/atproto/client.py
+++ b/backend/src/backend/_internal/atproto/client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from collections.abc import AsyncIterable, Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any, BinaryIO
 
@@ -17,6 +18,12 @@ from backend._internal.auth import (
     get_client_auth_method,
     get_refresh_token_lifetime_days,
 )
+
+# factory that produces a fresh async iterator over the request body. used
+# for streaming uploads where the body must be re-emitted on retry (DPoP
+# nonce mismatch, transient network error). the factory is what the caller
+# hands us; we never store an iterator ourselves.
+StreamBodyFactory = Callable[[], AsyncIterable[bytes]]
 
 logger = logging.getLogger(__name__)
 
@@ -342,26 +349,87 @@ async def make_pds_request(
     )
 
 
+async def _signed_streaming_post(
+    oauth_session: OAuthSession,
+    url: str,
+    body_factory: StreamBodyFactory,
+    headers: dict[str, str],
+) -> httpx.Response:
+    """POST a streaming body to a DPoP-protected URL with nonce retry.
+
+    upstream `OAuthClient.make_authenticated_request` retries internally on
+    a DPoP nonce mismatch but reuses the same `kwargs` dict — which means
+    an async-iterator body gets exhausted on the first attempt and the
+    retry submits an empty body. for streaming uploads we must call the
+    factory anew per attempt, so this helper reimplements just the DPoP
+    signing + nonce-retry shape.
+    """
+    client_obj = get_oauth_client()
+    # OAuthClient does not expose its DPoP helper on the public surface, but
+    # the alternative is reimplementing DPoP proof creation here. an upstream
+    # contribution to make `make_authenticated_request` body-factory-aware
+    # is the right durable fix; until that lands, borrow `_dpop`.
+    dpop = client_obj._dpop
+    response: httpx.Response | None = None
+    for attempt in range(2):
+        proof = dpop.create_proof(
+            method="POST",
+            url=url,
+            private_key=oauth_session.dpop_private_key,
+            nonce=oauth_session.dpop_pds_nonce,
+            access_token=oauth_session.access_token,
+        )
+        request_headers = dict(headers)
+        request_headers["Authorization"] = f"DPoP {oauth_session.access_token}"
+        request_headers["DPoP"] = proof
+        async with httpx.AsyncClient(timeout=httpx.Timeout(None)) as http:
+            response = await http.post(
+                url, headers=request_headers, content=body_factory()
+            )
+        if dpop.is_dpop_nonce_error(response):
+            new_nonce = dpop.extract_nonce_from_response(response)
+            if new_nonce and attempt == 0:
+                oauth_session.dpop_pds_nonce = new_nonce
+                await client_obj.session_store.save_session(oauth_session)
+                continue
+        return response
+    assert response is not None
+    return response
+
+
 async def upload_blob(
     auth_session: AuthSession,
-    data: bytes | BinaryIO,
+    *,
+    data: bytes | BinaryIO | None = None,
+    body_factory: StreamBodyFactory | None = None,
+    content_length: int | None = None,
     content_type: str,
 ) -> BlobRef:
     """upload a blob to the user's PDS.
 
-    args:
-        auth_session: authenticated user session
-        data: binary data or file-like object to upload
-        content_type: MIME type (e.g., audio/mpeg, audio/wav)
+    callers must pick exactly one of two body shapes:
+
+    - `data`: in-memory bytes or a sync file-like object. correct for
+      small blobs (track artwork, profile avatars) where buffering is cheap.
+    - `body_factory` + `content_length`: a callable returning a fresh async
+      iterator of chunks plus the total byte length. correct for any audio
+      blob; never buffers the body in worker memory. the factory is invoked
+      per attempt so retries (DPoP nonce, transient network) get a fresh
+      stream.
 
     returns:
         blob reference dict: {"$type": "blob", "ref": {"$link": CID}, "mimeType": str, "size": int}
 
     raises:
         PayloadTooLargeError: if PDS rejects due to size limit (413)
-        ValueError: if session is invalid
+        ValueError: if session is invalid or args are inconsistent
         Exception: if upload fails after retry
     """
+    if (data is None) == (body_factory is None):
+        raise ValueError("upload_blob requires exactly one of data or body_factory")
+    if body_factory is not None and content_length is None:
+        raise ValueError("body_factory requires content_length")
+
     oauth_data = auth_session.oauth_session
     if not oauth_data or "access_token" not in oauth_data:
         raise ValueError(
@@ -371,21 +439,37 @@ async def upload_blob(
     oauth_session = reconstruct_oauth_session(oauth_data)
     url = f"{oauth_data['pds_url']}/xrpc/com.atproto.repo.uploadBlob"
 
-    # read data if it's a file-like object
-    blob_data = data if isinstance(data, bytes) else data.read()
+    # buffered branch: existing small-blob callers pass `data`; we keep the
+    # bytes/file-like handling so artwork uploads continue to work unchanged.
+    blob_data: bytes | None = None
+    if body_factory is None:
+        assert data is not None
+        blob_data = data if isinstance(data, bytes) else data.read()
 
-    response = None  # defensive: bind before the loop
+    response: httpx.Response | None = None
     has_refreshed = False
 
     for attempt in range(_PDS_MAX_ATTEMPTS):
         try:
-            response = await get_oauth_client().make_authenticated_request(
-                session=oauth_session,
-                method="POST",
-                url=url,
-                content=blob_data,
-                headers={"Content-Type": content_type},
-            )
+            if body_factory is not None:
+                assert content_length is not None
+                response = await _signed_streaming_post(
+                    oauth_session,
+                    url,
+                    body_factory,
+                    headers={
+                        "Content-Type": content_type,
+                        "Content-Length": str(content_length),
+                    },
+                )
+            else:
+                response = await get_oauth_client().make_authenticated_request(
+                    session=oauth_session,
+                    method="POST",
+                    url=url,
+                    content=blob_data,
+                    headers={"Content-Type": content_type},
+                )
         except _TRANSIENT_HTTP_ERRORS as e:
             if attempt < _PDS_MAX_ATTEMPTS - 1:
                 backoff = _backoff_for_attempt(attempt)

--- a/backend/src/backend/_internal/clients/clap.py
+++ b/backend/src/backend/_internal/clients/clap.py
@@ -4,7 +4,6 @@ client for generating audio and text embeddings via Modal-hosted CLAP model.
 used for semantic vibe search (text-to-audio matching).
 """
 
-import base64
 import logging
 from dataclasses import dataclass
 from typing import Self
@@ -35,7 +34,7 @@ class ClapClient:
 
     usage:
         client = ClapClient.from_settings()
-        result = await client.embed_audio(audio_bytes)
+        result = await client.embed_audio(audio_url)
         result = await client.embed_text("dark ambient techno")
     """
 
@@ -61,27 +60,26 @@ class ClapClient:
             text_timeout_seconds=settings.modal.text_timeout_seconds,
         )
 
-    async def embed_audio(self, audio_bytes: bytes) -> EmbeddingResult:
-        """generate an embedding from audio bytes.
+    async def embed_audio(self, audio_url: str) -> EmbeddingResult:
+        """generate an embedding from a publicly fetchable audio URL.
+
+        the Modal endpoint pulls a Range-limited slice of `audio_url`
+        itself (only the first ~30 s are needed for CLAP), so the worker
+        never has to download or buffer the audio.
 
         args:
-            audio_bytes: raw audio file bytes
+            audio_url: public URL of the audio file (e.g. R2 CDN URL)
 
         returns:
             EmbeddingResult with 512-dim embedding or error
         """
-        b64_audio = base64.b64encode(audio_bytes).decode("utf-8")
-
-        logfire.info(
-            "requesting audio embedding",
-            audio_size_kb=len(audio_bytes) / 1024,
-        )
+        logfire.info("requesting audio embedding", audio_url=audio_url)
 
         try:
             async with httpx.AsyncClient(timeout=self.audio_timeout) as client:
                 response = await client.post(
                     self.embed_audio_url,
-                    json={"audio_b64": b64_audio},
+                    json={"audio_url": audio_url},
                 )
                 response.raise_for_status()
 

--- a/backend/src/backend/_internal/clients/transcoder.py
+++ b/backend/src/backend/_internal/clients/transcoder.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Self
 
+import aiofiles
 import httpx
 import logfire
 
@@ -21,10 +22,16 @@ MB = 1024 * 1024  # bytes per megabyte
 
 @dataclass
 class TranscodeResult:
-    """result from a transcode operation."""
+    """result from a transcode operation.
+
+    on success the transcoded bytes live at `output_path` on the worker's
+    local disk, not in memory. callers stream from that path to R2 / PDS
+    and unlink the file when done.
+    """
 
     success: bool
-    data: bytes | None
+    output_path: Path | None
+    output_size: int | None
     content_type: str | None
     error: str | None = None
 
@@ -70,19 +77,25 @@ class TranscoderClient:
         self,
         file_path: str | Path,
         source_format: str,
+        output_path: str | Path,
         target_format: str | None = None,
     ) -> TranscodeResult:
         """transcode audio file to a web-playable format.
 
-        streams the file to the transcoder service without loading into memory.
+        the source is streamed to the transcoder service via an httpx
+        multipart upload (file handle, no in-memory buffer). the response
+        body is streamed back to `output_path` chunk-by-chunk via aiofiles
+        — at no point does the worker hold the full transcoded audio in
+        memory. callers must arrange to unlink `output_path` when done.
 
         args:
             file_path: path to audio file on disk
             source_format: source format (e.g., "aiff", "flac")
+            output_path: where to write the transcoded result on local disk
             target_format: target format (defaults to settings.transcoder.target_format)
 
         returns:
-            TranscodeResult with transcoded bytes or error
+            TranscodeResult pointing at `output_path` on success.
 
         note:
             this operation can take 5-30+ seconds depending on file size.
@@ -90,6 +103,7 @@ class TranscoderClient:
         """
         target = target_format or self.target_format
         file_path = Path(file_path)
+        output_path = Path(output_path)
         filename = file_path.name
         file_size = os.path.getsize(file_path)
 
@@ -102,37 +116,47 @@ class TranscoderClient:
         )
 
         try:
-            # stream file to transcoder without loading into memory
             with open(file_path, "rb") as f:
-                async with httpx.AsyncClient(timeout=self.timeout) as client:
-                    response = await client.post(
+                async with (
+                    httpx.AsyncClient(timeout=self.timeout) as client,
+                    client.stream(
+                        "POST",
                         f"{self.service_url}/transcode",
                         files={"file": (filename, f, f"audio/{source_format}")},
                         params={"target": target},
                         headers=self._headers(),
-                    )
+                    ) as response,
+                ):
                     response.raise_for_status()
+                    content_type = response.headers.get("content-type")
+                    bytes_written = 0
+                    async with aiofiles.open(output_path, "wb") as out:
+                        async for chunk in response.aiter_bytes():
+                            await out.write(chunk)
+                            bytes_written += len(chunk)
 
-                    logfire.info(
-                        "transcode completed",
-                        filename=filename,
-                        source_format=source_format,
-                        target_format=target,
-                        input_size_mb=file_size / MB,
-                        output_size_mb=len(response.content) / MB,
-                    )
+                logfire.info(
+                    "transcode completed",
+                    filename=filename,
+                    source_format=source_format,
+                    target_format=target,
+                    input_size_mb=file_size / MB,
+                    output_size_mb=bytes_written / MB,
+                )
 
-                    return TranscodeResult(
-                        success=True,
-                        data=response.content,
-                        content_type=response.headers.get("content-type"),
-                    )
+                return TranscodeResult(
+                    success=True,
+                    output_path=output_path,
+                    output_size=bytes_written,
+                    content_type=content_type,
+                )
 
         except httpx.TimeoutException as e:
             logger.error("transcode timed out for %s: %s", filename, e)
             return TranscodeResult(
                 success=False,
-                data=None,
+                output_path=None,
+                output_size=None,
                 content_type=None,
                 error=f"transcode timed out after {self.timeout.read}s",
             )
@@ -147,7 +171,8 @@ class TranscoderClient:
             )
             return TranscodeResult(
                 success=False,
-                data=None,
+                output_path=None,
+                output_size=None,
                 content_type=None,
                 error=f"transcode service returned {e.response.status_code}: {error_body}",
             )
@@ -156,7 +181,8 @@ class TranscoderClient:
             logger.exception("unexpected error during transcode for %s", filename)
             return TranscodeResult(
                 success=False,
-                data=None,
+                output_path=None,
+                output_size=None,
                 content_type=None,
                 error=f"unexpected error: {e}",
             )

--- a/backend/src/backend/_internal/pds_backfill_tasks.py
+++ b/backend/src/backend/_internal/pds_backfill_tasks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import AsyncIterable
 
 import logfire
 from sqlalchemy import select
@@ -180,16 +181,25 @@ async def backfill_tracks_to_pds(
                     failed_count += 1
                     return
 
-                audio_data = await storage.get_file_data(
+                content_length = await storage.head_file(
                     track_data["file_id"],
                     track_data["file_type"],
                 )
-                if not audio_data:
+                if content_length is None:
                     failed_count += 1
                     return
 
+                track_file_id = track_data["file_id"]
+                track_file_type = track_data["file_type"]
+
+                def body_factory() -> AsyncIterable[bytes]:
+                    return storage.stream_file_data(track_file_id, track_file_type)
+
                 blob_ref = await upload_blob(
-                    auth_session, audio_data, audio_format.media_type
+                    auth_session,
+                    body_factory=body_factory,
+                    content_length=content_length,
+                    content_type=audio_format.media_type,
                 )
                 blob_cid = blob_ref.get("ref", {}).get("$link")
                 blob_size = blob_ref.get("size")

--- a/backend/src/backend/_internal/tasks/ml.py
+++ b/backend/src/backend/_internal/tasks/ml.py
@@ -2,7 +2,6 @@
 
 import logging
 
-import httpx
 import logfire
 from sqlalchemy import select
 
@@ -50,15 +49,10 @@ async def generate_embedding(track_id: int, audio_url: str) -> None:
             )
             return
 
-    # download audio from R2
-    async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
-        resp = await client.get(audio_url)
-        resp.raise_for_status()
-        audio_bytes = resp.content
-
-    # generate embedding via CLAP
+    # the Modal CLAP endpoint pulls a small Range slice of `audio_url`
+    # itself, so the worker never downloads or buffers the file.
     clap_client = get_clap_client()
-    embed_result = await clap_client.embed_audio(audio_bytes)
+    embed_result = await clap_client.embed_audio(audio_url)
 
     if not embed_result.success or not embed_result.embedding:
         logger.error(

--- a/backend/src/backend/api/tracks/mutations.py
+++ b/backend/src/backend/api/tracks/mutations.py
@@ -3,6 +3,7 @@
 import contextlib
 import json
 import logging
+from collections.abc import AsyncIterable
 from typing import Annotated
 from urllib.parse import urljoin
 
@@ -684,21 +685,6 @@ async def migrate_track_to_pds(
             detail="supporter-gated tracks cannot be migrated to PDS",
         )
 
-    # get the audio file from R2
-    try:
-        audio_data = await storage.get_file_data(track.file_id, track.file_type)
-        if not audio_data:
-            raise HTTPException(
-                status_code=404,
-                detail="audio file not found in storage",
-            )
-    except Exception as e:
-        logger.error(f"failed to fetch audio for track {track_id}: {e}", exc_info=True)
-        raise HTTPException(
-            status_code=500,
-            detail=f"failed to fetch audio file: {e}",
-        ) from e
-
     # determine content type from file type
     audio_format = AudioFormat.from_extension(track.file_type)
     if not audio_format:
@@ -708,9 +694,36 @@ async def migrate_track_to_pds(
         )
     content_type = audio_format.media_type
 
+    # confirm the audio object exists and capture its size for Content-Length;
+    # the body itself is streamed from R2 to the PDS, never buffered here.
+    try:
+        content_length = await storage.head_file(track.file_id, track.file_type)
+    except Exception as e:
+        logger.error(f"failed to head audio for track {track_id}: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=f"failed to fetch audio file: {e}",
+        ) from e
+    if content_length is None:
+        raise HTTPException(
+            status_code=404,
+            detail="audio file not found in storage",
+        )
+
+    file_id = track.file_id
+    file_type = track.file_type
+
+    def body_factory() -> AsyncIterable[bytes]:
+        return storage.stream_file_data(file_id, file_type)
+
     # upload blob to PDS
     try:
-        blob_ref = await upload_blob(auth_session, audio_data, content_type)
+        blob_ref = await upload_blob(
+            auth_session,
+            body_factory=body_factory,
+            content_length=content_length,
+            content_type=content_type,
+        )
         blob_cid = blob_ref.get("ref", {}).get("$link")
         blob_size = blob_ref.get("size")
 

--- a/backend/src/backend/api/tracks/revisions.py
+++ b/backend/src/backend/api/tracks/revisions.py
@@ -16,6 +16,7 @@ ungate, restore, then re-gate manually if needed.
 """
 
 import logging
+from collections.abc import AsyncIterable
 from datetime import datetime
 from typing import Annotated
 from urllib.parse import urljoin
@@ -258,12 +259,23 @@ async def restore_track_revision(
             )
             reupload_blob_ref: dict | None = None
             try:
-                audio_data = await storage.get_file_data(
+                content_length = await storage.head_file(
                     revision.file_id, revision.file_type
                 )
-                if audio_data:
+                if content_length is not None:
+                    revision_file_id = revision.file_id
+                    revision_file_type = revision.file_type
+
+                    def body_factory() -> AsyncIterable[bytes]:
+                        return storage.stream_file_data(
+                            revision_file_id, revision_file_type
+                        )
+
                     reupload_blob_ref = await upload_blob(
-                        auth_session, audio_data, content_type
+                        auth_session,
+                        body_factory=body_factory,
+                        content_length=content_length,
+                        content_type=content_type,
                     )
             except PayloadTooLargeError:
                 logfire.info(

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -5,11 +5,13 @@ import contextlib
 import json
 import logging
 import tempfile
+from collections.abc import AsyncIterable, Callable
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
 from typing import Annotated, Any, BinaryIO
 
+import aiofiles
 import logfire
 from docket import ConcurrencyLimit
 from fastapi import (
@@ -241,13 +243,18 @@ async def stage_image_to_storage(
 
 @dataclass
 class TranscodeInfo:
-    """result of transcoding an audio file."""
+    """result of transcoding an audio file.
+
+    both `original_file_id` (lossless source) and `transcoded_file_id`
+    (web-playable result) point at R2 objects. callers that need the
+    bytes (PDS upload, scanners) read them by streaming from R2 — the
+    worker never holds the full audio in memory.
+    """
 
     original_file_id: str
     original_file_type: str
     transcoded_file_id: str
     transcoded_file_type: str
-    transcoded_data: bytes
 
 
 @dataclass
@@ -263,19 +270,21 @@ class PdsBlobResult:
 async def _try_upload_to_pds(
     upload_id: str,
     auth_session: AuthSession,
-    file_data: bytes,
+    body_factory: Callable[[], AsyncIterable[bytes]],
+    content_length: int,
     content_type: str,
 ) -> PdsBlobResult:
     """attempt to upload audio blob to user's PDS.
 
-    this is a best-effort operation - if it fails due to size limits or other
-    errors, we fall back to R2-only storage. the canonical audio data lives on
-    the PDS when possible (embracing ATProto's data ownership ideals).
+    best-effort: on size or transient errors we fall back to R2-only.
 
     args:
         upload_id: job tracking ID
         auth_session: authenticated user session
-        file_data: audio file bytes (should match content_type)
+        body_factory: zero-arg callable returning a fresh async iterator of
+            audio bytes; called once per request attempt so retries get a
+            fresh stream
+        content_length: total byte size for the Content-Length header
         content_type: MIME type (e.g., audio/mpeg)
 
     returns:
@@ -290,7 +299,12 @@ async def _try_upload_to_pds(
     )
 
     try:
-        blob_ref = await upload_blob(auth_session, file_data, content_type)
+        blob_ref = await upload_blob(
+            auth_session,
+            body_factory=body_factory,
+            content_length=content_length,
+            content_type=content_type,
+        )
 
         # extract CID from blob ref: {"ref": {"$link": "<CID>"}, ...}
         cid = blob_ref.get("ref", {}).get("$link")
@@ -379,53 +393,70 @@ async def _transcode_audio(
         )
         return None
 
-    # fetch the lossless source bytes from storage
-    source_data = await storage.get_file_data(original_file_id, source_format)
-    if not source_data:
-        logfire.error(
-            "transcode aborted: source file missing from storage",
-            file_id=original_file_id,
-            format=source_format,
-        )
-        await job_service.update_progress(
-            upload_id,
-            JobStatus.FAILED,
-            "upload failed",
-            error="staged audio file missing from storage",
-        )
-        return None
-
-    logfire.info(
-        "loaded source bytes for transcode",
-        file_id=original_file_id,
-        format=source_format,
-        size_bytes=len(source_data),
-    )
-
-    # transcode to web-playable format. the transcoder client streams from a
-    # file path; spool the bytes to a worker-local temp file. this temp file
-    # is created and deleted entirely on this worker — it never crosses the
-    # request → worker boundary, so the multi-machine fly setup is fine.
-    await job_service.update_progress(
-        upload_id,
-        JobStatus.PROCESSING,
-        "transcoding audio...",
-        phase="transcode",
-        progress_pct=0.0,
-    )
-
-    spool_path: str | None = None
+    # we work entirely against worker-local temp files: the lossless source
+    # is streamed from R2 to `source_path`, ffmpeg runs in the transcoder
+    # service against that file, and the response body is streamed to
+    # `output_path`. these temp files exist only on this worker and are
+    # unlinked in the `finally` below — they never cross the request →
+    # worker boundary, which is fine on a multi-machine fly setup.
+    target_format = settings.transcoder.target_format
+    source_path: str | None = None
+    output_path: str | None = None
     try:
         with tempfile.NamedTemporaryFile(
             delete=False, suffix=f".{source_format}"
-        ) as spool:
-            spool_path = spool.name
-            spool.write(source_data)
+        ) as source_tmp:
+            source_path = source_tmp.name
+        with tempfile.NamedTemporaryFile(
+            delete=False, suffix=f".{target_format}"
+        ) as output_tmp:
+            output_path = output_tmp.name
+
+        # stream the lossless source from R2 to local disk in chunks; nothing
+        # is held in memory beyond a single chunk at a time.
+        bytes_streamed = 0
+        async with aiofiles.open(source_path, "wb") as source_file:
+            async for chunk in storage.stream_file_data(
+                original_file_id, source_format
+            ):
+                await source_file.write(chunk)
+                bytes_streamed += len(chunk)
+
+        if bytes_streamed == 0:
+            logfire.error(
+                "transcode aborted: source file missing from storage",
+                file_id=original_file_id,
+                format=source_format,
+            )
+            await job_service.update_progress(
+                upload_id,
+                JobStatus.FAILED,
+                "upload failed",
+                error="staged audio file missing from storage",
+            )
+            return None
+
+        logfire.info(
+            "streamed source to local disk for transcode",
+            file_id=original_file_id,
+            format=source_format,
+            size_bytes=bytes_streamed,
+        )
+
+        await job_service.update_progress(
+            upload_id,
+            JobStatus.PROCESSING,
+            "transcoding audio...",
+            phase="transcode",
+            progress_pct=0.0,
+        )
 
         client = get_transcoder_client()
-        result = await client.transcode_file(spool_path, source_format)
+        result = await client.transcode_file(
+            source_path, source_format, output_path=output_path
+        )
 
-        if not result.success or not result.data:
+        if not result.success or not result.output_path:
             await job_service.update_progress(
                 upload_id,
                 JobStatus.FAILED,
@@ -434,6 +465,18 @@ async def _transcode_audio(
             )
             return None
 
+        transcoded_filename = Path(filename).stem + f".{target_format}"
+        async with R2ProgressTracker(
+            job_id=upload_id,
+            message="saving transcoded file...",
+            phase="upload_transcoded",
+        ) as tracker:
+            with open(result.output_path, "rb") as transcoded_file:
+                transcoded_file_id = await storage.save(
+                    transcoded_file,
+                    transcoded_filename,
+                    progress_callback=tracker.on_progress,
+                )
     except Exception as e:
         logfire.error("transcode failed", error=str(e), exc_info=True)
         await job_service.update_progress(
@@ -444,31 +487,10 @@ async def _transcode_audio(
         )
         return None
     finally:
-        if spool_path:
-            with contextlib.suppress(Exception):
-                Path(spool_path).unlink(missing_ok=True)
-
-    # save transcoded file
-    target_format = settings.transcoder.target_format
-    transcoded_filename = Path(filename).stem + f".{target_format}"
-
-    try:
-        async with R2ProgressTracker(
-            job_id=upload_id,
-            message="saving transcoded file...",
-            phase="upload_transcoded",
-        ) as tracker:
-            transcoded_file_id = await storage.save(
-                BytesIO(result.data),
-                transcoded_filename,
-                progress_callback=tracker.on_progress,
-            )
-    except Exception as e:
-        logfire.error("failed to save transcoded file", error=str(e), exc_info=True)
-        await job_service.update_progress(
-            upload_id, JobStatus.FAILED, "upload failed", error=str(e)
-        )
-        return None
+        for tmp in (source_path, output_path):
+            if tmp:
+                with contextlib.suppress(Exception):
+                    Path(tmp).unlink(missing_ok=True)
 
     logfire.info(
         "transcoded file saved",
@@ -481,7 +503,6 @@ async def _transcode_audio(
         original_file_type=source_format,
         transcoded_file_id=transcoded_file_id,
         transcoded_file_type=target_format,
-        transcoded_data=result.data,
     )
 
 
@@ -595,10 +616,9 @@ async def _upload_to_pds(
 ) -> PdsBlobResult | None:
     """phase 4: upload to PDS (best-effort). returns None if skipped.
 
-    when the source was transcoded, the playable bytes are already in
-    memory (`sr.transcode_info.transcoded_data`). otherwise we download
-    the playable bytes from storage — there's no machine-local temp file
-    to read from in the worker.
+    audio bytes are streamed directly from R2 to the PDS — the worker
+    never holds the full file in memory. content length is sourced from
+    a HEAD request so the PDS can validate up-front without buffering.
     """
     if audio_info.is_gated:
         return None
@@ -609,24 +629,27 @@ async def _upload_to_pds(
         return None
 
     content_type = sr.playable_format.media_type
-    if sr.transcode_info:
-        pds_file_data = sr.transcode_info.transcoded_data
-    else:
-        playable_ext = (
-            sr.playable_format.value if sr.playable_format else ctx.audio_extension
+    playable_ext = sr.playable_format.value
+    file_id = sr.file_id
+
+    content_length = await storage.head_file(file_id, playable_ext)
+    if content_length is None:
+        logfire.warning(
+            "pds blob upload skipped: file not found in storage",
+            file_id=file_id,
+            file_type=playable_ext,
         )
-        fetched = await storage.get_file_data(sr.file_id, playable_ext)
-        if fetched is None:
-            logfire.warning(
-                "pds blob upload skipped: file not found in storage",
-                file_id=sr.file_id,
-                file_type=playable_ext,
-            )
-            return None
-        pds_file_data = fetched
+        return None
+
+    def body_factory() -> AsyncIterable[bytes]:
+        return storage.stream_file_data(file_id, playable_ext)
 
     return await _try_upload_to_pds(
-        ctx.upload_id, ctx.auth_session, pds_file_data, content_type
+        ctx.upload_id,
+        ctx.auth_session,
+        body_factory,
+        content_length,
+        content_type,
     )
 
 

--- a/backend/src/backend/storage/protocol.py
+++ b/backend/src/backend/storage/protocol.py
@@ -1,6 +1,6 @@
 """storage protocol for type-safe dependency injection."""
 
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 from io import BytesIO
 from typing import BinaryIO, Protocol, runtime_checkable
 
@@ -34,6 +34,33 @@ class StorageProtocol(Protocol):
         file_id: str,
         file_type: str,
     ) -> bytes | None: ...
+
+    def stream_file_data(
+        self,
+        file_id: str,
+        file_type: str,
+        *,
+        chunk_size: int = 1024 * 1024,
+    ) -> AsyncIterator[bytes]:
+        """async-iterate over the file body in `chunk_size` chunks.
+
+        the implementation must keep the underlying connection open for the
+        lifetime of iteration (the returned async iterator owns it). callers
+        must consume to completion or arrange for cancellation.
+        """
+        ...
+
+    async def head_file(
+        self,
+        file_id: str,
+        file_type: str,
+    ) -> int | None:
+        """return the byte size of the stored object, or None if missing.
+
+        used to set Content-Length on streaming uploads to consumers that
+        require it (e.g. PDS uploadBlob).
+        """
+        ...
 
     async def delete(self, file_id: str, file_type: str | None = None) -> bool: ...
 

--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -1,7 +1,7 @@
 """cloudflare R2 storage for audio files."""
 
 import time
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 from io import BytesIO
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO
@@ -19,6 +19,11 @@ from backend.config import settings
 from backend.models.track import Track
 from backend.utilities.database import db_session
 from backend.utilities.hashing import hash_file_chunked
+
+# default chunk size for streaming reads. 1MB matches aiobotocore's default
+# part size and keeps per-chunk python overhead negligible against a multi-MB
+# file. callers that want different granularity can override.
+STREAM_CHUNK_SIZE = 1024 * 1024
 
 # content-hashed files never change — cache forever
 IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
@@ -349,6 +354,76 @@ class R2Storage:
                     if e.response.get("Error", {}).get("Code") == "404":
                         return None
                     raise
+
+    async def stream_file_data(
+        self,
+        file_id: str,
+        file_type: str,
+        *,
+        chunk_size: int = STREAM_CHUNK_SIZE,
+    ) -> AsyncIterator[bytes]:
+        """stream the audio body in fixed-size chunks.
+
+        the s3 client is held open for the lifetime of iteration via the
+        async generator's frame. callers must consume to completion or
+        cancel; partial iteration leaves the connection to be torn down by
+        gc, which is correct but noisier than explicit close.
+        """
+        audio_format = AudioFormat.from_extension(f".{file_type.lower()}")
+        if not audio_format:
+            logfire.warning(
+                "unsupported file type for stream_file_data",
+                file_id=file_id,
+                file_type=file_type,
+            )
+            return
+        key = f"audio/{file_id}{audio_format.extension}"
+
+        with logfire.span(
+            "R2 stream_file_data",
+            file_id=file_id,
+            file_type=file_type,
+            chunk_size=chunk_size,
+        ):
+            async with self._s3_client() as client:
+                try:
+                    response = await client.get_object(
+                        Bucket=self.audio_bucket_name, Key=key
+                    )
+                except client.exceptions.NoSuchKey:
+                    logfire.warning("R2 file not found", file_id=file_id, key=key)
+                    return
+                except ClientError as e:
+                    if e.response.get("Error", {}).get("Code") == "404":
+                        return
+                    raise
+
+                async for chunk in response["Body"].iter_chunks(chunk_size=chunk_size):
+                    yield chunk
+
+    async def head_file(
+        self,
+        file_id: str,
+        file_type: str,
+    ) -> int | None:
+        """return the byte size of an audio object via HEAD, or None if missing."""
+        audio_format = AudioFormat.from_extension(f".{file_type.lower()}")
+        if not audio_format:
+            return None
+        key = f"audio/{file_id}{audio_format.extension}"
+        async with self._s3_client() as client:
+            try:
+                response = await client.head_object(
+                    Bucket=self.audio_bucket_name, Key=key
+                )
+            except client.exceptions.NoSuchKey:
+                return None
+            except ClientError as e:
+                if e.response.get("Error", {}).get("Code") in ("404", "NoSuchKey"):
+                    return None
+                raise
+            size = response.get("ContentLength")
+            return int(size) if size is not None else None
 
     async def delete(self, file_id: str, file_type: str | None = None) -> bool:
         """delete media file from R2.

--- a/backend/tests/api/test_upload_storage_cleanup.py
+++ b/backend/tests/api/test_upload_storage_cleanup.py
@@ -141,7 +141,6 @@ class TestPhase1To5FailureDeletesStagedMedia:
                 original_file_type="flac",
                 transcoded_file_id="transcoded-mp3-id",
                 transcoded_file_type="mp3",
-                transcoded_data=b"",
             ),
         )
         with (

--- a/backend/tests/api/track_audio_replace/test_revisions.py
+++ b/backend/tests/api/track_audio_replace/test_revisions.py
@@ -446,21 +446,22 @@ class TestRestoreEndpoint:
                 (TRACK_URI, "bafyRESTOREDWITHFRESHBLOB"),
             ]
         )
-        # storage returns the R2 bytes, upload_blob mints a fresh CID
+        # storage HEAD reports the R2 size, upload_blob streams the bytes
+        # back to PDS as a fresh blob.
         reupload_ref = {
             "$type": "blob",
             "ref": {"$link": "bafkreiFRESH"},
             "mimeType": "audio/wav",
             "size": 4096,
         }
-        get_file_data_mock = AsyncMock(return_value=b"fake-audio-bytes")
+        head_file_mock = AsyncMock(return_value=4096)
         upload_blob_mock = AsyncMock(return_value=reupload_ref)
 
         with (
             patch("backend.api.tracks.revisions.update_record", update_record_mock),
             patch(
-                "backend.api.tracks.revisions.storage.get_file_data",
-                get_file_data_mock,
+                "backend.api.tracks.revisions.storage.head_file",
+                head_file_mock,
             ),
             patch("backend.api.tracks.revisions.upload_blob", upload_blob_mock),
         ):
@@ -480,11 +481,14 @@ class TestRestoreEndpoint:
         assert first_record["audioBlob"]["ref"]["$link"] == "bafkreiGCdBLOB"
         assert second_record["audioBlob"]["ref"]["$link"] == "bafkreiFRESH"
 
-        # re-upload happened with the R2 bytes
-        get_file_data_mock.assert_awaited_once_with("ORIGINAL", "wav")
+        # the streaming re-upload was driven by the revision's R2 file
+        head_file_mock.assert_awaited_once_with("ORIGINAL", "wav")
         upload_blob_mock.assert_awaited_once()
-        assert upload_blob_mock.call_args.args[1] == b"fake-audio-bytes"
-        assert upload_blob_mock.call_args.args[2] == "audio/wav"
+        upload_blob_kwargs = upload_blob_mock.await_args.kwargs
+        assert upload_blob_kwargs["content_length"] == 4096
+        assert upload_blob_kwargs["content_type"] == "audio/wav"
+        # streaming path: the body is a fresh-iterator factory, not bytes
+        assert callable(upload_blob_kwargs["body_factory"])
 
         # DB reflects the fresh blob — audio_storage stays "both", pds_blob_cid
         # is the re-uploaded CID (not the original GC'd one, not null)

--- a/backend/tests/integration/test_longform_upload.py
+++ b/backend/tests/integration/test_longform_upload.py
@@ -1,0 +1,109 @@
+"""regression test: long-form audio uploads must complete end-to-end.
+
+context — 2026-05-06 → 2026-05-10 prod outage: the docket worker buffered
+the entire audio file in memory at multiple points (R2 → worker, transcode
+result, PDS uploadBlob, CLAP embedding). on a 90-minute upload that pile
+of buffers crossed the worker's 2GB cap, the worker OOM'd, fly's
+on-failure restart policy gave up after 10 retries, and uploads were
+broken for ~4 days before a user noticed.
+
+the fix shipped streaming everywhere. this test is the regression guard:
+upload an audio file long enough that any reintroduced buffer would OOM
+the worker, and assert the upload reaches `completed`. if a future change
+re-buffers the file, this test fails on the merge that introduced it
+instead of on a user's tweet.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .utils.audio import save_longform_drone
+
+if TYPE_CHECKING:
+    from plyrfm import AsyncPlyrClient
+
+# 60 min @ 22.05 kHz mono 16-bit ≈ 150 MB on disk. enough to OOM a 2 GB
+# worker if the upload pipeline buffers even one or two copies of the
+# file (which it did before this PR), but small enough to upload through
+# CI in a few minutes. timeout headroom: 1200s for the slow path —
+# multipart upload + transcode (no-op for WAV) + R2 staging + PDS upload
+# + scanners + ATProto record creation.
+LONGFORM_DURATION_SEC = 60 * 60
+LONGFORM_TIMEOUT_SEC = 1200.0
+
+pytestmark = [pytest.mark.integration, pytest.mark.timeout(int(LONGFORM_TIMEOUT_SEC))]
+
+
+@pytest.fixture(scope="session")
+def longform_wav(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """generate a single 60-minute mono WAV for the test session.
+
+    session-scoped so we don't pay the 150 MB write cost more than once
+    if we add additional long-form tests later.
+    """
+    path = tmp_path_factory.mktemp("longform") / "drone_60min.wav"
+    return save_longform_drone(path, duration_sec=LONGFORM_DURATION_SEC)
+
+
+async def test_longform_upload_completes(
+    user1_client: AsyncPlyrClient, longform_wav: Path
+) -> None:
+    """uploading a 60-min WAV must reach `completed`, not stall in `processing`.
+
+    fails-loud regression check for the worker-OOM class of bugs: any
+    buffer-the-whole-file reintroduction in the upload pipeline will OOM
+    the worker on a file this size, the upload will never transition to
+    `completed`, and this test will time out.
+    """
+    client = user1_client
+    file_size_mb = longform_wav.stat().st_size / (1024 * 1024)
+    assert file_size_mb > 100, (
+        f"longform fixture must be > 100MB to exercise streaming; got {file_size_mb:.0f}MB"
+    )
+
+    with open(longform_wav, "rb") as f:
+        post_response = await client._client.post(
+            client._url("/tracks/"),
+            headers=client._auth_headers,
+            files={"file": (longform_wav.name, f)},
+            data={
+                "title": "longform streaming regression",
+                "tags": json.dumps(["integration-test", "longform-regression"]),
+            },
+            timeout=LONGFORM_TIMEOUT_SEC,
+        )
+    post_response.raise_for_status()
+    upload_id = post_response.json()["upload_id"]
+
+    track_id: int | None = None
+    try:
+        async with client._client.stream(
+            "GET",
+            client._url(f"/tracks/uploads/{upload_id}/progress"),
+            headers=client._auth_headers,
+            timeout=LONGFORM_TIMEOUT_SEC,
+        ) as stream:
+            async for line in stream.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                payload = json.loads(line[6:])
+                status = payload.get("status")
+                if status == "completed":
+                    track_id = int(payload["track_id"])
+                    break
+                if status == "failed":
+                    raise ValueError(
+                        f"longform upload failed: {payload.get('error', 'unknown')}"
+                    )
+        assert track_id is not None, "upload stream ended without a terminal event"
+
+        track = await client.get_track(track_id)
+        assert track.title == "longform streaming regression"
+    finally:
+        if track_id is not None:
+            await client.delete(track_id)

--- a/backend/tests/integration/test_longform_upload.py
+++ b/backend/tests/integration/test_longform_upload.py
@@ -17,11 +17,13 @@ instead of on a user's tweet.
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
+from .conftest import IntegrationSettings
 from .utils.audio import save_longform_drone
 
 if TYPE_CHECKING:
@@ -40,12 +42,23 @@ pytestmark = [pytest.mark.integration, pytest.mark.timeout(int(LONGFORM_TIMEOUT_
 
 
 @pytest.fixture(scope="session")
-def longform_wav(tmp_path_factory: pytest.TempPathFactory) -> Path:
+def longform_wav(
+    tmp_path_factory: pytest.TempPathFactory,
+    integration_settings: IntegrationSettings,
+) -> Path:
     """generate a single 60-minute mono WAV for the test session.
 
-    session-scoped so we don't pay the 150 MB write cost more than once
-    if we add additional long-form tests later.
+    skips ahead of the ffmpeg shell-out when the integration env can't run:
+    the regular backend `test` workflow collects this file (no `-m
+    integration` filter) but doesn't have ffmpeg installed and doesn't have
+    `PLYR_TEST_TOKEN_1`, so eagerly invoking `ffmpeg` here would explode
+    the unrelated check. session-scoped so we don't pay the 150 MB write
+    cost more than once if we add additional long-form tests later.
     """
+    if not integration_settings.has_primary_token:
+        pytest.skip("PLYR_TEST_TOKEN_1 not set")
+    if not shutil.which("ffmpeg"):
+        pytest.skip("ffmpeg not available; long-form fixture cannot be generated")
     path = tmp_path_factory.mktemp("longform") / "drone_60min.wav"
     return save_longform_drone(path, duration_sec=LONGFORM_DURATION_SEC)
 

--- a/backend/tests/integration/utils/audio.py
+++ b/backend/tests/integration/utils/audio.py
@@ -214,6 +214,61 @@ def save_drone_as(
     return path
 
 
+def save_longform_drone(
+    path: Path,
+    duration_sec: float,
+    *,
+    sample_rate: int = 22050,
+    note: str = "A4",
+) -> Path:
+    """generate a long-form mono sine WAV via ffmpeg lavfi.
+
+    pure-python WAV synthesis (`save_drone`) is fine for short fixtures
+    but quadratic in duration on the python side; for tests that need
+    tens of minutes of audio we shell out to ffmpeg's `sine` source,
+    which produces the file in under a second regardless of length.
+
+    args:
+        path: destination .wav path
+        duration_sec: total duration in seconds (e.g. 3600 for 60 min)
+        sample_rate: samples per second; 22050 mono keeps a 60-min file
+            at ~150MB while still passing real audio decoders
+        note: musical note name for the sine frequency
+
+    returns:
+        the destination path (now a valid WAV file)
+    """
+    import shutil
+    import subprocess
+
+    if not shutil.which("ffmpeg"):
+        msg = "ffmpeg not found - required for long-form audio fixtures"
+        raise FileNotFoundError(msg)
+
+    freq = note_to_freq(note)
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            f"sine=frequency={freq}:duration={duration_sec}",
+            "-ar",
+            str(sample_rate),
+            "-ac",
+            "1",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return path
+
+
 def save_drone_as_opus(
     path: Path,
     note: str = "A4",

--- a/backend/tests/test_pds_network_retry.py
+++ b/backend/tests/test_pds_network_retry.py
@@ -147,7 +147,9 @@ class TestUploadBlobNetworkRetry:
             "backend._internal.atproto.client.get_oauth_client",
             return_value=mock_client,
         ):
-            result = await upload_blob(mock_auth_session, b"fake-audio", "audio/mpeg")
+            result = await upload_blob(
+                mock_auth_session, data=b"fake-audio", content_type="audio/mpeg"
+            )
 
         assert result == blob_ref
         assert mock_client.make_authenticated_request.call_count == 2
@@ -167,7 +169,9 @@ class TestUploadBlobNetworkRetry:
             ),
             pytest.raises(Exception, match=r"blob upload failed after \d+ attempts"),
         ):
-            await upload_blob(mock_auth_session, b"fake-audio", "audio/mpeg")
+            await upload_blob(
+                mock_auth_session, data=b"fake-audio", content_type="audio/mpeg"
+            )
 
     async def test_does_not_retry_payload_too_large(
         self, mock_auth_session: AuthSession
@@ -184,7 +188,9 @@ class TestUploadBlobNetworkRetry:
             ),
             pytest.raises(Exception, match="blob too large"),
         ):
-            await upload_blob(mock_auth_session, b"huge-audio", "audio/mpeg")
+            await upload_blob(
+                mock_auth_session, data=b"huge-audio", content_type="audio/mpeg"
+            )
 
         assert mock_client.make_authenticated_request.call_count == 1
 

--- a/backend/tests/test_pds_network_retry.py
+++ b/backend/tests/test_pds_network_retry.py
@@ -194,6 +194,35 @@ class TestUploadBlobNetworkRetry:
 
         assert mock_client.make_authenticated_request.call_count == 1
 
+    async def test_streaming_upload_rejects_unsafe_pds_url(
+        self,
+        mock_auth_session: AuthSession,
+    ) -> None:
+        """streaming uploads must mirror the SDK's `is_safe_url` check.
+
+        regression: `_signed_streaming_post` bypasses
+        `OAuthClient.make_authenticated_request` to support body factories,
+        which means it has to mirror upstream's URL validation explicitly —
+        otherwise a malicious or malformed `pds_url` in stored session data
+        could redirect user audio bytes to a private network address.
+        """
+        # rewrite the session's PDS URL to a private/unsafe one. nothing in
+        # the streaming flow should reach the network: the URL check should
+        # raise before httpx is touched.
+        mock_auth_session.oauth_session["pds_url"] = "http://127.0.0.1:8080"
+
+        async def _factory():
+            yield b"audio chunk 1"
+            yield b"audio chunk 2"
+
+        with pytest.raises(ValueError, match="Unsafe URL"):
+            await upload_blob(
+                mock_auth_session,
+                body_factory=_factory,
+                content_length=26,
+                content_type="audio/mpeg",
+            )
+
 
 class TestMakePdsRequestAuthRefresh:
     """make_pds_request refreshes and retries on 401 regardless of body shape.

--- a/backend/tests/test_transcoder.py
+++ b/backend/tests/test_transcoder.py
@@ -1,8 +1,11 @@
 """tests for transcoder client."""
 
 import tempfile
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock, Mock, patch
+from typing import Any
+from unittest.mock import Mock, patch
 
 import httpx
 import pytest
@@ -33,120 +36,169 @@ def temp_audio_file() -> Path:
         return Path(f.name)
 
 
+@pytest.fixture
+def temp_output_file() -> Path:
+    """destination path for transcoded output."""
+    with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as f:
+        return Path(f.name)
+
+
+def _make_streaming_response(
+    chunks: list[bytes], headers: dict[str, str] | None = None
+) -> tuple[Mock, Any]:
+    """build a mock that mimics httpx's streaming response context manager."""
+    response = Mock()
+    response.headers = headers or {"content-type": "audio/mpeg"}
+    response.raise_for_status.return_value = None
+
+    async def aiter_bytes() -> AsyncIterator[bytes]:
+        for chunk in chunks:
+            yield chunk
+
+    response.aiter_bytes = aiter_bytes
+
+    @asynccontextmanager
+    async def cm(*_args: Any, **_kwargs: Any) -> AsyncIterator[Mock]:
+        yield response
+
+    return response, cm
+
+
 async def test_transcoder_client_success(
-    transcoder_client: TranscoderClient, temp_audio_file: Path
+    transcoder_client: TranscoderClient,
+    temp_audio_file: Path,
+    temp_output_file: Path,
 ) -> None:
-    """test TranscoderClient.transcode_file() with successful response."""
-    mock_response = Mock()
-    mock_response.content = b"transcoded mp3 data"
-    mock_response.headers = {"content-type": "audio/mpeg"}
-    mock_response.raise_for_status.return_value = None
+    """successful transcode streams the response body to output_path."""
+    response, stream_cm = _make_streaming_response(
+        [b"transcoded ", b"mp3 data"], {"content-type": "audio/mpeg"}
+    )
 
-    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
-        mock_post.return_value = mock_response
-
-        result = await transcoder_client.transcode_file(temp_audio_file, "aiff")
+    with patch("httpx.AsyncClient.stream", side_effect=stream_cm):
+        result = await transcoder_client.transcode_file(
+            temp_audio_file, "aiff", output_path=temp_output_file
+        )
 
     assert result.success is True
-    assert result.data == b"transcoded mp3 data"
+    assert result.output_path == temp_output_file
+    assert result.output_size == len(b"transcoded mp3 data")
     assert result.content_type == "audio/mpeg"
     assert result.error is None
-    mock_post.assert_called_once()
+    assert temp_output_file.read_bytes() == b"transcoded mp3 data"
 
-    # verify the call included auth header
-    call_kwargs = mock_post.call_args.kwargs
-    assert call_kwargs["headers"] == {"X-Transcoder-Key": "test-token"}
-    assert call_kwargs["params"] == {"target": "mp3"}
-
-    # cleanup
     temp_audio_file.unlink(missing_ok=True)
+    temp_output_file.unlink(missing_ok=True)
 
 
 async def test_transcoder_client_timeout(
-    transcoder_client: TranscoderClient, temp_audio_file: Path
+    transcoder_client: TranscoderClient,
+    temp_audio_file: Path,
+    temp_output_file: Path,
 ) -> None:
-    """test TranscoderClient.transcode_file() timeout handling."""
-    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
-        mock_post.side_effect = httpx.TimeoutException("timeout")
-
-        result = await transcoder_client.transcode_file(temp_audio_file, "aiff")
+    """timeout during transcode is surfaced as an error."""
+    with patch(
+        "httpx.AsyncClient.stream", side_effect=httpx.TimeoutException("timeout")
+    ):
+        result = await transcoder_client.transcode_file(
+            temp_audio_file, "aiff", output_path=temp_output_file
+        )
 
     assert result.success is False
-    assert result.data is None
+    assert result.output_path is None
     assert result.error is not None
     assert "timed out" in result.error
 
-    # cleanup
     temp_audio_file.unlink(missing_ok=True)
+    temp_output_file.unlink(missing_ok=True)
 
 
 async def test_transcoder_client_http_error(
-    transcoder_client: TranscoderClient, temp_audio_file: Path
+    transcoder_client: TranscoderClient,
+    temp_audio_file: Path,
+    temp_output_file: Path,
 ) -> None:
-    """test TranscoderClient.transcode_file() HTTP error handling."""
+    """HTTP error during transcode is surfaced as an error."""
     mock_response = Mock()
     mock_response.status_code = 500
     mock_response.text = "Internal Server Error"
 
-    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
-        mock_post.side_effect = httpx.HTTPStatusError(
+    with patch(
+        "httpx.AsyncClient.stream",
+        side_effect=httpx.HTTPStatusError(
             "Server Error",
             request=Mock(),
             response=mock_response,
+        ),
+    ):
+        result = await transcoder_client.transcode_file(
+            temp_audio_file, "aiff", output_path=temp_output_file
         )
 
-        result = await transcoder_client.transcode_file(temp_audio_file, "aiff")
-
     assert result.success is False
-    assert result.data is None
+    assert result.output_path is None
     assert result.error is not None
     assert "500" in result.error
     assert "Internal Server Error" in result.error
 
-    # cleanup
     temp_audio_file.unlink(missing_ok=True)
+    temp_output_file.unlink(missing_ok=True)
 
 
 async def test_transcoder_client_unexpected_error(
-    transcoder_client: TranscoderClient, temp_audio_file: Path
+    transcoder_client: TranscoderClient,
+    temp_audio_file: Path,
+    temp_output_file: Path,
 ) -> None:
-    """test TranscoderClient.transcode_file() unexpected error handling."""
-    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
-        mock_post.side_effect = RuntimeError("unexpected error")
-
-        result = await transcoder_client.transcode_file(temp_audio_file, "aiff")
+    """unexpected exceptions are caught and surfaced as errors."""
+    with patch(
+        "httpx.AsyncClient.stream", side_effect=RuntimeError("unexpected error")
+    ):
+        result = await transcoder_client.transcode_file(
+            temp_audio_file, "aiff", output_path=temp_output_file
+        )
 
     assert result.success is False
-    assert result.data is None
+    assert result.output_path is None
     assert result.error is not None
     assert "unexpected" in result.error.lower()
 
-    # cleanup
     temp_audio_file.unlink(missing_ok=True)
+    temp_output_file.unlink(missing_ok=True)
 
 
 async def test_transcoder_client_custom_target_format(
-    transcoder_client: TranscoderClient, temp_audio_file: Path
+    transcoder_client: TranscoderClient,
+    temp_audio_file: Path,
+    temp_output_file: Path,
 ) -> None:
-    """test TranscoderClient.transcode_file() with custom target format."""
-    mock_response = Mock()
-    mock_response.content = b"transcoded aac data"
-    mock_response.headers = {"content-type": "audio/aac"}
-    mock_response.raise_for_status.return_value = None
+    """custom target_format is passed through as a query param."""
+    captured: dict[str, Any] = {}
 
-    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
-        mock_post.return_value = mock_response
+    @asynccontextmanager
+    async def stream_cm(method: str, url: str, **kwargs: Any) -> AsyncIterator[Mock]:
+        captured["method"] = method
+        captured["url"] = url
+        captured.update(kwargs)
+        response = Mock()
+        response.headers = {"content-type": "audio/aac"}
+        response.raise_for_status.return_value = None
 
+        async def aiter_bytes() -> AsyncIterator[bytes]:
+            yield b"transcoded aac data"
+
+        response.aiter_bytes = aiter_bytes
+        yield response
+
+    with patch("httpx.AsyncClient.stream", side_effect=stream_cm):
         result = await transcoder_client.transcode_file(
-            temp_audio_file, "flac", target_format="aac"
+            temp_audio_file, "flac", output_path=temp_output_file, target_format="aac"
         )
 
     assert result.success is True
-    call_kwargs = mock_post.call_args.kwargs
-    assert call_kwargs["params"] == {"target": "aac"}
+    assert captured["params"] == {"target": "aac"}
 
-    # cleanup
     temp_audio_file.unlink(missing_ok=True)
+    temp_output_file.unlink(missing_ok=True)
 
 
 def test_transcoder_client_from_settings() -> None:

--- a/docs/internal/retrospectives/2025-11-02-custom-domain-issue.md
+++ b/docs/internal/retrospectives/2025-11-02-custom-domain-issue.md
@@ -1,0 +1,81 @@
+## problem
+
+currently using cloudflare-generated domain `relay-4i6.pages.dev` which is:
+- not stable or memorable for users
+- hardcoded in FastAPI CORS configuration
+- not suitable for production deployment
+- creates tight coupling between frontend deployment and backend configuration
+
+## desired outcome
+
+1. **custom domain acquisition and setup**
+   - register domain (e.g., `relay.fm`, `relay.music`, etc.)
+   - configure DNS with cloudflare
+   - set up SSL/TLS certificates
+
+2. **environment-specific subdomains**
+   - `relay.{domain}` → production
+   - `staging.relay.{domain}` → staging (main branch)
+   - `dev.relay.{domain}` → development (optional, could stay localhost)
+
+3. **backend configuration updates**
+   - remove hardcoded domains from CORS
+   - use environment variables for allowed origins
+   - support multiple environments via configuration
+
+## implementation considerations
+
+### domain setup
+- cloudflare pages supports custom domains
+- fly.io supports custom domains
+- need to configure both frontend and backend
+
+### CORS configuration
+currently in `src/relay/main.py`:
+```python
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["https://relay-4i6.pages.dev"],  # hardcoded
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+```
+
+should become:
+```python
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.cors_allowed_origins,  # from env
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+```
+
+### environment variables needed
+- `CORS_ALLOWED_ORIGINS` (comma-separated list)
+- `FRONTEND_URL` (for OAuth redirects)
+- `BACKEND_URL` (for API base URL)
+
+## files requiring changes
+
+1. `src/relay/config.py` - add domain configuration settings
+2. `src/relay/main.py` - update CORS to use env vars
+3. `fly.toml` - add custom domain configuration
+4. cloudflare pages settings - configure custom domain
+5. `README.md` - document domain configuration
+
+## dependencies
+
+- domain registration ($10-15/year)
+- DNS configuration (cloudflare)
+- SSL certificate setup (automatic with cloudflare)
+
+## priority
+
+**high** - blocks professional deployment and creates maintenance burden with hardcoded values
+
+## related issues
+
+- depends on three-environment strategy for staging subdomain

--- a/docs/internal/retrospectives/2025-11-02-performance-issue.md
+++ b/docs/internal/retrospectives/2025-11-02-performance-issue.md
@@ -1,0 +1,102 @@
+## problem 1: file upload buffering
+
+**location**: src/relay/storage/r2.py:42-68, src/relay/storage/filesystem.py:18-37
+
+both storage backends load entire audio files into memory (`content = file.read()`), then calculate SHA-256 hash on full content. with 50-200MB WAV files, concurrent uploads will exhaust memory on 1GB Fly.io VMs.
+
+### recommended solution
+
+**streaming hash calculation**:
+```python
+CHUNK_SIZE = 8 * 1024 * 1024  # 8MB chunks
+
+hasher = hashlib.sha256()
+while chunk := file.read(CHUNK_SIZE):
+    hasher.update(chunk)
+file_id = hasher.hexdigest()[:16]
+```
+
+**boto3 multipart uploads**:
+```python
+from boto3.s3.transfer import TransferConfig
+
+self.client.upload_fileobj(
+    file,
+    Bucket=self.bucket_name,
+    Key=key,
+    Config=TransferConfig(
+        multipart_threshold=5 * 1024 * 1024,
+        multipart_chunksize=CHUNK_SIZE,
+        max_concurrency=10
+    )
+)
+```
+
+**benefits**: constant memory usage regardless of file size, proper R2 multipart handling
+
+---
+
+## problem 2: API response caching
+
+**location**: src/relay/api/tracks.py:193-223 (list_tracks PDS resolution)
+
+every GET /tracks call creates fresh `AsyncDidResolver` and hits public DID endpoints for each unique artist. with dozens of tracks, this becomes a waterfall of outbound HTTP causing 200+ms page loads.
+
+### recommended solution
+
+**implement Redis caching with fastapi-cache2** (Redis already configured in settings):
+
+```python
+from fastapi_cache import FastAPICache
+from fastapi_cache.backends.redis import RedisBackend
+from fastapi_cache.decorator import cache
+
+# startup
+redis = aioredis.from_url(settings.redis_url)
+FastAPICache.init(RedisBackend(redis), prefix="relay-cache")
+
+# apply to resolution
+@cache(expire=86400)  # 24 hours
+async def resolve_handle(handle: str) -> dict | None:
+    ...
+```
+
+**TTL recommendations** (based on ATProto specifications):
+- DID resolution: 24 hours max (per ATProto docs)
+- handle → DID mapping: 24 hours
+- profile data (display name, avatar): 1-4 hours
+- PDS URLs: 24 hours (rarely change)
+
+### alternative: persist PDS URLs
+
+store resolved PDS alongside artist records to eliminate resolution on every list_tracks call.
+
+---
+
+## implementation priority
+
+### high priority (immediate memory concerns)
+1. streaming hash calculation - prevents OOM
+2. boto3 upload_fileobj - proper multipart handling
+3. DID resolution caching - 24h TTL with Redis
+
+### medium priority (performance optimization)
+4. profile caching - 1-4h TTL reduces latency
+5. PDS URL persistence - eliminates redundant resolutions
+6. cache warming - pre-populate featured artists
+
+### low priority (advanced features)
+7. resumable uploads - TUS protocol if reliability issues emerge
+8. event-based cache invalidation - if firehose integration added
+9. stale-while-revalidate - for high-traffic endpoints
+
+## references
+
+- AWS recommends 8MB chunks for multipart uploads
+- ATProto docs specify 24h max TTL for identity metadata
+- fastapi-cache2: https://github.com/long2ice/fastapi-cache
+- boto3 transfer config: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html#boto3.s3.transfer.TransferConfig
+
+## priority
+
+**high** - memory exhaustion risk under load, significant latency improvements

--- a/docs/internal/retrospectives/2025-11-02-play-count-abuse-issue.md
+++ b/docs/internal/retrospectives/2025-11-02-play-count-abuse-issue.md
@@ -1,0 +1,60 @@
+## problem
+
+the `/tracks/{track_id}/play` endpoint (src/relay/api/tracks.py:432-448) is unauthenticated and has no throttling, making it trivial to artificially inflate play counts via automated scripts. since play counts are a primary engagement metric, this threatens platform integrity.
+
+## abuse patterns to prevent
+
+- bot networks generating artificial plays
+- automated scripts looping tracks
+- multiple account creation for metric inflation
+- coordinated fraud campaigns
+
+## recommended technical approach
+
+### phase 1: foundational measures (immediate)
+
+1. **minimum play duration validation** (industry standard: 30 seconds)
+   - require client to call endpoint after 30s of confirmed playback
+   - prevents rapid-fire automated increments
+
+2. **rate limiting**
+   - per IP: 100 plays/hour (token bucket algorithm)
+   - per authenticated user: 500 plays/day
+   - use `slowapi` middleware for implementation
+
+3. **authentication requirement**
+   - require valid session for play count increments
+   - enables per-user tracking and quotas
+   - tie plays to DIDs for cross-reference
+
+### phase 2: advanced detection (future)
+
+4. **lightweight device fingerprinting**
+   - collect: user agent, screen size, timezone, language
+   - identify duplicate devices without sophisticated tracking
+
+5. **engagement metrics**
+   - track beyond raw plays: likes, shares, playlist adds, listener retention
+   - flag accounts with suspicious play-to-engagement ratios
+
+6. **behavioral analysis**
+   - identify non-human patterns (no breaks, geographic anomalies)
+   - ML models if scale demands (platform-wide fraud detection)
+
+## implementation notes
+
+- start conservatively - prioritize monitoring over blocking
+- consider async validation: count initially, flag for review
+- avoid false positives (<0.01% industry benchmark)
+- implement exponential backoff on suspicious activity
+
+## references
+
+- spotify uses 30-second threshold + financial penalties (€10/month per fraudulent track)
+- soundcloud partnered with DataDome for real-time bot detection
+- deezer caps individual accounts at 1,000 streams
+- music fights fraud alliance (2023) shares cross-platform fraud data
+
+## priority
+
+**high** - directly impacts platform credibility and artist revenue fairness

--- a/docs/internal/retrospectives/2025-11-02-session-security-issue.md
+++ b/docs/internal/retrospectives/2025-11-02-session-security-issue.md
@@ -1,0 +1,129 @@
+## problem
+
+**location**: src/relay/_internal/auth.py, src/relay/models/session.py, src/relay/api/auth.py
+
+current OAuth session implementation has several security gaps:
+
+1. **session_id exposed in URL** (line 55, api/auth.py) - vulnerable to referrer leaks, browser history
+2. **no encryption at rest** - DPoP private keys, access tokens, refresh tokens stored as plaintext JSON in PostgreSQL
+3. **no token rotation** - refresh tokens never rotated, violating OAuth 2.1 best practices
+4. **no session expiration enforcement** - `expires_at` field exists but not validated
+5. **missing cookie security attributes** - no HttpOnly, Secure, SameSite flags
+
+## security requirements (OAuth 2.1 + ATProto)
+
+### OWASP & RFC 9700 standards:
+- never store tokens in localStorage (XSS vulnerability)
+- refresh tokens must rotate on each use
+- access tokens: 15-30 minutes max
+- HttpOnly cookies for session IDs
+- encryption at rest for sensitive data
+
+### ATProto-specific requirements:
+- DPoP keys: unique per session, never shared across devices
+- access tokens: maximum 30 minutes
+- refresh tokens (public clients): 2 weeks total session lifetime
+- DPoP nonces: 5-minute max lifetime
+
+## recommended implementation
+
+### P0: immediate fixes
+
+1. **use HTTP-only cookies instead of URL parameters**:
+```python
+response = RedirectResponse(url=f"{settings.frontend_url}{redirect_path}")
+response.set_cookie(
+    key="session_id",
+    value=session_id,
+    httponly=True,
+    secure=True,
+    samesite="lax",
+    max_age=1209600  # 2 weeks
+)
+```
+
+2. **implement column-level encryption using pgcrypto**:
+```python
+# enable extension
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+# encrypt before storing
+encrypted_data = await db.execute(
+    text("SELECT pgp_sym_encrypt(:data, :key)"),
+    {"data": json.dumps(oauth_session), "key": settings.encryption_key}
+)
+```
+
+3. **implement refresh token rotation**:
+- on each token refresh, generate new access + refresh tokens
+- invalidate old refresh token
+- detect and block reuse attempts (security breach indicator)
+
+### P1: session management
+
+4. **enforce session expiration**:
+```python
+async def get_session(session_id: str) -> Session | None:
+    if db_session.expires_at and datetime.now(UTC) > db_session.expires_at:
+        await delete_session(session_id)
+        return None
+```
+
+5. **add session timeouts to model**:
+```python
+class UserSession(Base):
+    created_at: Mapped[datetime]
+    last_activity: Mapped[datetime]  # auto-update on access
+    idle_timeout_minutes: Mapped[int] = 30
+    absolute_timeout_hours: Mapped[int] = 336  # 2 weeks
+    expires_at: Mapped[datetime]
+```
+
+6. **automatic session cleanup** (background task):
+```python
+await db.execute(
+    delete(UserSession).where(
+        UserSession.expires_at < datetime.now(UTC)
+    )
+)
+```
+
+### P2: advanced security
+
+7. **DPoP key encryption** (separate from tokens, using AES-256-GCM)
+8. **audit logging** - track session creation, token refresh, security events
+9. **rate limiting** - prevent brute force (slowapi: 10 login attempts/minute)
+10. **session fingerprinting** - detect hijacking via IP/user-agent validation
+
+## implementation priority matrix
+
+| Priority | Issue | Impact | Effort |
+|----------|-------|--------|--------|
+| **P0** | session_id in URL | high | low |
+| **P0** | no encryption at rest | high | medium |
+| **P0** | no token rotation | high | medium |
+| **P1** | no expiration enforcement | medium | low |
+| **P1** | missing cookie attributes | medium | low |
+| **P2** | no DPoP key rotation | medium | high |
+| **P2** | no audit logging | low | low |
+| **P3** | no rate limiting | low | medium |
+
+## files requiring changes
+
+1. `src/relay/models/session.py` - add encryption, timeouts, indexes
+2. `src/relay/_internal/auth.py` - implement encryption, rotation, validation
+3. `src/relay/api/auth.py` - remove URL params, add secure cookies
+4. `src/relay/config.py` - add encryption_key, cookie settings
+5. database migration - encrypted columns, new fields
+
+## references
+
+- OWASP session management: https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
+- OAuth 2.1 BCP (RFC 9700): https://datatracker.ietf.org/doc/rfc9700/
+- ATProto OAuth spec: https://atproto.com/specs/oauth
+- DPoP specification: https://datatracker.ietf.org/doc/html/rfc9449
+- PostgreSQL pgcrypto: https://www.postgresql.org/docs/current/pgcrypto.html
+
+## priority
+
+**critical** - session_id URL exposure is immediate risk, encryption at rest required before wider deployment

--- a/docs/internal/retrospectives/2025-11-02-three-environments-issue.md
+++ b/docs/internal/retrospectives/2025-11-02-three-environments-issue.md
@@ -1,0 +1,170 @@
+## problem
+
+currently have only two environments:
+- **local development** → connects to dev database
+- **production** → deployed from main branch
+
+this means every merge to main immediately goes to production with no staging validation. no way to test changes in a production-like environment before user-facing deployment.
+
+## desired outcome
+
+implement three-tier deployment strategy:
+
+| environment | trigger | frontend URL | backend URL | database | purpose |
+|-------------|---------|--------------|-------------|----------|---------|
+| **development** | local | localhost:5173 | localhost:8000 | neon dev | local development |
+| **staging** | push to main | staging.relay.{domain} | staging-api.fly.dev | neon staging | pre-production validation |
+| **production** | github release | relay.{domain} | relay-api.fly.dev | neon prod | user-facing deployment |
+
+## workflow
+
+1. **local development**:
+   - developer works on feature branch
+   - connects to dev database
+   - tests locally
+
+2. **staging deployment** (automatic):
+   - PR merged to main
+   - github actions deploys:
+     - frontend → cloudflare pages (staging)
+     - backend → fly.io (staging app)
+   - uses staging database
+   - team validates changes
+
+3. **production release** (manual):
+   - create github release (e.g., `v1.2.3`)
+   - github actions deploys:
+     - frontend → cloudflare pages (production)
+     - backend → fly.io (production app)
+   - uses production database
+   - users see changes
+
+## implementation plan
+
+### 1. neon database setup
+currently have 2 databases, need 3:
+- `relay-dev` (existing)
+- `relay-staging` (new)
+- `relay-prod` (existing)
+
+### 2. fly.io apps
+currently have 1 app, need 2:
+- `relay-api` (production)
+- `relay-api-staging` (new)
+
+each with separate environment variables:
+```
+DATABASE_URL → neon staging/prod
+R2_BUCKET_NAME → relay-staging/relay-prod
+FRONTEND_URL → staging/production frontend URL
+CORS_ALLOWED_ORIGINS → staging/production domains
+```
+
+### 3. cloudflare pages
+configure multiple environments:
+- production branch: `production` (new branch)
+- preview branch: `main` (current behavior becomes staging)
+
+environment variables:
+```
+PUBLIC_API_URL → staging vs production backend
+```
+
+### 4. github actions workflows
+
+**.github/workflows/deploy-staging.yml**:
+```yaml
+name: deploy staging
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: flyctl deploy --app relay-api-staging
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+```
+
+**.github/workflows/deploy-production.yml**:
+```yaml
+name: deploy production
+on:
+  release:
+    types: [published]
+
+jobs:
+  promote-to-production:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          git checkout -b production
+          git push origin production --force
+      - run: flyctl deploy --app relay-api
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+```
+
+### 5. database migrations
+
+**staging**: automatic via fly.io release command (re-enable after fixing timeouts)
+**production**: manual approval before release
+- option A: require manual migration before release
+- option B: github actions workflow with approval gate
+- option C: fly.io release command with longer timeout
+
+## files requiring changes
+
+1. `.github/workflows/deploy-staging.yml` (new)
+2. `.github/workflows/deploy-production.yml` (new)
+3. `fly.toml` → `fly.staging.toml` + `fly.production.toml`
+4. cloudflare pages settings - branch configuration
+5. `README.md` - document deployment process
+6. `docs/deployment/` - new deployment guide
+
+## infrastructure costs
+
+current: ~$5-6/month
+after:
+- fly.io staging app: +$5/month (shared-cpu-1x)
+- neon staging database: free tier (5GB limit)
+- cloudflare pages: free (unlimited)
+
+**new total**: ~$10-11/month
+
+## migration steps
+
+1. create neon staging database
+2. create fly.io staging app
+3. configure staging environment variables
+4. create github actions workflows
+5. configure cloudflare pages branches
+6. test staging deployment
+7. create first production release
+8. update documentation
+
+## benefits
+
+- catch bugs before production
+- validate database migrations safely
+- team can test changes in production-like environment
+- clear release process with versioning
+- rollback capability via github releases
+
+## priority
+
+**high** - required for safe deployment practices before opening to users
+
+## dependencies
+
+- requires custom domain for staging subdomain
+- addresses anxiety mentioned in STATUS.md about deployment safety
+
+## related issues
+
+- complements #8 (runtime resilience) by enabling safe testing
+- supports #26 (session hardening) by allowing staging validation

--- a/docs/internal/retrospectives/2025-11-04-multi-tab-playback-issue.md
+++ b/docs/internal/retrospectives/2025-11-04-multi-tab-playback-issue.md
@@ -1,0 +1,224 @@
+# multi-tab playback coordination issue
+
+**date**: 2025-11-04
+**branch**: `feat/cross-tab-queue-sync`
+**status**: unresolved
+
+## problem statement
+
+we successfully implemented cross-tab queue synchronization using BroadcastChannel. the queue state now syncs perfectly between tabs (no more 409 conflicts). however, there's a critical issue with playback:
+
+**the symptom**: when auto-advance is enabled and a track ends, the queue advances to the next track correctly, but the next track does not start playing. playback just stops.
+
+**expected behavior**: when a track ends in tab 1 with auto-advance enabled, the next track should load and start playing automatically in tab 1.
+
+**actual behavior**: the queue index advances to the next track, the UI updates to show the new track, but audio playback does not start. the player remains paused.
+
+## context
+
+### what we built (successfully)
+
+- cross-tab queue synchronization via BroadcastChannel (commit e4bd8f2)
+- when one tab updates the queue, it broadcasts to other tabs
+- other tabs fetch the latest state to stay in sync
+- no more 409 conflicts from concurrent queue mutations
+
+### the new requirement
+
+we need to ensure that when auto-advance happens:
+1. only the tab that was playing should continue playing the next track
+2. other tabs should update their UI but not take over audio playback
+
+### relevant code structure
+
+**`frontend/src/lib/queue.svelte.ts`**:
+- Queue class with reactive state using Svelte 5 runes
+- Methods: `next()`, `previous()`, `goTo()`, etc.
+- BroadcastChannel setup in `initialize()`
+- `pushQueue()` sends updates to server and broadcasts to other tabs
+
+**`frontend/src/lib/components/Player.svelte`**:
+- Manages audio playback state
+- Syncs with queue state via reactive effects
+- Has a loading mechanism: when track changes, it loads the new audio file
+- Has `shouldAutoPlay` flag to indicate playback should start after loading completes
+
+**key flow**:
+1. Track ends → `handleTrackEnded()` calls `queue.next()`
+2. `queue.next()` increments index, schedules push to server
+3. Effect in Player.svelte sees queue change, loads new track
+4. After loading completes, should auto-play if conditions are met
+
+## attempted solutions
+
+### attempt 1: add `lastUpdateWasLocal` flag
+
+**approach**:
+- added reactive `lastUpdateWasLocal = $state(true)` to Queue class
+- set to `true` at start of all local mutation methods (next, previous, etc.)
+- set to `false` when receiving BroadcastChannel message from another tab
+- in Player.svelte, only auto-play when `queue.lastUpdateWasLocal` is true
+
+**code changes**:
+```typescript
+// in queue.svelte.ts
+lastUpdateWasLocal = $state(true);
+
+next() {
+  if (this.currentIndex < this.tracks.length - 1) {
+    this.lastUpdateWasLocal = true;  // mark as local
+    this.currentIndex += 1;
+    this.schedulePush();
+  }
+}
+
+// in Player.svelte
+if (trackChanged) {
+  player.currentTrack = queue.currentTrack;
+  if (queue.lastUpdateWasLocal) {
+    player.paused = false;  // only auto-play for local updates
+  }
+}
+```
+
+**result**: auto-advance stopped working entirely. queue advanced but playback didn't start.
+
+### attempt 2: use `shouldAutoPlay` flag instead
+
+**change**: instead of setting `player.paused = false` directly, set `shouldAutoPlay = true` to let the loading mechanism handle it:
+
+```typescript
+if (trackChanged) {
+  player.currentTrack = queue.currentTrack;
+  if (queue.lastUpdateWasLocal) {
+    shouldAutoPlay = true;  // changed from player.paused = false
+  }
+}
+```
+
+**result**: same problem. queue advanced but playback didn't start.
+
+### attempt 3: ignore own broadcasts
+
+**hypothesis**: maybe the tab receives its own broadcast and sets `lastUpdateWasLocal = false`, breaking auto-play
+
+**change**: ignore broadcasts with the same revision number we already have:
+
+```typescript
+this.channel.onmessage = (event) => {
+  if (event.data.type === 'queue-updated') {
+    // ignore our own broadcasts
+    if (event.data.revision === this.revision) {
+      return;
+    }
+
+    this.lastUpdateWasLocal = false;
+    void this.fetchQueue(true);
+  }
+};
+```
+
+**result**: same problem. queue still advances but playback doesn't start.
+
+## what we observe
+
+1. **auto-advance IS happening**: the queue index increments, UI updates to show next track
+2. **loading IS happening**: the audio element src changes, loading events fire
+3. **playback is NOT starting**: despite `shouldAutoPlay = true`, the track doesn't play
+4. **manual controls work fine**: clicking next/previous buttons works and plays the next track
+
+## debugging notes
+
+### what should happen (original code before our changes)
+
+```typescript
+// original Player.svelte effect
+if (trackChanged) {
+  player.playTrack(queue.currentTrack);  // this worked
+  previousQueueIndex = queue.currentIndex;
+}
+```
+
+where `playTrack()` is:
+```typescript
+playTrack(track: Track) {
+  if (this.currentTrack?.id === track.id) {
+    this.paused = !this.paused;
+  } else {
+    this.currentTrack = track;
+    this.paused = false;  // sets paused immediately
+  }
+}
+```
+
+the original code set `paused = false` immediately when the track changed, and another effect handled waiting for loading:
+
+```typescript
+// sync paused state with audio element
+$effect(() => {
+  if (!player.audioElement || isLoadingTrack) return;  // waits for loading
+
+  if (player.paused) {
+    player.audioElement.pause();
+  } else {
+    player.audioElement.play().catch(err => {
+      console.error('playback failed:', err);
+      player.paused = true;
+    });
+  }
+});
+```
+
+### the issue with our changes
+
+we're trying to conditionally set `paused = false` or `shouldAutoPlay = true` based on `queue.lastUpdateWasLocal`, but something in this flow is breaking.
+
+possibilities:
+1. timing issue: `lastUpdateWasLocal` gets reset before the effect runs?
+2. effect dependency issue: effects not firing in the right order?
+3. reactive state not updating when we think it is?
+4. the flag is working but something else is preventing playback?
+
+## what to investigate
+
+1. **add console.log statements** to trace the exact flow:
+   - when `queue.next()` is called
+   - value of `lastUpdateWasLocal` at each step
+   - when Player effect runs and what it sees
+   - when `shouldAutoPlay` gets set and what happens next
+
+2. **check Logfire traces** for the auto-advance flow to see what's happening server-side and in the queue sync
+
+3. **consider alternative approaches**:
+   - instead of a flag, track which tab ID is "active player"?
+   - use a different mechanism to coordinate playback across tabs?
+   - accept that all tabs will try to play and rely on browser to handle it?
+
+4. **verify the issue isn't elsewhere**:
+   - does `handleTrackEnded()` actually call `queue.next()`?
+   - is auto-advance preference actually enabled when this happens?
+   - is there an error being swallowed somewhere?
+
+## original issue this was trying to solve
+
+from STATUS.md:
+
+> when a track ends and auto-advances to the next track, **both tabs** receive the queue update and try to start playing the new track. the browser only allows one tab to play audio at a time, so it alternates which tab "wins" the audio playback race.
+
+so the original problem was: tabs switch back and forth randomly.
+now the problem is: no tabs play at all.
+
+## files modified
+
+- `frontend/src/lib/queue.svelte.ts`: added `lastUpdateWasLocal` flag and broadcast filtering
+- `frontend/src/lib/components/Player.svelte`: conditional auto-play based on flag
+
+## next steps for whoever picks this up
+
+1. review the original code flow without our changes (git diff HEAD~1)
+2. add detailed logging to understand when and why playback isn't starting
+3. consider whether the `lastUpdateWasLocal` approach is fundamentally flawed
+4. maybe the solution is simpler: just let the original behavior work and accept that tabs might occasionally switch?
+5. or maybe we need a different coordination mechanism entirely
+
+good luck. i'm sorry i couldn't solve this.

--- a/docs/internal/retrospectives/2025-11-07-player-positioning-analysis.md
+++ b/docs/internal/retrospectives/2025-11-07-player-positioning-analysis.md
@@ -1,0 +1,214 @@
+# player positioning analysis
+
+## problems
+
+### 1. hardcoded bottom spacing
+**queue toggle button** (`+layout.svelte:193`):
+```css
+.queue-toggle {
+  bottom: 120px; /* hardcoded - assumes player height */
+}
+```
+
+**problem**: button stays 120px from bottom even when player isn't visible (no track loaded)
+
+**queue padding** (`Queue.svelte:144`):
+```css
+.queue {
+  padding: 1.5rem 1.25rem 140px; /* hardcoded player height assumption */
+}
+```
+
+**problem**: bottom padding doesn't adjust to actual player presence/height
+
+### 2. mobile browser viewport issues
+
+mobile browsers (especially safari) have dynamic UI bars that change viewport height:
+- address bar shows/hides when scrolling
+- bottom toolbar shows/hides
+- `100vh` doesn't account for these dynamic changes
+
+**player** uses `position: fixed; bottom: 0` which should stick to bottom, but:
+- may show gap between player and actual screen bottom on some mobile browsers
+- doesn't use `env(safe-area-inset-bottom)` for devices with notches/home indicators
+
+### 3. no dynamic height calculation
+
+player height varies:
+- desktop: `~100px` (padding + content)
+- mobile: `~200px` (column layout)
+
+but spacing is **hardcoded** everywhere instead of using:
+- css variables to communicate player height
+- dynamic calculation with javascript
+- css environment variables for safe areas
+
+## solution approaches
+
+### option 1: css custom properties (recommended)
+
+set player height as css variable, use throughout:
+
+```css
+/* Player.svelte */
+.player {
+  --player-height: 100px; /* or calculate dynamically */
+  position: fixed;
+  bottom: 0;
+  height: var(--player-height);
+}
+
+/* +layout.svelte */
+.queue-toggle {
+  bottom: calc(var(--player-height, 0px) + 20px);
+}
+
+/* Queue.svelte */
+.queue {
+  padding-bottom: calc(var(--player-height, 0px) + 40px);
+}
+```
+
+**pros**: simple, css-only, performant
+**cons**: requires consistent height, no player = need conditional logic
+
+### option 2: safe area insets + dynamic calculation
+
+use css environment variables for mobile safety:
+
+```css
+.player {
+  position: fixed;
+  bottom: 0;
+  /* account for ios notch/home indicator */
+  padding-bottom: max(1rem, env(safe-area-inset-bottom));
+}
+
+.queue-toggle {
+  /* stack above player + safe area */
+  bottom: calc(var(--player-height, 0px) + env(safe-area-inset-bottom) + 20px);
+}
+```
+
+**pros**: works with device notches/safe areas
+**cons**: more complex calculation
+
+### option 3: conditional rendering based on player state
+
+make queue toggle position conditional on whether player is showing:
+
+```svelte
+<button
+  class="queue-toggle"
+  class:player-visible={player.currentTrack}
+  style="bottom: {player.currentTrack ? '120px' : '20px'}"
+>
+```
+
+**pros**: explicit, easy to understand
+**cons**: requires reactive state, inline styles
+
+### option 4: use dvh (dynamic viewport height)
+
+replace `100vh` with `100dvh` (dynamic viewport height):
+
+```css
+.queue-sidebar {
+  height: 100dvh; /* adjusts for mobile browser UI */
+}
+```
+
+**pros**: modern, handles mobile browsers automatically
+**cons**: newer css, may need fallback for older browsers
+
+## recommended fix
+
+**combination approach**:
+
+1. **add css custom property for player height**
+   - set `--player-height` on `:root` when player mounts
+   - update when player height changes (desktop/mobile)
+   - default to `0px` when no player
+
+2. **use safe area insets**
+   - add `env(safe-area-inset-bottom)` to player bottom padding
+   - ensures player sits above device notches/home indicators
+
+3. **use dvh for full-height elements**
+   - replace `100vh` with `100dvh` where appropriate
+   - fallback to `100vh` for older browsers
+
+4. **conditional positioning**
+   - queue toggle: `calc(var(--player-height) + 20px + env(safe-area-inset-bottom))`
+   - queue padding: `calc(var(--player-height) + 40px + env(safe-area-inset-bottom))`
+
+## implementation
+
+### Player.svelte
+
+```svelte
+<script>
+  import { onMount } from 'svelte';
+
+  onMount(() => {
+    // set player height css variable
+    function updatePlayerHeight() {
+      const playerEl = document.querySelector('.player');
+      if (playerEl) {
+        const height = playerEl.offsetHeight;
+        document.documentElement.style.setProperty('--player-height', `${height}px`);
+      } else {
+        document.documentElement.style.setProperty('--player-height', '0px');
+      }
+    }
+
+    updatePlayerHeight();
+    window.addEventListener('resize', updatePlayerHeight);
+    return () => window.removeEventListener('resize', updatePlayerHeight);
+  });
+</script>
+
+<style>
+  .player {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 1rem 2rem;
+    padding-bottom: max(1rem, env(safe-area-inset-bottom));
+  }
+</style>
+```
+
+### +layout.svelte
+
+```css
+.queue-toggle {
+  position: fixed;
+  bottom: calc(var(--player-height, 0px) + 20px + env(safe-area-inset-bottom, 0px));
+  right: 20px;
+}
+
+@media (max-width: 768px) {
+  .queue-toggle {
+    /* on mobile, player is taller - but use same calculation */
+    bottom: calc(var(--player-height, 0px) + 20px + env(safe-area-inset-bottom, 0px));
+  }
+}
+```
+
+### Queue.svelte
+
+```css
+.queue {
+  padding: 1.5rem 1.25rem calc(var(--player-height, 0px) + 40px + env(safe-area-inset-bottom, 0px));
+}
+```
+
+## benefits
+
+1. **no gaps**: player always flush with screen bottom (using safe-area-insets)
+2. **dynamic positioning**: queue toggle moves based on actual player height
+3. **conditional**: when no player, everything positioned correctly near bottom
+4. **mobile-friendly**: accounts for dynamic browser UI and device notches
+5. **maintainable**: single source of truth (--player-height variable)

--- a/docs/internal/retrospectives/2025-11-07-queue-401-analysis.md
+++ b/docs/internal/retrospectives/2025-11-07-queue-401-analysis.md
@@ -1,0 +1,217 @@
+# queue 401 errors analysis
+
+## problem
+
+console shows 401 errors when not logged in:
+```
+:8001/queue/:1  Failed to load resource: the server responded with a status of 401 (Unauthorized)
+queue.svelte.ts:186 failed to fetch queue: Error: failed to fetch queue: Unauthorized
+:8001/auth/me:1  Failed to load resource: the server responded with a status of 401 (Unauthorized)
+:8001/queue/:1  Failed to load resource: the server responded with a status of 401 (Unauthorized)
+queue.svelte.ts:369 failed to push queue: Error: failed to push queue: Unauthorized
+```
+
+## root cause
+
+**queue.svelte.ts** (`line 576-578`):
+```typescript
+if (browser) {
+  void queue.initialize();
+}
+```
+
+this runs **immediately** when the module loads, before checking if user is logged in.
+
+**initialize()** (`line 73-113`):
+- sets up broadcast channel
+- calls `await this.fetchQueue()` at line 109
+
+**fetchQueue()** (`line 139-190`):
+- checks for `sessionId` in localStorage (line 153)
+- conditionally adds `Authorization` header (line 156-158)
+- BUT: always makes the fetch request (line 164)
+- backend endpoint **requires auth** (line 34 in `backend/api/queue.py`)
+
+**backend requirement** (`backend/api/queue.py:34`):
+```python
+session: Session = Depends(require_auth)
+```
+
+## why it happens
+
+1. page loads
+2. queue module executes, calls `queue.initialize()`
+3. `initialize()` calls `fetchQueue()`
+4. user not logged in → no `sessionId` in localStorage
+5. fetch still happens, just without auth header
+6. backend returns 401
+7. error logged to console
+
+same issue with `pushQueue()`:
+- called from `schedulePush()` → called from any queue mutation
+- always tries to sync, even when not authenticated
+
+## solution
+
+**don't initialize queue for unauthenticated users**
+
+options:
+
+### option 1: skip initialization when not logged in
+
+```typescript
+// queue.svelte.ts
+async initialize() {
+  if (!browser || this.initialized) return;
+
+  const sessionId = localStorage.getItem('session_id');
+  if (!sessionId) {
+    // no session, skip initialization
+    this.initialized = true;
+    return;
+  }
+
+  // ... rest of initialization
+}
+```
+
+**pros**: simple, minimal changes
+**cons**: queue won't work at all when not logged in (but that's probably fine - who needs a queue when not logged in?)
+
+### option 2: gracefully handle 401 in fetch/push
+
+```typescript
+async fetchQueue(force = false) {
+  // ... existing code ...
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      // not authenticated, skip silently
+      return;
+    }
+    throw new Error(`failed to fetch queue: ${response.statusText}`);
+  }
+
+  // ... rest
+}
+```
+
+**pros**: no errors logged for expected 401s
+**cons**: still makes unnecessary network requests
+
+### option 3: check auth before any server operation
+
+```typescript
+private isAuthenticated(): boolean {
+  return !!localStorage.getItem('session_id');
+}
+
+async fetchQueue(force = false) {
+  if (!browser) return;
+  if (!this.isAuthenticated()) return; // skip if not authenticated
+
+  // ... rest
+}
+
+async pushQueue(): Promise<boolean> {
+  if (!browser) return false;
+  if (!this.isAuthenticated()) return false; // skip if not authenticated
+
+  // ... rest
+}
+```
+
+**pros**: no unnecessary requests, no errors
+**cons**: need to add check to every server operation
+
+## recommended fix
+
+**combination of option 1 + option 3**:
+
+1. **skip initialization when not authenticated** (option 1)
+   - queue operations won't be set up for unauthenticated users
+   - prevents initial fetch error
+
+2. **guard fetch/push operations** (option 3)
+   - even if queue somehow gets used while logged out
+   - prevents any 401 errors from reaching console
+
+3. **reinitialize on login** (new)
+   - when user logs in, initialize the queue
+   - requires adding an init call after successful auth
+
+## implementation (completed)
+
+### queue.svelte.ts
+
+```typescript
+async initialize() {
+  if (!browser || this.initialized) return;
+  this.initialized = true;
+
+  // ... setup tabId, autoAdvance, broadcast channel ...
+
+  // only fetch from server if authenticated
+  if (this.isAuthenticated()) {
+    await this.fetchQueue();
+  }
+
+  // ... event listeners (visibilitychange, beforeunload) ...
+}
+
+private isAuthenticated(): boolean {
+  if (!browser) return false;
+  return !!localStorage.getItem('session_id');
+}
+
+async fetchQueue(force = false) {
+  if (!browser) return;
+  if (!this.isAuthenticated()) return; // skip if not authenticated
+
+  // ... rest of existing code (fetch from server, apply snapshot)
+}
+
+async pushQueue(): Promise<boolean> {
+  if (!browser) return false;
+  if (!this.isAuthenticated()) return false; // skip if not authenticated
+
+  // ... rest of existing code (send to server)
+}
+```
+
+**key insight**: these guards ONLY prevent server communication, not local queue operations. all queue methods (addTracks, setQueue, playNow, next, previous, toggleShuffle, moveTrack, removeTrack, etc.) work independently and update local state. they call `schedulePush()` which eventually tries `pushQueue()`, but if that returns false silently, the local state still works perfectly.
+
+### auth callback (after login)
+
+wherever user logs in successfully, fetch queue state:
+
+```typescript
+// after successful login
+localStorage.setItem('session_id', sessionId);
+// queue is already initialized, just fetch server state
+await queue.fetchQueue(true); // force fetch to get persisted state
+```
+
+## benefits
+
+1. **no 401 errors** when not logged in
+2. **no unnecessary requests** to authenticated endpoints
+3. **queue works for everyone** - local state works without auth
+4. **server sync when authenticated** - persisted state synced for logged-in users
+5. **clean console** - no spurious errors
+6. **proper separation** - local functionality always available, persistence only when authenticated
+
+## edge cases
+
+**what if user logs out?**
+- queue keeps running in current implementation
+- should probably clear queue and stop syncing
+- add `queue.destroy()` method?
+
+**what if session expires?**
+- 401 on next fetch/push
+- could detect and handle gracefully (clear queue, show login prompt?)
+
+**what about multi-tab?**
+- broadcast channel still works if all tabs are authenticated
+- if one tab logs out, others continue normally (each has own sessionId check)

--- a/docs/internal/retrospectives/2025-11-08-double-loading-analysis.md
+++ b/docs/internal/retrospectives/2025-11-08-double-loading-analysis.md
@@ -1,0 +1,63 @@
+# double loading state analysis
+
+## problem
+On hard refresh of homepage:
+1. Tracks appear immediately (from cache)
+2. "loading tracks..." appears briefly
+3. Tracks appear again
+
+## root cause
+
+**frontend/src/lib/tracks.svelte.ts:**
+```typescript
+class TracksCache {
+    tracks = $state<Track[]>(loadCachedTracks());  // loads from localStorage immediately
+    loading = $state(false);  // starts as false
+
+    async fetch(force = false): Promise<void> {
+        if (!force && this.loading) return;
+
+        this.loading = true;  // <-- THIS causes the loading UI to show
+        // ... fetch from server
+        this.loading = false;
+    }
+}
+```
+
+**frontend/src/routes/+page.svelte:**
+```typescript
+let tracks = $derived(tracksCache.tracks);  // has cached data immediately
+let loadingTracks = $derived(tracksCache.loading);  // false, then true, then false
+
+onMount(async () => {
+    // ...
+    tracksCache.fetch();  // triggers loading = true
+});
+```
+
+**Render sequence:**
+1. Initial render: `tracks.length > 0` (cached), `loading = false` → shows tracks
+2. `fetch()` called: `loading = true` → shows "loading tracks..."
+3. Fetch completes: `loading = false`, `tracks` updated → shows tracks again
+
+## solution
+
+Only show loading state if we don't have cached data:
+
+```typescript
+// +page.svelte
+let showLoading = $derived(loadingTracks && tracks.length === 0);
+
+{#if showLoading}
+    <p class="loading-text">loading tracks...</p>
+{:else if !hasTracks}
+    <p class="empty">no tracks yet</p>
+{:else}
+    <!-- tracks -->
+{/if}
+```
+
+This way:
+- If we have cached tracks → show them while fetching in background
+- If we don't have cached tracks → show loading state
+- No flicker between states

--- a/docs/internal/retrospectives/2025-11-08-player-scroll-issue-analysis.md
+++ b/docs/internal/retrospectives/2025-11-08-player-scroll-issue-analysis.md
@@ -1,0 +1,62 @@
+# player scroll and positioning issues
+
+## problems
+
+1. **Gap at bottom of screen**: White/gray bar visible between player bottom and screen bottom on mobile
+2. **Content cut off**: Can't scroll far enough to see last track - it's hidden behind/below the player
+
+## root cause
+
+**frontend/src/routes/+page.svelte (line 89):**
+```css
+main {
+    padding: 0 1rem 120px;  /* hardcoded 120px */
+}
+```
+
+**frontend/src/lib/components/Player.svelte (lines 304-313):**
+```css
+.player {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 1rem 2rem;
+    padding-bottom: max(1rem, env(safe-area-inset-bottom));
+    /* actual height varies by content + safe area */
+}
+```
+
+## issue 1: hardcoded padding doesn't match dynamic player height
+
+The homepage uses `120px` bottom padding, but:
+- Player height varies based on content and layout
+- On mobile with safe area insets, player can be taller
+- Gap appears because padding doesn't match actual player height
+
+## issue 2: safe area insets not properly handled
+
+The player uses `env(safe-area-inset-bottom)` for its own padding, but the page content doesn't account for this. So:
+- Player sits at `bottom: 0` (correct)
+- But its internal padding pushes content up
+- Page padding doesn't account for this extra space
+- Last track gets cut off
+
+## solution
+
+Use the same dynamic `--player-height` variable we created in PR #101:
+
+**frontend/src/routes/+page.svelte:**
+```css
+main {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 0 1rem calc(var(--player-height, 120px) + env(safe-area-inset-bottom, 0px));
+}
+```
+
+This ensures:
+- Bottom padding matches actual player height
+- Safe area insets are accounted for
+- No gap at bottom of screen
+- All content scrollable

--- a/docs/internal/retrospectives/2025-11-11-upload-crash-analysis.md
+++ b/docs/internal/retrospectives/2025-11-11-upload-crash-analysis.md
@@ -1,0 +1,204 @@
+# upload crash analysis
+
+## problem report
+
+user (doom.bsky.social) attempted to upload an hour-long mix multiple times over several hours from both laptop and iPhone. the upload:
+- loaded the file successfully from phone
+- timed out when hitting "publish"
+- showed no progress
+- reset the form fields automatically
+
+### original user interaction transcript
+
+```
+nate: Hey man tryna upload a mix to your site and it's crashing. My friend Stella said you could maybe help.
+
+nate: damn ok, one min lemme look
+
+[investigation begins]
+
+nate: hmm can you tell me roughly when you tried?
+nate: and file format and rough duration?
+nate: not seeing the spans just yet
+
+user: A few times over the last couple hours, from phone and laptop. It's an hour mix.
+      It loaded the file from the phone but when I hit publish it just timed out and
+      never showed any progress then refreshed the fields itself
+```
+
+## logfire investigation
+
+### what we found
+- **laptop upload (04:25:34)**: successful POST /tracks/ with 200 status, took 4.5s, completed background processing
+- **iPhone attempts (around 04:20)**: NO POST /tracks/ requests logged at all
+- user was authenticated and viewing their profile page on iPhone
+- multiple successful GET /artists/by-handle/doom.bsky.social from iPhone user agent
+
+### what this means
+the frontend never sent the POST request from mobile. the failure occurred **before** the HTTP request was made, ruling out:
+- backend timeouts
+- SSE connection issues
+- server-side errors
+- network connection problems (other requests worked)
+
+## code analysis
+
+### current implementation (frontend/src/lib/uploader.svelte.ts:49-64)
+
+```typescript
+fetch(`${API_URL}/tracks/`, {
+    method: 'POST',
+    body: formData,
+    headers: {
+        'Authorization': `Bearer ${sessionId}`
+    }
+})
+```
+
+the upload flow:
+1. user selects file in portal/+page.svelte
+2. on submit, `handleUpload()` captures file reference (line 192-224)
+3. calls `uploader.upload()` which:
+   - creates FormData
+   - **appends file directly** - FormData handles the file streaming internally
+   - sends POST request
+4. backend reads via UploadFile which streams from request body
+
+### what we initially suspected but is NOT the issue
+
+we thought the problem was `await file.read()` reading entire file into memory, but **the code doesn't do this**. FormData in browsers handles File objects efficiently without loading into memory.
+
+### actual problem areas
+
+1. **no error handling around fetch** (uploader.svelte.ts:50-64)
+   - if fetch() throws before getting response (network error, memory issue, timeout), only generic catch at line 126 handles it
+   - on mobile, large file uploads can fail silently due to:
+     - iOS memory pressure causing tab reload
+     - mobile browser resource limits
+     - network state changes during upload
+     - background tab throttling
+
+2. **no upload progress indication**
+   - fetch() with FormData provides no progress events for upload phase
+   - user sees "uploading track..." toast but no percentage
+   - for 100MB file on mobile network, could take 30s-2min with no feedback
+
+3. **no explicit file size validation**
+   - portal/+page.svelte shows warning at line 31-34 for files >10MB
+   - but no hard limit or user confirmation for very large files (>50MB)
+   - mobile browsers may silently fail on large uploads
+
+4. **form reset timing** (portal/+page.svelte:203-218)
+   - form clears **immediately** before upload starts
+   - if upload fails before POST is sent, user loses all form data
+   - this matches reported behavior: "timed out... then refreshed the fields itself"
+
+## root cause hypothesis
+
+on iPhone, when uploading 100MB+ file:
+1. user hits submit
+2. form clears immediately (line 203-218)
+3. `uploader.upload()` starts creating FormData
+4. either:
+   - iOS kills the tab due to memory pressure during FormData creation
+   - fetch() call fails silently before sending request
+   - network timeout occurs during initial upload phase
+5. error caught by generic handler (line 126-129)
+6. toast shows "network error" but form already cleared
+7. user sees: form reset + error message (matches "timed out and refreshed the fields")
+
+## proposed solution
+
+### phase 1: immediate fixes (required for mobile uploads to work)
+
+1. **add XMLHttpRequest with progress tracking**
+   - replace fetch() with XHR for upload progress events
+   - show real-time upload percentage in toast
+   - detect stalls (no progress for >30s) and show appropriate error
+
+2. **delay form reset until upload starts successfully**
+   - only clear form after receiving upload_id from server
+   - on error before upload_id, restore form state
+   - prevents data loss on mobile failures
+
+3. **add explicit file size warnings**
+   - warn at 50MB: "large file, may take several minutes on mobile"
+   - warn at 100MB: "very large file, wifi recommended"
+   - consider soft limit at 200MB with confirmation
+
+4. **improve error messages**
+   - detect if on mobile device
+   - provide mobile-specific guidance: "try wifi", "keep screen on", etc.
+   - log more details about failure point
+
+### phase 2: proper streaming upload (ideal long-term solution)
+
+1. **chunked upload with resumability**
+   - split large files into 5-10MB chunks
+   - upload chunks sequentially with progress tracking
+   - store chunk state to allow resume after interruption
+   - backend endpoint: POST /tracks/chunks/{upload_id}
+
+2. **background upload service**
+   - use service worker to handle uploads
+   - survives page reloads and tab switches
+   - periodic sync for failed uploads
+
+3. **compress before upload (optional)**
+   - for wav/aiff files, offer client-side transcoding to mp3
+   - reduces upload time significantly
+   - requires web audio API + worker thread
+
+### phase 3: mobile-specific optimizations
+
+1. **detect and warn about problematic conditions**
+   - low battery (navigator.getBattery)
+   - cellular vs wifi (navigator.connection.effectiveType)
+   - background tab detection (document.hidden)
+
+2. **keep-alive mechanisms**
+   - play silent audio to prevent iOS from suspending tab
+   - request wake lock during upload (navigator.wakeLock)
+   - show persistent notification during upload
+
+## implementation priority
+
+**critical (do now):**
+- add XHR with progress tracking (fixes "no feedback" issue)
+- delay form reset until upload_id received (fixes "lost data" issue)
+- improve error handling and messages (helps debugging)
+
+**important (do soon):**
+- add file size warnings and limits (sets expectations)
+- mobile device detection and specific guidance (improves UX)
+
+**nice to have (future):**
+- chunked upload with resumability (proper fix for large files)
+- service worker background upload (best mobile experience)
+
+## testing plan
+
+1. test 100MB+ file upload on:
+   - iPhone Safari (primary issue)
+   - Android Chrome
+   - desktop browsers (regression test)
+
+2. test failure scenarios:
+   - switch tabs during upload
+   - lock phone during upload
+   - poor network conditions (throttle to 3G)
+   - intentional network interruption
+
+3. test progress indicators:
+   - verify percentage updates smoothly
+   - verify stall detection works
+   - verify error messages are helpful
+
+## acceptance criteria
+
+upload from mobile considered "fixed" when:
+- 100MB file uploads successfully from iPhone
+- user sees progress percentage throughout upload
+- on failure, user gets helpful error message
+- on failure, form data is not lost (or user is warned before retry)
+- upload survives brief tab switches on mobile

--- a/docs/internal/retrospectives/2025-11-12-banana-mix-incident.md
+++ b/docs/internal/retrospectives/2025-11-12-banana-mix-incident.md
@@ -1,0 +1,178 @@
+# banana mix incident retrospective
+
+**date**: 2025-11-12
+**issue**: track 56 ("banana mix") returned 404 from R2 despite having valid database and ATProto records
+
+## what happened
+
+1. stellz uploaded "banana mix" at 00:05:51 UTC → created track 56 with file_id `589c8ce7032583c7`
+2. UI feedback was slow, she thought upload failed
+3. stellz uploaded same file again at 00:07:22 UTC → created track 57 with same file_id `589c8ce7032583c7`
+4. both uploads pointed to same R2 object: `audio/589c8ce7032583c7.mp3`
+5. stellz deleted track 57 at 00:08:20 UTC
+6. deletion called `storage.delete(track.file_id)` which removed the R2 file
+7. track 56 left with dangling R2 reference → 404 errors
+
+## root cause
+
+three distinct bugs enabled this:
+
+1. **no duplicate detection**: same file can create multiple tracks (file_id unique constraint removed in migration `ba46ea4ba64e`)
+2. **unsafe R2 deletion**: `storage.delete()` doesn't check refcount before deleting files
+3. **orphaned ATProto records**: `delete_track()` doesn't clean up PDS records, leaving `fm.plyr.track` records after track deletion
+
+## timeline
+
+```
+00:05:51 - track 56 created (first upload)
+00:07:22 - track 57 created (duplicate upload, same file_id)
+00:08:20 - track 57 deleted → R2 file removed
+         - track 56 now broken (404)
+         - ATProto record for track 57 orphaned on PDS
+```
+
+## how we fixed it
+
+### immediate fix
+
+stellz sent correct file via google drive. uploaded manually using aws cli:
+
+```bash
+# ad-hoc upload script (masks secrets to first 4 chars)
+cd ~/Downloads && \
+AWS_ACCESS_KEY_ID=ca05... \
+AWS_SECRET_ACCESS_KEY=860e... \
+aws s3 cp stellz_banana_mix.mp3 \
+  s3://audio-prod/audio/589c8ce7032583c7.mp3 \
+  --endpoint-url https://8feb... \
+  --content-type audio/mpeg
+```
+
+stellz manually deleted orphaned ATProto record `3m5hup67fpr2c` from her PDS.
+
+### created backfill script
+
+created `scripts/backfill_missing_r2_file.py` for future incidents:
+
+```python
+class BackfillSettings(BaseSettings):
+    database_url: str = Field(validation_alias="ADMIN_DATABASE_URL")
+    aws_access_key_id: str = Field(validation_alias="ADMIN_AWS_ACCESS_KEY_ID")
+    aws_secret_access_key: str = Field(validation_alias="ADMIN_AWS_SECRET_ACCESS_KEY")
+    r2_endpoint_url: str = Field(validation_alias="ADMIN_R2_ENDPOINT_URL")
+    r2_bucket: str = Field(validation_alias="ADMIN_R2_BUCKET")
+
+# usage:
+# uv run scripts/backfill_missing_r2_file.py <audio_file> <track_id>
+```
+
+uses `ADMIN_*` prefixed env vars to target production database/storage.
+
+## what we need to prevent this
+
+### 1. add duplicate detection (high priority)
+
+in `src/backend/api/tracks.py`, after `storage.save()`:
+
+```python
+# after getting file_id from storage
+async with db_session() as db:
+    stmt = select(Track).where(
+        Track.file_id == file_id,
+        Track.artist_did == artist_did
+    )
+    existing = await db.execute(stmt)
+    if existing.scalar_one_or_none():
+        # return 409 with existing track instead of creating duplicate
+        return Response(status_code=409, content={"existing_track_id": existing.id})
+```
+
+this prevents re-uploads from creating duplicate rows.
+
+### 2. make R2 deletions reference-safe (high priority)
+
+in `src/backend/storage/r2.py:delete()`:
+
+```python
+async def delete(self, file_id: str) -> bool:
+    # check refcount before deleting
+    async with db_session() as db:
+        stmt = select(func.count()).select_from(Track).where(Track.file_id == file_id)
+        result = await db.execute(stmt)
+        refcount = result.scalar_one()
+
+        if refcount > 1:
+            logfire.info("skipping R2 delete, file still referenced", file_id=file_id, refcount=refcount)
+            return False
+
+    # safe to delete - only one reference
+    async with self.async_session.client(...) as client:
+        await client.delete_object(Bucket=self.audio_bucket_name, Key=key)
+```
+
+prevents "delete duplicate and nuke original" scenario.
+
+### 3. clean up ATProto records on delete (high priority)
+
+in `src/backend/api/tracks.py:delete_track()`:
+
+```python
+# before deleting DB row
+if track.atproto_record_uri:
+    try:
+        await delete_record_by_uri(auth_session, track.atproto_record_uri)
+    except Exception as e:
+        if "404" in str(e):
+            # record already gone, that's fine
+            pass
+        else:
+            # other errors should bubble
+            raise
+
+# then delete DB row
+await db.delete(track)
+```
+
+keeps PDS in sync with our database.
+
+### 4. improve UI feedback (medium priority)
+
+slow upload feedback caused the duplicate upload. add:
+- progress indicator during upload
+- disable upload button after click
+- show clear success/error states
+
+### 5. optional: restore uniqueness constraint
+
+if we decide duplicates should never exist, re-add partial unique index:
+
+```sql
+CREATE UNIQUE INDEX tracks_file_id_artist_did_key
+ON tracks(file_id, artist_did);
+```
+
+keeps database honest even if code forgets the check.
+
+## lessons learned
+
+- removing unique constraints enables subtle race conditions
+- deletion operations need refcount checks for shared resources
+- ATProto records must be kept in sync with local state
+- slow UI feedback can trigger duplicate submissions
+- need better tooling for production debugging (backfill script helps)
+
+## related files
+
+- `src/backend/api/tracks.py` - upload and delete endpoints
+- `src/backend/storage/r2.py` - R2 storage operations
+- `alembic/versions/ba46ea4ba64e_remove_unique_constraint_from_tracks_.py` - migration that removed unique constraint
+- `scripts/backfill_missing_r2_file.py` - manual recovery script
+- `scripts/delete_track.py` - track deletion (has same ATProto cleanup issue)
+
+## action items
+
+- [ ] implement duplicate detection in upload endpoint
+- [ ] add refcount check to `storage.delete()`
+- [ ] clean up ATProto records in `delete_track()`
+- [ ] add upload progress indicator to UI
+- [ ] consider restoring unique constraint on `(file_id, artist_did)`

--- a/docs/internal/retrospectives/2025-11-17-connection-pool-outage.md
+++ b/docs/internal/retrospectives/2025-11-17-connection-pool-outage.md
@@ -1,0 +1,108 @@
+# postmortem: production outage 2025-11-17
+
+## summary
+
+complete API outage for 4 minutes (05:04-05:08 UTC). all requests returned 500 errors due to database connection pool exhaustion.
+
+## timeline (UTC)
+
+- **05:04:45** - first connection pool exhaustion event
+- **05:06:00** - all API requests failing with 30s timeouts
+- **05:08:35** - manual restart via `flyctl apps restart relay-api`
+- **05:08:50** - service restored and healthy
+
+**total downtime: ~4 minutes**
+
+## root cause
+
+the queue service uses asyncpg for PostgreSQL LISTEN/NOTIFY cross-instance synchronization. the connection initialization in `_connect()` had **no timeout**:
+
+```python
+# BEFORE (problematic code)
+self.conn = await asyncpg.connect(db_url)
+```
+
+when Neon database was slow or unresponsive, `asyncpg.connect()` hung indefinitely. this exhausted SQLAlchemy's connection pool (configured with `pool_size=5, max_overflow=0`).
+
+with all 5 connections stuck waiting for the queue listener, every incoming API request timed out after 30s trying to acquire a database connection.
+
+## the fix
+
+wrapped the connection call in `asyncio.wait_for()` with a configurable timeout:
+
+```python
+# AFTER (hotfix)
+timeout = settings.database.queue_connect_timeout  # default 3.0s
+self.conn = await asyncio.wait_for(asyncpg.connect(db_url), timeout=timeout)
+```
+
+### why 3 seconds?
+
+analyzed logfire production data to establish baseline:
+- healthy connections: 2-4ms (typical)
+- p99 latency: 549ms
+- chosen timeout: 3.0s (5x headroom over p99)
+
+this provides sufficient buffer for transient slowness while failing fast enough to retry via the existing reconnection logic in `_listen_loop()`.
+
+### configuration
+
+added `QUEUE_CONNECT_TIMEOUT` environment variable to DatabaseSettings:
+- default: 3.0 seconds
+- configurable per environment
+- allows runtime adjustment without code changes
+
+## contributing factors
+
+1. **no timeout policy** - asyncpg connection calls assumed fast/reliable database
+2. **small connection pool** - 5 connections with no overflow meant rapid exhaustion
+3. **cascading failure** - queue listener blocked → pool exhausted → all requests failed
+4. **no circuit breaker** - no mechanism to detect/isolate failing queue listener
+
+## impact
+
+- **duration**: 4 minutes
+- **scope**: 100% of API traffic (all endpoints)
+- **user experience**: complete service unavailability
+- **data loss**: none (failure mode was read-only connection exhaustion)
+
+## lessons learned
+
+### what went well
+- **observability**: logfire traces immediately showed connection pool exhaustion pattern
+- **baseline data**: p99 latency metrics informed timeout selection
+- **quick recovery**: manual restart restored service in <1 minute
+- **retry logic**: existing reconnection loop in `_listen_loop()` worked once timeout added
+
+### what went wrong
+- **missing timeout**: critical network call had no failure boundary
+- **no proactive monitoring**: connection pool exhaustion not detected until total failure
+- **manual intervention**: required human to restart service
+
+### action items
+
+#### completed
+- [x] deployed hotfix with configurable timeout (PR #280)
+- [x] added specific TimeoutError handling and logging
+- [x] documented timeout selection rationale in code comments
+
+#### planned
+- [ ] audit all asyncpg/network calls for missing timeouts
+- [ ] add connection pool metrics to logfire dashboards
+- [ ] implement connection pool exhaustion alerts
+- [ ] consider larger pool size or max_overflow for better degradation
+- [ ] evaluate circuit breaker pattern for queue listener
+- [ ] document timeout policy in backend/CLAUDE.md
+
+## related issues
+
+- PR #280: queue connection timeout hotfix
+- issue #XXX: audit network timeouts (to be created)
+- issue #XXX: connection pool monitoring (to be created)
+
+## references
+
+- logfire trace showing outage: [link to trace if available]
+- hotfix PR: https://github.com/zzstoatzz/plyr.fm/pull/280
+- queue service code: `src/backend/_internal/queue.py`
+- database settings: `src/backend/config.py`

--- a/docs/internal/retrospectives/2025-11-17-database-connection-pooling-analysis.md
+++ b/docs/internal/retrospectives/2025-11-17-database-connection-pooling-analysis.md
@@ -1,0 +1,379 @@
+# database connection pooling analysis
+
+analysis of current pooling configuration vs Nebula best practices, following the connection pool outage.
+
+## current state (plyr.fm)
+
+### where connections are created
+
+**primary connection pool** - `src/backend/utilities/database.py:42-51`
+```python
+engine = create_async_engine(
+    settings.database.url,
+    echo=settings.app.debug,
+    pool_pre_ping=True,      # ✅ verify connections before use
+    pool_recycle=3600,       # ❌ hardcoded 1 hour
+    pool_use_lifo=True,      # ✅ reuse recent connections
+    pool_size=5,             # ❌ hardcoded
+    max_overflow=0,          # ❌ hardcoded, no overflow allowed
+    **kwargs,
+)
+```
+
+**queue listener** - `src/backend/_internal/queue.py:67`
+```python
+# separate asyncpg connection for LISTEN/NOTIFY
+timeout = settings.database.queue_connect_timeout  # ✅ 3.0s default (just added)
+self.conn = await asyncio.wait_for(asyncpg.connect(db_url), timeout=timeout)
+```
+
+### what we're missing
+
+1. **no statement timeout** - queries can run indefinitely
+2. **no connection timeout** - pool checkout can hang (except queue listener now)
+3. **no pool timeout** - waiting for available connection has no limit
+4. **hardcoded pool settings** - can't adjust per environment
+5. **no overflow** - immediate failure when 5 connections are busy
+
+## nebula's approach
+
+from `sandbox/nebula/src/prefect_cloud/settings.py:120-156`:
+
+### configurable settings
+
+```python
+class NebulaDatabaseSettings(BaseSettings):
+    timeout: Optional[float] = Field(
+        default=2,
+        description="statement timeout in seconds applied to all database interactions"
+    )
+
+    connection_timeout: Optional[float] = Field(
+        default=3,
+        description="connection timeout in seconds applied to all database interactions"
+    )
+
+    pool_recycle: Optional[float] = Field(
+        default=2 * HOUR,  # 7200 seconds
+        description="time after which a connection will be recycled"
+    )
+
+    pool_size: Optional[int] = Field(
+        default=5,
+        description="database connections to keep in pool at a time"
+    )
+
+    pool_max_overflow: Optional[int] = Field(
+        default=0,
+        description="dynamic connections if pool is exhausted"
+    )
+
+    pool_pre_ping: bool = Field(
+        default=True,
+        description="ping database before using connection from pool"
+    )
+```
+
+### how they apply these settings
+
+from `sandbox/nebula/src/prefect_cloud/utilities/database.py:100-127`:
+
+```python
+kwargs: dict[str, Any] = {
+    "connect_args": {
+        "prepared_statement_name_func": lambda: f"__asyncpg_{uuid.uuid4()}__",
+        "statement_cache_size": 0,
+        "prepared_statement_cache_size": 0,
+        "server_settings": {
+            "jit": "off",
+            "plan_cache_mode": plan_cache_mode,
+        },
+    }
+}
+
+# apply database timeout (statement timeout)
+if timeout := database_settings.timeout:
+    kwargs["connect_args"].update(dict(command_timeout=timeout))
+
+# apply connection timeout
+if connection_timeout := database_settings.connection_timeout:
+    kwargs["connect_args"].update(dict(timeout=connection_timeout))
+    kwargs["pool_timeout"] = connection_timeout  # ⭐ also set pool timeout
+
+engine = create_async_engine(
+    database_settings.connection_url.get_secret_value(),
+    echo=database_settings.echo,
+    pool_pre_ping=database_settings.pool_pre_ping,
+    pool_use_lifo=True,
+    pool_recycle=database_settings.pool_recycle,
+    pool_size=database_settings.pool_size,
+    max_overflow=database_settings.pool_max_overflow,
+    **kwargs,
+)
+```
+
+## key differences
+
+| setting | plyr.fm (current) | nebula | notes |
+|---------|-------------------|--------|-------|
+| **pool_size** | 5 (hardcoded) | 5 (configurable) | same default, but nebula can adjust |
+| **max_overflow** | 0 (hardcoded) | 0 (configurable) | both strict by default, but nebula flexible |
+| **pool_recycle** | 3600s (hardcoded) | 7200s (configurable) | nebula recycles less frequently |
+| **pool_pre_ping** | True | True (configurable) | ✅ both enabled |
+| **pool_use_lifo** | True | True | ✅ both enabled |
+| **statement timeout** | ❌ none | 2s (configurable) | **critical missing** |
+| **connection timeout** | ❌ none | 3s (configurable) | **critical missing** |
+| **pool timeout** | ❌ none | = connection_timeout | **critical missing** |
+
+## why these settings matter
+
+### statement timeout (`command_timeout`)
+- limits how long a single SQL query can run
+- prevents runaway queries from holding connections
+- nebula uses 2s default - aggressive but appropriate for API workloads
+- **without this**: slow queries hold connections indefinitely
+
+### connection timeout (`timeout`)
+- limits how long we wait to establish initial connection
+- prevents hanging when database is slow/unresponsive
+- nebula uses 3s default
+- **without this**: connection attempts hang indefinitely (our outage!)
+
+### pool timeout
+- limits how long we wait for an available connection from pool
+- prevents requests from hanging when pool is exhausted
+- nebula sets it equal to connection_timeout
+- **without this**: requests wait forever when all 5 connections are busy
+
+### pool_size and max_overflow
+- pool_size: persistent connections kept open
+- max_overflow: additional connections opened on demand
+- total max connections = pool_size + max_overflow
+- **tradeoff**:
+  - larger pool = more memory/connections, but better concurrency
+  - max_overflow > 0 = graceful degradation under load
+  - max_overflow = 0 = hard limit, fails fast (current approach)
+
+### pool_recycle
+- how long before recycling a connection
+- prevents stale connections from lingering
+- **too short**: unnecessary connection churn
+- **too long**: may hit database timeout and get forcibly closed
+- nebula uses 2 hours, we use 1 hour
+- both are reasonable, depends on database config
+
+## recommendations
+
+### tier 1: critical (fix immediately)
+
+1. **add statement timeout**
+   - default: 10s (more lenient than nebula's 2s for music streaming)
+   - configurable via `DATABASE_STATEMENT_TIMEOUT`
+   - apply via `command_timeout` in connect_args
+
+2. **add connection timeout**
+   - default: 3s (same as nebula, same as queue listener)
+   - configurable via `DATABASE_CONNECTION_TIMEOUT`
+   - apply via `timeout` in connect_args
+
+3. **add pool timeout**
+   - set equal to connection_timeout
+   - prevents requests hanging when pool exhausted
+   - apply via `pool_timeout` parameter
+
+### tier 2: important (add soon)
+
+4. **make pool_size configurable**
+   - keep default of 5
+   - allow override via `DATABASE_POOL_SIZE`
+   - enables per-environment tuning
+
+5. **make max_overflow configurable**
+   - keep default of 0 (strict)
+   - allow override via `DATABASE_MAX_OVERFLOW`
+   - enables graceful degradation if needed
+
+6. **make pool_recycle configurable**
+   - increase default to 7200s (2 hours, same as nebula)
+   - allow override via `DATABASE_POOL_RECYCLE`
+
+### tier 3: nice to have
+
+7. **add pool monitoring**
+   - track `engine.pool.checkedout()` (active connections)
+   - track `engine.pool.size()` (total pool size)
+   - log/alert when pool utilization > 80%
+   - nebula does this with prometheus metrics
+
+8. **document pool settings**
+   - add section to `backend/CLAUDE.md`
+   - explain each setting and when to adjust
+   - provide guidance for scaling
+
+## proposed config structure
+
+```python
+class DatabaseSettings(RelaySettingsSection):
+    """Database configuration."""
+
+    url: str = Field(
+        default="postgresql+asyncpg://localhost/plyr",
+        validation_alias="DATABASE_URL",
+        description="PostgreSQL connection string",
+    )
+
+    # timeouts
+    statement_timeout: float = Field(
+        default=10.0,
+        validation_alias="DATABASE_STATEMENT_TIMEOUT",
+        description="Timeout in seconds for SQL statement execution (command_timeout)",
+    )
+
+    connection_timeout: float = Field(
+        default=3.0,
+        validation_alias="DATABASE_CONNECTION_TIMEOUT",
+        description="Timeout in seconds for establishing database connections",
+    )
+
+    queue_connect_timeout: float = Field(
+        default=3.0,
+        validation_alias="QUEUE_CONNECT_TIMEOUT",
+        description="Timeout in seconds for queue listener database connections",
+    )
+
+    # pool settings
+    pool_size: int = Field(
+        default=5,
+        validation_alias="DATABASE_POOL_SIZE",
+        description="Number of database connections to keep in pool",
+    )
+
+    pool_max_overflow: int = Field(
+        default=0,
+        validation_alias="DATABASE_MAX_OVERFLOW",
+        description="Maximum connections to create beyond pool_size when pool is exhausted",
+    )
+
+    pool_recycle: int = Field(
+        default=7200,  # 2 hours
+        validation_alias="DATABASE_POOL_RECYCLE",
+        description="Seconds before recycling a connection (prevents stale connections)",
+    )
+
+    pool_pre_ping: bool = Field(
+        default=True,
+        validation_alias="DATABASE_POOL_PRE_PING",
+        description="Verify connection health before using from pool",
+    )
+```
+
+## proposed database.py changes
+
+```python
+def get_engine() -> AsyncEngine:
+    """retrieve an async sqlalchemy engine."""
+    loop = get_running_loop()
+    cache_key = (loop, settings.database.url)
+
+    if cache_key not in ENGINES:
+        kwargs: dict[str, Any] = {}
+
+        if "asyncpg" in settings.database.url:
+            kwargs["connect_args"] = {
+                "prepared_statement_name_func": lambda: f"__asyncpg_{uuid.uuid4()}__",
+                "statement_cache_size": 0,
+                "prepared_statement_cache_size": 0,
+            }
+
+            # apply statement timeout
+            if settings.database.statement_timeout:
+                kwargs["connect_args"]["command_timeout"] = settings.database.statement_timeout
+
+            # apply connection timeout
+            if settings.database.connection_timeout:
+                kwargs["connect_args"]["timeout"] = settings.database.connection_timeout
+                kwargs["pool_timeout"] = settings.database.connection_timeout
+
+        engine = create_async_engine(
+            settings.database.url,
+            echo=settings.app.debug,
+            pool_pre_ping=settings.database.pool_pre_ping,
+            pool_recycle=settings.database.pool_recycle,
+            pool_use_lifo=True,
+            pool_size=settings.database.pool_size,
+            max_overflow=settings.database.pool_max_overflow,
+            **kwargs,
+        )
+
+        # instrument sqlalchemy with logfire if enabled
+        if settings.observability.enabled:
+            import logfire
+            logfire.instrument_sqlalchemy(engine.sync_engine)
+
+        ENGINES[cache_key] = engine
+
+    return ENGINES[cache_key]
+```
+
+## production values to consider
+
+for current scale (small number of users, single fly.io instance):
+
+```bash
+# keep current strict pool
+DATABASE_POOL_SIZE=5
+DATABASE_MAX_OVERFLOW=0
+
+# add critical timeouts
+DATABASE_STATEMENT_TIMEOUT=10.0  # lenient for music uploads
+DATABASE_CONNECTION_TIMEOUT=3.0  # fail fast on db issues
+
+# longer recycle (same as nebula)
+DATABASE_POOL_RECYCLE=7200
+```
+
+if we need to scale or see pool exhaustion under load:
+
+```bash
+# option 1: larger strict pool
+DATABASE_POOL_SIZE=10
+DATABASE_MAX_OVERFLOW=0
+
+# option 2: smaller pool with overflow
+DATABASE_POOL_SIZE=5
+DATABASE_MAX_OVERFLOW=5  # allows 10 total under load
+```
+
+## relationship to the outage
+
+the 2025-11-17 outage happened because:
+
+1. queue listener's `asyncpg.connect()` had no timeout
+2. neon database was slow
+3. connection hung indefinitely
+4. **all 5 connections in pool stuck waiting**
+5. new API requests couldn't acquire connections
+6. requests timed out after 30s
+
+adding timeouts prevents this cascade:
+- **connection_timeout=3s**: queue listener fails fast, retries
+- **pool_timeout=3s**: API requests fail fast (503) instead of hanging
+- **statement_timeout=10s**: prevents slow queries from holding connections
+
+## next steps
+
+1. implement tier 1 changes (critical timeouts)
+2. test in staging with various timeout scenarios
+3. deploy to production with monitoring
+4. observe pool utilization for 1 week
+5. implement tier 2 changes (configurable pool settings)
+6. document in backend/CLAUDE.md
+
+## references
+
+- nebula settings: `sandbox/nebula/src/prefect_cloud/settings.py`
+- nebula database utils: `sandbox/nebula/src/prefect_cloud/utilities/database.py`
+- our database utils: `src/backend/utilities/database.py`
+- our config: `src/backend/config.py`
+- sqlalchemy pooling docs: https://docs.sqlalchemy.org/en/20/core/pooling.html
+- asyncpg connection docs: https://magicstack.github.io/asyncpg/current/api/index.html#connection

--- a/docs/internal/retrospectives/2025-11-17-performance-investigation.md
+++ b/docs/internal/retrospectives/2025-11-17-performance-investigation.md
@@ -1,0 +1,289 @@
+# Performance Investigation Retrospective - November 17-18, 2025
+
+## Problem Statement
+
+plyr.fm was experiencing severe performance issues:
+- Pages showing "no tracks" initially, then loading after several seconds
+- Everything felt "laggy" with no clear explanation
+- User experience was degrading with no visibility into the root cause
+
+## Investigation Process
+
+### Phase 1: Initial Logfire Analysis
+
+Queried Logfire for slow HTTP requests and found two major issues:
+
+1. **Queue NOTIFY hangs**: `PUT /queue/` requests hanging for **938 seconds** (15.6 minutes)
+   - Root cause: Neon PostgreSQL closing connections server-side, but asyncpg thinking connection was still alive
+   - Fix: Added 1-second timeout on NOTIFY operations and 5-second heartbeat loop to detect zombie connections
+   - Followed Prefect Nebula's proven LISTEN/NOTIFY pattern
+   - PR #270 - separate issue from tracks performance
+
+2. **Slow GET /tracks/ requests**: Taking 2-2.5 seconds consistently
+   - This became our focus for the rest of the investigation
+
+### Phase 2: Hypothesis - PDS Resolution
+
+**Initial theory**: Resolving ATProto PDS URLs for artists was causing the slowness.
+
+Added debug instrumentation to PDS resolution in `src/backend/api/tracks.py`:
+```python
+with logfire.span("resolve PDS URLs", artist_count=len(artists_to_resolve)):
+    # ... resolution code
+```
+
+**Result**: No spans appeared in traces. The code path wasn't even being hit - all artists had cached PDS URLs.
+
+**Lesson**: Instrument before assuming. We wasted time on the wrong hypothesis.
+
+### Phase 3: Hypothesis - R2 get_url Operations
+
+**Theory**: R2 `head_object` calls to check which image format exists were the bottleneck.
+
+Added instrumentation to `src/backend/storage/r2.py`:
+```python
+async def get_url(self, file_id: str) -> str | None:
+    with logfire.span("R2 get_url", file_id=file_id):
+        # ... check audio formats, then image formats
+```
+
+**Result**: Still no R2 spans showing up in traces.
+
+**Why**: Tracks with missing `image_id` never call `get_url()` at all. The conditional check prevented execution:
+```python
+if not image_url and track.image_id:  # if image_id is None, never executes
+    image_url = await track.get_image_url()
+```
+
+### Phase 4: Instrumentation - Track Serialization
+
+Added instrumentation to `src/backend/schemas.py`:
+```python
+async def from_track(...) -> "TrackResponse":
+    with logfire.span("serialize track", track_id=track.id):
+        # ...
+
+async def from_album(...) -> "AlbumSummary":
+    with logfire.span("serialize album", album_id=album.id):
+        # ...
+```
+
+**Result**: Serialization was FAST - under 2ms per track, ~0.4ms per album.
+
+This definitively ruled out serialization as the bottleneck.
+
+### Phase 5: The Real Culprit - Database Performance
+
+Looking at complete traces revealed:
+- **Database queries**: ~1-1.2 seconds total
+- **Serialization**: ~2-3ms total
+- **First connection**: 480ms
+- **Session query**: 171ms
+- **Simple SELECT queries**: 78-157ms each (should be <10ms)
+
+**Root cause**: Neon PostgreSQL connection pooling and serverless scaling issues, not application code.
+
+The ~1 second variance (sometimes 1s, sometimes 2.5s) was due to:
+- Neon serverless scaling state (warm vs cold)
+- Connection pool state
+- Network conditions
+- Whether session was already cached
+
+## Critical Discovery: Error Swallowing
+
+While adding instrumentation, we removed broad exception handling:
+
+**Before**:
+```python
+try:
+    await client.head_object(Bucket=bucket, Key=key)
+    return url
+except client.exceptions.NoSuchKey:
+    continue
+except Exception:  # ← SWALLOWING ALL ERRORS
+    continue
+```
+
+**After**:
+```python
+try:
+    await client.head_object(Bucket=bucket, Key=key)
+    return url
+except client.exceptions.NoSuchKey:
+    continue
+# removed broad exception handler
+```
+
+### The Explosion
+
+After deployment, Logfire immediately showed errors:
+```
+ClientError: An error occurred (404) when calling the HeadObject operation: Not Found
+```
+
+**Tracks failing**: 37, 38, 39, 70, 72
+**Time per 404**: 150-600ms
+**Impact**: Entire track serialization failing, requests returning errors
+
+### Why This Happened
+
+R2/S3 can raise **two different exceptions** for missing objects:
+1. `client.exceptions.NoSuchKey` - S3-specific exception
+2. `ClientError` with code `"404"` - generic boto3 error
+
+We only caught the first one. The second was being swallowed by `except Exception: continue`.
+
+### The Fix
+
+Wrote `sandbox/test_r2_404.py` to verify actual R2 behavior:
+```python
+async def test_r2_404():
+    # ... test with real R2 credentials
+    try:
+        await client.head_object(Bucket=bucket, Key=fake_key)
+    except client.exceptions.NoSuchKey as e:
+        print("caught NoSuchKey")  # never executed
+    except ClientError as e:
+        print(f"caught ClientError: {e.response['Error']['Code']}")  # "404"
+```
+
+**Confirmed**: R2 raises `ClientError` with code `"404"`, not `NoSuchKey`.
+
+Updated error handling:
+```python
+try:
+    await client.head_object(Bucket=bucket, Key=key)
+    return url
+except client.exceptions.NoSuchKey:
+    continue
+except ClientError as e:
+    if e.response.get("Error", {}).get("Code") == "404":
+        continue
+    raise  # re-raise non-404 errors
+```
+
+## What We Learned
+
+### Good Decisions
+
+1. **Added comprehensive instrumentation** - Logfire spans gave us visibility into every operation
+2. **Removed error swallowing** - Exposed real bugs that were silently degrading performance
+3. **Tested assumptions** - Wrote `test_r2_404.py` to verify actual R2 behavior before deploying fix
+4. **Followed patterns** - Used Prefect Nebula's proven LISTEN/NOTIFY pattern for queue service
+
+### Bad Decisions
+
+1. **Jumped to conclusions** - Spent time instrumenting PDS resolution without checking if code path was even executing
+2. **Didn't read boto3 docs carefully** - Assumed `NoSuchKey` was the only exception for missing objects
+3. **Error handling was defensive but wrong** - `except Exception: continue` hid real bugs for months
+
+### Unresolved Issues
+
+1. **Database performance** - Neon connection pooling and query performance still needs investigation
+   - SQLAlchemy pool settings (pool_pre_ping, pool_size, max_overflow)
+   - Neon serverless scaling configuration
+   - Why simple queries take 78-157ms instead of <10ms
+
+2. **R2 image storage inconsistency** - Multiple tracks have `image_id` set but files don't exist in R2
+   - Need to audit database vs R2 for orphaned references
+   - Consider adding validation/cleanup job
+
+## Call to Action: Technical Debt in tracks.py
+
+This investigation exposed a deeper problem: **`src/backend/api/tracks.py` is a mess**.
+
+### Current Problems
+
+1. **Massive function complexity**: `list_tracks()` is 100+ lines doing:
+   - Database queries (multiple SELECT statements)
+   - PDS URL caching and resolution
+   - Track serialization
+   - Like count aggregation
+   - Album hydration
+   - ATProto URL construction
+
+2. **Poor separation of concerns**: API endpoint directly orchestrates:
+   - Data access layer (SQLAlchemy queries)
+   - External service calls (R2, PDS resolution)
+   - Business logic (caching, deduplication)
+   - Response serialization
+
+3. **Hidden dependencies**:
+   - `TrackResponse.from_track()` can trigger R2 calls
+   - `AlbumSummary.from_album()` can trigger R2 calls
+   - No clear contract about what's async and what does I/O
+
+4. **Error handling inconsistency**:
+   - Some errors swallowed silently
+   - Some errors propagate and fail entire request
+   - No clear policy on partial failures
+
+5. **Performance characteristics unclear**:
+   - Hard to predict what will be slow
+   - Hard to optimize individual pieces
+   - Can't easily parallelize independent operations
+
+### What Needs to Happen
+
+We need to **drastically improve the situation in tracks.py** through systematic refactoring:
+
+1. **Extract data access layer**:
+   ```python
+   class TrackRepository:
+       async def get_tracks_with_related(self, filters: TrackFilters) -> list[Track]:
+           # all SQLAlchemy queries here
+   ```
+
+2. **Separate serialization from I/O**:
+   ```python
+   # Should never do I/O - all data must be pre-fetched
+   def serialize_track(track: Track, image_url: str | None, ...) -> TrackResponse:
+       # pure data transformation
+   ```
+
+3. **Explicit service layer for external calls**:
+   ```python
+   class MediaService:
+       async def batch_resolve_image_urls(self, file_ids: list[str]) -> dict[str, str]:
+           # explicit, batch-able R2 operations
+   ```
+
+4. **Clear error handling policy**:
+   - Document what errors are expected vs exceptional
+   - Decide when to fail fast vs return partial results
+   - Add circuit breakers for external service failures
+
+5. **Performance budgets**:
+   - Database queries: <50ms total
+   - External service calls: <100ms total
+   - Serialization: <5ms total
+   - **Total request time: <200ms**
+
+### Priority
+
+This is not optional. The current code:
+- Makes debugging nearly impossible
+- Hides performance problems
+- Will continue to cause production issues
+- Wastes engineering time on investigations like this one
+
+**We need to allocate time to eliminate this technical debt before it causes more severe problems.**
+
+## Timeline
+
+- **Nov 17, 23:00**: Started investigation, found 938s queue hangs
+- **Nov 18, 01:13**: Merged PR #269 (PDS instrumentation - wrong path)
+- **Nov 18, 01:36**: Merged PR #270 (queue timeout fix - correct)
+- **Nov 18, 01:58**: Merged PR #271 (R2 instrumentation + removed error swallowing)
+- **Nov 18, 02:10**: Merged PR #272 (track serialization instrumentation)
+- **Nov 18, 02:20**: Discovered ClientError 404s in production
+- **Nov 18, 02:37**: Wrote test_r2_404.py, verified actual exception type
+- **Nov 18, 02:40**: Created PR #273 (ClientError 404 handling)
+
+## Conclusion
+
+We successfully identified and fixed the queue hang issue. We ruled out several false hypotheses for track loading performance. We exposed real bugs by removing error swallowing, then fixed them properly.
+
+**But the core database performance issue remains unresolved**, and the investigation revealed that `tracks.py` needs serious refactoring before we can make meaningful improvements.
+
+The instrumentation we added will be invaluable for future investigations, but we can't debug our way out of technical debt.

--- a/docs/internal/retrospectives/2025-11-20-silent-atproto-failure.md
+++ b/docs/internal/retrospectives/2025-11-20-silent-atproto-failure.md
@@ -1,0 +1,316 @@
+# silent atproto record creation failure
+
+**date**: 2025-11-20
+**issue**: track 85 ("me and who") created successfully in database and R2, but ATProto record creation silently failed, leaving track in inconsistent state
+
+## what happened
+
+observed user behavior:
+1. uploaded track at 01:53:01 UTC → track 85 created
+2. viewed track at 01:57:14 UTC
+3. attempted to restore ATProto record at 01:59:36 UTC → 400 error
+4. deleted track at 02:03:43 UTC
+
+the user noticed their track wasn't synced to their PDS, tried to fix it with the restore-record endpoint, then gave up and deleted the track entirely.
+
+## trace analysis
+
+### upload trace: `019a9ef70b8fb6e1f00ef1406dbc6505`
+
+the upload followed this sequence:
+
+```
+01:53:01.839 - POST /tracks/ received
+01:53:02.047 - background processing started
+01:53:02.047 - "preparing to save audio file"
+01:53:02.048 - R2 save span started
+01:53:02.054 - "uploading to R2" (audio/2b582e312c5fe925.m4a to audio-prod)
+01:53:02.891 - "R2 upload complete"
+01:53:02.893 - "storage.save completed" (file_id: 2b582e312c5fe925)
+01:53:02.908 - R2 save span started (image)
+01:53:02.909 - "uploading to R2" (8e3bf334910404e1.jpg to images-prod)
+01:53:03.142 - "R2 upload complete" (image)
+01:53:03.156 - INSERT INTO tracks (database write)
+01:53:03.803 - HTTP GET to Bluesky (chat convo lookup)
+01:53:04.071 - HTTP POST to Bluesky (send notification)
+01:53:04.072 - "sent notification for track 85 to 3m4pexey3kl2j"
+01:53:04.073 - UPDATE tracks SET notification_sent=true
+```
+
+**what's missing**: no ATProto record creation phase.
+
+expected sequence according to `src/backend/api/tracks/uploads.py:224-251`:
+
+```python
+# line 227: we have r2_url, so this condition is true
+if r2_url:
+    # line 228-232: should see this status update
+    upload_tracker.update_status(
+        upload_id,
+        UploadStatus.PROCESSING,
+        "creating atproto record...",
+        phase="atproto",
+    )
+    # line 234-247: should see create_track_record call
+    try:
+        result = await create_track_record(...)
+        if result:
+            atproto_uri, atproto_cid = result
+    # line 248-251: if fails, just logs warning
+    except Exception as e:
+        logger.warning(
+            f"failed to create ATProto record: {e}", exc_info=True
+        )
+```
+
+we never saw the "creating atproto record..." log message in the trace. this means either:
+1. ATProto record creation threw an exception immediately (caught at line 248)
+2. `create_track_record()` returned `None` or falsy value
+3. something else prevented this code block from executing
+
+### restore attempt trace: `019a9efd115b0fabccca5d90bd23e3a3`
+
+```
+01:59:36.539 - POST /tracks/85/restore-record
+01:59:36.797 - HTTP GET to ATProto: list records with collection=app.relay.track
+01:59:36.799 - endpoint returned 400
+```
+
+the restore-record endpoint queried the user's PDS looking for existing track records but found none matching track 85, confirming the ATProto record was never created.
+
+### deletion trace: `019a9f00d558279bc31e387744ec4f7b`
+
+```
+02:03:43.320 - DELETE /tracks/85
+02:03:43.367 - "attempting R2 delete" (file_id: 2b582e312c5fe925, refcount: 1)
+02:03:43.648 - "R2 file deleted" (audio/2b582e312c5fe925.m4a)
+02:03:43.652 - DELETE FROM tracks WHERE tracks.id = 85
+```
+
+user cleaned up the orphaned track. proper cleanup happened because refcount was 1.
+
+## code path analysis
+
+### upload background processing
+
+`src/backend/api/tracks/uploads.py:37-339` (`_process_upload_background`)
+
+the function has multiple phases:
+1. **validation** (lines 58-68): audio format check
+2. **upload** (lines 70-112): save to R2 with progress tracking
+3. **duplicate check** (lines 114-136): query for existing track with same file_id
+4. **image upload** (lines 145-174): save image to R2 if provided
+5. **feature resolution** (lines 191-222): resolve featured artist handles
+6. **atproto** (lines 224-251): create ATProto record ← **the problem area**
+7. **database** (lines 253-290): create track record
+8. **notification** (lines 292-304): send Bluesky DM
+
+**critical behavior at lines 248-251**:
+
+```python
+except Exception as e:
+    logger.warning(
+        f"failed to create ATProto record: {e}", exc_info=True
+    )
+```
+
+if ATProto record creation fails for any reason:
+- exception is caught and logged as warning
+- `atproto_uri` and `atproto_cid` remain `None`
+- processing continues to database phase
+- track is created with `atproto_record_uri=None`
+- notification is sent
+- upload marked as COMPLETED
+
+### what the user experienced
+
+from the user's perspective:
+1. uploaded track "me and who" successfully
+2. received notification that upload completed
+3. went to their PDS, found no record
+4. tried restore-record endpoint, got 400 error
+5. decided to delete the track rather than leave it broken
+
+## why this is not ideal
+
+### 1. silent failures create inconsistent state
+
+the system allowed a track to exist in the database without corresponding ATProto record. this violates the implicit assumption that every track should be synced to the user's PDS. from `CLAUDE.md`:
+
+> **ATProto namespaces**: NEVER use Bluesky lexicons (app.bsky.*). ALWAYS use our namespace (fm.plyr.*) for ALL records
+
+if we can't create the ATProto record, we shouldn't create the track at all.
+
+### 2. user received success feedback for partial failure
+
+the upload was marked as COMPLETED and notification was sent, even though a critical step failed. user expected their track to be available on their PDS but it wasn't.
+
+### 3. no mechanism for automatic recovery
+
+once in this state, there's no automatic way to fix it:
+- the background task already completed
+- restore-record endpoint exists but returned 400 (likely because it couldn't find matching data)
+- user's only option was manual deletion
+
+### 4. leaves resources in limbo
+
+R2 files were uploaded successfully and consuming storage, but track wasn't fully functional. if user hadn't manually deleted, these would remain as orphaned resources.
+
+### 5. lack of observability
+
+the failure reason isn't visible in Logfire:
+- no error spans captured
+- no exception traces
+- just missing log messages where ATProto phase should be
+- had to infer failure from absence of expected logs
+
+## questions raised
+
+### why did ATProto record creation fail?
+
+we can't determine from the trace because the exception was swallowed. possibilities:
+- network timeout to user's PDS
+- authentication issue with auth_session
+- malformed record data
+- rate limiting from PDS
+- PDS was temporarily unavailable
+
+### should ATProto record creation block upload success?
+
+current design treats it as optional (catches exception, continues). but the restore-record endpoint and user behavior suggest it's actually required. if track isn't on PDS, user considers it broken.
+
+### what's the right failure mode?
+
+if ATProto record creation fails:
+1. should we fail the entire upload?
+2. should we retry automatically?
+3. should we queue for later retry?
+4. should we create track anyway and mark as "needs sync"?
+
+each has tradeoffs around user experience, data consistency, and system complexity.
+
+## related patterns in codebase
+
+### similar optional external operations
+
+`src/backend/api/tracks/uploads.py:292-304` (notification sending):
+
+```python
+try:
+    await notification_service.send_track_notification(track)
+    track.notification_sent = True
+    await db.commit()
+except Exception as e:
+    logger.warning(
+        f"failed to send notification for track {track.id}: {e}"
+    )
+```
+
+notification failures are also caught and logged but don't fail the upload. this makes sense because:
+- notification is truly optional
+- track is still fully functional without notification
+- notification_sent flag tracks the state
+
+but ATProto record creation is different - it's fundamental to the track's existence on the network.
+
+### cleanup on failure
+
+other phases do proper cleanup when they fail. for example, lines 313-322:
+
+```python
+except IntegrityError as e:
+    await db.rollback()
+    error_msg = f"database constraint violation: {e!s}"
+    upload_tracker.update_status(
+        upload_id, UploadStatus.FAILED, "upload failed", error=error_msg
+    )
+    # cleanup: delete uploaded file
+    with contextlib.suppress(Exception):
+        await storage.delete(file_id, audio_format.value)
+```
+
+if database write fails, R2 files are cleaned up. but if ATProto fails, nothing is cleaned up.
+
+## related files
+
+- `src/backend/api/tracks/uploads.py:224-251` - ATProto record creation with silent failure
+- `src/backend/_internal/atproto/__init__.py` - likely contains `create_track_record()` implementation
+- `src/backend/api/tracks/router.py` - probably contains restore-record endpoint
+- trace: `019a9ef70b8fb6e1f00ef1406dbc6505` (upload)
+- trace: `019a9efd115b0fabccca5d90bd23e3a3` (failed restore)
+- trace: `019a9f00d558279bc31e387744ec4f7b` (deletion)
+
+## impact
+
+- **user impact**: user uploaded track, got success message, but track wasn't synced to PDS. had to manually delete.
+- **data consistency**: track existed in database and R2 but not on ATProto network
+- **observability**: failure reason not visible in logs or traces
+- **support burden**: user had to diagnose issue themselves, try restore endpoint, then clean up manually
+
+## lessons learned
+
+- silent failures are worse than loud failures when they create inconsistent state
+- external system calls (PDS) should have explicit retry/fallback strategy
+- success/failure should be binary at the API boundary, even if internal operations are multi-phase
+- warning logs without failure signals hide problems from monitoring
+- absence of expected logs in traces is a debugging signal (but easy to miss)
+
+## resolution (2025-11-20)
+
+### root cause identified
+
+the actual failure was **option 3** from our initial analysis: "something else prevented this code block from executing."
+
+when FilesystemStorage was removed in commit `6a14f1b` (2025-11-18), the storage module was refactored to use a `_StorageProxy` wrapper around `R2Storage`:
+
+```python
+# src/backend/storage/__init__.py
+class _StorageProxy:
+    """proxy that lazily initializes storage."""
+    def __getattr__(self, name: str):
+        return getattr(_get_storage(), name)
+
+storage = _StorageProxy()  # type: ignore[assignment]
+```
+
+this broke all `isinstance(storage, R2Storage)` checks throughout the codebase:
+
+```python
+# src/backend/api/tracks/uploads.py:138-143 (before fix)
+r2_url = None
+if isinstance(storage, R2Storage):  # ← always False!
+    r2_url = await storage.get_url(
+        file_id, file_type="audio", extension=ext[1:]
+    )
+```
+
+because `storage` is a `_StorageProxy` instance (not `R2Storage`), the isinstance check failed, `get_url()` was never called, and `r2_url` remained `None`.
+
+this caused the upload to skip ATProto record creation entirely (line 227's `if r2_url:` check failed), creating tracks in database/R2 without corresponding PDS records.
+
+### the fix
+
+**PR #299** (2025-11-20): removed all `isinstance(storage, R2Storage)` checks since storage is always R2Storage now that FilesystemStorage is gone.
+
+affected files:
+- `src/backend/api/tracks/uploads.py` - audio URL generation
+- `src/backend/api/tracks/metadata_service.py` - image URL generation
+- `src/backend/api/albums.py` - album image URL
+- `src/backend/models/track.py` - track image URL getter
+- `src/backend/models/album.py` - album image URL getter
+
+### what we learned
+
+1. **proxy objects break isinstance checks**: when wrapping an object with a proxy, runtime type checks on the proxy fail. the proxy should either inherit from the wrapped type or expose a different interface entirely.
+
+2. **removing backends requires checking all type guards**: when we removed FilesystemStorage, we should have searched for all `isinstance(storage, R2Storage)` checks and evaluated whether they were still necessary.
+
+3. **missing environment variables can be caught early**: production was also missing `R2_PUBLIC_BUCKET_URL` environment variable (never set after R2 migration). this would have caused the same failure even without the isinstance bug. deployment should validate required env vars.
+
+4. **integration tests needed for upload flow**: we had no test that verified the full upload → ATProto sync → notification flow. the bug shipped because our tests mocked storage and never exercised the real isinstance check.
+
+5. **Logfire trace gaps are red flags**: the absence of "R2 get_url" spans in the upload trace was a strong signal something was wrong, but it wasn't caught until user reported the issue.
+
+### user impact
+
+this bug affected all uploads between 2025-11-18 (when #288 merged) and 2025-11-20 (when #299 fixed it). affected users received success notifications but their tracks weren't synced to their PDS, requiring manual cleanup.

--- a/docs/internal/retrospectives/2025-12-02-connection-pool-outage-recurrence.md
+++ b/docs/internal/retrospectives/2025-12-02-connection-pool-outage-recurrence.md
@@ -1,0 +1,139 @@
+# postmortem: production outage 2025-12-02
+
+## summary
+
+API outage for ~5 minutes (01:55-02:00 UTC). all requests returned 500 errors due to database connection pool exhaustion. this is a **recurrence** of the [2025-11-17 incident](./2025-11-17-connection-pool-outage.md) with a different trigger mechanism.
+
+## timeline (UTC)
+
+- **01:49:57** - last successful request before incident
+- **01:50:00 - 01:54:51** - **5 minute gap with no traffic** (site idle)
+- **01:54:51** - queue listener heartbeat times out (`SELECT 1` doesn't respond in 5s)
+- **01:54:51** - heartbeat marks asyncpg connection as dead, closes it
+- **01:55:19** - queue listener begins reconnection attempts with exponential backoff
+- **01:55:34** - first reconnection attempt times out after 15s
+- **01:55:56** - first user request arrives: `GET /tracks/114`
+- **01:55:56** - **connection hangs for 333 seconds (5.5 minutes!)** attempting to connect
+- **01:56:41** - second request arrives, also hangs (198s)
+- **01:57:40** - three more requests arrive, all hang (213s each)
+- **01:57:43** - **pool exhausted**: new requests get `QueuePool limit of size 5 overflow 0 reached`
+- **01:57:43 - 01:59:09** - all API endpoints return 500 with 30s connection timeout
+- **02:00:04** - queue listener finally reconnects successfully
+- **02:00:09** - SQLAlchemy connections recover, normal operation resumes
+
+**total downtime: ~5 minutes**
+
+## root cause
+
+**Neon serverless cold start after idle period.**
+
+the 5-minute gap with no traffic caused Neon to scale down. when requests resumed:
+
+1. the queue listener's heartbeat (`SELECT 1`) timed out because Neon was cold
+2. heartbeat correctly marked the connection as dead and closed it
+3. the queue listener's reconnection attempts timed out (15s each)
+4. **critically**: the SQLAlchemy pool connections also went stale during the idle period
+5. when user requests arrived, they tried to use stale pooled connections
+6. these connections hung waiting for Neon to wake up
+7. **5 connections hung = pool exhausted = all new requests fail**
+
+### why did connections hang instead of failing fast?
+
+the SQLAlchemy pool has `pool_pre_ping=True`, which should detect dead connections. however:
+- pre-ping runs a `SELECT 1` on checkout
+- if Neon is cold, the `SELECT 1` itself hangs instead of failing
+- the connection doesn't appear "dead" to SQLAlchemy - it's waiting, not closed
+- result: 5 requests each hold a connection, waiting 3-5+ minutes for Neon to respond
+
+### the smoking gun from logfire
+
+```
+GET /tracks/114 at 01:55:56 → duration: 333,882ms (5.5 minutes!)
+  └─ connect span → duration: 333,866ms (connection acquisition hung)
+GET /tracks/92 at 01:56:41 → duration: 198,542ms (3.3 minutes!)
+GET /tracks/ at 01:57:40 → duration: 213,495ms (3.5 minutes!)
+GET /preferences/ at 01:57:40 → duration: 213,355ms
+GET /stats at 01:57:40 → duration: 134,223ms
+```
+
+these 5 requests consumed all 5 pool connections. every subsequent request waited 30s then got:
+```
+TimeoutError: QueuePool limit of size 5 overflow 0 reached, connection timed out, timeout 30.00
+```
+
+## why the nov 17 fix wasn't enough
+
+the [nov 17 hotfix](./2025-11-17-connection-pool-outage.md) added a 15s timeout to `asyncpg.connect()` for the queue listener. this fix **is working** - we can see the queue listener timing out and retrying correctly.
+
+but the fix only addressed the **queue listener's asyncpg connection**. it did not address:
+
+1. **SQLAlchemy pool connections** - these are separate and have no wake-up timeout
+2. **Neon cold start latency** - can exceed 10+ seconds, causing `pool_pre_ping` to hang
+3. **pool sizing** - 5 connections with 0 overflow means any 5 slow requests = total outage
+
+## contributing factors
+
+1. **Neon serverless cold starts** - idle period caused database to scale down
+2. **small connection pool** - `pool_size=5, max_overflow=0` provides no buffer
+3. **no connection timeout** - SQLAlchemy connections wait indefinitely for Neon
+4. **pool_pre_ping doesn't help cold starts** - ping hangs same as query would
+5. **cascading failure** - 5 slow connections = pool exhausted = 100% failure rate
+
+## impact
+
+- **duration**: ~5 minutes
+- **scope**: 100% of API traffic (all endpoints)
+- **user experience**: complete service unavailability
+- **data loss**: none
+
+## lessons learned
+
+### what went well
+
+- **observability**: logfire clearly showed the connection hang pattern with exact durations
+- **queue listener fix working**: the nov 17 timeout fix is working - queue reconnected successfully
+- **self-recovery**: service recovered automatically once Neon woke up (no manual restart needed)
+
+### what went wrong
+
+- **incomplete fix**: nov 17 only fixed queue listener, not SQLAlchemy pool
+- **Neon cold start not accounted for**: didn't consider idle period → cold start scenario
+- **pool too small**: 5 connections with no overflow is fragile
+
+## recommended fixes
+
+### immediate (must do)
+
+1. **add `connection_timeout` to SQLAlchemy connections** (config already exists but may not be set)
+   - set `DATABASE_CONNECTION_TIMEOUT=10` in production
+   - this adds `timeout` to asyncpg connect_args
+
+2. **increase pool size and add overflow**
+   - `DATABASE_POOL_SIZE=10` (from 5)
+   - `DATABASE_MAX_OVERFLOW=5` (from 0)
+   - allows 15 concurrent connections, better degradation
+
+### short-term
+
+3. **reduce `pool_timeout`** - currently 30s, consider 10s to fail faster
+
+4. **add Neon keepalive** - periodic query to prevent cold starts during low traffic
+   - could use existing healthcheck endpoint
+   - or dedicated cron/scheduled task
+
+### long-term
+
+5. **circuit breaker pattern** - detect pool exhaustion, fail fast with 503
+6. **connection pool metrics** - alert when pool utilization exceeds threshold
+7. **Neon provisioned compute** - eliminate cold starts entirely (cost tradeoff)
+
+## related incidents
+
+- [2025-11-17 connection pool outage](./2025-11-17-connection-pool-outage.md) - same failure mode, different trigger
+
+## references
+
+- logfire traces showing incident: production spans 01:54-02:01 UTC
+- queue service code: `src/backend/_internal/queue.py`
+- database config: `src/backend/config.py`
+- database utilities: `src/backend/utilities/database.py`

--- a/docs/internal/retrospectives/2026-04-02-deploy-outage-oom-kill.md
+++ b/docs/internal/retrospectives/2026-04-02-deploy-outage-oom-kill.md
@@ -1,0 +1,117 @@
+# postmortem: production outage 2026-04-02
+
+## summary
+
+API outage for ~6 minutes (02:34-02:40 UTC). after a deploy, Fly auto-stopped one machine (low traffic). the remaining machine became unresponsive for unknown reasons — the process was "started" per Fly but produced zero Logfire spans. because Fly has **no HTTP health checks configured**, it never detected the failure and never restarted the machine. when a replacement machine finally started, it was **OOM killed** (1GB memory exhausted in 20 seconds). manual intervention was required to restore service.
+
+## timeline (UTC, 2026-04-02)
+
+| time | event |
+|------|-------|
+| 02:27:01 | deploy starts — both machines receive new image (`deployment-01KN5SXJ2GYCVWT7EN0NF1G851`) |
+| 02:27:13 | machine 2 (`91859e9f`) starts |
+| 02:27:29 | both machines complete startup (notification bot, queue service, docket worker, db pool warm) |
+| 02:27:33 | normal traffic resumes — requests serving fine (20-130ms) |
+| 02:27:56 | slow requests: `GET /discover/network` 2594ms, `GET /tracks/` 1675ms (post-deploy cold paths) |
+| 02:32:20 | last successful HTTP request: `GET /tracks/top` (44ms) |
+| 02:32:31 | queue listener heartbeat timeout on one machine — asyncpg connection marked dead, reconnection begins |
+| 02:32:57 | queue listener reconnection fails (15s timeout), retrying with backoff |
+| 02:33:26 | last Logfire span before silence (moderation scan HTTP call) |
+| **02:34:33** | **one machine shuts down gracefully** — Fly auto-stop (`auto_stop_machines = 'stop'`). all services report orderly shutdown. |
+| 02:34:33 – 02:39:38 | **OUTAGE: remaining machine is "started" but producing zero spans.** no HTTP requests, no background work, nothing in Logfire. Fly has no health checks to detect this. |
+| 02:39:38 | manual intervention: `fly machine restart` on machine 2 |
+| 02:39:49 | machine 2 crashes during restart (exit_code=-1), auto-restarts at 02:39:53 |
+| 02:39:59 | Fly proxy auto-starts machine 1 (incoming traffic detected) |
+| 02:40:13 | machine 1 completes startup |
+| **02:40:20** | **machine 1 OOM killed** after 20 seconds (exit_code=137, oom_killed=true) |
+| 02:40:21 | machine 1 auto-restarts, stays up this time |
+| 02:41:01 | both machines serving traffic normally |
+
+**total downtime: ~6 minutes** (02:34:33 – 02:40:43)
+
+## root causes
+
+### 1. no Fly health checks — frozen machine went undetected
+
+fly.toml has **no `[[http_service.checks]]` section**. the remaining machine became unresponsive (zero Logfire output from 02:33 to 02:39) but Fly still considered it "started." with health checks, Fly would have detected the failure within seconds and auto-restarted the machine, preventing the outage entirely.
+
+**what froze the machine is unknown.** the queue listener had reconnection issues (heartbeat timeout at 02:32:31), but the queue listener is decoupled from the HTTP server — it uses `asyncio.create_task()` and catches all exceptions internally. it should not be able to freeze the process. possible causes:
+- memory pressure causing the process to become unresponsive (1GB is tight)
+- asyncio event loop blocked by something unrelated to the queue listener
+- the process died without graceful shutdown (hard crash/OOM that Fly's event log truncated)
+
+### 2. Fly auto-stop reduced to single machine
+
+`auto_stop_machines = 'stop'` with `min_machines_running = 1` means Fly will stop one machine during low-traffic periods. the graceful shutdown at 02:34:33 is consistent with Fly sending SIGTERM to the idle machine. this left a single machine — and when that machine froze, there was no redundancy.
+
+### 3. OOM kill on recovery (1GB machine)
+
+machine 1 was OOM killed (exit_code=137) after only **20 seconds** of operation. startup allocates: db connection pool (10 connections), httpx clients, notification bot auth, queue service, docket worker, background tasks. with 6 minutes of queued requests arriving immediately, 1GB was not enough.
+
+## what already works (corrections from initial analysis)
+
+investigation confirmed that several fixes from prior incidents are **already in place**:
+
+- **database pool**: `pool_size=10`, `max_overflow=5`, `pool_pre_ping=True`, `pool_recycle=1800s` — all implemented
+- **connection timeouts**: `connection_timeout=10s`, `statement_timeout=10s`, `pool_timeout=10s` — all set
+- **queue listener isolation**: uses `asyncio.create_task()`, catches all exceptions internally with exponential backoff, will not crash the HTTP server
+
+the queue listener is **not** the cause of the process death (contrary to the previous two incidents). something else froze or killed the remaining machine.
+
+## impact
+
+- **duration**: ~6 minutes
+- **scope**: 100% API traffic
+- **user impact**: complete service unavailability
+- **data loss**: none
+- **recovery**: manual intervention required
+
+## action items
+
+### immediate
+
+1. **add Fly HTTP health checks** — the single fix that would have prevented this outage. Fly would detect the unresponsive machine and restart it automatically.
+   ```toml
+   [[http_service.checks]]
+     interval = "10s"
+     timeout = "5s"
+     grace_period = "30s"
+     method = "GET"
+     path = "/health"
+   ```
+
+### if needed
+
+2. **increase VM memory to 2GB** — only if OOM kills recur after health checks are added. the OOM may have been a one-time burst from 6 minutes of queued traffic.
+3. **set `min_machines_running = 2`** — only if single-machine failures continue to cause outages despite health checks.
+
+### investigate
+
+4. **what froze machine 2?** — the queue listener is decoupled and shouldn't affect HTTP serving. need to understand what caused zero output for 6 minutes while Fly reported the machine as "started." possible approaches:
+   - add memory usage logging to startup / periodic intervals
+   - check if the OOM kill event for machine 1 (visible in events) has a counterpart for machine 2 (events truncated to 5)
+
+### longer term
+
+5. **uptime monitoring / alerting** — external check that pages when the API is unresponsive
+6. **Neon keepalive** — periodic query to prevent cold starts during idle periods
+
+## related incidents
+
+- [2025-11-17 connection pool outage](./2025-11-17-connection-pool-outage.md) — queue listener timeout, pool exhaustion
+- [2025-12-02 connection pool outage recurrence](./2025-12-02-connection-pool-outage-recurrence.md) — Neon cold start, pool exhaustion
+
+## key difference from previous incidents
+
+previous incidents had a clear causal chain: queue listener fails → pool exhausts → requests time out → self-recovery.
+
+this incident: one machine auto-stopped, remaining machine froze for unknown reasons, no health checks to detect it, replacement machine OOM killed. **the root cause of the freeze is still unknown** — the queue listener (blamed in prior incidents) is properly isolated and should not be a factor.
+
+## references
+
+- fly machine events: `fly machine status {id} -a relay-api`
+- logfire traces: production spans 02:27-02:43 UTC, 2026-04-02
+- fly config: `backend/fly.toml`
+- queue service: `backend/src/backend/_internal/queue.py`
+- database config: `backend/src/backend/config.py`
+- health endpoint: `backend/src/backend/api/meta.py:17`

--- a/docs/internal/retrospectives/2026-04-22-pages-migration-env-vars-wiped.md
+++ b/docs/internal/retrospectives/2026-04-22-pages-migration-env-vars-wiped.md
@@ -1,0 +1,111 @@
+# postmortem: cloudflare pages post-migration build failures 2026-04-22
+
+## summary
+
+after migrating from the `Nate@prefect.io` Cloudflare account to `N8@zzstoatzz.io` on 2026-04-18, the `plyr-fm` and `plyr-fm-stg` Cloudflare Pages projects were recreated as "Direct Uploads" type with no git integration. on 2026-04-22 we restored the git integration by deleting the (still-active) prefect.io Pages projects and recreating fresh projects on the zzstoatzz account with `source.type = "github"` set via POST. every git-driven build that followed failed silently — the POST accepted `deployment_configs.production.env_vars` in the body but did not persist them, and `build_config.destination_dir` reverted to an incorrect value. the CF webhook was firing correctly, but every build errored on `import { PUBLIC_API_URL } from '$env/static/public'` because the variable wasn't present at build time. manual `wrangler pages deploy` calls from a developer machine (with `PUBLIC_API_URL` set in the shell) masked the real problem for ~3 hours by keeping the live site on a known-good ad-hoc deploy — at the cost of one ~45-minute window where `/track/[id]` and `/u/[handle]` 404'd on prod because an earlier local build baked `http://localhost:8001` into `API_URL`.
+
+## timeline (UTC)
+
+| time | event |
+|------|-------|
+| 2026-04-18T07:40 | CF account migration: new `plyr-fm` + `plyr-fm-stg` Pages projects created on zzstoatzz account as **Direct Uploads** (no git source). prefect.io projects remain git-integrated against the repo. |
+| 2026-04-18 → 2026-04-22 | prefect.io projects receive **stealth builds** on every push to `main` / `production-fe` — their custom domains are deactivated so nobody sees the output, but CF keeps rebuilding them. ~2,945 deploys on `plyr-fm-stg` + ~3,547 on `plyr-fm` accumulate over 4 days. |
+| 2026-04-19T05:42 | someone runs `wrangler pages deploy` once against the zzstoatzz `plyr-fm` project with commit `a4977bc2` (#1310). this becomes the "live" production bundle. no further deploys for 3 days. |
+| 2026-04-19 → 2026-04-22 | `just release` pushes to `production-fe` do nothing: new-account projects have no git integration, prefect.io builds are invisible. nobody notices because the frozen #1310 bundle keeps serving. |
+| 2026-04-22T13:30 | audio-replace feature (#1311-#1313) is reported "not on prod" — investigation reveals the frozen-bundle situation. |
+| 2026-04-22T14:20 | decision: delete the prefect.io projects (requires grinding through ~6,500 deployment deletions), create fresh zzstoatzz projects with git source via API POST. |
+| 2026-04-22T15:25 | new `plyr-fm-stg` created with `source.type: "github"` via `POST /pages/projects`. POST body includes `deployment_configs.production.env_vars: { PUBLIC_API_URL, SKIP_DEPENDENCY_INSTALL }` and `build_config.destination_dir: "frontend/.svelte-kit/cloudflare"`. POST returns 200. **no follow-up GET to verify env_vars persisted.** |
+| 2026-04-22T15:25 | initial build manually triggered via `POST /deployments?branch=main` — succeeds. looks like the migration worked. |
+| 2026-04-22T15:34 | same pattern for `plyr-fm`. |
+| 2026-04-22T15:52 | `just release` (version `2026.0422.155233`) — `production-fe` push does not trigger an auto-build. assumed to be a CF webhook quirk. manually POST'd `/deployments` to work around it. build succeeds (direct upload path; still no SvelteKit build step). |
+| 2026-04-22T18:12 | second release (`2026.0422.181250`) — same behavior, same manual workaround. |
+| 2026-04-22T18:16 | PR #1326 merged (frontend-only button font fix). `just release-frontend-only` pushes `main → production-fe`. webhook still doesn't fire. fallback: `bun run build` locally **without `PUBLIC_API_URL` set**, then `wrangler pages deploy`. baked-in `API_URL = 'http://localhost:8001'`. |
+| **2026-04-22T18:23** | **outage window begins**: `/track/[id]`, `/u/[handle]` return 404 on prod. SSR load functions call `fetch('http://localhost:8001/...')` from the worker runtime, fail, throw `error(404)`. home page + static routes still serve fine. |
+| 2026-04-22T19:05 | user reports "everything is 4o4ing". diagnosis takes ~15 min — frontend routes that do `+page.server.ts` data loading are all failing, param-less routes are fine. |
+| 2026-04-22T19:53 | redeploy via local `wrangler pages deploy` with `PUBLIC_API_URL=https://api.plyr.fm bun run build` — **outage ends**. ~45 min after onset. |
+| 2026-04-22T19:57 | user asks a sharper question: why doesn't CF git auto-build? user separately discovers the GitHub App integration had `plyr.fm` deselected (manual mistake during earlier debugging) — re-selects the repo. |
+| 2026-04-22T19:58 | #1327 merged, `just release-frontend-only`. GitHub webhook delivery now flows to CF. |
+| 2026-04-22T20:13 | verify via `wrangler pages deployment list`: **both `plyr-fm` and `plyr-fm-stg` show failed builds** for commit `8f20e8e` — the CF webhook has been firing all along since the GH reconnect. build logs (via CF API `/deployments/{id}/history/logs`) show `import { PUBLIC_API_URL } from '$env/static/public'` → rollup can't resolve. |
+| 2026-04-22T20:15 | GET project config via API: **`env_vars: null` on both production and preview deployment_configs.** the POST from 15:25 silently dropped them. `destination_dir` is `.svelte-kit/cloudflare` (missing `frontend/` prefix) — also reverted. |
+| 2026-04-22T20:17 | PATCH both projects to restore `env_vars` and corrected `destination_dir`. GET verifies the values persist this time. |
+| 2026-04-22T20:18 | `POST /deployments/{id}/retry` on both failed builds — both queue successfully. |
+
+**user-visible outage: ~45 minutes** (prod SSR routes, partial). root-cause silent build failures: **4 days** (from 2026-04-18 recreation window through 2026-04-22 fix).
+
+## root causes
+
+### 1. CF Pages API silently dropped `env_vars` on project creation
+
+`POST /accounts/{id}/pages/projects` accepted `deployment_configs.production.env_vars` in the body and returned a 200 response, but the created project came back with `env_vars: null`. no error, no warning. the OpenAPI schema documents the field as part of the create-project request body; either CF has a bug in its create path that ignores the nested env_vars, or a subsequent operation (e.g. my own `wrangler pages deploy --branch=production-fe`) wiped them. either way, **any CF-driven build with the project in this state breaks on `$env/static/public` imports**. 
+
+### 2. follow-up GET-to-verify was skipped
+
+after the POST, the returned body wasn't inspected for env_vars, and no subsequent GET confirmed the values were retrievable. the check that would have caught this took 2 lines and ran successfully after the fix.
+
+### 3. manual `wrangler pages deploy` masked the build failure
+
+using `wrangler pages deploy <built-directory> --branch=production-fe` uploads an already-built bundle as a new deployment. it skips the CF build pipeline entirely, so missing `env_vars` never surface. the live site served from these ad-hoc deploys while the parallel git-triggered builds were failing silently — and no one noticed, because the manual deploys kept the site green.
+
+### 4. local `bun run build` can bake the wrong API URL into the bundle
+
+SvelteKit's `$env/static/public` inlines `PUBLIC_API_URL` into the compiled bundle at build time. when `bun run build` runs locally without `PUBLIC_API_URL` set, the `|| 'http://localhost:8001'` fallback in `frontend/src/lib/config.ts:3` gets baked in. any `wrangler pages deploy` of that bundle renders prod SSR useless.
+
+### 5. CF account migration didn't carry over git integration
+
+the original 2026-04-18 migration created **Direct Uploads** projects on the new account instead of git-integrated ones. CF doesn't support converting a Direct Uploads project to a git-integrated one (API error `8000069`: *"You cannot update the `source` object in a Direct Uploads project"*). this required deleting + recreating the projects on 2026-04-22 — but also required deleting the leftover prefect.io projects (still holding the repo lock on the old account, error `8000093`), which individually required deleting ~6,500 aggregated deployments by hand via API pagination. none of this was in any runbook.
+
+### 6. CF Pages GitHub App installation had the repo deselected
+
+separate but adjacent: at some point during debugging on 2026-04-22, `zzstoatzz/plyr.fm` got removed from the GitHub App's repository access list. this silently stopped CF from receiving any webhook events. the user fixed this by re-adding the repo. this is why the first two `just release` calls today (`15:52`, `18:12`) had no matching CF-side build record — the webhook literally never reached CF.
+
+## impact
+
+- **duration of user-visible outage**: ~45 minutes (2026-04-22T18:23 → 19:53)
+- **scope of user-visible outage**: `/track/[id]`, `/u/[handle]`, and any other SSR route whose `+page.server.ts` fetches from `${API_URL}/...`. auth'd pages, static pages, client-side-loaded pages all fine.
+- **data loss**: none
+- **duration of silent misconfiguration**: 4 days (2026-04-18 → 2026-04-22). no builds were actually happening on the new account's Pages; the site served a frozen commit (`a4977bc2` / #1310) that predated audio-replace (#1311-#1313) and all subsequent frontend work.
+- **engineering time burned**: most of a day across debugging, project recreation, deployment-deletion grinding, and recovery.
+
+## action items
+
+### immediate (done or in-flight)
+
+1. **PATCH both projects to restore env_vars + destination_dir** — done 2026-04-22T20:17.
+2. **retry the two failed CF-driven builds** — done. verify via live bundle version flip.
+3. **write this retro** — meta, done.
+
+### post-incident
+
+4. **add a `docs/internal/runbooks/cloudflare-migration.md` runbook** covering:
+   - the Direct-Uploads-can't-be-converted trap (error 8000069)
+   - the cross-account repo lock (error 8000093) and that deleting projects with accumulated deployments requires iterating `DELETE /deployments/{id}?force=true` per deployment
+   - the mandatory verify-after-write step: after any create/patch on a Pages project, `GET /projects/{name}` and diff against the intended config
+   - the GitHub App installation step on the receiving CF account (explicit re-selection of repo after account move)
+   - the build-config keys that tend to revert: `destination_dir`, `env_vars`, `preview_deployment_setting`
+5. **never deploy from local** — append to `.claude/CLAUDE.md` / `docs/internal/deployment/environments.md`: local `wrangler pages deploy` is banned because (a) it can bake wrong env vars into the bundle, (b) it masks CF-driven build failures by keeping the site green. deployments happen in CI only, whether via CF git integration or GHA workflow.
+6. **consider: a `just verify-pages-config` script** that hits the CF API and diffs `env_vars` / `build_config` against a checked-in spec. would have caught this in 2 seconds on 2026-04-18.
+7. **consider: GHA workflow as defense-in-depth** — originally proposed in #1323 (closed). if CF's git integration breaks again (it's already broken twice: dashboard-vs-API create path, GH App install scope), a `workflow_dispatch`-able GHA workflow that runs `wrangler pages deploy` with `PUBLIC_API_URL` set from CI secrets gives us a manual recovery lever that isn't a developer's laptop.
+
+### investigate (low priority)
+
+8. **why did the CF POST silently drop env_vars?** — either a bug in `POST /pages/projects`'s create path, or a subsequent `wrangler pages deploy --branch=...` call wiped the `deployment_configs` section as a side effect. either is fixable on CF's side; worth filing with support if we reproduce.
+
+## related incidents
+
+- [2025-11-12 banana mix incident](./2025-11-12-banana-mix-incident.md) — also caused by silent state: R2 delete didn't check refcount. theme: **we trust that successful API calls preserve the state we asked for**, which isn't always true.
+- [2025-11-17 connection pool outage](./2025-11-17-connection-pool-outage.md) — also surfaced only after a change unrelated to the root cause (a migration) amplified a pre-existing hole.
+
+## key lesson
+
+**successful ≠ persisted**. every create/patch against an external API needs an immediately-subsequent GET that inspects the fields we care about. today's ~45-minute outage (and the 4-day silent-deploy problem preceding it) is entirely contained by a GET-after-POST that would have taken 2 seconds to write.
+
+the secondary lesson — **local deploys are a load-bearing anti-pattern** — was already in our memory conventions. I violated it repeatedly today to "unstick" things, and the `localhost:8001`-baked-into-prod outcome is a textbook demonstration of why the rule exists.
+
+## references
+
+- `scripts/release` — pushes `main → production-fe`, relies on CF git integration to pick up
+- `frontend/src/lib/config.ts:3` — `API_URL` fallback to `localhost:8001` (this is the chekhov's gun that fired)
+- `docs/internal/deployment/environments.md` — describes the intended CF Pages build config (fixed today in #1324)
+- CF API: `POST /accounts/{id}/pages/projects`, `PATCH /accounts/{id}/pages/projects/{name}`, `POST /deployments/{id}/retry`
+- PRs affected / involved: #1311, #1312, #1313 (audio-replace), #1318-#1320 (audio revisions), #1323 (closed GHA workflow PR), #1324 (docs fix), #1325 (blob re-upload fix), #1326 (button font fix), #1327 (button font follow-up)
+- releases: `2026.0422.155233`, `2026.0422.181250`

--- a/docs/internal/retrospectives/2026-05-10-worker-oom-loop-streaming.md
+++ b/docs/internal/retrospectives/2026-05-10-worker-oom-loop-streaming.md
@@ -1,0 +1,111 @@
+# postmortem: 4-day silent worker outage (audio uploads broken) 2026-05-06 → 2026-05-10
+
+## summary
+
+the docket worker process group on `relay-api` OOM-killed itself out of fly's auto-restart budget on **2026-05-06 18:56 UTC**. fly's restart policy (`on-failure` with `max_retries: 10`) gave up after 10 consecutive kills and left the worker machine `stopped`. for the next **3 days, 23 hours, 30 minutes** every track upload's `POST /tracks/` returned 200 and queued a `run_track_upload` task into Redis, but no worker existed to drain it. uploads sat at "uploading to storage… 100%" forever. the outage was discovered when `@cameron.stream` reported it on bsky on 2026-05-10 17:23 UTC; it was resolved at 19:02 UTC with `fly machine start`.
+
+at least three users were affected: `@just.cameron.stream` (6 stuck uploads), `@flo.by` (2), and the maintainer (1). of the 9 stranded jobs, 3 recovered when the worker came back; 6 were unrecoverable because the user's OAuth session had expired between when the upload was staged and when the task finally got to run.
+
+the proximate cause was OOM at the worker's 2 GB memory cap. the structural cause is that the upload pipeline buffers the **entire audio file** in worker memory at four distinct points (R2 read, transcode result, PDS `uploadBlob`, CLAP embedding base64). on long-form audio (90-min podcast = ~900 MB WAV), `concurrency=10` task fan-out at cold-start crosses 2 GB easily.
+
+## timeline (UTC)
+
+| time | event |
+|------|-------|
+| 2026-05-06 18:56:21 | last successful `run_track_upload` span (trace `019dfea5f07ebd920a0158ed521c54f8`). |
+| 2026-05-06 18:56:42 | worker `initializing docket worker` — first restart of the OOM loop. |
+| 2026-05-06 18:56 – 19:31 | 10 init → ready → silent-death cycles, ~5 min apart. each one OOM-killed (exit_code=137, oom_killed=true). |
+| 2026-05-06 19:31:55 | last worker init log. fly hits `restart.policy.max_retries = 10` and stops trying. machine state: `stopped`. |
+| 2026-05-06 → 2026-05-10 | **silent outage.** `POST /tracks/` keeps queuing `run_track_upload` tasks; nothing consumes them. 9 user uploads strand. |
+| 2026-05-10 17:23 | `@cameron.stream` reports the outage on bsky. |
+| 2026-05-10 18:58:23 | maintainer reproduces locally; upload also strands. |
+| 2026-05-10 19:02:25 | `fly machine start` on the worker. |
+| 2026-05-10 19:02:48 | worker OOM-kills again 23 s after start (cold-start backlog drain at concurrency=10). |
+| 2026-05-10 19:02:49 | fly auto-restarts. this restart survives. queue starts draining. |
+| 2026-05-10 19:08:26 | maintainer marks 7 stale `processing` jobs as failed in DB so the frontend stops showing indefinite progress toasts. |
+| 2026-05-10 19:09 – 19:09:36 | three of the 9 stranded jobs complete after all (Cameron's most recent + 2 of flo.by's) — they overrode the failed-marker UPDATE because the worker was actively writing progress. |
+| 2026-05-10 19:15:01 | worker OOMs again — confirms 2 GB is undersized for the post-cold-start fan-out, not just for the initial drain. |
+
+## root causes
+
+### 1. upload pipeline buffers full audio bytes (the structural bug)
+
+four distinct points held the entire file in worker memory:
+
+- **R2 read**: `R2Storage.get_file_data()` does `await body.read()` and returns `bytes` (`backend/src/backend/storage/r2.py:333`).
+- **transcode source spool**: `await get_file_data(...)` then `spool.write(source_data)` (`backend/src/backend/api/tracks/uploads.py:383, 423`).
+- **transcode result**: transcoder client returned `response.content` as `bytes`, worker re-uploaded with `BytesIO(result.data)` (`backend/src/backend/_internal/clients/transcoder.py:127`, `uploads.py:462`).
+- **PDS `uploadBlob`**: `upload_blob` accepted `bytes`/`BinaryIO` only and passed it as `content=` to httpx — single in-memory blob, not an iterator (`backend/src/backend/_internal/atproto/client.py:375-386`).
+- **CLAP embedding (worst offender)**: the worker downloaded the entire R2 audio, base64-encoded it (× 1.33), and POSTed it as JSON to Modal — even though the Modal endpoint only uses the **first 30 seconds** of audio (`services/clap/app.py:121-124`).
+
+with `concurrency=10` and post-upload fan-out (scan_copyright + classify_genres + generate_embedding all running per upload), each in-flight upload could be holding the audio bytes 3–5 times simultaneously. on a long-form file this trivially crosses 2 GB.
+
+### 2. fly restart policy gave up after 10 OOMs
+
+worker machine config: `"restart": {"policy": "on-failure", "max_retries": 10}`. after 10 consecutive OOMs in the cold-start backlog drain, fly stopped trying and left the machine `stopped`. for a singleton stateful worker this is the wrong policy — there's no situation where giving up improves outcomes.
+
+### 3. nothing observed the worker's death
+
+three independent gaps any one of which would have surfaced the outage in minutes:
+- **no logfire alert** on "no `run_track_upload` spans in the last N minutes." we have HTTP error rate alerts but nothing that watches for *absence* of a worker-emitted span.
+- **no fly health check on the worker process group**. the existing health check is scoped to `[http_service]`, which only applies to the `app` group. a worker check pinging a tiny TCP listener on the worker would have triggered fly to restart it; it would not have helped *here* because the worker was already exhausted out of fly's retry budget, but it would catch a stuck-loop variant.
+- **no postgres-side reaper** for upload jobs stuck in `processing` past a reasonable wall-clock budget. the `jobs` table is the durable record of what users want done; nothing watches it.
+
+## impact
+
+- **duration**: 3 days 23 hours 30 minutes (May 6 18:56 UTC → May 10 19:02 UTC).
+- **scope**: 100% of new track uploads.
+- **user impact**: complete failure to upload, no error message — frontend stuck on "uploading to storage… 100%" indefinitely. some users retried multiple times; others gave up.
+- **data loss**: 6 of 9 stranded uploads unrecoverable because OAuth sessions expired before the worker came back. user-visible loss: the lossless source bytes were preserved in R2 (still are) but the user must redo the upload to get a track row + PDS record.
+- **detection**: external — user tweet, not internal monitoring.
+- **recovery**: manual `fly machine start`, then a follow-up `fly machine start` after a second OOM at 19:15.
+
+## what this PR ships
+
+end-to-end streaming for the audio path, plus a regression test that fails any future PR that re-introduces buffering on long-form audio.
+
+| change | file(s) | what it eliminates |
+|--------|---------|--------------------|
+| `StorageProtocol.stream_file_data()` (async iter of chunks) + `head_file()` (size for Content-Length) | `backend/src/backend/storage/{protocol,r2}.py` | the `bytes`-returning `get_file_data` call site |
+| `upload_blob(body_factory, content_length, content_type)` keyword form; existing `data=` form retained for small blobs (artwork, profile avatars) | `backend/src/backend/_internal/atproto/client.py` | full file held in memory before PDS POST |
+| `_signed_streaming_post` helper that supports DPoP + body factories per attempt (the upstream `make_authenticated_request` retries with the same kwargs, exhausting an async iterator) | `backend/src/backend/_internal/atproto/client.py` | inability to retry streaming uploads on DPoP nonce mismatch |
+| transcoder client streams response → /tmp via `httpx.AsyncClient.stream` + `aiofiles`, returns `output_path` not `bytes` | `backend/src/backend/_internal/clients/transcoder.py` | full transcoded blob held in memory |
+| `_transcode_audio` streams R2 → /tmp source, runs transcoder, streams /tmp → R2 via existing `R2.save` (which streams) | `backend/src/backend/api/tracks/uploads.py` | full lossless source held in memory |
+| `_upload_to_pds` streams R2 → PDS uniformly (drops the special transcoded-data branch since the transcoded file is now in R2 like everything else) | `backend/src/backend/api/tracks/uploads.py` | full playable file held in memory before PDS |
+| Modal CLAP service accepts `audio_url` and pulls a Range-limited slice itself; client passes the URL through | `services/clap/app.py`, `backend/src/backend/_internal/clients/clap.py`, `backend/src/backend/_internal/tasks/ml.py`, `scripts/backfill_embeddings.py` | full file downloaded to worker + base64 encoded × 1.33 just to ship to Modal |
+| migrate-to-PDS, restore-revision, PDS backfill task | `backend/src/backend/api/tracks/{mutations,revisions}.py`, `backend/src/backend/_internal/pds_backfill_tasks.py` | three more `get_file_data` callers buffered the file before PDS upload |
+| long-form regression test: 60-min mono WAV (~150 MB) generated via ffmpeg lavfi at fixture time, uploaded through real API, polled to completion | `backend/tests/integration/test_longform_upload.py`, `backend/tests/integration/utils/audio.py` | future PRs that re-buffer will fail this test instead of an angry user tweet |
+| CI integration-tests timeout 15 min → 30 min | `.github/workflows/integration-tests.yml` | accommodates the long-form regression test |
+
+`TranscodeInfo.transcoded_data: bytes` is removed — nothing reads it now that the worker streams from R2 instead.
+
+## what this PR does NOT ship (deliberate, follow-up tasks)
+
+these would have prevented or shortened the outage independently of the streaming fix; tracked separately so the streaming change ships clean.
+
+1. **logfire alert on absent worker spans.** `no run_track_upload spans in 5 min` would have paged at 19:01 UTC on 2026-05-06.
+2. **postgres reaper for stuck `processing` jobs.** any job in `processing` for > N minutes gets failed (or re-enqueued) by a periodic task. this would have made the outage self-healing the moment the worker came back.
+3. **fly worker restart policy.** change from `on-failure` (`max_retries=10`) to `always` (no limit). there's no scenario where giving up on a singleton worker helps.
+4. **fly worker health check.** small TCP listener inside `backend.worker` so fly can detect a process that's running-but-stuck (the streaming fix doesn't address that class of failure).
+5. **bigger picture: PDS uploadBlob byte-streaming has a known gap** — DPoP nonce mismatch on first attempt after long idle can exhaust an async iterator before the retry inside upstream `OAuthClient.make_authenticated_request`. the workaround in this PR is `_signed_streaming_post`, which reimplements just enough of the DPoP flow to call the body factory per attempt. the durable fix is upstreaming a body-factory parameter into `atproto_oauth.OAuthClient` itself.
+
+## key takeaways
+
+- **the upload pipeline holds long-form audio in RAM.** "the worker has 2 GB" is irrelevant when each in-flight upload buffers the file 3–5 times. memory bumps would only delay the same OOM.
+- **`restart.policy = on-failure with max_retries`** is wrong for a singleton worker. fly should keep trying forever; the outage class we care about is "we need a human" and giving up after 10 tries is exactly that.
+- **the gap between "the worker is dead" and "we know the worker is dead" was 4 days.** that's the most expensive number in this incident. an alert on "no worker spans in 5 min" closes it.
+- **content-hashed staging files saved us from total loss.** even after 4 days, the lossless source bytes were still in R2 — for the 3 users whose OAuth sessions hadn't expired we recovered without their participation. for the 6 we couldn't, the cost was a re-upload, not lost art.
+
+## related
+
+- 2026-04-02 deploy-outage-oom-kill — separate OOM class (HTTP `app` machine, 1 GB → 2 GB). same lesson about cold-start memory pressure that we apparently failed to generalize.
+- #1357 — the open issue tracking "in-memory upload pipeline." this PR partially addresses #1357 by removing the buffer points; the pipeline still spools to /tmp during transcode (necessary for ffmpeg input) but no longer holds bytes in process memory.
+- #1359 — split worker into its own fly process group. that change protected the HTTP server from worker OOMs (correct), but did not prevent the worker itself from OOMing (this PR).
+
+## references
+
+- fly machine events: `fly machine status 6e8204deb36148 -a relay-api`
+- logfire production traces 2026-05-06 18:56 – 19:32 UTC and 2026-05-10 19:02 – 19:15 UTC
+- stranded jobs: `jobs` table where `type='upload' and status='processing' and created_at > '2026-05-06T18:56'` (manually marked failed at 19:08:26)
+- worker entrypoint: `backend/src/backend/worker.py`
+- restart policy: `backend/src/backend/_internal/background.py:docket_worker_lifespan`

--- a/docs/internal/retrospectives/README.md
+++ b/docs/internal/retrospectives/README.md
@@ -1,0 +1,29 @@
+# retrospectives
+
+postmortems, incident analyses, and design investigations for plyr.fm
+
+## naming convention
+
+all files follow the format: `YYYY-MM-DD-descriptive-name.md`
+
+## categories
+
+### incidents & outages
+- production issues that caused service degradation or downtime
+- includes root cause analysis, timeline, and prevention measures
+
+### performance investigations
+- deep dives into performance bottlenecks
+- optimization strategies and results
+
+### design analyses
+- architectural decisions and trade-offs
+- feature planning and implementation approaches
+
+### issue retrospectives
+- significant bugs and their resolutions
+- lessons learned from edge cases
+
+## index
+
+use `ls -1` to see chronologically sorted list of all retrospectives.

--- a/loq.toml
+++ b/loq.toml
@@ -40,7 +40,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1507
+max_lines = 1530
 
 [[rules]]
 path = "backend/src/backend/config.py"
@@ -48,7 +48,7 @@ max_lines = 1000
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
-max_lines = 828
+max_lines = 903
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"
@@ -268,7 +268,7 @@ max_lines = 567
 
 [[rules]]
 path = "backend/tests/api/track_audio_replace/test_revisions.py"
-max_lines = 668
+max_lines = 672
 
 [[rules]]
 path = "frontend/src/routes/embed/track/[[]id[]]/+page.svelte"
@@ -281,3 +281,7 @@ max_lines = 652
 [[rules]]
 path = "frontend/src/routes/playlist/[[]id[]]/+page.svelte"
 max_lines = 2589
+
+[[rules]]
+path = "backend/src/backend/_internal/atproto/client.py"
+max_lines = 541

--- a/loq.toml
+++ b/loq.toml
@@ -284,4 +284,4 @@ max_lines = 2589
 
 [[rules]]
 path = "backend/src/backend/_internal/atproto/client.py"
-max_lines = 541
+max_lines = 550

--- a/scripts/backfill_embeddings.py
+++ b/scripts/backfill_embeddings.py
@@ -36,7 +36,6 @@ import asyncio
 import logging
 import time
 
-import httpx
 from sqlalchemy import select
 
 from backend._internal.clients.clap import get_clap_client
@@ -55,7 +54,6 @@ logger = logging.getLogger(__name__)
 async def _embed_one(
     track: Track,
     artist: Artist,
-    http: httpx.AsyncClient,
     clap_client: object,
     sem: asyncio.Semaphore,
     counter: dict[str, int],
@@ -72,11 +70,7 @@ async def _embed_one(
                 "embedding [%d/%d] track %d: %s", idx, total, track.id, track.title
             )
 
-            resp = await http.get(r2_url)
-            resp.raise_for_status()
-            audio_bytes = resp.content
-
-            embed_result = await clap_client.embed_audio(audio_bytes)
+            embed_result = await clap_client.embed_audio(r2_url)
 
             if not embed_result.success or not embed_result.embedding:
                 logger.warning(
@@ -152,12 +146,11 @@ async def backfill_embeddings(
     counter: dict[str, int] = {"started": 0, "embedded": 0, "failed": 0}
     t0 = time.monotonic()
 
-    async with httpx.AsyncClient(timeout=httpx.Timeout(120.0)) as http:
-        tasks = [
-            _embed_one(track, artist, http, clap_client, sem, counter, len(rows))
-            for track, artist in rows
-        ]
-        await asyncio.gather(*tasks)
+    tasks = [
+        _embed_one(track, artist, clap_client, sem, counter, len(rows))
+        for track, artist in rows
+    ]
+    await asyncio.gather(*tasks)
 
     elapsed = time.monotonic() - t0
     logger.info(

--- a/services/clap/app.py
+++ b/services/clap/app.py
@@ -53,24 +53,51 @@ class ClapService:
 
     @modal.fastapi_endpoint(method="POST")
     def embed_audio(self, item: dict) -> dict:
-        """generate embedding from base64-encoded audio bytes.
+        """generate embedding from a presigned audio URL.
 
-        expects: {"audio_b64": "<base64 string>"}
+        expects one of:
+            {"audio_url": "https://..."}    — preferred: Modal pulls a Range
+                                              of bytes itself; the plyr.fm
+                                              worker never holds the file.
+            {"audio_b64": "<base64 string>"} — legacy buffered path, kept
+                                              for backwards compatibility
+                                              with old clients.
+
         returns: {"embedding": [float, ...], "dimensions": 512}
+
+        only the first ~30 seconds are needed for CLAP — see the chunking
+        below — so when given a URL we fetch a single Range request capped
+        at 12 MB. that's enough for >30 s at any reasonable bitrate
+        (e.g. 320 kbps mp3 ≈ 40 KB/s, 24 MB/min) and never runs away on a
+        90-minute upload.
         """
         import subprocess
         import tempfile
         import traceback
 
+        import httpx
         import soundfile as sf
         import torch
         import torch.nn.functional as F
 
-        if not (audio_b64 := item.get("audio_b64")):
-            return {"error": "missing audio_b64 field"}
+        # 12 MB caps fetch size for any input; soundfile + ffmpeg can
+        # decode well past 30 s of audio from this much data even at
+        # 320 kbps, and many short tracks fit entirely.
+        AUDIO_FETCH_LIMIT = 12 * 1024 * 1024
 
         try:
-            audio_bytes = base64.b64decode(audio_b64)
+            if audio_url := item.get("audio_url"):
+                with httpx.Client(timeout=httpx.Timeout(60.0)) as client:
+                    resp = client.get(
+                        audio_url,
+                        headers={"Range": f"bytes=0-{AUDIO_FETCH_LIMIT - 1}"},
+                    )
+                    resp.raise_for_status()
+                    audio_bytes = resp.content
+            elif audio_b64 := item.get("audio_b64"):
+                audio_bytes = base64.b64decode(audio_b64)
+            else:
+                return {"error": "missing audio_url or audio_b64 field"}
 
             # try soundfile first (handles wav, flac, ogg natively)
             try:


### PR DESCRIPTION
## Why this PR exists

production was silently broken from **2026-05-06 18:56 UTC → 2026-05-10 19:02 UTC** — almost exactly 4 days. every track upload during that window stranded at \"uploading to storage… 100%\" forever. `POST /tracks/` returned 200 and queued a `run_track_upload` task into Redis, but the docket worker process group was dead and nothing was draining the queue. discovered when @cameron.stream tweeted about it, not by any internal alerting.

**root cause** is structural, not a one-off:

1. the upload pipeline buffers the **entire audio file** in worker memory at four distinct points (R2 read, transcode result, PDS `uploadBlob`, CLAP embedding base64).
2. with `concurrency=10` and post-upload fan-out (scan_copyright + classify_genres + generate_embedding all running per upload), each in-flight upload could be holding the bytes 3–5 times simultaneously.
3. on the cold-start backlog drain after a deploy, a long-form upload OOM-killed the 2 GB worker (exit_code=137, oom_killed=true). fly's `restart.policy = on-failure max_retries = 10` gave up after 10 consecutive OOMs and left the machine `stopped`.

read the full postmortem: **[docs/internal/retrospectives/2026-05-10-worker-oom-loop-streaming.md](../blob/fix/audio-upload-streaming-end-to-end/docs/internal/retrospectives/2026-05-10-worker-oom-loop-streaming.md)** — that's the one in this PR that documents what just happened. timeline, the 9 stranded users, every buffer point with file:line, root causes, and what's intentionally NOT in this PR (alerting on absent worker spans, postgres reaper for stuck `processing` jobs, `restart.policy = always`).

## On the retrospectives directory

this PR also imports the team's local sandbox/retrospectives knowledge base into `docs/internal/retrospectives/` as a one-time bulk move — `sandbox/` is in .gitignore so none of it had ever been committed even though the convention has existed since 2025-11. all 19 historical retros come along with **`2026-05-10-worker-oom-loop-streaming.md`** (the new one for this incident). bringing them into git makes them reviewable, cross-linkable from PRs, and visible to anyone reading the repo without already having the user's local notes.

## What this PR ships (streaming end-to-end)

| change | files | what it eliminates |
|---|---|---|
| `StorageProtocol.stream_file_data()` (async iter of chunks) + `head_file()` (size for Content-Length) | `backend/src/backend/storage/{protocol,r2}.py` | the `bytes`-returning `get_file_data` call site on the audio upload path |
| `upload_blob(body_factory=..., content_length=..., content_type=...)`; existing `data=` form retained for small in-memory blobs (artwork, profile avatars) | `backend/src/backend/_internal/atproto/client.py` | full file held in memory before PDS POST |
| `_signed_streaming_post` helper that supports DPoP + body factories per attempt | `backend/src/backend/_internal/atproto/client.py` | inability to retry streaming uploads on DPoP nonce mismatch (upstream `make_authenticated_request` reuses the same kwargs on its inner retry, exhausting any async iterator) |
| transcoder client streams response → /tmp via `httpx.AsyncClient.stream` + `aiofiles`, returns `output_path` not `bytes` | `backend/src/backend/_internal/clients/transcoder.py` | full transcoded blob held in memory |
| `_transcode_audio` streams R2 → /tmp source, runs transcoder, streams /tmp → R2 via existing `R2.save` (which streams) | `backend/src/backend/api/tracks/uploads.py` | full lossless source held in memory |
| `_upload_to_pds` streams R2 → PDS uniformly (drops the special transcoded-data branch since the transcoded file is now in R2 like everything else) | `backend/src/backend/api/tracks/uploads.py` | full playable file held in memory before PDS |
| Modal CLAP service accepts `audio_url` and Range-fetches the first ~12 MB itself (model only uses the first 30 s); worker no longer downloads or base64-encodes the file | `services/clap/app.py`, `backend/src/backend/_internal/clients/clap.py`, `backend/src/backend/_internal/tasks/ml.py`, `scripts/backfill_embeddings.py` | full file downloaded to worker + base64 encoded × 1.33 just to ship to Modal |
| migrate-to-PDS, restore-revision, PDS backfill task | `backend/src/backend/api/tracks/{mutations,revisions}.py`, `backend/src/backend/_internal/pds_backfill_tasks.py` | three more `get_file_data` callers buffered the file before PDS upload |
| **long-form regression test**: 60-min mono WAV (~150 MB) generated via ffmpeg lavfi at fixture time, uploaded through real API, polled to completion | `backend/tests/integration/test_longform_upload.py`, `backend/tests/integration/utils/audio.py` | future PRs that re-buffer fail this test instead of an angry user tweet |
| CI integration-tests timeout 15 min → 30 min | `.github/workflows/integration-tests.yml` | accommodates the long-form regression test |

`TranscodeInfo.transcoded_data: bytes` is removed — nothing reads it now that the worker streams from R2 instead.

## Modal CLAP service redeploy required

`services/clap/app.py` changed: it now accepts `{\"audio_url\": ...}` and Range-fetches the first 12 MB itself. the `audio_b64` path is kept for backwards-compat so the redeploy can lag behind the merge if needed. after merge: \`uvx modal deploy services/clap/app.py\`.

## Test plan

- [ ] CI integration tests pass against staging (the 60-min long-form test is the load-bearing one)
- [ ] manual: upload a regular short track via the UI, see it complete normally
- [ ] manual: upload a > 30-min track via the UI, see it complete (this is the case prod was silently failing on)
- [ ] manual: redeploy Modal CLAP, confirm vibe-search still works (ie. embedding generation succeeds for new uploads)
- [ ] worker memory under cold-start drain stays under 2 GB (smoke test by triggering a backlog drain after deploy)

## Out of scope (deliberate, follow-up)

documented in the postmortem under \"what this PR does NOT ship\":
1. logfire alert on absent worker spans
2. postgres reaper for stuck \`processing\` jobs
3. fly worker `restart.policy = always`
4. fly worker tcp health check
5. upstream `atproto_oauth.OAuthClient` body-factory support (then we can remove `_signed_streaming_post`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)