### PR TITLE
feat(copyright): inline change-link on the rights panel owner line

### DIFF
--- a/frontend/src/lib/components/CopyrightRightsPanel.svelte
+++ b/frontend/src/lib/components/CopyrightRightsPanel.svelte
@@ -104,7 +104,8 @@
 	{:else if enabled}
 		{#if ownerSummary}
 			<p class="hint owner-line">
-				rights credited to <strong>{ownerSummary}</strong>
+				rights credited to <strong>{ownerSummary}</strong> ·
+				<a href="/portal">change</a>
 			</p>
 		{/if}
 


### PR DESCRIPTION
small UX tweak per the latest review: the "rights credited to {name}" line in the upload/edit copyright panel now links to /portal so the user can re-edit their publishingOwner config without leaving the track form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)