### PR TITLE
feat(copyright): portal section + scope-upgrade plumbing (phase 2)

### DIFF
--- a/backend/alembic/versions/2026_05_14_124145_2ff28fd69210_add_paradigm_data_and_redirect_to_to_.py
+++ b/backend/alembic/versions/2026_05_14_124145_2ff28fd69210_add_paradigm_data_and_redirect_to_to_.py
@@ -1,0 +1,38 @@
+"""add paradigm_data and redirect_to to pending_scope_upgrades
+
+Revision ID: 2ff28fd69210
+Revises: 16cfa67553bd
+Create Date: 2026-05-14 12:41:45.668071
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2ff28fd69210"
+down_revision: str | Sequence[str] | None = "16cfa67553bd"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "pending_scope_upgrades",
+        sa.Column("paradigm_data", postgresql.JSONB(), nullable=True),
+    )
+    op.add_column(
+        "pending_scope_upgrades",
+        sa.Column("redirect_to", sa.String(length=256), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("pending_scope_upgrades", "redirect_to")
+    op.drop_column("pending_scope_upgrades", "paradigm_data")

--- a/backend/src/backend/_internal/auth/account_groups.py
+++ b/backend/src/backend/_internal/auth/account_groups.py
@@ -262,6 +262,8 @@ class PendingScopeUpgradeData:
     did: str
     old_session_id: str
     requested_scopes: str
+    paradigm_data: dict | None = None
+    redirect_to: str | None = None
 
 
 async def save_pending_scope_upgrade(
@@ -269,6 +271,8 @@ async def save_pending_scope_upgrade(
     did: str,
     old_session_id: str,
     requested_scopes: str,
+    paradigm_data: dict | None = None,
+    redirect_to: str | None = None,
 ) -> None:
     """save pending scope upgrade metadata keyed by OAuth state."""
     from backend.models import PendingScopeUpgrade
@@ -279,6 +283,8 @@ async def save_pending_scope_upgrade(
             did=did,
             old_session_id=old_session_id,
             requested_scopes=requested_scopes,
+            paradigm_data=paradigm_data,
+            redirect_to=redirect_to,
         )
         db.add(pending)
         await db.commit()
@@ -308,6 +314,8 @@ async def get_pending_scope_upgrade(state: str) -> PendingScopeUpgradeData | Non
             did=pending.did,
             old_session_id=pending.old_session_id,
             requested_scopes=pending.requested_scopes,
+            paradigm_data=pending.paradigm_data,
+            redirect_to=pending.redirect_to,
         )
 
 

--- a/backend/src/backend/_internal/auth/oauth.py
+++ b/backend/src/backend/_internal/auth/oauth.py
@@ -23,6 +23,7 @@ from jose import jwk
 from sqlalchemy import select
 
 from backend._internal.auth.session import (
+    _check_copyright_paradigm,
     _check_teal_preference,
     _compute_refresh_token_expires_at,
     get_client_auth_method,
@@ -125,18 +126,20 @@ def get_public_jwks() -> dict | None:
         return None
 
 
-def get_oauth_client(include_teal: bool = False) -> OAuthClient:
+def get_oauth_client(
+    include_teal: bool = False, include_indiemusi: bool = False
+) -> OAuthClient:
     """create an OAuth client with the appropriate scopes.
 
     if OAUTH_JWK is configured, creates a confidential client with
     private_key_jwt authentication. otherwise creates a public client.
     """
-    scope = (
-        settings.atproto.resolved_scope_with_teal(
-            settings.teal.play_collection, settings.teal.status_collection
-        )
-        if include_teal
-        else settings.atproto.resolved_scope
+    scope = settings.atproto.resolved_scope_with_extras(
+        teal_play=settings.teal.play_collection if include_teal else None,
+        teal_status=settings.teal.status_collection if include_teal else None,
+        indiemusi_tokens=(
+            settings.indiemusi.scope_tokens() if include_indiemusi else None
+        ),
     )
 
     # load confidential client key if configured
@@ -162,7 +165,12 @@ def get_oauth_client_for_scope(scope: str) -> OAuthClient:
     include_teal = scopes.matches(
         "repo", collection=settings.teal.play_collection, action="create"
     )
-    return get_oauth_client(include_teal=include_teal)
+    include_indiemusi = scopes.matches(
+        "repo", collection=settings.indiemusi.song_collection, action="create"
+    )
+    return get_oauth_client(
+        include_teal=include_teal, include_indiemusi=include_indiemusi
+    )
 
 
 async def start_oauth_flow(
@@ -170,7 +178,8 @@ async def start_oauth_flow(
 ) -> tuple[str, str]:
     """start OAuth flow and return (auth_url, state).
 
