### PR TITLE
fix(loq): raise limits for settings + upload pages

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -160,7 +160,7 @@ max_lines = 3954
 
 [[rules]]
 path = "frontend/src/routes/settings/+page.svelte"
-max_lines = 1568
+max_lines = 1588
 
 [[rules]]
 path = "frontend/src/routes/track/\\[id\\]/+page.svelte"
@@ -176,7 +176,7 @@ max_lines = 1299
 
 [[rules]]
 path = "frontend/src/routes/upload/+page.svelte"
-max_lines = 904
+max_lines = 905
 
 [[rules]]
 path = "services/moderation/src/admin.rs"


### PR DESCRIPTION
Follow-up to #1436. The client-picker additions pushed two files over their loq limits, leaving the `pre_commit` check red on main across #1436–#1438:

- `settings/+page.svelte` 1568 → 1588 (the 'open links in' panel + styles)
- `upload/+page.svelte` 904 → 905 (the `profileLink` import)

Raised via `just loq-relax` (no golf). loq is green locally (832 files ok); the app build is unaffected (loq is a line-count lint, not part of the vite build), so the production deploy was not impacted.

My miss: I validated with `svelte-check`+`eslint` but not the full pre-commit suite. Verifying CI green before merge this time.