### PR TITLE
feat(auth): identify ourselves to bsky's edge with a real User-Agent

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -73,6 +73,11 @@ primary_region = 'iad'
   R2_ENDPOINT_URL = 'https://8feb33b5fb57ce2bc093bc6f4141f40a.r2.cloudflarestorage.com'
   R2_PUBLIC_BUCKET_URL = 'https://pub-d4ed8a1e39d44dac85263d86ad5676fd.r2.dev'
   ATPROTO_PDS_URL = 'https://pds.zzstoatzz.io'
+  # Identify ourselves to bsky.social's edge so generic-SDK-UA WAF rules
+  # don't 403 us. See bluesky-social/atproto#4764 and our 2026-05-17 outage.
+  # Unset this env var (locally remove the line or `fly secrets unset`) to
+  # fall back to httpx's default `python-httpx/X.Y` User-Agent.
+  ATPROTO_USER_AGENT = 'plyr.fm/1.0 (+https://plyr.fm)'
 
 # secrets to set via: fly secrets set KEY=value -a relay-api
 # - DATABASE_URL (neon postgres connection string)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "sqlalchemy>=2.0.36",
     "alembic>=1.14.0",
     "asyncpg>=0.30.0",
-    "atproto @ git+https://github.com/zzstoatzz/atproto@oauth-full",
+    "atproto @ git+https://github.com/zzstoatzz/atproto@4577e6532bb540a64d5037fde26d7921416a7058",
     "boto3>=1.37.0",
     "python-multipart>=0.0.20",
     "python-jose[cryptography]>=3.3.0",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -302,8 +302,8 @@ wheels = [
 
 [[package]]
 name = "atproto"
-version = "0.0.2.dev1"
-source = { git = "https://github.com/zzstoatzz/atproto?rev=oauth-full#3459f9f696c0f32a81e2d6ae24a87cbcb2bf7d1f" }
+version = "0.0.2.dev5"
+source = { git = "https://github.com/zzstoatzz/atproto?rev=4577e6532bb540a64d5037fde26d7921416a7058#4577e6532bb540a64d5037fde26d7921416a7058" }
 dependencies = [
     { name = "click" },
     { name = "cryptography" },
@@ -381,7 +381,7 @@ requires-dist = [
     { name = "aioboto3", specifier = ">=15.5.0" },
     { name = "alembic", specifier = ">=1.14.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
-    { name = "atproto", git = "https://github.com/zzstoatzz/atproto?rev=oauth-full" },
+    { name = "atproto", git = "https://github.com/zzstoatzz/atproto?rev=4577e6532bb540a64d5037fde26d7921416a7058" },
     { name = "beartype", specifier = ">=0.22.8" },
     { name = "boto3", specifier = ">=1.37.0" },
     { name = "cachetools", specifier = ">=6.2.1" },


### PR DESCRIPTION
## Why

bsky.social's edge has been returning 403 to our backend's `python-httpx/0.28.1` requests today (see spans from 03:44 UTC onward). Same fly machine sending the same request via `urllib` returns 200. The discriminator is the request fingerprint (User-Agent).

Third-party evidence this is a real, recurring pattern:
- **[bluesky-social/atproto#4764](https://github.com/bluesky-social/atproto/issues/4764)** — multiple devs reporting identical 403s on `bsky.social/.well-known/oauth-authorization-server`, most recent comment from `@darlosworld` on 2026-05-17 (today, hours before our backend started seeing it). Previous incidents resolved themselves after ~24h with no client change.
- **[anthropics/claude-code#47390](https://github.com/anthropics/claude-code/issues/47390)** — exactly this shape: MCP OAuth SDK sends empty/generic User-Agent during `.well-known` discovery, gets 403 from WAF-protected hosts. Different SDK, same root cause.

## What this does

Bumps the `atproto` fork pin to [`4577e65`](https://github.com/zzstoatzz/atproto/commit/4577e6532bb540a64d5037fde26d7921416a7058), which adds opt-in support for an `ATPROTO_USER_AGENT` env var. If set, the SDK overrides httpx's module-level default User-Agent process-wide on import. If unset, httpx falls back to `python-httpx/0.28.1` exactly as today — **no behavior change for anyone not opting in**.

`backend/fly.toml` sets `ATPROTO_USER_AGENT = 'plyr.fm/1.0 (+https://plyr.fm)'` so we identify ourselves to bsky's edge as a real atproto app instead of an anonymous Python script.

## Easy revert

Two ways, either is fast:
1. **Just unset the env var.** Remove the `ATPROTO_USER_AGENT` line from `fly.toml` and redeploy, OR `fly secrets unset ATPROTO_USER_AGENT -a relay-api`. The SDK falls back to httpx default. No code revert.
2. **Revert this PR.** Single commit. Pins go back to old SDK commit + old fly.toml env.

## Test plan

- [x] `uv lock` resolves cleanly to the new SDK commit
- [x] verified env-var-set: `ATPROTO_USER_AGENT='plyr.fm/1.0 (+https://plyr.fm)' uv run python -c 'import atproto_oauth, httpx; print(httpx.AsyncClient().headers.get(\"user-agent\"))'` → `plyr.fm/1.0 (+https://plyr.fm)`
- [x] verified env-var-unset preserves default: `python-httpx/0.28.1`
- [ ] After staging deploy: check spans for `bsky.social` requests — expect to see successful 200s on `.well-known/oauth-authorization-server`
- [ ] If staging looks good, ship to prod via `just release` and verify aila / `zzstoatzzdevlog.bsky.social` can sign in

## Caveat

Past similar incidents on this exact endpoint (per #4764) resolved on their own after ~24h with no client change. There's a real chance bsky's edge stops 403ing us by tomorrow regardless of this PR. But identifying ourselves with a proper UA is good practice regardless, and removes the most likely client-side discriminator from the equation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)