-    uses extended scope if user has enabled teal.fm scrobbling.
+    uses extended scope if user has enabled teal.fm scrobbling or has opted
+    into a copyright paradigm.
     """
     from backend._internal.atproto.handles import resolve_handle
 
@@ -180,12 +189,18 @@ async def start_oauth_flow(
         if resolved:
             did = resolved["did"]
             wants_teal = await _check_teal_preference(did)
-            client = get_oauth_client(include_teal=wants_teal)
-            logger.info(f"starting OAuth for {handle} (did={did}, teal={wants_teal})")
+            wants_indiemusi = await _check_copyright_paradigm(did)
+            client = get_oauth_client(
+                include_teal=wants_teal, include_indiemusi=wants_indiemusi
+            )
+            logger.info(
+                f"starting OAuth for {handle} (did={did}, "
+                f"teal={wants_teal}, indiemusi={wants_indiemusi})"
+            )
         else:
             # fallback to base client if resolution fails
             # (OAuth flow will resolve handle again internally)
-            client = get_oauth_client(include_teal=False)
+            client = get_oauth_client()
             logger.info(f"starting OAuth for {handle} (resolution failed, using base)")
 
         auth_url, state = await client.start_authorization(handle, prompt=prompt)
@@ -198,12 +213,20 @@ async def start_oauth_flow(
 
 
 async def start_oauth_flow_with_scopes(
-    handle: str, include_teal: bool, prompt: PromptType | None = None
+    handle: str,
+    include_teal: bool = False,
+    include_indiemusi: bool = False,
+    prompt: PromptType | None = None,
 ) -> tuple[str, str]:
     """start OAuth flow with explicit scope selection (used for scope upgrades)."""
     try:
-        client = get_oauth_client(include_teal=include_teal)
-        logger.info(f"starting scope upgrade OAuth for {handle} (teal={include_teal})")
+        client = get_oauth_client(
+            include_teal=include_teal, include_indiemusi=include_indiemusi
+        )
+        logger.info(
+            f"starting scope upgrade OAuth for {handle} "
+            f"(teal={include_teal}, indiemusi={include_indiemusi})"
+        )
         auth_url, state = await client.start_authorization(handle, prompt=prompt)
         return auth_url, state
     except Exception as e:

--- a/backend/src/backend/_internal/auth/session.py
+++ b/backend/src/backend/_internal/auth/session.py
@@ -298,3 +298,17 @@ async def _check_teal_preference(did: str) -> bool:
         )
         pref = result.scalar_one_or_none()
         return pref is True
+
+
+async def _check_copyright_paradigm(did: str) -> bool:
+    """check if user has opted into the indiemusi copyright paradigm."""
+    from backend.models import UserCopyrightConfig
+
+    async with db_session() as db:
+        result = await db.execute(
+            select(UserCopyrightConfig.paradigm).where(
+                UserCopyrightConfig.user_did == did
+            )
+        )
+        paradigm = result.scalar_one_or_none()
+        return paradigm == settings.indiemusi.paradigm_id

--- a/backend/src/backend/_internal/copyright.py
+++ b/backend/src/backend/_internal/copyright.py
@@ -1,0 +1,95 @@
+"""copyright paradigm config — read/write helpers + callback completion.
+
+a copyright paradigm captures rights metadata in a domain-specific shape (the
+first one is indiemusi.ch alpha). users opt in once, granting plyr.fm scopes
+to write paradigm-specific records to their PDS alongside fm.plyr.track.
+"""
+
+import logging
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+
+from backend._internal import Session as AuthSession
+from backend._internal.atproto.records.ch_indiemusi import (
+    PublishingOwnerInput,
+    create_publishing_owner_record,
+)
+from backend.config import settings
+from backend.models import UserCopyrightConfig
+from backend.utilities.database import db_session
+
+logger = logging.getLogger(__name__)
+
+
+async def get_user_copyright_config(did: str) -> UserCopyrightConfig | None:
+    async with db_session() as db:
+        result = await db.execute(
+            select(UserCopyrightConfig).where(UserCopyrightConfig.user_did == did)
+        )
+        return result.scalar_one_or_none()
+
+
+async def upsert_user_copyright_config(
+    did: str,
+    paradigm: str,
+    config_uri: str | None,
+    paradigm_data: dict[str, Any] | None,
+) -> None:
+    """upsert a user_copyright_configs row keyed by user_did."""
+    async with db_session() as db:
+        stmt = (
+            insert(UserCopyrightConfig)
+            .values(
+                user_did=did,
+                paradigm=paradigm,
+                config_uri=config_uri,
+                paradigm_data=paradigm_data,
+            )
+            .on_conflict_do_update(
+                index_elements=[UserCopyrightConfig.user_did],
+                set_={
+                    "paradigm": paradigm,
+                    "config_uri": config_uri,
+                    "paradigm_data": paradigm_data,
+                },
+            )
+        )
+        await db.execute(stmt)
+        await db.commit()
+
+
+async def delete_user_copyright_config(did: str) -> None:
+    async with db_session() as db:
+        result = await db.execute(
+            select(UserCopyrightConfig).where(UserCopyrightConfig.user_did == did)
+        )
+        if row := result.scalar_one_or_none():
+            await db.delete(row)
+            await db.commit()
+
+
+async def complete_indiemusi_setup(
+    auth_session: AuthSession, paradigm_data: dict[str, Any]
+) -> None:
+    """callback-side completion for the indiemusi paradigm.
+
+    runs after the new (upgraded) session has indiemusi scopes. writes the
+    publishingOwner record to the user's PDS and saves the config row pointing
+    at it. paradigm_data is the validated PublishingOwnerInput as a dict
+    (model_dump(by_alias=True)).
+    """
+    owner = PublishingOwnerInput.model_validate(paradigm_data)
+    uri, _cid = await create_publishing_owner_record(auth_session, owner)
+    await upsert_user_copyright_config(
+        did=auth_session.did,
+        paradigm=settings.indiemusi.paradigm_id,
+        config_uri=uri,
+        paradigm_data=owner.model_dump(by_alias=True, exclude_none=True),
+    )
+    logger.info(
+        "completed indiemusi setup for %s (publishingOwner=%s)",
+        auth_session.did,
+        uri,
+    )

--- a/backend/src/backend/api/__init__.py
+++ b/backend/src/backend/api/__init__.py
@@ -7,6 +7,7 @@ from backend.api.discover import router as discover_router
 from backend.api.meta import router as meta_router
 from backend.api.audio import router as audio_router
 from backend.api.auth import router as auth_router
+from backend.api.copyright import router as copyright_router
 from backend.api.exports import router as exports_router
 from backend.api.for_you import router as for_you_router
 from backend.api.jams import router as jams_router
@@ -28,6 +29,7 @@ __all__ = [
     "artists_router",
     "audio_router",
     "auth_router",
+    "copyright_router",
     "discover_router",
     "exports_router",
     "for_you_router",

--- a/backend/src/backend/api/auth.py
+++ b/backend/src/backend/api/auth.py
@@ -24,6 +24,7 @@ from backend._internal import (
     get_pending_add_account,
     get_pending_dev_token,
     get_pending_scope_upgrade,
+    get_session,
     get_session_group,
     get_user_flags,
     handle_oauth_callback,
@@ -39,6 +40,7 @@ from backend._internal import (
     switch_active_account,
 )
 from backend._internal.auth import get_refresh_token_lifetime_days
+from backend._internal.copyright import complete_indiemusi_setup
 from backend._internal.tasks import schedule_atproto_sync
 from backend.config import settings
 from backend.models import Artist, get_db
@@ -249,6 +251,22 @@ async def oauth_callback(
         # create new session with upgraded scopes
         session_id = await create_session(did, handle, oauth_session)
 
+        # paradigm-specific post-upgrade work (e.g., write a publishingOwner
+        # record to the user's PDS now that the scopes are in place)
+        if pending_scope_upgrade.paradigm_data and (
+            pending_scope_upgrade.requested_scopes == "indiemusi"
+        ):
+            try:
+                new_session = await get_session(session_id)
+                if new_session:
+                    await complete_indiemusi_setup(
+                        new_session, pending_scope_upgrade.paradigm_data
+                    )
+            except Exception as e:
+                logger.error("indiemusi setup completion failed for %s: %s", did, e)
+                # fall through — user still gets the upgraded session and can
+                # retry the setup from the portal
+
         # clean up pending record
         await delete_pending_scope_upgrade(state)
 
@@ -258,8 +276,9 @@ async def oauth_callback(
         # schedule ATProto sync (via docket if enabled, else asyncio)
         await schedule_atproto_sync(session_id, did)
 
+        redirect_path = pending_scope_upgrade.redirect_to or "/settings"
         return RedirectResponse(
-            url=f"{settings.frontend.url}/settings?exchange_token={exchange_token}&scope_upgraded=true",
+            url=f"{settings.frontend.url}{redirect_path}?exchange_token={exchange_token}&scope_upgraded=true",
             status_code=303,
         )
 

--- a/backend/src/backend/api/copyright.py
+++ b/backend/src/backend/api/copyright.py
@@ -1,0 +1,161 @@
+"""copyright paradigm api endpoints.
+
+a copyright paradigm is an opt-in shape for capturing rights metadata about a
+track. the first paradigm is indiemusi.ch alpha; the API is shaped so future
+paradigms can plug in without changing the endpoint contract.
+"""
+
+import logging
+
+from atproto_oauth.scopes import ScopesSet
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from backend._internal import (
+    Session,
+    require_auth,
+    save_pending_scope_upgrade,
+    start_oauth_flow_with_scopes,
+)
+from backend._internal.atproto.records.ch_indiemusi import (
+    PublishingOwnerInput,
+)
+from backend._internal.atproto.records.fm_plyr.track import delete_record_by_uri
+from backend._internal.copyright import (
+    complete_indiemusi_setup,
+    delete_user_copyright_config,
+    get_user_copyright_config,
+)
+from backend.config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/copyright", tags=["copyright"])
+
+
+# --- response models ---------------------------------------------------------
+
+
+class CopyrightConfigResponse(BaseModel):
+    """current copyright paradigm state for a user."""
+
+    paradigm: str
+    config_uri: str | None
+    paradigm_data: dict | None
+
+
+class CopyrightSetupRequest(BaseModel):
+    """opt into a copyright paradigm. payload schema depends on paradigm."""
+
+    paradigm: str
+    publishing_owner: PublishingOwnerInput
+
+
+class CopyrightSetupResponse(BaseModel):
+    """result of /copyright/setup.
+
+    when scope upgrade is required, auth_url is the URL the frontend should
+    redirect to. when the current session already has the paradigm's scopes,
+    the setup completes directly and auth_url is null.
+    """
+
+    auth_url: str | None = None
+    complete: bool = False
+
+
+# --- scope helpers -----------------------------------------------------------
+
+
+def _has_indiemusi_scopes(session: Session) -> bool:
+    """check if the session has scopes to write indiemusi records."""
+    if not session.oauth_session:
+        return False
+    scopes = ScopesSet.from_string(session.oauth_session.get("scope", ""))
+    return scopes.matches(
+        "repo", collection=settings.indiemusi.song_collection, action="create"
+    )
+
+
+# --- endpoints ---------------------------------------------------------------
+
+
+@router.get("/config")
+async def get_config(
+    session: Session = Depends(require_auth),
+) -> CopyrightConfigResponse | None:
+    """return the user's current copyright config, or null if none."""
+    cfg = await get_user_copyright_config(session.did)
+    if not cfg:
+        return None
+    return CopyrightConfigResponse(
+        paradigm=cfg.paradigm,
+        config_uri=cfg.config_uri,
+        paradigm_data=cfg.paradigm_data,
+    )
+
+
+@router.post("/setup")
+async def setup(
+    body: CopyrightSetupRequest,
+    session: Session = Depends(require_auth),
+) -> CopyrightSetupResponse:
+    """opt into a copyright paradigm.
+
+    if the session already has the required scopes, writes the paradigm actor
+    record immediately and returns `complete=True`. otherwise, kicks off an
+    OAuth scope upgrade and returns `auth_url` for the frontend to redirect to;
+    the callback finishes the write once the new session is in place.
+    """
+    if body.paradigm != settings.indiemusi.paradigm_id:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unsupported paradigm: {body.paradigm!r}",
+        )
+    if not settings.indiemusi.enabled:
+        raise HTTPException(status_code=404, detail="indiemusi paradigm disabled")
+
+    paradigm_data = body.publishing_owner.model_dump(by_alias=True, exclude_none=True)
+
+    if _has_indiemusi_scopes(session):
+        # session already has scopes — write directly, no OAuth round-trip
+        await complete_indiemusi_setup(session, paradigm_data)
+        return CopyrightSetupResponse(complete=True)
+
+    # need a scope upgrade — stash the payload and redirect through OAuth
+    auth_url, state = await start_oauth_flow_with_scopes(
+        session.handle, include_indiemusi=True
+    )
+    await save_pending_scope_upgrade(
+        state=state,
+        did=session.did,
+        old_session_id=session.session_id,
+        requested_scopes="indiemusi",
+        paradigm_data=paradigm_data,
+        redirect_to="/portal",
+    )
+    return CopyrightSetupResponse(auth_url=auth_url)
+
+
+@router.post("/disconnect")
+async def disconnect(
+    session: Session = Depends(require_auth),
+) -> dict[str, bool]:
+    """delete the user's copyright config and best-effort delete the PDS record."""
+    cfg = await get_user_copyright_config(session.did)
+    if not cfg:
+        return {"deleted": False}
+
+    if cfg.config_uri:
+        try:
+            await delete_record_by_uri(session, cfg.config_uri)
+        except Exception as e:
+            # best-effort — we still want to clear the local row even if PDS write fails
+            logger.warning(
+                "failed to delete PDS record %s for %s: %s",
+                cfg.config_uri,
+                session.did,
+                e,
+            )
+
+    await delete_user_copyright_config(session.did)
+    return {"deleted": True}

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -515,6 +515,29 @@ class AtprotoSettings(AppSettingsSection):
         teal_scopes = [f"repo:{teal_play}", f"repo:{teal_status}"]
         return f"{base} {' '.join(teal_scopes)}"
 
