### PR TITLE
fix(now-playing): claim throttle before await to stop duplicate burst sends

### DIFF
--- a/backend/src/backend/_internal/notifications.py
+++ b/backend/src/backend/_internal/notifications.py
@@ -1,6 +1,7 @@
 """notification service for relay events."""
 
 import logging
+import time
 from dataclasses import dataclass
 
 import logfire
@@ -25,13 +26,21 @@ class NotificationResult:
 class NotificationService:
     """service for sending notifications about relay events."""
 
+    # if setup fails (e.g. bsky.social returning 403 during a WAF incident),
+    # retry no more than once per this many seconds. each track upload would
+    # otherwise re-attempt the login and hammer the upstream during outages.
+    _SETUP_RETRY_COOLDOWN_S = 60.0
+
     def __init__(self):
         self.client: AsyncClient | None = None
         self.dm_client: AsyncClient | None = None
         self.recipient_did: str | None = None
+        self._last_setup_attempt: float = 0.0
 
     async def setup(self):
-        """initialize the notification service."""
+        """initialize the notification service. safe to call repeatedly."""
+        self._last_setup_attempt = time.monotonic()
+
         if not settings.notify.enabled:
             logger.info("notification service disabled")
             return
@@ -68,7 +77,7 @@ class NotificationService:
                 {"actor": settings.notify.recipient_handle}
             )
             self.recipient_did = profile.did
-            logger.debug(
+            logger.info(
                 f"resolved {settings.notify.recipient_handle} to {self.recipient_did}"
             )
 
@@ -79,6 +88,23 @@ class NotificationService:
             self.client = None
             self.dm_client = None
             self.recipient_did = None
+
+    async def ensure_ready(self) -> str | None:
+        """return the resolved recipient DID if the service is ready, else None.
+
+        if state is broken (recipient_did missing) and notifications are
+        enabled, attempt to re-run setup() to recover. retries are rate-
+        limited by _SETUP_RETRY_COOLDOWN_S so a sustained upstream outage
+        doesn't get amplified into every-upload login attempts.
+        """
+        if self.recipient_did is not None:
+            return self.recipient_did
+        if not settings.notify.enabled:
+            return None
+        if (time.monotonic() - self._last_setup_attempt) < self._SETUP_RETRY_COOLDOWN_S:
+            return None
+        await self.setup()
+        return self.recipient_did
 
     async def _send_dm_to_did(
         self, recipient_did: str, message_text: str
@@ -161,7 +187,8 @@ class NotificationService:
         matches: list[dict],
     ) -> NotificationResult | None:
         """send admin-only notification about a copyright flag."""
-        if not self.recipient_did:
+        recipient_did = await self.ensure_ready()
+        if recipient_did is None:
             logger.warning("recipient not set, skipping notification")
             return None
 
@@ -188,7 +215,7 @@ class NotificationService:
         if track_url:
             message_text += f"\n{track_url}"
 
-        result = await self._send_dm_to_did(self.recipient_did, message_text)
+        result = await self._send_dm_to_did(recipient_did, message_text)
         if result.success:
             logger.info(f"sent copyright flag notification for track {track_id}")
         return result
@@ -208,7 +235,8 @@ class NotificationService:
             categories: list of violated policy categories
             context: where the image was uploaded (e.g., "track cover", "album cover")
         """
-        if not self.recipient_did:
+        recipient_did = await self.ensure_ready()
+        if recipient_did is None:
             logger.warning("recipient not set, skipping notification")
             return None
 
@@ -221,7 +249,7 @@ class NotificationService:
             f"categories: {categories_str}"
         )
 
-        result = await self._send_dm_to_did(self.recipient_did, message_text)
+        result = await self._send_dm_to_did(recipient_did, message_text)
         if result.success:
             logger.info(f"sent image flag notification for {image_id}")
         return result
@@ -237,7 +265,8 @@ class NotificationService:
         description: str | None,
     ) -> NotificationResult | None:
         """send notification about a new user report."""
-        if not self.recipient_did:
+        recipient_did = await self.ensure_ready()
+        if recipient_did is None:
             logger.warning("recipient not set, skipping notification")
             return None
 
@@ -264,14 +293,15 @@ class NotificationService:
             desc = description[:200] + "..." if len(description) > 200 else description
             message_text += f'\n"{desc}"'
 
-        result = await self._send_dm_to_did(self.recipient_did, message_text)
+        result = await self._send_dm_to_did(recipient_did, message_text)
         if result.success:
             logger.info(f"sent user report notification for report {report_id}")
         return result
 
     async def send_track_notification(self, track: Track) -> NotificationResult | None:
         """send notification about a new track."""
-        if not self.recipient_did:
+        recipient_did = await self.ensure_ready()
+        if recipient_did is None:
             logger.warning("recipient not set, skipping notification")
             return None
 
@@ -298,7 +328,7 @@ class NotificationService:
                 f"uploaded: {track.created_at.strftime('%b %d at %H:%M UTC')}"
             )
 
-        result = await self._send_dm_to_did(self.recipient_did, message_text)
+        result = await self._send_dm_to_did(recipient_did, message_text)
         if result.success:
             logger.info(f"sent notification for track {track.id}")
         return result
@@ -317,7 +347,8 @@ class NotificationService:
         on-call (you) jump straight to logfire / DB to investigate without
         another query.
         """
-        if not self.recipient_did:
+        recipient_did = await self.ensure_ready()
+        if recipient_did is None:
             logger.warning("recipient not set, skipping reaper notification")
             return None
 
@@ -342,7 +373,7 @@ class NotificationService:
             f"runbook: docs/internal/retrospectives/2026-05-10-worker-oom-loop-streaming.md"
         )
 
