### PR TITLE
feat(playback): drop "auto-play next", surface "keep playing" on mobile

### DIFF
--- a/frontend/src/lib/components/ProfileMenu.svelte
+++ b/frontend/src/lib/components/ProfileMenu.svelte
@@ -2,7 +2,6 @@
 	import { portal } from 'svelte-portal';
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
-	import { queue } from '$lib/queue.svelte';
 	import { preferences, FONT_OPTIONS, type Theme, type FontFamily } from '$lib/preferences.svelte';
 	import { ambient } from '$lib/ambient.svelte';
 	import { API_URL } from '$lib/config';
@@ -45,7 +44,7 @@
 
 	let currentColor = $derived(preferences.accentColor ?? '#6a9fff');
 	let currentFont = $derived(preferences.fontFamily);
-	let autoAdvance = $derived(preferences.autoAdvance);
+	let keepPlaying = $derived(preferences.keepPlaying);
 	let currentTheme = $derived(preferences.theme);
 
 	let ambientGradient = $derived(ambient.gradient);
@@ -65,10 +64,6 @@
 		if (currentColor) {
 			applyColorLocally(currentColor);
 		}
-	});
-
-	$effect(() => {
-		queue.setAutoAdvance(autoAdvance);
 	});
 
 	onMount(() => {
@@ -128,12 +123,9 @@
 		await preferences.updateUiSettings({ font_family: font });
 	}
 
-	async function handleAutoAdvanceToggle(event: Event) {
-		const input = event.target as HTMLInputElement;
-		const value = input.checked;
-		queue.setAutoAdvance(value);
-		localStorage.setItem('autoAdvance', value ? '1' : '0');
-		await preferences.update({ auto_advance: value });
+	async function handleKeepPlayingToggle(event: Event) {
+		const value = (event.target as HTMLInputElement).checked;
+		await preferences.updateUiSettings({ keep_playing: value });
 	}
 
 	function selectTheme(theme: Theme) {
@@ -447,8 +439,8 @@
 					<section class="settings-section">
 						<h3>playback</h3>
 						<label class="toggle">
-							<input type="checkbox" checked={autoAdvance} oninput={handleAutoAdvanceToggle} />
-							<span class="toggle-text">auto-play next</span>
+							<input type="checkbox" checked={keepPlaying} oninput={handleKeepPlayingToggle} />
+							<span class="toggle-text">keep playing</span>
 						</label>
 					</section>
 

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -631,12 +631,6 @@
 	});
 
 	function handleTrackEnded() {
-		if (!queue.autoAdvance) {
-			player.reset();
-			nowPlaying.clear();
-			return;
-		}
-
 		const next = queue.autoAdvanceTrack;
 		if (!next) {
 			player.reset();

--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -90,10 +90,6 @@ class PreferencesManager {
 		return this.data?.accent_color ?? null;
 	}
 
-	get autoAdvance(): boolean {
-		return this.data?.auto_advance ?? DEFAULT_PREFERENCES.auto_advance;
-	}
-
 	get allowComments(): boolean {
 		return this.data?.allow_comments ?? DEFAULT_PREFERENCES.allow_comments;
 	}

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -33,7 +33,6 @@ class Queue {
 	currentIndex = $state(0);
 	shuffle = $state(false);
 	originalOrder = $state<Track[]>([]);
-	autoAdvance = $state(true);
 	progressMs = $state(0);
 
 	/**
@@ -132,13 +131,6 @@ class Queue {
 			.filter(({ index }) => index > this.currentIndex);
 	}
 
-	setAutoAdvance(value: boolean) {
-		this.autoAdvance = value;
-		if (browser) {
-			localStorage.setItem('autoAdvance', value ? '1' : '0');
-		}
-	}
-
 	async initialize() {
 		if (!browser || this.initialized) return;
 		this.initialized = true;
@@ -149,11 +141,6 @@ class Queue {
 		} else {
 			this.tabId = this.createTabId();
 			sessionStorage.setItem('queue_tab_id', this.tabId);
-		}
-
-		const savedAutoAdvance = localStorage.getItem('autoAdvance');
-		if (savedAutoAdvance !== null) {
-			this.autoAdvance = savedAutoAdvance !== '0';
 		}
 
 		// set up cross-tab synchronization
@@ -326,11 +313,6 @@ class Queue {
 
 		this.shuffle = state.shuffle;
 
-		// sync autoAdvance from server
-		if (state.auto_advance !== undefined) {
-			this.autoAdvance = state.auto_advance;
-		}
-
 		if (state.progress_ms !== undefined) {
 			this.progressMs = state.progress_ms;
 		}
@@ -426,7 +408,6 @@ class Queue {
 				current_track_id: this.currentTrack?.file_id ?? null,
 				shuffle: this.shuffle,
 				original_order_ids: this.originalOrder.map((t) => t.file_id),
-				auto_advance: this.autoAdvance,
 				progress_ms: this.progressMs,
 				continuation_from_index: this.continuationFromIndex,
 				continuation_suppressed: this.suppressContinuation

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -137,12 +137,12 @@
 	});
 
 	// "keep playing": when the queue runs low, extend it with a continuation
-	// from For You. extends auto-advance, so it only runs when auto-advance is
-	// on; jams own their own queue. tracks are appended ahead of the current
-	// track ending so Player.svelte's synchronous prefetch path can resolve them.
+	// from For You. jams own their own queue. tracks are appended ahead of the
+	// current track ending so Player.svelte's synchronous prefetch path can
+	// resolve them.
 	$effect(() => {
 		if (!browser) return;
-		const enabled = preferences.keepPlaying && preferences.autoAdvance;
+		const enabled = preferences.keepPlaying;
 		if (!enabled) {
 			// setting off: tear down any materialized "next from" tail so it doesn't
 			// outlive the toggle (the tail is persisted in server queue state)

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -10,7 +10,6 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 	import { preferences, FONT_OPTIONS, type Theme, type FontFamily } from '$lib/preferences.svelte';
 	import { AT_CLIENTS, DEFAULT_AT_CLIENT } from '$lib/atclients';
 	import { ambient } from '$lib/ambient.svelte';
-	import { queue } from '$lib/queue.svelte';
 
 	let loading = $state(true);
 
@@ -24,7 +23,6 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 	let currentColor = $derived(preferences.accentColor ?? '#6a9fff');
 	let currentFont = $derived(preferences.fontFamily);
 	let currentClient = $derived(preferences.atprotoClient ?? DEFAULT_AT_CLIENT);
-	let autoAdvance = $derived(preferences.autoAdvance);
 	let keepPlaying = $derived(preferences.keepPlaying);
 	let backgroundImageUrl = $derived(preferences.uiSettings.background_image_url ?? '');
 	let backgroundTile = $derived(preferences.uiSettings.background_tile ?? false);
@@ -228,14 +226,6 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 
 	function selectTheme(theme: Theme) {
 		preferences.setTheme(theme);
-	}
-
-	async function handleAutoAdvanceToggle(event: Event) {
-		const input = event.target as HTMLInputElement;
-		const value = input.checked;
-		queue.setAutoAdvance(value);
-		localStorage.setItem('autoAdvance', value ? '1' : '0');
-		await preferences.update({ auto_advance: value });
 	}
 
 	async function handleKeepPlayingToggle(event: Event) {
@@ -621,20 +611,6 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		<section class="settings-section">
 			{@render sectionHeading('playback')}
 			<div class="settings-card">
-				<div class="setting-row">
-					<div class="setting-info">
-						<h3>auto-play next</h3>
-						<p>when a track ends, automatically play the next item in your queue</p>
-					</div>
-					<label class="toggle-switch">
-						<input
-							type="checkbox"
-							checked={autoAdvance}
-							onchange={handleAutoAdvanceToggle}
-						/>
-						<span class="toggle-slider"></span>
-					</label>
-				</div>
 				<div class="setting-row">
 					<div class="setting-info">
 						<h3>keep playing</h3>


### PR DESCRIPTION
The mobile settings preview showed **auto-play next**; full settings showed **auto-play next** *and* **keep playing**. Two toggles that both read as "automatically play more," side by side — you couldn't tell them apart. This drops auto-play next entirely and makes "keep playing" the single playback toggle, shown in both places.

### why
They were also wrongly coupled — "keep playing" only ran when auto-advance was on. They're actually **orthogonal**:
- **keep playing** refills the *queue* with for-you picks so it never runs dry.
- **auto-play next** controlled whether playback *steps forward* on its own.

Auto-advancing through a queue is table-stakes (Spotify/Apple/YouTube don't offer a switch for it), so it becomes **always-on**, leaving "keep playing" as the one genuinely-optional control. Standing alone, the name is unambiguous.

<details>
<summary>changes</summary>

- **Player.svelte** — auto-advance is unconditional (removed the `queue.autoAdvance` gate in `handleTrackEnded`).
- **queue.svelte.ts** — removed the dead `autoAdvance` state, `setAutoAdvance`, its `localStorage`, and the `auto_advance` field from the queue-state sync payload.
- **+layout.svelte** — the "keep playing" continuation effect keys only on `preferences.keepPlaying` now (was `keepPlaying && autoAdvance`).
- **settings/+page.svelte** — removed the auto-play-next row + handler + derived.
- **ProfileMenu.svelte** (the mobile preview) — removed the auto-play-next toggle + its queue-sync effect; the playback section now toggles **keep playing**.
- **preferences.svelte.ts** — removed the now-unused `autoAdvance` getter.
</details>

<details>
<summary>intentional non-behaviors / notes</summary>

- **Behavior change:** the handful of users who deliberately set "auto-play next" *off* (stop-after-each-track) lose that — auto-advance is now always on. Deemed acceptable.
- **Backend `auto_advance` is left intact but vestigial.** The DB column + `/preferences` field still exist and default `true`; the frontend simply stops reading/writing them. Dropping the queue-state `auto_advance` from the client is safe because the PUT body is `dict[str, Any]` and the backend re-injects `auto_advance` from prefs on read. A future cleanup can drop the column via migration.
- Verified locally: eslint clean, svelte-check 0/0, loq green.
- Visual QA on staging still warranted (the mobile preview toggle + full settings layout).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)