### PR TITLE
ops: never give up restarting the worker + runbook for silence alert

### DIFF
--- a/backend/fly.staging.toml
+++ b/backend/fly.staging.toml
@@ -61,6 +61,14 @@ primary_region = 'iad'
   cpu_kind = 'shared'
   cpus = 1
 
+# always restart the worker on exit, with no retry budget. mirrors prod
+# fly.toml — staging needs the same restart policy so the silence /
+# crash-loop alerts can be smoke-tested against staging before going to
+# prod (see docs/internal/runbooks/worker-silence-alert.md).
+[[restart]]
+  policy = "always"
+  processes = ["worker"]
+
 # secrets to set via: fly secrets set KEY=value -a relay-api-staging
 # - DATABASE_URL (neon postgres connection string)
 # - AWS_ACCESS_KEY_ID (cloudflare R2)

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -53,6 +53,19 @@ primary_region = 'iad'
   cpu_kind = 'shared'
   cpus = 1
 
+# always restart the worker on exit, with no retry budget. fly's default
+# (`on-failure`, max_retries=10) gave up after 10 consecutive OOMs on
+# 2026-05-06 and left the machine `stopped` for ~4 days; see
+# docs/internal/retrospectives/2026-05-10-worker-oom-loop-streaming.md.
+# for a singleton worker that owns the only consumer of the upload queue,
+# there is no scenario where giving up is the correct outcome — a noisy
+# restart loop is loud (alerting catches it) and useful (occasional
+# successful runs drain the queue). `app` keeps fly's default because
+# it has health checks + multiple machines for HTTP redundancy.
+[[restart]]
+  policy = "always"
+  processes = ["worker"]
+
 [env]
   PORT = '8000'
   STORAGE_BACKEND = 'r2'

--- a/docs/internal/runbooks/README.md
+++ b/docs/internal/runbooks/README.md
@@ -7,7 +7,7 @@ operational procedures for production incidents.
 ## available runbooks
 
 - [connection pool exhaustion](/runbooks/connection-pool-exhaustion/) - 500s everywhere, queue listener down, stuck connections
-- [worker silence alert](/runbooks/worker-silence-alert/) - docket worker has stopped processing tasks while the HTTP API is still accepting uploads
+- [worker silence + crash-loop alerts](/runbooks/worker-silence-alert/) - docket worker has stopped processing tasks, or is restart-looping faster than a healthy deploy would explain
 
 ## when to use
 

--- a/docs/internal/runbooks/README.md
+++ b/docs/internal/runbooks/README.md
@@ -7,6 +7,7 @@ operational procedures for production incidents.
 ## available runbooks
 
 - [connection pool exhaustion](/runbooks/connection-pool-exhaustion/) - 500s everywhere, queue listener down, stuck connections
+- [worker silence alert](/runbooks/worker-silence-alert/) - docket worker has stopped processing tasks while the HTTP API is still accepting uploads
 
 ## when to use
 

--- a/docs/internal/runbooks/worker-silence-alert.md
+++ b/docs/internal/runbooks/worker-silence-alert.md
@@ -1,29 +1,46 @@
 ---
-title: "alert: worker silence"
+title: "alerts: worker silence + crash loop"
 ---
 
-an alert that fires when the docket worker process group has not produced
-any task-completion span in a window where it should have. catches the
-2026-05-10 failure mode (worker dead, fly stopped restarting it, nobody
-noticed for four days) within minutes instead of days.
+two alerts that, together, catch the operational failure modes of the
+docket worker. both target the 2026-05-10 incident class (worker dead,
+fly stopped restarting it, nobody noticed for four days), but from
+opposite sides.
 
 see [docs/internal/retrospectives/2026-05-10-worker-oom-loop-streaming.md](../retrospectives/2026-05-10-worker-oom-loop-streaming.md)
 for the incident this addresses.
 