-        result = await self._send_dm_to_did(self.recipient_did, message_text)
+        result = await self._send_dm_to_did(recipient_did, message_text)
         if result.success:
             logger.info(
                 "sent reaper notification (reaped=%d, affected=%d)",

--- a/backend/src/backend/_internal/tasks/hooks.py
+++ b/backend/src/backend/_internal/tasks/hooks.py
@@ -182,7 +182,18 @@ async def _mark_notification_sent(track_id: int) -> None:
 
 
 async def _send_track_notification(track_id: int) -> None:
-    """send notification for new track, if not already sent."""
+    """send notification for new track, if not already sent.
+
+    `notification_sent` is only flipped to True when:
+      - the DM actually succeeded, OR
+      - notifications are globally disabled (otherwise Jetstream would
+        keep re-firing on every identity sync forever).
+
+    if a DM was attempted but failed (transient bsky issue, recipient_did
+    not yet resolved, etc.), leave the row untouched so the next caller —
+    typically Jetstream's identity-update consumer firing the same hook —
+    has a chance to retry once the upstream recovers.
+    """
     from backend._internal.notifications import notification_service
 
     try:
@@ -197,8 +208,11 @@ async def _send_track_notification(track_id: int) -> None:
                 return
             if track.notification_sent:
                 return
-            await notification_service.send_track_notification(track)
-            track.notification_sent = True
-            await db.commit()
+            result = await notification_service.send_track_notification(track)
+            sent_ok = result is not None and result.success
+            disabled = result is None and not settings.notify.enabled
+            if sent_ok or disabled:
+                track.notification_sent = True
+                await db.commit()
     except Exception as e:
         logger.warning(f"failed to send notification for track {track_id}: {e}")

--- a/backend/tests/_internal/test_notification_service.py
+++ b/backend/tests/_internal/test_notification_service.py
@@ -1,0 +1,80 @@
+"""tests for the NotificationService.ensure_ready() retry path.
+
+regression: during the 2026-05-17 bsky.social WAF JA4 incident, every
+process that started during the WAF window had setup() fail silently and
+stayed broken until the next restart — every track upload skipped its
+notification, and `notification_sent` was marked true unconditionally so
+Jetstream couldn't retry. ensure_ready() runs setup() lazily on each
+send attempt (rate-limited by cooldown) so a transient upstream outage
+doesn't permanently break the service.
+"""
+
+from unittest.mock import patch
+
+from backend._internal.notifications import NotificationService
+
+NOTIF_SETTINGS = "backend._internal.notifications.settings"
+
+
+class TestEnsureReady:
+    async def test_returns_did_when_already_ready(self) -> None:
+        service = NotificationService()
+        service.recipient_did = "did:plc:abc"
+
+        assert await service.ensure_ready() == "did:plc:abc"
+
+    async def test_returns_none_when_disabled(self) -> None:
+        service = NotificationService()
+
+        with patch(NOTIF_SETTINGS) as mock_settings:
+            mock_settings.notify.enabled = False
+            assert await service.ensure_ready() is None
+
+    async def test_calls_setup_when_recipient_missing_and_cooldown_elapsed(
+        self,
+    ) -> None:
+        service = NotificationService()
+        # last attempt was so long ago the cooldown has elapsed
+        service._last_setup_attempt = 0.0
+
+        async def fake_setup() -> None:
+            service._last_setup_attempt = 1e9
+            service.recipient_did = "did:plc:resolved"
+
+        with (
+            patch(NOTIF_SETTINGS) as mock_settings,
+            patch.object(service, "setup", side_effect=fake_setup) as mock_setup,
+        ):
+            mock_settings.notify.enabled = True
+            assert await service.ensure_ready() == "did:plc:resolved"
+            mock_setup.assert_awaited_once()
+
+    async def test_skips_setup_within_cooldown(self) -> None:
+        service = NotificationService()
+        # "just attempted setup" — cooldown should suppress the retry
+        import time
+
+        service._last_setup_attempt = time.monotonic()
+
+        with (
+            patch(NOTIF_SETTINGS) as mock_settings,
+            patch.object(service, "setup") as mock_setup,
+        ):
+            mock_settings.notify.enabled = True
+            assert await service.ensure_ready() is None
+            mock_setup.assert_not_called()
+
+    async def test_returns_none_when_setup_still_fails(self) -> None:
+        service = NotificationService()
+        service._last_setup_attempt = 0.0
+
+        async def failing_setup() -> None:
+            service._last_setup_attempt = 1e9
+            # recipient_did stays None — upstream still broken
+
+        with (
+            patch(NOTIF_SETTINGS) as mock_settings,
+            patch.object(service, "setup", side_effect=failing_setup),
+        ):
+            mock_settings.notify.enabled = True
+            assert await service.ensure_ready() is None

--- a/backend/tests/test_post_create_hooks.py
+++ b/backend/tests/test_post_create_hooks.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal.atproto.client import pds_blob_url
+from backend._internal.notifications import NotificationResult
 from backend._internal.tasks.hooks import resolve_audio_url, run_post_track_create_hooks
 from backend.models import Artist, Track
 
@@ -292,6 +293,139 @@ class TestRunPostTrackCreateHooks:
             )
 
         mock_service.send_track_notification.assert_not_called()
