### PR TITLE
feat(auth): surface upstream 503 for bsky edge block instead of stack-trace 400

### DIFF
--- a/backend/src/backend/_internal/auth/oauth.py
+++ b/backend/src/backend/_internal/auth/oauth.py
@@ -173,6 +173,33 @@ def get_oauth_client_for_scope(scope: str) -> OAuthClient:
     )
 
 
+def _bsky_edge_block_error(exc: Exception, handle: str) -> HTTPException | None:
+    """detect the bsky.social edge-block failure mode and surface a clear message.
+
+    bluesky-social/atproto#4764 — bsky.social's edge has been observed returning
+    403 to httpx-shaped requests from cloud egress, breaking handle resolution
+    and OAuth metadata fetches for `*.bsky.social` users. when that happens the
+    SDK surfaces a stack-trace flavored `Failed to resolve handle` error that
+    looks like a plyr.fm bug; this rewrites it to make the upstream cause clear.
+    """
+    msg = str(exc)
+    is_bsky_handle = handle.endswith(".bsky.social")
+    looks_like_edge_block = ("403 Forbidden" in msg and "bsky.social" in msg) or (
+        is_bsky_handle and "Failed to resolve handle" in msg
+    )
+    if not looks_like_edge_block:
+        return None
+    return HTTPException(
+        status_code=503,
+        detail=(
+            "Bluesky's servers are currently blocking sign-in requests from our "
+            "backend. This is a temporary upstream issue on Bluesky's side, not "
+            "an account problem — please try again in a few minutes. Tracking: "
+            "https://github.com/bluesky-social/atproto/issues/4764"
+        ),
+    )
+
+
 async def start_oauth_flow(
     handle: str, prompt: PromptType | None = None
 ) -> tuple[str, str]:
