### PR TITLE
fix(#1356): pause player when track changes from remote tab sync

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -544,6 +544,8 @@
 				// only set shouldAutoPlay if this was a local update (not from another tab's broadcast)
 				if (queue.lastUpdateWasLocal) {
 					shouldAutoPlay = true;
+				} else {
+					player.paused = true;
 				}
 			} else if (indexChanged) {
 				player.currentTime = 0;


### PR DESCRIPTION
## Problem

When two plyr.fm tabs are open, pressing play in one tab causes both tabs to play audio simultaneously.

## Root Cause

When the queue syncs from a remote tab (via BroadcastChannel), `player.currentTrack` is updated but `player.paused` is never set to `true`. The existing guard correctly prevents `shouldAutoPlay` from being set, but since `player.paused` is still `false` from the previous playback, the audio source loads and starts playing once loading completes.

**The flow on the remote tab:**
1. Was playing track X → `player.paused = false`, audio playing
2. Queue syncs from BroadcastChannel → `player.currentTrack = Y` (track changed)
3. Track-change effect sets `isLoadingTrack = true`, audio loader changes `<audio>` src to Y's URL
4. Paused-sync effect returns early because `isLoadingTrack` is `true`
5. Y finishes loading → `isLoadingTrack = false`
6. Paused-sync effect fires: `player.paused` is still `false` → `audio.play()` fires

## Fix

Add `player.paused = true` in the else branch of the `lastUpdateWasLocal` check in `Player.svelte`, so that when a track change arrives from a remote tab's broadcast, the player pauses playback.

Closes #1356