### PR TITLE
fix(copyright): validate IPI / ISWC / ISRC formats with inline frontend errors

### DIFF
--- a/backend/src/backend/_internal/atproto/records/ch_indiemusi/__init__.py
+++ b/backend/src/backend/_internal/atproto/records/ch_indiemusi/__init__.py
@@ -9,6 +9,9 @@ from backend._internal.atproto.records.ch_indiemusi.actor_publishing_owner impor
     create_publishing_owner_record,
 )
 from backend._internal.atproto.records.ch_indiemusi.models import (
+    IPI_PATTERN,
+    ISRC_PATTERN,
+    ISWC_PATTERN,
     InterestedPartyInput,
     MasterOwnerInput,
     PublishingOwnerInput,
@@ -28,6 +31,9 @@ from backend._internal.atproto.records.ch_indiemusi.song import (
 )
 
 __all__ = [
+    "IPI_PATTERN",
+    "ISRC_PATTERN",
+    "ISWC_PATTERN",
     "InterestedPartyInput",
     "MasterOwnerInput",
     "PublishingOwnerInput",

--- a/backend/src/backend/_internal/atproto/records/ch_indiemusi/models.py
+++ b/backend/src/backend/_internal/atproto/records/ch_indiemusi/models.py
@@ -3,9 +3,35 @@
 the API accepts these from the frontend; the build_* helpers in sibling modules
 turn validated inputs into the dicts sent to the PDS. royalty percentages are
 basis points per the lexicon (10000 = 100%).
+
+format patterns for the registry-issued identifiers (IPI, ISWC, ISRC) are
+applied here so invalid values fail fast at the API boundary instead of being
+written to the user's PDS as garbage records.
 """
 
 from pydantic import BaseModel, ConfigDict, Field
+
+# IPI Name Number — CISAC-assigned identifier, exactly 11 numeric digits.
+# Wikipedia: "The IPI Name Number is composed of eleven numeric digits."
+# Leading zeros are part of the canonical form ("01145982828"). The older
+# 9-digit CAE numbering was retired in 2001 when the IPI database replaced it.
+IPI_PATTERN = r"^\d{11}$"
+
+# ISWC — International Standard Musical Work Code.
+# Spec: "T" prefix + 9-digit work identifier + 1 check digit (mod-10).
+# 11 chars without separators, 13 with hyphens. We accept the hyphenated form
+# T-DDDDDDDDD-C (matches Hilke's storage convention and the lexicon's maxLength
+# of 13) or the bare T-prefix form. The period-grouped variant
+# T-DDD.DDD.DDD-C is presentation-only and runs to 15 chars — outside the
+# lexicon bound, so users should strip dots before submitting.
+ISWC_PATTERN = r"^T-?\d{9}-?\d$"
+
+# ISRC — International Standard Recording Code.
+# Spec (IFPI): CC (2-letter country, ISO 3166-1 alpha-2 or special codes QM/QZ/
+# QT/CP/DG/ZZ) + XXX (3 alphanumeric registrant) + YY (2-digit year) + NNNNN
+# (5-digit designation). 12 chars total; hyphens are presentation-only and
+# don't fit the lexicon's maxLength=12, so we require the bare 12-char form.
+ISRC_PATTERN = r"^[A-Z]{2}[A-Z0-9]{3}\d{2}\d{5}$"
 
 
 class PublishingOwnerInput(BaseModel):
@@ -17,7 +43,7 @@ class PublishingOwnerInput(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    ipi: str | None = Field(default=None, max_length=11)
+    ipi: str | None = Field(default=None, max_length=11, pattern=IPI_PATTERN)
     first_name: str | None = Field(default=None, max_length=255, alias="firstName")
     last_name: str | None = Field(default=None, max_length=255, alias="lastName")
     company_name: str | None = Field(default=None, max_length=255, alias="companyName")
@@ -37,7 +63,7 @@ class InterestedPartyInput(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     did: str | None = Field(default=None, pattern=r"^did:[a-z]+:.+$")
-    ipi: str | None = Field(default=None, max_length=11)
+    ipi: str | None = Field(default=None, max_length=11, pattern=IPI_PATTERN)
     name: str | None = Field(default=None, max_length=255)
     role: str | None = Field(
         default=None,
@@ -75,6 +101,7 @@ class SongInput(BaseModel):
     iswc: str | None = Field(
         default=None,
         max_length=13,
+        pattern=ISWC_PATTERN,
         description="ISWC (International Standard Musical Work Code).",
     )
     interested_parties: list[InterestedPartyInput] = Field(
@@ -115,6 +142,7 @@ class RecordingInput(BaseModel):
     isrc: str | None = Field(
         default=None,
         max_length=12,
+        pattern=ISRC_PATTERN,
         description="ISRC (International Standard Recording Code).",
     )
     duration: int | None = Field(

--- a/backend/src/backend/_internal/copyright.py
+++ b/backend/src/backend/_internal/copyright.py
@@ -16,6 +16,8 @@ from sqlalchemy.orm import selectinload
 
 from backend._internal import Session as AuthSession
 from backend._internal.atproto.records.ch_indiemusi import (
+    ISRC_PATTERN,
+    ISWC_PATTERN,
     InterestedPartyInput,
     MasterOwnerInput,
     PublishingOwnerInput,
@@ -56,8 +58,8 @@ class TrackRightsInput(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    iswc: str | None = Field(default=None, max_length=13)
-    isrc: str | None = Field(default=None, max_length=12)
+    iswc: str | None = Field(default=None, max_length=13, pattern=ISWC_PATTERN)
+    isrc: str | None = Field(default=None, max_length=12, pattern=ISRC_PATTERN)
     master_owner: MasterOwnerInput | None = Field(default=None, alias="masterOwner")
     additional_interested_parties: list[InterestedPartyInput] = Field(
         default_factory=list,

--- a/backend/tests/_internal/test_copyright_format_validation.py
+++ b/backend/tests/_internal/test_copyright_format_validation.py
@@ -1,0 +1,128 @@
+"""regression tests for the IPI / ISWC / ISRC format validators.
+
+verifies the pydantic patterns anchor at the lexicon-shape layer
+(ch_indiemusi.models). without these the API would happily forward garbage
+strings to the user's PDS as rights records.
+
+formats anchored to:
+- IPI Name Number: CISAC — 11 numeric digits
+- ISWC: T + 9 digits + check digit, hyphens or periods conventional
+- ISRC: CC (2 letters) + XXX (3 alnum) + YY (2 digits) + NNNNN (5 digits)
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from backend._internal.atproto.records.ch_indiemusi import (
+    PublishingOwnerInput,
+)
+from backend._internal.copyright import TrackRightsInput
+
+# --- IPI ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ipi",
+    [
+        "01145982828",  # Hilke's IPI
+        "00591706432",  # Anna Murphy
+        "00380771742",  # Red Brick Records
+        "00045620792",  # Prince (Wikipedia example)
+    ],
+)
+def test_ipi_accepts_canonical_11_digits(ipi: str) -> None:
+    PublishingOwnerInput.model_validate({"ipi": ipi})
+
+
+@pytest.mark.parametrize(
+    "ipi",
+    [
+        "asdfasdf",  # garbage from the screenshot
+        "123456789",  # 9 digits (deprecated CAE format)
+        "1234567890",  # 10 digits
+        "123456789012",  # 12 digits
+        "0114598282A",  # letter in last position
+        "01145 982828",  # space
+        "01145-982828",  # hyphen
+    ],
+)
+def test_ipi_rejects_non_canonical(ipi: str) -> None:
+    with pytest.raises(ValidationError):
+        PublishingOwnerInput.model_validate({"ipi": ipi})
+
+
+def test_ipi_none_allowed() -> None:
+    """ipi is optional — absent or null is fine."""
+    PublishingOwnerInput.model_validate({})
+    PublishingOwnerInput.model_validate({"ipi": None})
+
+
+# --- ISWC --------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "iswc",
+    [
+        "T-330690274-5",  # Hilke's "soul" — hyphens (13 chars)
+        "T3306902745",  # no separators (11 chars)
+        "T-3306902745",  # hyphen prefix only (12 chars)
+        "T-000000001-0",  # canonical Dancing Queen, hyphens only
+    ],
+)
+def test_iswc_accepts_canonical_shapes(iswc: str) -> None:
+    TrackRightsInput.model_validate({"iswc": iswc})
+
+
+@pytest.mark.parametrize(
+    "iswc",
+    [
+        "asdf",  # garbage
+        "330690274-5",  # missing T prefix
+        "t-330690274-5",  # lowercase t (spec is uppercase)
+        "T-33069027-5",  # 8 digits not 9
+        "T-330690274",  # missing check digit
+        "T-330_690_274-5",  # invalid separator (underscore)
+        "T-330,690,274-5",  # commas (not allowed)
+        # period-grouped form is spec-valid for presentation but is 15 chars,
+        # over the lexicon's maxLength=13 — users must strip dots first
+        "T-000.000.001-0",
+    ],
+)
+def test_iswc_rejects_non_canonical(iswc: str) -> None:
+    with pytest.raises(ValidationError):
+        TrackRightsInput.model_validate({"iswc": iswc})
+
+
+# --- ISRC --------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "isrc",
+    [
+        "CHD542500009",  # Hilke's recording — no separators, 12 chars
+        "USRC17607839",  # generic US ISRC
+        "QMT0X2342342",  # special distributor code QM (post-2010 US overflow)
+        "GBAYE8600001",  # UK example, no separators
+    ],
+)
+def test_isrc_accepts_canonical_shapes(isrc: str) -> None:
+    TrackRightsInput.model_validate({"isrc": isrc})
+
+
+@pytest.mark.parametrize(
+    "isrc",
+    [
+        "asdfasdfsda",  # garbage
+        "chd542500009",  # lowercase — spec is uppercase
+        "CHD54250000",  # 11 chars (1 too short)
+        "CHD5425000099",  # 13 chars (1 too long)
+        "CH-D54-AA-00009",  # non-digit year
+        "CH-D54-25-0000A",  # non-digit designation
+        # hyphenated presentation form is 15 chars, over the lexicon's
+        # maxLength=12 — users must strip hyphens before submitting
+        "CH-D54-25-00009",
+    ],
+)
+def test_isrc_rejects_non_canonical(isrc: str) -> None:
+    with pytest.raises(ValidationError):
+        TrackRightsInput.model_validate({"isrc": isrc})

