### PR TITLE
feat(copyright): feature-flag the paradigm surface behind `copyright-paradigm`

### DIFF
--- a/backend/src/backend/_internal/auth/session.py
+++ b/backend/src/backend/_internal/auth/session.py
@@ -301,7 +301,18 @@ async def _check_teal_preference(did: str) -> bool:
 
 
 async def _check_copyright_paradigm(did: str) -> bool:
-    """check if user has opted into the indiemusi copyright paradigm."""
+    """check if user should have the indiemusi copyright paradigm scopes
+    re-requested on this OAuth flow.
+
+    requires BOTH:
+    - an active user_copyright_configs row (the user actually opted in), AND
+    - the `copyright-paradigm` feature flag on this DID
+
+    without the flag check, a user opted in pre-flag-rollback would keep
+    requesting indiemusi scopes on every sign-in even after we'd disabled
+    the feature for them — defeating the point of feature flagging.
+    """
+    from backend._internal.feature_flags import has_flag
     from backend.models import UserCopyrightConfig
 
     async with db_session() as db:
@@ -311,4 +322,6 @@ async def _check_copyright_paradigm(did: str) -> bool:
             )
         )
         paradigm = result.scalar_one_or_none()
-        return paradigm == settings.indiemusi.paradigm_id
+        if paradigm != settings.indiemusi.paradigm_id:
+            return False
+        return await has_flag(db, did, "copyright-paradigm")

--- a/backend/src/backend/_internal/feature_flags.py
+++ b/backend/src/backend/_internal/feature_flags.py
@@ -13,6 +13,7 @@ from backend.models.feature_flag import FeatureFlag
 KNOWN_FLAGS = frozenset(
     {
         "vibe-search",  # enable semantic vibe search in Cmd+K
+        "copyright-paradigm",  # enable the indiemusi.ch copyright paradigm UI + endpoints
     }
 )
 

