### PR TITLE
feat(uploads): decouple publish from MP3 optimization — AIFF publishes instantly as WAV

### DIFF
--- a/backend/src/backend/_internal/tasks/__init__.py
+++ b/backend/src/backend/_internal/tasks/__init__.py
@@ -84,6 +84,7 @@ def _build_background_tasks() -> list:
     import time.
     """
     from backend._internal.jetstream import consume_jetstream
+    from backend.api.tracks.audio_optimize import optimize_track_audio
     from backend.api.tracks.audio_replace import run_track_audio_replace
     from backend.api.tracks.uploads import run_track_upload
 
@@ -121,6 +122,7 @@ def _build_background_tasks() -> list:
         scan_image_moderation,
         run_track_upload,
         run_track_audio_replace,
+        optimize_track_audio,
         reap_stuck_uploads,
     ]
 

--- a/backend/src/backend/api/tracks/audio_optimize.py
+++ b/backend/src/backend/api/tracks/audio_optimize.py
@@ -1,0 +1,340 @@
+"""deferred MP3 optimization for tracks published with the interim WAV rendition.
+
+a lossless (AIFF) upload publishes immediately with a fast 16-bit WAV
+compatibility rendition (see `uploads._store_audio`) so the track exists in
+seconds and plays in every browser, instead of blocking on a multi-minute,
+single-threaded MP3 encode. this background task then produces the smaller MP3
+streaming rendition from the lossless original, swaps it in as the canonical
+playable file, and writes the single PDS `audioBlob` — all off the upload's
+critical path. nothing here is reaped by the stuck-upload reaper (it runs under
+a distinct `JobType.OPTIMIZE` row) and it uses a generous transcoder timeout
+since no user is waiting.
+
+failure is safe: the track simply stays on its WAV rendition (fully consistent
+— DB row, R2 object, and PDS record all agree), and the orphaned MP3 (if any)
+is cleaned up. docket retries the task.
+"""
+
+import contextlib
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+
+import logfire
+from docket import ConcurrencyLimit
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from backend._internal import get_session
+from backend._internal.atproto.records import build_track_record, update_record
+from backend._internal.audio import AudioFormat
+from backend._internal.background import get_docket
+from backend._internal.jobs import job_service
+from backend._internal.tasks.hooks import invalidate_tracks_discovery_cache
+from backend.api.tracks.uploads import (
+    AudioInfo,
+    PdsBlobResult,
+    StorageResult,
+    UploadContext,
+    _transcode_audio,
+    _upload_to_pds,
+)
+from backend.config import settings
+from backend.models import Track
+from backend.models.job import JobStatus, JobType
+from backend.storage import storage
+from backend.utilities.database import db_session
+
+logger = logging.getLogger(__name__)
+
+OPTIMIZE_TARGET_FORMAT = "mp3"
+
+
+class _OptimizeAbort(Exception):
+    """internal signal to abort the optimization; the track stays on WAV."""
+
+
+@dataclass
+class _AudioState:
+    """immutable audio identifiers captured at the start of optimization.
+
+    the lossless original and the interim WAV don't change while we encode, so
+    we snapshot them once. mutable metadata (title / album / image / …) is
+    re-read right before the record rebuild instead — the encode can run for
+    minutes, plenty of time for a concurrent edit we must not clobber.
+    """
+
+    track_id: int
+    artist_did: str
+    atproto_record_uri: str
+    original_file_id: str
+    original_file_type: str
+    interim_file_id: str
+    interim_file_type: str
+    created_at: datetime
+
+
+@dataclass
+class _MetadataState:
+    """track metadata re-read immediately before rebuilding the ATProto record."""
+
+    title: str
+    artist_display_name: str
+    album: str | None
+    duration: int | None
+    features: list[dict]
+    image_url: str | None
+    description: str | None
+    support_gate: dict | None
+    atproto_record_uri: str
+
+
+def _needs_optimization(track: Track) -> bool:
+    """a track is optimizable iff it currently serves the interim WAV rendition
+    over a lossless original. an already-swapped (mp3) track is a no-op, which
+    makes the task idempotent under docket retries."""
+    return (
+        track.file_type == AudioFormat.WAV.value
+        and track.original_file_id is not None
+        and track.original_file_type is not None
+    )
+
+
+async def _load_audio_state(track_id: int) -> _AudioState | None:
+    """initial load + idempotency guard. returns None to skip (not found, or
+    already optimized)."""
+    async with db_session() as db:
+        track = (
+            await db.execute(select(Track).where(Track.id == track_id))
+        ).scalar_one_or_none()
+        if track is None:
+            logger.warning("optimize: track %s not found", track_id)
+            return None
+        if not track.atproto_record_uri:
+            logger.warning(
+                "optimize: track %s has no ATProto record; skipping", track_id
+            )
+            return None
+        if not _needs_optimization(track):
+            logfire.info(
+                "optimize: track already optimized or not applicable",
+                track_id=track_id,
+                file_type=track.file_type,
+            )
+            return None
+        # mypy/ty: _needs_optimization guarantees these are set
+        assert track.original_file_id is not None
+        assert track.original_file_type is not None
+        return _AudioState(
+            track_id=track.id,
+            artist_did=track.artist_did,
+            atproto_record_uri=track.atproto_record_uri,
+            original_file_id=track.original_file_id,
+            original_file_type=track.original_file_type,
+            interim_file_id=track.file_id,
+            interim_file_type=track.file_type,
+            created_at=track.created_at,
+        )
+
+
+async def _refresh_metadata(state: _AudioState) -> _MetadataState:
+    """re-read mutable metadata right before publishing so a concurrent
+    `PATCH /tracks/{id}` during the (minutes-long) encode isn't clobbered."""
+    async with db_session() as db:
+        track = (
+            await db.execute(
+                select(Track)
+                .options(selectinload(Track.artist))
+                .where(Track.id == state.track_id)
+            )
+        ).scalar_one_or_none()
+        if track is None or not track.atproto_record_uri:
+            raise _OptimizeAbort("track removed during optimization")
+        return _MetadataState(
+            title=track.title,
+            artist_display_name=track.artist.display_name,
+            album=track.album,
+            duration=track.duration,
+            features=list(track.features) if track.features else [],
+            image_url=await track.get_image_url(),
+            description=track.description,
+            support_gate=dict(track.support_gate) if track.support_gate else None,
+            atproto_record_uri=track.atproto_record_uri,
+        )
+
+
+async def _commit_optimize_swap(
+    state: _AudioState,
+    sr: StorageResult,
+    pds_result: PdsBlobResult | None,
+    new_record_cid: str,
+) -> None:
+    """swap the playable rendition to MP3 in a single statement.
+
+    only audio fields are touched — title/album/features/etc. are left alone so
+    a concurrent metadata edit survives. the lossless original is preserved.
+    genre/embedding provenance is NOT cleared: the audio content is unchanged
+    (same source), so those results stay valid.
+    """
+    has_pds_blob = bool(pds_result and pds_result.cid)
+    async with db_session() as db:
+        track = await db.get(Track, state.track_id)
+        if track is None:
+            raise _OptimizeAbort("track removed during optimization")
+        track.file_id = sr.file_id
+        track.file_type = OPTIMIZE_TARGET_FORMAT
+        track.r2_url = sr.r2_url
+        track.original_file_id = state.original_file_id
+        track.original_file_type = state.original_file_type
+        track.audio_storage = "both" if has_pds_blob else "r2"
+        track.pds_blob_cid = pds_result.cid if pds_result else None
+        track.pds_blob_size = pds_result.size if pds_result else None
+        track.atproto_record_cid = new_record_cid
+        await db.commit()
+
+
+async def optimize_track_audio(
+    track_id: int,
+    session_id: str,
+    concurrency: ConcurrencyLimit = ConcurrencyLimit(
+        "session_id", max_concurrent=2
+    ),
+) -> None:
+    """produce + swap in the MP3 streaming rendition for a WAV-published track.
+
+    enqueued by the upload / audio-replace pipelines right after a lossless
+    track is published with its interim WAV rendition.
+    """
+    with logfire.span("optimize track audio", track_id=track_id):
+        session = await get_session(session_id)
+        if session is None:
+            logger.warning(
+                "optimize: session %s gone; track %s stays on WAV",
+                session_id,
+                track_id,
+            )
+            return
+
+        state = await _load_audio_state(track_id)
+        if state is None:
+            return
+
+        job_id = await job_service.create_job(
+            JobType.OPTIMIZE, state.artist_did, "optimizing audio..."
+        )
+
+        new_mp3_file_id: str | None = None
+        try:
+            transcode_info = await _transcode_audio(
+                job_id,
+                state.original_file_id,
+                f"track.{state.original_file_type}",
+                state.original_file_type,
+                target_format=OPTIMIZE_TARGET_FORMAT,
+                timeout_seconds=settings.transcoder.optimize_timeout_seconds,
+            )
+            if not transcode_info:
+                # _transcode_audio already marked the job failed with detail.
+                raise _OptimizeAbort("transcode to mp3 failed")
+            new_mp3_file_id = transcode_info.transcoded_file_id
+
+            mp3_url = await storage.get_url(
+                new_mp3_file_id, file_type="audio", extension=OPTIMIZE_TARGET_FORMAT
+            )
+            if not mp3_url:
+                raise _OptimizeAbort("failed to resolve mp3 url")
+
+            sr = StorageResult(
+                file_id=new_mp3_file_id,
+                original_file_id=state.original_file_id,
+                original_file_type=state.original_file_type,
+                playable_format=AudioFormat.MP3,
+                r2_url=mp3_url,
+                transcode_info=transcode_info,
+                needs_optimization=False,
+            )
+            audio_info = AudioInfo(
+                format=AudioFormat.MP3, duration=None, is_gated=False
+            )
+            phase_ctx = UploadContext(
+                upload_id=job_id,
+                auth_session=session,
+                audio_file_id=new_mp3_file_id,
+                filename=f"track.{OPTIMIZE_TARGET_FORMAT}",
+                duration=None,
+                title="",
+                artist_did=state.artist_did,
+                album=None,
+                album_id=None,
+                features_json=None,
+                tags=[],
+            )
+            pds_result = await _upload_to_pds(phase_ctx, audio_info, sr)
+            if pds_result and (refreshed := await get_session(session_id)):
+                session = refreshed
+
+            meta = await _refresh_metadata(state)
+            new_record = await build_track_record(
+                title=meta.title,
+                artist=meta.artist_display_name,
+                audio_url=mp3_url,
+                file_type=OPTIMIZE_TARGET_FORMAT,
+                album=meta.album,
+                duration=meta.duration,
+                features=meta.features or None,
+                image_url=meta.image_url,
+                support_gate=meta.support_gate,
+                audio_blob=pds_result.blob_ref if pds_result else None,
+                description=meta.description,
+                created_at=state.created_at,
+            )
+            _, new_cid = await update_record(
+                auth_session=session,
+                record_uri=meta.atproto_record_uri,
+                record=new_record,
+            )
+
+            await _commit_optimize_swap(state, sr, pds_result, new_cid)
+
+        except Exception as e:
+            # leave the track on its WAV rendition (consistent); drop the
+            # orphaned MP3. docket retries; the track keeps playing meanwhile.
+            if new_mp3_file_id:
+                with contextlib.suppress(Exception):
+                    await storage.delete(new_mp3_file_id, OPTIMIZE_TARGET_FORMAT)
+            await job_service.update_progress(
+                job_id, JobStatus.FAILED, "optimization failed", error=str(e)
+            )
+            if isinstance(e, _OptimizeAbort):
+                logger.warning("optimize: aborted for track %s: %s", track_id, e)
+            else:
+                logger.exception(
+                    "optimize: track %s failed; staying on WAV", track_id
+                )
+            return
+
+        # post-commit: the interim WAV is now orphaned — delete it. best-effort;
+        # a leaked WAV is harmless (no row references it) and cheap to sweep.
+        with contextlib.suppress(Exception):
+            await storage.delete(state.interim_file_id, state.interim_file_type)
+        with contextlib.suppress(Exception):
+            await invalidate_tracks_discovery_cache()
+
+        await job_service.update_progress(
+            job_id,
+            JobStatus.COMPLETED,
+            "audio optimized",
+            result={"track_id": track_id, "file_id": new_mp3_file_id},
+        )
+        logfire.info(
+            "optimize: swapped track to mp3 rendition",
+            track_id=track_id,
+            mp3_file_id=new_mp3_file_id,
+        )
+
+
+async def schedule_optimize_track_audio(track_id: int, session_id: str) -> None:
+    """enqueue the deferred MP3 optimization for a WAV-published track."""
+    docket = get_docket()
+    await docket.add(optimize_track_audio)(track_id, session_id)
+    logfire.info("scheduled track audio optimization", track_id=track_id)