-## what to alert on
+| alert | what it catches |
+|---|---|
+| **worker silence** | worker is not running tasks while the system is taking new uploads (the 2026-05-10 shape exactly) |
+| **worker crash loop** | worker keeps starting and dying — the failure mode that `restart.policy = "always"` makes possible. without this, the unbounded restart hides under "loud" but never pages |
+
+## alert 1: worker silence
+
+### what to alert on
 
 the worker is unhealthy if **both** of these are true in the same window:
 
 1. the HTTP API is alive (so we know the system isn't fully down) — at
    least one successful `POST /tracks/` in the window
-2. the worker emitted zero spans for any of the recurring tasks it owns
+2. the worker emitted zero task-execution spans
    (`run_track_upload`, `consume_jetstream`, `sync_copyright_resolutions`,
    `scrobble_to_teal`, `warm_follow_graph`)
 
 condition (1) prevents the alert from firing during a planned full-stack
-deploy. condition (2) is the actual silence we care about.
+deploy. condition (2) is the actual silence we care about. when nobody
+is uploading at all (e.g. middle of the night), this alert is silent by
+design — the crash-loop alert below covers idle-worker failure modes
+where there's no upload traffic to compare against.
 
-## logfire saved query
+filtering by `attributes->>'docket.task' IN (...)` instead of `IS NOT
+NULL` means we count *task execution* on the worker, not the noisier
+`docket.add` spans (which the HTTP `app` process emits when it queues
+work, regardless of whether anything is consuming it). "queue is being
+added to but nothing is being executed" is the exact shape of the
+2026-05-10 failure.
+
+### logfire saved query
 
 run this against `production` on a 5-minute window. the alert fires when
 `worker_task_count = 0` AND `upload_attempt_count > 0`.
@@ -68,51 +85,120 @@ worker_task_count = 0 AND upload_attempt_count > 0
 window: 5 minutes. evaluate every 1 minute. notification: page (slack
 or pagerduty depending on what we route alerts through).
 
-## how to wire it up in logfire
-
-1. open [https://logfire.pydantic.dev/zzstoatzz/plyr](https://logfire.pydantic.dev/zzstoatzz/plyr)
-2. SQL Explorer → paste the query above
-3. confirm it returns one row with two integer columns
-4. save the query as `alert: worker silence (production)`
-5. create a monitor on the saved query with the condition above
-6. add a notification target for the monitor
-
-## how to test the alert without breaking production
-
-1. open [https://logfire.pydantic.dev/zzstoatzz/plyr](https://logfire.pydantic.dev/zzstoatzz/plyr)
-2. modify the query to filter on `deployment_environment = 'staging'` and
-   shorten the window to 1 minute
-3. on staging, stop the worker machine: `fly machine stop <worker-id> -a relay-api-staging`
-4. trigger an upload via stg.plyr.fm to bump `upload_attempt_count`
-5. confirm the monitor fires within ~1 minute
-6. restart the staging worker: `fly machine start <worker-id> -a relay-api-staging`
-
-## what to do when this alert fires
+### what to do when this alert fires
 
 1. check fly machine state: `fly status -a relay-api`. if any worker is
    `stopped` (and not `started`), start it: `fly machine start <id> -a relay-api`
-2. confirm the worker is consuming the queue: query the saved alert
+2. confirm the worker is consuming the queue: query the saved silence
    query manually and verify `worker_task_count > 0` in the next window
-3. if the worker keeps OOM-killing, investigate memory usage — the
-   2026-05-10 fix removed the in-memory audio buffers that were the
-   common OOM cause, but new code paths could regress this
+3. if the worker keeps OOM-killing, the crash-loop alert below should
+   also be firing — follow that runbook section instead
 4. if the worker is started but no spans are appearing, suspect a stuck
    loop (network hang on PDS, DB connection wedged) — `fly machine
    restart <id>` to bounce it
 5. open an issue with the logfire trace so the failure mode gets a
    proper retrospective even if the alert was the only signal
 
-## why this query and not just "any worker span"
+## alert 2: worker crash loop
 
-filtering by `attributes->>'docket.task' IN (...)` instead of `IS NOT NULL`
-means we count *task-completion* spans specifically, not the noisier
-`docket.add` spans (which are emitted by the HTTP `app` process when it
-queues work, not by the worker process executing it). a queue with new
-tasks being added but no tasks being executed is exactly the failure
-shape we care about; counting `docket.add` would mask it.
+### why this exists
 
-the listed task names cover both the on-demand work (`run_track_upload`,
-`scrobble_to_teal`, etc.) and the recurring schedule (`consume_jetstream`,
-`sync_copyright_resolutions`, `warm_follow_graph`) so the alert fires even
-during quiet periods when nobody is uploading — the recurring tasks tick
-every few minutes regardless and the worker emits a span on each tick.
+`restart.policy = "always"` (the change in this PR's `fly.toml`) means
+fly restarts the worker forever, with no retry budget. that's the right
+default — silent permanent failure was what made 2026-05-10 a four-day
+outage. but it makes a new failure mode possible: a "poison pill" task
+or systemic bug that crashes the worker every time it tries to start,
+keeping the system in a churning loop indefinitely. this alert catches
+that, so the bound on retry-forever is *human attention*, not arbitrary
+machine giving-up.
+
+### what to alert on
+
+the worker is starting more often than a healthy worker should. a
+healthy worker starts once per deploy (rare) — anything more is either
+a deploy in progress (transient, alert auto-clears) or a bug.
+
+threshold: more than **5 worker starts in 10 minutes** is unhealthy.
+that gives a deploy enough room (typically 1–2 starts per machine across
+2 worker machines) without burying a real loop.
+
+### logfire saved query
+
+```sql
+SELECT
+  COUNT(*) AS worker_start_count,
+  -- include the timestamps of recent starts in the alert payload so
+  -- the on-call has the data to investigate without writing a new query
+  array_agg(start_timestamp ORDER BY start_timestamp DESC) AS recent_starts
+FROM records
+WHERE deployment_environment = 'production'
+  AND start_timestamp > NOW() - INTERVAL '10 minutes'
+  AND span_name = 'worker process ready'
+```
+
+`worker process ready` is logged by `backend/worker.py` once on each
+successful startup, so each row counts exactly one worker-restart event.
+
+alert condition:
+
+```
+worker_start_count > 5
+```
+
+window: 10 minutes. evaluate every 1 minute.
+
+### what to do when this alert fires
+
+1. check fly machine state: `fly status -a relay-api`. confirm the worker
+   machine is alternating between `started` and `stopped` rather than
+   sitting steady-state `started`
+2. pull the recent crash reasons:
+   `fly machine status <worker-id> -a relay-api` and look at the event
+   log for `exit_code` / `oom_killed` fields
+3. if it's an OOM loop on a poison-pill task: stop the worker manually
+   with `fly machine stop <id> -a relay-api` to break the loop, then
+   identify which task is killing it (look at the latest spans before
+   the crash), and either fix the code or manually drop the task from
+   redis
+4. if the worker is crashing on startup (failing before `worker process
+   ready` even logs once), suspect a deploy regression — check the
+   most recent merged PR for backend changes
+5. open an issue with the logfire trace and update this runbook with
+   anything we learned
+
+## how to wire both alerts up in logfire
+
+for each of the two saved queries above:
+
+1. open [https://logfire.pydantic.dev/zzstoatzz/plyr](https://logfire.pydantic.dev/zzstoatzz/plyr)
+2. SQL Explorer → paste the query
+3. confirm it returns the expected shape
+4. save the query (`alert: worker silence (production)` and
+   `alert: worker crash loop (production)`)
+5. create a monitor on the saved query with the condition above
+6. add a notification target for the monitor
+
+## how to test the alerts without breaking production
+
+these instructions assume the staging fly app `relay-api-staging` has
+the same `restart.policy = "always"` config as production (it does, per
+`backend/fly.staging.toml`) and that staging emits to the same logfire
+project under `deployment_environment = 'staging'`.
+
+**testing the silence alert:**
+
+1. duplicate the silence query, swap `deployment_environment = 'staging'`,
+   shorten window to 1 minute
+2. stop the staging worker: `fly machine stop <worker-id> -a relay-api-staging`
+3. trigger an upload via stg.plyr.fm to bump `upload_attempt_count`
+4. confirm the monitor fires within ~1 minute
+5. restart the staging worker: `fly machine start <worker-id> -a relay-api-staging`
+
+**testing the crash-loop alert:**
+
+1. duplicate the crash-loop query, swap to staging, shorten window to
+   2 minutes and lower threshold to `worker_start_count > 2`
+2. on staging, repeatedly bounce the worker:
+   `for i in 1 2 3 4; do fly machine restart <id> -a relay-api-staging; sleep 20; done`
+3. confirm the monitor fires within ~2 minutes
+4. clean up: leave the worker steady-state started

--- a/docs/internal/runbooks/worker-silence-alert.md
+++ b/docs/internal/runbooks/worker-silence-alert.md
@@ -1,0 +1,118 @@
+---
+title: "alert: worker silence"
+---
+
+an alert that fires when the docket worker process group has not produced
+any task-completion span in a window where it should have. catches the
+2026-05-10 failure mode (worker dead, fly stopped restarting it, nobody
+noticed for four days) within minutes instead of days.
+
+see [docs/internal/retrospectives/2026-05-10-worker-oom-loop-streaming.md](../retrospectives/2026-05-10-worker-oom-loop-streaming.md)
+for the incident this addresses.
+
+## what to alert on
+
+the worker is unhealthy if **both** of these are true in the same window:
+
+1. the HTTP API is alive (so we know the system isn't fully down) — at
+   least one successful `POST /tracks/` in the window
+2. the worker emitted zero spans for any of the recurring tasks it owns
+   (`run_track_upload`, `consume_jetstream`, `sync_copyright_resolutions`,
+   `scrobble_to_teal`, `warm_follow_graph`)
+
+condition (1) prevents the alert from firing during a planned full-stack
+deploy. condition (2) is the actual silence we care about.
+
+## logfire saved query
+
+run this against `production` on a 5-minute window. the alert fires when
+`worker_task_count = 0` AND `upload_attempt_count > 0`.
+
+```sql
+WITH window_bounds AS (
+  SELECT
+    NOW() - INTERVAL '5 minutes' AS window_start,
+    NOW() AS window_end
+)
+SELECT
+  -- spans emitted by the worker process. if this is zero while the
+  -- HTTP API is taking new uploads, the worker is dead or wedged.
+  COUNT(*) FILTER (
+    WHERE attributes->>'docket.task' IN (
+      'run_track_upload',
+      'consume_jetstream',
+      'sync_copyright_resolutions',
+      'scrobble_to_teal',
+      'warm_follow_graph'
+    )
+  ) AS worker_task_count,
+
+  -- successful POST /tracks/ requests as a liveness signal for the
+  -- HTTP path, so we don't page during a full-stack deploy window.
+  COUNT(*) FILTER (
+    WHERE span_name = 'POST /tracks/'
+      AND http_response_status_code = 200
+  ) AS upload_attempt_count
+FROM records, window_bounds
+WHERE deployment_environment = 'production'
+  AND start_timestamp >= window_bounds.window_start
+  AND start_timestamp <  window_bounds.window_end
+```
+
+alert condition (in logfire's monitor configuration):
+
+```
+worker_task_count = 0 AND upload_attempt_count > 0
+```
+
+window: 5 minutes. evaluate every 1 minute. notification: page (slack
+or pagerduty depending on what we route alerts through).
+
+## how to wire it up in logfire
+
+1. open [https://logfire.pydantic.dev/zzstoatzz/plyr](https://logfire.pydantic.dev/zzstoatzz/plyr)
+2. SQL Explorer → paste the query above
+3. confirm it returns one row with two integer columns
+4. save the query as `alert: worker silence (production)`
+5. create a monitor on the saved query with the condition above
+6. add a notification target for the monitor
+
+## how to test the alert without breaking production
+
+1. open [https://logfire.pydantic.dev/zzstoatzz/plyr](https://logfire.pydantic.dev/zzstoatzz/plyr)
+2. modify the query to filter on `deployment_environment = 'staging'` and
+   shorten the window to 1 minute
+3. on staging, stop the worker machine: `fly machine stop <worker-id> -a relay-api-staging`
+4. trigger an upload via stg.plyr.fm to bump `upload_attempt_count`
+5. confirm the monitor fires within ~1 minute
+6. restart the staging worker: `fly machine start <worker-id> -a relay-api-staging`
+
+## what to do when this alert fires
+
+1. check fly machine state: `fly status -a relay-api`. if any worker is
+   `stopped` (and not `started`), start it: `fly machine start <id> -a relay-api`
+2. confirm the worker is consuming the queue: query the saved alert
+   query manually and verify `worker_task_count > 0` in the next window
+3. if the worker keeps OOM-killing, investigate memory usage — the
+   2026-05-10 fix removed the in-memory audio buffers that were the
+   common OOM cause, but new code paths could regress this
+4. if the worker is started but no spans are appearing, suspect a stuck
+   loop (network hang on PDS, DB connection wedged) — `fly machine
+   restart <id>` to bounce it
+5. open an issue with the logfire trace so the failure mode gets a
+   proper retrospective even if the alert was the only signal
+
+## why this query and not just "any worker span"
+
+filtering by `attributes->>'docket.task' IN (...)` instead of `IS NOT NULL`
+means we count *task-completion* spans specifically, not the noisier
+`docket.add` spans (which are emitted by the HTTP `app` process when it
+queues work, not by the worker process executing it). a queue with new
+tasks being added but no tasks being executed is exactly the failure
+shape we care about; counting `docket.add` would mask it.
+
+the listed task names cover both the on-demand work (`run_track_upload`,
+`scrobble_to_teal`, etc.) and the recurring schedule (`consume_jetstream`,
+`sync_copyright_resolutions`, `warm_follow_graph`) so the alert fires even
+during quiet periods when nobody is uploading — the recurring tasks tick
+every few minutes regardless and the worker emits a span on each tick.


### PR DESCRIPTION
## Why this PR exists

operational follow-up to #1389 (the streaming refactor) that closes the
2026-05-06 failure mode at the layer below the application code. with
this merged, the same OOM that triggered the 4-day outage would either
self-heal (fly keeps restarting the worker until it succeeds) or page
someone within minutes (the silence alert fires on absence of worker
spans).

see [docs/internal/retrospectives/2026-05-10-worker-oom-loop-streaming.md](../blob/main/docs/internal/retrospectives/2026-05-10-worker-oom-loop-streaming.md) for the full incident narrative.

## What changes

### `backend/fly.toml` — never give up restarting the worker

today the worker uses fly's default machine-level restart policy:
`policy = "on-failure"` with `max_retries = 10`. plain english: \"if the
worker process exits non-zero, restart it; after 10 consecutive failures,
stop and leave the machine stopped.\" that 10-retry budget is exactly
what got exhausted during the May 6 cold-start OOM loop, leaving the
machine sitting `stopped` for the next ~4 days.

this PR adds a `[[restart]]` block scoped to `processes = [\"worker\"]`
with `policy = \"always\"`. plain english: \"if the worker process exits,
restart it. forever, no retry budget.\" for a singleton consumer of the
upload queue there's no scenario where giving up is the correct action —
worst case is a noisy restart loop, which is exactly what we want the
alerting in this PR to catch.

`app` keeps fly's default because it already has HTTP health checks and
multiple machines for redundancy; it doesn't have the same singleton
fragility.

### `docs/internal/runbooks/worker-silence-alert.md` — a saved-query alert

today our monitoring watches for *errors*. on May 6 there were no errors
to watch — the worker was simply not running, so no spans of any kind.
the existing alerts had nothing to fire on.

this PR documents a logfire saved-query that fires when **both** of these
are true in the same 5-minute window:

1. the HTTP API accepted at least one `POST /tracks/` (so we know the
   system isn't fully down — prevents the alert from firing during a
   planned full-stack deploy)
2. the worker emitted **zero** task-execution spans
   (`run_track_upload`, `consume_jetstream`, `sync_copyright_resolutions`,
   `scrobble_to_teal`, `warm_follow_graph`)

condition (2) is the key part — it counts task *execution* on the worker,
not the noisier `docket.add` spans (which the HTTP `app` process emits
when it queues work, regardless of whether anything is consuming it).
\"queue is being added to but nothing is being executed\" is the exact
shape of the May 6 failure.

the runbook walks through:
- the SQL query, with explicit comments on each filter
- how to wire up the saved query + monitor in the logfire UI
- how to test the alert against staging (stop a staging worker
  machine, trigger an upload, confirm the alert fires)
- what to do when it fires in production

wiring up the saved query in the logfire UI is a manual one-time step;
this PR is purely the runbook so the convention is reviewable and
linkable from the retrospective.

## What this PR does NOT include

- **stuck-job reaper** — a periodic task that scans the `jobs` table for
  upload jobs stuck in `processing` past a wall-clock budget and marks
  them failed. needs design discussion (threshold, retry behavior, R2
  cleanup interaction). lands in a follow-up PR.
- **fly tcp health check on the worker** — distinct from restart policy:
  catches a process that's running-but-stuck rather than one that exited.
  for the May 6 incident specifically (clean OOM kill) it wouldn't have
  helped, so lower priority. lands in the same follow-up PR or its own.

## Test plan

- [ ] `fly config validate` passes locally (verified before commit)
- [ ] CI pre-commit + type checks pass
- [ ] after merge: confirm the worker machines pick up the new restart
      policy on next deploy via `fly machine status <id> -d -a relay-api`
      (the `restart` field should read `{\"policy\": \"always\"}`)
- [ ] manual: stop the staging worker machine, queue an upload, verify
      fly auto-restarts the machine instead of leaving it stopped
- [ ] manual: wire up the logfire saved query + monitor per the runbook,
      then test it against staging by following the steps in the runbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)