### PR TITLE
fix(player): pause on remote index-only queue updates (follow-up to #1424)

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -549,9 +549,12 @@
 				}
 			} else if (indexChanged) {
 				player.currentTime = 0;
-				// only auto-play if this was a local update
+				// only auto-play if this was a local update; remote updates pause to
+				// avoid two tabs playing the same track in parallel (mirrors #1424)
 				if (queue.lastUpdateWasLocal) {
 					player.paused = false;
+				} else {
+					player.paused = true;
 				}
 				previousQueueIndex = queue.currentIndex;
 			}


### PR DESCRIPTION
## Summary

Follow-up to #1424 (aila's "pause player when track changes from remote tab sync"). The fix she landed covers the `trackChanged` branch in the queue-sync effect; this PR mirrors it onto the `indexChanged` branch so the parallel-playback bug can't sneak back in through a rare path.

## What was missing

`Player.svelte`'s queue-sync effect has two branches:

- **`trackChanged`** (line 539) — handled by #1424: remote updates now set \`player.paused = true\` so two tabs don't play the new track simultaneously.
- **`indexChanged`** without trackChanged (line 550) — was still only writing \`player.paused\` on local updates. If Tab B had \`player.paused = false\` from prior playback and Tab A advanced the index to a different position holding the same track id (queue with duplicates, reorder that lands on the same track, etc.), Tab B would resume playing once \`isLoadingTrack\` flipped — same shape as #1356.

## Fix

Two-line symmetric change: remote `indexChanged` now also sets `player.paused = true`. Same conditional shape aila used on the `trackChanged` branch (`if (queue.lastUpdateWasLocal) ... else ...`).

## Test plan

- [ ] open two tabs, queue with duplicate tracks (same id at index 0 and index 2)
- [ ] in tab A: play, jump to index 2 — tab B should pick up the index change without starting audio
- [ ] confirm trackChanged path (the one #1424 fixed) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)