### PR TITLE
docs: add frontend/.env.example so contributors don't have to discover it

### DIFF
--- a/docs/internal/local-development/setup.md
+++ b/docs/internal/local-development/setup.md
@@ -22,9 +22,11 @@ uv sync
 # install frontend dependencies
 cd frontend && bun install && cd ..
 
-# copy environment template
-cp .env.example .env
-# edit .env with your credentials
+# copy environment templates
+cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
+# edit backend/.env with your credentials
+# frontend/.env points at the local backend on :8001 by default
 
 # run backend
 uv run uvicorn backend.main:app --reload --host 0.0.0.0 --port 8001

--- a/docs/public/contributing.md
+++ b/docs/public/contributing.md
@@ -43,7 +43,9 @@ cd frontend && bun install && cd ..
 
 # configure environment
 cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
 # edit backend/.env — see the setup guide linked below for details
+# frontend/.env defaults to the local backend on :8001 and works as-is
 ```
 
 ### running the stack

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,6 @@
+# plyr.fm frontend configuration
+
+# backend api base url — must match the host:port your backend is serving on.
+# SvelteKit resolves PUBLIC_* vars at build/dev time, so this file needs to
+# exist before `bun run dev` even if you're using the default value.
+PUBLIC_API_URL=http://localhost:8001


### PR DESCRIPTION
## Summary
- new `frontend/.env.example` with `PUBLIC_API_URL=http://localhost:8001` and a note about SvelteKit resolving `PUBLIC_*` at dev time
- `docs/public/contributing.md` and `docs/internal/local-development/setup.md` quickstarts now include `cp frontend/.env.example frontend/.env`

Context: aila ([forking the repo](https://github.com/zzstoatzz/plyr.fm/pull/1393)) had to add a frontend `.env` by hand to get sample audio loading — it wasn't documented anywhere. This closes that gap.

## Test plan
- [ ] `cp frontend/.env.example frontend/.env` then `just frontend run` starts cleanly
- [ ] docs render correctly on docs.plyr.fm preview