### PR TITLE
refactor(portal): extract playlists section into PlaylistsSection.svelte

### DIFF
--- a/frontend/src/lib/components/portal/PlaylistsSection.svelte
+++ b/frontend/src/lib/components/portal/PlaylistsSection.svelte
@@ -1,0 +1,231 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import WaveLoading from '$lib/components/WaveLoading.svelte';
+	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
+	import type { Playlist } from '$lib/types';
+	import { API_URL } from '$lib/config';
+
+	let playlists = $state<Playlist[]>([]);
+	let loadingPlaylists = $state(false);
+
+	async function loadMyPlaylists() {
+		loadingPlaylists = true;
+		try {
+			const response = await fetch(`${API_URL}/lists/playlists`, {
+				credentials: 'include'
+			});
+			if (response.ok) {
+				playlists = await response.json();
+			}
+		} catch (_e) {
+			console.error('failed to load playlists:', _e);
+		} finally {
+			loadingPlaylists = false;
+		}
+	}
+
+	onMount(loadMyPlaylists);
+</script>
+
+<section class="playlists-section">
+	<div class="section-header">
+		<h2>your playlists</h2>
+		<a href="/library" class="view-playlists-link">manage playlists →</a>
+	</div>
+
+	{#if loadingPlaylists}
+		<div class="loading-container">
+			<WaveLoading size="lg" message="loading playlists..." />
+		</div>
+	{:else if playlists.length === 0}
+		<p class="empty">no playlists yet - <a href="/library">create a new playlist</a></p>
+	{:else}
+		<div class="playlists-grid">
+			{#each playlists as playlist}
+				<a href="/playlist/{playlist.id}" class="playlist-card">
+					{#if playlist.image_url}
+						<SensitiveImage src={playlist.image_url} compact tooltipPosition="above">
+							<img src={playlist.image_url} alt="{playlist.name} cover" class="playlist-cover" />
+						</SensitiveImage>
+					{:else}
+						<div class="playlist-cover-placeholder">
+							<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+								<line x1="8" y1="6" x2="21" y2="6"></line>
+								<line x1="8" y1="12" x2="21" y2="12"></line>
+								<line x1="8" y1="18" x2="21" y2="18"></line>
+								<line x1="3" y1="6" x2="3.01" y2="6"></line>
+								<line x1="3" y1="12" x2="3.01" y2="12"></line>
+								<line x1="3" y1="18" x2="3.01" y2="18"></line>
+							</svg>
+						</div>
+					{/if}
+					<div class="playlist-info">
+						<h3 class="playlist-title">{playlist.name}</h3>
+						<p class="playlist-stats">{playlist.track_count} {playlist.track_count === 1 ? 'track' : 'tracks'}</p>
+					</div>
+				</a>
+			{/each}
+		</div>
+	{/if}
+</section>
+
+<style>
+	/* shared page-level primitives — duplicated here because Svelte scoped CSS
+	   does not cross the component boundary; the parent keeps its own copies for
+	   the remaining sections. */
+	.section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 1rem;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	.section-header h2 {
+		margin-bottom: 0;
+	}
+
+	.empty {
+		color: var(--text-muted);
+		padding: 2rem;
+		text-align: center;
+		background: var(--bg-tertiary);
+		border-radius: var(--radius-md);
+		border: 1px solid var(--border-subtle);
+	}
+
+	.loading-container {
+		display: flex;
+		justify-content: center;
+		padding: 3rem 1rem;
+	}
+
+	/* playlists section */
+	.playlists-section {
+		margin-top: 3rem;
+	}
+
+	.playlists-section h2 {
+		font-size: var(--text-page-heading);
+		margin-bottom: 1.5rem;
+	}
+
+	.view-playlists-link {
+		color: var(--text-secondary);
+		text-decoration: none;
+		font-size: var(--text-sm);
+		padding: 0.35rem 0.6rem;
+		background: var(--bg-tertiary);
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--border-default);
+		transition: all 0.15s;
+		white-space: nowrap;
+	}
+
+	.view-playlists-link:hover {
+		border-color: var(--accent);
+		color: var(--accent);
+		background: var(--bg-hover);
+	}
+
+	.playlists-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+		gap: 1.5rem;
+	}
+
+	.playlist-card {
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-md);
+		padding: 1rem;
+		transition: all 0.2s;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.playlist-card:hover {
+		border-color: var(--accent);
+		transform: translateY(-2px);
+	}
+
+	.playlist-cover {
+		width: 100%;
+		aspect-ratio: 1;
+		border-radius: var(--radius-base);
+		object-fit: cover;
+	}
+
+	.playlist-cover-placeholder {
+		width: 100%;
+		aspect-ratio: 1;
+		border-radius: var(--radius-base);
+		background: linear-gradient(135deg, rgba(var(--accent-rgb, 139, 92, 246), 0.15), rgba(var(--accent-rgb, 139, 92, 246), 0.05));
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--accent);
+	}
+
+	.playlist-info {
+		min-width: 0;
+		flex: 1;
+	}
+
+	.playlist-title {
+		font-size: var(--text-lg);
+		font-weight: 600;
+		color: var(--text-primary);
+		margin: 0 0 0.25rem 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.playlist-stats {
+		font-size: var(--text-sm);
+		color: var(--text-tertiary);
+		margin: 0;
+	}
+
+	@media (max-width: 600px) {
+		.playlists-section h2 {
+			font-size: var(--text-xl);
+		}
+
+		.section-header {
+			margin-bottom: 0.75rem;
+		}
+
+		.playlists-section {
+			margin-top: 2rem;
+		}
+
+		.playlists-grid {
+			grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+			gap: 0.75rem;
+		}
+
+		.playlist-card {
+			padding: 0.75rem;
+			gap: 0.5rem;
+		}
+
+		.playlist-title {
+			font-size: var(--text-sm);
+		}
+
+		.playlist-stats {
+			font-size: var(--text-xs);
+		}
+
+		.view-playlists-link {
+			font-size: var(--text-xs);
+			padding: 0.3rem 0.5rem;
+		}
+	}
+</style>

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -16,7 +16,6 @@
 	import CopyrightRightsPanel from '$lib/components/CopyrightRightsPanel.svelte';
 	import type { TrackRights } from '$lib/components/CopyrightRightsPanel.svelte';
 	import type { Track, FeaturedArtist, AlbumSummary } from '$lib/types';
-	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import AudioRevisionsSheet from '$lib/components/AudioRevisionsSheet.svelte';
 	import { API_URL, getServerConfig } from '$lib/config';

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -12,9 +12,10 @@
 	import PdsAudioUploadsToggle from '$lib/components/PdsAudioUploadsToggle.svelte';
 	import PdsBackfillControl from '$lib/components/PdsBackfillControl.svelte';
 	import CopyrightSection from '$lib/components/CopyrightSection.svelte';
+	import PlaylistsSection from '$lib/components/portal/PlaylistsSection.svelte';
 	import CopyrightRightsPanel from '$lib/components/CopyrightRightsPanel.svelte';
 	import type { TrackRights } from '$lib/components/CopyrightRightsPanel.svelte';
-	import type { Track, FeaturedArtist, AlbumSummary, Playlist } from '$lib/types';
+	import type { Track, FeaturedArtist, AlbumSummary } from '$lib/types';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import AudioRevisionsSheet from '$lib/components/AudioRevisionsSheet.svelte';
@@ -100,10 +101,6 @@
 	// album management state
 	let albums = $state<AlbumSummary[]>([]);
 	let loadingAlbums = $state(false);
-
-	// playlist management state
-	let playlists = $state<Playlist[]>([]);
-	let loadingPlaylists = $state(false);
 
 	// share links state
 	interface ShareLinkUser {
@@ -203,7 +200,6 @@
 				loadMyTracks(),
 				loadArtistProfile(),
 				loadMyAlbums(),
-				loadMyPlaylists(),
 				loadShares()
 			]);
 		} catch (_e) {
@@ -323,22 +319,6 @@
 			console.error('failed to load albums:', _e);
 		} finally {
 			loadingAlbums = false;
-		}
-	}
-
-	async function loadMyPlaylists() {
-		loadingPlaylists = true;
-		try {
-			const response = await fetch(`${API_URL}/lists/playlists`, {
-				credentials: 'include'
-			});
-			if (response.ok) {
-				playlists = await response.json();
-			}
-		} catch (_e) {
-			console.error('failed to load playlists:', _e);
-		} finally {
-			loadingPlaylists = false;
 		}
 	}
 
