### PR TITLE
feat(profiles): open atproto links in the client of your choice

### DIFF
--- a/frontend/src/lib/atclients.ts
+++ b/frontend/src/lib/atclients.ts
@@ -1,0 +1,67 @@
+// preferred atproto client — open profiles and records in the app of your choice.
+// the registry below is the single source of truth; add an entry to support a new client.
+import { browser } from '$app/environment';
+import { preferences } from '$lib/preferences.svelte';
+
+export interface AtClient {
+	value: string;
+	label: string;
+	iconUrl: string;
+	profileUrl: (handleOrDid: string) => string;
+	recordUrl?: (atUri: string) => string;
+}
+
+const BSKY: AtClient = {
+	value: 'bsky',
+	label: 'Bluesky',
+	iconUrl: 'https://web-cdn.bsky.app/static/apple-touch-icon.png',
+	profileUrl: (h) => `https://bsky.app/profile/${h}`
+};
+
+export const AT_CLIENTS: AtClient[] = [
+	BSKY,
+	{
+		value: 'deer',
+		label: 'deer.social',
+		iconUrl: 'https://deer.social/favicon.ico',
+		profileUrl: (h) => `https://deer.social/profile/${h}`
+	},
+	{
+		value: 'blacksky',
+		label: 'Blacksky',
+		iconUrl: 'https://blacksky.community/static/apple-touch-icon.png',
+		profileUrl: (h) => `https://blacksky.community/profile/${h}`
+	},
+	{
+		value: 'pdsls',
+		label: 'pdsls',
+		iconUrl: 'https://pdsls.dev/favicon.ico',
+		profileUrl: (h) => `https://pdsls.dev/at/${h}`,
+		recordUrl: (uri) => `https://pdsls.dev/at/${uri.replace(/^at:\/\//, '')}`
+	}
+];
+
+export const DEFAULT_AT_CLIENT = BSKY.value;
+
+function storedClientValue(): string | null {
+	// account preference wins; fall back to the per-browser cache so links also
+	// resolve for logged-out viewers and before preferences finish loading.
+	if (preferences.atprotoClient) return preferences.atprotoClient;
+	if (browser) return localStorage.getItem('atprotoClient');
+	return null;
+}
+
+export function getPreferredClient(): AtClient {
+	const value = storedClientValue();
+	return AT_CLIENTS.find((c) => c.value === value) ?? BSKY;
+}
+
+export function profileLink(handleOrDid: string): string {
+	return getPreferredClient().profileUrl(handleOrDid);
+}
+
+export function recordLink(atUri: string): string {
+	const client = getPreferredClient();
+	if (client.recordUrl) return client.recordUrl(atUri);
+	return `https://pdsls.dev/at/${atUri.replace(/^at:\/\//, '')}`;
+}

--- a/frontend/src/lib/components/AlbumUploadForm.svelte
+++ b/frontend/src/lib/components/AlbumUploadForm.svelte
@@ -9,6 +9,7 @@
 	import { setReturnUrl } from '$lib/utils/return-url';
 	import { preflightAuth } from '$lib/upload-form-stash';
 	import { getServerConfig, API_URL } from '$lib/config';
+	import { profileLink } from '$lib/atclients';
 
 	const AUDIO_EXTENSIONS = ['.mp3', '.wav', '.m4a', '.aiff', '.aif', '.flac'];
 	const FILE_INPUT_ACCEPT =
@@ -529,7 +530,7 @@
 			permission, or the content may be removed to keep plyr.fm in
 			compliance. For any questions or concerns, please DM
 			<a
-				href="https://bsky.app/profile/zzstoatzz.io"
+				href={profileLink('zzstoatzz.io')}
 				target="_blank"
 				rel="noopener">@zzstoatzz.io</a
 			> :) have a nice day!

--- a/frontend/src/lib/components/LinksMenu.svelte
+++ b/frontend/src/lib/components/LinksMenu.svelte
@@ -2,8 +2,10 @@
 	import { portal } from 'svelte-portal';
 	import PlatformStats from './PlatformStats.svelte';
 	import { feedback } from '$lib/feedback.svelte';
