### PR TITLE
refactor(sheets): unify on BottomSheet frame; swipe-from-body like instagram comments

### DIFF
--- a/frontend/src/lib/components/AudioRevisionsSheet.svelte
+++ b/frontend/src/lib/components/AudioRevisionsSheet.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import BottomSheet from './BottomSheet.svelte';
+
 	interface RevisionRow {
 		id: number;
 		track_id: number;
@@ -68,149 +70,77 @@
 		if (rev.was_gated) parts.push('was gated');
 		return parts.join(' · ');
 	}
-
-	function handleBackdropClick(event: MouseEvent) {
-		if (event.target === event.currentTarget) onClose();
-	}
-
-	function stopPropagation(event: MouseEvent) {
-		event.stopPropagation();
-	}
-
-	function handleSheetKeydown(event: KeyboardEvent) {
-		if (event.key === 'Escape') {
-			event.preventDefault();
-			onClose();
-		}
-	}
 </script>
 
-<div
-	class="sheet-backdrop"
-	class:open
-	role="presentation"
-	onclick={handleBackdropClick}
+<BottomSheet
+	{open}
+	{onClose}
+	ariaLabel="version history"
+	maxWidth="480px"
+	maxHeight="70vh"
+	centerOnDesktop
 >
-	<div
-		class="sheet"
-		role="dialog"
-		aria-modal="true"
-		aria-label="version history"
-		tabindex="-1"
-		onclick={stopPropagation}
-		onkeydown={handleSheetKeydown}
-	>
-		<div class="sheet-handle"></div>
-		<div class="sheet-header">
-			<div class="sheet-titles">
-				<span class="sheet-title">version history</span>
-				<span class="sheet-subtitle">{trackTitle}</span>
-			</div>
-			<button class="sheet-close" onclick={onClose} aria-label="close">
-				<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-					<line x1="18" y1="6" x2="6" y2="18"></line>
-					<line x1="6" y1="6" x2="18" y2="18"></line>
-				</svg>
-			</button>
+	<div class="sheet-header">
+		<div class="sheet-titles">
+			<span class="sheet-title">version history</span>
+			<span class="sheet-subtitle">{trackTitle}</span>
 		</div>