--- a/backend/src/backend/api/tracks/audio_optimize.py
+++ b/backend/src/backend/api/tracks/audio_optimize.py
@@ -303,14 +303,21 @@ async def optimize_track_audio(
             )
             if not transcode_info:
                 # _transcode_audio already marked the job failed with detail.
-                raise _OptimizeAbort("transcode to mp3 failed")
+                # this is the transient family (transcoder timeout / 5xx / I/O
+                # error) — raise a plain exception so docket retries under
+                # `_OPTIMIZE_RETRY`. a genuinely bad source would also have
+                # failed the WAV remux on the publish path, which it didn't.
+                raise RuntimeError("transcode to mp3 failed; see job error detail")
             new_mp3_file_id = transcode_info.transcoded_file_id
 
             mp3_url = await storage.get_url(
                 new_mp3_file_id, file_type="audio", extension=OPTIMIZE_TARGET_FORMAT
             )
             if not mp3_url:
-                raise _OptimizeAbort("failed to resolve mp3 url")
+                # transient R2 hiccup; retry rather than give up on the track.
+                raise RuntimeError(
+                    f"failed to resolve mp3 url for file_id={new_mp3_file_id}"
+                )
 
             sr = StorageResult(
                 file_id=new_mp3_file_id,

--- a/backend/src/backend/api/tracks/audio_optimize.py
+++ b/backend/src/backend/api/tracks/audio_optimize.py
@@ -18,11 +18,12 @@ is cleaned up. docket retries the task.
 import contextlib
 import logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import logfire
-from docket import ConcurrencyLimit
+from docket import ConcurrencyLimit, ExponentialRetry
 from sqlalchemy import select
+from sqlalchemy import update as sa_update
 from sqlalchemy.orm import selectinload
 
 from backend._internal import get_session
@@ -49,9 +50,22 @@ logger = logging.getLogger(__name__)
 
 OPTIMIZE_TARGET_FORMAT = "mp3"
 
+# docket retry on transient failures (transcoder hiccup, PDS 5xx, DB blip).
+# fewer attempts than the ingest tasks because each retry re-runs the ~minutes
+# MP3 encode, so hammering is wasteful — a small handful with real backoff is
+# the right shape. terminal aborts (_OptimizeAbort) are caught and swallowed so
+# docket sees a clean completion and does not retry them.
+_OPTIMIZE_RETRY = ExponentialRetry(
+    attempts=3,
+    minimum_delay=timedelta(seconds=30),
+    maximum_delay=timedelta(minutes=5),
+)
+
 
 class _OptimizeAbort(Exception):
-    """internal signal to abort the optimization; the track stays on WAV."""
+    """internal signal that the optimization can't (or shouldn't) proceed —
+    the track is no longer in the state we captured, or its session is gone.
+    swallowed by the orchestrator so docket does not retry."""
 
 
 @dataclass
@@ -163,47 +177,95 @@ async def _refresh_metadata(state: _AudioState) -> _MetadataState:
         )
 
 
+async def _verify_still_optimizable(state: _AudioState) -> None:
+    """abort if the track has been replaced/edited under us during the encode.
+
+    closes the race with `audio_replace` (and any direct audio mutation): the
+    MP3 encode can run for minutes, plenty of time for a user to upload new
+    audio. if we proceed without checking, we'd push a stale MP3 to the PDS
+    record on top of the replacement and overwrite the DB row to match —
+    silently undoing the user's replace.
+
+    this check minimizes the race window before `update_record` but doesn't
+    eliminate it; `_commit_optimize_swap` does the atomic CAS as the backstop.
+    """
+    async with db_session() as db:
+        row = (
+            await db.execute(
+                select(Track.file_id, Track.original_file_id).where(
+                    Track.id == state.track_id
+                )
+            )
+        ).first()
+        if row is None:
+            raise _OptimizeAbort("track removed during optimization")
+        current_file_id, current_original_file_id = row
+        if (
+            current_file_id != state.interim_file_id
+            or current_original_file_id != state.original_file_id
+        ):
+            raise _OptimizeAbort(
+                f"track audio changed during optimization "
+                f"(file_id={current_file_id} vs captured {state.interim_file_id}; "
+                f"original={current_original_file_id} vs captured "
+                f"{state.original_file_id})"
+            )
+
+
 async def _commit_optimize_swap(
     state: _AudioState,
     sr: StorageResult,
     pds_result: PdsBlobResult | None,
     new_record_cid: str,
-) -> None:
-    """swap the playable rendition to MP3 in a single statement.
+) -> bool:
+    """conditional swap to the MP3 rendition. succeeds iff the track is still
+    pointing at the captured interim WAV + lossless original (CAS via WHERE).
+
+    returns True on success, False on CAS-miss — i.e. another operation has
+    moved the audio under us between the pre-publish guard and now. the caller
+    decides what to do with the new MP3 in the CAS-miss case (it stays for
+    inconsistency-avoidance when PDS has already been updated to reference it).
 
     only audio fields are touched — title/album/features/etc. are left alone so