--- a/frontend/src/lib/components/CopyrightRightsPanel.svelte
+++ b/frontend/src/lib/components/CopyrightRightsPanel.svelte
@@ -62,6 +62,25 @@
 			masterOwner: name ? { name } : null
 		};
 	}
+
+	// format patterns mirror the backend's pydantic validators
+	// (ch_indiemusi/models.py). client-side checks give immediate feedback;
+	// the backend still rejects anything that slips through.
+	const iswcError = $derived.by(() => {
+		const v = (rights.iswc ?? '').trim();
+		if (!v) return null;
+		return /^T-?\d{9}-?\d$/.test(v)
+			? null
+			: 'ISWC should look like T-330690274-5 (T + 9 digits + check digit)';
+	});
+
+	const isrcError = $derived.by(() => {
+		const v = (rights.isrc ?? '').trim();
+		if (!v) return null;
+		return /^[A-Z]{2}[A-Z0-9]{3}\d{2}\d{5}$/.test(v)
+			? null
+			: 'ISRC should look like CHD542500009 — uppercase, 12 chars, no hyphens';
+	});
 </script>
 
 <div class="rights-panel" class:disabled>
@@ -107,7 +126,12 @@
 					value={rights.iswc ?? ''}
 					oninput={(e) => (rights = { ...rights, iswc: (e.currentTarget as HTMLInputElement).value })}
 					{disabled}