-		<div class="sheet-content">
-			{#if loading}
-				<div class="sheet-loading">
-					{#each [1, 2, 3] as _, i (i)}
-						<div class="revision-skeleton">
-							<div class="icon-skeleton"></div>
-							<div class="text-skeleton-stack">
-								<div class="text-skeleton wide"></div>
-								<div class="text-skeleton narrow"></div>
-							</div>
-							<div class="btn-skeleton"></div>
-						</div>
-					{/each}
-				</div>
-			{:else if error}
-				<div class="sheet-empty error">{error}</div>
-			{:else if revisions.length > 0}
-				<div class="revisions-list">
-					{#each revisions as rev (rev.id)}
-						<div class="revision-row">
-							<div class="revision-icon" aria-hidden="true">
-								<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-									<path d="M9 18V5l12-2v13"></path>
-									<circle cx="6" cy="18" r="3"></circle>
-									<circle cx="18" cy="16" r="3"></circle>
-								</svg>
-							</div>
-							<div class="revision-info">
-								<span class="revision-format">{formatFormat(rev)}</span>
-								<span class="revision-meta">{buildSubtitle(rev)}</span>
-							</div>
-							<button
-								class="restore-btn"
-								onclick={() => onRestore(rev)}
-							>
-								restore
-							</button>
-						</div>
-					{/each}
-				</div>
-			{:else}
-				<div class="sheet-empty">
-					no previous versions yet — replace the audio to start building history
-				</div>
-			{/if}
-		</div>
+		<button class="sheet-close" onclick={onClose} aria-label="close">
+			<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+				<line x1="18" y1="6" x2="6" y2="18"></line>
+				<line x1="6" y1="6" x2="18" y2="18"></line>
+			</svg>
+		</button>
 	</div>
-</div>
+	<div class="sheet-content">
+		{#if loading}
+			<div class="sheet-loading">
+				{#each [1, 2, 3] as _, i (i)}
+					<div class="revision-skeleton">
+						<div class="icon-skeleton"></div>
+						<div class="text-skeleton-stack">
+							<div class="text-skeleton wide"></div>
+							<div class="text-skeleton narrow"></div>
+						</div>
+						<div class="btn-skeleton"></div>
+					</div>
+				{/each}
+			</div>
+		{:else if error}
+			<div class="sheet-empty error">{error}</div>
+		{:else if revisions.length > 0}
+			<div class="revisions-list">
+				{#each revisions as rev (rev.id)}
+					<div class="revision-row">
+						<div class="revision-icon" aria-hidden="true">
+							<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+								<path d="M9 18V5l12-2v13"></path>
+								<circle cx="6" cy="18" r="3"></circle>
+								<circle cx="18" cy="16" r="3"></circle>
+							</svg>
+						</div>
+						<div class="revision-info">
+							<span class="revision-format">{formatFormat(rev)}</span>
+							<span class="revision-meta">{buildSubtitle(rev)}</span>
+						</div>
+						<button
+							class="restore-btn"
+							onclick={() => onRestore(rev)}
+						>
+							restore
+						</button>
+					</div>
+				{/each}
+			</div>
+		{:else}
+			<div class="sheet-empty">
+				no previous versions yet — replace the audio to start building history
+			</div>
+		{/if}
+	</div>
+</BottomSheet>
 
 <style>
-	.sheet-backdrop {
-		position: fixed;
-		inset: 0;
-		background: color-mix(in srgb, var(--bg-primary) 60%, transparent);
-		backdrop-filter: blur(4px);
-		-webkit-backdrop-filter: blur(4px);
-		z-index: 9999;
-		opacity: 0;
-		pointer-events: none;
-		transition: opacity 0.15s;
-		display: flex;
-		align-items: flex-end;
-		justify-content: center;
-	}
-
-	.sheet-backdrop.open {
-		opacity: 1;
-		pointer-events: auto;
-	}
-
-	.sheet {
-		width: 100%;
-		max-width: 480px;
-		max-height: 70vh;
-		background: var(--bg-secondary);
-		border: 1px solid var(--border-subtle);
-		border-bottom: none;
-		border-radius: var(--radius-xl) var(--radius-xl) 0 0;
-		display: flex;
-		flex-direction: column;
-		transform: translateY(100%);
-		transition: transform 0.2s ease-out;
-		padding-bottom: env(safe-area-inset-bottom, 0px);
-	}
-
-	.sheet-backdrop.open .sheet {
-		transform: translateY(0);
-	}
-
-	.sheet-handle {
-		width: 32px;
-		height: 4px;
-		background: var(--border-default);
-		border-radius: 2px;
-		margin: 0.75rem auto 0;
-		flex-shrink: 0;
-	}
-
 	.sheet-header {
 		display: flex;
 		align-items: flex-start;
@@ -410,42 +340,11 @@
 		100% { background-position: -200% 0; }
 	}
 
-	@media (min-width: 600px) {
-		.sheet-backdrop {
-			align-items: center;
-		}
-
-		.sheet {
-			border-radius: var(--radius-xl);
-			border-bottom: 1px solid var(--border-subtle);
-			max-width: 480px;
-			max-height: 70vh;
-			transform: scale(0.95);
-			opacity: 0;
-			transition: transform 0.2s ease-out, opacity 0.15s;
-		}
-
-		.sheet-backdrop.open .sheet {
-			transform: scale(1);
-			opacity: 1;
-		}
-
-		.sheet-handle {
-			display: none;
-		}
-	}
-
 	@media (prefers-reduced-motion: reduce) {
 		.icon-skeleton,
 		.text-skeleton,
 		.btn-skeleton {
 			animation: none;
-		}
-		.sheet {
-			transition: none;
-		}
-		.sheet-backdrop {
-			transition: none;
 		}
 	}
 </style>

--- a/frontend/src/lib/components/BottomSheet.svelte
+++ b/frontend/src/lib/components/BottomSheet.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+	import { tick, type Snippet } from 'svelte';
+	import { swipeToDismiss } from '$lib/swipe-to-dismiss';
+
+	interface Props {
+		open: boolean;
+		onClose: () => void;
+		ariaLabel: string;
+		/** css max-width override (default: '400px') */
+		maxWidth?: string;
+		/** css max-height override (default: '60vh') */
+		maxHeight?: string;
+		/** on desktop (>=600px), switch from bottom sheet to centered modal */
+		centerOnDesktop?: boolean;
+		children: Snippet;
+	}
+
+	let {
+		open,
+		onClose,
+		ariaLabel,
+		maxWidth = '400px',
+		maxHeight = '60vh',
+		centerOnDesktop = false,
+		children
+	}: Props = $props();
+
+	let sheetEl: HTMLDivElement | null = $state(null);
+	let previousFocus: HTMLElement | null = null;
+
+	function handleBackdropClick(event: MouseEvent) {
+		if (event.target === event.currentTarget) onClose();
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			onClose();
+		} else if (event.key === 'Tab') {
+			trapFocus(event);
+		}
+	}
+
+	function trapFocus(event: KeyboardEvent) {
+		if (!sheetEl) return;
+		const focusable = sheetEl.querySelectorAll<HTMLElement>(
+			'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+		);
+		if (focusable.length === 0) {
+			event.preventDefault();
+			sheetEl.focus();
+			return;
+		}
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+		const active = document.activeElement as HTMLElement | null;
+
+		if (event.shiftKey && active === first) {
+			event.preventDefault();
+			last.focus();
+		} else if (!event.shiftKey && active === last) {
+			event.preventDefault();
+			first.focus();
+		}
+	}
+
+	$effect(() => {
+		if (open && sheetEl) {
+			previousFocus = document.activeElement as HTMLElement | null;
+			// defer to next tick so the open transition can begin before focus moves
+			tick().then(() => sheetEl?.focus({ preventScroll: true }));
+		} else if (!open && previousFocus) {
+			previousFocus.focus?.();
+			previousFocus = null;
+		}
+	});
+</script>
+
+<svelte:window onkeydown={open ? handleKeydown : null} />
+
+<div
+	class="sheet-backdrop"
+	class:open
+	class:center-desktop={centerOnDesktop}
+	role="presentation"
+	onclick={handleBackdropClick}
+	inert={open ? undefined : true}
+>
+	<div
+		bind:this={sheetEl}
+		class="sheet"
+		role="dialog"
+		aria-modal="true"
+		aria-label={ariaLabel}
+		tabindex="-1"
+		style="--bottom-sheet-max-width: {maxWidth}; --bottom-sheet-max-height: {maxHeight};"
+		{@attach swipeToDismiss(onClose)}
+	>
+		<div class="sheet-handle-area" role="presentation">
+			<div class="sheet-handle"></div>
+		</div>
+		{@render children()}
+	</div>
+</div>
+
+<style>
+	.sheet-backdrop {
+		position: fixed;
+		inset: 0;
+		background: color-mix(in srgb, var(--bg-primary) 60%, transparent);
+		backdrop-filter: blur(4px);
+		-webkit-backdrop-filter: blur(4px);
+		z-index: 9999;
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 0.15s;
+		display: flex;
+		align-items: flex-end;
+		justify-content: center;
+	}
+
+	.sheet-backdrop.open {
+		opacity: 1;
+		pointer-events: auto;
+	}
+
+	.sheet {
+		width: 100%;
+		max-width: var(--bottom-sheet-max-width, 400px);
+		max-height: var(--bottom-sheet-max-height, 60vh);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-subtle);
+		border-bottom: none;
+		border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+		display: flex;
+		flex-direction: column;
+		transform: translateY(100%);
+		transition: transform 0.2s ease-out;
+		padding-bottom: env(safe-area-inset-bottom, 0px);
+		/* let the browser scroll vertically by default; the gesture only takes
+		   over when our pointer handler explicitly applies a transform */
+		touch-action: pan-y;
+	}
+
+	.sheet-backdrop.open .sheet {
+		transform: translateY(0);
+	}
+
+	.sheet-handle-area {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		padding: 0.75rem 1rem 0.5rem;
+		flex-shrink: 0;
+		-webkit-user-select: none;
+		user-select: none;
+	}
+
+	.sheet-handle {
+		width: 36px;
+		height: 4px;
+		background: var(--border-default);
+		border-radius: 2px;
+		flex-shrink: 0;
+	}
+
+	@media (min-width: 600px) {
+		.sheet-backdrop.center-desktop {
+			align-items: center;
+		}
+
+		.sheet-backdrop.center-desktop .sheet {
+			border-radius: var(--radius-xl);
+			border-bottom: 1px solid var(--border-subtle);
+			transform: scale(0.95);
+			opacity: 0;
+			transition:
+				transform 0.2s ease-out,
+				opacity 0.15s;
+		}
+
+		.sheet-backdrop.center-desktop.open .sheet {
+			transform: scale(1);
+			opacity: 1;
+		}
+
+		.sheet-backdrop.center-desktop .sheet-handle-area {
+			display: none;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.sheet,
+		.sheet-backdrop {
+			transition: none;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/LikersSheet.svelte
+++ b/frontend/src/lib/components/LikersSheet.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { likersSheet } from '$lib/likers-sheet.svelte';
 	import { getRefreshedAvatar, triggerAvatarRefresh, hasAttemptedRefresh } from '$lib/avatar-refresh.svelte';
-	import { swipeToDismiss } from '$lib/swipe-to-dismiss';
+	import BottomSheet from './BottomSheet.svelte';
 	import SensitiveImage from './SensitiveImage.svelte';
 	import type { LikerData } from '$lib/tooltip-cache.svelte';
 
@@ -29,151 +29,69 @@
 		if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`;
 		return `${Math.floor(seconds / 604800)}w ago`;
 	}
-
-	function handleBackdropClick(event: MouseEvent) {
-		if (event.target === event.currentTarget) likersSheet.close();
-	}
 </script>
 
-<div
-	class="sheet-backdrop"
-	class:open={likersSheet.isOpen}
-	role="presentation"
-	onclick={handleBackdropClick}
+<BottomSheet
+	open={likersSheet.isOpen}
+	onClose={() => likersSheet.close()}
+	ariaLabel="liked by"
 >
-	<div
-		class="sheet"
-		role="dialog"
-		aria-modal="true"
-		aria-label="liked by"
-		{@attach swipeToDismiss(() => likersSheet.close())}
-	>
-		<div class="sheet-handle-area" data-sheet-handle role="presentation">
-			<div class="sheet-handle"></div>
-		</div>
-		<div class="sheet-header">
-			<span class="sheet-title">
-				{likersSheet.likeCount} {likersSheet.likeCount === 1 ? 'like' : 'likes'}
-			</span>
-			<button class="sheet-close" onclick={() => likersSheet.close()} aria-label="close">
-				<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-					<line x1="18" y1="6" x2="6" y2="18"></line>
-					<line x1="6" y1="6" x2="18" y2="18"></line>
-				</svg>
-			</button>
-		</div>
-		<div class="sheet-content">
-			{#if likersSheet.loading}
-				<div class="sheet-loading">
-					{#each [1, 2, 3] as _, i (i)}
-						<div class="liker-skeleton">
-							<div class="avatar-skeleton"></div>
-							<div class="text-skeleton"></div>
-						</div>
-					{/each}
-				</div>
-			{:else if likersSheet.error}
-				<div class="sheet-empty">{likersSheet.error}</div>
-			{:else if likersSheet.likers.length > 0}
-				<div class="likers-list">
-					{#each likersSheet.likers as liker (liker.did)}
-						{@const displayUrl = getDisplayUrl(liker)}
-						{@const showFallback = shouldShowFallback(liker)}
-						<a href="/u/{liker.handle}/liked" class="liker-row" onclick={() => likersSheet.close()}>
-							<div class="liker-avatar">
-								{#if displayUrl && !showFallback}
-									<SensitiveImage src={displayUrl} compact>
-										<img
-											src={displayUrl}
-											alt=""
-											onerror={() => handleAvatarError(liker.did)}
-										/>
-									</SensitiveImage>
-								{:else}
-									<span class="liker-initial">{(liker.display_name || liker.handle).charAt(0).toUpperCase()}</span>
-								{/if}
-							</div>
-							<div class="liker-info">
-								<span class="liker-name">{liker.display_name || liker.handle}</span>
-								<span class="liker-time">{formatTime(liker.liked_at)}</span>
-							</div>
-						</a>
-					{/each}
-				</div>
-			{:else}
-				<div class="sheet-empty">be the first to like this</div>
-			{/if}
-		</div>
+	<div class="sheet-header">
+		<span class="sheet-title">
+			{likersSheet.likeCount} {likersSheet.likeCount === 1 ? 'like' : 'likes'}
+		</span>
+		<button class="sheet-close" onclick={() => likersSheet.close()} aria-label="close">
+			<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+				<line x1="18" y1="6" x2="6" y2="18"></line>
+				<line x1="6" y1="6" x2="18" y2="18"></line>
+			</svg>
+		</button>
 	</div>
-</div>
+	<div class="sheet-content">
+		{#if likersSheet.loading}
+			<div class="sheet-loading">
+				{#each [1, 2, 3] as _, i (i)}
+					<div class="liker-skeleton">
+						<div class="avatar-skeleton"></div>
+						<div class="text-skeleton"></div>
+					</div>
+				{/each}
+			</div>
+		{:else if likersSheet.error}
+			<div class="sheet-empty">{likersSheet.error}</div>
+		{:else if likersSheet.likers.length > 0}
+			<div class="likers-list">
+				{#each likersSheet.likers as liker (liker.did)}
+					{@const displayUrl = getDisplayUrl(liker)}
+					{@const showFallback = shouldShowFallback(liker)}
+					<a href="/u/{liker.handle}/liked" class="liker-row" onclick={() => likersSheet.close()}>
+						<div class="liker-avatar">
+							{#if displayUrl && !showFallback}
+								<SensitiveImage src={displayUrl} compact>
+									<img
+										src={displayUrl}
+										alt=""
+										onerror={() => handleAvatarError(liker.did)}
+									/>
+								</SensitiveImage>
+							{:else}
+								<span class="liker-initial">{(liker.display_name || liker.handle).charAt(0).toUpperCase()}</span>
+							{/if}
+						</div>
+						<div class="liker-info">
+							<span class="liker-name">{liker.display_name || liker.handle}</span>
+							<span class="liker-time">{formatTime(liker.liked_at)}</span>
+						</div>
+					</a>
+				{/each}
+			</div>
+		{:else}
+			<div class="sheet-empty">be the first to like this</div>
+		{/if}
+	</div>
+</BottomSheet>
 
 <style>
-	.sheet-backdrop {
-		position: fixed;
-		inset: 0;
-		background: color-mix(in srgb, var(--bg-primary) 60%, transparent);
-		backdrop-filter: blur(4px);
-		-webkit-backdrop-filter: blur(4px);
-		z-index: 9999;
-		opacity: 0;
-		pointer-events: none;
-		transition: opacity 0.15s;
-		display: flex;
-		align-items: flex-end;
-		justify-content: center;
-	}
-
-	.sheet-backdrop.open {
-		opacity: 1;
-		pointer-events: auto;
-	}
-
-	.sheet {
-		width: 100%;
-		max-width: 400px;
-		max-height: 60vh;
-		background: var(--bg-secondary);
-		border: 1px solid var(--border-subtle);
-		border-bottom: none;
-		border-radius: var(--radius-xl) var(--radius-xl) 0 0;
-		display: flex;
-		flex-direction: column;
-		transform: translateY(100%);
-		transition: transform 0.2s ease-out;
-		padding-bottom: env(safe-area-inset-bottom, 0px);
-	}
-
-	.sheet-backdrop.open .sheet {
-		transform: translateY(0);
-	}
-
-	.sheet-handle-area {
-		/* expanded hit target (>= 44px tall) so a thumb-flick anywhere along the
-		   top strip triggers swipe-to-dismiss. visible handle stays small. */
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		padding: 0.75rem 1rem 0.5rem;
-		flex-shrink: 0;
-		cursor: grab;
-		/* prevent ios from interpreting the vertical drag as scroll */
-		touch-action: none;
-		-webkit-user-select: none;
-		user-select: none;
-	}
-
-	.sheet-handle-area:active {
-		cursor: grabbing;
-	}
-
-	.sheet-handle {
-		width: 36px;
-		height: 4px;
-		background: var(--border-default);
-		border-radius: 2px;
-		flex-shrink: 0;
-	}
-
 	.sheet-header {
 		display: flex;
 		align-items: center;
@@ -331,12 +249,6 @@
 		.avatar-skeleton,
 		.text-skeleton {
 			animation: none;
-		}
-		.sheet {
-			transition: none;
-		}
-		.sheet-backdrop {
-			transition: none;
 		}
 	}
 </style>

--- a/frontend/src/lib/swipe-to-dismiss.ts
+++ b/frontend/src/lib/swipe-to-dismiss.ts
@@ -1,34 +1,33 @@
-// swipe-to-dismiss attachment for bottom sheets.
+// swipe-to-dismiss attachment for bottom sheets — instagram-comments style.
 //
-// the visual handle on a bottom sheet is a near-universal mobile affordance
-// (iOS sheets, android bottom sheets) that signals "drag me down to close".
-// without this attachment the affordance lies — the handle is decorative and
-// the only dismiss is tapping a small × or the backdrop.
+// gesture activates anywhere on the sheet, but only when the inner scroller is
+// pinned at the top. once the user has scrolled into the content, a downward
+// swipe scrolls (browser default) rather than dragging the sheet. when scroll
+// is at top, a downward swipe drags the sheet; release past the threshold or
+// at sufficient velocity dismisses.
 //
 // usage:
 //   <div class="sheet" {@attach swipeToDismiss(() => sheet.close())}>
-//     <div class="sheet-handle-area" data-sheet-handle>
-//       <div class="sheet-handle"></div>
-//     </div>
 //     ...
+//     <div class="sheet-content">...</div>
 //   </div>
 //
-// the attachment is applied to the sheet element. it locates its handle by
-// `[data-sheet-handle]` and binds pointer listeners there. drag updates the
-// sheet's inline transform; release either dismisses (call `onDismiss`) past
-// the threshold/velocity, or snaps back by clearing the inline transform.
+// the attachment binds on the sheet element; it locates the inner scroller via
+// `scrollSelector` (default `.sheet-content`) to gate activation.
 
 import type { Attachment } from 'svelte/attachments';
 
 interface SwipeToDismissOptions {
-	/** css selector for the drag handle within the sheet (default: `[data-sheet-handle]`) */
-	handleSelector?: string;
+	/** css selector for the inner scroll container that gates activation (default: `.sheet-content`) */
+	scrollSelector?: string;
 	/** distance in px past which release dismisses (default: 80) */
 	dismissDeltaPx?: number;
 	/** downward velocity in px/ms past which release dismisses (default: 0.5) */
 	dismissVelocityPxPerMs?: number;
 	/** ms to wait before clearing the inline dismiss transform (default: 250, matches sheet transition) */
 	dismissResetMs?: number;
+	/** minimum vertical delta (px) before activation, used to suppress accidental drags from taps (default: 6) */
+	activationDeltaPx?: number;
 }
 
 export function swipeToDismiss(
@@ -36,37 +35,86 @@ export function swipeToDismiss(
 	options: SwipeToDismissOptions = {}
 ): Attachment<HTMLElement> {
 	const {
-		handleSelector = '[data-sheet-handle]',
+		scrollSelector = '.sheet-content',
 		dismissDeltaPx = 80,
 		dismissVelocityPxPerMs = 0.5,
-		dismissResetMs = 250
+		dismissResetMs = 250,
+		activationDeltaPx = 6
 	} = options;
 
 	return (sheet) => {
-		const handle = sheet.querySelector<HTMLElement>(handleSelector);
-		if (!handle) return;
-
-		let dragging = false;
+		let tracking = false;
+		let active = false;
+		let startX = 0;
 		let startY = 0;
 		let delta = 0;
 		let lastY = 0;
 		let lastT = 0;
 		let velocity = 0;
+		let scroller: HTMLElement | null = null;
+		let pointerId = -1;
+
+		function findScroller(): HTMLElement | null {
+			return sheet.querySelector<HTMLElement>(scrollSelector);
+		}
+
+		function scrollAtTop(): boolean {
+			// no scroller (single-page sheet) ⇒ always at top
+			return !scroller || scroller.scrollTop <= 0;
+		}
 
 		function down(event: PointerEvent) {
-			dragging = true;
+			// only react to touch/pen drags; mouse users have the close button + backdrop + escape
+			if (event.pointerType === 'mouse') return;
+			tracking = true;
+			active = false;
+			scroller = findScroller();
+			startX = event.clientX;
 			startY = event.clientY;
 			lastY = event.clientY;
 			lastT = event.timeStamp;
 			delta = 0;
 			velocity = 0;
-			handle!.setPointerCapture(event.pointerId);
+			pointerId = event.pointerId;
+		}
+
+		function activate(event: PointerEvent) {
+			active = true;
+			try {
+				sheet.setPointerCapture(event.pointerId);
+			} catch {
+				// pointer may have been released between move events; ignore
+			}
 			sheet.style.transition = 'none';
 		}
 
 		function move(event: PointerEvent) {
-			if (!dragging) return;
-			const d = Math.max(0, event.clientY - startY);
+			if (!tracking || event.pointerId !== pointerId) return;
+			const dx = event.clientX - startX;
+			const dy = event.clientY - startY;
+
+			if (!active) {
+				// not yet activated — decide whether to take over
+				if (Math.abs(dy) < activationDeltaPx) return; // below noise floor
+				if (Math.abs(dx) > Math.abs(dy)) {
+					// horizontal-dominant: not a dismiss gesture
+					tracking = false;
+					return;
+				}
+				if (dy <= 0) {
+					// upward: never a dismiss
+					tracking = false;
+					return;
+				}
+				if (!scrollAtTop()) {
+					// downward but scroller has scrolled — let the browser scroll
+					tracking = false;
+					return;
+				}
+				activate(event);
+			}
+
+			const d = Math.max(0, dy);
 			const dt = event.timeStamp - lastT;
 			if (dt > 0) velocity = (event.clientY - lastY) / dt;
 			lastY = event.clientY;
@@ -75,10 +123,14 @@ export function swipeToDismiss(
 			sheet.style.transform = `translateY(${d}px)`;
 		}
 
-		function up() {
-			if (!dragging) return;
-			dragging = false;
-			// restore the css transition so snap-back / dismiss animate
+		function up(event: PointerEvent) {
+			if (!tracking || event.pointerId !== pointerId) return;
+			const wasActive = active;
+			tracking = false;
+			active = false;
+			pointerId = -1;
+			if (!wasActive) return;
+
 			sheet.style.transition = '';
 			const shouldDismiss = delta > dismissDeltaPx || velocity > dismissVelocityPxPerMs;
 			if (shouldDismiss) {
@@ -96,16 +148,16 @@ export function swipeToDismiss(
 			}
 		}
 
-		handle.addEventListener('pointerdown', down);
-		handle.addEventListener('pointermove', move);
-		handle.addEventListener('pointerup', up);
-		handle.addEventListener('pointercancel', up);
+		sheet.addEventListener('pointerdown', down);
+		sheet.addEventListener('pointermove', move);
+		sheet.addEventListener('pointerup', up);
+		sheet.addEventListener('pointercancel', up);
 
 		return () => {
-			handle.removeEventListener('pointerdown', down);
-			handle.removeEventListener('pointermove', move);
-			handle.removeEventListener('pointerup', up);
-			handle.removeEventListener('pointercancel', up);
+			sheet.removeEventListener('pointerdown', down);
+			sheet.removeEventListener('pointermove', move);
+			sheet.removeEventListener('pointerup', up);
+			sheet.removeEventListener('pointercancel', up);
 		};
 	};
 }


### PR DESCRIPTION
## Summary

- Extract `BottomSheet.svelte` — one frame component that owns backdrop, handle affordance, `role="dialog"` + `aria-modal` + `aria-label`, Escape-to-dismiss, focus trap + restore, `inert` on the backdrop while closed, `prefers-reduced-motion`, `safe-area-inset-bottom`, and the swipe gesture. Consumers provide `{ open, onClose, ariaLabel, children }` plus optional `maxWidth` / `maxHeight` / `centerOnDesktop`.
- Rewrite the swipe-to-dismiss gesture (`$lib/swipe-to-dismiss.ts`) to **Instagram-comments style** — the gesture binds on the whole sheet, not the tiny handle. It activates only when motion is dominantly vertical-down **and** the inner scroll container (`.sheet-content` by default) is at `scrollTop === 0`. Once the user has scrolled into the content, a downward swipe scrolls; once back at top, the next swipe drags the sheet. Mouse pointers are excluded (close button + backdrop click + Escape already cover them on desktop).
- Migrate `LikersSheet.svelte` and `AudioRevisionsSheet.svelte` onto the frame. `AudioRevisionsSheet` keeps its existing 600px+ centered-modal behavior via `centerOnDesktop`. Both gain the body-level swipe; `AudioRevisionsSheet` also gains focus management for the first time.

Closes #1348.

### Why the gesture change

The old gesture required users to grab a 36×4px decorative handle at the very top of the sheet — bad UX. Now you can swipe down from anywhere on the sheet body. The scroll-aware gate (only dismisses when the scroller is at the top) is what makes it feel right alongside scrollable content, matching the Instagram comments / iOS sheets mental model.

### Scope notes

- Other "sheets" listed in the issue: `routes/playlist/[id]/+page.svelte`'s `.search-modal` is a centered modal (not a bottom sheet), and `routes/u/[handle]/album/[slug]/+page.svelte` / `routes/liked/+page.svelte` don't contain inline bottom-sheet markup. Left out of scope; revisit in a Dialog unification if/when that ticket gets filed.
- `inert` is applied to the backdrop while closed (removes the offscreen sheet from focus order). True background-inert-while-open requires walking sibling DOM or portaling — kept simple; can be a follow-up if real-world focus leakage is observed.
- The `centerOnDesktop` prop is the one piece of "abstraction for a concrete consumer" — it serves `AudioRevisionsSheet` today; without it that consumer would need scoped-CSS overrides into the frame, which Svelte's scoping makes ugly.

## Test plan

- [ ] On mobile (or DevTools mobile emulation), open the likers sheet from a track's heart-count tooltip. Confirm: swipe-down from anywhere on the sheet (header, list, empty area) dismisses it. Scroll the list, then try swiping down mid-list — the list scrolls instead. Scroll back to top, swipe down — dismisses.
- [ ] Same on the audio-revisions sheet (track edit modal → "version history"). Confirm: gesture works on both the list area and the header.
- [ ] On desktop (≥600px), the audio-revisions sheet still appears as a centered modal with scale-in animation. The handle is hidden.
- [ ] Both sheets dismiss on Escape, backdrop click, and the × button.
- [ ] Tab cycles focus within the open sheet without escaping to the page underneath. On close, focus returns to whatever element opened the sheet.
- [ ] `prefers-reduced-motion: reduce` disables the slide / scale transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)