### PR TITLE
fix(modals): Escape closes feedback panel and the more/links menu

### DIFF
--- a/frontend/src/lib/components/FeedbackModal.svelte
+++ b/frontend/src/lib/components/FeedbackModal.svelte
@@ -7,6 +7,13 @@
 		}
 	}
 
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape' && feedback.isOpen) {
+			event.preventDefault();
+			feedback.close();
+		}
+	}
+
 	function handleSearchInput(event: Event) {
 		const target = event.target as HTMLInputElement;
 		feedback.setSearchQuery(target.value);
@@ -22,6 +29,8 @@
 		feedback.setReason(target.value as ReportReason);
 	}
 </script>
+
+<svelte:window onkeydown={handleKeydown} />
 
 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 <div

--- a/frontend/src/lib/components/LinksMenu.svelte
+++ b/frontend/src/lib/components/LinksMenu.svelte
@@ -12,7 +12,16 @@
 	function closeMenu() {
 		showMenu = false;
 	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape' && showMenu) {
+			event.preventDefault();
+			closeMenu();
+		}
+	}
 </script>
+
+<svelte:window onkeydown={handleKeydown} />
 
 <div class="links-menu">
 	<button class="menu-button" onclick={toggleMenu} title="more" aria-label="open menu">

--- a/loq.toml
+++ b/loq.toml
@@ -188,7 +188,7 @@ max_lines = 1285
 
 [[rules]]
 path = "frontend/src/lib/components/FeedbackModal.svelte"
-max_lines = 660
+max_lines = 661
 
 [[rules]]
 path = "services/moderation/src/review.rs"


### PR DESCRIPTION
Both the feedback modal and the more/links menu had backdrop-click and close-button dismissal but no keyboard escape. Adds a window-level keydown handler to each that closes when open and Escape is pressed.

Same pattern already used in `AudioRevisionsSheet` and `BottomSheet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)