--- a/backend/src/backend/api/copyright.py
+++ b/backend/src/backend/api/copyright.py
@@ -14,6 +14,7 @@ from sqlalchemy import select
 
 from backend._internal import (
     Session,
+    has_flag,
     require_auth,
     save_pending_scope_upgrade,
     start_oauth_flow_with_scopes,
@@ -34,6 +35,22 @@ from backend.utilities.database import db_session
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/copyright", tags=["copyright"])
+
+# feature flag for the entire copyright-paradigm surface. ungated user
+# requests get a 404 — same shape they'd see for any unmounted endpoint, so
+# we don't leak the existence of the feature to users we haven't enrolled.
+COPYRIGHT_PARADIGM_FLAG = "copyright-paradigm"
+
+
+async def _require_copyright_flag(session: Session) -> None:
+    """guard every /copyright/* endpoint behind the per-user feature flag.
+
+    flagged users see normal behavior; everyone else gets a 404 (not 403) so
+    the existence of the feature isn't leaked while we're rolling out.
+    """
+    async with db_session() as db:
+        if not await has_flag(db, session.did, COPYRIGHT_PARADIGM_FLAG):
+            raise HTTPException(status_code=404, detail="not found")
 
 
 # --- response models ---------------------------------------------------------
@@ -87,6 +104,7 @@ async def get_config(
     session: Session = Depends(require_auth),
 ) -> CopyrightConfigResponse | None:
     """return the user's current copyright config, or null if none."""
+    await _require_copyright_flag(session)
     cfg = await get_user_copyright_config(session.did)
     if not cfg:
         return None
@@ -109,6 +127,7 @@ async def setup(
     OAuth scope upgrade and returns `auth_url` for the frontend to redirect to;
     the callback finishes the write once the new session is in place.
     """
+    await _require_copyright_flag(session)
     if body.paradigm != settings.indiemusi.paradigm_id:
         raise HTTPException(
             status_code=400,
@@ -164,6 +183,7 @@ async def disconnect(
     clear them through). users must clear each via DELETE /tracks/{id}/copyright
     before disconnecting.
     """
+    await _require_copyright_flag(session)
     cfg = await get_user_copyright_config(session.did)
     if not cfg:
         return {"deleted": False}

--- a/backend/src/backend/api/tracks/copyright.py
+++ b/backend/src/backend/api/tracks/copyright.py
@@ -25,6 +25,7 @@ from backend._internal.copyright import (
     clear_track_rights,
     write_track_rights,
 )
+from backend.api.copyright import _require_copyright_flag
 from backend.models import Track, get_db
 
 from .router import router
@@ -64,6 +65,7 @@ async def set_track_copyright(
     creates a fresh song + recording on first call, updates existing rkeys on
     subsequent calls. always flips the track into copyright gating.
     """
+    await _require_copyright_flag(auth_session)
     track = await _load_owned_track(db, track_id, auth_session)
     try:
         result = await write_track_rights(auth_session, track, body)
@@ -83,6 +85,7 @@ async def clear_track_copyright(
     auth_session: AuthSession = Depends(require_auth),
 ) -> TrackCopyrightResponse:
     """delete rights records for this track and clear the columns + gate."""
+    await _require_copyright_flag(auth_session)
     track = await _load_owned_track(db, track_id, auth_session)
     await clear_track_rights(auth_session, track)
     return TrackCopyrightResponse(

--- a/backend/tests/api/test_copyright_feature_flag.py
+++ b/backend/tests/api/test_copyright_feature_flag.py
@@ -1,0 +1,166 @@
+"""tests: every /copyright/* and /tracks/{id}/copyright endpoint is gated by
+the `copyright-paradigm` feature flag.
+
+we 404 (not 403) so we don't leak the existence of the rollout to users who
+aren't enrolled — same shape unmounted endpoints have.
+
+also locks `_check_copyright_paradigm` so a user with an extant config row
+but no flag stops getting indiemusi scopes re-requested on every fresh login.
+"""
+
+from collections.abc import Generator
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import Session, enable_flag, require_auth
+from backend._internal.auth.session import _check_copyright_paradigm
+from backend._internal.copyright import upsert_user_copyright_config
+from backend.config import settings
+from backend.main import app
+from backend.models import Artist
+
+_TEST_DID = "did:test:copyright-flag-user"
+
+
+class _MockSession(Session):
+    def __init__(self) -> None:
+        self.did = _TEST_DID
+        self.handle = "flag-user.bsky.social"
+        self.session_id = "test_session_flag"
+        self.access_token = "tok"
+        self.refresh_token = "ref"
+        self.oauth_session = {
+            "did": _TEST_DID,
+            "handle": self.handle,
+            "pds_url": "https://test.pds",
+            "authserver_iss": "https://auth.test",
+            "scope": "atproto",
+            "access_token": "tok",
+            "refresh_token": "ref",
+            "dpop_private_key_pem": "fake",
+            "dpop_authserver_nonce": "",
+            "dpop_pds_nonce": "",
+        }
+
+
+@pytest.fixture
+def auth_app(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
+    async def mock_require_auth() -> Session:
+        return _MockSession()
+
+    app.dependency_overrides[require_auth] = mock_require_auth
+    yield app
+    app.dependency_overrides.clear()
+
+
+# --- endpoint gate ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method,path,body",
+    [
+        ("GET", "/copyright/config", None),
+        (
+            "POST",
+            "/copyright/setup",
+            {
+                "paradigm": "indiemusi-alpha",
+                "publishing_owner": {"firstName": "x", "lastName": "y"},
+            },
+        ),
+        ("POST", "/copyright/disconnect", None),
+        ("POST", "/tracks/9999/copyright", {}),
+        ("DELETE", "/tracks/9999/copyright", None),
+    ],
+)
+async def test_endpoints_404_without_flag(
+    auth_app: FastAPI,
+    db_session: AsyncSession,
+    method: str,
+    path: str,
+    body: dict | None,
+) -> None:
+    """every copyright endpoint returns 404 when the caller lacks the flag.
+
+    404 (not 403) so the rollout boundary isn't leaked to non-enrolled users.
+    """
+    async with AsyncClient(
+        transport=ASGITransport(app=auth_app), base_url="http://test"
+    ) as client:
+        if method == "GET":
+            response = await client.get(path)
+        elif method == "POST":
+            response = await client.post(path, json=body or {})
+        elif method == "DELETE":
+            response = await client.delete(path)
+        else:
+            pytest.fail(f"unexpected method {method}")
+    assert response.status_code == 404
+
+
+async def test_config_passes_through_with_flag(
+    auth_app: FastAPI, db_session: AsyncSession
+) -> None:
+    """gate raises only when the flag is missing — with it set, normal behavior
+    (here: returns null because no config row exists yet)."""
+    await enable_flag(db_session, _TEST_DID, "copyright-paradigm")
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=auth_app), base_url="http://test"
+    ) as client:
+        response = await client.get("/copyright/config")
+    assert response.status_code == 200
+    assert response.json() is None
+
+
+# --- _check_copyright_paradigm gate ----------------------------------------
+
+
+async def test_check_paradigm_false_without_flag(db_session: AsyncSession) -> None:
+    """a user with a copyright config row but no flag must NOT have indiemusi
+    scopes re-requested on their next sign-in — defeats the rollback if we did.
+    """
+    did = "did:test:opted-in-but-unflagged"
+    db_session.add(Artist(did=did, handle="x.example", display_name="X"))
+    await db_session.commit()
+    await upsert_user_copyright_config(
+        did=did,
+        paradigm=settings.indiemusi.paradigm_id,
+        config_uri=None,
+        paradigm_data={"firstName": "x", "lastName": "y"},
+    )
+
+    assert await _check_copyright_paradigm(did) is False
+
+
+async def test_check_paradigm_true_when_both_set(db_session: AsyncSession) -> None:
+    """config row AND flag → re-request indiemusi scopes on login."""
+    did = "did:test:opted-in-and-flagged"
+    db_session.add(Artist(did=did, handle="y.example", display_name="Y"))
+    await db_session.commit()
+    await upsert_user_copyright_config(
+        did=did,
+        paradigm=settings.indiemusi.paradigm_id,
+        config_uri=None,
+        paradigm_data={"firstName": "x", "lastName": "y"},
+    )
+    await enable_flag(db_session, did, "copyright-paradigm")
+    await db_session.commit()
+
+    assert await _check_copyright_paradigm(did) is True
+
+
+async def test_check_paradigm_false_when_only_flag_set(
+    db_session: AsyncSession,
+) -> None:
+    """flag without an opt-in config → no scope re-request (no record to update)."""
+    did = "did:test:flagged-but-not-opted-in"
+    db_session.add(Artist(did=did, handle="z.example", display_name="Z"))
+    await enable_flag(db_session, did, "copyright-paradigm")
+    await db_session.commit()
+
+    assert await _check_copyright_paradigm(did) is False

--- a/backend/tests/api/test_copyright_feature_flag.py
+++ b/backend/tests/api/test_copyright_feature_flag.py
@@ -106,6 +106,11 @@ async def test_config_passes_through_with_flag(
 ) -> None:
     """gate raises only when the flag is missing — with it set, normal behavior
     (here: returns null because no config row exists yet)."""
+    # feature_flags has an FK to artists.did, so we need the row first
+    db_session.add(
+        Artist(did=_TEST_DID, handle="flag-user.example", display_name="Flag User")
+    )
+    await db_session.commit()
     await enable_flag(db_session, _TEST_DID, "copyright-paradigm")
     await db_session.commit()
 

--- a/backend/tests/api/test_copyright_followups.py
+++ b/backend/tests/api/test_copyright_followups.py
@@ -79,7 +79,9 @@ def test_p3_additional_performance_splits_over_100_percent_rejected() -> None:
 
 @pytest.fixture
 async def _user_with_paradigm(db_session: AsyncSession):
-    """seed an artist + copyright config for the test user DID."""
+    """seed an artist + copyright config + feature flag for the test user DID."""
+    from backend._internal import enable_flag
+
     did = "did:test:copyright-user"
     db_session.add(
         Artist(
@@ -99,6 +101,10 @@ async def _user_with_paradigm(db_session: AsyncSession):
             "ipi": "00000000000",
         },
     )
+    # the feature-flag gate now wraps every /copyright/* endpoint; the
+    # endpoint-level tests in this module exercise the in-flag path
+    await enable_flag(db_session, did, "copyright-paradigm")
+    await db_session.commit()
     yield did
     # let the session-scoped cleanup handle teardown
 

--- a/backend/tests/api/test_copyright_setup.py
+++ b/backend/tests/api/test_copyright_setup.py
@@ -52,7 +52,29 @@ class _MockSession(Session):
 
 
 @pytest.fixture
-def app_without_scopes(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
+async def _seed_copyright_flag(db_session: AsyncSession) -> None:
+    """seed Artist + copyright-paradigm flag for the mock session DID.
+
+    every endpoint test in this module exercises the in-flag path; the
+    out-of-flag 404 contract is covered separately in
+    test_copyright_feature_flag.py.
+    """
+    from backend._internal import enable_flag
+    from backend.models import Artist
+
+    did = "did:test:copyright-user"
+    db_session.add(
+        Artist(did=did, handle="copyright-user.bsky.social", display_name="Test")
+    )
+    await db_session.commit()
+    await enable_flag(db_session, did, "copyright-paradigm")
+    await db_session.commit()
+
+
+@pytest.fixture
+def app_without_scopes(
+    db_session: AsyncSession, _seed_copyright_flag: None
+) -> Generator[FastAPI, None, None]:
     """session has no indiemusi scopes — setup should kick off OAuth."""
 
     async def mock_require_auth() -> Session:
@@ -64,7 +86,9 @@ def app_without_scopes(db_session: AsyncSession) -> Generator[FastAPI, None, Non
 
 
 @pytest.fixture
-def app_with_scopes(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
+def app_with_scopes(
+    db_session: AsyncSession, _seed_copyright_flag: None
+) -> Generator[FastAPI, None, None]:
     """session has indiemusi scopes — setup should complete in place."""
 
     indiemusi_scope = " ".join(settings.indiemusi.scope_tokens())

--- a/frontend/src/lib/components/CopyrightRightsPanel.svelte
+++ b/frontend/src/lib/components/CopyrightRightsPanel.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
-	import { API_URL } from '$lib/config';
+	import { API_URL, COPYRIGHT_PARADIGM_FLAG } from '$lib/config';
+	import { auth } from '$lib/auth.svelte';
 	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
+
+	// hide the panel entirely for users without the feature flag. parents
+	// (upload page, edit form) keep rendering normally — they just see no
+	// copyright section in the form.
+	const flagEnabled = $derived(
+		auth.user?.enabled_flags?.includes(COPYRIGHT_PARADIGM_FLAG) ?? false
+	);
 
 	export type TrackRights = {
 		iswc?: string;
@@ -83,6 +91,7 @@
 	});
 </script>
 
+{#if flagEnabled}
 <div class="rights-panel" class:disabled>
 	<label class="enable-row">
 		<input
@@ -187,6 +196,7 @@
 		</p>
 	{/if}
 </div>
+{/if}
 
 <style>
 	.rights-panel {

--- a/frontend/src/lib/components/CopyrightSection.svelte
+++ b/frontend/src/lib/components/CopyrightSection.svelte
@@ -1,7 +1,15 @@
 <script lang="ts">
-	import { API_URL } from '$lib/config';
+	import { API_URL, COPYRIGHT_PARADIGM_FLAG } from '$lib/config';
 	import { toast } from '$lib/toast.svelte';
+	import { auth } from '$lib/auth.svelte';
 	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
+
+	// hide the entire section for users who don't have the copyright-paradigm
+	// feature flag. backend endpoints 404 for unflagged users too, so even a
+	// devtools poke wouldn't see anything useful.
+	const flagEnabled = $derived(
+		auth.user?.enabled_flags?.includes(COPYRIGHT_PARADIGM_FLAG) ?? false
+	);
 
 	type PublishingOwner = {
 		ipi?: string;
@@ -186,10 +194,11 @@
 	}
 
 	$effect(() => {
-		fetchConfig();
+		if (flagEnabled) fetchConfig();
 	});
 </script>
 
+{#if flagEnabled}
 <section class="copyright-section">
 	<div class="section-header">
 		<h2>copyright</h2>
@@ -362,6 +371,7 @@
 		</form>
 	{/if}
 </section>
+{/if}
 
 <style>
 	.copyright-section {

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -4,6 +4,7 @@ export const API_URL = PUBLIC_API_URL || 'http://localhost:8001';
 export const TYPEAHEAD_URL = 'https://typeahead.waow.tech';
 
 export const VIBE_SEARCH_FLAG = 'vibe-search';
+export const COPYRIGHT_PARADIGM_FLAG = 'copyright-paradigm';
 
 /**
  * generate atprotofans support URL for an artist.

--- a/loq.toml
+++ b/loq.toml
@@ -292,7 +292,7 @@ max_lines = 513
 
 [[rules]]
 path = "frontend/src/lib/components/CopyrightSection.svelte"
-max_lines = 645
+max_lines = 655
 
 [[rules]]
 path = "backend/tests/api/test_copyright_followups.py"

--- a/loq.toml
+++ b/loq.toml
@@ -296,4 +296,4 @@ max_lines = 655
 
 [[rules]]
 path = "backend/tests/api/test_copyright_followups.py"
-max_lines = 570
+max_lines = 576


### PR DESCRIPTION
lets the merged copyright code (phases 1-3 plus all fixes — already in main) ship to prod dormant. flag-enrolled users see the full UX; everyone else gets a 404 on the API and a hidden frontend section — same shape they'd see for any unmounted feature.

mirrors the existing `vibe-search` flag pattern exactly.

## backend

- `KNOWN_FLAGS` adds `copyright-paradigm` alongside `vibe-search`
- new `_require_copyright_flag(session)` guard in `api/copyright.py` — applied to every `/copyright/*` endpoint and to `POST` + `DELETE /tracks/{id}/copyright`
- `_check_copyright_paradigm` (the login-time scope-extension probe) now requires BOTH the config row AND the flag. without this, a user opted in pre-rollout would keep re-requesting indiemusi scopes on every fresh login even after we'd disabled the feature for them — defeats the rollback path
- 404 (not 403) so the rollout boundary isn't leaked to non-enrolled users

## frontend

- `COPYRIGHT_PARADIGM_FLAG` const in `lib/config.ts`
- `CopyrightSection` only renders and only fetches `/copyright/config` when the flag is set (no spurious 404 spans on portal loads for unenrolled users)
- `CopyrightRightsPanel` returns null without the flag — parents (upload + edit forms) just see no copyright panel

## tests (`test_copyright_feature_flag.py`)

- parametrized 404 across every `/copyright/*` and `/tracks/{id}/copyright` endpoint when the flag is missing
- passes-through confirmation when the flag is set
- three cases pinning `_check_copyright_paradigm` semantics: false without flag, true with both, false when flag-only-no-row

## rollout

1. land this PR
2. release to prod (\`just release\`) — feature is dormant
3. enable flag for own DID via the admin script (\`uv run scripts/enable_flag.py did:plc:xbtmt2zjwlrfegqvch7fboei copyright-paradigm\`)
4. dogfood on prod with real account
5. broaden — enable for partner accounts (Hilke, others), then flip on for all when ready
6. when ready, drop the flag check entirely

## follow-up

#1409 (publishingOwner record manager — currently open) introduces new endpoints (\`/copyright/publishing-owners\`, \`/copyright/use-owner\`) that aren't yet covered by this gate. once #1409 merges, a small rebase will apply \`_require_copyright_flag\` to those too. Doing that as a follow-up rather than coordinating two open branches.

## test plan
- [x] 9 tests collect + lint + type-check
- [ ] CI green
- [ ] manual: hit `/copyright/config` on prod as an unflagged user, expect 404; enable flag, expect 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)