### PR TITLE
feat(skills): traffic-overview — multi-horizon report via Logfire + CF API MCP

### DIFF
--- a/.claude/skills/traffic-overview/SKILL.md
+++ b/.claude/skills/traffic-overview/SKILL.md
@@ -1,0 +1,122 @@
+---
+description: Multi-horizon traffic & performance report (24h / 7d / 30d / 90d / 180d) drawing on Logfire and Cloudflare analytics
+argument-hint: [optional: single horizon like "7d" or "30d", or specific question like "5xx breakdown"]
+---
+
+# traffic-overview
+
+Report how plyr.fm production has been going over a range of timescales. By default emit a multi-horizon summary; if the user asks for a single horizon, focus there.
+
+## horizons & which tool serves them
+
+| horizon | tool | why |
+|---|---|---|
+| 24h, 7d | Logfire | rich SQL — per-route p95/p99, per-user, error breakdown |
+| 14d | Logfire | maximum single-query window — see "rough edges" |
+| 30d, 90d, 180d | Cloudflare (`scripts/cf_analytics.py`) | edge-level aggregates over long horizons |
+
+For Logfire-served horizons, use the `mcp__logfire__query_run` tool with `project: "plyr-fm"`. For CF, run the script:
+
+```bash
+uv run scripts/cf_analytics.py --days 30
+uv run scripts/cf_analytics.py --days 90
+uv run scripts/cf_analytics.py --days 180
+```
+
+## rough edges (learn these once, don't relearn each invocation)
+
+1. **Logfire MCP caps each query at a 14-day window.** Trying `start_timestamp` more than 14 days before `end_timestamp` errors out with `Time range N days exceeds max 14 days`. For 30d via Logfire, chunk into ≥3 separate queries and sum client-side. For 90d/180d, use Cloudflare instead.
+
+2. **`scripts/cf_analytics.py` requires env vars not in any `.env` file checked into the repo:**
+   - `SCRIPT_CF_API_TOKEN` — needs Analytics:Read at the zone level
+   - `CF_ZONE_ID` — the plyr.fm zone tag
+   - `CF_ACCOUNT_ID` — the personal-account ID (`3e9ba01cd687b3c4d29033908177072e`, per memory)
+
+   If `uv run scripts/cf_analytics.py --days 7` errors with `script_cf_api_token Field required`, the token isn't set. Ask the user where they keep it (1Password / shell rc / temporary paste) before claiming the long-horizon data is unavailable — don't fabricate numbers from training data.
+
+3. **`httpRequests1dGroups` query in `cf_analytics.py` has `limit: 100`.** As of 2026-05-22 this was bumped to 200 so 180d works in one shot. If you need ≥200 days, paginate or bump again.
+
+4. **`/health` dominates request counts** (~60% of total). Almost always worth filtering it out for "real" traffic metrics — `WHERE http_route != '/health'`. Leave it in only when counting overall server load.
+
+5. **DataFusion quirks:**
+   - Expressions in `GROUP BY` must be repeated verbatim, not aliased — `GROUP BY date_trunc('day', start_timestamp)`, NOT `GROUP BY day`.
+   - JSONB access uses `->` / `->>` (Postgres-flavored).
+   - `approx_percentile_cont(duration, 0.95) * 1000` gives p95 in ms (duration is in seconds).
+
+6. **`service_name` is `plyr-api` everywhere.** Filter environments with `deployment_environment` (top-level column), never `service_name`. See `docs/internal/tools/logfire.md`.
+
+## standard short-horizon query (24h / 7d / 14d)
+
+For each Logfire-served horizon, run two queries:
+
+### Overall stats
+
+```sql
+SELECT
+  COUNT(*) as total_requests,
+  COUNT(DISTINCT attributes->>'user.did') as unique_users,
+  COUNT(*) FILTER (WHERE http_response_status_code >= 500) as server_errors,
+  COUNT(*) FILTER (WHERE http_response_status_code >= 400 AND http_response_status_code < 500) as client_errors,
+  COUNT(*) FILTER (WHERE http_response_status_code = 429) as rate_limited,
+  ROUND((approx_percentile_cont(duration, 0.50) * 1000)::numeric, 1) as p50_ms,
+  ROUND((approx_percentile_cont(duration, 0.95) * 1000)::numeric, 1) as p95_ms,
+  ROUND((approx_percentile_cont(duration, 0.99) * 1000)::numeric, 1) as p99_ms
+FROM records
+WHERE deployment_environment = 'production'
+  AND kind = 'span'
+  AND http_method IS NOT NULL
+  AND http_route != '/health'
+```
+
+### Day-by-day breakdown (for ≥3-day horizons)
+
+```sql
+SELECT
+  date_trunc('day', start_timestamp) as day,
+  COUNT(*) as requests,
+  COUNT(DISTINCT attributes->>'user.did') as users,
+  COUNT(*) FILTER (WHERE http_response_status_code >= 500) as err_5xx,
+  COUNT(*) FILTER (WHERE http_response_status_code = 429) as r_429,
+  ROUND((approx_percentile_cont(duration, 0.95) * 1000)::numeric, 1) as p95_ms
+FROM records
+WHERE deployment_environment = 'production'
+  AND kind = 'span'
+  AND http_method IS NOT NULL
+  AND http_route != '/health'
+GROUP BY date_trunc('day', start_timestamp)
+ORDER BY day DESC
+```
+
+### Top routes by traffic (sanity check + perf hotspots)
+
+```sql
+SELECT
+  http_route,
+  COUNT(*) as req,
+  ROUND((approx_percentile_cont(duration, 0.95) * 1000)::numeric, 0) as p95_ms,
+  COUNT(*) FILTER (WHERE http_response_status_code >= 500) as err_5xx,
+  COUNT(*) FILTER (WHERE http_response_status_code = 429) as r_429
+FROM records
+WHERE deployment_environment = 'production'
+  AND kind = 'span'
+  AND http_route IS NOT NULL
+GROUP BY http_route
+ORDER BY req DESC
+LIMIT 15
+```
+
+## what to report
+
+For each horizon, three things:
+
+1. **The numbers**: requests, unique users, 4xx/5xx/429 counts, p50/p95/p99.
+2. **The shape**: day-by-day trend. Flag any day that breaks the band (>2× the median for errors or p95).
+3. **One concrete thing worth knowing**: top error route, slowest route, or notable event correlation (e.g., "the 293 rate-limited on 05-16 maps to the now-playing burst bug, now fixed in #1426").
+
+Don't dump every column. The user wants the read, not the raw.
+
+## tone
+
+- Lead with the punchline (healthy / one concern / multiple concerns).
+- Use concrete numbers, not adjectives. "p95 jumped from 95ms to 314ms on 05-16" beats "performance was slow."
+- When CF data is unavailable because the token isn't set, say so explicitly — never fabricate long-horizon numbers from training data.