+	import { getPreferredClient } from '$lib/atclients';
 
 	let showMenu = $state(false);
+	let client = $derived(getPreferredClient());
 
 	function toggleMenu() {
 		showMenu = !showMenu;
@@ -57,24 +59,15 @@
 			</div>
 			<nav class="menu-links">
 				<a
-					href="https://bsky.app/profile/plyr.fm"
+					href={client.profileUrl('plyr.fm')}
 					target="_blank"
 					rel="noopener noreferrer"
 					class="menu-link"
 				>
-					<svg
-						width="24"
-						height="24"
-						viewBox="0 0 600 530"
-						fill="currentColor"
-					>
-						<path
-							d="m135.72 44.03c66.496 49.921 138.02 151.14 164.28 205.46 26.262-54.316 97.782-155.54 164.28-205.46 47.98-36.021 125.72-63.892 125.72 24.795 0 17.712-10.155 148.79-16.111 170.07-20.703 73.984-96.144 92.854-163.25 81.433 117.3 19.964 147.14 86.092 82.697 152.22-122.39 125.59-175.91-31.511-189.63-71.766-2.514-7.3797-3.6904-10.832-3.7077-7.8964-0.0174-2.9357-1.1937 0.51669-3.7077 7.8964-13.714 40.255-67.233 197.36-189.63 71.766-64.444-66.128-34.605-132.26 82.697-152.22-67.108 11.421-142.55-7.4491-163.25-81.433-5.9562-21.282-16.111-152.36-16.111-170.07 0-88.687 77.742-60.816 125.72-24.795z"
-						/>
-					</svg>
+					<img src={client.iconUrl} alt="" width="24" height="24" class="menu-icon-img" />
 					<div class="link-info">
-						<span class="link-title">bluesky profile</span>
-						<span class="link-subtitle">@plyr.fm</span>
+						<span class="link-title">profile</span>
+						<span class="link-subtitle">@plyr.fm on {client.label}</span>
 					</div>
 				</a>
 				<a
@@ -106,13 +99,19 @@
 					rel="noopener noreferrer"
 					class="menu-link"
 				>
-					<img
-						src="https://cdn.bsky.app/img/avatar/plain/did:plc:wshs7t2adsemcrrd4snkeqli/bafkreif6z53z4ukqmdgwstspwh5asmhxheblcd2adisoccl4fflozc3kva@jpeg"
-						alt="Tangled"
+					<svg
 						width="24"
 						height="24"
-						class="tangled-menu-icon"
-					/>
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<polyline points="16 18 22 12 16 6"></polyline>
+						<polyline points="8 6 2 12 8 18"></polyline>
+					</svg>
 					<div class="link-info">
 						<span class="link-title">source code</span>
 						<span class="link-subtitle">tangled.org</span>
@@ -304,13 +303,13 @@
 		color: var(--accent);
 	}
 
