### PR TITLE
fix(copyright): disconnect is DB-only; use-owner tolerates unknown fields

### DIFF
--- a/backend/src/backend/_internal/copyright.py
+++ b/backend/src/backend/_internal/copyright.py
@@ -19,6 +19,7 @@ from backend._internal.atproto.client import parse_at_uri
 from backend._internal.atproto.records.ch_indiemusi import (
     ISRC_PATTERN,
     ISWC_PATTERN,
+    KNOWN_OWNER_KEYS,
     InterestedPartyInput,
     MasterOwnerInput,
     PublishingOwnerInput,
@@ -294,11 +295,15 @@ async def use_owner_for_user(auth_session: AuthSession, uri: str) -> dict[str, A
     if not isinstance(fresh_value, dict):
         raise ValueError(f"PDS returned non-dict record value for {uri}")
 
-    # cache the modeled subset for prefill / summary — but only fields we
-    # recognize. anything else lives only on PDS, fetched fresh on edit.
-    parsed = PublishingOwnerInput.model_validate(
-        {k: v for k, v in fresh_value.items() if k != "$type"}
-    )
+    # cache the modeled subset for prefill / summary. extract only keys plyr
+    # models — anything else (other clients' fields, future lexicon extensions)
+    # lives only on PDS and is preserved on edit via merge_publishing_owner_for_put.
+    # passing the full record body to PublishingOwnerInput would 400 on records
+    # written by other clients, since the model is `extra="forbid"`.
+    known_only = {
+        k: v for k, v in fresh_value.items() if k in KNOWN_OWNER_KEYS and k != "$type"
+    }
+    parsed = PublishingOwnerInput.model_validate(known_only)
     modeled = parsed.model_dump(by_alias=True, exclude_none=True)
 
     await upsert_user_copyright_config(

--- a/backend/src/backend/api/copyright.py
+++ b/backend/src/backend/api/copyright.py
@@ -10,7 +10,6 @@ load what's already there, let the user pick or extend, never silently
 clobber records other clients may have written.
 """
 
-import logging
 from typing import Annotated, Any
 
 from atproto_oauth.scopes import ScopesSet
@@ -30,7 +29,6 @@ from backend._internal.atproto.records.ch_indiemusi import (
     PublishingOwnerInput,
     list_publishing_owner_records,
 )
-from backend._internal.atproto.records.fm_plyr.track import delete_record_by_uri
 from backend._internal.copyright import (
     create_owner_for_user,
     delete_owner_for_user,
@@ -42,8 +40,6 @@ from backend._internal.copyright import (
 from backend.config import settings
 from backend.models import Track
 from backend.utilities.database import db_session
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/copyright", tags=["copyright"])
 
@@ -386,12 +382,18 @@ async def use_publishing_owner(
 async def disconnect(
     session: Session = Depends(require_auth),
 ) -> dict[str, bool]:
-    """delete the user's copyright config and best-effort delete the PDS record.
+    """clear the user's local copyright config row.
 
     refuses with 409 when the user still has tracks carrying rights metadata —
     those would be left orphaned (gated, with no paradigm config to update or
     clear them through). users must clear each via DELETE /tracks/{id}/copyright
     before disconnecting.
+
+    DB-only: the user's PDS publishingOwner records are NOT touched. after
+    #1409, `config_uri` can reference a record authored by another client (the
+    "link" path of the record manager); deleting it here would silently destroy
+    data plyr never owned. explicit PDS deletion is the record manager's
+    DELETE /publishing-owners/{rkey} only.
     """
     await _require_copyright_flag(session)
     cfg = await get_user_copyright_config(session.did)
@@ -422,18 +424,6 @@ async def disconnect(
                 ],
             ).model_dump(),
         )
-
-    if cfg.config_uri:
-        try:
-            await delete_record_by_uri(session, cfg.config_uri)
-        except Exception as e:
-            # best-effort — we still want to clear the local row even if PDS write fails
-            logger.warning(
-                "failed to delete PDS record %s for %s: %s",
-                cfg.config_uri,
-                session.did,
-                e,
-            )
 
     await delete_user_copyright_config(session.did)
     return {"deleted": True}

--- a/backend/tests/api/test_copyright_feature_flag.py
+++ b/backend/tests/api/test_copyright_feature_flag.py
@@ -59,10 +59,16 @@ def auth_app(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
 # --- endpoint gate ---------------------------------------------------------
 
 
+_OWNER_BODY = {
+    "publishing_owner": {"firstName": "x", "lastName": "y"},
+}
+
+
 @pytest.mark.parametrize(
     "method,path,body",
     [
         ("GET", "/copyright/config", None),
+        # legacy alias still gated
         (
             "POST",
             "/copyright/setup",
@@ -71,7 +77,18 @@ def auth_app(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
                 "publishing_owner": {"firstName": "x", "lastName": "y"},
             },
         ),
+        # record manager (added in #1409)
+        ("GET", "/copyright/publishing-owners", None),
+        ("POST", "/copyright/publishing-owners", _OWNER_BODY),
+        ("PUT", "/copyright/publishing-owners/abc", _OWNER_BODY),
+        ("DELETE", "/copyright/publishing-owners/abc", None),
+        (
+            "POST",
+            "/copyright/use-owner",
+            {"uri": "at://did:test:x/ch.indiemusi.alpha.actor.publishingOwner/abc"},
+        ),
         ("POST", "/copyright/disconnect", None),
+        # per-track copyright endpoints
         ("POST", "/tracks/9999/copyright", {}),
         ("DELETE", "/tracks/9999/copyright", None),
     ],
@@ -94,6 +111,8 @@ async def test_endpoints_404_without_flag(
             response = await client.get(path)
         elif method == "POST":
             response = await client.post(path, json=body or {})
+        elif method == "PUT":
+            response = await client.put(path, json=body or {})
         elif method == "DELETE":
             response = await client.delete(path)
         else:

--- a/backend/tests/api/test_copyright_followups.py
+++ b/backend/tests/api/test_copyright_followups.py
@@ -504,11 +504,45 @@ async def test_p1_2_disconnect_409_when_copyright_tracks_exist(
 async def test_p1_2_disconnect_proceeds_when_no_copyright_tracks(
     auth_app: FastAPI, _user_with_paradigm: str, db_session: AsyncSession
 ) -> None:
-    # no tracks with copyright_song_uri set
+    """disconnect clears the local config row and does NOT touch PDS.
+
+    after the post-#1409 review, /copyright/disconnect is DB-only:
+    `config_uri` may reference a record authored by another client (the
+    "link" path of the record manager), so we never delete from PDS on
+    disconnect. explicit PDS deletion is the record manager's
+    DELETE /publishing-owners/{rkey} only.
+    """
+    async with AsyncClient(
+        transport=ASGITransport(app=auth_app), base_url="http://test"
+    ) as client:
+        response = await client.post("/copyright/disconnect")
+
+    assert response.status_code == 200
+    assert response.json() == {"deleted": True}
+
+    cfg = (
+        await db_session.execute(
+            select(UserCopyrightConfig).where(
+                UserCopyrightConfig.user_did == _user_with_paradigm
+            )
+        )
+    ).scalar_one_or_none()
+    assert cfg is None
+
+
+async def test_p1_2_disconnect_does_not_touch_pds(
+    auth_app: FastAPI, _user_with_paradigm: str, db_session: AsyncSession
+) -> None:
+    """regression: disconnect must not call any PDS delete helper.
+
+    pre-fix, `delete_record_by_uri` was best-effort called on `config_uri`.
+    after #1409 a linked record may be owned by another client; deleting it
+    here would silently destroy data plyr never wrote.
+    """
     with patch(
-        "backend.api.copyright.delete_record_by_uri",
+        "backend._internal.atproto.records.fm_plyr.track.delete_record_by_uri",
         new_callable=AsyncMock,
-    ):
+    ) as mock_delete:
         async with AsyncClient(
             transport=ASGITransport(app=auth_app), base_url="http://test"
         ) as client:
@@ -516,6 +550,7 @@ async def test_p1_2_disconnect_proceeds_when_no_copyright_tracks(
 
     assert response.status_code == 200
     assert response.json() == {"deleted": True}
+    mock_delete.assert_not_called()
 
 
 # --- P2.2: supporter probe skips copyright-typed gates -----------------------
@@ -574,3 +609,61 @@ async def test_p2_2_listing_skips_supporter_probe_for_copyright(
             response = await client.get("/tracks/")
         assert response.status_code == 200
         mock_probe.assert_not_called()
+
+
+# --- post-#1409 review: use-owner tolerates unknown fields -------------------
+
+
+async def test_use_owner_accepts_records_with_unknown_fields(
+    _user_with_paradigm: str, db_session: AsyncSession
+) -> None:
+    """regression: linking to a record that carries fields plyr doesn't model
+    (other clients' extensions, future lexicon additions) must NOT 400.
+
+    pre-fix, `use_owner_for_user` round-tripped the full fetched record body
+    through `PublishingOwnerInput.model_validate`, which is `extra="forbid"` —
+    so any record with `taxId`, `notes`, or any other foreign key would reject
+    here, exactly the interop case the record manager exists to support.
+    """
+    from backend._internal.copyright import (
+        get_user_copyright_config,
+        use_owner_for_user,
+    )
+
+    did = _user_with_paradigm
+    uri = f"at://{did}/{settings.indiemusi.publishing_owner_collection}/withextras"
+    fetched = {
+        "uri": uri,
+        "value": {
+            "$type": settings.indiemusi.publishing_owner_collection,
+            "firstName": "Hilke",
+            "lastName": "Ros",
+            "ipi": "01145982828",
+            "collectingSociety": "Suisa",
+            # foreign fields plyr doesn't model — must not cause a 400
+            "taxId": "CHE-123.456.789",
+            "notes": "primary identity for solo work",
+        },
+    }
+
+    sess = _fake_session(did)
+    with patch(
+        "backend._internal.copyright.get_publishing_owner_record",
+        new_callable=AsyncMock,
+    ) as mock_get:
+        mock_get.return_value = fetched
+        modeled = await use_owner_for_user(sess, uri)
+
+    # modeled cache contains only known keys (camelCase aliases)
+    assert modeled == {
+        "firstName": "Hilke",
+        "lastName": "Ros",
+        "ipi": "01145982828",
+        "collectingSociety": "Suisa",
+    }
+    assert "taxId" not in modeled
+    assert "notes" not in modeled
+
+    cfg = await get_user_copyright_config(did)
+    assert cfg is not None
+    assert cfg.config_uri == uri

--- a/backend/tests/api/test_copyright_followups.py
+++ b/backend/tests/api/test_copyright_followups.py
@@ -26,7 +26,9 @@ from backend._internal import Session, require_auth
 from backend._internal.copyright import (
     TrackRightsInput,
     clear_track_rights,
+    get_user_copyright_config,
     upsert_user_copyright_config,
+    use_owner_for_user,
     write_track_rights,
 )
 from backend.config import settings
@@ -625,11 +627,6 @@ async def test_use_owner_accepts_records_with_unknown_fields(
     so any record with `taxId`, `notes`, or any other foreign key would reject
     here, exactly the interop case the record manager exists to support.
     """
-    from backend._internal.copyright import (
-        get_user_copyright_config,
-        use_owner_for_user,
-    )
-
     did = _user_with_paradigm
     uri = f"at://{did}/{settings.indiemusi.publishing_owner_collection}/withextras"
     fetched = {

--- a/loq.toml
+++ b/loq.toml
@@ -296,8 +296,8 @@ max_lines = 800
 
 [[rules]]
 path = "backend/tests/api/test_copyright_followups.py"
-max_lines = 576
+max_lines = 669
 
 [[rules]]
 path = "backend/src/backend/_internal/copyright.py"
-max_lines = 644
+max_lines = 649


### PR DESCRIPTION
## Summary

Three follow-ups from codex's post-#1409 review:

- **P1 — disconnect (release blocker)**: `/copyright/disconnect` no longer deletes the PDS `publishingOwner` record. After #1409, `config_uri` may reference a record authored by another client (the "link" path of the record manager); the prior best-effort delete on disconnect would silently destroy data plyr never wrote. Explicit PDS deletion is now the record manager's `DELETE /publishing-owners/{rkey}` only.
- **P2 — use-owner unknown fields**: `use_owner_for_user` now filters the fetched record body to `KNOWN_OWNER_KEYS` before `PublishingOwnerInput.model_validate`. The model is `extra="forbid"`, so any record carrying foreign fields (other clients' extensions, future lexicon additions) was previously 400 — exactly the interop case the record manager exists to support.
- **P3 — feature-flag coverage**: the 404 parametrize in `test_copyright_feature_flag.py` now covers every new endpoint added in #1409 (`/publishing-owners` CRUD + `/use-owner`), so the flag gate is regression-locked across the whole surface.

## Test plan

- [x] `ruff check` / `ruff format` / `ty check` clean
- [x] `loq` limits raised by `uvx loq relax` (not hand-edited)
- [ ] CI green
- New regression tests:
  - `test_p1_2_disconnect_does_not_touch_pds` — asserts disconnect makes no PDS-delete call
  - `test_use_owner_accepts_records_with_unknown_fields` — covers the `taxId` / `notes` interop case end-to-end through `use_owner_for_user`
  - Existing `test_p1_2_disconnect_proceeds_when_no_copyright_tracks` updated to assert the local config row is cleared (and no PDS call is needed)
  - Flag-gate parametrize now also exercises `GET/POST /copyright/publishing-owners`, `PUT/DELETE /copyright/publishing-owners/{rkey}`, `POST /copyright/use-owner`

cc @zzstoatzz — follows up on the review of #1409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)