@@ -1519,47 +1499,7 @@
 			{/if}
 		</section>
 
-		<section class="playlists-section">
-			<div class="section-header">
-				<h2>your playlists</h2>
-				<a href="/library" class="view-playlists-link">manage playlists →</a>
-			</div>
-
-			{#if loadingPlaylists}
-				<div class="loading-container">
-					<WaveLoading size="lg" message="loading playlists..." />
-				</div>
-			{:else if playlists.length === 0}
-				<p class="empty">no playlists yet - <a href="/library">create a new playlist</a></p>
-			{:else}
-				<div class="playlists-grid">
-					{#each playlists as playlist}
-						<a href="/playlist/{playlist.id}" class="playlist-card">
-							{#if playlist.image_url}
-								<SensitiveImage src={playlist.image_url} compact tooltipPosition="above">
-									<img src={playlist.image_url} alt="{playlist.name} cover" class="playlist-cover" />
-								</SensitiveImage>
-							{:else}
-								<div class="playlist-cover-placeholder">
-									<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-										<line x1="8" y1="6" x2="21" y2="6"></line>
-										<line x1="8" y1="12" x2="21" y2="12"></line>
-										<line x1="8" y1="18" x2="21" y2="18"></line>
-										<line x1="3" y1="6" x2="3.01" y2="6"></line>
-										<line x1="3" y1="12" x2="3.01" y2="12"></line>
-										<line x1="3" y1="18" x2="3.01" y2="18"></line>
-									</svg>
-								</div>
-							{/if}
-							<div class="playlist-info">
-								<h3 class="playlist-title">{playlist.name}</h3>
-								<p class="playlist-stats">{playlist.track_count} {playlist.track_count === 1 ? 'track' : 'tracks'}</p>
-							</div>
-						</a>
-					{/each}
-				</div>
-			{/if}
-		</section>
+		<PlaylistsSection />
 
 		<section class="shares-section">
 			<div class="section-header">
@@ -3073,97 +3013,6 @@
 		margin: 0;
 	}
 
-	/* playlists section */
-	.playlists-section {
-		margin-top: 3rem;
-	}
-
-	.playlists-section h2 {
-		font-size: var(--text-page-heading);
-		margin-bottom: 1.5rem;
-	}
-
-	.view-playlists-link {
-		color: var(--text-secondary);
-		text-decoration: none;
-		font-size: var(--text-sm);
-		padding: 0.35rem 0.6rem;
-		background: var(--bg-tertiary);
-		border-radius: var(--radius-sm);
-		border: 1px solid var(--border-default);
-		transition: all 0.15s;
-		white-space: nowrap;
-	}
-
-	.view-playlists-link:hover {
-		border-color: var(--accent);
-		color: var(--accent);
-		background: var(--bg-hover);
-	}
-
-	.playlists-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-		gap: 1.5rem;
-	}
-
-	.playlist-card {
-		background: var(--bg-tertiary);
-		border: 1px solid var(--border-subtle);
-		border-radius: var(--radius-md);
-		padding: 1rem;
-		transition: all 0.2s;
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		text-decoration: none;
-		color: inherit;
-	}
-
-	.playlist-card:hover {
-		border-color: var(--accent);
-		transform: translateY(-2px);
-	}
-
-	.playlist-cover {
-		width: 100%;
-		aspect-ratio: 1;
-		border-radius: var(--radius-base);
-		object-fit: cover;
-	}
-
-	.playlist-cover-placeholder {
-		width: 100%;
-		aspect-ratio: 1;
-		border-radius: var(--radius-base);
-		background: linear-gradient(135deg, rgba(var(--accent-rgb, 139, 92, 246), 0.15), rgba(var(--accent-rgb, 139, 92, 246), 0.05));
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		color: var(--accent);
-	}
-
-	.playlist-info {
-		min-width: 0;
-		flex: 1;
-	}
-
-	.playlist-title {
-		font-size: var(--text-lg);
-		font-weight: 600;
-		color: var(--text-primary);
-		margin: 0 0 0.25rem 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	.playlist-stats {
-		font-size: var(--text-sm);
-		color: var(--text-tertiary);
-		margin: 0;
-	}
-
 	/* shares section */
 	.shares-section {
 		margin-top: 3rem;
@@ -3720,7 +3569,6 @@
 		.profile-section h2,
 		.tracks-section h2,
 		.albums-section h2,
-		.playlists-section h2,
 		.data-section h2 {
 			font-size: var(--text-xl);
 		}
@@ -3799,7 +3647,6 @@
 		/* tracks mobile */
 		.tracks-section,
 		.albums-section,
-		.playlists-section,
 		.data-section {
 			margin-top: 2rem;
 		}
@@ -3934,28 +3781,5 @@
 			font-size: var(--text-sm);
 		}
 
-		/* playlists mobile */
-		.playlists-grid {
-			grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-			gap: 0.75rem;
-		}
-
-		.playlist-card {
-			padding: 0.75rem;
-			gap: 0.5rem;
-		}
-
-		.playlist-title {
-			font-size: var(--text-sm);
-		}
-
-		.playlist-stats {
-			font-size: var(--text-xs);
-		}
-
-		.view-playlists-link {
-			font-size: var(--text-xs);
-			padding: 0.3rem 0.5rem;
-		}
 	}
 </style>


### PR DESCRIPTION
Extracts the read-only "your playlists" section of `portal/+page.svelte` into a co-located, self-loading child component. Parent shrinks **3961 → 3785** lines (-176). No behavior change.

<details>
<summary>details</summary>

**Files created**
- `frontend/src/lib/components/portal/PlaylistsSection.svelte` (231 lines, loq green)

**State moved into the child**
- `playlists: $state<Playlist[]>([])`
- `loadingPlaylists: $state(false)`

**Functions moved into the child**
- `loadMyPlaylists()` — the section owns all the state it touches, so the child self-loads via `onMount(loadMyPlaylists)` instead of being driven by the parent's `onMount` `Promise.all`. `loadMyPlaylists` already swallowed its own errors (`try/catch` + `console.error`), so dropping it from the aggregate `error = 'failed to load portal data'` path is a no-op.

**Props / callbacks**
- none — the section is read-only (display list + static `<a>` links to `/library` and `/playlist/{id}`). No create/edit/delete happens here, so there is no parent state to invalidate.

**CSS handling**
- Owned selectors moved verbatim into the child's scoped `<style>`: `.playlists-section`, `.playlists-section h2`, `.view-playlists-link(:hover)`, `.playlists-grid`, `.playlist-card(:hover)`, `.playlist-cover`, `.playlist-cover-placeholder`, `.playlist-info`, `.playlist-title`, `.playlist-stats`, plus the 600px `/* playlists mobile */` overrides.
- Shared page-level primitives (`.section-header`, `.section-header h2`, `.empty`, `.loading-container`) are **duplicated** (minimally) into the child because Svelte scoped CSS does not cross the component boundary. The parent keeps its own copies for the other sections (tracks/albums/shares/data) — none were removed.
- The grouped multi-section mobile rules survive in the parent; only the now-dead `.playlists-section` / `.playlists-section h2` tokens were dropped from them (the child re-declares its own h2 sizing and section margin), which also clears the two `css_unused_selector` warnings.
- `SensitiveImage` wrapper (compact, `tooltipPosition="above"`) preserved exactly to keep NSFW-blur gating on playlist covers.

**Verification**
- `just frontend check` → 0 errors, 0 warnings
- `uvx loq` → green (841 files ok)

Visual QA on staging is still needed — svelte-check cannot catch CSS-scoping regressions at runtime.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)