+					aria-invalid={iswcError ? 'true' : undefined}
+					aria-describedby={iswcError ? 'copyright-rights-iswc-error' : undefined}
 				/>
+				{#if iswcError}
+					<p class="field-error" id="copyright-rights-iswc-error">{iswcError}</p>
+				{/if}
 			</div>
 
 			<div class="form-group">
@@ -127,7 +151,12 @@
 					value={rights.isrc ?? ''}
 					oninput={(e) => (rights = { ...rights, isrc: (e.currentTarget as HTMLInputElement).value })}
 					{disabled}
+					aria-invalid={isrcError ? 'true' : undefined}
+					aria-describedby={isrcError ? 'copyright-rights-isrc-error' : undefined}
 				/>
+				{#if isrcError}
+					<p class="field-error" id="copyright-rights-isrc-error">{isrcError}</p>
+				{/if}
 			</div>
 		</div>
 
@@ -254,6 +283,16 @@
 	.form-group input:focus {
 		outline: none;
 		border-color: var(--accent);
+	}
+
+	.form-group input[aria-invalid='true'] {
+		border-color: var(--danger, #e5484d);
+	}
+
+	.field-error {
+		margin: 0.35rem 0 0;
+		font-size: var(--text-xs);
+		color: var(--danger, #e5484d);
 	}
 
 	.form-group input:disabled {

--- a/frontend/src/lib/components/CopyrightSection.svelte
+++ b/frontend/src/lib/components/CopyrightSection.svelte
@@ -31,9 +31,20 @@
 	let companyName = $state('');
 	let collectingSociety = $state('');
 
+	// IPI Name Number — CISAC spec, exactly 11 digits (leading zeros included).
+	// matches the backend pattern in ch_indiemusi/models.py.
+	const ipiError = $derived.by(() => {
+		const v = ipi.trim();
+		if (!v) return null;
+		return /^\d{11}$/.test(v) ? null : 'IPI must be exactly 11 digits';
+	});
+
 	const canSubmit = $derived(
-		(ownerKind === 'individual' && firstName.trim() !== '' && lastName.trim() !== '') ||
-			(ownerKind === 'company' && companyName.trim() !== '')
+		!ipiError &&
+			((ownerKind === 'individual' &&
+				firstName.trim() !== '' &&
+				lastName.trim() !== '') ||
+				(ownerKind === 'company' && companyName.trim() !== ''))
 	);
 
 	async function fetchConfig() {
@@ -315,7 +326,12 @@
 					disabled={saving}
 					maxlength="11"
 					placeholder="e.g. 00012345678"
+					aria-invalid={ipiError ? 'true' : undefined}
+					aria-describedby={ipiError ? 'copyright-ipi-error' : undefined}
 				/>
+				{#if ipiError}
+					<p class="field-error" id="copyright-ipi-error">{ipiError}</p>
+				{/if}
 			</div>
 
 			<div class="form-group">
@@ -537,6 +553,16 @@
 	input[type='text']:focus {
 		outline: none;
 		border-color: var(--accent);
+	}
+
+	input[type='text'][aria-invalid='true'] {
+		border-color: var(--danger, #e5484d);
+	}
+
+	.field-error {
+		margin-top: 0.35rem;
+		font-size: var(--text-xs);
+		color: var(--danger, #e5484d);
 	}
 
 	input[type='text']:disabled {

--- a/loq.toml
+++ b/loq.toml
@@ -292,7 +292,7 @@ max_lines = 513
 
 [[rules]]
 path = "frontend/src/lib/components/CopyrightSection.svelte"
-max_lines = 621
+max_lines = 645
 
 [[rules]]
 path = "backend/tests/api/test_copyright_followups.py"


### PR DESCRIPTION
[screenshot in chat showed "asdfasdf" sailing through as an IPI](https://github.com/zzstoatzz/plyr.fm) with no validation other than max_length=11. backend would happily forward that to the user's PDS as a publishingOwner record. fixing.

## what was missing

- `PublishingOwnerInput.ipi` and `InterestedPartyInput.ipi`: only `max_length=11`, no format check
- `TrackRightsInput.iswc` / `SongInput.iswc`: only `max_length=13`, no format check
- `TrackRightsInput.isrc` / `RecordingInput.isrc`: only `max_length=12`, no format check
- no frontend validation — the placeholders showed example formats but nothing actually rejected garbage

## what's in

### backend — pattern constants in `ch_indiemusi/models.py`

verified against authoritative specs (CISAC for IPI/ISWC, IFPI for ISRC) and Hilke's real records, not guessed:

```py
# IPI Name Number — Wikipedia: "composed of eleven numeric digits"
# 9-digit CAE predecessor retired 2001
IPI_PATTERN = r"^\d{11}$"

# ISWC — T + 9 digits + 1 check digit. spec allows hyphens and periods, but
# the period-grouped form (T-DDD.DDD.DDD-C) runs to 15 chars — over the
# lexicon's maxLength=13. accept hyphenated only.
ISWC_PATTERN = r"^T-?\d{9}-?\d$"

# ISRC — CC (2 letters) + XXX (3 alnum) + YY (2 digits) + NNNNN (5 digits).
# IFPI: hyphens are presentation-only. hyphenated form is 15 chars, over
# the lexicon's maxLength=12. require the bare 12-char form.
ISRC_PATTERN = r"^[A-Z]{2}[A-Z0-9]{3}\d{2}\d{5}$"
```

applied to:
- `PublishingOwnerInput.ipi` and `InterestedPartyInput.ipi`
- `TrackRightsInput.iswc` and `.isrc`
- (these compose through `SongInput` / `RecordingInput` at write time; the API boundary is the validating layer)

### frontend — inline `.field-error` with `aria-invalid` red border

- `CopyrightSection`: IPI field shows inline error when non-empty and not matching `/^\d{11}$/`. `canSubmit` derived now includes `!ipiError`, so the save button is disabled until cleared
- `CopyrightRightsPanel`: same treatment for ISWC + ISRC. backend remains the final defense for the upload/edit submission paths (which don't have their own gating button)

both regexes mirror the backend exactly so the inline check is consistent.

### regression tests — 35 cases in `test_copyright_format_validation.py`

accepted shapes anchored to:
- IPI: Hilke (`01145982828`), Anna Murphy, Red Brick Records, Prince (Wikipedia)
- ISWC: Hilke's "soul" (`T-330690274-5`), Dancing Queen-style hyphens, bare and prefix-only variants
- ISRC: Hilke's recording (`CHD542500009`), generic US, distributor code QM, UK example

rejected shapes anchored to:
- garbage from the screenshot (`asdfasdf`)
- common mistakes (lowercase, missing prefix, wrong length, bad separators, deprecated CAE 9-digit)
- spec-valid presentation forms that don't fit lexicon maxLength (period-grouped ISWC, hyphenated ISRC)

## decision: lexicon maxLength wins over spec presentation forms

Wikipedia confirms that ISWC `T-000.000.001-0` (15 chars, period-grouped) and ISRC `CH-D54-25-00009` (15 chars, hyphenated) are both spec-valid for presentation but **not** for storage. the lexicon's `maxLength` bounds (13 and 12) only fit the no-period ISWC and no-separator ISRC respectively. error messages tell the user the exact format to enter.

## test plan
- [x] 35 unit tests pass locally (no DB required)
- [x] ruff + ty + svelte-check
- [ ] CI green
- [ ] manual: paste a hyphenated ISRC, see inline error; switch to bare form, error clears; save proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)