### PR TITLE
feat(playback): "keep playing" — ambient queue continuation from For You

### DIFF
--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -51,13 +51,14 @@
 			.filter(({ index }) => index > currentIdx);
 	});
 
-	// the "next from: for you" tail (ambient backfill) is rendered as a
-	// separate, labeled zone below the explicit queue. jams have no ambient.
+	// the "next from: for you" tail (ambient backfill) is the contiguous suffix
+	// at/after queue.ambientFromIndex, rendered as a separate labeled zone below
+	// the explicit queue. jams have no ambient tail.
 	const explicitUpcoming = $derived(
-		jam.active ? upcoming : upcoming.filter(({ track }) => !queue.ambientFileIds.has(track.file_id))
+		jam.active ? upcoming : upcoming.filter(({ index }) => index < queue.ambientFromIndex)
 	);
 	const ambientUpcoming = $derived(
-		jam.active ? [] : upcoming.filter(({ track }) => queue.ambientFileIds.has(track.file_id))
+		jam.active ? [] : upcoming.filter(({ index }) => index >= queue.ambientFromIndex)
 	);
 
 	const outputParticipant = $derived.by<JamParticipant | null>(() => {

--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -51,6 +51,15 @@
 			.filter(({ index }) => index > currentIdx);
 	});
 
