### PR TITLE
refactor(portal): extract profile section into ProfileSection.svelte

### DIFF
--- a/frontend/src/lib/components/portal/ProfileSection.svelte
+++ b/frontend/src/lib/components/portal/ProfileSection.svelte
@@ -1,0 +1,561 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { API_URL } from '$lib/config';
+	import { toast } from '$lib/toast.svelte';
+	import { auth } from '$lib/auth.svelte';
+
+	interface Props {
+		atprotofansEligible: boolean;
+		checkingAtprotofans: boolean;
+	}
+
+	let { atprotofansEligible, checkingAtprotofans }: Props = $props();
+
+	let displayName = $state('');
+	let bio = $state('');
+	let avatarUrl = $state('');
+	// support link mode: 'none' | 'atprotofans' | 'custom'
+	let supportLinkMode = $state<'none' | 'atprotofans' | 'custom'>('none');
+	let customSupportUrl = $state('');
+	let savingProfile = $state(false);
+
+	async function loadArtistProfile() {
+		try {
+			const [artistRes, prefsRes] = await Promise.all([
+				fetch(`${API_URL}/artists/me`, { credentials: 'include' }),
+				fetch(`${API_URL}/preferences/`, { credentials: 'include' })
+			]);
+
+			if (artistRes.ok) {
+				const artist = await artistRes.json();
+				displayName = artist.display_name;
+				bio = artist.bio || '';
+				avatarUrl = artist.avatar_url || '';
+			}
+
+			if (prefsRes.ok) {
+				const prefs = await prefsRes.json();
+				// parse support_url into mode + custom URL
+				const url = prefs.support_url || '';
+				if (!url) {
+					supportLinkMode = 'none';
+					customSupportUrl = '';
+				} else if (url === 'atprotofans') {
+					supportLinkMode = 'atprotofans';
+					customSupportUrl = '';
+				} else {
+					supportLinkMode = 'custom';
+					customSupportUrl = url;
+				}
+			}
+		} catch (_e) {
+			console.error('failed to load artist profile:', _e);
+		}
+	}
+
+	async function saveProfile(e: SubmitEvent) {
+		e.preventDefault();
+		savingProfile = true;
+
+		try {
+			// compute support_url value based on mode
+			let supportUrlValue = '';
+			if (supportLinkMode === 'atprotofans') {
+				supportUrlValue = 'atprotofans';
+			} else if (supportLinkMode === 'custom') {
+				const trimmed = customSupportUrl.trim();
+				if (trimmed && !trimmed.startsWith('https://')) {
+					toast.error('custom support link must start with https://');
+					savingProfile = false;
+					return;
+				}
+				supportUrlValue = trimmed;
+			}
+
+			// save artist profile and support URL in parallel
+			const [artistRes, prefsRes] = await Promise.all([
+				fetch(`${API_URL}/artists/me`, {
+					method: 'PUT',
+					headers: { 'Content-Type': 'application/json' },
+					credentials: 'include',
+					body: JSON.stringify({
+						display_name: displayName,
+						bio: bio || null,
+						avatar_url: avatarUrl || null
+					})
+				}),
+				fetch(`${API_URL}/preferences/`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					credentials: 'include',
+					body: JSON.stringify({ support_url: supportUrlValue })
+				})
+			]);
+
+			if (artistRes.ok && prefsRes.ok) {
+				toast.success('profile updated');
+			} else if (!artistRes.ok) {
+				const errorData = await artistRes.json();
+				toast.error(errorData.detail || 'failed to update profile');
+			} else {
+				toast.error('failed to update support link');
+			}
+		} catch (e) {
+			toast.error(`network error: ${e instanceof Error ? e.message : 'unknown error'}`);
+		} finally {
+			savingProfile = false;
+		}
+	}
+
+	onMount(loadArtistProfile);
+</script>
+
+<section class="profile-section">
+	<div class="section-header">
+		<h2>profile</h2>
+		{#if auth.user}
+			<a href="/u/{auth.user.handle}" class="view-profile-link">view public profile</a>
+		{/if}
+	</div>
+
+	<form onsubmit={saveProfile}>
+		<div class="form-group">
+			<label for="display-name">artist name *</label>
+			<input
+				id="display-name"
+				type="text"
+				bind:value={displayName}
+				required
+				disabled={savingProfile}
+				placeholder="your artist name"
+			/>
+			<p class="hint">this is shown on all your tracks</p>
+		</div>
+
+		<div class="form-group">
+			<label for="bio">bio (optional)</label>
+			<textarea
+				id="bio"
+				bind:value={bio}
+				disabled={savingProfile}
+				placeholder="tell us about your music..."
+				rows="4"
+				maxlength="2560"
+			></textarea>
+			{#if bio.length > 0}
+				<div class="char-count">{bio.length} / 2560</div>
+			{/if}
+		</div>
+
+		<div class="form-group">
+			<label for="avatar">avatar url (optional)</label>
+			<input
+				id="avatar"
+				type="url"
+				bind:value={avatarUrl}
+				disabled={savingProfile}
+				placeholder="https://example.com/avatar.jpg"
+			/>
+			{#if avatarUrl}
+				<div class="avatar-preview">
+					<img src={avatarUrl} alt="avatar preview" />
+				</div>
+			{/if}
+		</div>
+
+		<div class="form-group support-link-group" role="group" aria-labelledby="support-link-label">
+			<span id="support-link-label" class="form-label">support link (optional)</span>
+			<div class="support-options">
+				<label class="support-option">
+					<input
+						type="radio"
+						name="support-mode"
+						value="none"
+						bind:group={supportLinkMode}
+						disabled={savingProfile}
+					/>
+					<span>none</span>
+				</label>
+				<label class="support-option" class:disabled={!atprotofansEligible && supportLinkMode !== 'atprotofans'}>
+					<input
+						type="radio"
+						name="support-mode"
+						value="atprotofans"
+						bind:group={supportLinkMode}
+						disabled={savingProfile || (!atprotofansEligible && supportLinkMode !== 'atprotofans')}
+					/>
+					<span>atprotofans</span>
+					{#if checkingAtprotofans}
+						<span class="support-status">checking...</span>
+					{:else if !atprotofansEligible}
+						<a href="https://atprotofans.com" target="_blank" rel="noopener" class="support-setup-link">set up</a>
+					{:else}
+						<a href="https://atprotofans.com/u/{auth.user?.did}" target="_blank" rel="noopener" class="support-status-link">profile ready</a>
+					{/if}
+				</label>
+				<label class="support-option">
+					<input
+						type="radio"
+						name="support-mode"
+						value="custom"
+						bind:group={supportLinkMode}
+						disabled={savingProfile}
+					/>
+					<span>custom link</span>
+				</label>
+			</div>
+			{#if supportLinkMode === 'custom'}
+				<input
+					id="custom-support-url"
+					type="url"
+					bind:value={customSupportUrl}
+					disabled={savingProfile}
+					placeholder="https://ko-fi.com/yourname"
+					class="custom-support-input"
+				/>
+			{/if}
+			<p class="hint">
+				{#if supportLinkMode === 'atprotofans'}
+					uses <a href="https://atprotofans.com" target="_blank" rel="noopener">atprotofans</a> for ATProto-native support
+				{:else if supportLinkMode === 'custom'}
+					link to Ko-fi, Patreon, or similar - shown on your profile
+				{:else}
+					no support link will be shown on your profile
+				{/if}
+			</p>
+		</div>
+
+		<button type="submit" disabled={savingProfile || !displayName}>
+			{savingProfile ? 'saving...' : 'save profile'}
+		</button>
+	</form>
+</section>
+
+<style>
+	/* shared page-level primitives — duplicated here because Svelte scoped CSS
+	   does not cross the component boundary; the parent keeps its own copies for
+	   the remaining sections. */
+	.section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 1rem;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	.section-header h2 {
+		margin-bottom: 0;
+	}
+
+	form {
+		background: var(--bg-tertiary);
+		padding: 1.25rem;
+		border-radius: var(--radius-md);
+		border: 1px solid var(--border-subtle);
+	}
+
+	.form-group {
+		margin-bottom: 1rem;
+	}
+
+	.form-group:last-of-type {
+		margin-bottom: 1.25rem;
+	}
+
+	label {
+		display: block;
+		color: var(--text-secondary);
+		margin-bottom: 0.4rem;
+		font-size: var(--text-sm);
+	}
+
+	input[type='text'],
+	input[type='url'],
+	textarea {
+		width: 100%;
+		padding: 0.6rem 0.75rem;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-sm);
+		color: var(--text-primary);
+		font-size: var(--text-base);
+		font-family: inherit;
+		transition: all 0.15s;
+	}
+
+	input[type='text']:focus,
+	input[type='url']:focus,
+	textarea:focus {
+		outline: none;
+		border-color: var(--accent);
+	}
+
+	input[type='text']:disabled,
+	input[type='url']:disabled,
+	textarea:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	textarea {
+		resize: vertical;
+		min-height: 80px;
+	}
+
+	.hint {
+		margin-top: 0.35rem;
+		font-size: var(--text-xs);
+		color: var(--text-muted);
+	}
+
+	.char-count {
+		font-size: var(--text-xs);
+		color: var(--text-tertiary);
+		text-align: right;
+	}
+
+	.hint a {
+		color: var(--accent);
+		text-decoration: none;
+	}
+
+	.hint a:hover {
+		text-decoration: underline;
+	}
+
+	/* profile section */
+	.profile-section {
+		margin-bottom: 2rem;
+	}
+
+	.profile-section h2 {
+		font-size: var(--text-page-heading);
+		margin-bottom: 1rem;
+	}
+
+	.view-profile-link {
+		color: var(--text-secondary);
+		text-decoration: none;
+		font-size: var(--text-sm);
+		padding: 0.35rem 0.6rem;
+		background: var(--bg-tertiary);
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--border-default);
+		transition: all 0.15s;
+		white-space: nowrap;
+	}
+
+	.view-profile-link:hover {
+		border-color: var(--accent);
+		color: var(--accent);
+		background: var(--bg-hover);
+	}
+
+	/* support link options */
+	.support-link-group .form-label {
+		display: block;
+		color: var(--text-secondary);
+		margin-bottom: 0.6rem;
+		font-size: var(--text-sm);
+	}
+
+	.support-options {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		margin-bottom: 0.75rem;
+	}
+
+	.support-option {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.6rem 0.75rem;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-base);
+		cursor: pointer;
+		transition: all 0.15s;
+		margin-bottom: 0;
+	}
+
+	.support-option:hover {
+		border-color: var(--border-emphasis);
+	}
+
+	.support-option:has(input:checked) {
+		border-color: var(--accent);
+		background: color-mix(in srgb, var(--accent) 8%, var(--bg-primary));
+	}
+
+	.support-option input[type='radio'] {
+		width: 16px;
+		height: 16px;
+		accent-color: var(--accent);
+		margin: 0;
+	}
+
+	.support-option span {
+		font-size: var(--text-base);
+		color: var(--text-primary);
+	}
+
+	.support-status {
+		margin-left: auto;
+		font-size: var(--text-xs);
+		color: var(--text-tertiary);
+	}
+
+	.support-setup-link,
+	.support-status-link {
+		margin-left: auto;
+		font-size: var(--text-xs);
+		text-decoration: none;
+	}
+
+	.support-setup-link {
+		color: var(--accent);
+	}
+
+	.support-status-link {
+		color: var(--success, #22c55e);
+	}
+
+	.support-setup-link:hover,
+	.support-status-link:hover {
+		text-decoration: underline;
+	}
+
+	.support-option.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.support-option.disabled input {
+		cursor: not-allowed;
+	}
+
+	.custom-support-input {
+		width: 100%;
+		padding: 0.6rem 0.75rem;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-sm);
+		color: var(--text-primary);
+		font-size: var(--text-base);
+		font-family: inherit;
+		transition: all 0.15s;
+		margin-bottom: 0.5rem;
+	}
+
+	.custom-support-input:focus {
+		outline: none;
+		border-color: var(--accent);
+	}
+
+	.custom-support-input:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.avatar-preview {
+		margin-top: 1rem;
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.avatar-preview img {
+		width: 64px;
+		height: 64px;
+		border-radius: var(--radius-full);
+		object-fit: cover;
+		border: 2px solid var(--border-default);
+	}
+
+	/* form submit buttons only */
+	form button[type="submit"] {
+		width: 100%;
+		padding: 0.75rem;
+		background: var(--accent);
+		color: var(--text-primary);
+		border: none;
+		border-radius: var(--radius-sm);
+		font-size: var(--text-lg);
+		font-weight: 600;
+		font-family: inherit;
+		cursor: pointer;
+		transition: all 0.2s;
+	}
+
+	form button[type="submit"]:hover:not(:disabled) {
+		background: var(--accent-hover);
+		transform: translateY(-1px);
+		box-shadow: 0 4px 12px color-mix(in srgb, var(--accent) 30%, transparent);
+	}
+
+	form button[type="submit"]:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+		transform: none;
+	}
+
+	form button[type="submit"]:active:not(:disabled) {
+		transform: translateY(0);
+	}
+
+	/* mobile responsive */
+	@media (max-width: 600px) {
+		.profile-section h2 {
+			font-size: var(--text-xl);
+		}
+
+		.section-header {
+			margin-bottom: 0.75rem;
+		}
+
+		.view-profile-link {
+			font-size: var(--text-xs);
+			padding: 0.3rem 0.5rem;
+		}
+
+		form {
+			padding: 1rem;
+		}
+
+		.form-group {
+			margin-bottom: 0.85rem;
+		}
+
+		label {
+			font-size: var(--text-sm);
+			margin-bottom: 0.3rem;
+		}
+
+		input[type='text'],
+		input[type='url'],
+		textarea {
+			padding: 0.5rem 0.6rem;
+			font-size: var(--text-base);
+		}
+
+		textarea {
+			min-height: 70px;
+		}
+
+		.hint {
+			font-size: var(--text-xs);
+		}
+
+		.avatar-preview img {
+			width: 48px;
+			height: 48px;
+		}
+
+		form button[type="submit"] {
+			padding: 0.6rem;
+			font-size: var(--text-base);
+		}
+	}
+</style>

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -10,6 +10,7 @@
 	import PdsBackfillControl from '$lib/components/PdsBackfillControl.svelte';
 	import CopyrightSection from '$lib/components/CopyrightSection.svelte';
 	import PlaylistsSection from '$lib/components/portal/PlaylistsSection.svelte';
+	import ProfileSection from '$lib/components/portal/ProfileSection.svelte';
 	import TracksSection from '$lib/components/portal/TracksSection.svelte';
 	import AlbumsSection from '$lib/components/portal/AlbumsSection.svelte';
 	import SharesSection from '$lib/components/portal/SharesSection.svelte';
@@ -26,15 +27,7 @@
 	let tracksHasMore = $state(false);
 	let loadingTracks = $state(false);
 	let loadingMoreTracks = $state(false);
-	// profile editing state
-	let displayName = $state('');
-	let bio = $state('');
-	let avatarUrl = $state('');
-	// support link mode: 'none' | 'atprotofans' | 'custom'
-	let supportLinkMode = $state<'none' | 'atprotofans' | 'custom'>('none');
-	let customSupportUrl = $state('');
-	let savingProfile = $state(false);
-	// atprotofans eligibility - checked on mount
+	// atprotofans eligibility - checked on mount; shared with TracksSection + ProfileSection
 	let atprotofansEligible = $state(false);
 	let checkingAtprotofans = $state(false);
 
@@ -110,7 +103,7 @@
 		try {
 			await Promise.all([
 				loadMyTracks(),
-				loadArtistProfile(),
+				checkAtprotofansEligibility(),
 				loadMyAlbums()
 			]);
 		} catch (_e) {
@@ -182,41 +175,6 @@
 		}
 	}
 
-	async function loadArtistProfile() {
-		try {
-			const [artistRes, prefsRes] = await Promise.all([
-				fetch(`${API_URL}/artists/me`, { credentials: 'include' }),
-				fetch(`${API_URL}/preferences/`, { credentials: 'include' }),
-				checkAtprotofansEligibility()
-			]);
-
-			if (artistRes.ok) {
-				const artist = await artistRes.json();
-				displayName = artist.display_name;
-				bio = artist.bio || '';
-				avatarUrl = artist.avatar_url || '';
-			}
-
-			if (prefsRes.ok) {
-				const prefs = await prefsRes.json();
-				// parse support_url into mode + custom URL
-				const url = prefs.support_url || '';
-				if (!url) {
-					supportLinkMode = 'none';
-					customSupportUrl = '';
-				} else if (url === 'atprotofans') {
-					supportLinkMode = 'atprotofans';
-					customSupportUrl = '';
-				} else {
-					supportLinkMode = 'custom';
-					customSupportUrl = url;
-				}
-			}
-		} catch (_e) {
-			console.error('failed to load artist profile:', _e);
-		}
-	}
-
 	async function loadMyAlbums() {
 		if (!auth.user) return;
 		loadingAlbums = true;
@@ -230,60 +188,6 @@
 			console.error('failed to load albums:', _e);
 		} finally {
 			loadingAlbums = false;
-		}
-	}
-
-	async function saveProfile(e: SubmitEvent) {
-		e.preventDefault();
-		savingProfile = true;
-
-		try {
-			// compute support_url value based on mode
-			let supportUrlValue = '';
-			if (supportLinkMode === 'atprotofans') {
-				supportUrlValue = 'atprotofans';
-			} else if (supportLinkMode === 'custom') {
-				const trimmed = customSupportUrl.trim();
-				if (trimmed && !trimmed.startsWith('https://')) {
-					toast.error('custom support link must start with https://');
-					savingProfile = false;
-					return;
-				}
-				supportUrlValue = trimmed;
-			}
-
-			// save artist profile and support URL in parallel
-			const [artistRes, prefsRes] = await Promise.all([
-				fetch(`${API_URL}/artists/me`, {
-					method: 'PUT',
-					headers: { 'Content-Type': 'application/json' },
-					credentials: 'include',
-					body: JSON.stringify({
-						display_name: displayName,
-						bio: bio || null,
-						avatar_url: avatarUrl || null
-					})
-				}),
-				fetch(`${API_URL}/preferences/`, {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					credentials: 'include',
-					body: JSON.stringify({ support_url: supportUrlValue })
-				})
-			]);
-
-			if (artistRes.ok && prefsRes.ok) {
-				toast.success('profile updated');
-			} else if (!artistRes.ok) {
-				const errorData = await artistRes.json();
-				toast.error(errorData.detail || 'failed to update profile');
-			} else {
-				toast.error('failed to update support link');
-			}
-		} catch (e) {
-			toast.error(`network error: ${e instanceof Error ? e.message : 'unknown error'}`);
-		} finally {
-			savingProfile = false;
 		}
 	}
 
@@ -462,124 +366,7 @@
 			<h2>artist portal</h2>
 		</div>
 
-		<section class="profile-section">
-			<div class="section-header">
-				<h2>profile</h2>
-				<a href="/u/{auth.user.handle}" class="view-profile-link">view public profile</a>
-			</div>
-
-			<form onsubmit={saveProfile}>
-				<div class="form-group">
-					<label for="display-name">artist name *</label>
-					<input
-						id="display-name"
-						type="text"
-						bind:value={displayName}
-						required
-						disabled={savingProfile}
-						placeholder="your artist name"
-					/>
-					<p class="hint">this is shown on all your tracks</p>
-				</div>
-
-				<div class="form-group">
-					<label for="bio">bio (optional)</label>
-					<textarea
-						id="bio"
-						bind:value={bio}
-						disabled={savingProfile}
-						placeholder="tell us about your music..."
-						rows="4"
-						maxlength="2560"
-					></textarea>
-					{#if bio.length > 0}
-						<div class="char-count">{bio.length} / 2560</div>
-					{/if}
-				</div>
-
-				<div class="form-group">
-					<label for="avatar">avatar url (optional)</label>
-					<input
-						id="avatar"
-						type="url"
-						bind:value={avatarUrl}
-						disabled={savingProfile}
-						placeholder="https://example.com/avatar.jpg"
-					/>
-					{#if avatarUrl}
-						<div class="avatar-preview">
-							<img src={avatarUrl} alt="avatar preview" />
-						</div>
-					{/if}
-				</div>
-
-				<div class="form-group support-link-group" role="group" aria-labelledby="support-link-label">
-					<span id="support-link-label" class="form-label">support link (optional)</span>
-					<div class="support-options">
-						<label class="support-option">
-							<input
-								type="radio"
-								name="support-mode"
-								value="none"
-								bind:group={supportLinkMode}
-								disabled={savingProfile}
-							/>
-							<span>none</span>
-						</label>
-						<label class="support-option" class:disabled={!atprotofansEligible && supportLinkMode !== 'atprotofans'}>
-							<input
-								type="radio"
-								name="support-mode"
-								value="atprotofans"
-								bind:group={supportLinkMode}
-								disabled={savingProfile || (!atprotofansEligible && supportLinkMode !== 'atprotofans')}
-							/>
-							<span>atprotofans</span>
-							{#if checkingAtprotofans}
-								<span class="support-status">checking...</span>
-							{:else if !atprotofansEligible}
-								<a href="https://atprotofans.com" target="_blank" rel="noopener" class="support-setup-link">set up</a>
-							{:else}
-								<a href="https://atprotofans.com/u/{auth.user?.did}" target="_blank" rel="noopener" class="support-status-link">profile ready</a>
-							{/if}
-						</label>
-						<label class="support-option">
-							<input
-								type="radio"
-								name="support-mode"
-								value="custom"
-								bind:group={supportLinkMode}
-								disabled={savingProfile}
-							/>
-							<span>custom link</span>
-						</label>
-					</div>
-					{#if supportLinkMode === 'custom'}
-						<input
-							id="custom-support-url"
-							type="url"
-							bind:value={customSupportUrl}
-							disabled={savingProfile}
-							placeholder="https://ko-fi.com/yourname"
-							class="custom-support-input"
-						/>
-					{/if}
-					<p class="hint">
-						{#if supportLinkMode === 'atprotofans'}
-							uses <a href="https://atprotofans.com" target="_blank" rel="noopener">atprotofans</a> for ATProto-native support
-						{:else if supportLinkMode === 'custom'}
-							link to Ko-fi, Patreon, or similar - shown on your profile
-						{:else}
-							no support link will be shown on your profile
-						{/if}
-					</p>
-				</div>
-
-				<button type="submit" disabled={savingProfile || !displayName}>
-					{savingProfile ? 'saving...' : 'save profile'}
-				</button>
-			</form>
-		</section>
+		<ProfileSection {atprotofansEligible} {checkingAtprotofans} />
 
 		<CopyrightSection />
 
@@ -757,15 +544,6 @@
 		margin: 0;
 	}
 
-	.profile-section {
-		margin-bottom: 2rem;
-	}
-
-	.profile-section h2 {
-		font-size: var(--text-page-heading);
-		margin-bottom: 1rem;
-	}
-
 	.section-header {
 		display: flex;
 		justify-content: space-between;
@@ -777,24 +555,6 @@
 
 	.section-header h2 {
 		margin-bottom: 0;
-	}
-
-	.view-profile-link {
-		color: var(--text-secondary);
-		text-decoration: none;
-		font-size: var(--text-sm);
-		padding: 0.35rem 0.6rem;
-		background: var(--bg-tertiary);
-		border-radius: var(--radius-sm);
-		border: 1px solid var(--border-default);
-		transition: all 0.15s;
-		white-space: nowrap;
-	}
-
-	.view-profile-link:hover {
-		border-color: var(--accent);
-		color: var(--accent);
-		background: var(--bg-hover);
 	}
 
 	.settings-link {
@@ -880,21 +640,6 @@
 		color: var(--accent);
 	}
 
-	form {
-		background: var(--bg-tertiary);
-		padding: 1.25rem;
-		border-radius: var(--radius-md);
-		border: 1px solid var(--border-subtle);
-	}
-
-	.form-group {
-		margin-bottom: 1rem;
-	}
-
-	.form-group:last-of-type {
-		margin-bottom: 1.25rem;
-	}
-
 	label {
 		display: block;
 		color: var(--text-secondary);
@@ -902,9 +647,7 @@
 		font-size: var(--text-sm);
 	}
 
-	input[type='text'],
-	input[type='url'],
-	textarea {
+	input[type='text'] {
 		width: 100%;
 		padding: 0.6rem 0.75rem;
 		background: var(--bg-primary);
@@ -916,197 +659,14 @@
 		transition: all 0.15s;
 	}
 
-	input[type='text']:focus,
-	input[type='url']:focus,
-	textarea:focus {
+	input[type='text']:focus {
 		outline: none;
 		border-color: var(--accent);
 	}
 
-	input[type='text']:disabled,
-	input[type='url']:disabled,
-	textarea:disabled {
+	input[type='text']:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
-	}
-
-	textarea {
-		resize: vertical;
-		min-height: 80px;
-	}
-
-	.hint {
-		margin-top: 0.35rem;
-		font-size: var(--text-xs);
-		color: var(--text-muted);
-	}
-
-	.char-count {
-		font-size: var(--text-xs);
-		color: var(--text-tertiary);
-		text-align: right;
-	}
-
-	.hint a {
-		color: var(--accent);
-		text-decoration: none;
-	}
-
-	.hint a:hover {
-		text-decoration: underline;
-	}
-
-	/* support link options */
-	.support-link-group .form-label {
-		display: block;
-		color: var(--text-secondary);
-		margin-bottom: 0.6rem;
-		font-size: var(--text-sm);
-	}
-
-	.support-options {
-		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
-		margin-bottom: 0.75rem;
-	}
-
-	.support-option {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		padding: 0.6rem 0.75rem;
-		background: var(--bg-primary);
-		border: 1px solid var(--border-default);
-		border-radius: var(--radius-base);
-		cursor: pointer;
-		transition: all 0.15s;
-		margin-bottom: 0;
-	}
-
-	.support-option:hover {
-		border-color: var(--border-emphasis);
-	}
-
-	.support-option:has(input:checked) {
-		border-color: var(--accent);
-		background: color-mix(in srgb, var(--accent) 8%, var(--bg-primary));
-	}
-
-	.support-option input[type='radio'] {
-		width: 16px;
-		height: 16px;
-		accent-color: var(--accent);
-		margin: 0;
-	}
-
-	.support-option span {
-		font-size: var(--text-base);
-		color: var(--text-primary);
-	}
-
-	.support-status {
-		margin-left: auto;
-		font-size: var(--text-xs);
-		color: var(--text-tertiary);
-	}
-
-	.support-setup-link,
-	.support-status-link {
-		margin-left: auto;
-		font-size: var(--text-xs);
-		text-decoration: none;
-	}
-
-	.support-setup-link {
-		color: var(--accent);
-	}
-
-	.support-status-link {
-		color: var(--success, #22c55e);
-	}
-
-	.support-setup-link:hover,
-	.support-status-link:hover {
-		text-decoration: underline;
-	}
-
-	.support-option.disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-
-	.support-option.disabled input {
-		cursor: not-allowed;
-	}
-
-	.custom-support-input {
-		width: 100%;
-		padding: 0.6rem 0.75rem;
-		background: var(--bg-primary);
-		border: 1px solid var(--border-default);
-		border-radius: var(--radius-sm);
-		color: var(--text-primary);
-		font-size: var(--text-base);
-		font-family: inherit;
-		transition: all 0.15s;
-		margin-bottom: 0.5rem;
-	}
-
-	.custom-support-input:focus {
-		outline: none;
-		border-color: var(--accent);
-	}
-
-	.custom-support-input:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-
-	.avatar-preview {
-		margin-top: 1rem;
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-	}
-
-	.avatar-preview img {
-		width: 64px;
-		height: 64px;
-		border-radius: var(--radius-full);
-		object-fit: cover;
-		border: 2px solid var(--border-default);
-	}
-
-	/* form submit buttons only */
-	form button[type="submit"] {
-		width: 100%;
-		padding: 0.75rem;
-		background: var(--accent);
-		color: var(--text-primary);
-		border: none;
-		border-radius: var(--radius-sm);
-		font-size: var(--text-lg);
-		font-weight: 600;
-		font-family: inherit;
-		cursor: pointer;
-		transition: all 0.2s;
-	}
-
-	form button[type="submit"]:hover:not(:disabled) {
-		background: var(--accent-hover);
-		transform: translateY(-1px);
-		box-shadow: 0 4px 12px color-mix(in srgb, var(--accent) 30%, transparent);
-	}
-
-	form button[type="submit"]:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-		transform: none;
-	}
-
-	form button[type="submit"]:active:not(:disabled) {
-		transform: translateY(0);
 	}
 
 	/* your data section */
@@ -1358,7 +918,6 @@
 			font-size: var(--text-2xl);
 		}
 
-		.profile-section h2,
 		.data-section h2 {
 			font-size: var(--text-xl);
 		}
@@ -1367,46 +926,13 @@
 			margin-bottom: 0.75rem;
 		}
 
-		.view-profile-link {
-			font-size: var(--text-xs);
-			padding: 0.3rem 0.5rem;
-		}
-
-		form {
-			padding: 1rem;
-		}
-
-		.form-group {
-			margin-bottom: 0.85rem;
-		}
-
 		label {
 			font-size: var(--text-sm);
 			margin-bottom: 0.3rem;
 		}
 
-		input[type='text'],
-		input[type='url'],
-		textarea {
+		input[type='text'] {
 			padding: 0.5rem 0.6rem;
-			font-size: var(--text-base);
-		}
-
-		textarea {
-			min-height: 70px;
-		}
-
-		.hint {
-			font-size: var(--text-xs);
-		}
-
-		.avatar-preview img {
-			width: 48px;
-			height: 48px;
-		}
-
-		button[type="submit"] {
-			padding: 0.6rem;
 			font-size: var(--text-base);
 		}
 

--- a/loq.toml
+++ b/loq.toml
@@ -317,3 +317,7 @@ max_lines = 1740
 [[rules]]
 path = "frontend/src/lib/components/portal/SharesSection.svelte"
 max_lines = 585
+
+[[rules]]
+path = "frontend/src/lib/components/portal/ProfileSection.svelte"
+max_lines = 561


### PR DESCRIPTION
extracts the artist profile form out of the portal page into a co-located `ProfileSection.svelte`; parent `+page.svelte` drops from **1461 → 987 lines**.

<details>
<summary>what moved / what stayed</summary>

**created**
- `frontend/src/lib/components/portal/ProfileSection.svelte`

**moved into the child** (now component-local `$state` + self-loaded on mount)
- state: `displayName`, `bio`, `avatarUrl`, `supportLinkMode`, `customSupportUrl`, `savingProfile`
- functions: `saveProfile()`, plus the profile half of the old `loadArtistProfile()` (the child fetches `/artists/me` + `/preferences/` on mount via `onMount`)

**stayed parent-owned** (shared with `TracksSection`)
- `atprotofansEligible` + `checkingAtprotofans` — passed into `ProfileSection` as props
- `checkAtprotofansEligibility()` — writes the shared flag; it was previously co-invoked inside `loadArtistProfile()`, now invoked directly from the parent `onMount` `Promise.all`

**CSS — duplicated, not globalized**
The generic page-level primitives (`.section-header`, `.section-header h2`, `.char-count`, and the bare `form` / `label` / `input[type]` / `textarea` / `.form-group` / `.hint`) are duplicated per-component across this codebase (each page keeps its own scoped copy; the global stylesheet defines none of them). Globalizing would bleed portal styling into liked/upload/library/home/Queue, so `ProfileSection` gets its own scoped copies, matching the precedent in `PlaylistsSection.svelte` / `TracksSection.svelte`. Also duplicated into the child: `.profile-section`, `.view-profile-link`, all `.support-*`, `.avatar-preview`, `.custom-support-input`, `form button[type="submit"]`, and the section's mobile rules.

In the parent, the now-orphaned profile CSS was removed (`form`, `.form-group`, `.hint`, `.char-count`, `input[type='url']`, `textarea`, all `.support-*`, `.avatar-preview`, `.custom-support-input`, `form button[type="submit"]`, `.profile-section`, `.view-profile-link`). Rules still used by remaining parent markup were kept: bare `input[type='text']` (+`:focus`/`:disabled`) and `label` still style the account-deletion confirm input/labels; `.section-header` still styles the data section. For the grouped mobile `h2` rule, only the dead `.profile-section h2` token was dropped (kept `.data-section h2`); the grouped input selector kept `input[type='text']` and dropped the dead `url`/`textarea` tokens.

</details>

verify gate (run from repo root): `just frontend check` → 0 errors / 0 warnings, `cd frontend && bun run lint` → clean, `uvx loq` → green (`ProfileSection.svelte` limit relaxed to 561).

visual QA on staging is still required — this is a markup/CSS move and scoped-CSS duplication can drift subtly; the profile form should look and behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)