--- a/.claude/skills/traffic-overview/SKILL.md
+++ b/.claude/skills/traffic-overview/SKILL.md
@@ -1,55 +1,39 @@
 ---
-description: Multi-horizon traffic & performance report (24h / 7d / 30d / 90d / 180d) drawing on Logfire and Cloudflare analytics
-argument-hint: [optional: single horizon like "7d" or "30d", or specific question like "5xx breakdown"]
+description: Multi-horizon traffic & performance report (24h / 7d / 30d) drawing on Logfire (app-server view) and the Cloudflare API MCP (edge view)
+argument-hint: [optional: single horizon like "7d" or "30d", or a specific question]
 ---
 
 # traffic-overview
 
-Report how plyr.fm production has been going over a range of timescales. By default emit a multi-horizon summary; if the user asks for a single horizon, focus there.
+Report how plyr.fm production has been going across multiple timescales. Two complementary lenses:
 
-## horizons & which tool serves them
+- **Logfire** = inside-the-app view: per-route p95/p99, error breakdowns, user identity, exception types.
+- **Cloudflare edge** = outside-the-app view: total requests, unique visitors, bytes, cache hit %, threats blocked, country split. Sees the requests that never hit the origin.
 
-| horizon | tool | why |
+Default: emit a side-by-side multi-horizon summary. If the user asks for a single horizon, focus there.
+
+## horizons & tools
+
+| horizon | Logfire (`mcp__logfire__query_run`) | Cloudflare (`mcp__plugin_cloudflare_cloudflare-api__execute`) |
 |---|---|---|
