### PR TITLE
fix(storage): type R2 keys so save/read extension drift becomes unrepresentable

### DIFF
--- a/backend/src/backend/_internal/audio.py
+++ b/backend/src/backend/_internal/audio.py
@@ -69,6 +69,17 @@ class AudioFormat(str, Enum):
         return [f.extension for f in cls]
 
     @classmethod
+    def all_stored_extensions(cls) -> tuple[str, ...]:
+        """every extension we might find in R2, INCLUDING aliases.
+
+        used by fallback-scan paths that probe storage when the extension
+        isn't known up front. iterating `AudioFormat` directly would miss
+        `.aif` (it shares an enum member with `.aiff`) — that's how stuck
+        `.aif` blobs become invisible to cleanup. always probe both.
+        """
+        return ("mp3", "wav", "m4a", "aif", "aiff", "flac", "webm", "ogg")
+
+    @classmethod
     def supported_extensions_str(cls) -> str:
         """get formatted string of supported extensions."""
         return ", ".join(cls.all_extensions())

--- a/backend/src/backend/_internal/export_tasks.py
+++ b/backend/src/backend/_internal/export_tasks.py
@@ -21,6 +21,7 @@ from backend.config import settings
 from backend.models import Track
 from backend.models.job import JobStatus
 from backend.storage import storage
+from backend.storage.keys import AudioKey, InvalidMediaExtension
 from backend.storage.r2 import UploadProgressTracker
 from backend.utilities.database import db_session
 from backend.utilities.progress import R2ProgressTracker
@@ -104,10 +105,22 @@ async def process_export(export_id: str, artist_did: str) -> None:
                     if c.isalnum() or c in (" ", ".", "-", "_", "(", ")")
                 )
 
