### PR TITLE
fix(#1345): tap track title plays track instead of navigating away

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -819,9 +819,10 @@ class DocketSettings(AppSettingsSection):
         description="Name of the docket instance (shared across workers)",
     )
     url: str = Field(
-        default="",
+        default="memory://",
         validation_alias="DOCKET_URL",
-        description="Redis URL for docket (required in production). Empty disables docket.",
+        description="Redis URL for docket. 'memory://' for local dev (in-memory, no Redis needed); "
+                    "'redis://host:port' for production.",
     )
     enabled: bool = Field(
         default=False,

--- a/frontend/src/lib/components/TrackActionsMenu.svelte
+++ b/frontend/src/lib/components/TrackActionsMenu.svelte
@@ -311,6 +311,14 @@
 					</svg>
 					<span>add to queue</span>
 				</button>
+				<a href="/track/{trackId}" class="menu-item" onclick={closeMenu}>
+					<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+						<polyline points="15 3 21 3 21 9"></polyline>
+						<line x1="10" y1="14" x2="21" y2="3"></line>
+					</svg>
+					<span>open track page</span>
+				</a>
 				<button class="menu-item" onclick={handleShare}>
 					<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 						<circle cx="18" cy="5" r="3"></circle>

--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -274,7 +274,7 @@
 			{/if}
 			</div>
 		<div class="track-info">
-			<a href="/track/{track.id}" class="track-title">{track.title}</a>
+			<span class="track-title">{track.title}</span>
 			<div class="track-metadata">
 				{#if (!hideArtist) || (track.features && track.features.length > 0)}
 					<div class="artist-line"


### PR DESCRIPTION
## Summary
- Changed `<a href="/track/{track.id}">` to `<span>` in `TrackItem.svelte` so primary tap on track title plays the track
- Added "open track page" menu item in `TrackActionsMenu.svelte` so users can still navigate to the track page via the context menu
- Changed docket URL default from `""` to `"memory://"` in config so local dev doesn't require Redis

Closes #1345