### PR TITLE
fix(auth): declare indiemusi scopes in oauth metadata + lock the coupling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,22 @@ repos:
         files: ^frontend/src/routes/privacy/\+page\.svelte$
         pass_filenames: true
 
+      - id: check-oauth-scope-universe
+        name: oauth scope universe (runtime ⊆ published metadata)
+        # runs when any of:
+        #   - the runtime scope composer (config.py)
+        #   - the metadata endpoint (api/meta.py)
+        #   - the oauth client construction (auth/oauth.py)
+        #   - any lexicon record module (records/*)
+        # changes. cheap to run (~0.5s pytest startup + 1 instant test). guards
+        # against adding a new repo: scope to the runtime composer but forgetting
+        # to declare it in /oauth-client-metadata.json — failure mode is PAR
+        # invalid_scope at login, hard to debug without auth-server logs.
+        entry: bash -c 'cd backend && uv run pytest tests/api/test_oauth_client_metadata.py -q'
+        language: system
+        files: ^backend/src/backend/(config\.py|api/meta\.py|_internal/auth/oauth\.py|_internal/atproto/records/.+)
+        pass_filenames: false
+
       - id: cargo-check-moderation
         name: cargo check (moderation)
         entry: bash -c 'cd services/moderation && cargo check --quiet'

--- a/backend/src/backend/_internal/CLAUDE.md
+++ b/backend/src/backend/_internal/CLAUDE.md
@@ -21,3 +21,14 @@ gotchas:
 - file_id is sha256 hash truncated to 16 chars
 - queue cache is TTL-based (5min), hydration includes duplicate track_ids
 - background tasks use docket (Redis-backed) with asyncio fallback for local dev
+- **OAuth scope coupling**: when adding a new lexicon integration (new `repo:` token),
+  THREE places must update together or PAR fails with `invalid_scope` at login:
+  1. `AtprotoSettings.resolved_scope_with_extras` in `backend/config.py` —
+     the runtime composer that decides which scopes a flow asks for
+  2. `get_oauth_client` / `get_oauth_client_for_scope` /
+     `start_oauth_flow_with_scopes` in `_internal/auth/oauth.py` — the
+     flags that turn the new scope on/off per flow
+  3. `client_metadata()` in `api/meta.py` — the published universe that
+     the authserver checks every PAR against
+  the regression test `tests/api/test_oauth_client_metadata.py` asserts
+  the published universe is a superset of every integration's tokens.

--- a/backend/src/backend/api/CLAUDE.md
+++ b/backend/src/backend/api/CLAUDE.md
@@ -6,6 +6,11 @@ auth:
 - all endpoints except `/auth/*` require session cookie
 - OAuth 2.1 flow via ATProto: `/auth/authorize`, `/auth/callback`, `/auth/logout`
 - session management in `_internal/auth.py`
+- `/oauth-client-metadata.json` (`meta.py`) publishes the **universe** of scopes
+  this client may ever request. authservers reject any PAR with a scope not
+  in this universe, so whenever you add a new integration's scopes to the
+  runtime composer in `AtprotoSettings.resolved_scope_with_extras`, you MUST
+  also add them here. regression: `tests/api/test_oauth_client_metadata.py`
 
 resources:
 - **tracks**: upload, edit, delete, like/unlike, play count tracking, timed comments

--- a/backend/src/backend/api/meta.py
+++ b/backend/src/backend/api/meta.py
@@ -51,13 +51,24 @@ async def client_metadata() -> dict[str, Any]:
     # extract base URL from client_id for client_uri
     client_uri = settings.atproto.client_id.replace("/oauth-client-metadata.json", "")
 