-	.tangled-menu-icon {
+	.menu-icon-img {
 		border-radius: var(--radius-sm);
 		opacity: 0.7;
 		transition: opacity 0.2s, box-shadow 0.2s;
 	}
 
-	.menu-link:hover .tangled-menu-icon {
+	.menu-link:hover .menu-icon-img {
 		opacity: 1;
 		box-shadow: 0 0 0 2px var(--accent);
 	}

--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -25,6 +25,7 @@ export interface UiSettings {
 	use_playing_artwork_as_background?: boolean;
 	pds_audio_uploads_enabled?: boolean;
 	font_family?: FontFamily;
+	atproto_client?: string;
 }
 
 export interface Preferences {
@@ -126,6 +127,10 @@ class PreferencesManager {
 
 	get fontFamily(): FontFamily {
 		return this.data?.ui_settings?.font_family ?? DEFAULT_FONT;
+	}
+
+	get atprotoClient(): string | null {
+		return this.data?.ui_settings?.atproto_client ?? null;
 	}
 
 	applyFont(font: FontFamily): void {
@@ -254,6 +259,8 @@ class PreferencesManager {
 				const font = this.data.ui_settings?.font_family ?? DEFAULT_FONT;
 				localStorage.setItem('fontFamily', font);
 				this.applyFont(font);
+				const atClient = this.data.ui_settings?.atproto_client;
+				if (atClient) localStorage.setItem('atprotoClient', atClient);
 				this.applyTheme(this.data.theme);
 				if (this.data.theme === 'live') {
 					ambient.activate();

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -8,6 +8,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 	import { toast } from '$lib/toast.svelte';
 	import { auth } from '$lib/auth.svelte';
 	import { preferences, FONT_OPTIONS, type Theme, type FontFamily } from '$lib/preferences.svelte';
+	import { AT_CLIENTS, DEFAULT_AT_CLIENT } from '$lib/atclients';
 	import { ambient } from '$lib/ambient.svelte';
 	import { queue } from '$lib/queue.svelte';
 
@@ -22,6 +23,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 	let currentTheme = $derived(preferences.theme);
 	let currentColor = $derived(preferences.accentColor ?? '#6a9fff');
 	let currentFont = $derived(preferences.fontFamily);
+	let currentClient = $derived(preferences.atprotoClient ?? DEFAULT_AT_CLIENT);
 	let autoAdvance = $derived(preferences.autoAdvance);
 	let backgroundImageUrl = $derived(preferences.uiSettings.background_image_url ?? '');
 	let backgroundTile = $derived(preferences.uiSettings.background_tile ?? false);
@@ -59,6 +61,11 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		{ value: 'system', label: 'auto', icon: 'auto' },
 		{ value: 'live', label: 'live', icon: 'live' }
 	];
+
+	function selectClient(value: string) {
+		preferences.updateUiSettings({ atproto_client: value });
+		localStorage.setItem('atprotoClient', value);
+	}
 
 	onMount(async () => {
 		// check if exchange_token is in URL (from OAuth callback)
@@ -525,6 +532,26 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 								onclick={() => selectFont(option.value)}
 							>
 								{option.label}
+							</button>
+						{/each}
+					</div>
+				</div>
+
+				<div class="setting-row">
+					<div class="setting-info">
+						<h3>open links in</h3>
+						<p>choose which app profile and record links open in across plyr.fm</p>
+					</div>
+					<div class="client-controls">
+						{#each AT_CLIENTS as client}
+							<button
+								class="client-btn"
+								class:active={currentClient === client.value}
+								onclick={() => selectClient(client.value)}
+								title={client.label}
+							>
+								<img src={client.iconUrl} alt="" width="20" height="20" loading="lazy" />
+								<span>{client.label}</span>
 							</button>
 						{/each}
 					</div>
@@ -1133,6 +1160,52 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		background: color-mix(in srgb, var(--accent) 15%, transparent);
 		border-color: var(--accent);
 		color: var(--accent);
+	}
+
+	/* atproto client controls */
+	.client-controls {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+		flex-shrink: 0;
+	}
+
+	.client-btn {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.3rem;
+		padding: 0.5rem 0.6rem;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-md);
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: all 0.15s;
+		min-width: 64px;
+	}
+
+	.client-btn:hover {
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+
+	.client-btn.active {
+		background: color-mix(in srgb, var(--accent) 15%, transparent);
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+
+	.client-btn img {
+		width: 20px;
+		height: 20px;
+		border-radius: var(--radius-sm);
+	}
+
+	.client-btn span {
+		font-size: 0.65rem;
+		text-transform: lowercase;
+		letter-spacing: 0.02em;
 	}
 
 	/* background controls */

--- a/frontend/src/routes/u/[handle]/+error.svelte
+++ b/frontend/src/routes/u/[handle]/+error.svelte
@@ -3,36 +3,36 @@
 	import { page } from '$app/stores';
 	import { AtpAgent } from '@atproto/api';
 	import { APP_NAME } from '$lib/branding';
+	import { profileLink } from '$lib/atclients';
 
 	const status = $page.status;
 	const handle = $page.params.handle;
 	const isDid = handle?.startsWith('did:') ?? false;
 
-	let checkingBluesky = $state(false);
-	let blueskyProfileExists = $state(false);
-	let blueskyUrl = $state('');
+	let checking = $state(false);
+	let profileExists = $state(false);
+	let profileUrl = $state('');
 
 	onMount(async () => {
-		// bluesky handle resolution only works with handles, not DIDs
+		// handle resolution only works with handles, not DIDs
 		if (isDid) return;
 
-		// if this is a 404, check if the handle exists on the ATProto network
+		// if this is a 404, check if the handle exists on the atproto network
 		if (status === 404 && handle) {
-			checkingBluesky = true;
+			checking = true;
 			try {
-				// use ATProto SDK for proper handle resolution (works with any PDS)
 				const agent = new AtpAgent({ service: 'https://public.api.bsky.app' });
 				const response = await agent.resolveHandle({ handle });
 
 				if (response.data.did) {
-					blueskyProfileExists = true;
-					blueskyUrl = `https://bsky.app/profile/${handle}`;
+					profileExists = true;
+					profileUrl = profileLink(handle);
 				}
 			} catch (_e) {
-				// handle doesn't exist on ATProto network
-				blueskyProfileExists = false;
+				// handle doesn't exist on the atproto network
+				profileExists = false;
 			} finally {
-				checkingBluesky = false;
+				checking = false;
 			}
 		}
 	});
@@ -53,14 +53,14 @@
 
 	<h1>404</h1>
 
-	{#if checkingBluesky}
+	{#if checking}
 		<p class="error-message">checking if @{handle} exists...</p>
-	{:else if blueskyProfileExists}
+	{:else if profileExists}
 		<p class="error-message">@{handle} hasn't joined {APP_NAME} yet</p>
-		<p class="error-detail">but they're on Bluesky!</p>
+		<p class="error-detail">but they're in the atmosphere!</p>
 		<div class="actions">
-			<a href={blueskyUrl} target="_blank" rel="noopener" class="bsky-link">
-				view their Bluesky profile
+			<a href={profileUrl} target="_blank" rel="noopener" class="profile-link">
+				view their profile
 			</a>
 			<a href="/" class="home-link">go home</a>
 		</div>
@@ -123,7 +123,7 @@
 	}
 
 	.home-link,
-	.bsky-link {
+	.profile-link {
 		color: var(--accent);
 		text-decoration: none;
 		font-size: var(--text-xl);
@@ -134,12 +134,12 @@
 		display: inline-block;
 	}
 
-	.bsky-link {
+	.profile-link {
 		background: var(--accent);
 		color: var(--bg-primary);
 	}
 
-	.bsky-link:hover {
+	.profile-link:hover {
 		background: var(--accent-hover);
 		border-color: var(--accent-hover);
 	}

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -21,6 +21,7 @@
 		hasAttemptedRefresh
 	} from '$lib/avatar-refresh.svelte';
 	import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
+	import { profileLink } from '$lib/atclients';
 	import { getAtprotofansProfile, getAtprotofansSupporters, type Supporter } from '$lib/atprotofans';
 	import type { PageData } from './$types';
 
@@ -423,7 +424,7 @@ $effect(() => {
 				<div class="artist-info">
 					<h1>{artist.display_name}</h1>
 					<div class="handle-row">
-						<a href="https://bsky.app/profile/{artist.handle}" target="_blank" rel="noopener" class="handle">
+						<a href={profileLink(artist.handle)} target="_blank" rel="noopener" class="handle">
 							@{artist.handle}
 						</a>
 						{#if isSupporter}
@@ -561,12 +562,12 @@ $effect(() => {
 						{artist.display_name} hasn't uploaded any music to {APP_NAME}.
 					</p>
 					<a
-						href="https://bsky.app/profile/{artist.handle}"
+						href={profileLink(artist.handle)}
 						target="_blank"
 						rel="noopener"
-						class="bsky-link"
+						class="profile-link"
 					>
-						view their Bluesky profile
+						view their profile
 					</a>
 				</div>
 			{:else}
@@ -1206,7 +1207,7 @@ $effect(() => {
 		margin: 0 0 1.5rem 0;
 	}
 
-	.bsky-link {
+	.profile-link {
 		color: var(--accent);
 		text-decoration: none;
 		font-size: var(--text-lg);
@@ -1217,7 +1218,7 @@ $effect(() => {
 		display: inline-block;
 	}
 
-	.bsky-link:hover {
+	.profile-link:hover {
 		background: var(--accent);
 		color: var(--bg-primary);
 	}

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -13,6 +13,7 @@
 	import type { TrackRights } from "$lib/components/CopyrightRightsPanel.svelte";
 	import type { FeaturedArtist, AlbumSummary, Artist } from "$lib/types";
 	import { API_URL, getServerConfig } from "$lib/config";
+	import { profileLink } from "$lib/atclients";
 	import { uploader } from "$lib/uploader.svelte";
 	import { toast } from "$lib/toast.svelte";
 	import { auth } from "$lib/auth.svelte";
@@ -536,7 +537,7 @@
 					permission, or the content may be removed to keep plyr.fm in
 					compliance. For any questions or concerns, please DM
 					<a
-						href="https://bsky.app/profile/zzstoatzz.io"
+						href={profileLink('zzstoatzz.io')}
 						target="_blank"
 						rel="noopener">@zzstoatzz.io</a
 					> :) have a nice day!


### PR DESCRIPTION
Makes "which atproto app a profile/record link opens in" a user-selectable, templated preference — and removes the hardcoded-Bluesky assumptions that treated bsky.app as *the* client. Modeled on the `clients.js` pattern shared across `leaflet-search` / `status` / `@chicago.at`.

Pick your client in **settings → appearance → "open links in"** (same panel UX as theme/font), and every profile link across the app routes through it.

<details>
<summary>what's in it</summary>

- **`frontend/src/lib/atclients.ts`** — `AT_CLIENTS` registry (`{ value, label, iconUrl, profileUrl, recordUrl? }`) seeded with **Bluesky · deer.social · Blacksky · pdsls**, plus `profileLink()` / `recordLink()` helpers. Choice resolves: account preference → `localStorage` fallback (so logged-out viewers + pre-load renders still work) → Bluesky default. Adding a client is a one-entry edit.
- **settings** — new "open links in" picker matching the existing theme/font button grid. Persisted in `ui_settings.atproto_client` (JSONB, no migration — the POST handler already merges partial `ui_settings`) and mirrored to `localStorage` like `font_family`/`theme`.
- **templated profile links** — artist page handle (`u/[handle]`), 404 page, `LinksMenu` (plyr.fm's own profile, now shown with the chosen client's icon), and the upload/album "DM @zzstoatzz.io" credit.
- **branding neutralized** — `"bluesky profile"` → `"profile"`, `"but they're on Bluesky!"` → `"…in the atmosphere!"`, `"view their Bluesky profile"` → `"view their profile"`, the butterfly SVGs and the `cdn.bsky.app`-hosted "source code" icon removed (`.bsky-link` → `.profile-link`).
</details>

<details>
<summary>scope + follow-up</summary>

Scoped to the **user-facing client choice + branding**. Deliberately **out of scope** (a real infra change — tracked for a follow-up): plyr's backend Bluesky dependencies — `public.api.bsky.app` (profile/handle resolution, incl. the `+error.svelte` resolver kept here) and `cdn.bsky.app` (avatar URLs) — plus the home-page "your bluesky network" copy and the profile-setup "bluesky avatar" copy, which are coupled to those data sources.

The **login page** is intentionally untouched: it's already pluralistic (Bluesky **and** Blacksky as account hosts) and concerns *account creation*, not which client to view content in.
</details>

<details>
<summary>validation</summary>

- `just frontend check` → 0 errors / 0 warnings
- `bun run lint` (eslint) → clean
- No `bsky.app/profile` constructions remain outside the registry.

No frontend test harness exists (no vitest), so the helper is kept pure/typed; worth a quick manual pass on the picker + that links update live.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)