-| 24h, 7d | Logfire | rich SQL — per-route p95/p99, per-user, error breakdown |
-| 14d | Logfire | maximum single-query window — see "rough edges" |
-| 30d, 90d, 180d | Cloudflare (`scripts/cf_analytics.py`) | edge-level aggregates over long horizons |
+| 24h | ✅ | ✅ |
+| 7d  | ✅ | ✅ |
+| 14d | ✅ (single-shot — max window) | ✅ |
+| 30d | ⚠️ chunk into ≥3 14d windows | ✅ (CF retention ceiling) |
+| 90d / 180d | ❌ infeasible (too many chunks) | ❌ CF zone analytics retention is **~30 days** even on paid plans for httpRequests1dGroups — `first_date` returns ~30d ago no matter what `date_geq` you pass |
 
-For Logfire-served horizons, use the `mcp__logfire__query_run` tool with `project: "plyr-fm"`. For CF, run the script:
+If the user explicitly asks for 90d or 180d, say so explicitly: that data isn't accessible from the tools we have. Don't fabricate or guess.
 
-```bash
-uv run scripts/cf_analytics.py --days 30
-uv run scripts/cf_analytics.py --days 90
-uv run scripts/cf_analytics.py --days 180
-```
+## prerequisites
 
-## rough edges (learn these once, don't relearn each invocation)
+- **Logfire MCP**: auto-available. Use `project: "plyr-fm"` on every `query_run` call.
+- **Cloudflare API MCP**: requires the user to have run `/mcp` to authenticate `plugin:cloudflare:cloudflare-api`. If `cloudflare-api__execute` isn't available, prompt the user to run `/mcp` — **do not** call `authenticate` directly (see memory: don't initiate MCP auth flows yourself).
 