+    # the published `scope` is the *universe* of scopes the client may request
+    # across all flows. authservers (Bluesky's, custom PDS') reject any PAR
+    # whose scope isn't a subset of this declaration. compose with every
+    # integration we might ever ask for — runtime decides which subset to
+    # actually send for a given user's flow.
     metadata: dict[str, Any] = {
         "client_id": settings.atproto.client_id,
         "client_name": settings.app.name,
         "client_uri": client_uri,
         "redirect_uris": [settings.atproto.redirect_uri],
-        "scope": settings.atproto.resolved_scope_with_teal(
-            settings.teal.play_collection, settings.teal.status_collection
+        "scope": settings.atproto.resolved_scope_with_extras(
+            teal_play=settings.teal.play_collection,
+            teal_status=settings.teal.status_collection,
+            indiemusi_tokens=(
+                settings.indiemusi.scope_tokens()
+                if settings.indiemusi.enabled
+                else None
+            ),
         ),
         "grant_types": ["authorization_code", "refresh_token"],
         "response_types": ["code"],

--- a/backend/tests/api/test_oauth_client_metadata.py
+++ b/backend/tests/api/test_oauth_client_metadata.py
@@ -1,0 +1,61 @@
+"""regression test: published OAuth client metadata must list every scope
+the runtime can possibly request.
+
+if the published `scope` doesn't include something the runtime sends as part
+of a PAR (Pushed Authorization Request), the authserver returns 400
+`invalid_scope` and the user can't sign in. we hit this when phase 2 added
+the indiemusi scopes to runtime composition but the metadata endpoint kept
+using the older teal-only composition — every fresh login that wanted
+indiemusi scopes failed.
+
+calls the endpoint handler directly (rather than going through AsyncClient)
+so the test doesn't need redis / slowapi infrastructure to run locally.
+"""
+
+import pytest
+
+from backend.api.meta import client_metadata
+from backend.config import settings
+
+
+async def _published_scope_tokens() -> set[str]:
+    metadata = await client_metadata()
+    return set(metadata["scope"].split())
+
+
+async def test_oauth_metadata_declares_indiemusi_scopes() -> None:
+    """every scope token the runtime can request must appear in the published
+    scope universe — otherwise the authserver rejects the PAR.
+    """
+    declared = await _published_scope_tokens()
+
+    # base atproto + blob (sanity)
+    assert "atproto" in declared
+    assert "blob:*/*" in declared
+
+    # indiemusi paradigm scopes — the bug this guards against
+    for token in settings.indiemusi.scope_tokens():
+        assert token in declared, (
+            f"indiemusi scope {token!r} missing from published OAuth metadata; "
+            f"runtime can request it but PAR will be rejected as invalid_scope"
+        )
+
+
+async def test_oauth_metadata_declares_teal_scopes() -> None:
+    """parallel guard for teal — same failure mode, different feature."""
+    declared = await _published_scope_tokens()
+    assert f"repo:{settings.teal.play_collection}" in declared
+    assert f"repo:{settings.teal.status_collection}" in declared
+
+
+async def test_oauth_metadata_omits_indiemusi_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """when the indiemusi paradigm is feature-disabled, those scopes must
+    not be declared — declaring scopes we don't actually offer is sloppy
+    (and may confuse downstream tools that audit grants).
+    """
+    monkeypatch.setattr(settings.indiemusi, "enabled", False)
+    declared = await _published_scope_tokens()
+    for token in settings.indiemusi.scope_tokens():
+        assert token not in declared


### PR DESCRIPTION
login was failing with `400 invalid_scope: "repo:ch.indiemusi.alpha.song" is not declared in the client metadata` for fresh OAuth flows after sign-out. phase 2 added the indiemusi scopes to the runtime composer (`AtprotoSettings.resolved_scope_with_extras`) but \`/oauth-client-metadata.json\` was still using the older \`resolved_scope_with_teal\` composer, so the authserver had no record of indiemusi in this client's universe and rejected every PAR that asked for it.

## the fix

`api/meta.py::client_metadata` composes scope via `resolved_scope_with_extras` with all three integration kwargs filled in — the runtime composer is now the single source of truth.

published universe now reads:
```
atproto blob:*/* repo:fm.plyr.dev.track repo:fm.plyr.dev.like repo:fm.plyr.dev.comment
repo:fm.plyr.dev.list repo:fm.plyr.dev.actor.profile
repo:fm.teal.alpha.feed.play repo:fm.teal.alpha.actor.status
repo:ch.indiemusi.alpha.song repo:ch.indiemusi.alpha.recording
repo:ch.indiemusi.alpha.actor.publishingOwner
```

## guards against this recurring

three layers because per the user, I've made this exact "added a new scope, forgot to declare it in metadata" mistake a few times:

1. **regression tests** (`tests/api/test_oauth_client_metadata.py`) — three cases asserting the published universe is a superset of every integration's tokens, plus a guard that disabled integrations don't leak. Calls `client_metadata()` directly so it runs locally without redis/slowapi infrastructure (~0.4s)

2. **pre-commit hook** (`check-oauth-scope-universe`) — runs the test on changes to:
   - `config.py` (the runtime composer lives here)
   - `api/meta.py` (the published metadata endpoint)
   - `_internal/auth/oauth.py` (the OAuth client factory)
   - any `_internal/atproto/records/*` file (new lexicon integration)

   so missing a declaration trips before the commit lands, not at a real user's first login

3. **CLAUDE.md updates**:
   - `_internal/CLAUDE.md`: gotcha block explicitly listing the three places that must update together when adding a new `repo:` scope
   - `api/CLAUDE.md`: shorter cross-reference next to the auth section

## test plan
- [x] regression tests pass locally (3 cases)
- [x] pre-commit hook executes the test on changes to the relevant files
- [x] published metadata endpoint output verified to include all indiemusi scope tokens
- [ ] CI green
- [ ] manual: sign out, sign in — PAR should succeed (no `invalid_scope`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)