### PR TITLE
feat(settings): deep-linkable section headers

### DIFF
--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, tick } from 'svelte';
 	import { invalidateAll } from '$app/navigation';
 	import Header from '$lib/components/Header.svelte';
 import WaveLoading from '$lib/components/WaveLoading.svelte';
@@ -66,6 +66,27 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		preferences.updateUiSettings({ atproto_client: value });
 	}
 
+	// deep-linkable section headers: slug the title so a #hash can target it
+	const slugify = (s: string) =>
+		s
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, '-')
+			.replace(/^-+|-+$/g, '');
+
+	function linkToSection(e: MouseEvent, slug: string) {
+		e.preventDefault();
+		document.getElementById(slug)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		history.pushState(null, '', `#${slug}`);
+	}
+
+	function scrollToHash() {
+		const slug = window.location.hash.slice(1);
+		if (!slug) return;
+		window.requestAnimationFrame(() => {
+			document.getElementById(slug)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		});
+	}
+
 	onMount(async () => {
 		// check if exchange_token is in URL (from OAuth callback)
 		const params = new URLSearchParams(window.location.search);
@@ -118,6 +139,8 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 
 		await loadDeveloperTokens();
 		loading = false;
+		await tick();
+		scrollToHash();
 	});
 
 	async function loadDeveloperTokens() {
@@ -440,8 +463,17 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 			<a href="/portal" class="portal-link">manage your content →</a>
 		</div>
 
+		{#snippet sectionHeading(title: string)}
+			{@const slug = slugify(title)}
+			<h2 id={slug}>
+				<a href="#{slug}" class="section-anchor" onclick={(e) => linkToSection(e, slug)}>
+					{title}<span class="anchor-hash" aria-hidden="true">#</span>
+				</a>
+			</h2>
+		{/snippet}
+
 		<section class="settings-section">
-			<h2>appearance</h2>
+			{@render sectionHeading('appearance')}
 			<div class="settings-card">
 				<div class="setting-row">
 					<div class="setting-info">
@@ -581,7 +613,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		</section>
 
 		<section class="settings-section">
-			<h2>playback</h2>
+			{@render sectionHeading('playback')}
 			<div class="settings-card">
 				<div class="setting-row">
 					<div class="setting-info">
@@ -601,7 +633,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		</section>
 
 		<section class="settings-section">
-			<h2>privacy & display</h2>
+			{@render sectionHeading('privacy & display')}
 			<div class="settings-card">
 				<div class="setting-row">
 					<div class="setting-info">
@@ -652,7 +684,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		</section>
 
 		<section class="settings-section">
-			<h2>integrations</h2>
+			{@render sectionHeading('integrations')}
 			<div class="settings-card">
 				<div class="setting-row">
 					<div class="setting-info">
@@ -711,7 +743,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		</section>
 
 		<section class="settings-section">
-			<h2>developer</h2>
+			{@render sectionHeading('developer')}
 			<div class="settings-card">
 				<div class="setting-info full-width">
 					<h3>developer tokens</h3>
@@ -798,7 +830,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		</section>
 
 		<section class="settings-section">
-			<h2>experimental</h2>
+			{@render sectionHeading('experimental')}
 			<div class="settings-card">
 				<div class="setting-row">
 					<div class="setting-info">
@@ -983,6 +1015,25 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		color: var(--text-tertiary);
 		margin-bottom: 0.75rem;
 		text-shadow: var(--text-shadow, none);
+		/* keep the target clear of the sticky header when deep-linked */
+		scroll-margin-top: 5rem;
+	}
+
+	.section-anchor {
+		color: inherit;
+		text-decoration: none;
+	}
+
+	.anchor-hash {
+		margin-left: 0.35em;
+		color: var(--accent);
+		opacity: 0;
+		transition: opacity 0.12s ease;
+	}
+
+	.section-anchor:hover .anchor-hash,
+	.section-anchor:focus-visible .anchor-hash {
+		opacity: 0.7;
 	}
 
 	.settings-card {

--- a/loq.toml
+++ b/loq.toml
@@ -160,7 +160,7 @@ max_lines = 3954
 
 [[rules]]
 path = "frontend/src/routes/settings/+page.svelte"
-max_lines = 1588
+max_lines = 1637
 
 [[rules]]
 path = "frontend/src/routes/track/\\[id\\]/+page.svelte"


### PR DESCRIPTION
Settings section headers are now deep-linkable, so you can share a link that jumps straight to a section (e.g. `plyr.fm/settings#integrations`) — handy for a Bluesky post pointing at a specific setting.

Each heading (appearance, playback, privacy & display, integrations, developer, experimental) gets a slugged `id` and a markdown-style hover `#`. Clicking updates the URL hash (copy it from the address bar — no clipboard hijack, no toast) and smooth-scrolls; on load the page scrolls to the hashed section once content mounts.

<details>
<summary>details</summary>

- A `{#snippet sectionHeading(title)}` keeps the six headings DRY; `slugify()` derives the id (`privacy & display` → `privacy-display`).
- `scroll-margin-top` on headings keeps the target clear of the sticky header.
- `loq` limit relaxed for `settings/+page.svelte` (line-count only; the section markup naturally lives inline here).
- svelte-check 0/0, eslint clean.

**Known limitation:** logged-out visitors to `/settings` are redirected to `/login`, which drops the hash today — so a *public* link deep-links cleanly only for signed-in users. Preserving the hash through the login flow is a possible follow-up.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)