### PR TITLE
fix(settings): move "open links in" picker into integrations

### DIFF
--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -538,26 +538,6 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 
 				<div class="setting-row">
 					<div class="setting-info">
-						<h3>open links in</h3>
-						<p>choose which app profile and record links open in across plyr.fm</p>
-					</div>
-					<div class="client-controls">
-						{#each AT_CLIENTS as client}
-							<button
-								class="client-btn"
-								class:active={currentClient === client.value}
-								onclick={() => selectClient(client.value)}
-								title={client.label}
-							>
-								<img src={client.iconUrl} alt="" width="20" height="20" loading="lazy" />
-								<span>{client.label}</span>
-							</button>
-						{/each}
-					</div>
-				</div>
-
-				<div class="setting-row">
-					<div class="setting-info">
 						<h3>background image</h3>
 						<p>set a custom background image (URL){#if usePlayingArtwork} — used as fallback when nothing is playing{/if}</p>
 					</div>
@@ -708,6 +688,25 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 						<span>authorization expired — disable and re-enable to reconnect</span>
 					</div>
 				{/if}
+				<div class="setting-row">
+					<div class="setting-info">
+						<h3>open links in</h3>
+						<p>choose which app profile and record links open in across plyr.fm</p>
+					</div>
+					<div class="client-controls">
+						{#each AT_CLIENTS as client}
+							<button
+								class="client-btn"
+								class:active={currentClient === client.value}
+								onclick={() => selectClient(client.value)}
+								title={client.label}
+							>
+								<img src={client.iconUrl} alt="" width="20" height="20" loading="lazy" />
+								<span>{client.label}</span>
+							</button>
+						{/each}
+					</div>
+				</div>
 			</div>
 		</section>
 


### PR DESCRIPTION
Moves the "open links in" client picker out of **appearance** and into **integrations** (next to teal.fm scrobbling).

It controls where outbound atproto profile/record links hand off to — an interop preference, not a visual one. It was sitting next to theme/font/background purely out of convenience; `integrations` is the right home.

<details>
<summary>details</summary>

- Pure move within `frontend/src/routes/settings/+page.svelte` — no logic change (`AT_CLIENTS`, `selectClient`, `currentClient` all unchanged).
- `appearance` now reads theme → accent → font → background → playing-artwork.
- `integrations` now reads teal.fm scrobbling → open links in.
- `just frontend check` clean (0 errors / 0 warnings). Net −1 line, no loq impact.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)