+
+    async def test_marks_sent_only_when_dm_succeeded(
+        self, db_session: AsyncSession
+    ) -> None:
+        """regression (#1424): when send_track_notification returns None
+        (recipient_did failed to resolve) while notifications are enabled,
+        notification_sent must stay False so the Jetstream identity-update
+        consumer has a chance to retry.
+        """
+        artist = await _create_artist(db_session)
+        track = await _create_track(db_session, artist)
+
+        mock_service = AsyncMock()
+        # `None` ⇒ recipient not set; this is what the bug paved over before
+        mock_service.send_track_notification = AsyncMock(return_value=None)
+
+        with (
+            patch(MOCK_COPYRIGHT_PATH, new_callable=AsyncMock),
+            patch(MOCK_EMBEDDING_PATH, new_callable=AsyncMock),
+            patch(MOCK_GENRE_PATH, new_callable=AsyncMock),
+            patch(MOCK_NOTIFICATION_PATH, mock_service),
+            patch(MOCK_REDIS_PATH, return_value=AsyncMock()),
+            patch(MOCK_SETTINGS_PATH) as mock_settings,
+        ):
+            mock_settings.modal.enabled = False
+            mock_settings.turbopuffer.enabled = False
+            mock_settings.replicate.enabled = False
+            mock_settings.notify.enabled = True
+            await run_post_track_create_hooks(
+                track.id, audio_url="https://r2.example.com/test.mp3"
+            )
+
+        await db_session.refresh(track)
+        assert track.notification_sent is False
+
+    async def test_marks_sent_when_notifications_disabled(
+        self, db_session: AsyncSession
+    ) -> None:
+        """when notifications are globally disabled, mark the track sent so
+        Jetstream's identity-update consumer doesn't keep firing the hook
+        forever for a notification that will never go out.
+        """
+        artist = await _create_artist(db_session)
+        track = await _create_track(db_session, artist)
+
+        mock_service = AsyncMock()
+        mock_service.send_track_notification = AsyncMock(return_value=None)
+
+        with (
+            patch(MOCK_COPYRIGHT_PATH, new_callable=AsyncMock),
+            patch(MOCK_EMBEDDING_PATH, new_callable=AsyncMock),
+            patch(MOCK_GENRE_PATH, new_callable=AsyncMock),
+            patch(MOCK_NOTIFICATION_PATH, mock_service),
+            patch(MOCK_REDIS_PATH, return_value=AsyncMock()),
+            patch(MOCK_SETTINGS_PATH) as mock_settings,
+        ):
+            mock_settings.modal.enabled = False
+            mock_settings.turbopuffer.enabled = False
+            mock_settings.replicate.enabled = False
+            mock_settings.notify.enabled = False
+            await run_post_track_create_hooks(
+                track.id, audio_url="https://r2.example.com/test.mp3"
+            )
+
+        await db_session.refresh(track)
+        assert track.notification_sent is True
+
+    async def test_marks_sent_on_dm_success(self, db_session: AsyncSession) -> None:
+        artist = await _create_artist(db_session)
+        track = await _create_track(db_session, artist)
+
+        mock_service = AsyncMock()
+        mock_service.send_track_notification = AsyncMock(
+            return_value=NotificationResult(success=True, recipient_did="did:plc:abc")
+        )
+
+        with (
+            patch(MOCK_COPYRIGHT_PATH, new_callable=AsyncMock),
+            patch(MOCK_EMBEDDING_PATH, new_callable=AsyncMock),
+            patch(MOCK_GENRE_PATH, new_callable=AsyncMock),
+            patch(MOCK_NOTIFICATION_PATH, mock_service),
+            patch(MOCK_REDIS_PATH, return_value=AsyncMock()),
+            patch(MOCK_SETTINGS_PATH) as mock_settings,
+        ):
+            mock_settings.modal.enabled = False
+            mock_settings.turbopuffer.enabled = False
+            mock_settings.replicate.enabled = False
+            mock_settings.notify.enabled = True
+            await run_post_track_create_hooks(
+                track.id, audio_url="https://r2.example.com/test.mp3"
+            )
+
+        await db_session.refresh(track)
+        assert track.notification_sent is True
+
+    async def test_does_not_mark_sent_on_dm_failure(
+        self, db_session: AsyncSession
+    ) -> None:
+        """recipient is reachable but the DM itself failed (rate limit,
+        blocked, network) — leave notification_sent False so the Jetstream
+        identity-update consumer retries.
+        """
+        artist = await _create_artist(db_session)
+        track = await _create_track(db_session, artist)
+
+        mock_service = AsyncMock()
+        mock_service.send_track_notification = AsyncMock(
+            return_value=NotificationResult(
+                success=False,
+                recipient_did="did:plc:abc",
+                error="429 rate limited",
+                error_type="network",
+            )
+        )
+
+        with (
+            patch(MOCK_COPYRIGHT_PATH, new_callable=AsyncMock),
+            patch(MOCK_EMBEDDING_PATH, new_callable=AsyncMock),
+            patch(MOCK_GENRE_PATH, new_callable=AsyncMock),
+            patch(MOCK_NOTIFICATION_PATH, mock_service),
+            patch(MOCK_REDIS_PATH, return_value=AsyncMock()),
+            patch(MOCK_SETTINGS_PATH) as mock_settings,
+        ):
+            mock_settings.modal.enabled = False
+            mock_settings.turbopuffer.enabled = False
+            mock_settings.replicate.enabled = False
+            mock_settings.notify.enabled = True
+            await run_post_track_create_hooks(
+                track.id, audio_url="https://r2.example.com/test.mp3"
+            )
+
+        await db_session.refresh(track)
+        assert track.notification_sent is False
 
     async def test_skips_copyright_when_flagged(self, db_session: AsyncSession) -> None:
         artist = await _create_artist(db_session)

