### PR TITLE
fix(uploads): copyright-gated uploads no longer require atprotofans setup

### DIFF
--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -545,7 +545,14 @@ async def _validate_audio(ctx: UploadContext) -> AudioInfo:
         raise UploadPhaseError(f"unsupported file type: .{ctx.audio_extension}")
 
     is_gated = ctx.support_gate is not None
-    if is_gated:
+    # the atprotofans requirement applies ONLY to supporter-gated tracks
+    # (support_gate.type == "any"). copyright-typed gates use the same
+    # private-storage pipeline but have a different access policy (any
+    # authenticated listener), so atprotofans setup must not be required.
+    gate_type = (
+        ctx.support_gate.get("type") if isinstance(ctx.support_gate, dict) else None
+    )
+    if gate_type == "any":
         async with db_session() as db:
             prefs_result = await db.execute(
                 select(UserPreferences).where(UserPreferences.did == ctx.artist_did)

--- a/backend/tests/api/test_upload_copyright_gate.py
+++ b/backend/tests/api/test_upload_copyright_gate.py
@@ -1,0 +1,86 @@
+"""regression test: copyright-gated uploads must not require atprotofans setup.
+
+bug seen on staging 2026-05-15: a track upload with the copyright toggle
+flipped on failed in the docket worker's `_validate_audio` phase with
+"supporter gating requires atprotofans to be enabled in settings". the
+validator was scoping atprotofans-required to `support_gate is not None`
+instead of `support_gate.type == "any"`, so copyright-typed gates
+(`{"type": "copyright"}`) triggered the same check even though copyright
+access doesn't depend on atprotofans at all.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import Session
+from backend.api.tracks.uploads import (
+    UploadContext,
+    UploadPhaseError,
+    _validate_audio,
+)
+from backend.models import Artist
+
+
+def _ctx(
+    artist_did: str, *, support_gate: dict | None, filename: str = "test.mp3"
+) -> UploadContext:
+    """build a minimal UploadContext for _validate_audio."""
+    return UploadContext(
+        upload_id="test-upload-id",
+        auth_session=Session.__new__(Session),
+        audio_file_id="test_file_id",
+        filename=filename,
+        duration=60,
+        title="test track",
+        artist_did=artist_did,
+        album=None,
+        album_id=None,
+        features_json=None,
+        tags=[],
+        support_gate=support_gate,
+    )
+
+
+async def test_copyright_gate_does_not_require_atprotofans(
+    db_session: AsyncSession,
+) -> None:
+    """the original bug: copyright-typed gate must pass validation without
+    the user having atprotofans configured.
+    """
+    did = "did:test:copyright-no-fans"
+    db_session.add(Artist(did=did, handle="someone.example", display_name="Someone"))
+    await db_session.commit()
+    # no UserPreferences row at all — definitely no atprotofans setup
+
+    ctx = _ctx(did, support_gate={"type": "copyright"})
+    info = await _validate_audio(ctx)
+    # validation must pass; the upload would continue into _store_audio
+    assert info.is_gated is True
+
+
+async def test_supporter_gate_still_requires_atprotofans(
+    db_session: AsyncSession,
+) -> None:
+    """the original guard for supporter gating remains: type=="any" without
+    atprotofans configured must still raise.
+    """
+    did = "did:test:supporter-no-fans"
+    db_session.add(Artist(did=did, handle="someone-else.example", display_name="Other"))
+    await db_session.commit()
+
+    ctx = _ctx(did, support_gate={"type": "any"})
+    with pytest.raises(UploadPhaseError, match="atprotofans"):
+        await _validate_audio(ctx)
+
+
+async def test_public_upload_skips_atprotofans_check(
+    db_session: AsyncSession,
+) -> None:
+    """public uploads (support_gate=None) never touch the user_preferences check."""
+    did = "did:test:public-upload"
+    db_session.add(Artist(did=did, handle="public.example", display_name="Public"))
+    await db_session.commit()
+
+    ctx = _ctx(did, support_gate=None)
+    info = await _validate_audio(ctx)
+    assert info.is_gated is False

--- a/loq.toml
+++ b/loq.toml
@@ -40,7 +40,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1617
+max_lines = 1624
 
 [[rules]]
 path = "backend/src/backend/config.py"


### PR DESCRIPTION
## bug

a track upload with the copyright toggle on failed on staging 2026-05-15 with this error on the job row:

```
"supporter gating requires atprotofans to be enabled in settings"
```

found via logfire trace of the failed upload (job id \`ada95a5c-d8a1-4649-9a73-0b43d6ae62fb\`). the upload made it through R2 staging fine, hit \`run_track_upload\`, then aborted in \`_validate_audio\` after the \`user_preferences\` lookup.

## root cause

\`api/tracks/uploads.py::_validate_audio\` predates the copyright gate type. it checks atprotofans setup whenever \`support_gate is not None\`:

\`\`\`py
is_gated = ctx.support_gate is not None
if is_gated:
    # ...look up user_preferences, require support_url == \"atprotofans\"
\`\`\`

since phase 3 wired copyright through the same \`support_gate\` field (with \`type: \"copyright\"\`) to reuse the gated-storage pipeline, this prerequisite started firing for copyright uploads too — even though copyright access has nothing to do with atprotofans.

## fix

scope the atprotofans requirement to \`gate_type == \"any\"\`:

\`\`\`py
gate_type = (
    ctx.support_gate.get(\"type\") if isinstance(ctx.support_gate, dict) else None
)
if gate_type == \"any\":
    # supporter gating requires atprotofans
\`\`\`

copyright uploads now flow through the gated pipeline normally.

## regression test

\`backend/tests/api/test_upload_copyright_gate.py\` — three cases against the \`_validate_audio\` phase directly:

1. **copyright gate + no atprotofans setup → passes**: the original bug.
2. **supporter gate + no atprotofans setup → still raises**: existing contract preserved.
3. **public upload → skips the prefs check entirely**: confirms we didn't regress the no-gate path.

## not in this PR (follow-up)

while investigating I noticed a separate constraint at \`_store_audio\`: gated tracks can't use lossless formats. that's because \`_transcode_audio\` writes the transcoded MP3 via \`storage.save()\` (public bucket) — for a gated upload that would leak the playable file even though the original was private. real but distinct issue. filing a follow-up to thread \`gated=\` through the transcode path and use \`storage.save_gated\` accordingly.

## test plan
- [x] 3 regression tests pass locally
- [x] ruff + ty + svelte
- [ ] CI green
- [ ] manual on staging: retry the upload that failed; expect it to complete + song/recording records appear on PDS

🤖 Generated with [Claude Code](https://claude.com/claude-code)