### PR TITLE
fix(queue): "keep playing" toggle tears down the continuation tail

### DIFF
--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -587,6 +587,28 @@ class Queue {
 		this.continuationFromIndex = this.tracks.length;
 	}
 
+	/**
+	 * Drop the auto-generated "next from" tail, keeping the explicit queue (and
+	 * the currently-playing track if playback already advanced into the tail).
+	 * Called when "keep playing" is turned off — the tail is materialized into
+	 * `tracks` and persisted server-side, so declining to refill it isn't enough;
+	 * the existing tail has to be removed or it outlives the setting.
+	 */
+	clearContinuation() {
+		if (this.jamBridge) return; // jam owns the queue; never a continuation tail
+		if (this.continuationFromIndex >= this.tracks.length) return; // no tail
+
+		const keepUpTo = Math.max(this.continuationFromIndex, this.currentIndex + 1);
+		if (keepUpTo < this.tracks.length) {
+			const removedIds = new Set(this.tracks.slice(keepUpTo).map((t) => t.file_id));
+			this.tracks = this.tracks.slice(0, keepUpTo);
+			this.originalOrder = this.originalOrder.filter((t) => !removedIds.has(t.file_id));
+		}
+		this.continuationFromIndex = this.tracks.length;
+		this.lastUpdateWasLocal = true;
+		this.syncState();
+	}
+
 	setQueue(tracks: Track[], startIndex = 0) {
 		if (tracks.length === 0) {
 			this.clear();

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -143,9 +143,15 @@
 	$effect(() => {
 		if (!browser) return;
 		const enabled = preferences.keepPlaying && preferences.autoAdvance;
+		if (!enabled) {
+			// setting off: tear down any materialized "next from" tail so it doesn't
+			// outlive the toggle (the tail is persisted in server queue state)
+			untrack(() => queue.clearContinuation());
+			return;
+		}
 		const playing = queue.currentTrack !== null;
 		const low = queue.upNext.length <= CONTINUATION_LOW_WATER;
-		if (enabled && playing && low && !jam.active) {
+		if (playing && low && !jam.active) {
 			untrack(() => void queue.fillContinuation());
 		}
 	});

--- a/loq.toml
+++ b/loq.toml
@@ -128,11 +128,11 @@ max_lines = 906
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"
-max_lines = 875
+max_lines = 897
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"
-max_lines = 824
+max_lines = 830
 
 [[rules]]
 path = "frontend/src/routes/costs/+page.svelte"


### PR DESCRIPTION
The **"keep playing"** toggle appeared to do nothing — the "next from: for you" zone showed whether the setting was on *or* off. This makes the toggle actually authoritative: turning it off removes the materialized tail.

## why it was broken

When "keep playing" is on, `queue.fillContinuation()` appends **real** For You tracks to `queue.tracks` (they have to be real, ahead-of-time entries so `Player.svelte`'s synchronous prefetch path can resolve the next source on `ended` — no `await` allowed there) and persists the `continuation_from_index` boundary into **server queue state** (so the tail keeps its identity across reload and cross-tab sync).

The layout backfill effect only *gated future fills* on the setting. It never tore down an **already-materialized** tail. So once generated, the tail + boundary survived: toggling off stopped new fills but left the existing 20-track tail in the queue, and it re-hydrated from the server on every load.

Confirmed against the live prod queue for the reporting account: `n_tracks = 22`, `current_index = 0`, `continuation_from_index = 2` → 2 explicit tracks + a full 20-track (`CONTINUATION_BATCH`) For You tail rendering under "next from: for you".

## what changed

- **`Queue.clearContinuation()`** (new) — drops the contiguous suffix at/after `continuationFromIndex`, keeping the explicit queue. If playback has already advanced *into* the tail, it keeps everything up to and including the current track (`keepUpTo = max(continuationFromIndex, currentIndex + 1)`) so the current track isn't yanked out from under the player. Resets the boundary to `tracks.length`, prunes the removed ids from `originalOrder`, and syncs.
- **layout backfill `$effect`** — when `enabled` (`keepPlaying && autoAdvance`) is false, calls `clearContinuation()` and returns, instead of only skipping the fill.

## behavior after this change

- toggle **off** → tail is pruned immediately; queue ends at your explicit picks; playback stops when they run out.
- toggle **on** while playing + low → fills as before.
- existing stuck queues (like the one above) **self-heal** on next load *if the setting is off* — the effect runs on mount and prunes. If the setting is on, the tail correctly stays (the feature is working).

## intentional non-behaviors / edge cases (for review)

- **No-op guards**: `clearContinuation()` returns early when there's no tail (`continuationFromIndex >= tracks.length`) so the mount-time effect doesn't push a redundant sync, and when a jam is active (jams own the queue and never have a continuation tail).
- **`originalOrder` pruning by `file_id`** is safe: continuation tracks are deduped against the whole queue in `appendContinuation`, so a tail track's `file_id` is unique in the queue — filtering it out can't remove an explicit duplicate.
- **Disabling `auto-advance`** also prunes the tail, by design: keep-playing is an extension of auto-play-next, so it can't function without it.
- **Mid-tail playback**: turning off while a continuation track is the *current* track keeps that track playing, then stops (no further tail). Deliberate.
- **Reactivity**: the `clearContinuation()` call is wrapped in `untrack`, and the disabled branch reads only `keepPlaying`/`autoAdvance` — so the effect re-runs on toggle changes, not on the queue mutation it triggers (no loop).
- `suppressContinuation` (the "clear up next" intent) is left untouched — orthogonal to this toggle.

## verification

- `just frontend check` (svelte-check): 0 errors / 0 warnings
- `bun run lint` (eslint): clean
- `uvx loq`: clean (both files relaxed via `just loq-relax`, no golfing)
- No frontend test harness (no vitest) — verified by code-path analysis + live prod-state confirmation above. No backend changes, no migration (rides schema-less `ui_settings` + free-form queue `state`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)