--- a/frontend/src/lib/now-playing.svelte.ts
+++ b/frontend/src/lib/now-playing.svelte.ts
@@ -73,9 +73,15 @@ class NowPlayingService {
 			this.reportTimer = null;
 		}
 
-		await this.sendReport(track, isPlaying, currentTimeMs, durationMs);
+		// claim the throttle BEFORE awaiting the network round-trip. svelte's
+		// `bind:currentTime` fires timeupdate ~4–60Hz during playback; if we
+		// updated these AFTER the await, the dozens of effect runs that come
+		// in during the ~100ms sendReport would each see stale state, pass
+		// both throttle gates, and dispatch parallel duplicate fetches —
+		// observed in prod as 5–9 simultaneous POSTs on every 10s bucket flip.
 		this.lastReportTime = now;
 		this.lastReportedState = stateFingerprint;
+		await this.sendReport(track, isPlaying, currentTimeMs, durationMs);
 	}
 
 	private pendingState: { track: Track; isPlaying: boolean; currentTimeMs: number; durationMs: number } | null = null;

--- a/loq.toml
+++ b/loq.toml
@@ -301,3 +301,7 @@ max_lines = 669
 [[rules]]
 path = "backend/src/backend/_internal/copyright.py"
 max_lines = 649
+
+[[rules]]
+path = "backend/tests/test_post_create_hooks.py"
+max_lines = 505


