### PR TITLE
feat(shortcuts): open settings with Cmd/Ctrl+,

### DIFF
--- a/docs/internal/frontend/keyboard-shortcuts.md
+++ b/docs/internal/frontend/keyboard-shortcuts.md
@@ -31,6 +31,18 @@ the search modal supports fuzzy matching across tracks, artists, albums, and tag
 
 ---
 
+### Cmd/Ctrl+, - open settings
+
+**location**: `frontend/src/routes/+layout.svelte`
+
+navigates to the settings page. mirrors the platform-independent "preferences" convention — **Cmd+,** on macOS, **Ctrl+,** on windows/linux (also VS Code's settings shortcut).
+
+**behavior**:
+- works from anywhere, including input fields (uses modifier key)
+- desktop-oriented — mobile has no modifier keys, so use the settings button in the menu instead
+
+---
+
 ### Q - toggle queue
 
 **location**: `frontend/src/routes/+layout.svelte`

--- a/docs/public/listeners.md
+++ b/docs/public/listeners.md
@@ -76,6 +76,7 @@ your records — likes, playlists, comments — are stored on your [PDS](/glossa
 | `l` | next track |
 | `q` | toggle queue |
 | `cmd+k` | search |
+| `cmd+,` | open settings |
 | `m` | mute / unmute |
 
 ## leaving

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -15,7 +15,7 @@
 	import LikersSheet from '$lib/components/LikersSheet.svelte';
 	import { onMount, onDestroy, untrack } from 'svelte';
 	import { page } from '$app/stores';
-	import { afterNavigate } from '$app/navigation';
+	import { afterNavigate, goto } from '$app/navigation';
 	import { auth } from '$lib/auth.svelte';
 	import { preferences } from '$lib/preferences.svelte';
 	import { ambient } from '$lib/ambient.svelte';
@@ -245,6 +245,14 @@
 		if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
 			event.preventDefault();
 			search.toggle();
+			return;
+		}
+
+		// Cmd/Ctrl+, : open settings (the idiomatic "preferences" shortcut —
+		// Cmd+, on macOS, Ctrl+, elsewhere). works from anywhere, like search.
+		if ((event.metaKey || event.ctrlKey) && event.key === ',') {
+			event.preventDefault();
+			goto('/settings');
 			return;
 		}
 

--- a/loq.toml
+++ b/loq.toml
@@ -132,7 +132,7 @@ max_lines = 863
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"
-max_lines = 816
+max_lines = 824
 
 [[rules]]
 path = "frontend/src/routes/costs/+page.svelte"


### PR DESCRIPTION
Adds a keyboard shortcut to open settings: **Cmd+,** on macOS, **Ctrl+,** on windows/linux — the idiomatic, platform-independent "preferences" binding (it's the macOS system convention and also VS Code's settings shortcut).

## Design
- Handled in the root layout alongside `Cmd/Ctrl+K`, **before** the modifier-ignore guard, so (like search) it works from anywhere including input fields.
- Uses `event.key === ','` + `metaKey || ctrlKey` — no platform branching needed.
- `goto('/settings')`.
- **Mobile**: no modifier keys exist, so this is a desktop affordance by nature; mobile users open settings via the menu button (unchanged).

## Docs
- `docs/internal/frontend/keyboard-shortcuts.md` — new section.
- `docs/public/listeners.md` — added `cmd+,` to the shortcut table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)