### PR TITLE
docs: brief mention of private playlists in listeners.md

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -141,6 +141,8 @@ verified-safe paths (audited, no change required): `ingest.py` jetstream/PDS eve
 
 **collaborative playlists are the obvious next step**, and they're the trigger for substrate adoption: "private → selectively shared" is a multi-member permissioned context, exactly the shape dholms's spec serves. when that UX shows up, the migration path is to lift `items_json` onto a shared SpaceRecord and add a member list — which is what v1 (#1385) prefigured, minus the speculation about today's lexicon shape. #1384's substrate-time plan column should reflect "yes, when sharing lands" rather than "may always stay app-layer."
 
+**docs**: `docs/public/listeners.md` now mentions private playlists in passing with the "why it's app-layer for now + substrate on the way" framing (one paragraph after the build-a-playlist step + parenthetical in the feature list).
+
 ---
 
 #### cover-art background scrim — readability fix (PR #1381, May 8, closes #1374)
@@ -455,5 +457,5 @@ see the [contributing guide](https://docs.plyr.fm/contributing/) for setup instr
 
 ---
 
-this is a living document. last updated 2026-05-13 (first external contribution from @ailawav.bsky.social — `DOCKET_URL=memory://` default + `frontend/.env.example` follow-ups; 4-day upload OOM outage closed end-to-end via streaming refactor + ops backstops + stuck-job reaper; private playlists app-layer v2 + visibility toggle; cover-art scrim; artist identity backfill; backlog-maintenance skill).
+this is a living document. last updated 2026-05-13 (first external contribution from @ailawav.bsky.social — `DOCKET_URL=memory://` default + `frontend/.env.example` follow-ups; 4-day upload OOM outage closed end-to-end via streaming refactor + ops backstops + stuck-job reaper; private playlists app-layer v2 + visibility toggle, docs/public/listeners.md updated with brief mention; cover-art scrim; artist identity backfill; backlog-maintenance skill).
 

--- a/docs/public/listeners.md
+++ b/docs/public/listeners.md
@@ -46,12 +46,14 @@ even today, other apps (like [aetheros.computer](https://aetheros.computer)) alr
 
    ![track actions menu — like, add to playlist, queue, share](/screenshots/track-actions-menu.png)
 
+   playlists can be **public** (published to your atmosphere account, readable by any compatible app) or **private** (stays in plyr.fm). private playlists live in plyr.fm's database for now because the part of the AT Protocol that supports shared-but-permissioned data ([permissioned spaces](https://github.com/bluesky-social/atproto/compare/permissioned-data)) is still being designed upstream — once it ships, private and selectively-shared playlists will move to your atmosphere account too.
+
 to track and [visualize your listening history](https://teal-appview-production.up.railway.app/), you can [enable teal.fm scrobbling in your settings](https://plyr.fm/settings).
 
 ## what you get
 
 - **stream audio** — music, podcasts, sound art, whatever creators publish
-- **like, comment, and build playlists** — all yours, not locked into plyr.fm
+- **like, comment, and build playlists** (public or private) — all yours, not locked into plyr.fm
 - **timed comments** — leave reactions at specific moments in a track
 - **jams** — create shared listening rooms and listen with friends in real time
 


### PR DESCRIPTION
## Summary
- adds one paragraph to `docs/public/listeners.md` (right after the "build a playlist" step) explaining that private playlists live in plyr.fm's database rather than the user's atmosphere account because atproto's permissioned-data substrate is still being designed upstream — once it ships, private and selectively-shared playlists will move to the atmosphere account too
- adjusts the "what you get" bullet with a `(public or private)` parenthetical so the feature list isn't silent about the option
- STATUS.md "docs" line under the private-playlists section notes the docs were updated; footer mention added

## Test plan
- [ ] read the paragraph on a docs preview — does the substrate framing read clearly to a listener who doesn't already know what "permissioned spaces" means?
- [ ] confirm the link to https://github.com/bluesky-social/atproto/compare/permissioned-data is the right one to point listeners at (versus dholms's leaflet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)