+                # route through the typed-key path: same R2 key derivation
+                # as every other read/write site. see backend/storage/keys.py.
+                try:
+                    audio_key = AudioKey.for_file(export_file_id, export_file_type)
+                except InvalidMediaExtension:
+                    logfire.warn(
+                        "skipping track: unsupported file_type for export",
+                        track_id=track.id,
+                        file_type=export_file_type,
+                    )
+                    continue
+
                 track_info.append(
                     {
                         "track": track,
-                        "key": f"audio/{export_file_id}.{export_file_type}",
+                        "key": audio_key.key,
                         "filename": filename,
                         "temp_path": temp_path / filename,
                     }

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -3,10 +3,9 @@
 import asyncio
 import logging
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Annotated, Literal, cast
+from typing import Annotated, Literal
 
 import logfire
-from botocore.exceptions import ClientError
 from fastapi import Depends, HTTPException, Query
 from pydantic import BaseModel
 from redis.exceptions import RedisError
@@ -16,7 +15,6 @@ from sqlalchemy.orm import selectinload
 
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session, get_supported_artists, require_auth
-from backend._internal.audio import AudioFormat
 from backend.config import settings
 from backend.models import (
     Artist,
@@ -43,10 +41,6 @@ from .constants import DISCOVERY_CACHE_KEY, DISCOVERY_CACHE_TTL_SECONDS
 from .router import router
 
 logger = logging.getLogger(__name__)
-
-
-if TYPE_CHECKING:
-    from backend.storage.r2 import R2Storage
 
 
 class TracksListResponse(BaseModel):
@@ -568,20 +562,13 @@ async def get_my_file_sizes(
     sizes: dict[int, int] = {}
 
     async def get_size(track_id: int, file_id: str, file_type: str) -> None:
-        audio_format = AudioFormat.from_extension(file_type)
-        if not audio_format:
-            return
-        key = f"audio/{file_id}{audio_format.extension}"
-        r2 = cast("R2Storage", storage)
+        # routes through the typed-key path: head_file builds the R2 key via
+        # AudioKey.for_file(file_id, file_type), so this endpoint can't drift
+        # from how save() wrote the object. see backend/storage/keys.py.
         async with semaphore:
-            try:
-                async with r2._s3_client() as client:
-                    response = await client.head_object(
-                        Bucket=storage.audio_bucket_name, Key=key
-                    )
-                    sizes[track_id] = response["ContentLength"]
-            except ClientError:
-                pass  # file not found or other error — skip
+            size = await storage.head_file(file_id, file_type)
+        if size is not None:
+            sizes[track_id] = size
 
     await asyncio.gather(
         *(

--- a/backend/src/backend/storage/keys.py
+++ b/backend/src/backend/storage/keys.py
@@ -1,0 +1,112 @@
+"""typed R2 keys for audio and image objects.
+
+every R2 read/write/delete in r2.py routes through one of these two types.
+the dataclass constructor validates the extension against AudioFormat /
+ImageFormat and stores the raw filename extension (not a canonical /
+normalized form) so a `.aif` upload reads back via `.aif`, a `.jpeg` via
+`.jpeg`, etc. save and read share the same key because they share the
+same type — there is no second path that can disagree.
+
+historical context: this exists because the same save/read extension-drift
+bug shipped in #332, #797, #849, #1202, and woody.fm 2026-05-16 — each
+fix touched one side and missed the other. typing the key makes the bug
+unrepresentable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+from backend._internal.audio import AudioFormat
+from backend._internal.image import ImageFormat
+
+
+class InvalidMediaExtension(ValueError):
+    """raised when a key is constructed with an extension we don't store."""
+
+
+def _strip_ext(raw: str) -> str:
+    return raw.lower().lstrip(".")
+
+
+@dataclass(frozen=True, slots=True)
+class AudioKey:
+    """R2 key for an audio object stored under `audio/<file_id>.<ext>`.
+
+    construct via `from_filename` at upload time or `for_file` when
+    rehydrating from `(file_id, file_type)` stored in the database. both
+    paths validate the extension against `AudioFormat`, so an unsupported
+    extension never reaches R2.
+    """
+
+    file_id: str
+    extension: str
+
+    def __post_init__(self) -> None:
+        if not self.file_id:
+            raise InvalidMediaExtension("file_id is required")
+        if AudioFormat.from_extension(self.extension) is None:
+            raise InvalidMediaExtension(
+                f"unsupported audio extension: {self.extension!r} "
+                f"(supported: {AudioFormat.supported_extensions_str()})"
+            )
+
+    @classmethod
+    def from_filename(cls, file_id: str, filename: str) -> AudioKey:
+        """build from a user-supplied filename (validates the suffix)."""
+        return cls(file_id=file_id, extension=_strip_ext(PurePosixPath(filename).suffix))
+
+    @classmethod
+    def for_file(cls, file_id: str, file_type: str) -> AudioKey:
+        """build from `(file_id, file_type)` as stored in the tracks table."""
+        return cls(file_id=file_id, extension=_strip_ext(file_type))
+
+    @property
+    def key(self) -> str:
+        return f"audio/{self.file_id}.{self.extension}"
+
+    @property
+    def format(self) -> AudioFormat:
+        # validated in __post_init__, so this can't return None
+        return AudioFormat.from_extension(self.extension)  # type: ignore[return-value]
+
+
+@dataclass(frozen=True, slots=True)
+class ImageKey:
+    """R2 key for an image object stored under `images/<file_id>.<ext>`.
+
+    image extensions are preserved as-uploaded — `.jpg` and `.jpeg` produce
+    distinct keys (matching #1202's resolution). construct via
+    `from_filename` at upload time or `for_file` when rehydrating.
+    """
+
+    file_id: str
+    extension: str
+
+    def __post_init__(self) -> None:
+        if not self.file_id:
+            raise InvalidMediaExtension("file_id is required")
+        try:
+            ImageFormat(self.extension)
+        except ValueError as exc:
+            supported = ", ".join(sorted(f.value for f in ImageFormat))
+            raise InvalidMediaExtension(
+                f"unsupported image extension: {self.extension!r} (supported: {supported})"
+            ) from exc
+
+    @classmethod
+    def from_filename(cls, file_id: str, filename: str) -> ImageKey:
+        return cls(file_id=file_id, extension=_strip_ext(PurePosixPath(filename).suffix))
+
+    @classmethod
+    def for_file(cls, file_id: str, file_type: str) -> ImageKey:
+        return cls(file_id=file_id, extension=_strip_ext(file_type))
+
+    @property
+    def key(self) -> str:
+        return f"images/{self.file_id}.{self.extension}"
+
+    @property
+    def format(self) -> ImageFormat:
+        return ImageFormat(self.extension)

--- a/backend/src/backend/storage/keys.py
+++ b/backend/src/backend/storage/keys.py
@@ -55,7 +55,9 @@ class AudioKey:
     @classmethod
     def from_filename(cls, file_id: str, filename: str) -> AudioKey:
         """build from a user-supplied filename (validates the suffix)."""
-        return cls(file_id=file_id, extension=_strip_ext(PurePosixPath(filename).suffix))
+        return cls(
+            file_id=file_id, extension=_strip_ext(PurePosixPath(filename).suffix)
+        )
 
     @classmethod
     def for_file(cls, file_id: str, file_type: str) -> AudioKey:
@@ -97,7 +99,9 @@ class ImageKey:
 
     @classmethod
     def from_filename(cls, file_id: str, filename: str) -> ImageKey:
-        return cls(file_id=file_id, extension=_strip_ext(PurePosixPath(filename).suffix))
+        return cls(
+            file_id=file_id, extension=_strip_ext(PurePosixPath(filename).suffix)
+        )
 
     @classmethod
     def for_file(cls, file_id: str, file_type: str) -> ImageKey:

--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -17,6 +17,7 @@ from backend._internal.audio import AudioFormat
 from backend._internal.image import ImageFormat
 from backend.config import settings
 from backend.models.track import Track
+from backend.storage.keys import AudioKey, ImageKey, InvalidMediaExtension
 from backend.utilities.database import db_session
 from backend.utilities.hashing import hash_file_chunked
 
@@ -143,33 +144,34 @@ class R2Storage:
         filename: str,
         progress_callback: Callable[[float], None] | None = None,
     ) -> str:
-        """save media file to R2 using streaming upload with chunked hashing."""
+        """save media file to R2 using streaming upload with chunked hashing.
+
+        the destination key is derived from a typed `AudioKey` / `ImageKey`
+        constructed from the filename — every reader uses the same type, so
+        save and read can't disagree about the extension.
+        """
         with logfire.span("R2 save", filename=filename):
             # compute hash in chunks (constant memory)
             file_id = hash_file_chunked(file)[:16]
             logfire.info("computed file hash", file_id=file_id)
 
-            # determine file extension and type
-            ext = Path(filename).suffix.lower()
-
-            # try audio format first
-            audio_format = AudioFormat.from_extension(ext)
-            if audio_format:
-                key = f"audio/{file_id}{ext}"
-                media_type = audio_format.media_type
+            # determine file extension and type via the typed key constructors
+            try:
+                audio_key = AudioKey.from_filename(file_id, filename)
+                key = audio_key.key
+                media_type = audio_key.format.media_type
                 image_format = None
-            else:
-                # try image format
+            except InvalidMediaExtension as exc:
                 image_format, is_valid = ImageFormat.validate_and_extract(filename)
-                if is_valid and image_format:
-                    key = f"images/{file_id}{ext}"
-                    media_type = image_format.media_type
-                else:
+                if not (is_valid and image_format):
                     raise ValueError(
-                        f"unsupported file type: {ext}. "
+                        f"unsupported file type: {Path(filename).suffix}. "
                         f"supported audio: {AudioFormat.supported_extensions_str()}, "
                         f"supported image: jpg, jpeg, png, webp, gif"
-                    )
+                    ) from exc
+                image_key = ImageKey.from_filename(file_id, filename)
+                key = image_key.key
+                media_type = image_format.media_type
 
             # get file size for progress tracking
             # file pointer already reset by hash_file_chunked
@@ -243,33 +245,32 @@ class R2Storage:
             async with self._s3_client() as client:
                 # if file_type is "image", skip audio checks
                 if file_type != "image":
-                    # if extension is provided, try single format
                     if extension:
-                        # normalize extension (remove leading dot if present)
-                        ext = extension.lstrip(".")
-                        key = f"audio/{file_id}.{ext}"
-
                         try:
-                            await client.head_object(
-                                Bucket=self.audio_bucket_name, Key=key
-                            )
-                            return f"{self.public_audio_bucket_url}/{key}"
-                        except client.exceptions.NoSuchKey:
-                            # if specific extension not found, fall through to None
+                            audio_key = AudioKey.for_file(file_id, extension)
+                        except InvalidMediaExtension:
                             if file_type == "audio":
                                 return None
-                        except ClientError as e:
-                            if e.response.get("Error", {}).get("Code") == "404":
+                        else:
+                            key = audio_key.key
+                            try:
+                                await client.head_object(
+                                    Bucket=self.audio_bucket_name, Key=key
+                                )
+                                return f"{self.public_audio_bucket_url}/{key}"
+                            except client.exceptions.NoSuchKey:
                                 if file_type == "audio":
                                     return None
-                            else:
-                                raise
-
-                    # fallback: try all audio formats
+                            except ClientError as e:
+                                if e.response.get("Error", {}).get("Code") == "404":
+                                    if file_type == "audio":
+                                        return None
+                                else:
+                                    raise
                     else:
-                        for audio_format in AudioFormat:
-                            key = f"audio/{file_id}{audio_format.extension}"
-
+                        # probe every stored extension (including .aif/.aiff aliases)
+                        for ext in AudioFormat.all_stored_extensions():
+                            key = AudioKey.for_file(file_id, ext).key
                             try:
                                 await client.head_object(
                                     Bucket=self.audio_bucket_name, Key=key
@@ -282,14 +283,12 @@ class R2Storage:
                                     continue
                                 raise
 
-                    # if explicitly looking for audio, stop here
                     if file_type == "audio":
                         return None
 
                 # try image formats
                 for image_format in ImageFormat:
-                    key = f"images/{file_id}.{image_format.value}"
-
+                    key = ImageKey.for_file(file_id, image_format.value).key
                     try:
                         await client.head_object(Bucket=self.image_bucket_name, Key=key)
                         return f"{self.public_image_bucket_url}/{key}"
@@ -318,17 +317,15 @@ class R2Storage:
         """
         with logfire.span("R2 get_file_data", file_id=file_id, file_type=file_type):
             async with self._s3_client() as client:
-                # build key from file_id and file_type
-                audio_format = AudioFormat.from_extension(f".{file_type.lower()}")
-                if not audio_format:
+                try:
+                    key = AudioKey.for_file(file_id, file_type).key
+                except InvalidMediaExtension:
                     logfire.warning(
                         "unsupported file type for get_file_data",
                         file_id=file_id,
                         file_type=file_type,
                     )
                     return None
-
-                key = f"audio/{file_id}{audio_format.extension}"
 
                 try:
                     response = await client.get_object(
@@ -369,15 +366,15 @@ class R2Storage:
         cancel; partial iteration leaves the connection to be torn down by
         gc, which is correct but noisier than explicit close.
         """
-        audio_format = AudioFormat.from_extension(f".{file_type.lower()}")
-        if not audio_format:
+        try:
+            key = AudioKey.for_file(file_id, file_type).key
+        except InvalidMediaExtension:
             logfire.warning(
                 "unsupported file type for stream_file_data",
                 file_id=file_id,
                 file_type=file_type,
             )
             return
-        key = f"audio/{file_id}{audio_format.extension}"
 
         with logfire.span(
             "R2 stream_file_data",
@@ -407,10 +404,10 @@ class R2Storage:
         file_type: str,
     ) -> int | None:
         """return the byte size of an audio object via HEAD, or None if missing."""
-        audio_format = AudioFormat.from_extension(f".{file_type.lower()}")
-        if not audio_format:
+        try:
+            key = AudioKey.for_file(file_id, file_type).key
+        except InvalidMediaExtension:
             return None
-        key = f"audio/{file_id}{audio_format.extension}"
         async with self._s3_client() as client:
             try:
                 response = await client.head_object(
@@ -470,13 +467,13 @@ class R2Storage:
         async with self._s3_client() as client:
             # if file_type is provided, delete the exact key
             if file_type:
-                audio_format = AudioFormat.from_extension(f".{file_type.lower()}")
-                if audio_format:
-                    key = f"audio/{file_id}{audio_format.extension}"
+                try:
+                    key = AudioKey.for_file(file_id, file_type).key
+                except InvalidMediaExtension:
+                    key = None
+                if key is not None:
                     try:
-                        # check if object exists first
                         await client.head_object(Bucket=self.audio_bucket_name, Key=key)
-                        # object exists, delete it
                         await client.delete_object(
                             Bucket=self.audio_bucket_name, Key=key
                         )
@@ -497,14 +494,11 @@ class R2Storage:
                         )
                         return False
 
-            # fallback: try audio formats (for legacy rows or when file_type is None)
-            for audio_format in AudioFormat:
-                key = f"audio/{file_id}{audio_format.extension}"
-
+            # fallback: probe every stored audio extension (incl. .aif/.aiff aliases)
+            for ext in AudioFormat.all_stored_extensions():
+                key = AudioKey.for_file(file_id, ext).key
                 try:
-                    # check if object exists first
                     await client.head_object(Bucket=self.audio_bucket_name, Key=key)
-                    # object exists, delete it
                     await client.delete_object(Bucket=self.audio_bucket_name, Key=key)
                     logfire.info(
                         "R2 file deleted",
@@ -514,7 +508,6 @@ class R2Storage:
                     )
                     return True
                 except client.exceptions.ClientError as e:
-                    # object doesn't exist or delete failed, try next format
                     logfire.debug(
                         "R2 delete failed for format",
                         file_id=file_id,
@@ -525,12 +518,9 @@ class R2Storage:
 
             # try image formats
             for image_format in ImageFormat:
-                key = f"images/{file_id}.{image_format.value}"
-
+                key = ImageKey.for_file(file_id, image_format.value).key
                 try:
-                    # check if object exists first
                     await client.head_object(Bucket=self.image_bucket_name, Key=key)
-                    # object exists, delete it
                     await client.delete_object(Bucket=self.image_bucket_name, Key=key)
                     logfire.info(
                         "R2 image deleted",
@@ -540,7 +530,6 @@ class R2Storage:
                     )
                     return True
                 except client.exceptions.ClientError as e:
-                    # object doesn't exist or delete failed, try next format
                     logfire.debug(
                         "R2 delete failed for image format",
                         file_id=file_id,
@@ -565,17 +554,17 @@ class R2Storage:
         wasted round trips). the image URL already encodes the correct
         extension, so we can build the key directly.
         """
-        # extract extension from URL: ".../images/abc123.png?..." → ".png"
-        ext = PurePosixPath(image_url.split("?")[0]).suffix.lower()
-        if not ext:
+        # extract extension from URL: ".../images/abc123.png?..." → "png"
+        ext = PurePosixPath(image_url.split("?")[0]).suffix.lower().lstrip(".")
+        try:
+            key = ImageKey.for_file(file_id, ext).key
+        except InvalidMediaExtension:
             logfire.warning(
-                "delete_image: could not extract extension from URL, falling back",
+                "delete_image: could not derive image key from URL, falling back",
                 file_id=file_id,
                 image_url=image_url,
             )
             return await self.delete(file_id)
-
-        key = f"images/{file_id}{ext}"
         async with self._s3_client() as client:
             try:
                 await client.delete_object(Bucket=self.image_bucket_name, Key=key)
@@ -610,17 +599,18 @@ class R2Storage:
             file_id = hash_file_chunked(file)[:16]
             logfire.info("computed file hash for gated content", file_id=file_id)
 
-            # determine file extension - only audio supported for gated content
-            ext = Path(filename).suffix.lower()
-            audio_format = AudioFormat.from_extension(ext)
-            if not audio_format:
+            # only audio is supported for gated content
+            try:
+                audio_key = AudioKey.from_filename(file_id, filename)
+            except InvalidMediaExtension as exc:
                 raise ValueError(
-                    f"unsupported audio type for gated content: {ext}. "
+                    f"unsupported audio type for gated content: "
+                    f"{Path(filename).suffix}. "
                     f"supported: {AudioFormat.supported_extensions_str()}"
-                )
+                ) from exc
 
-            key = f"audio/{file_id}{ext}"
-            media_type = audio_format.media_type
+            key = audio_key.key
+            media_type = audio_key.format.media_type
 
             # get file size for progress tracking
             file_size = file.seek(0, 2)
@@ -698,9 +688,11 @@ class R2Storage:
 
         async with self._s3_client() as client:
             if file_type:
-                audio_format = AudioFormat.from_extension(f".{file_type.lower()}")
-                if audio_format:
-                    key = f"audio/{file_id}{audio_format.extension}"
+                try:
+                    key = AudioKey.for_file(file_id, file_type).key
+                except InvalidMediaExtension:
+                    key = None
+                if key is not None:
                     try:
                         await client.head_object(
                             Bucket=self.private_audio_bucket_name, Key=key
@@ -725,9 +717,9 @@ class R2Storage:
                         )
                         return False
 
-            # fallback: try every audio format
-            for audio_format in AudioFormat:
-                key = f"audio/{file_id}{audio_format.extension}"
+            # fallback: probe every stored audio extension (incl. .aif/.aiff)
+            for ext in AudioFormat.all_stored_extensions():
+                key = AudioKey.for_file(file_id, ext).key
                 try:
                     await client.head_object(
                         Bucket=self.private_audio_bucket_name, Key=key
@@ -778,8 +770,7 @@ class R2Storage:
         if not self.private_audio_bucket_name:
             raise ValueError("R2_PRIVATE_BUCKET not configured")
 
-        ext = extension.lstrip(".")
-        key = f"audio/{file_id}.{ext}"
+        key = AudioKey.for_file(file_id, extension).key
         expiry = expires_in or self.presigned_url_expiry
 
         with logfire.span(
@@ -808,7 +799,8 @@ class R2Storage:
 
     def build_image_url(self, image_id: str, ext: str) -> str:
         """construct public image URL without HEAD checks."""
-        return f"{self.public_image_bucket_url}/images/{image_id}.{ext.lstrip('.')}"
+        key = ImageKey.for_file(image_id, ext).key
+        return f"{self.public_image_bucket_url}/{key}"
 
     async def save_thumbnail(self, thumbnail_data: bytes, image_id: str) -> str:
         """save a WebP thumbnail alongside the original image in R2."""
@@ -851,8 +843,7 @@ class R2Storage:
         if not self.private_audio_bucket_name:
             raise ValueError("R2_PRIVATE_BUCKET not configured")
 
-        ext = extension.lstrip(".")
-        key = f"audio/{file_id}.{ext}"
+        key = AudioKey.for_file(file_id, extension).key
 
         if to_private:
             src_bucket = self.audio_bucket_name

--- a/backend/tests/integration/utils/audio.py
+++ b/backend/tests/integration/utils/audio.py
@@ -110,9 +110,7 @@ def generate_drone(
 
         # generate sample
         sample_value = (
-            amplitude
-            * envelope
-            * math.sin(2 * math.pi * freq * t + phase_offset_rad)
+            amplitude * envelope * math.sin(2 * math.pi * freq * t + phase_offset_rad)
         )
         # convert to 16-bit signed integer
         sample_int = int(32767 * max(-1.0, min(1.0, sample_value)))

--- a/backend/tests/integration/utils/audio.py
+++ b/backend/tests/integration/utils/audio.py
@@ -2,9 +2,24 @@
 
 generates simple drone sounds (sine waves) without external dependencies.
 these are useful for testing upload/streaming without needing FFmpeg.
+
+every generator introduces a per-call random phase offset by default, so
+the produced bytes — and the resulting content-hashed `file_id` — differ
+on every invocation. this is intentional: deterministic test content
+uploaded against a shared staging bucket creates a hidden class of bug
+where stale R2 blobs from older test runs mask present-day regressions.
+example: woody.fm's 2026-05-16 `.aif` outage in production was masked in
+staging by an `audio/<drone-id>.aiff` blob written by a pre-#797 test
+run, which the buggy reader happily found and returned. randomized phase
+means each test run hits a fresh storage path with no stale shadow.
+
+pass `phase_offset_rad=0.0` explicitly when a deterministic file is
+genuinely required (e.g. asserting a known checksum). otherwise let it
+default.
 """
 
 import math
+import random
 import struct
 from io import BytesIO
 from pathlib import Path
@@ -54,6 +69,7 @@ def generate_drone(
     duration_sec: float = 2.0,
     sample_rate: int = 22050,
     amplitude: float = 0.3,
+    phase_offset_rad: float | None = None,
 ) -> BytesIO:
     """generate a pure sine wave drone as WAV audio.
 
@@ -65,6 +81,11 @@ def generate_drone(
         duration_sec: duration in seconds
         sample_rate: samples per second (lower = smaller file)
         amplitude: volume from 0.0 to 1.0
+        phase_offset_rad: starting phase of the sine wave, in radians.
+            defaults to a per-call random value so each generated drone has
+            a unique byte sequence (→ unique content-hashed file_id).
+            pass `0.0` for deterministic content when a known hash is
+            required. see module docstring for the bug class this prevents.
 
     returns:
         BytesIO containing valid WAV file data
@@ -75,6 +96,8 @@ def generate_drone(
     """
     freq = note_to_freq(note)
     num_samples = int(sample_rate * duration_sec)
+    if phase_offset_rad is None:
+        phase_offset_rad = random.uniform(0.0, 2.0 * math.pi)
 
     # generate sine wave with fade envelope
     samples = []
@@ -86,7 +109,11 @@ def generate_drone(
         envelope = fade_in * fade_out
 
         # generate sample
-        sample_value = amplitude * envelope * math.sin(2 * math.pi * freq * t)
+        sample_value = (
+            amplitude
+            * envelope
+            * math.sin(2 * math.pi * freq * t + phase_offset_rad)
+        )
         # convert to 16-bit signed integer
         sample_int = int(32767 * max(-1.0, min(1.0, sample_value)))
         samples.append(struct.pack("<h", sample_int))
@@ -220,6 +247,7 @@ def save_longform_drone(
     *,
     sample_rate: int = 22050,
     note: str = "A4",
+    deterministic: bool = False,
 ) -> Path:
     """generate a long-form mono sine WAV via ffmpeg lavfi.
 
@@ -234,6 +262,9 @@ def save_longform_drone(
         sample_rate: samples per second; 22050 mono keeps a 60-min file
             at ~150MB while still passing real audio decoders
         note: musical note name for the sine frequency
+        deterministic: if True, produce identical bytes every call. default
+            False so each call gets a unique content-hashed file_id; see the
+            module docstring for why this matters.
 
     returns:
         the destination path (now a valid WAV file)
@@ -246,6 +277,12 @@ def save_longform_drone(
         raise FileNotFoundError(msg)
 
     freq = note_to_freq(note)
+    # nudge the frequency by a microscopic, per-call random amount so the
+    # generated PCM samples differ even with identical params. inaudible
+    # (<<0.01 Hz at A4) but flips every sample bit → unique file_id.
+    if not deterministic:
+        freq += random.uniform(-0.001, 0.001)
+
     subprocess.run(
         [
             "ffmpeg",

--- a/backend/tests/integration/utils/test_audio.py
+++ b/backend/tests/integration/utils/test_audio.py
@@ -1,0 +1,59 @@
+"""tests for the drone audio generator.
+
+these are plain unit tests (no @pytest.mark.integration) — they don't
+need staging or a real backend. they guard the invariant that the
+fixture generator produces unique content per call, which is the
+property that lets upload integration tests actually exercise the code
+path under test instead of finding stale R2 state.
+"""
+
+import hashlib
+
+from tests.integration.utils.audio import (
+    generate_drone,
+    save_drone,
+)
+
+
+def test_generate_drone_produces_unique_content_by_default(tmp_path) -> None:
+    """two consecutive calls with identical params produce different bytes.
+
+    if this regresses, every upload integration test silently stops
+    exercising the storage pipeline and starts reading whatever stale
+    blob the *first* test run wrote. that's the failure mode that masked
+    woody.fm's 2026-05-16 outage. see audio.py module docstring.
+    """
+    a = generate_drone("A4", duration_sec=0.1).read()
+    b = generate_drone("A4", duration_sec=0.1).read()
+    assert a != b, "generate_drone() must vary content per call by default"
+
+
+def test_generate_drone_unique_file_ids(tmp_path) -> None:
+    """the property `save_drone` exists to provide: unique content-hashed
+    file_id per call (so upload tests don't collide on staged R2 keys).
+    """
+    p1 = save_drone(tmp_path / "a.wav", "A4", duration_sec=0.1)
+    p2 = save_drone(tmp_path / "b.wav", "A4", duration_sec=0.1)
+    h1 = hashlib.sha256(p1.read_bytes()).hexdigest()
+    h2 = hashlib.sha256(p2.read_bytes()).hexdigest()
+    assert h1 != h2, "save_drone must produce distinct file_ids on each call"
+
+
+def test_generate_drone_deterministic_when_phase_pinned() -> None:
+    """passing `phase_offset_rad=0.0` produces identical bytes — for callers
+    that genuinely need a known checksum (e.g. asserting a fixture against
+    a recorded hash). default behavior is randomized; this is the escape
+    hatch.
+    """
+    a = generate_drone("A4", duration_sec=0.1, phase_offset_rad=0.0).read()
+    b = generate_drone("A4", duration_sec=0.1, phase_offset_rad=0.0).read()
+    assert a == b, "explicit phase pinning must produce deterministic content"
+
+
+def test_generate_drone_still_produces_valid_wav() -> None:
+    """sanity: the randomized output is still a parseable WAV."""
+    wav = generate_drone("A4", duration_sec=0.1).read()
+    assert wav.startswith(b"RIFF"), "output must be a RIFF WAV"
+    assert b"WAVE" in wav[:12]
+    assert b"fmt " in wav
+    assert b"data" in wav

--- a/backend/tests/test_background_tasks.py
+++ b/backend/tests/test_background_tasks.py
@@ -133,7 +133,10 @@ async def test_process_export_downloads_concurrently() -> None:
     async def async_chunk_gen():
         yield b"mock audio data"
 
-    # create mock tracks
+    # create mock tracks. MagicMock auto-creates truthy attrs by default —
+    # explicitly null the lossless-original fields so the export branches
+    # down the playable file_id/file_type path (the typical mp3 upload
+    # shape) instead of trying to build an AudioKey from a MagicMock.
     mock_tracks = []
     for i in range(4):
         track = MagicMock()
@@ -141,6 +144,8 @@ async def test_process_export_downloads_concurrently() -> None:
         track.title = f"Track {i}"
         track.file_id = f"file_{i}"
         track.file_type = "mp3"
+        track.original_file_id = None
+        track.original_file_type = None
         mock_tracks.append(track)
 
     # mock database query

--- a/backend/tests/test_storage_keys.py
+++ b/backend/tests/test_storage_keys.py
@@ -1,0 +1,184 @@
+"""unit tests for typed R2 keys.
+
+these guard the invariant that lets `r2.py` be drift-free: every key
+construction goes through AudioKey / ImageKey, and the key string is a
+single deterministic function of (file_id, extension). there is no
+codepath that can produce a different key for the same logical object.
+"""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from backend._internal.audio import AudioFormat
+from backend._internal.image import ImageFormat
+from backend.storage.keys import AudioKey, ImageKey, InvalidMediaExtension
+
+
+class TestAudioKey:
+    @pytest.mark.parametrize(
+        ("file_id", "extension", "expected_key"),
+        [
+            ("abc123", "mp3", "audio/abc123.mp3"),
+            ("abc123", "wav", "audio/abc123.wav"),
+            ("abc123", "m4a", "audio/abc123.m4a"),
+            ("abc123", "flac", "audio/abc123.flac"),
+            ("abc123", "aiff", "audio/abc123.aiff"),
+            ("abc123", "aif", "audio/abc123.aif"),  # preserved as-uploaded
+            ("abc123", "webm", "audio/abc123.webm"),
+            ("abc123", "ogg", "audio/abc123.ogg"),
+        ],
+    )
+    def test_key_construction(
+        self, file_id: str, extension: str, expected_key: str
+    ) -> None:
+        assert AudioKey(file_id=file_id, extension=extension).key == expected_key
+
+    @pytest.mark.parametrize(
+        ("file_id", "filename", "expected_extension"),
+        [
+            ("abc123", "song.mp3", "mp3"),
+            ("abc123", "Song.MP3", "mp3"),
+            ("abc123", "song.aif", "aif"),
+            ("abc123", "song.aiff", "aiff"),
+            ("abc123", "song.AIF", "aif"),
+            ("abc123", "path/to/song.flac", "flac"),
+            ("abc123", "song with spaces.wav", "wav"),
+        ],
+    )
+    def test_from_filename(
+        self, file_id: str, filename: str, expected_extension: str
+    ) -> None:
+        key = AudioKey.from_filename(file_id, filename)
+        assert key.extension == expected_extension
+        assert key.file_id == file_id
+
+    @pytest.mark.parametrize(
+        ("file_type", "expected_extension"),
+        [
+            ("mp3", "mp3"),
+            ("MP3", "mp3"),
+            (".mp3", "mp3"),
+            (".MP3", "mp3"),
+            ("aif", "aif"),
+            ("aiff", "aiff"),
+        ],
+    )
+    def test_for_file_normalizes_input(
+        self, file_type: str, expected_extension: str
+    ) -> None:
+        key = AudioKey.for_file("abc123", file_type)
+        assert key.extension == expected_extension
+
+    def test_aif_and_aiff_produce_distinct_keys(self) -> None:
+        """the prevention guarantee: save and read for the same upload produce
+        the same key. an `.aif` upload reads back via `.aif`, NOT `.aiff`.
+        woody.fm 2026-05-16 broke because save used `.aif` and read normalized
+        to `.aiff`. with typed keys, save and read both call `for_file` or
+        `from_filename` with the same input → same `.key`.
+        """
+        save_side = AudioKey.from_filename("abc123", "song.aif")
+        read_side = AudioKey.for_file("abc123", "aif")
+        assert save_side.key == read_side.key == "audio/abc123.aif"
+
+        # the .aiff case stays distinct
+        save_aiff = AudioKey.from_filename("def456", "song.aiff")
+        read_aiff = AudioKey.for_file("def456", "aiff")
+        assert save_aiff.key == read_aiff.key == "audio/def456.aiff"
+
+    @pytest.mark.parametrize(
+        "extension",
+        ["mp4", "txt", "exe", "", "aifff", "MP3 "],
+    )
+    def test_rejects_unsupported_extension(self, extension: str) -> None:
+        with pytest.raises(InvalidMediaExtension):
+            AudioKey(file_id="abc123", extension=extension)
+
+    def test_rejects_empty_file_id(self) -> None:
+        with pytest.raises(InvalidMediaExtension):
+            AudioKey(file_id="", extension="mp3")
+
+    def test_format_property_resolves_aliases(self) -> None:
+        """both `.aif` and `.aiff` map to AudioFormat.AIFF for media-type lookup,
+        even though they produce distinct keys."""
+        assert AudioKey.for_file("abc123", "aif").format is AudioFormat.AIFF
+        assert AudioKey.for_file("abc123", "aiff").format is AudioFormat.AIFF
+        assert AudioKey.for_file("abc123", "mp3").format is AudioFormat.MP3
+
+    def test_frozen(self) -> None:
+        """frozen=True means once constructed, the key cannot drift."""
+        key = AudioKey.for_file("abc123", "mp3")
+        with pytest.raises(FrozenInstanceError):
+            key.extension = "wav"  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        assert AudioKey.for_file("abc123", "mp3") == AudioKey.for_file("abc123", "mp3")
+        assert AudioKey.for_file("abc123", "mp3") != AudioKey.for_file("abc123", "wav")
+        assert AudioKey.for_file("abc123", "mp3") != AudioKey.for_file("xyz789", "mp3")
+
+
+class TestImageKey:
+    @pytest.mark.parametrize(
+        ("file_id", "extension", "expected_key"),
+        [
+            ("abc123", "jpg", "images/abc123.jpg"),
+            ("abc123", "jpeg", "images/abc123.jpeg"),  # preserved distinct from .jpg
+            ("abc123", "png", "images/abc123.png"),
+            ("abc123", "webp", "images/abc123.webp"),
+            ("abc123", "gif", "images/abc123.gif"),
+        ],
+    )
+    def test_key_construction(
+        self, file_id: str, extension: str, expected_key: str
+    ) -> None:
+        assert ImageKey(file_id=file_id, extension=extension).key == expected_key
+
+    @pytest.mark.parametrize(
+        ("filename", "expected_extension"),
+        [
+            ("cover.jpg", "jpg"),
+            ("cover.JPG", "jpg"),
+            ("cover.jpeg", "jpeg"),
+            ("cover.JPEG", "jpeg"),
+            ("cover.png", "png"),
+            ("cover.webp", "webp"),
+            ("cover.gif", "gif"),
+        ],
+    )
+    def test_from_filename(self, filename: str, expected_extension: str) -> None:
+        assert ImageKey.from_filename("abc123", filename).extension == expected_extension
+
+    def test_jpg_and_jpeg_produce_distinct_keys(self) -> None:
+        """#1202 regression: `.jpeg` uploads were stored as `images/<id>.jpeg`
+        but URL builder said `.jpg`. with typed keys, both sides resolve to the
+        same extension and the same key.
+        """
+        save_side = ImageKey.from_filename("abc123", "cover.jpeg")
+        read_side = ImageKey.for_file("abc123", "jpeg")
+        assert save_side.key == read_side.key == "images/abc123.jpeg"
+
+        save_jpg = ImageKey.from_filename("def456", "cover.jpg")
+        read_jpg = ImageKey.for_file("def456", "jpg")
+        assert save_jpg.key == read_jpg.key == "images/def456.jpg"
+
+    @pytest.mark.parametrize(
+        "extension",
+        ["mp3", "tiff", "bmp", "heic", "", "PNG "],
+    )
+    def test_rejects_unsupported_extension(self, extension: str) -> None:
+        with pytest.raises(InvalidMediaExtension):
+            ImageKey(file_id="abc123", extension=extension)
+
+    def test_rejects_empty_file_id(self) -> None:
+        with pytest.raises(InvalidMediaExtension):
+            ImageKey(file_id="", extension="png")
+
+    def test_format_property(self) -> None:
+        assert ImageKey.for_file("abc", "jpg").format is ImageFormat.JPEG
+        assert ImageKey.for_file("abc", "jpeg").format is ImageFormat.JPEG_ALT
+        assert ImageKey.for_file("abc", "png").format is ImageFormat.PNG
+
+    def test_frozen(self) -> None:
+        key = ImageKey.for_file("abc123", "png")
+        with pytest.raises(FrozenInstanceError):
+            key.extension = "jpg"  # type: ignore[misc]

--- a/backend/tests/test_storage_keys.py
+++ b/backend/tests/test_storage_keys.py
@@ -146,7 +146,9 @@ class TestImageKey:
         ],
     )
     def test_from_filename(self, filename: str, expected_extension: str) -> None:
-        assert ImageKey.from_filename("abc123", filename).extension == expected_extension
+        assert (
+            ImageKey.from_filename("abc123", filename).extension == expected_extension
+        )
 
     def test_jpg_and_jpeg_produce_distinct_keys(self) -> None:
         """#1202 regression: `.jpeg` uploads were stored as `images/<id>.jpeg`

--- a/backend/tests/test_storage_types.py
+++ b/backend/tests/test_storage_types.py
@@ -3,6 +3,8 @@
 from io import BytesIO
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from backend.storage.protocol import StorageProtocol
 from backend.storage.r2 import R2Storage
 
@@ -118,3 +120,146 @@ async def test_save_thumbnail():
     assert call_kwargs[0][1] == "test-images"  # bucket
     assert call_kwargs[0][2] == "images/abc123_thumb.webp"  # key
     assert call_kwargs[1]["ExtraArgs"]["ContentType"] == "image/webp"
+
+
+# module-level so pytest.mark.parametrize can reference them and ruff doesn't
+# flag the class attribute as a mutable default.
+_AUDIO_CASES = [
+    # (upload filename, file_type as stored in DB, expected R2 key)
+    ("song.mp3", "mp3", "audio/abc123def4567890.mp3"),
+    ("song.wav", "wav", "audio/abc123def4567890.wav"),
+    ("song.m4a", "m4a", "audio/abc123def4567890.m4a"),
+    ("song.flac", "flac", "audio/abc123def4567890.flac"),
+    ("song.aiff", "aiff", "audio/abc123def4567890.aiff"),
+    # the critical alias case — Ableton's default export
+    ("song.aif", "aif", "audio/abc123def4567890.aif"),
+    # uppercase variant — the staging path lowercases at the boundary
+    ("song.AIF", "aif", "audio/abc123def4567890.aif"),
+    ("song.webm", "webm", "audio/abc123def4567890.webm"),
+    ("song.ogg", "ogg", "audio/abc123def4567890.ogg"),
+]
+
+_IMAGE_CASES = [
+    ("cover.jpg", "jpg", "images/abc123def4567890.jpg"),
+    # the critical alias case — #1202 broke when these diverged
+    ("cover.jpeg", "jpeg", "images/abc123def4567890.jpeg"),
+    ("cover.JPEG", "jpeg", "images/abc123def4567890.jpeg"),
+    ("cover.png", "png", "images/abc123def4567890.png"),
+    ("cover.webp", "webp", "images/abc123def4567890.webp"),
+    ("cover.gif", "gif", "images/abc123def4567890.gif"),
+]
+
+
+class TestAudioSaveReadRoundtrip:
+    """the fix that closes the bug class: for every supported audio extension
+    (and every alias), the key produced by `save()` is the same key reached
+    by `stream_file_data`, `head_file`, and `get_url`. would have caught:
+
+    - #797 (`.aif` burnout): save wrote `.aif`, DB had `aiff`, URL 404'd
+    - #1202 (`.jpeg` images): save wrote `.jpeg`, URL builder said `.jpg`
+    - woody.fm 2026-05-16: save wrote `.aif`, readers normalized to `.aiff`
+    """
+
+    @pytest.mark.parametrize(("filename", "file_type", "expected_key"), _AUDIO_CASES)
+    async def test_save_then_read_lands_on_same_key(
+        self, filename: str, file_type: str, expected_key: str
+    ) -> None:
+        s, mock_client = _mock_r2_storage()
+        file_obj = BytesIO(b"\x00" * 1024)
+
+        with patch(
+            "backend.storage.r2.hash_file_chunked", return_value="abc123def4567890"
+        ):
+            await s.save(file_obj, filename)
+
+        # 1. save wrote to expected_key
+        upload_call = mock_client.upload_fileobj.call_args
+        actual_save_key = upload_call.kwargs.get("Key") or upload_call.args[2]
+        assert actual_save_key == expected_key, (
+            f"save() wrote to {actual_save_key!r}, expected {expected_key!r}"
+        )
+
+        # 2. reader paths all reach the same key
+        mock_client.head_object.return_value = {"ContentLength": 1024}
+        mock_client.get_object.return_value = {"Body": AsyncMock()}
+
+        # head_file
+        mock_client.head_object.reset_mock()
+        await s.head_file("abc123def4567890", file_type)
+        head_call = mock_client.head_object.call_args
+        assert head_call.kwargs.get("Key") == expected_key
+
+        # get_url with explicit extension
+        mock_client.head_object.reset_mock()
+        await s.get_url(
+            "abc123def4567890", file_type="audio", extension=file_type
+        )
+        get_url_call = mock_client.head_object.call_args
+        assert get_url_call.kwargs.get("Key") == expected_key
+
+    @pytest.mark.parametrize(
+        ("filename", "file_type"),
+        [(case[0], case[1]) for case in _AUDIO_CASES],
+    )
+    async def test_delete_targets_exact_save_key(
+        self, filename: str, file_type: str
+    ) -> None:
+        """`delete(file_id, file_type)` must HEAD and DELETE the same key
+        save() wrote. woody.fm 2026-05-16 showed this drifting for `.aif`."""
+        s, mock_client = _mock_r2_storage()
+        file_obj = BytesIO(b"\x00" * 1024)
+
+        with patch(
+            "backend.storage.r2.hash_file_chunked", return_value="abc123def4567890"
+        ):
+            await s.save(file_obj, filename)
+
+        save_key = mock_client.upload_fileobj.call_args.kwargs.get("Key")
+        assert save_key is not None
+
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one.return_value = 1  # refcount: safe to delete
+        mock_db.execute = AsyncMock(return_value=mock_result)
+        mock_db_cm = AsyncMock()
+        mock_db_cm.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_db_cm.__aexit__ = AsyncMock(return_value=None)
+
+        mock_client.head_object.reset_mock()
+        mock_client.delete_object.reset_mock()
+        mock_client.head_object.return_value = {}
+
+        with patch("backend.storage.r2.db_session", return_value=mock_db_cm):
+            await s.delete("abc123def4567890", file_type=file_type)
+
+        head_keys = [c.kwargs.get("Key") for c in mock_client.head_object.call_args_list]
+        delete_keys = [
+            c.kwargs.get("Key") for c in mock_client.delete_object.call_args_list
+        ]
+        assert save_key in head_keys, f"delete didn't HEAD save key {save_key!r}"
+        assert save_key in delete_keys, f"delete didn't DELETE save key {save_key!r}"
+
+
+class TestImageSaveReadRoundtrip:
+    """same guarantee for image surfaces — closes #1202."""
+
+    @pytest.mark.parametrize(("filename", "ext", "expected_key"), _IMAGE_CASES)
+    async def test_save_then_build_url_match(
+        self, filename: str, ext: str, expected_key: str
+    ) -> None:
+        s, mock_client = _mock_r2_storage()
+        file_obj = BytesIO(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        with patch(
+            "backend.storage.r2.hash_file_chunked", return_value="abc123def4567890"
+        ):
+            await s.save(file_obj, filename)
+
+        save_key = mock_client.upload_fileobj.call_args.kwargs.get("Key")
+        assert save_key == expected_key
+
+        # build_image_url constructs a URL pointing at the same key
+        url = s.build_image_url("abc123def4567890", ext)
+        assert url.endswith(expected_key), (
+            f"url {url!r} doesn't end with save key {expected_key!r}"
+        )

--- a/backend/tests/test_storage_types.py
+++ b/backend/tests/test_storage_types.py
@@ -191,9 +191,7 @@ class TestAudioSaveReadRoundtrip:
 
         # get_url with explicit extension
         mock_client.head_object.reset_mock()
-        await s.get_url(
-            "abc123def4567890", file_type="audio", extension=file_type
-        )
+        await s.get_url("abc123def4567890", file_type="audio", extension=file_type)
         get_url_call = mock_client.head_object.call_args
         assert get_url_call.kwargs.get("Key") == expected_key
 
@@ -232,7 +230,9 @@ class TestAudioSaveReadRoundtrip:
         with patch("backend.storage.r2.db_session", return_value=mock_db_cm):
             await s.delete("abc123def4567890", file_type=file_type)
 
-        head_keys = [c.kwargs.get("Key") for c in mock_client.head_object.call_args_list]
+        head_keys = [
+            c.kwargs.get("Key") for c in mock_client.head_object.call_args_list
+        ]
         delete_keys = [
             c.kwargs.get("Key") for c in mock_client.delete_object.call_args_list
         ]


### PR DESCRIPTION
## Summary

Closes the recurring R2 key-construction drift bug at the type level. Every R2 read/write/delete now flows through `AudioKey` / `ImageKey` (frozen dataclasses in `backend/storage/keys.py`); save and read derive their key from the same type, so they cannot disagree.

## the bug we just fixed

woody.fm hit it in production today, 2026-05-16. 5 distinct `.aif` uploads from his catalog all stranded at \"× staged audio file missing from storage.\" the files were sitting in R2 the whole time at `audio/<id>.aif` — but `R2Storage.stream_file_data` / `head_file` / `get_url` / `delete` were all looking at `audio/<id>.aiff` because they normalized via `AudioFormat.from_extension`. `R2Storage.save` (line 158) stored under the raw extension. drift between two halves of the same module.

logfire trace: every retry produced the same `R2 file not found` at `audio/<id>.aiff` followed by a cleanup spray that probed `.mp3 .wav .m4a .aiff .flac .webm .ogg` — never `.aif`.

## the recurring bug class

| PR | when | surface |
|---|---|---|
| [#332](https://github.com/zzstoatzz/plyr.fm/pull/332) | early | save wrote `<id>.png`, read wanted `images/<id>.png` |
| [#797](https://github.com/zzstoatzz/plyr.fm/pull/797) | 2026-01-25 | DB stored \`'aiff'\`, file was \`.aif\`; **the fix flipped save to raw and forgot the readers — that's the regression woody.fm hit** |
| [#849](https://github.com/zzstoatzz/plyr.fm/pull/849) | 2026-02 | CLAP backfill reconstructed audio URL with different ext logic |
| [#1202](https://github.com/zzstoatzz/plyr.fm/pull/1202) | 2026-03-30 | save used `.jpeg`, URL builder used `ImageFormat.JPEG.value` = \`'jpg'\` |
| woody.fm | 2026-05-16 | save `.aif`, readers `.aiff` |

each prior fix touched one side and missed the other. with typed keys, the bug is unrepresentable.

## what changed

**`backend/src/backend/storage/keys.py`** (new): `AudioKey` and `ImageKey`, frozen dataclasses. Construct via `from_filename(file_id, filename)` at upload time or `for_file(file_id, file_type)` when rehydrating from the DB. `__post_init__` validates against `AudioFormat`/`ImageFormat`. `.key` property is the single source of truth.

**`backend/src/backend/storage/r2.py`**: every key-construction site (19 of them, audited end-to-end) now goes through one of those types. save methods return `file_id`; reader methods take `(file_id, file_type)` and construct an `AudioKey.for_file` internally. Public protocol stays compatible — no callsite migration needed.

**`backend/src/backend/_internal/audio.py`**: new `AudioFormat.all_stored_extensions()` that yields every extension we might find in R2, **including aliases** (`.aif` AND `.aiff`). Used by fallback-scan paths in `delete` / `get_url` so the cleanup spray actually covers what's on disk — the old code iterated `AudioFormat` directly and silently skipped `.aif` because `.aiff` is the canonical enum value.

**Test fixture hygiene** (`backend/tests/integration/utils/audio.py`): `generate_drone` now applies a random phase offset per call by default, and `save_longform_drone` nudges the sine frequency by a sub-Hz random delta. This is the property that lets upload integration tests *actually* exercise the storage pipeline instead of finding stale R2 state.

This matters because the existing `test_upload_aif` integration test passed against staging at 06:04 UTC this morning, while production users were hitting the bug at 18:42–19:14 UTC. The same fixture (2-second A4 drone, deterministic content) hashed to the same `file_id` every run; staging R2 still has a pre-#797 `audio/<drone-file-id>.aiff` blob from when save used canonical extensions. The buggy reader was finding that stale blob and reporting success — every CI run, for months.

Callers that genuinely need deterministic content opt in via `phase_offset_rad=0.0` or `deterministic=True`. Module docstring explains why.

## tests added

- **54 unit tests** for `AudioKey` / `ImageKey`: validation, normalization, alias preservation (`.aif` stays `.aif`, `.jpg` stays `.jpg`), immutability, equality, format resolution.
- **24 round-trip tests** in `test_storage_types.py` proving for every audio + image extension (and every alias): `save()` key == `head_file` / `get_url` / `delete` key. The test parametrized over `('song.aif', 'aif')` and `('song.AIF', 'aif')` is the specific case that would have caught woody.fm.
- **4 fixture-invariant tests** asserting `generate_drone()` produces unique content per call (and that the deterministic escape hatch still works).

## migration / data

None. All audio stored post-#797 used the raw filename extension; the new typed reader builds the same key. The `.aif` files woody.fm uploaded today will still be findable once the worker re-runs (the jobs are marked failed; he'll need to re-upload via the UI).

## Test plan

- [x] 164 unit tests pass locally (`uv run pytest tests/test_storage_keys.py tests/test_storage_types.py tests/test_audio_formats.py tests/test_image_formats.py tests/integration/utils/test_audio.py`)
- [x] `uv run ruff check` clean on touched files
- [x] `uv run ty check` clean on touched files
- [ ] CI full suite (DB tests can't run locally without Docker)
- [ ] Integration test suite runs against staging after deploy — with the new randomized fixture, `test_upload_aif` will now exercise a fresh `file_id` and actually exercise the storage round-trip
- [ ] DM woody.fm asking him to retry the 5 failed tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)