-    a concurrent metadata edit survives. the lossless original is preserved.
-    genre/embedding provenance is NOT cleared: the audio content is unchanged
-    (same source), so those results stay valid.
+    a concurrent metadata edit survives. genre/embedding provenance is NOT
+    cleared: the audio content is unchanged (same source), results stay valid.
     """
     has_pds_blob = bool(pds_result and pds_result.cid)
     async with db_session() as db:
-        track = await db.get(Track, state.track_id)
-        if track is None:
-            raise _OptimizeAbort("track removed during optimization")
-        track.file_id = sr.file_id
-        track.file_type = OPTIMIZE_TARGET_FORMAT
-        track.r2_url = sr.r2_url
-        track.original_file_id = state.original_file_id
-        track.original_file_type = state.original_file_type
-        track.audio_storage = "both" if has_pds_blob else "r2"
-        track.pds_blob_cid = pds_result.cid if pds_result else None
-        track.pds_blob_size = pds_result.size if pds_result else None
-        track.atproto_record_cid = new_record_cid
+        result = await db.execute(
+            sa_update(Track)
+            .where(
+                Track.id == state.track_id,
+                Track.file_id == state.interim_file_id,
+                Track.original_file_id == state.original_file_id,
+            )
+            .values(
+                file_id=sr.file_id,
+                file_type=OPTIMIZE_TARGET_FORMAT,
+                r2_url=sr.r2_url,
+                audio_storage="both" if has_pds_blob else "r2",
+                pds_blob_cid=pds_result.cid if pds_result else None,
+                pds_blob_size=pds_result.size if pds_result else None,
+                atproto_record_cid=new_record_cid,
+            )
+        )
         await db.commit()
+        return result.rowcount == 1  # type: ignore[union-attr]
 
 
 async def optimize_track_audio(
     track_id: int,
     session_id: str,
-    concurrency: ConcurrencyLimit = ConcurrencyLimit(
-        "session_id", max_concurrent=2
-    ),
+    concurrency: ConcurrencyLimit = ConcurrencyLimit("session_id", max_concurrent=2),
+    retry: ExponentialRetry = _OPTIMIZE_RETRY,
 ) -> None:
     """produce + swap in the MP3 streaming rendition for a WAV-published track.
 
     enqueued by the upload / audio-replace pipelines right after a lossless
-    track is published with its interim WAV rendition.
+    track is published with its interim WAV rendition. transient failures
+    (transcoder hiccup, PDS 5xx, DB blip) propagate so docket can retry under
+    `_OPTIMIZE_RETRY`; terminal aborts (track moved on, session gone, already
+    optimized) raise `_OptimizeAbort`, which is caught and swallowed.
     """
     with logfire.span("optimize track audio", track_id=track_id):
         session = await get_session(session_id)
@@ -224,6 +286,12 @@ async def optimize_track_audio(
         )
 
         new_mp3_file_id: str | None = None
+        # set True the moment update_record returns successfully. once that's
+        # happened, the PDS record references the new MP3 url + blob, so we
+        # must NOT delete the R2 object even if the DB swap subsequently fails
+        # — third-party PDS readers depend on the url being reachable. better
+        # to leak storage than 404 their playback.
+        pds_published = False
         try:
             transcode_info = await _transcode_audio(
                 job_id,
@@ -274,6 +342,10 @@ async def optimize_track_audio(
                 session = refreshed
 
             meta = await _refresh_metadata(state)
+            # last cheap check before we go write to PDS: bail if the track has
+            # been replaced/edited under us during the encode.
+            await _verify_still_optimizable(state)
+
             new_record = await build_track_record(
                 title=meta.title,
                 artist=meta.artist_display_name,
@@ -293,25 +365,52 @@ async def optimize_track_audio(
                 record_uri=meta.atproto_record_uri,
                 record=new_record,
             )
+            pds_published = True
 
-            await _commit_optimize_swap(state, sr, pds_result, new_cid)
+            swapped = await _commit_optimize_swap(state, sr, pds_result, new_cid)
+            if not swapped:
+                # CAS-miss: the track moved on between the pre-publish guard
+                # and now. PDS has been written to point at our MP3, so we
+                # cannot delete it — and an audio_replace racing us will (or
+                # already has) rebuilt the PDS record to its own audio,
+                # which will overwrite ours on the PDS side too. log the
+                # inconsistency and abort terminally.
+                raise _OptimizeAbort(
+                    f"track {track_id} audio changed between PDS write and DB "
+                    f"commit; leaving mp3 {new_mp3_file_id} in place"
+                )
 
-        except Exception as e:
-            # leave the track on its WAV rendition (consistent); drop the
-            # orphaned MP3. docket retries; the track keeps playing meanwhile.
-            if new_mp3_file_id:
+        except _OptimizeAbort as e:
+            # terminal: track is no longer in our captured state. don't retry.
+            # only clean up the new MP3 if we hadn't already pushed it to PDS;
+            # once the record points at the url, third-party readers may be
+            # using it.
+            if new_mp3_file_id and not pds_published:
                 with contextlib.suppress(Exception):
                     await storage.delete(new_mp3_file_id, OPTIMIZE_TARGET_FORMAT)
             await job_service.update_progress(
-                job_id, JobStatus.FAILED, "optimization failed", error=str(e)
+                job_id, JobStatus.FAILED, "optimization aborted", error=str(e)
             )
-            if isinstance(e, _OptimizeAbort):
-                logger.warning("optimize: aborted for track %s: %s", track_id, e)
-            else:
-                logger.exception(
-                    "optimize: track %s failed; staying on WAV", track_id
-                )
+            logger.warning("optimize: aborted for track %s: %s", track_id, e)
             return
+
+        except Exception as e:
+            # transient: let docket retry. same cleanup discipline — keep the
+            # mp3 if PDS already references it; the next attempt will reconcile.
+            if new_mp3_file_id and not pds_published:
+                with contextlib.suppress(Exception):
+                    await storage.delete(new_mp3_file_id, OPTIMIZE_TARGET_FORMAT)
+            await job_service.update_progress(
+                job_id,
+                JobStatus.FAILED,
+                "optimization failed (retrying)",
+                error=str(e),
+            )
+            logger.exception(
+                "optimize: track %s transient failure; re-raising for retry",
+                track_id,
+            )
+            raise
 
         # post-commit: the interim WAV is now orphaned — delete it. best-effort;
         # a leaked WAV is harmless (no row references it) and cheap to sweep.

--- a/backend/src/backend/api/tracks/audio_replace.py
+++ b/backend/src/backend/api/tracks/audio_replace.py
@@ -439,6 +439,7 @@ async def _process_replace_background(ctx: ReplaceContext) -> None:
             )
 
             track = await _commit_db_swap(state, audio_info, sr, pds_result, new_cid)
+            replaced_needs_optimization = sr.needs_optimization
 
         except UploadPhaseError as e:
             await _rollback_new_files(
@@ -497,6 +498,17 @@ async def _process_replace_background(ctx: ReplaceContext) -> None:
 
         with contextlib.suppress(Exception):
             await invalidate_tracks_discovery_cache()
+
+        # replacing with a lossless source publishes the interim WAV rendition
+        # (same fast path as upload); kick off the deferred MP3 optimization so
+        # the replaced track also ends up on the smaller streaming rendition.
+        # lazy import: audio_optimize pulls the phase helpers from uploads.
+        if replaced_needs_optimization:
+            from backend.api.tracks.audio_optimize import (
+                schedule_optimize_track_audio,
+            )
+
+            await schedule_optimize_track_audio(track.id, ctx.auth_session.session_id)
 
         await job_service.update_progress(
             ctx.job_id,

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -24,7 +24,7 @@ from fastapi import (
 )
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ValidationError
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -42,7 +42,10 @@ from backend._internal.atproto.handles import (
 )
 from backend._internal.audio import AudioFormat
 from backend._internal.background import get_docket
-from backend._internal.clients.transcoder import get_transcoder_client
+from backend._internal.clients.transcoder import (
+    TranscoderClient,
+    get_transcoder_client,
+)
 from backend._internal.copyright import TrackRightsInput, write_track_rights
 from backend._internal.image_uploads import (
     ImageUploadError,
@@ -156,6 +159,11 @@ class StorageResult:
     playable_format: AudioFormat
     r2_url: str | None
     transcode_info: "TranscodeInfo | None"
+    # True when this is a fast playable rendition (16-bit WAV remux of a
+    # lossless source) published ahead of the smaller MP3. signals the
+    # pipeline to skip the PDS blob at publish (the deferred optimize task
+    # writes the single canonical MP3 blob) and to enqueue that task.
+    needs_optimization: bool = False
 
 
 class UploadPhaseError(Exception):
@@ -376,6 +384,9 @@ async def _transcode_audio(
     original_file_id: str,
     filename: str,
     source_format: str,
+    *,
+    target_format: str,
+    timeout_seconds: int | None = None,
 ) -> TranscodeInfo | None:
     """transcode an already-staged audio file to a web-playable format.
 