+	// the "next from: for you" tail (ambient backfill) is rendered as a
+	// separate, labeled zone below the explicit queue. jams have no ambient.
+	const explicitUpcoming = $derived(
+		jam.active ? upcoming : upcoming.filter(({ track }) => !queue.ambientFileIds.has(track.file_id))
+	);
+	const ambientUpcoming = $derived(
+		jam.active ? [] : upcoming.filter(({ track }) => queue.ambientFileIds.has(track.file_id))
+	);
+
 	const outputParticipant = $derived.by<JamParticipant | null>(() => {
 		if (!jam.active || !jam.outputDid) return null;
 		return jam.participants.find((p) => p.did === jam.outputDid) ?? null;
@@ -160,6 +169,68 @@
 		touchDragElement = null;
 	}
 </script>
+
+{#snippet queueRow(track: Track, index: number, draggable: boolean)}
+	<div
+		class="queue-track"
+		class:drag-over={draggable && dragOverIndex === index && touchDragIndex !== index}
+		class:is-dragging={draggable && (touchDragIndex === index || draggedIndex === index)}
+		class:ambient={!draggable}
+		data-index={index}
+		{draggable}
+		role="button"
+		tabindex="0"
+		ondragstart={draggable ? (e) => handleDragStart(e, index) : undefined}
+		ondragover={draggable ? (e) => handleDragOver(e, index) : undefined}
+		ondrop={draggable ? (e) => handleDrop(e, index) : undefined}
+		ondragend={draggable ? handleDragEnd : undefined}
+		onclick={() => handleTrackClick(index)}
+		onkeydown={(e) => e.key === 'Enter' && handleTrackClick(index)}
+	>
+		{#if draggable}
+			<button
+				class="drag-handle"
+				ontouchstart={(e) => handleTouchStart(e, index)}
+				onclick={(e) => e.stopPropagation()}
+				aria-label="drag to reorder"
+				title="drag to reorder"
+			>
+				<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+					<circle cx="5" cy="3" r="1.5"></circle>
+					<circle cx="11" cy="3" r="1.5"></circle>
+					<circle cx="5" cy="8" r="1.5"></circle>
+					<circle cx="11" cy="8" r="1.5"></circle>
+					<circle cx="5" cy="13" r="1.5"></circle>
+					<circle cx="11" cy="13" r="1.5"></circle>
+				</svg>
+			</button>
+		{/if}
+
+		<div class="track-info">
+			<div class="track-title">{track.title}</div>
+			<div class="track-artist">
+				<a href="/u/{track.artist_handle}" onclick={(e) => e.stopPropagation()}>
+					{track.artist}
+				</a>
+			</div>
+		</div>
+
+		<button
+			class="remove-btn"
+			onclick={(e) => {
+				e.stopPropagation();
+				handleRemoveTrack(index);
+			}}
+			aria-label="remove from queue"
+			title="remove from queue"
+		>
+			<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+				<line x1="18" y1="6" x2="6" y2="18"></line>
+				<line x1="6" y1="6" x2="18" y2="18"></line>
+			</svg>
+		</button>
+	</div>
+{/snippet}
 
 {#if tracks.length > 0}
 	<div class="queue" class:jam-mode={jam.active}>
@@ -314,10 +385,10 @@
 			<section class="queue-upcoming">
 				<div class="section-header">
 					<h3>up next</h3>
-					<span>{upcoming.length}</span>
+					<span>{explicitUpcoming.length}</span>
 				</div>
 
-				{#if upcoming.length > 0}
+				{#if explicitUpcoming.length > 0 || ambientUpcoming.length > 0}
 					<div
 						class="queue-tracks"
 						role="list"
@@ -326,64 +397,16 @@
 						ontouchend={handleTouchEnd}
 						ontouchcancel={handleTouchEnd}
 					>
-						{#each upcoming as { track, index } (`${track.file_id}:${index}`)}
-							<div
-								class="queue-track"
-								class:drag-over={dragOverIndex === index && touchDragIndex !== index}
-								class:is-dragging={touchDragIndex === index || draggedIndex === index}
-								data-index={index}
-								draggable={true}
-								role="button"
-								tabindex="0"
-								ondragstart={(e) => handleDragStart(e, index)}
-								ondragover={(e) => handleDragOver(e, index)}
-								ondrop={(e) => handleDrop(e, index)}
-								ondragend={handleDragEnd}
-								onclick={() => handleTrackClick(index)}
-								onkeydown={(e) => e.key === 'Enter' && handleTrackClick(index)}
-							>
-								<button
-									class="drag-handle"
-									ontouchstart={(e) => handleTouchStart(e, index)}
-									onclick={(e) => e.stopPropagation()}
-									aria-label="drag to reorder"
-									title="drag to reorder"
-								>
-									<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-										<circle cx="5" cy="3" r="1.5"></circle>
-										<circle cx="11" cy="3" r="1.5"></circle>
-										<circle cx="5" cy="8" r="1.5"></circle>
-										<circle cx="11" cy="8" r="1.5"></circle>
-										<circle cx="5" cy="13" r="1.5"></circle>
-										<circle cx="11" cy="13" r="1.5"></circle>
-									</svg>
-								</button>
-
-								<div class="track-info">
-									<div class="track-title">{track.title}</div>
-									<div class="track-artist">
-										<a href="/u/{track.artist_handle}" onclick={(e) => e.stopPropagation()}>
-											{track.artist}
-										</a>
-									</div>
-								</div>
-
-								<button
-									class="remove-btn"
-									onclick={(e) => {
-										e.stopPropagation();
-										handleRemoveTrack(index);
-									}}
-									aria-label="remove from queue"
-									title="remove from queue"
-								>
-									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-										<line x1="18" y1="6" x2="6" y2="18"></line>
-										<line x1="6" y1="6" x2="18" y2="18"></line>
-									</svg>
-								</button>
-							</div>
+						{#each explicitUpcoming as { track, index } (`${track.file_id}:${index}`)}
+							{@render queueRow(track, index, true)}
 						{/each}
+
+						{#if ambientUpcoming.length > 0}
+							<div class="ambient-header">next from: for you</div>
+							{#each ambientUpcoming as { track, index } (`${track.file_id}:${index}`)}
+								{@render queueRow(track, index, false)}
+							{/each}
+						{/if}
 					</div>
 				{:else}
 					<div class="empty-up-next">
@@ -761,6 +784,39 @@
 		flex-direction: column;
 		gap: 0.5rem;
 		padding-right: 0.35rem;
+	}
+
+	/* "next from: for you" divider above the ambient backfill tail */
+	.ambient-header {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		margin-top: 0.35rem;
+		padding: 0 0.1rem 0.1rem;
+		font-size: var(--text-xs);
+		letter-spacing: 0.04em;
+		color: var(--text-tertiary);
+	}
+
+	.ambient-header::before {
+		content: '';
+		width: 6px;
+		height: 6px;
+		border-radius: var(--radius-full);
+		background: var(--accent);
+		opacity: 0.6;
+		flex-shrink: 0;
+	}
+
+	/* ambient rows read as tentative/auto-generated vs explicit queue items */
+	.queue-track.ambient {
+		border-style: dashed;
+		background: transparent;
+	}
+
+	.queue-track.ambient:hover {
+		background: var(--bg-hover);
+		border-style: solid;
 	}
 
 	.queue-track {

--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -51,14 +51,14 @@
 			.filter(({ index }) => index > currentIdx);
 	});
 
-	// the "next from: for you" tail (ambient backfill) is the contiguous suffix
-	// at/after queue.ambientFromIndex, rendered as a separate labeled zone below
-	// the explicit queue. jams have no ambient tail.
+	// the "next from: for you" tail (the auto-generated continuation) is the
+	// contiguous suffix at/after queue.continuationFromIndex, rendered as a
+	// separate labeled zone below the explicit queue. jams have no continuation.
 	const explicitUpcoming = $derived(
-		jam.active ? upcoming : upcoming.filter(({ index }) => index < queue.ambientFromIndex)
+		jam.active ? upcoming : upcoming.filter(({ index }) => index < queue.continuationFromIndex)
 	);
-	const ambientUpcoming = $derived(
-		jam.active ? [] : upcoming.filter(({ index }) => index >= queue.ambientFromIndex)
+	const continuationUpcoming = $derived(
+		jam.active ? [] : upcoming.filter(({ index }) => index >= queue.continuationFromIndex)
 	);
 
 	const outputParticipant = $derived.by<JamParticipant | null>(() => {
@@ -176,7 +176,7 @@
 		class="queue-track"
 		class:drag-over={draggable && dragOverIndex === index && touchDragIndex !== index}
 		class:is-dragging={draggable && (touchDragIndex === index || draggedIndex === index)}
-		class:ambient={!draggable}
+		class:continuation={!draggable}
 		data-index={index}
 		{draggable}
 		role="button"
@@ -389,7 +389,7 @@
 					<span>{explicitUpcoming.length}</span>
 				</div>
 
-				{#if explicitUpcoming.length > 0 || ambientUpcoming.length > 0}
+				{#if explicitUpcoming.length > 0 || continuationUpcoming.length > 0}
 					<div
 						class="queue-tracks"
 						role="list"
@@ -402,9 +402,9 @@
 							{@render queueRow(track, index, true)}
 						{/each}
 
-						{#if ambientUpcoming.length > 0}
-							<div class="ambient-header">next from: for you</div>
-							{#each ambientUpcoming as { track, index } (`${track.file_id}:${index}`)}
+						{#if continuationUpcoming.length > 0}
+							<div class="continuation-header">next from: for you</div>
+							{#each continuationUpcoming as { track, index } (`${track.file_id}:${index}`)}
 								{@render queueRow(track, index, false)}
 							{/each}
 						{/if}
@@ -787,8 +787,8 @@
 		padding-right: 0.35rem;
 	}
 
-	/* "next from: for you" divider above the ambient backfill tail */
-	.ambient-header {
+	/* "next from: for you" divider above the continuation tail */
+	.continuation-header {
 		display: flex;
 		align-items: center;
 		gap: 0.4rem;
@@ -799,7 +799,7 @@
 		color: var(--text-tertiary);
 	}
 
-	.ambient-header::before {
+	.continuation-header::before {
 		content: '';
 		width: 6px;
 		height: 6px;
@@ -809,13 +809,13 @@
 		flex-shrink: 0;
 	}
 
-	/* ambient rows read as tentative/auto-generated vs explicit queue items */
-	.queue-track.ambient {
+	/* continuation rows read as tentative/auto-generated vs explicit queue items */
+	.queue-track.continuation {
 		border-style: dashed;
 		background: transparent;
 	}
 
-	.queue-track.ambient:hover {
+	.queue-track.continuation:hover {
 		background: var(--bg-hover);
 		border-style: solid;
 	}

--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -26,6 +26,7 @@ export interface UiSettings {
 	pds_audio_uploads_enabled?: boolean;
 	font_family?: FontFamily;
 	atproto_client?: string;
+	keep_playing?: boolean;
 }
 
 export interface Preferences {
@@ -131,6 +132,11 @@ class PreferencesManager {
 
 	get atprotoClient(): string | null {
 		return this.data?.ui_settings?.atproto_client ?? null;
+	}
+
+	/** when the queue runs out, keep playing from the For You feed ("keep playing") */
+	get keepPlaying(): boolean {
+		return this.data?.ui_settings?.keep_playing ?? false;
 	}
 
 	applyFont(font: FontFamily): void {

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -4,8 +4,15 @@ import { API_URL } from './config';
 import { APP_BROADCAST_PREFIX } from './branding';
 import { auth } from './auth.svelte';
 import { player } from './player.svelte';
+import { forYouCache } from './for-you.svelte';
 
 const SYNC_DEBOUNCE_MS = 250;
+
+// "keep playing": when the queue drains to this many upcoming tracks, top the
+// tail up from the For You feed. tracks must be appended ahead of the current
+// track ending so Player.svelte's synchronous prefetch path can resolve them.
+export const AMBIENT_LOW_WATER = 2;
+const AMBIENT_BATCH = 20;
 
 /** bridge for routing queue mutations through a jam's WebSocket transport */
 export interface JamBridge {
@@ -28,6 +35,15 @@ class Queue {
 	originalOrder = $state<Track[]>([]);
 	autoAdvance = $state(true);
 	progressMs = $state(0);
+
+	/**
+	 * file_ids of tracks appended by the "keep playing" backfill (the
+	 * "next from: for you" tail). Client-only — not synced to the server,
+	 * which only ever sees flat track_ids; on reload the tail simply
+	 * re-tops-up. Reassigned (never mutated in place) so reads stay reactive.
+	 */
+	ambientFileIds = $state<Set<string>>(new Set());
+	private backfilling = false;
 
 	revision = $state<number | null>(null);
 	etag = $state<string | null>(null);
@@ -489,18 +505,67 @@ class Queue {
 
 	// ── track mutations (routed through bridge when jam active) ──
 
+	/**
+	 * Insertion point for explicit "add to queue": the first ambient ("next
+	 * from") track in the *upcoming* region, so explicit adds slot ahead of the
+	 * recommendation tail without ever disturbing already-played history (the
+	 * current track may itself be ambient once playback advances into the tail).
+	 */
+	private firstAmbientIndex(): number {
+		if (this.ambientFileIds.size === 0) return this.tracks.length;
+		for (let i = this.currentIndex + 1; i < this.tracks.length; i++) {
+			if (this.ambientFileIds.has(this.tracks[i].file_id)) return i;
+		}
+		return this.tracks.length;
+	}
+
 	addTracks(tracks: Track[], playNow = false) {
 		if (tracks.length === 0) return;
 
 		this.lastUpdateWasLocal = true;
-		this.tracks = [...this.tracks, ...tracks];
+
+		// explicit adds jump ahead of any ambient "next from: for you" tail so
+		// the user's own picks always play before recommendations
+		const insertAt = this.firstAmbientIndex();
+		this.tracks = [
+			...this.tracks.slice(0, insertAt),
+			...tracks,
+			...this.tracks.slice(insertAt)
+		];
 		this.originalOrder = [...this.originalOrder, ...tracks];
 
 		if (playNow) {
-			this.currentIndex = this.tracks.length - tracks.length;
+			this.currentIndex = insertAt;
 		}
 
 		this.syncState();
+	}
+
+	/**
+	 * Append recommendation tracks to the end of the queue as the "next from:
+	 * for you" tail (deduped against the existing queue + prior ambient adds).
+	 */
+	appendAmbient(tracks: Track[]) {
+		const inQueue = new Set(this.tracks.map((t) => t.file_id));
+		const fresh = tracks.filter(
+			(t) => !inQueue.has(t.file_id) && !this.ambientFileIds.has(t.file_id)
+		);
+		if (fresh.length === 0) return;
+
+		this.lastUpdateWasLocal = true;
+		this.tracks = [...this.tracks, ...fresh];
+		this.originalOrder = [...this.originalOrder, ...fresh];
+		this.ambientFileIds = new Set([
+			...this.ambientFileIds,
+			...fresh.map((t) => t.file_id)
+		]);
+		this.syncState();
+	}
+
+	private clearAmbient() {
+		if (this.ambientFileIds.size > 0) {
+			this.ambientFileIds = new Set();
+		}
 	}
 
 	setQueue(tracks: Track[], startIndex = 0) {
@@ -510,6 +575,7 @@ class Queue {
 		}
 
 		this.lastUpdateWasLocal = true;
+		this.clearAmbient();
 		this.tracks = [...tracks];
 		this.originalOrder = [...tracks];
 		this.currentIndex = this.clampIndex(startIndex);
@@ -518,7 +584,12 @@ class Queue {
 
 	playNow(track: Track, autoPlay = true) {
 		this.lastUpdateWasLocal = autoPlay;
-		const upNext = this.tracks.slice(this.currentIndex + 1);
+		// keep explicitly-queued up-next, but drop the stale "next from" tail —
+		// the new track is a new context, so let backfill regenerate it
+		const upNext = this.tracks
+			.slice(this.currentIndex + 1)
+			.filter((t) => !this.ambientFileIds.has(t.file_id));
+		this.clearAmbient();
 		this.tracks = [track, ...upNext];
 		this.originalOrder = [...this.tracks];
 		this.currentIndex = 0;
@@ -527,6 +598,7 @@ class Queue {
 
 	clear() {
 		this.lastUpdateWasLocal = true;
+		this.clearAmbient();
 		this.tracks = [];
 		this.originalOrder = [];
 		this.currentIndex = 0;
@@ -651,6 +723,12 @@ class Queue {
 		this.tracks = updated;
 		this.originalOrder = this.originalOrder.filter((track) => track.file_id !== removed.file_id);
 
+		if (this.ambientFileIds.has(removed.file_id)) {
+			const next = new Set(this.ambientFileIds);
+			next.delete(removed.file_id);
+			this.ambientFileIds = next;
+		}
+
 		if (updated.length === 0) {
 			this.currentIndex = 0;
 			this.syncState();
@@ -675,11 +753,49 @@ class Queue {
 		const currentTrack = this.tracks[this.currentIndex];
 		if (!currentTrack) return;
 
+		this.clearAmbient();
 		this.tracks = [currentTrack];
 		this.originalOrder = [currentTrack];
 		this.currentIndex = 0;
 
 		this.syncState();
+	}
+
+	/**
+	 * "keep playing": top up the queue tail from the For You feed. Appends
+	 * real tracks ahead of the current track ending so the Player's
+	 * synchronous prefetch can resolve them. No-op in a jam (jam owns the
+	 * queue) or when the feed has nothing fresh to offer.
+	 */
+	async fillFromForYou(): Promise<void> {
+		if (!browser) return;
+		if (this.jamBridge) return;
+		if (this.backfilling) return;
+
+		this.backfilling = true;
+		try {
+			if (forYouCache.tracks.length === 0) {
+				await forYouCache.fetch();
+			}
+
+			const inQueue = new Set(this.tracks.map((t) => t.file_id));
+			const currentId = this.currentTrack?.file_id;
+			const candidates = () =>
+				forYouCache.tracks.filter(
+					(t) => !inQueue.has(t.file_id) && t.file_id !== currentId
+				);
+
+			let fresh = candidates();
+			if (fresh.length < AMBIENT_BATCH && forYouCache.hasMore) {
+				await forYouCache.fetchMore();
+				fresh = candidates();
+			}
+
+			if (fresh.length === 0) return;
+			this.appendAmbient(fresh.slice(0, AMBIENT_BATCH));
+		} finally {
+			this.backfilling = false;
+		}
 	}
 
 	startPositionSave() {

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -11,8 +11,8 @@ const SYNC_DEBOUNCE_MS = 250;
 // "keep playing": when the queue drains to this many upcoming tracks, top the
 // tail up from the For You feed. tracks must be appended ahead of the current
 // track ending so Player.svelte's synchronous prefetch path can resolve them.
-export const AMBIENT_LOW_WATER = 2;
-const AMBIENT_BATCH = 20;
+export const CONTINUATION_LOW_WATER = 2;
+const CONTINUATION_BATCH = 20;
 
 /** bridge for routing queue mutations through a jam's WebSocket transport */
 export interface JamBridge {
@@ -37,25 +37,26 @@ class Queue {
 	progressMs = $state(0);
 
 	/**
-	 * Index where the "next from: for you" ambient tail begins. The tail is
-	 * always a contiguous suffix, so a single boundary captures it (vs a
-	 * file-id set, which mis-handles duplicates). Equals `tracks.length` when
-	 * there is no tail. Persisted in queue state as `ambient_from_index` so it
-	 * survives reload / cross-tab sync.
+	 * Index where the auto-generated continuation tail begins (rendered as
+	 * "next from: …"). The tail is always a contiguous suffix, so a single
+	 * boundary captures it (vs a file-id set, which mis-handles duplicates).
+	 * Equals `tracks.length` when there is no tail. Persisted in queue state as
+	 * `continuation_from_index` so it survives reload / cross-tab sync.
 	 */
-	ambientFromIndex = $state(0);
+	continuationFromIndex = $state(0);
 
 	/**
-	 * Transient "the user just cleared the queue" intent. Suppresses backfill
-	 * until the next explicit play context so "clear upcoming" actually clears.
-	 * Client-only — a fresh session resumes backfill.
+	 * "the user explicitly cleared the queue" intent. Suppresses backfill until
+	 * the next explicit play context so "clear upcoming" actually clears.
+	 * Persisted (`continuation_suppressed`) so the clear is authoritative across
+	 * tabs and reloads, not just in the tab that clicked it.
 	 */
-	suppressAmbient = false;
+	suppressContinuation = false;
 	private backfilling = false;
 
-	/** whether the track at `index` is part of the ambient ("next from") tail */
-	isAmbientIndex(index: number): boolean {
-		return index >= this.ambientFromIndex && index < this.tracks.length;
+	/** whether the track at `index` is part of the continuation tail */
+	isContinuationIndex(index: number): boolean {
+		return index >= this.continuationFromIndex && index < this.tracks.length;
 	}
 
 	revision = $state<number | null>(null);
@@ -340,13 +341,17 @@ class Queue {
 			this.tracks
 		);
 
-		// restore the ambient "next from" boundary (clamped). older states
+		// restore the continuation boundary (clamped). older states
 		// without the field => no tail (boundary at end).
-		const restored = state.ambient_from_index;
-		this.ambientFromIndex =
+		const restored = state.continuation_from_index;
+		this.continuationFromIndex =
 			typeof restored === 'number'
 				? Math.max(0, Math.min(restored, this.tracks.length))
 				: this.tracks.length;
+
+		// restore the "user cleared it" intent so clear stays authoritative
+		// across tabs/reload (a refilling tab can't undo another's clear)
+		this.suppressContinuation = state.continuation_suppressed ?? false;
 	}
 
 	resolveCurrentIndex(currentTrackId: string | null, index: number, tracks: Track[]): number {
@@ -423,7 +428,8 @@ class Queue {
 				original_order_ids: this.originalOrder.map((t) => t.file_id),
 				auto_advance: this.autoAdvance,
 				progress_ms: this.progressMs,
-				ambient_from_index: this.ambientFromIndex
+				continuation_from_index: this.continuationFromIndex,
+				continuation_suppressed: this.suppressContinuation
 			};
 
 			const headers: HeadersInit = {
@@ -531,12 +537,12 @@ class Queue {
 		if (tracks.length === 0) return;
 
 		this.lastUpdateWasLocal = true;
-		this.suppressAmbient = false;
+		this.suppressContinuation = false;
 
-		// explicit adds slot ahead of the ambient tail (so the user's own picks
+		// explicit adds slot ahead of the continuation tail (so the user's own picks
 		// play before recommendations) but never before the current track —
-		// which may itself be ambient once playback advances into the tail
-		const insertAt = Math.max(this.ambientFromIndex, this.currentIndex + 1);
+		// which may itself be in the continuation once playback advances into it
+		const insertAt = Math.max(this.continuationFromIndex, this.currentIndex + 1);
 		this.tracks = [
 			...this.tracks.slice(0, insertAt),
 			...tracks,
@@ -544,10 +550,10 @@ class Queue {
 		];
 		this.originalOrder = [...this.originalOrder, ...tracks];
 
-		// keep the ambient suffix starting after the inserted explicit tracks
-		this.ambientFromIndex =
-			insertAt <= this.ambientFromIndex
-				? this.ambientFromIndex + tracks.length
+		// keep the continuation suffix starting after the inserted explicit tracks
+		this.continuationFromIndex =
+			insertAt <= this.continuationFromIndex
+				? this.continuationFromIndex + tracks.length
 				: insertAt + tracks.length;
 
 		if (playNow) {
@@ -560,25 +566,25 @@ class Queue {
 	/**
 	 * Append recommendation tracks as the "next from: for you" tail (deduped
 	 * against the existing queue). The tail is a contiguous suffix anchored by
-	 * `ambientFromIndex`.
+	 * `continuationFromIndex`.
 	 */
-	appendAmbient(tracks: Track[]) {
+	appendContinuation(tracks: Track[]) {
 		const inQueue = new Set(this.tracks.map((t) => t.file_id));
 		const fresh = tracks.filter((t) => !inQueue.has(t.file_id));
 		if (fresh.length === 0) return;
 
 		this.lastUpdateWasLocal = true;
 		// if there's no tail yet, it begins where the current queue ends
-		if (this.ambientFromIndex >= this.tracks.length) {
-			this.ambientFromIndex = this.tracks.length;
+		if (this.continuationFromIndex >= this.tracks.length) {
+			this.continuationFromIndex = this.tracks.length;
 		}
 		this.tracks = [...this.tracks, ...fresh];
 		this.originalOrder = [...this.originalOrder, ...fresh];
 		this.syncState();
 	}
 
-	private resetAmbient() {
-		this.ambientFromIndex = this.tracks.length;
+	private resetContinuation() {
+		this.continuationFromIndex = this.tracks.length;
 	}
 
 	setQueue(tracks: Track[], startIndex = 0) {
@@ -588,34 +594,34 @@ class Queue {
 		}
 
 		this.lastUpdateWasLocal = true;
-		this.suppressAmbient = false;
+		this.suppressContinuation = false;
 		this.tracks = [...tracks];
 		this.originalOrder = [...tracks];
 		this.currentIndex = this.clampIndex(startIndex);
-		this.resetAmbient();
+		this.resetContinuation();
 		this.syncState();
 	}
 
 	playNow(track: Track, autoPlay = true) {
 		this.lastUpdateWasLocal = autoPlay;
-		this.suppressAmbient = false;
+		this.suppressContinuation = false;
 		// keep explicitly-queued up-next, but drop the stale "next from" tail —
 		// the new track is a new context, so let backfill regenerate it
-		const upNext = this.tracks.slice(this.currentIndex + 1, this.ambientFromIndex);
+		const upNext = this.tracks.slice(this.currentIndex + 1, this.continuationFromIndex);
 		this.tracks = [track, ...upNext];
 		this.originalOrder = [...this.tracks];
 		this.currentIndex = 0;
-		this.resetAmbient();
+		this.resetContinuation();
 		this.syncState();
 	}
 
 	clear() {
 		this.lastUpdateWasLocal = true;
-		this.suppressAmbient = false;
+		this.suppressContinuation = false;
 		this.tracks = [];
 		this.originalOrder = [];
 		this.currentIndex = 0;
-		this.resetAmbient();
+		this.resetContinuation();
 		this.syncState();
 	}
 
@@ -664,11 +670,11 @@ class Queue {
 		this.lastUpdateWasLocal = true;
 
 		// shuffle only the explicit up-next; leave the current track, history,
-		// and the ambient "next from" tail untouched
+		// and the auto-generated continuation tail untouched
 		const before = this.tracks.slice(0, this.currentIndex + 1);
-		const explicitEnd = Math.max(this.currentIndex + 1, this.ambientFromIndex);
+		const explicitEnd = Math.max(this.currentIndex + 1, this.continuationFromIndex);
 		const after = this.tracks.slice(this.currentIndex + 1, explicitEnd);
-		const ambientTail = this.tracks.slice(explicitEnd);
+		const continuationTail = this.tracks.slice(explicitEnd);
 
 		// if only one track in the explicit up next, nothing to shuffle
 		if (after.length <= 1) {
@@ -692,9 +698,9 @@ class Queue {
 			shuffled.every((track, i) => track.file_id === after[i].file_id)
 		);
 
-		// rebuild: history + current + shuffled explicit up-next + ambient tail.
+		// rebuild: history + current + shuffled explicit up-next + continuation tail.
 		// counts are preserved on both sides of the boundary, so it stays put.
-		this.tracks = [...before, ...shuffled, ...ambientTail];
+		this.tracks = [...before, ...shuffled, ...continuationTail];
 
 		this.schedulePush();
 	}
@@ -704,11 +710,11 @@ class Queue {
 		if (fromIndex < 0 || fromIndex >= this.tracks.length) return;
 		if (toIndex < 0 || toIndex >= this.tracks.length) return;
 
-		// the ambient "next from" tail isn't reorderable; clamp moves to the
+		// the continuation tail isn't reorderable; clamp moves to the
 		// explicit region so the suffix boundary stays stable
-		if (fromIndex >= this.ambientFromIndex) return;
-		if (this.ambientFromIndex < this.tracks.length) {
-			toIndex = Math.min(toIndex, this.ambientFromIndex - 1);
+		if (fromIndex >= this.continuationFromIndex) return;
+		if (this.continuationFromIndex < this.tracks.length) {
+			toIndex = Math.min(toIndex, this.continuationFromIndex - 1);
 		}
 		if (fromIndex === toIndex) return;
 
@@ -745,12 +751,12 @@ class Queue {
 		this.tracks = updated;
 		this.originalOrder = this.originalOrder.filter((track) => track.file_id !== removed.file_id);
 
-		// removing an explicit track shifts the ambient suffix left; removing an
-		// ambient one just shrinks it
-		if (index < this.ambientFromIndex) {
-			this.ambientFromIndex -= 1;
+		// removing an explicit track shifts the continuation suffix left; removing
+		// a continuation one just shrinks it
+		if (index < this.continuationFromIndex) {
+			this.continuationFromIndex -= 1;
 		}
-		this.ambientFromIndex = Math.min(this.ambientFromIndex, updated.length);
+		this.continuationFromIndex = Math.min(this.continuationFromIndex, updated.length);
 
 		if (updated.length === 0) {
 			this.currentIndex = 0;
@@ -777,11 +783,11 @@ class Queue {
 		if (!currentTrack) return;
 
 		// explicit "clear" intent — don't let backfill immediately refill it
-		this.suppressAmbient = true;
+		this.suppressContinuation = true;
 		this.tracks = [currentTrack];
 		this.originalOrder = [currentTrack];
 		this.currentIndex = 0;
-		this.resetAmbient();
+		this.resetContinuation();
 
 		this.syncState();
 	}
@@ -792,10 +798,10 @@ class Queue {
 	 * synchronous prefetch can resolve them. No-op in a jam (jam owns the
 	 * queue) or when the feed has nothing fresh to offer.
 	 */
-	async fillFromForYou(): Promise<void> {
+	async fillContinuation(): Promise<void> {
 		if (!browser) return;
 		if (this.jamBridge) return;
-		if (this.suppressAmbient) return;
+		if (this.suppressContinuation) return;
 		if (this.backfilling) return;
 
 		this.backfilling = true;
@@ -812,13 +818,13 @@ class Queue {
 				);
 
 			let fresh = candidates();
-			if (fresh.length < AMBIENT_BATCH && forYouCache.hasMore) {
+			if (fresh.length < CONTINUATION_BATCH && forYouCache.hasMore) {
 				await forYouCache.fetchMore();
 				fresh = candidates();
 			}
 
 			if (fresh.length === 0) return;
-			this.appendAmbient(fresh.slice(0, AMBIENT_BATCH));
+			this.appendContinuation(fresh.slice(0, CONTINUATION_BATCH));
 		} finally {
 			this.backfilling = false;
 		}

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -37,13 +37,26 @@ class Queue {
 	progressMs = $state(0);
 
 	/**
-	 * file_ids of tracks appended by the "keep playing" backfill (the
-	 * "next from: for you" tail). Client-only — not synced to the server,
-	 * which only ever sees flat track_ids; on reload the tail simply
-	 * re-tops-up. Reassigned (never mutated in place) so reads stay reactive.
+	 * Index where the "next from: for you" ambient tail begins. The tail is
+	 * always a contiguous suffix, so a single boundary captures it (vs a
+	 * file-id set, which mis-handles duplicates). Equals `tracks.length` when
+	 * there is no tail. Persisted in queue state as `ambient_from_index` so it
+	 * survives reload / cross-tab sync.
 	 */
-	ambientFileIds = $state<Set<string>>(new Set());
+	ambientFromIndex = $state(0);
+
+	/**
+	 * Transient "the user just cleared the queue" intent. Suppresses backfill
+	 * until the next explicit play context so "clear upcoming" actually clears.
+	 * Client-only — a fresh session resumes backfill.
+	 */
+	suppressAmbient = false;
 	private backfilling = false;
+
+	/** whether the track at `index` is part of the ambient ("next from") tail */
+	isAmbientIndex(index: number): boolean {
+		return index >= this.ambientFromIndex && index < this.tracks.length;
+	}
 
 	revision = $state<number | null>(null);
 	etag = $state<string | null>(null);
@@ -326,6 +339,14 @@ class Queue {
 			state.current_index,
 			this.tracks
 		);
+
+		// restore the ambient "next from" boundary (clamped). older states
+		// without the field => no tail (boundary at end).
+		const restored = state.ambient_from_index;
+		this.ambientFromIndex =
+			typeof restored === 'number'
+				? Math.max(0, Math.min(restored, this.tracks.length))
+				: this.tracks.length;
 	}
 
 	resolveCurrentIndex(currentTrackId: string | null, index: number, tracks: Track[]): number {
@@ -401,7 +422,8 @@ class Queue {
 				shuffle: this.shuffle,
 				original_order_ids: this.originalOrder.map((t) => t.file_id),
 				auto_advance: this.autoAdvance,
-				progress_ms: this.progressMs
+				progress_ms: this.progressMs,
+				ambient_from_index: this.ambientFromIndex
 			};
 
 			const headers: HeadersInit = {
@@ -505,34 +527,28 @@ class Queue {
 
 	// ── track mutations (routed through bridge when jam active) ──
 
-	/**
-	 * Insertion point for explicit "add to queue": the first ambient ("next
-	 * from") track in the *upcoming* region, so explicit adds slot ahead of the
-	 * recommendation tail without ever disturbing already-played history (the
-	 * current track may itself be ambient once playback advances into the tail).
-	 */
-	private firstAmbientIndex(): number {
-		if (this.ambientFileIds.size === 0) return this.tracks.length;
-		for (let i = this.currentIndex + 1; i < this.tracks.length; i++) {
-			if (this.ambientFileIds.has(this.tracks[i].file_id)) return i;
-		}
-		return this.tracks.length;
-	}
-
 	addTracks(tracks: Track[], playNow = false) {
 		if (tracks.length === 0) return;
 
 		this.lastUpdateWasLocal = true;
+		this.suppressAmbient = false;
 
-		// explicit adds jump ahead of any ambient "next from: for you" tail so
-		// the user's own picks always play before recommendations
-		const insertAt = this.firstAmbientIndex();
+		// explicit adds slot ahead of the ambient tail (so the user's own picks
+		// play before recommendations) but never before the current track —
+		// which may itself be ambient once playback advances into the tail
+		const insertAt = Math.max(this.ambientFromIndex, this.currentIndex + 1);
 		this.tracks = [
 			...this.tracks.slice(0, insertAt),
 			...tracks,
 			...this.tracks.slice(insertAt)
 		];
 		this.originalOrder = [...this.originalOrder, ...tracks];
+
+		// keep the ambient suffix starting after the inserted explicit tracks
+		this.ambientFromIndex =
+			insertAt <= this.ambientFromIndex
+				? this.ambientFromIndex + tracks.length
+				: insertAt + tracks.length;
 
 		if (playNow) {
 			this.currentIndex = insertAt;
@@ -542,30 +558,27 @@ class Queue {
 	}
 
 	/**
-	 * Append recommendation tracks to the end of the queue as the "next from:
-	 * for you" tail (deduped against the existing queue + prior ambient adds).
+	 * Append recommendation tracks as the "next from: for you" tail (deduped
+	 * against the existing queue). The tail is a contiguous suffix anchored by
+	 * `ambientFromIndex`.
 	 */
 	appendAmbient(tracks: Track[]) {
 		const inQueue = new Set(this.tracks.map((t) => t.file_id));
-		const fresh = tracks.filter(
-			(t) => !inQueue.has(t.file_id) && !this.ambientFileIds.has(t.file_id)
-		);
+		const fresh = tracks.filter((t) => !inQueue.has(t.file_id));
 		if (fresh.length === 0) return;
 
 		this.lastUpdateWasLocal = true;
+		// if there's no tail yet, it begins where the current queue ends
+		if (this.ambientFromIndex >= this.tracks.length) {
+			this.ambientFromIndex = this.tracks.length;
+		}
 		this.tracks = [...this.tracks, ...fresh];
 		this.originalOrder = [...this.originalOrder, ...fresh];
-		this.ambientFileIds = new Set([
-			...this.ambientFileIds,
-			...fresh.map((t) => t.file_id)
-		]);
 		this.syncState();
 	}
 
-	private clearAmbient() {
-		if (this.ambientFileIds.size > 0) {
-			this.ambientFileIds = new Set();
-		}
+	private resetAmbient() {
+		this.ambientFromIndex = this.tracks.length;
 	}
 
 	setQueue(tracks: Track[], startIndex = 0) {
@@ -575,33 +588,34 @@ class Queue {
 		}
 
 		this.lastUpdateWasLocal = true;
-		this.clearAmbient();
+		this.suppressAmbient = false;
 		this.tracks = [...tracks];
 		this.originalOrder = [...tracks];
 		this.currentIndex = this.clampIndex(startIndex);
+		this.resetAmbient();
 		this.syncState();
 	}
 
 	playNow(track: Track, autoPlay = true) {
 		this.lastUpdateWasLocal = autoPlay;
+		this.suppressAmbient = false;
 		// keep explicitly-queued up-next, but drop the stale "next from" tail —
 		// the new track is a new context, so let backfill regenerate it
-		const upNext = this.tracks
-			.slice(this.currentIndex + 1)
-			.filter((t) => !this.ambientFileIds.has(t.file_id));
-		this.clearAmbient();
+		const upNext = this.tracks.slice(this.currentIndex + 1, this.ambientFromIndex);
 		this.tracks = [track, ...upNext];
 		this.originalOrder = [...this.tracks];
 		this.currentIndex = 0;
+		this.resetAmbient();
 		this.syncState();
 	}
 
 	clear() {
 		this.lastUpdateWasLocal = true;
-		this.clearAmbient();
+		this.suppressAmbient = false;
 		this.tracks = [];
 		this.originalOrder = [];
 		this.currentIndex = 0;
+		this.resetAmbient();
 		this.syncState();
 	}
 
@@ -649,12 +663,14 @@ class Queue {
 
 		this.lastUpdateWasLocal = true;
 
-		// keep current track, shuffle everything after it
-		const current = this.tracks[this.currentIndex];
-		const before = this.tracks.slice(0, this.currentIndex);
-		const after = this.tracks.slice(this.currentIndex + 1);
+		// shuffle only the explicit up-next; leave the current track, history,
+		// and the ambient "next from" tail untouched
+		const before = this.tracks.slice(0, this.currentIndex + 1);
+		const explicitEnd = Math.max(this.currentIndex + 1, this.ambientFromIndex);
+		const after = this.tracks.slice(this.currentIndex + 1, explicitEnd);
+		const ambientTail = this.tracks.slice(explicitEnd);
 
-		// if only one track in up next, nothing to shuffle
+		// if only one track in the explicit up next, nothing to shuffle
 		if (after.length <= 1) {
 			return;
 		}
@@ -676,11 +692,9 @@ class Queue {
 			shuffled.every((track, i) => track.file_id === after[i].file_id)
 		);
 
-		// rebuild queue: everything before current + current + shuffled upcoming
-		this.tracks = [...before, current, ...shuffled];
-
-		// current index stays the same (it's in the same position)
-		// no need to update currentIndex
+		// rebuild: history + current + shuffled explicit up-next + ambient tail.
+		// counts are preserved on both sides of the boundary, so it stays put.
+		this.tracks = [...before, ...shuffled, ...ambientTail];
 
 		this.schedulePush();
 	}
@@ -689,6 +703,14 @@ class Queue {
 		if (fromIndex === toIndex) return;
 		if (fromIndex < 0 || fromIndex >= this.tracks.length) return;
 		if (toIndex < 0 || toIndex >= this.tracks.length) return;
+
+		// the ambient "next from" tail isn't reorderable; clamp moves to the
+		// explicit region so the suffix boundary stays stable
+		if (fromIndex >= this.ambientFromIndex) return;
+		if (this.ambientFromIndex < this.tracks.length) {
+			toIndex = Math.min(toIndex, this.ambientFromIndex - 1);
+		}
+		if (fromIndex === toIndex) return;
 
 		this.lastUpdateWasLocal = true;
 		const updated = [...this.tracks];
@@ -723,11 +745,12 @@ class Queue {
 		this.tracks = updated;
 		this.originalOrder = this.originalOrder.filter((track) => track.file_id !== removed.file_id);
 
-		if (this.ambientFileIds.has(removed.file_id)) {
-			const next = new Set(this.ambientFileIds);
-			next.delete(removed.file_id);
-			this.ambientFileIds = next;
+		// removing an explicit track shifts the ambient suffix left; removing an
+		// ambient one just shrinks it
+		if (index < this.ambientFromIndex) {
+			this.ambientFromIndex -= 1;
 		}
+		this.ambientFromIndex = Math.min(this.ambientFromIndex, updated.length);
 
 		if (updated.length === 0) {
 			this.currentIndex = 0;
@@ -753,10 +776,12 @@ class Queue {
 		const currentTrack = this.tracks[this.currentIndex];
 		if (!currentTrack) return;
 
-		this.clearAmbient();
+		// explicit "clear" intent — don't let backfill immediately refill it
+		this.suppressAmbient = true;
 		this.tracks = [currentTrack];
 		this.originalOrder = [currentTrack];
 		this.currentIndex = 0;
+		this.resetAmbient();
 
 		this.syncState();
 	}
@@ -770,6 +795,7 @@ class Queue {
 	async fillFromForYou(): Promise<void> {
 		if (!browser) return;
 		if (this.jamBridge) return;
+		if (this.suppressAmbient) return;
 		if (this.backfilling) return;
 
 		this.backfilling = true;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -100,6 +100,8 @@ export interface QueueState {
 	original_order_ids: string[];
 	auto_advance?: boolean;
 	progress_ms?: number;
+	/** index where the "next from: for you" ambient tail begins (== length when none) */
+	ambient_from_index?: number;
 }
 
 export interface QueueResponse {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -100,8 +100,10 @@ export interface QueueState {
 	original_order_ids: string[];
 	auto_advance?: boolean;
 	progress_ms?: number;
-	/** index where the "next from: for you" ambient tail begins (== length when none) */
-	ambient_from_index?: number;
+	/** index where the auto-generated continuation tail begins (== length when none) */
+	continuation_from_index?: number;
+	/** user explicitly cleared the queue — suppress backfill until next play context */
+	continuation_suppressed?: boolean;
 }
 
 export interface QueueResponse {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -21,7 +21,7 @@
 	import { ambient } from '$lib/ambient.svelte';
 	import { moderation } from '$lib/moderation.svelte';
 	import { player } from '$lib/player.svelte';
-	import { queue } from '$lib/queue.svelte';
+	import { queue, AMBIENT_LOW_WATER } from '$lib/queue.svelte';
 	import { jam } from '$lib/jam.svelte';
 	import { search } from '$lib/search.svelte';
 	import { browser } from '$app/environment';
@@ -134,6 +134,20 @@
 		player.currentTrack;
 		player.paused;
 		updateTitle();
+	});
+
+	// "keep playing": when the queue runs low, backfill the tail from For You.
+	// extends auto-advance, so it only runs when auto-advance is on; jams own
+	// their own queue. tracks are appended ahead of the current track ending
+	// so Player.svelte's synchronous prefetch path can resolve them.
+	$effect(() => {
+		if (!browser) return;
+		const enabled = preferences.keepPlaying && preferences.autoAdvance;
+		const playing = queue.currentTrack !== null;
+		const low = queue.upNext.length <= AMBIENT_LOW_WATER;
+		if (enabled && playing && low && !jam.active) {
+			untrack(() => void queue.fillFromForYou());
+		}
 	});
 
 	// set CSS custom property for queue width adjustment

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -21,7 +21,7 @@
 	import { ambient } from '$lib/ambient.svelte';
 	import { moderation } from '$lib/moderation.svelte';
 	import { player } from '$lib/player.svelte';
-	import { queue, AMBIENT_LOW_WATER } from '$lib/queue.svelte';
+	import { queue, CONTINUATION_LOW_WATER } from '$lib/queue.svelte';
 	import { jam } from '$lib/jam.svelte';
 	import { search } from '$lib/search.svelte';
 	import { browser } from '$app/environment';
@@ -136,17 +136,17 @@
 		updateTitle();
 	});
 
-	// "keep playing": when the queue runs low, backfill the tail from For You.
-	// extends auto-advance, so it only runs when auto-advance is on; jams own
-	// their own queue. tracks are appended ahead of the current track ending
-	// so Player.svelte's synchronous prefetch path can resolve them.
+	// "keep playing": when the queue runs low, extend it with a continuation
+	// from For You. extends auto-advance, so it only runs when auto-advance is
+	// on; jams own their own queue. tracks are appended ahead of the current
+	// track ending so Player.svelte's synchronous prefetch path can resolve them.
 	$effect(() => {
 		if (!browser) return;
 		const enabled = preferences.keepPlaying && preferences.autoAdvance;
 		const playing = queue.currentTrack !== null;
-		const low = queue.upNext.length <= AMBIENT_LOW_WATER;
+		const low = queue.upNext.length <= CONTINUATION_LOW_WATER;
 		if (enabled && playing && low && !jam.active) {
-			untrack(() => void queue.fillFromForYou());
+			untrack(() => void queue.fillContinuation());
 		}
 	});
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -25,6 +25,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 	let currentFont = $derived(preferences.fontFamily);
 	let currentClient = $derived(preferences.atprotoClient ?? DEFAULT_AT_CLIENT);
 	let autoAdvance = $derived(preferences.autoAdvance);
+	let keepPlaying = $derived(preferences.keepPlaying);
 	let backgroundImageUrl = $derived(preferences.uiSettings.background_image_url ?? '');
 	let backgroundTile = $derived(preferences.uiSettings.background_tile ?? false);
 	let usePlayingArtwork = $derived(preferences.uiSettings.use_playing_artwork_as_background ?? false);
@@ -235,6 +236,11 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		queue.setAutoAdvance(value);
 		localStorage.setItem('autoAdvance', value ? '1' : '0');
 		await preferences.update({ auto_advance: value });
+	}
+
+	async function handleKeepPlayingToggle(event: Event) {
+		const value = (event.target as HTMLInputElement).checked;
+		await preferences.updateUiSettings({ keep_playing: value });
 	}
 
 	function handleAutoDownloadToggle(enabled: boolean) {
@@ -625,6 +631,20 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 							type="checkbox"
 							checked={autoAdvance}
 							onchange={handleAutoAdvanceToggle}
+						/>
+						<span class="toggle-slider"></span>
+					</label>
+				</div>
+				<div class="setting-row">
+					<div class="setting-info">
+						<h3>keep playing</h3>
+						<p>when your queue runs out, keep playing from your for you feed</p>
+					</div>
+					<label class="toggle-switch">
+						<input
+							type="checkbox"
+							checked={keepPlaying}
+							onchange={handleKeepPlayingToggle}
 						/>
 						<span class="toggle-slider"></span>
 					</label>

--- a/loq.toml
+++ b/loq.toml
@@ -104,7 +104,7 @@ max_lines = 1186
 
 [[rules]]
 path = "frontend/src/lib/components/Queue.svelte"
-max_lines = 980
+max_lines = 1028
 
 [[rules]]
 path = "frontend/src/lib/components/SearchModal.svelte"
@@ -128,11 +128,11 @@ max_lines = 906
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"
-max_lines = 738
+max_lines = 831
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"
-max_lines = 802
+max_lines = 816
 
 [[rules]]
 path = "frontend/src/routes/costs/+page.svelte"
@@ -160,7 +160,7 @@ max_lines = 3954
 
 [[rules]]
 path = "frontend/src/routes/settings/+page.svelte"
-max_lines = 1637
+max_lines = 1657
 
 [[rules]]
 path = "frontend/src/routes/track/\\[id\\]/+page.svelte"

--- a/loq.toml
+++ b/loq.toml
@@ -128,7 +128,7 @@ max_lines = 906
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"
-max_lines = 857
+max_lines = 863
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"

--- a/loq.toml
+++ b/loq.toml
@@ -104,7 +104,7 @@ max_lines = 1186
 
 [[rules]]
 path = "frontend/src/lib/components/Queue.svelte"
-max_lines = 1028
+max_lines = 1029
 
 [[rules]]
 path = "frontend/src/lib/components/SearchModal.svelte"
@@ -128,7 +128,7 @@ max_lines = 906
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"
-max_lines = 831
+max_lines = 857
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"


### PR DESCRIPTION
When your queue runs dry, plyr just stops. This adds an opt-in **"keep playing"** setting that keeps playback going by pulling from your **For You** feed, surfaced in the queue panel as a distinct, labeled **"next from: for you"** zone (the Spotify "Next from: …" pattern). It always sits *after* anything you explicitly queued. **Default off.**

This is the *ambient continuation* slice of a long-standing cluster of continuous-playback requests (#1446, #1353, #1445). It does **not** close them — see "Scope" below.

## The load-bearing design decision

The natural instinct is to compute "what plays next" lazily when a track ends. **That doesn't work here.** The locked-screen / backgrounded-tab autoplay grace (esp. Android) requires the next track's audio to be swapped into the `<audio>` element **synchronously in the `ended` handler** — `Player.svelte` prefetches it into `preloadedNext` *while the current track is still playing* and there can be no `await` between the `ended` event and `audio.play()` (see `advanceToPreloadedSynchronously`).

So the continuation tracks must be **real entries appended to `queue.tracks` ahead of time**, where the existing prefetch effect can see and resolve them. The payoff: **zero changes to that delicate audio path** — `autoAdvanceTrack` (the seam whose docstring already anticipated "a feed continuation, or a recommendation") just returns a real track, and everything downstream works unchanged.

## How it works

- **Backfill trigger** (`+layout.svelte`, one global `$effect`): when `keepPlaying && autoAdvance && playing && !jam.active && upNext.length <= 2`, call `queue.fillFromForYou()`. Gated on `autoAdvance` because keep-playing is an *extension* of auto-play-next; `!jam.active` because jams own their own queue.
- **`fillFromForYou()`** (`queue.svelte.ts`): reuses the existing `forYouCache` (`fetch()` / cursor-based `fetchMore()`), dedupes against the current queue + current track, and appends up to 20 via `appendAmbient()`. Concurrency-guarded; no-op when the feed has nothing fresh (e.g. cold-start user → queue just ends, as today).
- **Two-zone queue model**: the auto-generated continuation is a contiguous suffix marked by a single boundary index (`continuationFromIndex`), persisted in the queue state dict (`continuation_from_index`) so it survives reload / cross-tab sync. `Queue.svelte` renders your explicit items under **up next**, then a **next from: for you** divider, then the continuation tail.
- **Explicit-first ordering**: `addTracks` (explicit "add to queue") now inserts *before* the first upcoming ambient track, so your own picks always play before recommendations. `firstAmbientIndex()` scans only the *upcoming* region so it never disturbs already-played history once playback advances into the tail.
- **Context resets**: `setQueue` / `playNow` / `clear` / `clearUpNext` reset the ambient set; `playNow` also drops the stale tail from the retained up-next so a freshly-tapped track regenerates its own continuation.

## Scope

<details>
<summary>What's deferred (and why this doesn't close the linked issues)</summary>

- **Piece B — collection click-to-continue** (#1446 playlist, #1353 artist catalog, #1344 phase 2): tapping track N of an *ordered* collection queues N+1 onward. Intentionally left out — the "is this an ordered collection" assumption needs its own design. Revisit once this lands.
- **Loop / repeat-one** (#1445): separate small follow-up.
- **Default-on**: kept off for a low-risk launch; can flip after dogfooding.
- **Known follow-up**: played tracks accumulate before `currentIndex` over marathon sessions (unbounded array growth). `track_ids` are tiny so it's fine for v1; trim-to-~50 in `appendAmbient` if it ever bites.

</details>

## Backend

**None.** The toggle rides in the schema-less `ui_settings` JSONB (the PUT already merges it pass-through), and `/for-you/` already exists and excludes the user's own tracks. No migration.

## Verification

- ✅ `svelte-check` (0/0), `eslint`, `uvx loq`, and a full production build all clean. No import cycle (`for-you.svelte` imports only config + types).
- Manual (no frontend test harness): toggle persists across reload; playing a single track surfaces the "next from: for you" tail within a beat and auto-advances seamlessly into it (incl. backgrounded tab — the synchronous fast path is unchanged); explicit "add to queue" lands above the tail and plays first; tapping a new track resets+regenerates the tail; toggling off mid-session stops further backfill; jams show no ambient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Jams

Keep-playing is **disabled in jams** by design (decided in review): no "next from" zone, and a jam's shared queue stops when it ends — same as today. The backfill effect guards `!jam.active` and the jam owns the queue via its WebSocket bridge. Host-driven jam continuation (the host's For You backfilling the shared room, synced to all participants) is a deliberately separate, larger design — not in this PR.

## Review follow-ups

- **Naming** (per maintainer): renamed the mechanism from the product-flavored "ambient" (which also collided with the existing live-weather *ambient* theme) to source-/product-agnostic **continuation**. The product layer keeps its own names — the `keepPlaying` pref and the "next from: for you" label — and the For You source coupling is isolated inside `fillContinuation()`.
- **Boundary model** (Codex P3): membership is position-based (a boundary index), not a file-id set, so duplicate tracks classify by position and removing one copy can't clear another's marker.
- **Authoritative clear** (Codex P2): the "user cleared the queue" intent is persisted in queue state (`continuation_suppressed`) and reset on the next explicit play/add, so clearing holds across tabs and reloads rather than being immediately refilled by another tab.