+    def resolved_scope_with_extras(
+        self,
+        *,
+        teal_play: str | None = None,
+        teal_status: str | None = None,
+        indiemusi_tokens: list[str] | None = None,
+    ) -> str:
+        """OAuth scope composed with optional integration extras.
+
+        args:
+            teal_play: teal.fm play collection NSID, present iff teal scopes wanted
+            teal_status: teal.fm status collection NSID, present iff teal scopes wanted
+            indiemusi_tokens: indiemusi paradigm scope tokens, present iff requested
+
+        either teal pair must both be set or both be None.
+        """
+        parts: list[str] = [self.resolved_scope]
+        if teal_play and teal_status:
+            parts.extend([f"repo:{teal_play}", f"repo:{teal_status}"])
+        if indiemusi_tokens:
+            parts.extend(indiemusi_tokens)
+        return " ".join(parts)
+
 
 class TealSettings(AppSettingsSection):
     """teal.fm integration settings for scrobbling.

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -22,6 +22,7 @@ from backend.api import (
     artists_router,
     audio_router,
     auth_router,
+    copyright_router,
     discover_router,
     exports_router,
     for_you_router,
@@ -184,3 +185,4 @@ app.include_router(stats_router)
 app.include_router(users_router)
 app.include_router(meta_router)
 app.include_router(xrpc_router)
+app.include_router(copyright_router)

--- a/backend/src/backend/models/pending_scope_upgrade.py
+++ b/backend/src/backend/models/pending_scope_upgrade.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import DateTime, String
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.models.database import Base
@@ -26,6 +27,15 @@ class PendingScopeUpgrade(Base):
     old_session_id: Mapped[str] = mapped_column(String(64), nullable=False)
     # the additional scopes being requested
     requested_scopes: Mapped[str] = mapped_column(String(512), nullable=False)
+    # paradigm-specific payload carried through the OAuth round-trip — the
+    # callback uses this to finish setting up the feature once the new session
+    # has the right scopes (e.g., writing a publishingOwner record on PDS).
+    paradigm_data: Mapped[dict | None] = mapped_column(
+        JSONB(none_as_null=True), nullable=True, default=None
+    )
+    # frontend path the callback should redirect to (e.g., "/portal"). null
+    # falls back to /settings, which is where teal upgrades land.
+    redirect_to: Mapped[str | None] = mapped_column(String(256), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),

--- a/backend/tests/api/test_copyright_setup.py
+++ b/backend/tests/api/test_copyright_setup.py
@@ -1,0 +1,258 @@
+"""tests for the copyright paradigm setup API.
+
+these are endpoint-level tests verifying:
+- the scope-upgrade-first path: when the session lacks indiemusi scopes,
+  /copyright/setup kicks off OAuth and stashes paradigm_data + redirect_to on
+  the pending_scope_upgrade row
+- the in-place path: when the session already has indiemusi scopes, setup
+  writes the publishingOwner record + saves the config row without redirect
+- bad paradigm IDs are rejected
+- disconnect deletes the config row
+"""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import Session, get_pending_scope_upgrade, require_auth
+from backend._internal.copyright import (
+    delete_user_copyright_config,
+    get_user_copyright_config,
+    upsert_user_copyright_config,
+)
+from backend.config import settings
+from backend.main import app
+
+
+class _MockSession(Session):
+    """mock session bypassing real auth — varies the granted scope per test."""
+
+    def __init__(self, *, scope: str = "atproto transition:generic") -> None:
+        self.did = "did:test:copyright-user"
+        self.handle = "copyright-user.bsky.social"
+        self.session_id = "test_session_for_copyright"
+        self.access_token = "test_token"
+        self.refresh_token = "test_refresh"
+        self.oauth_session = {
+            "did": self.did,
+            "handle": self.handle,
+            "pds_url": "https://test.pds",
+            "authserver_iss": "https://auth.test",
+            "scope": scope,
+            "access_token": "test_token",
+            "refresh_token": "test_refresh",
+            "dpop_private_key_pem": "fake_key",
+            "dpop_authserver_nonce": "",
+            "dpop_pds_nonce": "",
+        }
+
+
+@pytest.fixture
+def app_without_scopes(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
+    """session has no indiemusi scopes — setup should kick off OAuth."""
+
+    async def mock_require_auth() -> Session:
+        return _MockSession()
+
+    app.dependency_overrides[require_auth] = mock_require_auth
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def app_with_scopes(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
+    """session has indiemusi scopes — setup should complete in place."""
+
+    indiemusi_scope = " ".join(settings.indiemusi.scope_tokens())
+
+    async def mock_require_auth() -> Session:
+        return _MockSession(scope=f"atproto transition:generic {indiemusi_scope}")
+
+    app.dependency_overrides[require_auth] = mock_require_auth
+    yield app
+    app.dependency_overrides.clear()
+
+
+# --- GET /copyright/config ---------------------------------------------------
+
+
+async def test_get_config_returns_null_when_unconfigured(
+    app_without_scopes: FastAPI, db_session: AsyncSession
+) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app_without_scopes), base_url="http://test"
+    ) as client:
+        response = await client.get("/copyright/config")
+
+    assert response.status_code == 200
+    assert response.json() is None
+
+
+async def test_get_config_returns_existing(
+    app_without_scopes: FastAPI, db_session: AsyncSession
+) -> None:
+    await upsert_user_copyright_config(
+        did="did:test:copyright-user",
+        paradigm=settings.indiemusi.paradigm_id,
+        config_uri="at://did:test:copyright-user/ch.indiemusi.alpha.actor.publishingOwner/abc",
+        paradigm_data={"firstName": "Hilke", "lastName": "Ros"},
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app_without_scopes), base_url="http://test"
+    ) as client:
+        response = await client.get("/copyright/config")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["paradigm"] == settings.indiemusi.paradigm_id
+    assert body["paradigm_data"]["firstName"] == "Hilke"
+
+    # clean up for other tests
+    await delete_user_copyright_config("did:test:copyright-user")
+
+
+# --- POST /copyright/setup ---------------------------------------------------
+
+
+async def test_setup_without_scopes_kicks_off_oauth(
+    app_without_scopes: FastAPI, db_session: AsyncSession
+) -> None:
+    """no indiemusi scopes yet → returns auth_url and stashes paradigm_data."""
+    with patch(
+        "backend.api.copyright.start_oauth_flow_with_scopes",
+        new_callable=AsyncMock,
+    ) as mock_oauth:
+        mock_oauth.return_value = (
+            "https://auth.example.com/authorize?scope=indiemusi",
+            "test_state_indiemusi",
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app_without_scopes), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/copyright/setup",
+                json={
+                    "paradigm": settings.indiemusi.paradigm_id,
+                    "publishing_owner": {
+                        "firstName": "Hilke",
+                        "lastName": "Ros",
+                        "ipi": "01145982828",
+                        "collectingSociety": "Suisa",
+                    },
+                },
+            )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["auth_url"] == "https://auth.example.com/authorize?scope=indiemusi"
+    assert body["complete"] is False
+    mock_oauth.assert_called_once_with(
+        "copyright-user.bsky.social", include_indiemusi=True
+    )
+
+    # pending row was stashed with paradigm_data + portal redirect
+    pending = await get_pending_scope_upgrade("test_state_indiemusi")
+    assert pending is not None
+    assert pending.requested_scopes == "indiemusi"
+    assert pending.redirect_to == "/portal"
+    assert pending.paradigm_data == {
+        "firstName": "Hilke",
+        "lastName": "Ros",
+        "ipi": "01145982828",
+        "collectingSociety": "Suisa",
+    }
+
+
+async def test_setup_with_scopes_completes_in_place(
+    app_with_scopes: FastAPI, db_session: AsyncSession
+) -> None:
+    """when session already has the scopes, setup writes directly + returns complete=True."""
+    with patch(
+        "backend.api.copyright.complete_indiemusi_setup",
+        new_callable=AsyncMock,
+    ) as mock_complete:
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_scopes), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/copyright/setup",
+                json={
+                    "paradigm": settings.indiemusi.paradigm_id,
+                    "publishing_owner": {"companyName": "Red Brick Records"},
+                },
+            )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["auth_url"] is None
+    assert body["complete"] is True
+    mock_complete.assert_awaited_once()
+    args = mock_complete.await_args
+    assert args.args[1] == {"companyName": "Red Brick Records"}
+
+
+async def test_setup_rejects_unknown_paradigm(
+    app_without_scopes: FastAPI, db_session: AsyncSession
+) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app_without_scopes), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/copyright/setup",
+            json={
+                "paradigm": "not-a-real-paradigm",
+                "publishing_owner": {"firstName": "x", "lastName": "y"},
+            },
+        )
+
+    assert response.status_code == 400
+
+
+async def test_setup_requires_auth(db_session: AsyncSession) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/copyright/setup",
+            json={
+                "paradigm": settings.indiemusi.paradigm_id,
+                "publishing_owner": {"firstName": "x", "lastName": "y"},
+            },
+        )
+    assert response.status_code == 401
+
+
+# --- POST /copyright/disconnect ----------------------------------------------
+
+
+async def test_disconnect_clears_config(
+    app_without_scopes: FastAPI, db_session: AsyncSession
+) -> None:
+    await upsert_user_copyright_config(
+        did="did:test:copyright-user",
+        paradigm=settings.indiemusi.paradigm_id,
+        config_uri=None,  # no PDS-side record to delete
+        paradigm_data={"firstName": "x", "lastName": "y"},
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app_without_scopes), base_url="http://test"
+    ) as client:
+        response = await client.post("/copyright/disconnect")
+    assert response.status_code == 200
+    assert response.json() == {"deleted": True}
+    assert await get_user_copyright_config("did:test:copyright-user") is None
+
+
+async def test_disconnect_noop_when_unconfigured(
+    app_without_scopes: FastAPI, db_session: AsyncSession
+) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app_without_scopes), base_url="http://test"
+    ) as client:
+        response = await client.post("/copyright/disconnect")
+    assert response.status_code == 200
+    assert response.json() == {"deleted": False}

--- a/frontend/src/lib/components/CopyrightSection.svelte
+++ b/frontend/src/lib/components/CopyrightSection.svelte
@@ -1,0 +1,611 @@
+<script lang="ts">
+	import { API_URL } from '$lib/config';
+	import { toast } from '$lib/toast.svelte';
+
+	type PublishingOwner = {
+		ipi?: string;
+		firstName?: string;
+		lastName?: string;
+		companyName?: string;
+		collectingSociety?: string;
+	};
+
+	type CopyrightConfig = {
+		paradigm: string;
+		config_uri: string | null;
+		paradigm_data: PublishingOwner | null;
+	};
+
+	type OwnerKind = 'individual' | 'company';
+
+	let loading = $state(true);
+	let saving = $state(false);
+	let config = $state<CopyrightConfig | null>(null);
+	let expanded = $state(false);
+
+	let ownerKind = $state<OwnerKind>('individual');
+	let ipi = $state('');
+	let firstName = $state('');
+	let lastName = $state('');
+	let companyName = $state('');
+	let collectingSociety = $state('');
+
+	const paradigmLabel = 'indiemusi.ch alpha';
+
+	const canSubmit = $derived(
+		(ownerKind === 'individual' && firstName.trim() !== '' && lastName.trim() !== '') ||
+			(ownerKind === 'company' && companyName.trim() !== '')
+	);
+
+	async function fetchConfig() {
+		loading = true;
+		try {
+			const res = await fetch(`${API_URL}/copyright/config`, {
+				credentials: 'include'
+			});
+			if (!res.ok) throw new Error(`failed to load config (${res.status})`);
+			const data = (await res.json()) as CopyrightConfig | null;
+			config = data;
+		} catch (err) {
+			const message = err instanceof Error ? err.message : 'failed to load copyright config';
+			toast.error(message);
+		} finally {
+			loading = false;
+		}
+	}
+
+	function resetForm() {
+		ownerKind = 'individual';
+		ipi = '';
+		firstName = '';
+		lastName = '';
+		companyName = '';
+		collectingSociety = '';
+	}
+
+	function prefillFromConfig(data: PublishingOwner | null) {
+		resetForm();
+		if (!data) return;
+		ownerKind = data.companyName ? 'company' : 'individual';
+		ipi = data.ipi ?? '';
+		firstName = data.firstName ?? '';
+		lastName = data.lastName ?? '';
+		companyName = data.companyName ?? '';
+		collectingSociety = data.collectingSociety ?? '';
+	}
+
+	function openSetupForm() {
+		resetForm();
+		expanded = true;
+	}
+
+	function openEditForm() {
+		prefillFromConfig(config?.paradigm_data ?? null);
+		expanded = true;
+	}
+
+	function cancelForm() {
+		expanded = false;
+		resetForm();
+	}
+
+	async function handleSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		if (!canSubmit || saving) return;
+
+		const publishing_owner: PublishingOwner = {};
+		const ipiTrimmed = ipi.trim();
+		const collectingTrimmed = collectingSociety.trim();
+		if (ipiTrimmed) publishing_owner.ipi = ipiTrimmed;
+		if (collectingTrimmed) publishing_owner.collectingSociety = collectingTrimmed;
+		if (ownerKind === 'individual') {
+			publishing_owner.firstName = firstName.trim();
+			publishing_owner.lastName = lastName.trim();
+		} else {
+			publishing_owner.companyName = companyName.trim();
+		}
+
+		saving = true;
+		try {
+			const res = await fetch(`${API_URL}/copyright/setup`, {
+				method: 'POST',
+				credentials: 'include',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					paradigm: 'indiemusi-alpha',
+					publishing_owner
+				})
+			});
+			if (!res.ok) {
+				let message = `setup failed (${res.status})`;
+				try {
+					const errBody = await res.json();
+					if (errBody?.detail) message = String(errBody.detail);
+				} catch {
+					// ignore json parse errors
+				}
+				throw new Error(message);
+			}
+			const data = (await res.json()) as { auth_url: string | null; complete: boolean };
+			if (data.auth_url) {
+				window.location.href = data.auth_url;
+				return;
+			}
+			if (data.complete) {
+				toast.success('copyright paradigm configured');
+				expanded = false;
+				await fetchConfig();
+			}
+		} catch (err) {
+			const message = err instanceof Error ? err.message : 'failed to set up copyright paradigm';
+			toast.error(message);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function handleDisconnect() {
+		if (saving) return;
+		saving = true;
+		try {
+			const res = await fetch(`${API_URL}/copyright/disconnect`, {
+				method: 'POST',
+				credentials: 'include'
+			});
+			if (!res.ok) throw new Error(`disconnect failed (${res.status})`);
+			toast.success('copyright paradigm disconnected');
+			config = null;
+			expanded = false;
+			resetForm();
+		} catch (err) {
+			const message = err instanceof Error ? err.message : 'failed to disconnect';
+			toast.error(message);
+		} finally {
+			saving = false;
+		}
+	}
+
+	$effect(() => {
+		fetchConfig();
+	});
+</script>
+
+<section class="copyright-section">
+	<div class="section-header">
+		<h2>copyright</h2>
+	</div>
+
+	{#if loading}
+		<p class="loading-text">loading…</p>
+	{:else if config && !expanded}
+		<div class="config-summary">
+			<div class="summary-info">
+				<div class="summary-paradigm">{paradigmLabel}</div>
+				{#if config.paradigm_data?.ipi}
+					<div class="summary-row"><span class="summary-label">ipi</span> {config.paradigm_data.ipi}</div>
+				{/if}
+				{#if config.paradigm_data?.collectingSociety}
+					<div class="summary-row">
+						<span class="summary-label">collecting society</span> {config.paradigm_data.collectingSociety}
+					</div>
+				{/if}
+				{#if config.paradigm_data?.companyName}
+					<div class="summary-row"><span class="summary-label">company</span> {config.paradigm_data.companyName}</div>
+				{:else if config.paradigm_data?.firstName || config.paradigm_data?.lastName}
+					<div class="summary-row">
+						<span class="summary-label">owner</span>
+						{[config.paradigm_data.firstName, config.paradigm_data.lastName].filter(Boolean).join(' ')}
+					</div>
+				{/if}
+			</div>
+			<div class="summary-actions">
+				<button type="button" class="edit-btn" onclick={openEditForm} disabled={saving}>edit</button>
+				<button type="button" class="disconnect-btn" onclick={handleDisconnect} disabled={saving}>
+					{saving ? 'disconnecting…' : 'disconnect'}
+				</button>
+			</div>
+		</div>
+	{:else if !config && !expanded}
+		<div class="setup-prompt">
+			<p class="explainer">
+				publish rights metadata to your pds so other atproto music apps can show who owns what. uses
+				<a href="https://indiemusi.ch" target="_blank" rel="noopener">indiemusi.ch</a>'s lexicon.
+			</p>
+			<button type="button" class="setup-btn" onclick={openSetupForm}>set up copyright paradigm</button>
+		</div>
+	{:else}
+		<form onsubmit={handleSubmit}>
+			<div class="form-group">
+				<span class="form-label">paradigm</span>
+				<div class="paradigm-row">{paradigmLabel}</div>
+				<p class="hint">
+					only paradigm available right now. published by
+					<a href="https://indiemusi.ch" target="_blank" rel="noopener">indiemusi.ch</a>.
+				</p>
+			</div>
+
+			<div class="form-group" role="group" aria-labelledby="owner-kind-label">
+				<span id="owner-kind-label" class="form-label">publishing owner</span>
+				<div class="owner-kind-options">
+					<label class="owner-kind-option">
+						<input
+							type="radio"
+							name="owner-kind"
+							value="individual"
+							bind:group={ownerKind}
+							disabled={saving}
+						/>
+						<span>individual</span>
+					</label>
+					<label class="owner-kind-option">
+						<input
+							type="radio"
+							name="owner-kind"
+							value="company"
+							bind:group={ownerKind}
+							disabled={saving}
+						/>
+						<span>company</span>
+					</label>
+				</div>
+			</div>
+
+			{#if ownerKind === 'individual'}
+				<div class="form-group">
+					<label for="copyright-first-name">first name</label>
+					<input
+						id="copyright-first-name"
+						type="text"
+						bind:value={firstName}
+						disabled={saving}
+						maxlength="255"
+						placeholder="first name"
+					/>
+				</div>
+				<div class="form-group">
+					<label for="copyright-last-name">last name</label>
+					<input
+						id="copyright-last-name"
+						type="text"
+						bind:value={lastName}
+						disabled={saving}
+						maxlength="255"
+						placeholder="last name"
+					/>
+				</div>
+			{:else}
+				<div class="form-group">
+					<label for="copyright-company">company name</label>
+					<input
+						id="copyright-company"
+						type="text"
+						bind:value={companyName}
+						disabled={saving}
+						maxlength="255"
+						placeholder="company name"
+					/>
+				</div>
+			{/if}
+
+			<div class="form-group">
+				<label for="copyright-ipi">ipi (optional)</label>
+				<input
+					id="copyright-ipi"
+					type="text"
+					inputmode="numeric"
+					pattern="[0-9]*"
+					bind:value={ipi}
+					disabled={saving}
+					maxlength="11"
+					placeholder="e.g. 00012345678"
+				/>
+				<p class="hint">interested parties information number, if you have one</p>
+			</div>
+
+			<div class="form-group">
+				<label for="copyright-society">collecting society (optional)</label>
+				<input
+					id="copyright-society"
+					type="text"
+					bind:value={collectingSociety}
+					disabled={saving}
+					maxlength="255"
+					placeholder="ASCAP, BMI, Suisa, PRS, …"
+				/>
+			</div>
+
+			<div class="form-actions">
+				<button type="button" class="cancel-link" onclick={cancelForm} disabled={saving}>cancel</button>
+				<button type="submit" disabled={!canSubmit || saving}>
+					{saving ? 'saving…' : config ? 'save changes' : 'set up paradigm'}
+				</button>
+			</div>
+		</form>
+	{/if}
+</section>
+
+<style>
+	.copyright-section {
+		margin-bottom: 2rem;
+	}
+
+	.copyright-section h2 {
+		font-size: var(--text-page-heading);
+		margin-bottom: 1rem;
+	}
+
+	.section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 1rem;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	.section-header h2 {
+		margin-bottom: 0;
+	}
+
+	.loading-text {
+		color: var(--text-tertiary);
+		font-size: var(--text-sm);
+		margin: 0;
+	}
+
+	.setup-prompt {
+		background: var(--bg-tertiary);
+		padding: 1.25rem;
+		border-radius: var(--radius-md);
+		border: 1px solid var(--border-subtle);
+		display: flex;
+		flex-direction: column;
+		gap: 0.85rem;
+	}
+
+	.explainer {
+		margin: 0;
+		font-size: var(--text-sm);
+		color: var(--text-tertiary);
+		line-height: 1.5;
+	}
+
+	.explainer a {
+		color: var(--accent);
+		text-decoration: none;
+	}
+
+	.explainer a:hover {
+		text-decoration: underline;
+	}
+
+	.setup-btn {
+		align-self: flex-start;
+		padding: 0.6rem 1.1rem;
+		background: transparent;
+		border: 1px solid var(--accent);
+		border-radius: var(--radius-sm);
+		color: var(--accent);
+		font-size: var(--text-base);
+		font-weight: 500;
+		font-family: inherit;
+		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.setup-btn:hover {
+		background: color-mix(in srgb, var(--accent) 8%, transparent);
+	}
+
+	.config-summary {
+		background: var(--bg-tertiary);
+		padding: 1rem 1.25rem;
+		border-radius: var(--radius-md);
+		border: 1px solid var(--border-subtle);
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: 1rem;
+		flex-wrap: wrap;
+	}
+
+	.summary-info {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+		min-width: 0;
+	}
+
+	.summary-paradigm {
+		font-weight: 600;
+		color: var(--text-primary);
+		font-size: var(--text-base);
+	}
+
+	.summary-row {
+		font-size: var(--text-sm);
+		color: var(--text-tertiary);
+	}
+
+	.summary-label {
+		color: var(--text-muted);
+		margin-right: 0.4rem;
+	}
+
+	.summary-actions {
+		display: flex;
+		gap: 0.5rem;
+		flex-shrink: 0;
+	}
+
+	.edit-btn,
+	.disconnect-btn {
+		padding: 0.45rem 0.85rem;
+		background: transparent;
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-sm);
+		color: var(--text-secondary);
+		font-size: var(--text-sm);
+		font-family: inherit;
+		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.edit-btn:hover:not(:disabled) {
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+
+	.disconnect-btn:hover:not(:disabled) {
+		border-color: var(--danger, #e5484d);
+		color: var(--danger, #e5484d);
+	}
+
+	.edit-btn:disabled,
+	.disconnect-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	form {
+		background: var(--bg-tertiary);
+		padding: 1.25rem;
+		border-radius: var(--radius-md);
+		border: 1px solid var(--border-subtle);
+	}
+
+	.form-group {
+		margin-bottom: 1rem;
+	}
+
+	.form-group:last-of-type {
+		margin-bottom: 1.25rem;
+	}
+
+	label,
+	.form-label {
+		display: block;
+		color: var(--text-secondary);
+		margin-bottom: 0.4rem;
+		font-size: var(--text-sm);
+	}
+
+	input[type='text'] {
+		width: 100%;
+		padding: 0.6rem 0.75rem;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-sm);
+		color: var(--text-primary);
+		font-size: var(--text-base);
+		font-family: inherit;
+		transition: all 0.15s;
+	}
+
+	input[type='text']:focus {
+		outline: none;
+		border-color: var(--accent);
+	}
+
+	input[type='text']:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.paradigm-row {
+		padding: 0.6rem 0.75rem;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-sm);
+		color: var(--text-primary);
+		font-size: var(--text-base);
+	}
+
+	.hint {
+		margin-top: 0.35rem;
+		font-size: var(--text-xs);
+		color: var(--text-muted);
+	}
+
+	.hint a {
+		color: var(--accent);
+		text-decoration: none;
+	}
+
+	.hint a:hover {
+		text-decoration: underline;
+	}
+
+	.owner-kind-options {
+		display: flex;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+	}
+
+	.owner-kind-option {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.55rem 0.85rem;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+		font-size: var(--text-sm);
+		color: var(--text-secondary);
+		margin-bottom: 0;
+	}
+
+	.owner-kind-option input[type='radio'] {
+		margin: 0;
+	}
+
+	.form-actions {
+		display: flex;
+		justify-content: flex-end;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.cancel-link {
+		background: transparent;
+		border: none;
+		color: var(--text-tertiary);
+		font-family: inherit;
+		font-size: var(--text-sm);
+		cursor: pointer;
+		padding: 0.5rem 0.25rem;
+	}
+
+	.cancel-link:hover:not(:disabled) {
+		color: var(--text-secondary);
+		text-decoration: underline;
+	}
+
+	.cancel-link:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	form button[type='submit'] {
+		padding: 0.6rem 1.25rem;
+		background: var(--accent);
+		color: var(--text-primary);
+		border: none;
+		border-radius: var(--radius-sm);
+		font-size: var(--text-base);
+		font-weight: 600;
+		font-family: inherit;
+		cursor: pointer;
+		transition: all 0.2s;
+	}
+
+	form button[type='submit']:hover:not(:disabled) {
+		background: var(--accent-hover);
+	}
+
+	form button[type='submit']:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+</style>

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -11,6 +11,7 @@
 	import TagInput from '$lib/components/TagInput.svelte';
 	import PdsAudioUploadsToggle from '$lib/components/PdsAudioUploadsToggle.svelte';
 	import PdsBackfillControl from '$lib/components/PdsBackfillControl.svelte';
+	import CopyrightSection from '$lib/components/CopyrightSection.svelte';
 	import type { Track, FeaturedArtist, AlbumSummary, Playlist } from '$lib/types';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
@@ -136,6 +137,7 @@
 		const params = new URLSearchParams(window.location.search);
 		const exchangeToken = params.get('exchange_token');
 		const isDevToken = params.get('dev_token') === 'true';
+		const isScopeUpgrade = params.get('scope_upgraded') === 'true';
 
 		// redirect dev token callbacks to settings page
 		if (exchangeToken && isDevToken) {
@@ -157,7 +159,17 @@
 					// invalidate all load functions so they rerun with the new session cookie
 					await invalidateAll();
 					await auth.refresh();
-					await preferences.fetch(); const r = getReturnUrl(); if (r) { clearReturnUrl(); window.location.href = r; return; }
+					await preferences.fetch();
+					if (isScopeUpgrade) {
+						toast.success('copyright paradigm configured');
+					} else {
+						const r = getReturnUrl();
+						if (r) {
+							clearReturnUrl();
+							window.location.href = r;
+							return;
+						}
+					}
 				}
 			} catch (_e) {
 				console.error('failed to exchange token:', _e);
@@ -935,6 +947,8 @@
 				</button>
 			</form>
 		</section>
+
+		<CopyrightSection />
 
 		<a href="/upload" class="upload-card">
 			<div class="upload-card-icon">

--- a/loq.toml
+++ b/loq.toml
@@ -28,7 +28,7 @@ max_lines = 896
 
 [[rules]]
 path = "backend/src/backend/api/auth.py"
-max_lines = 807
+max_lines = 826
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
@@ -44,7 +44,7 @@ max_lines = 1560
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 1068
+max_lines = 1081
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
@@ -156,7 +156,7 @@ max_lines = 2446
 
 [[rules]]
 path = "frontend/src/routes/portal/+page.svelte"
-max_lines = 3882
+max_lines = 3896
 
 [[rules]]
 path = "frontend/src/routes/settings/+page.svelte"
@@ -285,3 +285,11 @@ max_lines = 2589
 [[rules]]
 path = "backend/src/backend/_internal/atproto/client.py"
 max_lines = 617
+
+[[rules]]
+path = "backend/src/backend/_internal/auth/oauth.py"
+max_lines = 513
+
+[[rules]]
+path = "frontend/src/lib/components/CopyrightSection.svelte"
+max_lines = 611


### PR DESCRIPTION
phase 2 of the indiemusi copyright paradigm (phase 1: #1400). users can now opt into the paradigm from the artist portal. setup triggers an OAuth scope upgrade granting plyr.fm permission to write rights metadata to the user's PDS. follow-up (phase 3) wires the upload + edit forms to actually write song/recording records and routes copyright-flagged audio through the existing supporter-gated storage path (no public PDS blob).

## backend

**api**
- new `api/copyright.py` router:
  - `GET /copyright/config` — returns current state (or null)
  - `POST /copyright/setup` — body `{ paradigm, publishing_owner }`. branches on whether the session already has indiemusi scopes:
    - **scopes missing** → kicks off OAuth scope upgrade with `paradigm_data` stashed on the pending row + `redirect_to=/portal`, returns `auth_url`
    - **scopes present** → writes publishingOwner record + saves the config row in place, returns `{ complete: true }`
  - `POST /copyright/disconnect` — deletes the row, best-effort deletes the PDS record

**callback**
- `/auth/callback` scope-upgrade branch now picks up any stashed `paradigm_data` and calls `complete_indiemusi_setup` on the new session before redirecting. honors `redirect_to` (defaults to `/settings` for backward compat with teal upgrades)

**scope composition**
- new `AtprotoSettings.resolved_scope_with_extras(*, teal_play, teal_status, indiemusi_tokens)` cleanly composes both integrations; `resolved_scope_with_teal` kept as a thin wrapper for callers that don't yet know about indiemusi
- `get_oauth_client` / `get_oauth_client_for_scope` / `start_oauth_flow_with_scopes` learn `include_indiemusi`
- `start_oauth_flow` (regular login) re-requests indiemusi scopes for users who already have a copyright config row, mirroring the existing teal pattern

**model + migration**
- migration `2ff28fd69210` adds `paradigm_data jsonb` and `redirect_to varchar(256)` to `pending_scope_upgrades` — both nullable so teal upgrades are unchanged

**tests** — 8 new endpoint tests cover both setup paths, paradigm rejection, the in-place vs OAuth branch, and disconnect.

## frontend

- new `lib/components/CopyrightSection.svelte` — self-contained section with three states (loading / not configured / configured) and an in-section form for publishing-owner fields. extracted to a component because `portal/+page.svelte` is at its loq limit (3.8k lines) — full decomposition of that page is a separate cleanup
- portal page imports the component, renders it after profile, and toasts "copyright paradigm configured" when landing back from the OAuth scope upgrade

## design notes

- the form has two paths via radio: **individual** (firstName + lastName) or **company** (companyName). matches Hilke's own data where both shapes appear
- paradigm picker is a single read-only row ("indiemusi.ch alpha") since there's only one paradigm — but the API contract treats it as one of many, so future additions are an enumeration change rather than a refactor
- copyright config and pending-upgrade rows are nullable on `config_uri` so a partial / interrupted setup can be retried without orphan state on the PDS

## what's deferred to phase 3
- upload + edit form integration (writes song + recording records alongside fm.plyr.track)
- routing copyright-flagged track audio through the supporter-gated storage path (no PDS blob, no public R2 URL — your "stored like atprotofans" constraint)
- the access-control decision for who can stream a copyright-flagged track (most likely "any authenticated listener")

## test plan
- [x] pytest collect + ruff + ty + svelte-check pass locally
- [ ] CI: integration tests pass (docker not available locally; deferred to CI per workflow)
- [ ] verify scope-upgrade redirect ends on /portal with a success toast
- [ ] verify in-place setup path (when session already has scopes from a re-login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)