### PR TITLE
fix(profiles): reference client registry + theme-safe logos

### DIFF
--- a/frontend/src/lib/atclients.ts
+++ b/frontend/src/lib/atclients.ts
@@ -1,5 +1,6 @@
 // preferred atproto client — open profiles and records in the app of your choice.
-// the registry below is the single source of truth; add an entry to support a new client.
+// the registry mirrors the shared client list in leaflet-search / status
+// (@zzstoatzz.io); keep it in sync with those rather than inventing entries.
 import { browser } from '$app/environment';
 import { preferences } from '$lib/preferences.svelte';
 
@@ -13,7 +14,7 @@ export interface AtClient {
 
 const BSKY: AtClient = {
 	value: 'bsky',
-	label: 'Bluesky',
+	label: 'bluesky',
 	iconUrl: 'https://web-cdn.bsky.app/static/apple-touch-icon.png',
 	profileUrl: (h) => `https://bsky.app/profile/${h}`
 };
@@ -21,16 +22,22 @@ const BSKY: AtClient = {
 export const AT_CLIENTS: AtClient[] = [
 	BSKY,
 	{
-		value: 'deer',
-		label: 'deer.social',
-		iconUrl: 'https://deer.social/favicon.ico',
-		profileUrl: (h) => `https://deer.social/profile/${h}`
-	},
-	{
 		value: 'blacksky',
-		label: 'Blacksky',
+		label: 'blacksky',
 		iconUrl: 'https://blacksky.community/static/apple-touch-icon.png',
 		profileUrl: (h) => `https://blacksky.community/profile/${h}`
+	},
+	{
+		value: 'witchsky',
+		label: 'witchsky',
+		iconUrl: 'https://witchsky.app/favicon.ico',
+		profileUrl: (h) => `https://witchsky.app/profile/${h}`
+	},
+	{
+		value: 'reddwarf',
+		label: 'red dwarf',
+		iconUrl: 'https://reddwarf.app/redstar.png',
+		profileUrl: (h) => `https://reddwarf.app/profile/${h}`
 	},
 	{
 		value: 'pdsls',

--- a/frontend/src/lib/components/LinksMenu.svelte
+++ b/frontend/src/lib/components/LinksMenu.svelte
@@ -304,13 +304,15 @@
 	}
 
 	.menu-icon-img {
+		/* light tile so any client logo (e.g. blacksky's black mark) stays legible */
 		border-radius: var(--radius-sm);
-		opacity: 0.7;
-		transition: opacity 0.2s, box-shadow 0.2s;
+		background: #fff;
+		padding: 2px;
+		box-sizing: border-box;
+		transition: box-shadow 0.2s;
 	}
 
 	.menu-link:hover .menu-icon-img {
-		opacity: 1;
 		box-shadow: 0 0 0 2px var(--accent);
 	}
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1197,9 +1197,15 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 	}
 
 	.client-btn img {
-		width: 20px;
-		height: 20px;
+		/* external client logos have arbitrary/transparent backgrounds (blacksky's
+		   mark is black and vanishes on dark) — sit them on a constant light tile so
+		   they stay legible in every theme */
+		width: 24px;
+		height: 24px;
+		padding: 2px;
+		box-sizing: border-box;
 		border-radius: var(--radius-sm);
+		background: #fff;
 	}
 
 	.client-btn span {


### PR DESCRIPTION
Follow-up to #1436. Two corrections:

1. **Use the actual reference list.** #1436 shipped an invented `deer.social` entry (unmaintained, and not present in any of the repos used as references). Replaced with the curated shared registry from `leaflet-search` / `status`: **bsky · blacksky · witchsky · reddwarf · pdsls**, with their real labels, profile URLs, and icon URLs. Added a comment pinning the file as a mirror of that shared list.
2. **Theme-safe logos.** External client logos have arbitrary/transparent backgrounds — blacksky's mark is black and disappeared on the dark theme. Logos now render on a constant light tile (settings picker + links menu) so they stay legible in every theme.

`just frontend check` → 0/0, eslint clean.