### PR TITLE
fix(profiles): scope preferred-client to the signed-in account

### DIFF
--- a/frontend/src/lib/atclients.ts
+++ b/frontend/src/lib/atclients.ts
@@ -1,7 +1,6 @@
 // preferred atproto client — open profiles and records in the app of your choice.
 // the registry mirrors the shared client list in leaflet-search / status
 // (@zzstoatzz.io); keep it in sync with those rather than inventing entries.
-import { browser } from '$app/environment';
 import { preferences } from '$lib/preferences.svelte';
 
 export interface AtClient {
@@ -50,17 +49,16 @@ export const AT_CLIENTS: AtClient[] = [
 
 export const DEFAULT_AT_CLIENT = BSKY.value;
 
-function storedClientValue(): string | null {
-	// account preference wins; fall back to the per-browser cache so links also
-	// resolve for logged-out viewers and before preferences finish loading.
-	if (preferences.atprotoClient) return preferences.atprotoClient;
-	if (browser) return localStorage.getItem('atprotoClient');
-	return null;
+// resolve a client purely from the account-scoped preference value.
+// deliberately does NOT read localStorage: a single global cache would leak one
+// account's choice into another after switching accounts (the picker reads the
+// account pref, so a global fallback makes links disagree with settings).
+export function resolveClient(value: string | null | undefined): AtClient {
+	return AT_CLIENTS.find((c) => c.value === value) ?? BSKY;
 }
 
 export function getPreferredClient(): AtClient {
-	const value = storedClientValue();
-	return AT_CLIENTS.find((c) => c.value === value) ?? BSKY;
+	return resolveClient(preferences.atprotoClient);
 }
 
 export function profileLink(handleOrDid: string): string {

--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -259,8 +259,6 @@ class PreferencesManager {
 				const font = this.data.ui_settings?.font_family ?? DEFAULT_FONT;
 				localStorage.setItem('fontFamily', font);
 				this.applyFont(font);
-				const atClient = this.data.ui_settings?.atproto_client;
-				if (atClient) localStorage.setItem('atprotoClient', atClient);
 				this.applyTheme(this.data.theme);
 				if (this.data.theme === 'live') {
 					ambient.activate();

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -64,7 +64,6 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 
 	function selectClient(value: string) {
 		preferences.updateUiSettings({ atproto_client: value });
-		localStorage.setItem('atprotoClient', value);
 	}
 
 	onMount(async () => {


### PR DESCRIPTION
**Account-isolation bug** (the recurring localStorage class). The preferred atproto client leaked across accounts:

1. Account A picks **pdsls** → writes A's account pref *and* a global `localStorage['atprotoClient']='pdsls'`.
2. Switch to account B (no pref). Settings picker reads the **account-scoped** value → shows the default (Bluesky) correctly.
3. But `getPreferredClient()` (used for link rendering) saw B's account pref was null and **fell through to the stale global localStorage** → opened links in A's pdsls. Settings and links disagreed.

**Fix:** resolve purely from the account-scoped pref via a new pure `resolveClient(value)`; remove *all* localStorage involvement (settings write, fetch mirror, resolver read). Link choice needs no flash-prevention, so the browser-global cache had no upside and broke isolation. Documented in-code why localStorage is forbidden here.

**Not affected:** theme/font/accent write localStorage *unconditionally* on every account load (always overwritten on switch), so they don't leak — only the optional client key did.

**Note:** no automated regression test — there's no frontend test harness (no vitest) and CI runs pre-commit only. The fix is structural (resolver takes only account-scoped state), but I can stand up vitest + a guard as a follow-up if you want belt-and-suspenders.

svelte-check 0/0, eslint clean, loq green.