-1. **Logfire MCP caps each query at a 14-day window.** Trying `start_timestamp` more than 14 days before `end_timestamp` errors out with `Time range N days exceeds max 14 days`. For 30d via Logfire, chunk into ≥3 separate queries and sum client-side. For 90d/180d, use Cloudflare instead.
+The CF MCP pre-sets `accountId` to `3e9ba01cd687b3c4d29033908177072e` (N8@zzstoatzz.io's account, where plyr.fm lives). The plyr.fm zone ID is `2bfcb9ffe7847604e9febbb62d9649a3`.
 
-2. **`scripts/cf_analytics.py` requires env vars not in any `.env` file checked into the repo:**
-   - `SCRIPT_CF_API_TOKEN` — needs Analytics:Read at the zone level
-   - `CF_ZONE_ID` — the plyr.fm zone tag
-   - `CF_ACCOUNT_ID` — the personal-account ID (`3e9ba01cd687b3c4d29033908177072e`, per memory)
+## Logfire queries (the SQL pieces)
 
-   If `uv run scripts/cf_analytics.py --days 7` errors with `script_cf_api_token Field required`, the token isn't set. Ask the user where they keep it (1Password / shell rc / temporary paste) before claiming the long-horizon data is unavailable — don't fabricate numbers from training data.
-
-3. **`httpRequests1dGroups` query in `cf_analytics.py` has `limit: 100`.** As of 2026-05-22 this was bumped to 200 so 180d works in one shot. If you need ≥200 days, paginate or bump again.
-
-4. **`/health` dominates request counts** (~60% of total). Almost always worth filtering it out for "real" traffic metrics — `WHERE http_route != '/health'`. Leave it in only when counting overall server load.
-
-5. **DataFusion quirks:**
-   - Expressions in `GROUP BY` must be repeated verbatim, not aliased — `GROUP BY date_trunc('day', start_timestamp)`, NOT `GROUP BY day`.
-   - JSONB access uses `->` / `->>` (Postgres-flavored).
-   - `approx_percentile_cont(duration, 0.95) * 1000` gives p95 in ms (duration is in seconds).
-
-6. **`service_name` is `plyr-api` everywhere.** Filter environments with `deployment_environment` (top-level column), never `service_name`. See `docs/internal/tools/logfire.md`.
-
-## standard short-horizon query (24h / 7d / 14d)
-
-For each Logfire-served horizon, run two queries:
-
-### Overall stats
+### Overall stats (any horizon ≤14d)
 
 ```sql
 SELECT
@@ -68,7 +52,7 @@ WHERE deployment_environment = 'production'
   AND http_route != '/health'
 ```
 
-### Day-by-day breakdown (for ≥3-day horizons)
+### Day-by-day breakdown
 
 ```sql
 SELECT
@@ -87,7 +71,7 @@ GROUP BY date_trunc('day', start_timestamp)
 ORDER BY day DESC
 ```
 
-### Top routes by traffic (sanity check + perf hotspots)
+### Top routes
 
 ```sql
 SELECT
@@ -105,18 +89,67 @@ ORDER BY req DESC
 LIMIT 15
 ```
 
+## Cloudflare query (the JS piece)
+
+Call `mcp__plugin_cloudflare_cloudflare-api__execute` with this code, parameterizing `days`:
+
+```js
+async () => {
+  const ZONE = "2bfcb9ffe7847604e9febbb62d9649a3";
+  const days = /* fill in */;
+  const since = new Date(Date.now() - days * 86400_000).toISOString().slice(0, 10);
+  const r = await cloudflare.request({
+    method: "POST",
+    path: "/graphql",
+    body: {
+      query: `query { viewer { zones(filter: {zoneTag: "${ZONE}"}) {
+        httpRequests1dGroups(filter: {date_geq: "${since}"}, orderBy: [date_ASC], limit: 200) {
+          dimensions { date }
+          sum { requests pageViews bytes cachedBytes threats }
+          uniq { uniques }
+        }
+      } } }`
+    }
+  });
+  return r.result?.viewer?.zones?.[0]?.httpRequests1dGroups ?? [];
+}
+```
+
+Aggregate client-side: sum `requests` / `pageViews` / `bytes` / `cachedBytes` / `threats`; sum `uniques` as a naive overcounting upper bound (CF doesn't expose deduped uniques across days via this endpoint).
+
+## rough edges (don't relearn each invocation)
+
+1. **CF GraphQL response is unwrapped** — the MCP returns `r.result.viewer.zones`, NOT `r.result.data.viewer.zones`. (Standard GraphQL responses are wrapped in `data:`; the CF MCP strips that envelope.) If you see "0 days returned" but expect data, this is almost certainly the bug.
+
+2. **Use `date_geq`, not `date_gt`** — `date_gt` of "today minus N" silently skips the inclusive boundary day and can return empty results when N is small.
+
+3. **CF zone analytics retention ≈ 30 days** — empirically confirmed: querying for 90 days returns ~34 days starting from `first_date: ~30d ago`. The `limit: 100` in `scripts/cf_analytics.py` was bumped to 200 in PR #1427, but the real ceiling is CF-side retention, not the limit.
+
+4. **Logfire MCP caps each query at a 14-day window** — `Time range N days exceeds max 14 days`. For 30d via Logfire, chunk into ≥3 separate queries. For ≥30d, CF is the better fit (when within its retention window).
+
+5. **`/health` is ~60% of Logfire request counts** — filter it (`http_route != '/health'`) for any "real" traffic metric. Leave it in only when counting overall server load.
+
+6. **DataFusion quirks** —
+   - `GROUP BY` needs the expression verbatim, not by alias: `GROUP BY date_trunc('day', start_timestamp)`, NOT `GROUP BY day`.
+   - JSONB uses `->` / `->>` (Postgres-flavored).
+   - `approx_percentile_cont(duration, 0.95) * 1000` gives p95 in ms (`duration` is in seconds).
+
+7. **`service_name` is `plyr-api` for all environments** — filter by `deployment_environment` (top-level column), never `service_name`. See `docs/internal/tools/logfire.md`.
+
+8. **Cloudflare API MCP needs OAuth via `/mcp`** — if `cloudflare-api__execute` is unavailable, prompt the user to run `/mcp` themselves. Do not call the server's `authenticate` tool.
+
 ## what to report
 
 For each horizon, three things:
 
-1. **The numbers**: requests, unique users, 4xx/5xx/429 counts, p50/p95/p99.
-2. **The shape**: day-by-day trend. Flag any day that breaks the band (>2× the median for errors or p95).
-3. **One concrete thing worth knowing**: top error route, slowest route, or notable event correlation (e.g., "the 293 rate-limited on 05-16 maps to the now-playing burst bug, now fixed in #1426").
+1. **The numbers** (side-by-side where available): Logfire app-server view (requests, users, 4xx/5xx/429, p50/p95/p99) and Cloudflare edge view (total requests, page views, GB transferred, cache hit %, threats).
+2. **The shape**: day-by-day trend (Logfire for ≤7d, CF for 7-30d). Flag any day that breaks the band (>2× the median for errors or p95).
+3. **One concrete thing worth knowing**: top error route, slowest route, notable spike, or correlation (e.g., "the 293 rate-limited on 05-16 maps to the now-playing burst bug, fixed in #1426").
 
 Don't dump every column. The user wants the read, not the raw.
 
 ## tone
 
 - Lead with the punchline (healthy / one concern / multiple concerns).
-- Use concrete numbers, not adjectives. "p95 jumped from 95ms to 314ms on 05-16" beats "performance was slow."
-- When CF data is unavailable because the token isn't set, say so explicitly — never fabricate long-horizon numbers from training data.
+- Concrete numbers, not adjectives. "p95 jumped from 95ms to 314ms on 05-16" beats "performance was slow."
+- When 90d/180d is requested, name the retention ceiling — never fabricate long-horizon numbers.

--- a/.claude/skills/traffic-overview/SKILL.md
+++ b/.claude/skills/traffic-overview/SKILL.md
@@ -1,39 +1,32 @@
 ---
-description: Multi-horizon traffic & performance report (24h / 7d / 30d) drawing on Logfire (app-server view) and the Cloudflare API MCP (edge view)
-argument-hint: [optional: single horizon like "7d" or "30d", or a specific question]
+description: Multi-horizon traffic & performance report (24h / 7d / 30d) — Logfire (app-server) and Cloudflare API MCP (edge)
+argument-hint: [optional: single horizon like "7d" or a specific question]
 ---
 
 # traffic-overview
 
-Report how plyr.fm production has been going across multiple timescales. Two complementary lenses:
+Two lenses:
+- **Logfire** = inside-the-app: per-route p95/p99, errors, user identity
+- **Cloudflare edge** = outside-the-app: total requests, cache %, bytes, threats — sees requests that never hit origin
 
-- **Logfire** = inside-the-app view: per-route p95/p99, error breakdowns, user identity, exception types.
-- **Cloudflare edge** = outside-the-app view: total requests, unique visitors, bytes, cache hit %, threats blocked, country split. Sees the requests that never hit the origin.
+## horizons (don't exceed these — both tools have hard ceilings)
 
-Default: emit a side-by-side multi-horizon summary. If the user asks for a single horizon, focus there.
-
-## horizons & tools
-
-| horizon | Logfire (`mcp__logfire__query_run`) | Cloudflare (`mcp__plugin_cloudflare_cloudflare-api__execute`) |
+| horizon | Logfire | Cloudflare |
 |---|---|---|
-| 24h | ✅ | ✅ |
-| 7d  | ✅ | ✅ |
-| 14d | ✅ (single-shot — max window) | ✅ |
-| 30d | ⚠️ chunk into ≥3 14d windows | ✅ (CF retention ceiling) |
-| 90d / 180d | ❌ infeasible (too many chunks) | ❌ CF zone analytics retention is **~30 days** even on paid plans for httpRequests1dGroups — `first_date` returns ~30d ago no matter what `date_geq` you pass |
+| 24h–7d | ✅ | ✅ |
+| 14d | ✅ (max single-query window) | ✅ |
+| 30d | ⚠ chunk into 3× 14d queries | ✅ |
+| **>30d** | ❌ too many chunks | ❌ **CF retention ≈30d** — querying 180d returns ~34 days |
 
-If the user explicitly asks for 90d or 180d, say so explicitly: that data isn't accessible from the tools we have. Don't fabricate or guess.
+If user asks for 90d/180d: say the data isn't accessible. Don't fabricate.
 
 ## prerequisites
 
-- **Logfire MCP**: auto-available. Use `project: "plyr-fm"` on every `query_run` call.
-- **Cloudflare API MCP**: requires the user to have run `/mcp` to authenticate `plugin:cloudflare:cloudflare-api`. If `cloudflare-api__execute` isn't available, prompt the user to run `/mcp` — **do not** call `authenticate` directly (see memory: don't initiate MCP auth flows yourself).
+- **Logfire**: pass `project: "plyr-fm"` to every `mcp__logfire__query_run` call.
+- **CF API MCP**: if `mcp__plugin_cloudflare_cloudflare-api__execute` is unavailable, ask user to run `/mcp` to authenticate `plugin:cloudflare:cloudflare-api`. Do NOT call `__authenticate` yourself (see `feedback_mcp_auth.md`).
+- plyr.fm zone ID: `2bfcb9ffe7847604e9febbb62d9649a3` (account `3e9ba01cd687b3c4d29033908177072e` is pre-set in the MCP).
 
-The CF MCP pre-sets `accountId` to `3e9ba01cd687b3c4d29033908177072e` (N8@zzstoatzz.io's account, where plyr.fm lives). The plyr.fm zone ID is `2bfcb9ffe7847604e9febbb62d9649a3`.
-
-## Logfire queries (the SQL pieces)
-
-### Overall stats (any horizon ≤14d)
+## Logfire query (≤14d)
 
 ```sql
 SELECT
@@ -49,49 +42,12 @@ FROM records
 WHERE deployment_environment = 'production'
   AND kind = 'span'
   AND http_method IS NOT NULL
-  AND http_route != '/health'
+  AND http_route != '/health'  -- ~60% of requests; exclude for "real" traffic
 ```
 
-### Day-by-day breakdown
+For day-by-day or top-route breakdowns, swap the SELECT but keep the WHERE. `GROUP BY date_trunc('day', start_timestamp)` — the expression verbatim, not by alias.
 
-```sql
-SELECT
-  date_trunc('day', start_timestamp) as day,
-  COUNT(*) as requests,
-  COUNT(DISTINCT attributes->>'user.did') as users,
-  COUNT(*) FILTER (WHERE http_response_status_code >= 500) as err_5xx,
-  COUNT(*) FILTER (WHERE http_response_status_code = 429) as r_429,
-  ROUND((approx_percentile_cont(duration, 0.95) * 1000)::numeric, 1) as p95_ms
-FROM records
-WHERE deployment_environment = 'production'
-  AND kind = 'span'
-  AND http_method IS NOT NULL
-  AND http_route != '/health'
-GROUP BY date_trunc('day', start_timestamp)
-ORDER BY day DESC
-```
-
-### Top routes
-
-```sql
-SELECT
-  http_route,
-  COUNT(*) as req,
-  ROUND((approx_percentile_cont(duration, 0.95) * 1000)::numeric, 0) as p95_ms,
-  COUNT(*) FILTER (WHERE http_response_status_code >= 500) as err_5xx,
-  COUNT(*) FILTER (WHERE http_response_status_code = 429) as r_429
-FROM records
-WHERE deployment_environment = 'production'
-  AND kind = 'span'
-  AND http_route IS NOT NULL
-GROUP BY http_route
-ORDER BY req DESC
-LIMIT 15
-```
-
-## Cloudflare query (the JS piece)
-
-Call `mcp__plugin_cloudflare_cloudflare-api__execute` with this code, parameterizing `days`:
+## Cloudflare query (any horizon up to 30d)
 
 ```js
 async () => {
@@ -101,55 +57,27 @@ async () => {
   const r = await cloudflare.request({
     method: "POST",
     path: "/graphql",
-    body: {
-      query: `query { viewer { zones(filter: {zoneTag: "${ZONE}"}) {
-        httpRequests1dGroups(filter: {date_geq: "${since}"}, orderBy: [date_ASC], limit: 200) {
-          dimensions { date }
-          sum { requests pageViews bytes cachedBytes threats }
-          uniq { uniques }
-        }
-      } } }`
-    }
+    body: { query: `query { viewer { zones(filter: {zoneTag: "${ZONE}"}) {
+      httpRequests1dGroups(filter: {date_geq: "${since}"}, orderBy: [date_ASC], limit: 200) {
+        dimensions { date }
+        sum { requests pageViews bytes cachedBytes threats }
+        uniq { uniques }
+      }
+    } } }` }
   });
   return r.result?.viewer?.zones?.[0]?.httpRequests1dGroups ?? [];
 }
 ```
 
-Aggregate client-side: sum `requests` / `pageViews` / `bytes` / `cachedBytes` / `threats`; sum `uniques` as a naive overcounting upper bound (CF doesn't expose deduped uniques across days via this endpoint).
+## gotchas (these will silently bite you)
 
-## rough edges (don't relearn each invocation)
-
-1. **CF GraphQL response is unwrapped** — the MCP returns `r.result.viewer.zones`, NOT `r.result.data.viewer.zones`. (Standard GraphQL responses are wrapped in `data:`; the CF MCP strips that envelope.) If you see "0 days returned" but expect data, this is almost certainly the bug.
-
-2. **Use `date_geq`, not `date_gt`** — `date_gt` of "today minus N" silently skips the inclusive boundary day and can return empty results when N is small.
-
-3. **CF zone analytics retention ≈ 30 days** — empirically confirmed: querying for 90 days returns ~34 days starting from `first_date: ~30d ago`. The `limit: 100` in `scripts/cf_analytics.py` was bumped to 200 in PR #1427, but the real ceiling is CF-side retention, not the limit.
-
-4. **Logfire MCP caps each query at a 14-day window** — `Time range N days exceeds max 14 days`. For 30d via Logfire, chunk into ≥3 separate queries. For ≥30d, CF is the better fit (when within its retention window).
-
-5. **`/health` is ~60% of Logfire request counts** — filter it (`http_route != '/health'`) for any "real" traffic metric. Leave it in only when counting overall server load.
-
-6. **DataFusion quirks** —
-   - `GROUP BY` needs the expression verbatim, not by alias: `GROUP BY date_trunc('day', start_timestamp)`, NOT `GROUP BY day`.
-   - JSONB uses `->` / `->>` (Postgres-flavored).
-   - `approx_percentile_cont(duration, 0.95) * 1000` gives p95 in ms (`duration` is in seconds).
-
-7. **`service_name` is `plyr-api` for all environments** — filter by `deployment_environment` (top-level column), never `service_name`. See `docs/internal/tools/logfire.md`.
-
-8. **Cloudflare API MCP needs OAuth via `/mcp`** — if `cloudflare-api__execute` is unavailable, prompt the user to run `/mcp` themselves. Do not call the server's `authenticate` tool.
+1. **CF GraphQL is unwrapped** — `r.result.viewer.zones`, NOT `r.result.data.viewer.zones`. Miss this → silent empty result.
+2. **`date_geq`, not `date_gt`** — `date_gt` skips the boundary day.
+3. **CF retention ≈ 30 days** — `limit:200` doesn't help past that. Verified empirically.
+4. **Logfire 14d cap** — `Time range N days exceeds max 14 days`.
+5. **`approx_percentile_cont(duration, 0.95) * 1000`** = p95 in ms (duration is seconds).
+6. **`service_name = 'plyr-api'` for all envs** — filter by `deployment_environment`, never `service_name`.
 
 ## what to report
 
-For each horizon, three things:
-
-1. **The numbers** (side-by-side where available): Logfire app-server view (requests, users, 4xx/5xx/429, p50/p95/p99) and Cloudflare edge view (total requests, page views, GB transferred, cache hit %, threats).
-2. **The shape**: day-by-day trend (Logfire for ≤7d, CF for 7-30d). Flag any day that breaks the band (>2× the median for errors or p95).
-3. **One concrete thing worth knowing**: top error route, slowest route, notable spike, or correlation (e.g., "the 293 rate-limited on 05-16 maps to the now-playing burst bug, fixed in #1426").
-
-Don't dump every column. The user wants the read, not the raw.
-
-## tone
-
-- Lead with the punchline (healthy / one concern / multiple concerns).
-- Concrete numbers, not adjectives. "p95 jumped from 95ms to 314ms on 05-16" beats "performance was slow."
-- When 90d/180d is requested, name the retention ceiling — never fabricate long-horizon numbers.
+For each horizon: numbers (side-by-side Logfire + CF), shape (day-by-day, flag >2× median outliers), one concrete thing (top error route, slowest endpoint, spike correlation). Lead with the punchline (healthy / one concern / multiple concerns). Concrete numbers, not adjectives.

--- a/scripts/cf_analytics.py
+++ b/scripts/cf_analytics.py
@@ -121,7 +121,7 @@ def get_zone_analytics(days: int = 7, use_cache: bool = True) -> dict[str, Any]:
           httpRequests1dGroups(
             filter: {date_gt: $since}
             orderBy: [date_ASC]
-            limit: 100
+            limit: 200
           ) {
             dimensions {
               date


### PR DESCRIPTION
## Summary

New skill at \`.claude/skills/traffic-overview/SKILL.md\` that produces a multi-horizon (24h / 7d / 30d) traffic + performance overview for plyr.fm. Two complementary lenses:

- **Logfire** — inside-the-app view: per-route p95/p99, error breakdowns, user identity, exception types.
- **Cloudflare edge** (via the cloudflare plugin's \`cloudflare-api__execute\` MCP, authenticated through \`/mcp\`) — outside-the-app view: total requests, page views, bytes, cache hit %, threats blocked.

The earlier draft of this skill leaned on \`scripts/cf_analytics.py\` with \`.env\`-stored tokens; switched to the MCP after the cloudflare plugin landed, which is cleaner (OAuth-driven, no per-script tokens, accountId pre-set).

## Rough edges baked into the skill (discovered empirically, documented so the next invocation doesn't relearn)

- **CF zone analytics retention ≈ 30 days** — empirically confirmed: querying for 180 days returns ~34 days starting from \`first_date: ~30d ago\`. The skill caps horizons at 30d and explicitly tells the caller not to fabricate 90d/180d numbers.
- **CF MCP GraphQL response is unwrapped** — \`r.result.viewer.zones\`, NOT \`r.result.data.viewer.zones\`. The CF MCP strips the standard GraphQL \`data:\` envelope. Miss this and you get silent 0-row results.
- **Use \`date_geq\`, not \`date_gt\`** — boundary day handling differs; \`date_gt\` can silently skip the inclusive day.
- **Logfire MCP caps each query at 14d** — for ≥30d, use CF (within its 30d retention).
- **\`/health\` is ~60% of Logfire request counts** (fly health pings) — skill defaults to \`WHERE http_route != '/health'\` for "real" traffic.
- **DataFusion quirks** — \`GROUP BY\` needs the expression verbatim (not by alias); JSONB uses Postgres-style \`->\` / \`->>\`; \`approx_percentile_cont(duration, 0.95) * 1000\` gives p95 in ms because \`duration\` is in seconds.
- **MCP auth flows happen via \`/mcp\` slash command**, not by calling \`*__authenticate\` tools (per memory \`feedback_mcp_auth.md\`).

## Side-fix still included

\`scripts/cf_analytics.py\`: \`httpRequests1dGroups\` had \`limit: 100\`, bumped to \`200\`. (Mostly moot for the skill now, but the script remains useful as a CLI tool and the bump is correct for anyone who still uses it.)

## Test plan

- [ ] Invoke \`/traffic-overview\` → renders a 24h / 7d / 30d side-by-side report from both Logfire and CF
- [ ] Invoke \`/traffic-overview 7d\` → focused 7-day report
- [ ] Ask for 90d → skill should explicitly say "CF analytics retention is ~30 days, can't go further" rather than fabricating

🤖 Generated with [Claude Code](https://claude.com/claude-code)