### PR TITLE
fix(plays): stop tab-refresh from inflating play counts (#1441)

### DIFF
--- a/backend/src/backend/api/tracks/playback.py
+++ b/backend/src/backend/api/tracks/playback.py
@@ -48,9 +48,7 @@ class PlayRequest(BaseModel):
     ref: str | None = None
 
 
-def _listener_key(
-    request: Request, response: Response, session: Session | None
-) -> str:
+def _listener_key(request: Request, response: Response, session: Session | None) -> str:
     """stable per-listener key for play-count dedup.
 
     authenticated listeners key on their DID; anonymous listeners key on a

--- a/backend/src/backend/api/tracks/playback.py
+++ b/backend/src/backend/api/tracks/playback.py
@@ -2,10 +2,12 @@
 
 import asyncio
 import logging
+import secrets
 from typing import Annotated
 
+import logfire
 from atproto_oauth.scopes import ScopesSet
-from fastapi import Body, Depends, HTTPException, Query
+from fastapi import Body, Depends, HTTPException, Query, Request, Response
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,16 +27,72 @@ from backend.models import (
 )
 from backend.schemas import PlayCountResponse, TrackResponse
 from backend.utilities.aggregations import get_like_counts, get_track_tags
+from backend.utilities.redis import get_async_redis_client
 
 from .router import router
 
 logger = logging.getLogger(__name__)
+
+# play-count dedup: a listener can only add one counted play per track within
+# roughly one track-length — you cannot genuinely finish the same track twice
+# inside its own duration. anonymous listeners key on a first-party cookie.
+_PLAY_ID_COOKIE = "plyr_play_id"
+_PLAY_DEDUP_MIN_TTL_S = 30
+_PLAY_DEDUP_MAX_TTL_S = 60 * 60
+_PLAY_DEDUP_DEFAULT_TTL_S = 5 * 60
 
 
 class PlayRequest(BaseModel):
     """optional request body for play endpoint."""
 
     ref: str | None = None
+
+
+def _listener_key(
+    request: Request, response: Response, session: Session | None
+) -> str:
+    """stable per-listener key for play-count dedup.
+
+    authenticated listeners key on their DID; anonymous listeners key on a
+    long-lived first-party cookie (best-effort — a cleared cookie counts again).
+    """
+    if session:
+        return f"did:{session.did}"
+    if anon_id := request.cookies.get(_PLAY_ID_COOKIE):
+        return f"anon:{anon_id}"
+    anon_id = secrets.token_urlsafe(16)
+    is_localhost = bool(settings.frontend.url) and settings.frontend.url.startswith(
+        "http://localhost"
+    )
+    response.set_cookie(
+        key=_PLAY_ID_COOKIE,
+        value=anon_id,
+        httponly=True,
+        secure=not is_localhost,
+        samesite="lax",
+        max_age=180 * 24 * 60 * 60,
+    )
+    return f"anon:{anon_id}"
+
+
+async def _claim_play(listener_key: str, track_id: int, ttl_seconds: int) -> bool:
+    """claim a play for (listener, track), allowing one per ``ttl_seconds`` window.
+
+    fails open (counts the play) when redis is unavailable so play counting never
+    hard-depends on the cache.
+    """
+    try:
+        claimed = await get_async_redis_client().set(
+            f"play-count:{listener_key}:{track_id}", "1", nx=True, ex=ttl_seconds
+        )
+    except Exception as exc:
+        logfire.warning(
+            "play-count dedup unavailable; counting play",
+            track_id=track_id,
+            error=str(exc),
+        )
+        return True
+    return bool(claimed)
 
 
 async def _resolve_track(
@@ -105,11 +163,17 @@ async def get_track(
 @router.post("/{track_id}/play")
 async def increment_play_count(
     track_id: int,
+    request: Request,
+    response: Response,
     db: Annotated[AsyncSession, Depends(get_db)],
     session: Session | None = Depends(get_optional_session),
     body: PlayRequest | None = Body(default=None),
 ) -> PlayCountResponse:
-    """Increment play count for a track (called after 30 seconds of playback).
+    """Increment play count for a track (called after sustained playback).
+
+    Deduplicated per listener per track for roughly one track-length, so
+    refreshing other tabs (or replaying the same position) does not inflate the
+    count while genuine repeat listens still count.
 
     If user has teal.fm scrobbling enabled and has the required scopes,
     also writes play record to their PDS.
@@ -125,6 +189,14 @@ async def increment_play_count(
 
     if not (track := result.scalar_one_or_none()):
         raise HTTPException(status_code=404, detail="track not found")
+
+    ttl = max(
+        _PLAY_DEDUP_MIN_TTL_S,
+        min(track.duration or _PLAY_DEDUP_DEFAULT_TTL_S, _PLAY_DEDUP_MAX_TTL_S),
+    )
+    if not await _claim_play(_listener_key(request, response, session), track_id, ttl):
+        logfire.info("play count deduped", track_id=track_id)
+        return PlayCountResponse(play_count=track.play_count)
 
     track.play_count += 1
 

--- a/backend/tests/api/test_play_count_dedup.py
+++ b/backend/tests/api/test_play_count_dedup.py
@@ -1,0 +1,225 @@
+"""regression tests for play-count dedup (issue #1441).
+
+refreshing other tabs while a track is playing used to increment its play count
+because each fresh tab re-reported a play from the restored playback position.
+the backend now deduplicates one counted play per (listener, track) for roughly
+one track-length, while genuine repeat listens after that window still count.
+"""
+
+from collections.abc import Generator
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import Session, get_optional_session
+from backend.main import app
+from backend.models import Artist, Track
+
+_ARTIST_DID = "did:plc:playcount_artist"
+
+
+class MockSession(Session):
+    """minimal session for the authenticated dedup path."""
+
+    def __init__(self, did: str = "did:test:listener") -> None:
+        self.did = did
+        self.handle = "listener.bsky.social"
+        self.session_id = "test_session_id"
+        self.access_token = "test_token"
+        self.refresh_token = "test_refresh"
+        self.oauth_session = {
+            "did": did,
+            "handle": "listener.bsky.social",
+            "pds_url": "https://test.pds",
+            "authserver_iss": "https://auth.test",
+            "scope": "atproto transition:generic",
+            "access_token": "test_token",
+            "refresh_token": "test_refresh",
+            "dpop_private_key_pem": "fake_key",
+            "dpop_authserver_nonce": "",
+            "dpop_pds_nonce": "",
+        }
+
+
+class _FakeRedis:
+    """in-memory stand-in implementing the SET NX EX semantics dedup relies on."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.ex_values: list[int | None] = []
+
+    async def set(
+        self, key: str, value: str, nx: bool = False, ex: int | None = None
+    ) -> bool | None:
+        self.ex_values.append(ex)
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        return True
+
+
+@pytest.fixture
+def fake_redis(monkeypatch: pytest.MonkeyPatch) -> _FakeRedis:
+    fake = _FakeRedis()
+    monkeypatch.setattr(
+        "backend.api.tracks.playback.get_async_redis_client", lambda: fake
+    )
+    return fake
+
+
+@pytest.fixture
+def authed_app(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
+    async def _session() -> Session:
+        return MockSession()
+
+    app.dependency_overrides[get_optional_session] = _session
+    yield app
+    app.dependency_overrides.pop(get_optional_session, None)
+
+
+@pytest.fixture
+def anon_app(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
+    async def _session() -> None:
+        return None
+
+    app.dependency_overrides[get_optional_session] = _session
+    yield app
+    app.dependency_overrides.pop(get_optional_session, None)
+
+
+async def _make_track(
+    db_session: AsyncSession, *, suffix: str, duration: int | None
+) -> Track:
+    artist = await db_session.get(Artist, _ARTIST_DID)
+    if artist is None:
+        artist = Artist(
+            did=_ARTIST_DID, handle="artist.bsky.social", display_name="Artist"
+        )
+        db_session.add(artist)
+        await db_session.flush()
+    track = Track(
+        title=f"track {suffix}",
+        artist_did=_ARTIST_DID,
+        file_id=f"file_{suffix}",
+        file_type="mp3",
+        play_count=0,
+        atproto_record_uri=f"at://{_ARTIST_DID}/fm.plyr.track/{suffix}",
+        atproto_record_cid=f"cid_{suffix}",
+        extra={"duration": duration} if duration is not None else {},
+    )
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+    return track
+
+
+def _client(test_app: FastAPI) -> AsyncClient:
+    # https base url so the Secure dedup cookie is stored + resent by the jar
+    return AsyncClient(transport=ASGITransport(app=test_app), base_url="https://test")
+
+
+async def test_refresh_does_not_double_count(
+    authed_app: FastAPI, db_session: AsyncSession, fake_redis: _FakeRedis
+) -> None:
+    """the #1441 repro: a second report for the same listener+track is deduped."""
+    track = await _make_track(db_session, suffix="dedup", duration=200)
+
+    async with _client(authed_app) as client:
+        first = await client.post(f"/tracks/{track.id}/play")
+        second = await client.post(f"/tracks/{track.id}/play")
+
+    assert first.json()["play_count"] == 1
+    assert second.json()["play_count"] == 1
+    # dedup window keyed off the track's duration
+    assert fake_redis.ex_values[0] == 200
+
+
+async def test_replay_after_window_counts_again(
+    authed_app: FastAPI, db_session: AsyncSession, fake_redis: _FakeRedis
+) -> None:
+    """once the dedup key expires, a genuine repeat listen counts."""
+    track = await _make_track(db_session, suffix="replay", duration=120)
+
+    async with _client(authed_app) as client:
+        first = await client.post(f"/tracks/{track.id}/play")
+        fake_redis.store.clear()  # simulate the SET NX key TTL elapsing
+        second = await client.post(f"/tracks/{track.id}/play")
+
+    assert first.json()["play_count"] == 1
+    assert second.json()["play_count"] == 2
+
+
+async def test_anonymous_deduped_by_cookie(
+    anon_app: FastAPI, db_session: AsyncSession, fake_redis: _FakeRedis
+) -> None:
+    """anon listeners are deduped via the first-party cookie within one client."""
+    track = await _make_track(db_session, suffix="anon", duration=200)
+
+    async with _client(anon_app) as client:
+        first = await client.post(f"/tracks/{track.id}/play")
+        assert "plyr_play_id" in first.cookies  # cookie minted on first play
+        second = await client.post(f"/tracks/{track.id}/play")
+
+    assert first.json()["play_count"] == 1
+    assert second.json()["play_count"] == 1
+
+
+async def test_distinct_anonymous_browsers_each_count(
+    anon_app: FastAPI, db_session: AsyncSession, fake_redis: _FakeRedis
+) -> None:
+    """two cookie-less clients are different listeners and both count."""
+    track = await _make_track(db_session, suffix="anon2", duration=200)
+
+    async with _client(anon_app) as a:
+        first = await a.post(f"/tracks/{track.id}/play")
+    async with _client(anon_app) as b:
+        second = await b.post(f"/tracks/{track.id}/play")
+
+    assert first.json()["play_count"] == 1
+    assert second.json()["play_count"] == 2
+
+
+@pytest.mark.parametrize(
+    ("duration", "expected_ttl"),
+    [(None, 300), (5, 30), (200, 200), (99999, 3600)],
+)
+async def test_dedup_ttl_clamped_to_track_duration(
+    authed_app: FastAPI,
+    db_session: AsyncSession,
+    fake_redis: _FakeRedis,
+    duration: int | None,
+    expected_ttl: int,
+) -> None:
+    track = await _make_track(
+        db_session, suffix=f"ttl{duration}", duration=duration
+    )
+
+    async with _client(authed_app) as client:
+        await client.post(f"/tracks/{track.id}/play")
+
+    assert fake_redis.ex_values[0] == expected_ttl
+
+
+async def test_counts_when_redis_unavailable(
+    authed_app: FastAPI,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dedup fails open: a redis outage must not block play counting."""
+    track = await _make_track(db_session, suffix="failopen", duration=200)
+
+    def boom() -> object:
+        raise RuntimeError("redis down")
+
+    monkeypatch.setattr(
+        "backend.api.tracks.playback.get_async_redis_client", boom
+    )
+
+    async with _client(authed_app) as client:
+        first = await client.post(f"/tracks/{track.id}/play")
+        second = await client.post(f"/tracks/{track.id}/play")
+
+    assert first.json()["play_count"] == 1
+    assert second.json()["play_count"] == 2

--- a/backend/tests/api/test_play_count_dedup.py
+++ b/backend/tests/api/test_play_count_dedup.py
@@ -192,9 +192,7 @@ async def test_dedup_ttl_clamped_to_track_duration(
     duration: int | None,
     expected_ttl: int,
 ) -> None:
-    track = await _make_track(
-        db_session, suffix=f"ttl{duration}", duration=duration
-    )
+    track = await _make_track(db_session, suffix=f"ttl{duration}", duration=duration)
 
     async with _client(authed_app) as client:
         await client.post(f"/tracks/{track.id}/play")
@@ -213,9 +211,7 @@ async def test_counts_when_redis_unavailable(
     def boom() -> object:
         raise RuntimeError("redis down")
 
-    monkeypatch.setattr(
-        "backend.api.tracks.playback.get_async_redis_client", boom
-    )
+    monkeypatch.setattr("backend.api.tracks.playback.get_async_redis_client", boom)
 
     async with _client(authed_app) as client:
         first = await client.post(f"/tracks/{track.id}/play")

--- a/frontend/src/lib/player.svelte.ts
+++ b/frontend/src/lib/player.svelte.ts
@@ -1,6 +1,10 @@
 import type { Track } from './types';
 import { API_URL } from './config';
 
+// natural timeupdate steps are sub-second; a larger jump is a seek, scrub, or a
+// restored hydration position — none of which is listened time.
+const PLAY_PROGRESS_SEEK_THRESHOLD_S = 5;
+
 // global player state using Svelte 5 runes
 class PlayerState {
 	currentTrack = $state<Track | null>(null);
@@ -19,6 +23,12 @@ class PlayerState {
 	// synchronous guard to prevent duplicate play count requests
 	// (reactive state updates are batched, so we need this to block rapid-fire calls)
 	private _playCountPending: number | null = null;
+
+	// accumulated *listened* time for the current track (seconds). only advances
+	// while playing and stepping forward naturally, so seeks and restored
+	// hydration positions never trip the play-count threshold on their own.
+	private _playedSeconds = 0;
+	private _lastProgressTime: number | null = null;
 
 	// lock play counting during track transitions to prevent spurious fires
 	// from stale currentTime/duration values before new audio loads
@@ -54,6 +64,18 @@ class PlayerState {
 			return;
 		}
 
+		// accumulate real listened time from forward playback only. a seek or a
+		// hydration position-restore jumps currentTime with nothing listened, so
+		// large or backward steps (and any step while paused) are ignored.
+		const now = this.currentTime;
+		if (this._lastProgressTime !== null) {
+			const delta = now - this._lastProgressTime;
+			if (!this.paused && delta > 0 && delta <= PLAY_PROGRESS_SEEK_THRESHOLD_S) {
+				this._playedSeconds += delta;
+			}
+		}
+		this._lastProgressTime = now;
+
 		// synchronous check to prevent race condition from batched reactive updates
 		if (this._playCountPending === this.currentTrack.id) {
 			return;
@@ -62,7 +84,7 @@ class PlayerState {
 		// threshold: minimum of 30 seconds or 50% of track duration
 		const threshold = Math.min(30, this.duration * 0.5);
 
-		if (this.currentTime >= threshold) {
+		if (this._playedSeconds >= threshold) {
 			// set synchronous guard immediately (before async fetch)
 			this._playCountPending = this.currentTrack.id;
 			this.playCountedForTrack = this.currentTrack.id;
@@ -85,6 +107,8 @@ class PlayerState {
 		this.playCountedForTrack = null;
 		this._playCountPending = null;
 		this._playCountLocked = true;
+		this._playedSeconds = 0;
+		this._lastProgressTime = null;
 	}
 
 	unlockPlayCount() {


### PR DESCRIPTION
Closes #1441. Refreshing other tabs while a track played was bumping its play count. Two reinforcing layers: the frontend now counts *listened* time instead of absolute position, and the backend dedupes one counted play per listener per track for ~one track-length.

### root cause
A play was counted once `currentTime >= min(30s, 50% duration)`. But a freshly loaded/refreshed tab restores the saved position by **seeking** there — so the seek alone satisfied the threshold with nothing listened to. It also counted while **paused** (e.g. cold load with autoplay blocked, sitting at a restored 35s).

<details>
<summary>the two layers</summary>

**Frontend — `player.svelte.ts`:** accumulate real listened time. Only forward, sub-5s, non-paused `currentTime` steps add up; seeks, scrubs, and hydration restores are ignored. Count fires when accumulated listened seconds reach the threshold. A paused-on-restore track never counts.

**Backend — `api/tracks/playback.py`:** `POST /{id}/play` now claims a Redis `SET NX` key `play-count:{listener}:{track}` with `ex = track duration` (clamped 30s–1h) before incrementing. Within that window a listener adds at most one count; genuine replays after the song ends count again. Authenticated listeners key on DID; anonymous on a long-lived first-party cookie (best-effort — mirrors the session cookie's attrs). **Fails open** (counts the play) if Redis is unavailable, and skips the increment + share-link event + teal scrobble on a dedup hit. Mirrors the existing teal-scrobble dedup pattern.

Either layer fixes the authenticated repro on its own; together they also cover the paused-counts bug and anonymous listeners.

</details>

<details>
<summary>tests + verification</summary>

- `backend/tests/api/test_play_count_dedup.py` (9 cases): refresh doesn't double-count, replay-after-window counts again, anon cookie dedup, distinct anon browsers each count, TTL clamps to duration (`None→300`, `5→30`, `200→200`, `99999→3600`), and fail-open when Redis is down. All pass.
- `ruff` + `ty` clean on changed files; `svelte-check` 0/0; `loq` ok.
- No automated frontend test — the repo has no JS test runner, so the `player.svelte.ts` change is covered by reasoning + the backend regression suite. Worth a manual multi-tab sanity check on staging.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)