@@ -205,7 +232,11 @@ async def start_oauth_flow(
 
         auth_url, state = await client.start_authorization(handle, prompt=prompt)
         return auth_url, state
+    except HTTPException:
+        raise
     except Exception as e:
+        if friendly := _bsky_edge_block_error(e, handle):
+            raise friendly from e
         raise HTTPException(
             status_code=400,
             detail=f"failed to start OAuth flow: {e}",
@@ -229,7 +260,11 @@ async def start_oauth_flow_with_scopes(
         )
         auth_url, state = await client.start_authorization(handle, prompt=prompt)
         return auth_url, state
+    except HTTPException:
+        raise
     except Exception as e:
+        if friendly := _bsky_edge_block_error(e, handle):
+            raise friendly from e
         raise HTTPException(
             status_code=400,
             detail=f"failed to start OAuth flow: {e}",

--- a/backend/tests/_internal/test_bsky_edge_block_error.py
+++ b/backend/tests/_internal/test_bsky_edge_block_error.py
@@ -1,0 +1,54 @@
+"""regression tests for the bsky.social edge-block friendly error.
+
+context: bluesky-social/atproto#4764 — bsky.social's edge has been observed
+returning 403 to httpx-shaped requests from cloud egress, breaking handle
+resolution and OAuth metadata fetches for `*.bsky.social` users. when that
+happens the SDK raises `ValueError('Failed to resolve handle: X')` which we
+otherwise surface as a stack-trace-flavored 400 — confusing for users since
+it looks like an account problem.
+
+`_bsky_edge_block_error` detects the failure shape and returns a 503 with a
+clear "upstream Bluesky issue, try again" message instead.
+"""
+
+from fastapi import HTTPException
+
+from backend._internal.auth.oauth import _bsky_edge_block_error
+
+
+def test_bsky_handle_with_resolution_failure_gets_friendly_503() -> None:
+    """typical end-user case: signing in with `*.bsky.social` handle hits SDK
+    `Failed to resolve handle` because the underlying httpx request 403'd."""
+    exc = ValueError("Failed to resolve handle: ailawav.bsky.social")
+    result = _bsky_edge_block_error(exc, "ailawav.bsky.social")
+    assert isinstance(result, HTTPException)
+    assert result.status_code == 503
+    assert "Bluesky's servers" in str(result.detail)
+    assert "4764" in str(result.detail)
+
+
+def test_explicit_403_on_bsky_social_url_gets_friendly_503() -> None:
+    """the auth-server-metadata leg: handle resolution succeeds (self-hosted PDS
+    works), but `fetch_authserver_metadata_async` 403s on bsky.social. message
+    contains '403 Forbidden' and 'bsky.social', should also surface friendly."""
+    exc = RuntimeError(
+        "Client error '403 Forbidden' for url "
+        "'https://bsky.social/.well-known/oauth-authorization-server'"
+    )
+    result = _bsky_edge_block_error(exc, "user.example.com")
+    assert isinstance(result, HTTPException)
+    assert result.status_code == 503
+
+
+def test_unrelated_failure_returns_none() -> None:
+    """genuinely-broken handles (typos on non-bsky domains) shouldn't trigger
+    the upstream-issue framing — those really are user errors."""
+    exc = ValueError("Failed to resolve handle: typo.example.com")
+    assert _bsky_edge_block_error(exc, "typo.example.com") is None
+
+
+def test_non_resolution_error_on_bsky_handle_returns_none() -> None:
+    """defensive: unrelated errors on a bsky handle (e.g. config / state issues)
+    shouldn't be masked as upstream — only the specific failure shape should."""
+    exc = RuntimeError("OAuth state store unavailable")
+    assert _bsky_edge_block_error(exc, "alice.bsky.social") is None

--- a/loq.toml
+++ b/loq.toml
@@ -288,7 +288,7 @@ max_lines = 617
 
 [[rules]]
 path = "backend/src/backend/_internal/auth/oauth.py"
-max_lines = 513
+max_lines = 549
 
 [[rules]]
 path = "frontend/src/lib/components/CopyrightSection.svelte"


### PR DESCRIPTION
## Why

bsky.social's edge has been returning 403 to httpx-shaped requests from cloud egress since 2026-05-17 03:44 UTC (see [bluesky-social/atproto#4764](https://github.com/bluesky-social/atproto/issues/4764)). The SDK surfaces this as \`ValueError: Failed to resolve handle: X\` which plyr.fm then wraps in:

\`\`\`
400: failed to start OAuth flow: Failed to resolve handle: zzstoatzzdevlog.bsky.social
\`\`\`

That reads to end users like an account problem on their end. It is not — it's a transient upstream issue at Bluesky's CDN/WAF that we have no client-side workaround for.

## What this does

\`_bsky_edge_block_error\` detects the two failure shapes observed in production spans:

1. SDK \`ValueError: Failed to resolve handle: <X>.bsky.social\` (handle resolution leg)
2. Exception messages containing \`403 Forbidden\` and \`bsky.social\` (auth server metadata fetch leg, hit during \`fetch_authserver_metadata_async\`)

When detected, returns **503** with a clear "upstream Bluesky issue, please try again in a few minutes" message linking the tracking issue.

Real account errors (typos on non-bsky domains, etc.) keep the existing 400 shape — only the specific failure pattern is rewritten.

Wired into both \`start_oauth_flow\` (new logins) and \`start_oauth_flow_with_scopes\` (copyright scope-upgrade).

## Why not a real fix

Investigated extensively today (urllib vs httpx, header tweaks, ALPN config, custom SSL contexts). Discriminator is TLS-fingerprint-level (JA3/JA4 likely) — every modern Python async HTTP lib (\`httpx\`, \`requests\`, \`aiohttp\`) gets 403 from fly egress; only stdlib \`urllib\` succeeds. Bypassing requires either:
- A custom httpx Transport that delegates to urllib (~30-60min fork work, untested at scale)
- Routing through a non-cloud egress proxy (infra change)
- Waiting it out — prior #4764 incidents resolved in ~24h on their own

This PR ships nicer error UX so the failure doesn't look like our bug. Investigation comment posted on #4764 with full reproduction matrix.

## Test plan

- [x] 4 unit tests in \`tests/_internal/test_bsky_edge_block_error.py\` — covers both detection shapes, plus two negative cases (real typo, unrelated error on bsky handle)
- [x] adjacent \`test_auth_modules.py\` + \`test_oauth_client_metadata.py\` still pass (10 tests)
- [x] ruff / loq clean
- [ ] after deploy: verify aila / \`zzstoatzzdevlog.bsky.social\` sees 503 with friendly message instead of 400 stack-trace