### PR TITLE
fix(now-playing): make the rate limit an abuse backstop, not a usage throttle

### DIFF
--- a/backend/src/backend/api/now_playing.py
+++ b/backend/src/backend/api/now_playing.py
@@ -22,6 +22,10 @@ from backend.utilities.rate_limit import limiter
 
 router = APIRouter(prefix="/now-playing", tags=["now-playing"])
 
+# the client heartbeat is one report per 10s (~6/min); this ceiling is a
+# script-abuse backstop set far above any real listener, not a usage throttle.
+NOW_PLAYING_LIMIT = "120/minute"
+
 
 class NowPlayingUpdate(BaseModel):
     """request to update now playing state."""
@@ -65,7 +69,7 @@ class NowPlayingResponse(BaseModel):
 
 
 @router.post("/")
-@limiter.limit("30/minute")
+@limiter.limit(NOW_PLAYING_LIMIT)
 async def update_now_playing(
     request: Request,
     update: NowPlayingUpdate,
@@ -96,7 +100,7 @@ async def update_now_playing(
 
 
 @router.delete("/")
-@limiter.limit("30/minute")
+@limiter.limit(NOW_PLAYING_LIMIT)
 async def clear_now_playing(
     request: Request,
     session: Session = Depends(require_auth),

--- a/backend/tests/api/test_now_playing.py
+++ b/backend/tests/api/test_now_playing.py
@@ -8,9 +8,11 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, now_playing_service
+from backend.api.now_playing import NOW_PLAYING_LIMIT
 from backend.config import settings
 from backend.main import app
 from backend.models import Artist
+from backend.utilities.rate_limit import limiter
 
 
 # create a mock session object
@@ -39,12 +41,15 @@ def test_app(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
 
     # clear the now_playing_service cache before each test
     now_playing_service._cache.clear()
+    # clear any rate-limit budget consumed by other tests sharing the client IP
+    limiter.reset()
 
     yield app
 
     # cleanup
     app.dependency_overrides.clear()
     now_playing_service._cache.clear()
+    limiter.reset()
 
 
 async def test_update_now_playing(test_app: FastAPI, db_session: AsyncSession):
@@ -340,3 +345,41 @@ async def test_update_now_playing_without_album(
     assert state is not None
     assert state.album_name is None
     assert state.image_url is None
+
+
+async def test_now_playing_burst_past_old_throttle_not_rate_limited(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    """a burst larger than the retired 30/min throttle must not be 429'd.
+
+    the client heartbeat is ~6/min; the server ceiling is a script-abuse
+    backstop, not a usage throttle. regression for listeners getting 429'd
+    during normal playback under the old 30/minute limit.
+    """
+    ceiling = int(NOW_PLAYING_LIMIT.split("/")[0])
+    burst = 31  # one past the retired throttle, comfortably under the backstop
+    assert burst > 30
+    assert burst <= ceiling
+
+    payload = {
+        "track_id": 123,
+        "file_id": "test-file-abc",
+        "track_name": "Test Track",
+        "artist_name": "Test Artist",
+        "duration_ms": 180000,
+        "progress_ms": 30000,
+        "is_playing": True,
+    }
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        statuses = [
+            (await client.post("/now-playing/", json=payload)).status_code
+            for _ in range(burst)
+        ]
+
+    assert all(s == 200 for s in statuses), (
+        f"burst of {burst} should not be rate-limited under {NOW_PLAYING_LIMIT}; "
+        f"got {statuses.count(429)} x 429"
+    )


### PR DESCRIPTION
now-playing's server-side rate limit was a 30/min throttle. but now-playing is a fixed ~6/min playback heartbeat — there's no amount of listening that's "too much" — so a 30/min cap could only ever fire on a malfunctioning/abusive client, and when it did it 429'd a real listener's playback updates. raise the POST/DELETE ceiling to **120/min (~20× the real heartbeat)** so it reads as a script-abuse backstop a real listener can never reach.

### why this came up
A 7-day Logfire pass flagged 530 `429`s, 453 of them on `/now-playing/`. Digging in: the 429s are **not** steady-state listening hitting a ceiling — they're concentrated on two pre-fix days (5/21–5/22), and on 5/22 a *single client* generated 247 of them (the pre-#1426 throttle self-race firing 5–9 parallel POSTs per 10s tick). After #1426 shipped, 429s went to ~0 (one small residual on 5/25 consistent with a stale open tab on the old bundle).

That made the limit's framing the real problem: a rate limit semantically says "you're using us too much," which is never true for a passive playback heartbeat.

### what changed
- `now_playing.py`: extract `NOW_PLAYING_LIMIT = "120/minute"` (was `"30/minute"` inline) and apply it to both POST and DELETE.

### why 120 and not "remove it"
The endpoint requires auth, writes a single per-user record (overwritten in place, no fan-out to scrobble/teal/docket), and is cheap — so there's no abuse vector *specific* to it that a per-route cap defends. The only residual concern is a generic "an authed session hammers our app server," which is a survival/backstop concern, not a usage one. 120/min keeps a hard ceiling for that case while sitting ~20× above any real listener. (A future option is to drop the per-route limit entirely and lean on edge/global protection, but a high backstop is the smaller, safer change now.)

<details>
<summary>regression test + verification</summary>

- `test_now_playing_burst_past_old_throttle_not_rate_limited`: fires a 31-report burst (one past the retired 30/min throttle) and asserts none are `429`'d, with a guard that the burst stays ≤ the configured ceiling (so dropping the ceiling back toward the old throttle fails the test).
- **Proved the assertion isn't vacuous**: temporarily set the ceiling to `5/minute` and confirmed the same ASGITransport harness produces `429`s — so the limiter genuinely enforces here and "all 200" is meaningful.
- The `test_app` fixture now calls `limiter.reset()` on setup/teardown so the per-IP (`get_remote_address`) budget can't leak between tests.

</details>

<details>
<summary>intentional non-behaviors</summary>

- Client-side throttle is unchanged — it remains the real cadence control (one report / 10s).
- The limiter key (per-IP via `get_remote_address`) is unchanged.
- No change to the GET (`by-handle`/`by-did`) endpoints — they're already `@limiter.exempt`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)