### PR TITLE
fix(portal): guard track-edit save against double-submit (#1460)

### DIFF
--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -37,6 +37,7 @@
 	let loadingMoreTracks = $state(false);
 	// track editing state
 	let editingTrackId = $state<number | null>(null);
+	let savingTrackEdit = $state(false);
 	let editTitle = $state('');
 	let editDescription = $state('');
 	let editAlbum = $state('');
@@ -633,6 +634,8 @@
 
 
 	async function saveTrackEdit(trackId: number) {
+		if (savingTrackEdit) return;
+		savingTrackEdit = true;
 		const formData = new FormData();
 		formData.append('title', editTitle);
 		formData.append('description', editDescription);
@@ -705,7 +708,9 @@
 			cancelEdit();
 			toast.success('track updated successfully');
 		} catch (e) {
-			alert(`network error: ${e instanceof Error ? e.message : 'unknown error'}`);
+			toast.error(`network error: ${e instanceof Error ? e.message : 'unknown error'}`);
+		} finally {
+			savingTrackEdit = false;
 		}
 	}
 
@@ -1336,6 +1341,7 @@
 											type="button"
 											class="edit-cancel-btn"
 											onclick={cancelEdit}
+											disabled={savingTrackEdit}
 										>
 											cancel
 										</button>
@@ -1343,10 +1349,10 @@
 											type="button"
 											class="edit-save-btn"
 											onclick={() => saveTrackEdit(track.id)}
-											disabled={hasUnresolvedEditFeaturesInput}
+											disabled={savingTrackEdit || hasUnresolvedEditFeaturesInput}
 											title={hasUnresolvedEditFeaturesInput ? "please select or clear featured artist" : "save changes"}
 										>
-											save changes
+											{savingTrackEdit ? 'saving...' : 'save changes'}
 										</button>
 									</div>
 								</div>

--- a/loq.toml
+++ b/loq.toml
@@ -156,7 +156,7 @@ max_lines = 2446
 
 [[rules]]
 path = "frontend/src/routes/portal/+page.svelte"
-max_lines = 3955
+max_lines = 3961
 
 [[rules]]
 path = "frontend/src/routes/settings/+page.svelte"


### PR DESCRIPTION
Clicking "save changes" twice on the track edit form fired two parallel `PATCH` requests; the second raced the first's `cancelEdit()` teardown and surfaced a jarring native `alert("network error")` — even though the edit had actually saved. Closes #1460.

`saveTrackEdit` was the **only** edit form in the frontend without a busy guard. Every other one — `saveProfile` (same file), `liked`, `playlist`, `album`, `profile/setup`, `CopyrightSection` — already has a saving flag + disabled button + "saving..." feedback. This brings the track edit in line.

<details>
<summary>changes</summary>

- new `savingTrackEdit` `$state` flag
- re-entrancy guard (`if (savingTrackEdit) return`) at the top of `saveTrackEdit`, with the flag reset in a `finally` so the early `!response.ok` return still clears it
- both edit buttons (`cancel` + `save changes`) disabled while saving; the save button shows `saving...` (matching `saveProfile`'s copy in the same file)
- the `catch` now uses `toast.error(...)` instead of `alert(...)` — this was the **last remaining `alert()` in the entire frontend**

</details>

<details>
<summary>scope / non-behaviors</summary>

- audited all six other edit/save forms before fixing; none needed changes — they already guard double-submit. this is a consistency fix that closes the one gap.
- did **not** extract the track-edit form into its own component. `portal/+page.svelte` is the known ~3.9k-line monolith; the +6 lines tripped loq, so the limit was relaxed via `just loq-relax` per project convention. a proper extraction is a separate, larger refactor.
- frontend-only; no backend or schema changes. no telemetry added (frontend logfire is off by convention).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)