### PR TITLE
chore: remove dead ATPROTO_PDS_URL env var

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,7 +36,6 @@ R2_PRIVATE_BUCKET=audio-private-dev  # private bucket for supporter-gated audio
 MAX_UPLOAD_SIZE_MB=1536  # max audio upload size (default: 1536MB / 1.5GB - supports 2-hour WAV)
 
 # atproto
-ATPROTO_PDS_URL=https://bsky.social
 ATPROTO_CLIENT_ID=
 ATPROTO_CLIENT_SECRET=
 ATPROTO_REDIRECT_URI=http://localhost:8000/auth/callback

--- a/backend/fly.staging.toml
+++ b/backend/fly.staging.toml
@@ -14,7 +14,6 @@ primary_region = 'iad'
   release_command = 'uv run --no-dev alembic upgrade head'
 
 [env]
-  ATPROTO_PDS_URL = 'https://pds.zzstoatzz.io'
   # Mirror backend/fly.toml — identify ourselves to bsky.social's edge so
   # generic SDK UAs don't 403 us. See #1416.
   ATPROTO_USER_AGENT = 'plyr.fm/1.0 (+https://plyr.fm)'

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -72,7 +72,6 @@ primary_region = 'iad'
   R2_BUCKET = 'audio-prod'
   R2_ENDPOINT_URL = 'https://8feb33b5fb57ce2bc093bc6f4141f40a.r2.cloudflarestorage.com'
   R2_PUBLIC_BUCKET_URL = 'https://pub-d4ed8a1e39d44dac85263d86ad5676fd.r2.dev'
-  ATPROTO_PDS_URL = 'https://pds.zzstoatzz.io'
   # Identify ourselves to bsky.social's edge so generic-SDK-UA WAF rules
   # don't 403 us. See bluesky-social/atproto#4764 and our 2026-05-17 outage.
   # Unset this env var (locally remove the line or `fly secrets unset`) to

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -380,11 +380,6 @@ class StorageSettings(AppSettingsSection):
 class AtprotoSettings(AppSettingsSection):
     """ATProto integration settings."""
 
-    pds_url: str = Field(
-        default="https://bsky.social",
-        validation_alias="ATPROTO_PDS_URL",
-        description="ATProto PDS URL",
-    )
     client_id: str = Field(
         default="",
         validation_alias="ATPROTO_CLIENT_ID",


### PR DESCRIPTION
AtprotoSettings.pds_url is defined but never read by any code — all PDS routing pulls the URL from the resolved DID document at runtime. Setting it to a single hardcoded value in fly.toml/fly.staging.toml is misleading; removes the dead config (toml lines + config field + .env.example).