### PR TITLE
fix(copy): drop bluesky-specific copy from avatar setup + handle placeholders

### DIFF
--- a/frontend/src/lib/components/ProfileMenu.svelte
+++ b/frontend/src/lib/components/ProfileMenu.svelte
@@ -522,7 +522,7 @@
 							<HandleAutocomplete
 								bind:value={newHandle}
 								onSelect={handleSelectHandle}
-								placeholder="handle.bsky.social"
+								placeholder="you.example.com"
 								disabled={addingAccount}
 							/>
 							<button

--- a/frontend/src/lib/components/UserMenu.svelte
+++ b/frontend/src/lib/components/UserMenu.svelte
@@ -270,7 +270,7 @@
 									<HandleAutocomplete
 										bind:value={newHandle}
 										onSelect={handleSelectHandle}
-										placeholder="handle.bsky.social"
+										placeholder="you.example.com"
 										disabled={addingAccount}
 									/>
 									<button

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -126,7 +126,7 @@
 					<HandleAutocomplete
 						bind:value={handle}
 						onSelect={handleSelect}
-						placeholder="you.bsky.social"
+						placeholder="you.example.com"
 						disabled={loading}
 					/>
 					<div class="handle-hint">

--- a/frontend/src/routes/profile/setup/+page.svelte
+++ b/frontend/src/routes/profile/setup/+page.svelte
@@ -181,9 +181,9 @@
 					/>
 					<p class="hint">
 						{#if fetchingAvatar}
-							discovering your bluesky avatar...
+							discovering your avatar...
 						{:else}
-							we'll try to use your bluesky avatar automatically
+							we'll try to use your existing avatar automatically
 						{/if}
 					</p>
 				</div>


### PR DESCRIPTION
The 🟡 batch from the frontend Bluesky-ism sweep — the remaining *user-visible* branding that's clearly in-spirit:

- **profile setup** — avatar hint no longer reads "discovering your **bluesky** avatar…" / "use your **bluesky** avatar"; now neutral ("your avatar" / "your existing avatar").
- **handle placeholders** — `login`, `UserMenu`, `ProfileMenu` use `you.example.com` instead of `*.bsky.social` (a handle is just a domain).

Intentionally left:
- the two profile-setup **comments** noting the avatar is fetched via the Bluesky API — accurate description of current backend behavior (part of the deferred AppView/CDN follow-up).
- the **login account-host guidance** (Bluesky/Blacksky "where to sign up") — deliberate, already plural, and a separate concern from "open in client."

`just frontend check` → 0/0, eslint clean.