@@ -391,6 +402,13 @@ async def _transcode_audio(
         original_file_id: storage file_id for the lossless source bytes
         filename: original filename (used to derive transcoded filename)
         source_format: source format (e.g., "aiff", "flac")
+        target_format: format to produce — "wav" for the fast compatibility
+            remux on the upload critical path, "mp3" for the deferred
+            optimization pass.
+        timeout_seconds: per-request transcoder timeout override. the WAV
+            remux is seconds, so the default (settings) is fine; the MP3
+            optimization runs off the critical path and passes a generous
+            value since no user is waiting on it.
 
     returns:
         TranscodeInfo with both file IDs, or None on failure
@@ -411,7 +429,6 @@ async def _transcode_audio(
     # `output_path`. these temp files exist only on this worker and are
     # unlinked in the `finally` below — they never cross the request →
     # worker boundary, which is fine on a multi-machine fly setup.
-    target_format = settings.transcoder.target_format
     source_path: str | None = None
     output_path: str | None = None
     try:
@@ -473,11 +490,20 @@ async def _transcode_audio(
         async def transcode_heartbeat() -> None:
             await job_service.heartbeat(upload_id)
 
-        client = get_transcoder_client()
+        if timeout_seconds is not None:
+            client = TranscoderClient(
+                service_url=str(settings.transcoder.service_url),
+                auth_token=settings.transcoder.auth_token,
+                timeout_seconds=timeout_seconds,
+                target_format=target_format,
+            )
+        else:
+            client = get_transcoder_client()
         result = await client.transcode_file(
             source_path,
             source_format,
             output_path=output_path,
+            target_format=target_format,
             heartbeat=transcode_heartbeat,
         )
 
@@ -582,11 +608,18 @@ async def _store_audio(ctx: UploadContext, audio_info: AudioInfo) -> StorageResu
                 "supporter-gated tracks cannot use lossless formats yet"
             )
 
-        # the handler-staged file_id IS the lossless original. transcoding
-        # downloads it from storage, produces the playable sibling, and
-        # registers the staged id as `original_file_id`.
+        # the handler-staged file_id IS the lossless original. we produce a
+        # fast 16-bit WAV compatibility rendition (a near-instant PCM rewrap,
+        # not the slow MP3 encode) so the track can publish immediately and
+        # play in every browser; the smaller MP3 is generated off the critical
+        # path by the deferred optimize task. the staged id becomes
+        # `original_file_id` (the lossless master, preserved untouched).
         transcode_info = await _transcode_audio(
-            ctx.upload_id, ctx.audio_file_id, ctx.filename, ctx.audio_extension
+            ctx.upload_id,
+            ctx.audio_file_id,
+            ctx.filename,
+            ctx.audio_extension,
+            target_format="wav",
         )
         if not transcode_info:
             raise UploadPhaseError("transcoding failed")
@@ -625,16 +658,29 @@ async def _store_audio(ctx: UploadContext, audio_info: AudioInfo) -> StorageResu
         playable_format=playable_format,
         r2_url=r2_url,
         transcode_info=transcode_info,
+        # a transcode here means we remuxed a lossless source to the interim
+        # WAV rendition, so the smaller MP3 still needs to be produced.
+        needs_optimization=transcode_info is not None,
     )
 
 
 async def _check_duplicate(ctx: UploadContext, sr: StorageResult) -> None:
-    """phase 3: check for duplicate tracks."""
+    """phase 3: check for duplicate tracks.
+
+    matches on the playable file_id OR the staged source id against an
+    existing track's `original_file_id`. the latter is what keeps dedup
+    robust for lossless re-uploads: the playable rendition swaps from WAV to
+    MP3 during optimization, so the playable file_id is not stable — but the
+    lossless source hash (the staged id) is.
+    """
     async with db_session() as db:
         result = await db.execute(
             select(Track).where(
-                Track.file_id == sr.file_id,
                 Track.artist_did == ctx.artist_did,
+                or_(
+                    Track.file_id == sr.file_id,
+                    Track.original_file_id == ctx.audio_file_id,
+                ),
             )
         )
         if existing := result.scalar_one_or_none():
@@ -653,6 +699,13 @@ async def _upload_to_pds(
     a HEAD request so the PDS can validate up-front without buffering.
     """
     if audio_info.is_gated:
+        return None
+
+    # the interim WAV rendition is large and throwaway — never push it to the
+    # user's PDS. the deferred optimize task writes the single canonical blob
+    # (the MP3) once. publishing now with audioUrl-only is an already-supported
+    # record shape (it's the same shape as the large-file R2-only fallback).
+    if sr.needs_optimization:
         return None
 
     async with db_session() as db:
@@ -1120,6 +1173,21 @@ async def _process_upload_background(ctx: UploadContext) -> None:
 
             # phase 7: post-upload tasks (tags, album sync, shared hooks)
             await _schedule_post_upload(ctx, sr, track, run_hooks=published_by_us)
+
+            # phase 8: for tracks published with the interim WAV rendition,
+            # kick off the deferred MP3 optimization. the track already exists
+            # and plays; this swaps in the smaller streaming rendition and
+            # writes the single canonical PDS blob off the critical path.
+            # (lazy import: audio_optimize imports the phase helpers from this
+            # module, so a top-level import would be circular.)
+            if published_by_us and sr.needs_optimization:
+                from backend.api.tracks.audio_optimize import (
+                    schedule_optimize_track_audio,
+                )
+
+                await schedule_optimize_track_audio(
+                    track.id, ctx.auth_session.session_id
+                )
 
             result: dict[str, Any] = {
                 "track_id": track.id,

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -739,6 +739,15 @@ class TranscoderSettings(AppSettingsSection):
         default=600,
         description="Timeout for transcoder requests (10 min default for large files)",
     )
+    optimize_timeout_seconds: int = Field(
+        default=3600,
+        description=(
+            "Timeout for the deferred MP3 optimization pass. Generous (1 hour) "
+            "because it runs off the upload critical path — no user is waiting "
+            "— so even a long lossless source can finish its single-threaded "
+            "encode without tripping the request timeout."
+        ),
+    )
     target_format: str = Field(
         default="mp3",
         description="Target format for transcoded files",

--- a/backend/src/backend/models/job.py
+++ b/backend/src/backend/models/job.py
@@ -27,6 +27,10 @@ class JobType(str, Enum):
     UPLOAD = "upload"
     EXPORT = "export"
     PDS_BACKFILL = "pds_backfill"
+    # deferred MP3 optimization of a track published with the interim WAV
+    # rendition. a distinct type so the stuck-upload reaper (which scans
+    # type='upload') never reaps a legitimately long encode running here.
+    OPTIMIZE = "optimize"
 
 
 class Job(Base):

--- a/backend/tests/api/test_audio_optimize.py
+++ b/backend/tests/api/test_audio_optimize.py
@@ -1,0 +1,481 @@
+"""tests for the decoupled publish/optimize audio pipeline.
+
+a lossless (AIFF) upload now publishes immediately with a fast 16-bit WAV
+compatibility rendition, then a deferred `optimize_track_audio` task produces
+the smaller MP3 streaming rendition off the critical path. these tests pin:
+
+- the publish side: `_store_audio` remuxes AIFF to WAV and flags optimization;
+  `_upload_to_pds` skips the (large, throwaway) WAV blob at publish.
+- the optimize side: the task swaps the playable rendition WAV -> MP3, preserves
+  the lossless original AND the record's createdAt, writes the single canonical
+  PDS blob, and deletes the orphaned interim WAV — and is a safe no-op / leaves
+  the track on WAV when it can't complete.
+
+regression for the 2026-05-27 incident where a 939MB AIFF blocked on an
+11-minute MP3 encode, exceeded the transcoder timeout, and produced no track.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import Session
+from backend._internal.audio import AudioFormat
+from backend.api.tracks.audio_optimize import optimize_track_audio
+from backend.api.tracks.uploads import (
+    AudioInfo,
+    PdsBlobResult,
+    StorageResult,
+    TranscodeInfo,
+    UploadContext,
+    UploadPhaseError,
+    _check_duplicate,
+    _store_audio,
+    _upload_to_pds,
+)
+from backend.config import settings
+from backend.models import Artist, Track
+
+OWNER_DID = "did:plc:optimizeowner"
+TRACK_URI = f"at://{OWNER_DID}/fm.plyr.track/3koptimize001"
+
+
+class _MockSession(Session):
+    """drop-in auth session that doesn't touch encryption (mirrors the
+    audio-replace suite's MockSession)."""
+
+    def __init__(self, did: str = OWNER_DID) -> None:
+        self.did = did
+        self.handle = "owner.bsky.social"
+        self.session_id = "session-id"
+        self.access_token = "tok"
+        self.refresh_token = "ref"
+        self.oauth_session = {
+            "did": did,
+            "handle": "owner.bsky.social",
+            "pds_url": "https://test.pds",
+            "authserver_iss": "https://auth.test",
+            "scope": "atproto transition:generic",
+            "access_token": "tok",
+            "refresh_token": "ref",
+            "dpop_private_key_pem": "fake_key",
+            "dpop_authserver_nonce": "",
+            "dpop_pds_nonce": "",
+        }
+
+
+@pytest.fixture
+async def owner(db_session: AsyncSession) -> Artist:
+    artist = Artist(did=OWNER_DID, handle="owner.bsky.social", display_name="Owner")
+    db_session.add(artist)
+    await db_session.commit()
+    await db_session.refresh(artist)
+    return artist
+
+
+def _wav_track(**overrides) -> Track:
+    """a track published with the interim WAV rendition over an AIFF original.
+
+    duration is a computed property backed by `extra`, so it's seeded there
+    (mirrors the audio-replace suite's `make_track`).
+    """
+    defaults = dict(
+        title="Long Mix",
+        artist_did=OWNER_DID,
+        file_id="WAVID",
+        file_type="wav",
+        original_file_id="AIFFID",
+        original_file_type="aiff",
+        atproto_record_uri=TRACK_URI,
+        atproto_record_cid="bafyWAV",
+        r2_url="https://audio.example/WAVID.wav",
+        audio_storage="r2",
+        extra={"duration": 5400},
+    )
+    defaults.update(overrides)
+    return Track(**defaults)
+
+
+def _transcode_info(transcoded_file_id: str, target: str) -> TranscodeInfo:
+    return TranscodeInfo(
+        original_file_id="AIFFID",
+        original_file_type="aiff",
+        transcoded_file_id=transcoded_file_id,
+        transcoded_file_type=target,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# publish side
+# --------------------------------------------------------------------------- #
+
+
+async def test_store_audio_remuxes_aiff_to_wav_and_flags_optimization() -> None:
+    """a lossless source produces the fast WAV rendition (not MP3) and marks the
+    result as still needing the deferred MP3 optimization."""
+    ctx = UploadContext(
+        upload_id="job-1",
+        auth_session=_MockSession(),
+        audio_file_id="AIFFID",
+        filename="mix.aiff",
+        duration=5400,
+        title="Long Mix",
+        artist_did=OWNER_DID,
+        album=None,
+        album_id=None,
+        features_json=None,
+        tags=[],
+    )
+    audio_info = AudioInfo(format=AudioFormat.AIFF, duration=5400, is_gated=False)
+
+    with (
+        patch(
+            "backend.api.tracks.uploads._transcode_audio",
+            new_callable=AsyncMock,
+            return_value=_transcode_info("WAVID", "wav"),
+        ) as mock_transcode,
+        patch(
+            "backend.api.tracks.uploads.storage.get_url",
+            new_callable=AsyncMock,
+            return_value="https://audio.example/WAVID.wav",
+        ),
+    ):
+        sr = await _store_audio(ctx, audio_info)
+
+    # remuxed to the WAV compatibility rendition, lossless kept as the original
+    assert mock_transcode.await_args.kwargs["target_format"] == "wav"
+    assert sr.playable_format == AudioFormat.WAV
+    assert sr.file_id == "WAVID"
+    assert sr.original_file_id == "AIFFID"
+    assert sr.original_file_type == "aiff"
+    assert sr.needs_optimization is True
+
+
+async def test_store_audio_web_playable_does_not_need_optimization() -> None:
+    """an already web-playable upload (mp3) is served as-is, no transcode, no
+    optimization."""
+    ctx = UploadContext(
+        upload_id="job-2",
+        auth_session=_MockSession(),
+        audio_file_id="MP3ID",
+        filename="song.mp3",
+        duration=180,
+        title="Song",
+        artist_did=OWNER_DID,
+        album=None,
+        album_id=None,
+        features_json=None,
+        tags=[],
+    )
+    audio_info = AudioInfo(format=AudioFormat.MP3, duration=180, is_gated=False)
+
+    with (
+        patch(
+            "backend.api.tracks.uploads._transcode_audio",
+            new_callable=AsyncMock,
+        ) as mock_transcode,
+        patch(
+            "backend.api.tracks.uploads.storage.get_url",
+            new_callable=AsyncMock,
+            return_value="https://audio.example/MP3ID.mp3",
+        ),
+    ):
+        sr = await _store_audio(ctx, audio_info)
+
+    mock_transcode.assert_not_awaited()
+    assert sr.needs_optimization is False
+    assert sr.file_id == "MP3ID"
+    assert sr.original_file_id is None
+
+
+async def test_upload_to_pds_skips_when_optimization_pending() -> None:
+    """the interim WAV must never be pushed to the user's PDS — the deferred
+    optimize task writes the single canonical MP3 blob instead."""
+    ctx = UploadContext(
+        upload_id="job-3",
+        auth_session=_MockSession(),
+        audio_file_id="WAVID",
+        filename="mix.aiff",
+        duration=5400,
+        title="Long Mix",
+        artist_did=OWNER_DID,
+        album=None,
+        album_id=None,
+        features_json=None,
+        tags=[],
+    )
+    audio_info = AudioInfo(format=AudioFormat.WAV, duration=5400, is_gated=False)
+    sr = StorageResult(
+        file_id="WAVID",
+        original_file_id="AIFFID",
+        original_file_type="aiff",
+        playable_format=AudioFormat.WAV,
+        r2_url="https://audio.example/WAVID.wav",
+        transcode_info=None,
+        needs_optimization=True,
+    )
+
+    # patch the PDS upload boundary so a regression (not skipping) would call it
+    with patch(
+        "backend.api.tracks.uploads.upload_blob", new_callable=AsyncMock
+    ) as mock_upload_blob:
+        result = await _upload_to_pds(ctx, audio_info, sr)
+
+    assert result is None
+    mock_upload_blob.assert_not_awaited()
+
+
+async def test_check_duplicate_matches_lossless_original(
+    db_session: AsyncSession, owner: Artist
+) -> None:
+    """dedup survives the WAV->MP3 swap: a re-uploaded AIFF is caught by its
+    stable source hash even though the existing track's playable file_id has
+    since changed to the MP3."""
+    track = _wav_track(file_id="MP3ID", file_type="mp3", original_file_id="AIFFID")
+    db_session.add(track)
+    await db_session.commit()
+
+    ctx = UploadContext(
+        upload_id="job-4",
+        auth_session=_MockSession(),
+        audio_file_id="AIFFID",  # same lossless source re-uploaded
+        filename="mix.aiff",
+        duration=5400,
+        title="Long Mix",
+        artist_did=OWNER_DID,
+        album=None,
+        album_id=None,
+        features_json=None,
+        tags=[],
+    )
+    sr = StorageResult(
+        file_id="DIFFERENT_WAV",
+        original_file_id="AIFFID",
+        original_file_type="aiff",
+        playable_format=AudioFormat.WAV,
+        r2_url="https://audio.example/DIFFERENT_WAV.wav",
+        transcode_info=None,
+        needs_optimization=True,
+    )
+
+    with pytest.raises(UploadPhaseError, match="duplicate"):
+        await _check_duplicate(ctx, sr)
+
+
+# --------------------------------------------------------------------------- #
+# optimize side
+# --------------------------------------------------------------------------- #
+
+
+@contextlib.contextmanager
+def _patch_optimize(
+    *,
+    transcode: TranscodeInfo | None,
+    pds: PdsBlobResult | None,
+    update_record_side_effect: object = None,
+    session: Session | None = None,
+    deleted: list[str] | None = None,
+):
+    """patch every external boundary of `optimize_track_audio`, leaving the real
+    DB reads/writes (_load_audio_state, _refresh_metadata, _commit_optimize_swap)
+    and the real record builder running against the seeded track.
+
+    yields a dict of the started mocks so tests can assert on them.
+    """
+    update_record_kwargs: dict = (
+        {"side_effect": update_record_side_effect}
+        if update_record_side_effect is not None
+        else {"return_value": (TRACK_URI, "bafyNEWREC")}
+    )
+
+    async def fake_delete(file_id: str, file_type: str | None = None) -> bool:
+        if deleted is not None:
+            deleted.append(file_id)
+        return True
+
+    job_service_mock = AsyncMock()
+    job_service_mock.create_job = AsyncMock(return_value="opt-job")
+
+    with (
+        patch(
+            "backend.api.tracks.audio_optimize.get_session",
+            new_callable=AsyncMock,
+            return_value=_MockSession() if session is None else session,
+        ),
+        patch(
+            "backend.api.tracks.audio_optimize._transcode_audio",
+            new_callable=AsyncMock,
+            return_value=transcode,
+        ) as mock_transcode,
+        patch(
+            "backend.api.tracks.audio_optimize.storage.get_url",
+            new_callable=AsyncMock,
+            return_value="https://audio.example/MP3NEW.mp3",
+        ),
+        patch(
+            "backend.api.tracks.audio_optimize._upload_to_pds",
+            new_callable=AsyncMock,
+            return_value=pds,
+        ) as mock_upload_to_pds,
+        patch(
+            "backend.api.tracks.audio_optimize.build_track_record",
+            new_callable=AsyncMock,
+            return_value={"$type": "fm.plyr.track", "title": "Long Mix"},
+        ) as mock_build_record,
+        patch(
+            "backend.api.tracks.audio_optimize.update_record",
+            AsyncMock(**update_record_kwargs),
+        ) as mock_update_record,
+        patch(
+            "backend.api.tracks.audio_optimize.storage.delete",
+            new_callable=AsyncMock,
+            side_effect=fake_delete,
+        ),
+        patch(
+            "backend.api.tracks.audio_optimize.invalidate_tracks_discovery_cache",
+            new_callable=AsyncMock,
+        ),
+        patch("backend.api.tracks.audio_optimize.job_service", job_service_mock),
+    ):
+        yield {
+            "transcode": mock_transcode,
+            "upload_to_pds": mock_upload_to_pds,
+            "build_record": mock_build_record,
+            "update_record": mock_update_record,
+        }
+
+
+async def test_optimize_swaps_wav_to_mp3_preserving_original_and_created_at(
+    db_session: AsyncSession, owner: Artist
+) -> None:
+    """happy path: WAV->MP3 swap, lossless original preserved, single PDS blob
+    written, record createdAt preserved, interim WAV deleted."""
+    track = _wav_track()
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+    track_id = track.id
+    original_created_at = track.created_at
+
+    deleted: list[str] = []
+    pds = PdsBlobResult(
+        blob_ref={"$type": "blob", "ref": {"$link": "bafyMP3BLOB"}, "size": 216},
+        cid="bafyMP3BLOB",
+        size=216,
+    )
+    with _patch_optimize(
+        transcode=_transcode_info("MP3NEW", "mp3"), pds=pds, deleted=deleted
+    ) as mocks:
+        await optimize_track_audio(track_id, "session-id")
+
+    # transcoded the lossless ORIGINAL to mp3 with the generous deferred timeout
+    call = mocks["transcode"].await_args
+    assert call.args[1] == "AIFFID"  # source = lossless original
+    assert call.args[3] == "aiff"  # source format
+    assert call.kwargs["target_format"] == "mp3"
+    assert (
+        call.kwargs["timeout_seconds"]
+        == settings.transcoder.optimize_timeout_seconds
+    )
+
+    # DB row swapped to the mp3 rendition; lossless original preserved
+    await db_session.refresh(track)
+    assert track.file_id == "MP3NEW"
+    assert track.file_type == "mp3"
+    assert track.r2_url == "https://audio.example/MP3NEW.mp3"
+    assert track.original_file_id == "AIFFID"
+    assert track.original_file_type == "aiff"
+    assert track.pds_blob_cid == "bafyMP3BLOB"
+    assert track.audio_storage == "both"
+    assert track.atproto_record_cid == "bafyNEWREC"
+
+    # the rebuilt record is built with the track's ORIGINAL createdAt, not a
+    # fresh one — so the optimization doesn't bump the track to "now".
+    assert mocks["build_record"].await_args.kwargs["created_at"] == original_created_at
+
+    # the interim WAV is now orphaned and was deleted
+    assert "WAVID" in deleted
+
+
+async def test_optimize_is_noop_when_already_mp3(
+    db_session: AsyncSession, owner: Artist
+) -> None:
+    """idempotency: a track already on the mp3 rendition is skipped (so docket
+    retries don't re-encode or clobber)."""
+    track = _wav_track(file_id="MP3DONE", file_type="mp3")
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+    track_id = track.id
+
+    with _patch_optimize(
+        transcode=_transcode_info("X", "mp3"), pds=None
+    ) as mocks:
+        await optimize_track_audio(track_id, "session-id")
+
+    mocks["transcode"].assert_not_awaited()
+    await db_session.refresh(track)
+    assert track.file_id == "MP3DONE"  # untouched
+
+
+async def test_optimize_failure_leaves_track_on_wav_and_drops_orphan_mp3(
+    db_session: AsyncSession, owner: Artist
+) -> None:
+    """if the record update fails after the MP3 was produced, the track stays on
+    its (consistent) WAV rendition and the orphaned MP3 is cleaned up."""
+    track = _wav_track()
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+    track_id = track.id
+
+    deleted: list[str] = []
+    with _patch_optimize(
+        transcode=_transcode_info("MP3NEW", "mp3"),
+        pds=None,
+        update_record_side_effect=RuntimeError("PDS putRecord exploded"),
+        deleted=deleted,
+    ):
+        await optimize_track_audio(track_id, "session-id")
+
+    # track unchanged — still on the WAV rendition
+    await db_session.refresh(track)
+    assert track.file_id == "WAVID"
+    assert track.file_type == "wav"
+
+    # the orphaned MP3 was deleted; the live WAV was NOT
+    assert "MP3NEW" in deleted
+    assert "WAVID" not in deleted
+
+
+async def test_optimize_skips_when_session_gone(
+    db_session: AsyncSession, owner: Artist
+) -> None:
+    """no session (expired) -> can't write to PDS; leave the track on WAV and
+    don't even start a transcode."""
+    track = _wav_track()
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+    track_id = track.id
+
+    with (
+        patch(
+            "backend.api.tracks.audio_optimize.get_session",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "backend.api.tracks.audio_optimize._transcode_audio",
+            new_callable=AsyncMock,
+        ) as mock_transcode,
+    ):
+        await optimize_track_audio(track_id, "session-id")
+
+    mock_transcode.assert_not_awaited()
+    await db_session.refresh(track)
+    assert track.file_id == "WAVID"

--- a/backend/tests/api/test_audio_optimize.py
+++ b/backend/tests/api/test_audio_optimize.py
@@ -83,19 +83,19 @@ def _wav_track(**overrides) -> Track:
     duration is a computed property backed by `extra`, so it's seeded there
     (mirrors the audio-replace suite's `make_track`).
     """
-    defaults = dict(
-        title="Long Mix",
-        artist_did=OWNER_DID,
-        file_id="WAVID",
-        file_type="wav",
-        original_file_id="AIFFID",
-        original_file_type="aiff",
-        atproto_record_uri=TRACK_URI,
-        atproto_record_cid="bafyWAV",
-        r2_url="https://audio.example/WAVID.wav",
-        audio_storage="r2",
-        extra={"duration": 5400},
-    )
+    defaults = {
+        "title": "Long Mix",
+        "artist_did": OWNER_DID,
+        "file_id": "WAVID",
+        "file_type": "wav",
+        "original_file_id": "AIFFID",
+        "original_file_type": "aiff",
+        "atproto_record_uri": TRACK_URI,
+        "atproto_record_cid": "bafyWAV",
+        "r2_url": "https://audio.example/WAVID.wav",
+        "audio_storage": "r2",
+        "extra": {"duration": 5400},
+    }
     defaults.update(overrides)
     return Track(**defaults)
 
@@ -378,8 +378,7 @@ async def test_optimize_swaps_wav_to_mp3_preserving_original_and_created_at(
     assert call.args[3] == "aiff"  # source format
     assert call.kwargs["target_format"] == "mp3"
     assert (
-        call.kwargs["timeout_seconds"]
-        == settings.transcoder.optimize_timeout_seconds
+        call.kwargs["timeout_seconds"] == settings.transcoder.optimize_timeout_seconds
     )
 
     # DB row swapped to the mp3 rendition; lossless original preserved
@@ -412,9 +411,7 @@ async def test_optimize_is_noop_when_already_mp3(
     await db_session.refresh(track)
     track_id = track.id
 
-    with _patch_optimize(
-        transcode=_transcode_info("X", "mp3"), pds=None
-    ) as mocks:
+    with _patch_optimize(transcode=_transcode_info("X", "mp3"), pds=None) as mocks:
         await optimize_track_audio(track_id, "session-id")
 
     mocks["transcode"].assert_not_awaited()
@@ -422,11 +419,12 @@ async def test_optimize_is_noop_when_already_mp3(
     assert track.file_id == "MP3DONE"  # untouched
 
 
-async def test_optimize_failure_leaves_track_on_wav_and_drops_orphan_mp3(
+async def test_optimize_transient_failure_raises_for_retry_and_drops_orphan_mp3(
     db_session: AsyncSession, owner: Artist
 ) -> None:
-    """if the record update fails after the MP3 was produced, the track stays on
-    its (consistent) WAV rendition and the orphaned MP3 is cleaned up."""
+    """transient failure before PDS publishes: the track stays on its WAV
+    rendition (consistent), the orphaned MP3 is cleaned up, and the exception
+    propagates so docket's `ExponentialRetry` can try again."""
     track = _wav_track()
     db_session.add(track)
     await db_session.commit()
@@ -434,11 +432,14 @@ async def test_optimize_failure_leaves_track_on_wav_and_drops_orphan_mp3(
     track_id = track.id
 
     deleted: list[str] = []
-    with _patch_optimize(
-        transcode=_transcode_info("MP3NEW", "mp3"),
-        pds=None,
-        update_record_side_effect=RuntimeError("PDS putRecord exploded"),
-        deleted=deleted,
+    with (
+        _patch_optimize(
+            transcode=_transcode_info("MP3NEW", "mp3"),
+            pds=None,
+            update_record_side_effect=RuntimeError("PDS putRecord exploded"),
+            deleted=deleted,
+        ),
+        pytest.raises(RuntimeError, match="PDS putRecord exploded"),
     ):
         await optimize_track_audio(track_id, "session-id")
 
@@ -447,9 +448,113 @@ async def test_optimize_failure_leaves_track_on_wav_and_drops_orphan_mp3(
     assert track.file_id == "WAVID"
     assert track.file_type == "wav"
 
-    # the orphaned MP3 was deleted; the live WAV was NOT
+    # the orphaned MP3 was deleted (PDS hadn't been told about it); the live
+    # WAV was NOT
     assert "MP3NEW" in deleted
     assert "WAVID" not in deleted
+
+
+async def test_optimize_aborts_when_track_replaced_during_encode(
+    db_session: AsyncSession, owner: Artist
+) -> None:
+    """race with `audio_replace`: if the track audio changes between when the
+    optimization captures state and when it goes to publish, the pre-publish
+    guard aborts terminally — the user's replacement is NOT clobbered."""
+    track = _wav_track()
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+    track_id = track.id
+
+    # simulate a concurrent audio_replace that lands between the optimize's
+    # _upload_to_pds and the pre-publish guard: side-effect on the PDS-upload
+    # boundary mutates the track row to a different rendition + lossless source.
+    from backend.utilities.database import db_session as app_db_session
+
+    async def replace_during_encode(*_a, **_kw):
+        async with app_db_session() as db:
+            row = await db.get(Track, track_id)
+            if row is not None:
+                row.file_id = "REPLACED_WAV"
+                row.original_file_id = "REPLACED_AIFF"
+                await db.commit()
+        return None  # _upload_to_pds returns None (no PDS blob)
+
+    deleted: list[str] = []
+    # _patch_optimize sets a default _upload_to_pds patch; we re-patch over it
+    # AFTER entering so our mutation side_effect wins.
+    with (
+        _patch_optimize(
+            transcode=_transcode_info("MP3NEW", "mp3"),
+            pds=None,
+            deleted=deleted,
+        ),
+        patch(
+            "backend.api.tracks.audio_optimize._upload_to_pds",
+            new_callable=AsyncMock,
+            side_effect=replace_during_encode,
+        ),
+    ):
+        await optimize_track_audio(track_id, "session-id")
+
+    # the user's replacement survives — optimize did NOT clobber it
+    await db_session.refresh(track)
+    assert track.file_id == "REPLACED_WAV"
+    assert track.original_file_id == "REPLACED_AIFF"
+
+    # the orphaned MP3 was cleaned up; we never published it to PDS
+    assert "MP3NEW" in deleted
+
+
+async def test_optimize_preserves_mp3_when_pds_published_then_cas_misses(
+    db_session: AsyncSession, owner: Artist
+) -> None:
+    """if a concurrent replace lands AFTER our PDS write but BEFORE our DB CAS,
+    the CAS misses and we abort — but we must NOT delete the MP3, because PDS
+    now references it and third-party readers may already be fetching the url.
+
+    better to leak storage than to 404 their playback. the racing replace will
+    overwrite our PDS record with its own audio shortly after.
+    """
+    track = _wav_track()
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+    track_id = track.id
+
+    # side-effect on update_record (which runs AFTER the pre-publish guard) —
+    # mutates the track AFTER PDS has been written, so the CAS in
+    # _commit_optimize_swap sees mismatched file_id and rowcount==0.
+    from backend.utilities.database import db_session as app_db_session
+
+    async def replace_after_pds_write(**_kwargs):
+        async with app_db_session() as db:
+            row = await db.get(Track, track_id)
+            if row is not None:
+                row.file_id = "REPLACED_AFTER_PDS"
+                row.original_file_id = "REPLACED_AIFF"
+                await db.commit()
+        return (TRACK_URI, "bafyNEWREC")
+
+    deleted: list[str] = []
+    with _patch_optimize(
+        transcode=_transcode_info("MP3NEW", "mp3"),
+        pds=PdsBlobResult(
+            blob_ref={"$type": "blob", "ref": {"$link": "bafyMP3"}, "size": 216},
+            cid="bafyMP3",
+            size=216,
+        ),
+        update_record_side_effect=replace_after_pds_write,
+        deleted=deleted,
+    ):
+        await optimize_track_audio(track_id, "session-id")
+
+    # the racing replace survived; our CAS correctly refused to overwrite it
+    await db_session.refresh(track)
+    assert track.file_id == "REPLACED_AFTER_PDS"
+
+    # CRUCIAL: the MP3 was NOT deleted — PDS references it
+    assert "MP3NEW" not in deleted
 
 
 async def test_optimize_skips_when_session_gone(

--- a/backend/tests/api/test_audio_optimize.py
+++ b/backend/tests/api/test_audio_optimize.py
@@ -454,6 +454,30 @@ async def test_optimize_transient_failure_raises_for_retry_and_drops_orphan_mp3(
     assert "WAVID" not in deleted
 
 
+async def test_optimize_transient_transcode_failure_raises_for_retry(
+    db_session: AsyncSession, owner: Artist
+) -> None:
+    """`_transcode_audio` returns None for the transient family (transcoder
+    timeout / 5xx / I/O error). That path must raise so docket's
+    `ExponentialRetry` actually fires — treating it as a terminal abort would
+    leave the track on WAV forever despite the explicit retry plumbing."""
+    track = _wav_track()
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+    track_id = track.id
+
+    with (
+        _patch_optimize(transcode=None, pds=None),
+        pytest.raises(RuntimeError, match="transcode to mp3 failed"),
+    ):
+        await optimize_track_audio(track_id, "session-id")
+
+    await db_session.refresh(track)
+    assert track.file_id == "WAVID"  # untouched; retry will try again
+    assert track.file_type == "wav"
+
+
 async def test_optimize_aborts_when_track_replaced_during_encode(
     db_session: AsyncSession, owner: Artist
 ) -> None:

--- a/backend/tests/test_transcoder.py
+++ b/backend/tests/test_transcoder.py
@@ -70,7 +70,7 @@ async def test_transcoder_client_success(
     temp_output_file: Path,
 ) -> None:
     """successful transcode streams the response body to output_path."""
-    response, stream_cm = _make_streaming_response(
+    _response, stream_cm = _make_streaming_response(
         [b"transcoded ", b"mp3 data"], {"content-type": "audio/mpeg"}
     )
 

--- a/loq.toml
+++ b/loq.toml
@@ -40,11 +40,11 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1624
+max_lines = 1692
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 1081
+max_lines = 1085
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
@@ -256,7 +256,7 @@ max_lines = 1050
 
 [[rules]]
 path = "backend/src/backend/api/tracks/audio_replace.py"
-max_lines = 813
+max_lines = 825
 
 [[rules]]
 path = "backend/tests/conftest.py"

--- a/loq.toml
+++ b/loq.toml
@@ -305,3 +305,7 @@ max_lines = 649
 [[rules]]
 path = "backend/tests/test_post_create_hooks.py"
 max_lines = 505
+
+[[rules]]
+path = "backend/tests/api/test_audio_optimize.py"
+max_lines = 584

--- a/loq.toml
+++ b/loq.toml
@@ -308,4 +308,4 @@ max_lines = 505
 
 [[rules]]
 path = "backend/tests/api/test_audio_optimize.py"
-max_lines = 584
+max_lines = 610

--- a/services/transcoder/Cargo.lock
+++ b/services/transcoder/Cargo.lock
@@ -176,6 +176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +693,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +807,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
 ]

--- a/services/transcoder/Cargo.toml
+++ b/services/transcoder/Cargo.toml
@@ -10,6 +10,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "signal", "process", "fs", "io-util"] }
+tokio-util = { version = "0.7", features = ["io"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tempfile = "3.10"

--- a/services/transcoder/src/main.rs
+++ b/services/transcoder/src/main.rs
@@ -18,6 +18,7 @@ use sanitize_filename::sanitize;
 use serde::Deserialize;
 use tempfile::TempDir;
 use tokio::{fs::File, io::AsyncWriteExt, net::TcpListener, process::Command};
+use tokio_util::io::ReaderStream;
 use tracing::{error, info, warn};
 
 #[derive(Debug, Deserialize, Default)]
@@ -119,9 +120,16 @@ async fn transcode(
     let output_path = temp_dir.path().join(format!("output.{}", target_ext));
     run_ffmpeg(&input_path, &output_path, &target_ext).await?;
 
-    let bytes = tokio::fs::read(&output_path)
+    // stream the output file back rather than reading it all into a Vec. a
+    // long lossless source produces a large output (a ~90-min WAV is ~900MB),
+    // and buffering that whole blob in memory OOM-kills a 1GB machine. we open
+    // the file now and hand the open handle to a ReaderStream; the TempDir
+    // drops when this function returns, unlinking the path, but the open fd
+    // keeps the bytes readable until the stream finishes (Unix unlinked-open).
+    let file = File::open(&output_path)
         .await
-        .map_err(|e| AppError::Io(format!("failed to read output file: {e}")))?;
+        .map_err(|e| AppError::Io(format!("failed to open output file: {e}")))?;
+    let body = Body::from_stream(ReaderStream::new(file));
 
     let media_type = match target_ext.as_str() {
         "mp3" => "audio/mpeg",
@@ -145,7 +153,7 @@ async fn transcode(
             HeaderValue::from_str(&format!("attachment; filename=\"{}\"", download_name))
                 .unwrap_or_else(|_| HeaderValue::from_static("attachment")),
         )
-        .body(Body::from(bytes))
+        .body(body)
         .map_err(|e| AppError::Http(e.to_string()))?;
 
     Ok(response)
@@ -222,7 +230,14 @@ async fn run_ffmpeg(input: &Path, output: &Path, target_ext: &str) -> Result<(),
             cmd.args(["-acodec", "libmp3lame", "-b:a", "320k", "-ar", "44100"]);
         }
         "wav" => {
-            cmd.args(["-acodec", "pcm_s16le", "-ar", "44100"]);
+            // compatibility remux: 16-bit little-endian PCM is the universal
+            // browser-playable floor. we deliberately do NOT force a sample
+            // rate or channel count — preserving the source keeps this a near-
+            // instant PCM rewrap (e.g. AIFF pcm_s16be -> WAV pcm_s16le is a
+            // byte-swap), instead of a full resample. the lossless master is
+            // retained separately by the caller, so 16-bit here is a delivery
+            // rendition, not the archival copy.
+            cmd.args(["-acodec", "pcm_s16le"]);
         }
         "m4a" => {
             cmd.args(["-acodec", "aac", "-b:a", "256k", "-ar", "44100"]);


### PR DESCRIPTION
**Lossless (AIFF) uploads no longer block on the slow MP3 encode.** They publish *immediately* with a fast 16-bit WAV compatibility rendition (a near-instant PCM rewrap), and a deferred background task produces the smaller MP3 streaming rendition off the critical path — swapping it in as the canonical playable file and writing the single PDS `audioBlob` when ready.

## why

woody.fm's upload of a **939 MB / ~90-min AIFF** failed twice with `"transcoding failed"` and produced no track. Diagnosis: the transcoder (1 shared CPU, 1 GB) takes **>10 min** to encode 90 min of audio with single-threaded `libmp3lame`, exceeding the client's **600 s** read timeout — and the encode was a *hard, deadline-bound prerequisite* for the track to exist. (It also tripped the stuck-upload reaper mid-encode, which is what surfaced it.)

The fix splits **publishing** from **optimization**: the track exists and plays in seconds; the economical MP3 is an enhancement, not a gate. AIFF and WAV are both uncompressed PCM, so AIFF→WAV is a byte-swap (seconds, any length), and WAV plays in every browser — whereas raw AIFF only plays in Safari/WebKit.

## what changed

**transcoder service** (`services/transcoder`)
- stream the output file back (`ReaderStream` over an open fd; the `TempDir` can drop because the unlinked-but-open fd keeps the bytes readable) instead of `fs::read`-ing the whole output into a `Vec` — a ~900 MB WAV output would OOM the 1 GB machine
- the `wav` target is now a **compatibility remux**: `pcm_s16le`, preserving source sample rate/channels (dropped the hardcoded `-ar 44100` resample)

**backend**
- `_store_audio` remuxes AIFF → WAV (not MP3) and sets `StorageResult.needs_optimization`
- `_upload_to_pds` skips at publish when `needs_optimization` — the interim WAV is large and throwaway; the deferred task writes the one canonical MP3 blob (publishing `audioUrl`-only is the already-supported large-file fallback shape)
- `_check_duplicate` also matches `original_file_id` so dedup survives the WAV→MP3 swap (the lossless source hash is stable; the playable `file_id` is not)
- new `api/tracks/audio_optimize.py` — `optimize_track_audio(track_id, session_id)`: transcodes the lossless original → MP3 (generous timeout), uploads the single PDS blob, rebuilds `fm.plyr.track` (preserving `createdAt`), swaps the rendition, deletes the interim WAV
- `audio_replace` enqueues the same optimization when a track's audio is replaced with a lossless source (shares `_store_audio`)

<details>
<summary>design notes & intentional non-behaviors</summary>

- **timeout, not OOM.** Confirmed via Fly machine events: the transcoder didn't crash (`oom_killed=false`); ffmpeg just ran past the client read timeout. So the fix is lifecycle (defer + generous timeout), not a memory bump.
- **streaming the *response* doesn't fix the encode timeout** — ffmpeg still runs to completion before the first byte. The deferred MP3 task instead uses `optimize_timeout_seconds` (default 3600) since no user waits; the on-critical-path WAV remux is seconds, so it never trips anything.
- **`JobType.OPTIMIZE`** is a distinct type so the stuck-upload reaper (scans `type='upload'`) never reaps a legitimately long MP3 encode.
- **canonical PDS blob is written once, as MP3.** The interim WAV is never pushed to the user's PDS (avoids a redundant ~900 MB upload). Between publish and optimize the record carries `audioUrl` (R2 WAV) and no `audioBlob`.
- **16-bit WAV is a delivery rendition, not the archival copy.** The lossless master is preserved untouched as `original_file_id`. 24-bit/hi-res WAV isn't universally browser-playable, so 16-bit is the compat floor (confirmed acceptable with @zzstoatzz.io for the initial cut).
- **failure is safe.** If the optimize can't complete (expired session, transcode failure, PDS error), the track stays on its fully-consistent WAV rendition and the orphaned MP3 is deleted; docket retries. The task is idempotent (a track already on MP3 is a no-op).
- **metadata is re-read right before the record rebuild** (the encode can run minutes) so a concurrent `PATCH /tracks/{id}` isn't clobbered; the swap touches audio fields only.
- **only AIFF is affected.** `is_web_playable = {mp3, wav, m4a, flac}`, so AIFF is the sole format that reached the transcoder; FLAC/WAV/M4A/MP3 paths are unchanged.

**deferred (not in this PR):**
- UI wording ("uploaded" vs "optimizing audio") — functionally the track plays the WAV then silently upgrades to MP3; a clean fast-follow.
- a global transcoder concurrency cap (currently keyed per-session, `max_concurrent=2`); fine at current upload volume.
- the reaper DM quality-of-life work (naming the stuck track) was explicitly deprioritized and stashed.

incidental: fixed a pre-existing RUF059 in `tests/test_transcoder.py` that `ruff check .` flags tree-wide.
</details>

## testing
- new `tests/api/test_audio_optimize.py` (8 tests): WAV remux + `needs_optimization` flag, PDS skip at publish, dedup via `original_file_id`, and the optimize task (WAV→MP3 swap preserving original + `createdAt`, single blob, interim-WAV deletion, idempotent no-op, safe-on-failure, skip-when-session-gone)
- full backend suite green (1123 passed); transcoder `cargo check` clean; lint + loq clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)