### PR DESCRIPTION
## Summary

Found while investigating why @woody.fm was tripping the `POST /now-playing/` 30/min rate limit during today's album upload — and discovered every active listener (including @zzstoatzz.io's own session) was hitting this proportional to playback length.

**Bug**: in `nowPlaying.report()`, the throttle bookkeeping (\`lastReportTime\` / \`lastReportedState\`) was updated **after** \`await sendReport(...)\`. \`bind:currentTime\` on the \`<audio>\` element fires \`timeupdate\` at ~4–60Hz during playback, so Svelte's \`\$effect\` in \`Player.svelte\` calls \`report()\` dozens of times per second. During the ~100ms network round-trip of the first send, every subsequent effect run saw **stale** state — fingerprint hadn't been updated, \`lastReportTime\` still showed 10s ago — so it passed both throttle gates and dispatched its own parallel \`fetch\`.

**Fix**: move the two state assignments **before** \`await sendReport(...)\`. One-line move. Subsequent effect runs during the in-flight send now see the updated fingerprint and early-return at line 50 as intended.

## Evidence (production, today)

For @woody.fm during a 2-album upload + listening session 2026-05-21 ~18:25–18:35 UTC:

| minute | 200 | 429 |
|---|---|---|
| 18:24 | 30 | 63 |
| 18:25 | 24 | 9 |
| 18:27 | 36 | 4 |
| 18:28 | 15 | 6 |

Drill-down on the exact bursts:

\`\`\`
18:27:01.045  POST 200    \
18:27:01.063  POST 200     |
18:27:01.079  POST 200     | 7 sends in 85ms
18:27:01.094  POST 200     | (every 10s)
18:27:01.113  POST 200     |
18:27:01.131  POST 200    /
... ~9s gap ...
18:27:11.126  POST 200    \
18:27:11.144  POST 200     |
18:27:11.162  POST 200     | 5 sends in 70ms
18:27:11.178  POST 200     |
18:27:11.195  POST 200    /
\`\`\`

That's the canonical signature of "in-flight check happens before async-set-state."

Cross-user: 4-hour aggregate, users with ≥50 calls:

| handle | total | 429 | calls/active-sec |
|---|---|---|---|
| woody.fm | 468 | 92 | 2.64 |
| zzstoatzz.io | 61 | 13 | 1.42 |

## Test plan

- [ ] Open prod (or staging) DevTools Network → filter \`now-playing\`. Play a track for ~2 minutes. Pre-fix: 1 send per 10s during playback. (Pre-fix would show 5–9 sends per 10s.)
- [ ] Trigger a play/pause toggle mid-playback: should see one immediate send for the state change, no burst.
- [ ] Logfire query post-deploy: \`SELECT date_trunc('minute', start_timestamp), COUNT(*) FROM records WHERE http_route = '/now-playing/' AND http_method = 'POST' AND deployment_environment = 'production' GROUP BY 1 ORDER BY 1 DESC LIMIT 20\` should show a roughly flat ~6/min ceiling per user during active playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)