### PR TITLE
chore: ruff-format follow-up to #1393

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -822,7 +822,7 @@ class DocketSettings(AppSettingsSection):
         default="memory://",
         validation_alias="DOCKET_URL",
         description="Redis URL for docket. 'memory://' for local dev (in-memory, no Redis needed); "
-                    "'redis://host:port' for production.",
+        "'redis://host:port' for production.",
     )
     enabled: bool = Field(
         default=False,


### PR DESCRIPTION
## Summary
- ruff-format re-indent on the continuation string in `DocketSettings.url` description — pre-commit didn't run on #1393 before merge
- no behavior change

## Test plan
- [x] `uv run pre-commit run --all-files` (on touched file) passes