### PR TITLE
refactor(pds): rename "backfill"/"migrate" → "save" for R2→PDS audio

### DIFF
--- a/backend/src/backend/_internal/jobs.py
+++ b/backend/src/backend/_internal/jobs.py
@@ -31,7 +31,7 @@ class JobService:
         for upload jobs, callers should pass `file_id`, `file_type`, and
         `is_gated` so the stuck-upload reaper can clean up the staged R2
         blob from the right bucket if the job stalls. other job types
-        (export, pds_backfill) leave them None.
+        (export, pds_save) leave them None.
         """
         async with db_session() as db:
             job = Job(

--- a/backend/src/backend/_internal/pds_save_tasks.py
+++ b/backend/src/backend/_internal/pds_save_tasks.py
@@ -1,4 +1,4 @@
-"""background tasks for backfilling audio blobs to user PDS."""
+"""background tasks for saving audio blobs to a user's PDS."""
 
 from __future__ import annotations
 
@@ -25,24 +25,24 @@ from backend.utilities.database import db_session
 logger = logging.getLogger(__name__)
 
 
-async def backfill_tracks_to_pds(
-    backfill_id: str,
+async def save_tracks_to_pds(
+    save_id: str,
     session_id: str,
     track_ids: list[int],
 ) -> None:
-    """backfill existing track audio to the user's PDS in the background.
+    """save existing track audio to the user's PDS in the background.
 
     args:
-        backfill_id: job ID for tracking progress
+        save_id: job ID for tracking progress
         session_id: OAuth session ID for authentication
-        track_ids: list of track IDs to backfill
+        track_ids: list of track IDs to save
     """
     auth_session = await get_session(session_id)
     if not auth_session:
         await job_service.update_progress(
-            backfill_id,
+            save_id,
             JobStatus.FAILED,
-            "backfill failed",
+            "save failed",
             error="session not found",
         )
         return
@@ -50,14 +50,14 @@ async def backfill_tracks_to_pds(
     total_count = len(track_ids)
     if total_count == 0:
         await job_service.update_progress(
-            backfill_id,
+            save_id,
             JobStatus.COMPLETED,
-            "no tracks to backfill",
+            "no tracks to save",
             progress_pct=100.0,
             result={
                 "total_count": 0,
                 "processed_count": 0,
-                "backfilled_count": 0,
+                "saved_count": 0,
                 "skipped_count": 0,
                 "failed_count": 0,
             },
@@ -65,21 +65,21 @@ async def backfill_tracks_to_pds(
         return
 
     await job_service.update_progress(
-        backfill_id,
+        save_id,
         JobStatus.PROCESSING,
-        "starting backfill...",
+        "starting save...",
         progress_pct=0.0,
         phase="init",
         result={
             "total_count": total_count,
             "processed_count": 0,
-            "backfilled_count": 0,
+            "saved_count": 0,
             "skipped_count": 0,
             "failed_count": 0,
         },
     )
 
-    backfilled_count = 0
+    saved_count = 0
     skipped_count = 0
     failed_count = 0
     processed_count = 0
@@ -93,14 +93,14 @@ async def backfill_tracks_to_pds(
     async def update_progress(message: str) -> None:
         progress_pct = (processed_count / total_count) * 100.0
         await job_service.update_progress(
-            backfill_id,
+            save_id,
             JobStatus.PROCESSING,
             message,
             progress_pct=progress_pct,
-            phase="backfill",
+            phase="save",
             result={
                 "processed_count": processed_count,
-                "backfilled_count": backfilled_count,
+                "saved_count": saved_count,
                 "skipped_count": skipped_count,
                 "failed_count": failed_count,
                 "last_processed_track_id": last_processed_track_id,
@@ -108,8 +108,8 @@ async def backfill_tracks_to_pds(
             },
         )
 
-    async def backfill_one(track_id: int) -> None:
-        nonlocal backfilled_count, skipped_count, failed_count, processed_count
+    async def save_one(track_id: int) -> None:
+        nonlocal saved_count, skipped_count, failed_count, processed_count
         nonlocal last_processed_track_id, last_status
 
         async with semaphore:
@@ -246,15 +246,15 @@ async def backfill_tracks_to_pds(
                         track.atproto_record_cid = new_record_cid
                     await db.commit()
 
-                backfilled_count += 1
-                one_status = "backfilled"
+                saved_count += 1
+                one_status = "saved"
 
             except PayloadTooLargeError:
                 skipped_count += 1
                 one_status = "skipped"
             except Exception as e:
                 logger.error(
-                    "pds backfill failed for track %s: %s",
+                    "pds save failed for track %s: %s",
                     track_id,
                     e,
                     exc_info=True,
@@ -266,21 +266,19 @@ async def backfill_tracks_to_pds(
                     processed_count += 1
                     last_processed_track_id = track_id
                     last_status = one_status
-                    await update_progress(
-                        f"backfilled {backfilled_count}/{total_count} tracks"
-                    )
+                    await update_progress(f"saved {saved_count}/{total_count} tracks")
 
-    await asyncio.gather(*(backfill_one(track_id) for track_id in track_ids))
+    await asyncio.gather(*(save_one(track_id) for track_id in track_ids))
 
-    if backfilled_count == 0 and failed_count > 0 and skipped_count == 0:
+    if saved_count == 0 and failed_count > 0 and skipped_count == 0:
         await job_service.update_progress(
-            backfill_id,
+            save_id,
             JobStatus.FAILED,
-            "backfill failed",
+            "save failed",
             progress_pct=100.0,
             result={
                 "processed_count": processed_count,
-                "backfilled_count": backfilled_count,
+                "saved_count": saved_count,
                 "skipped_count": skipped_count,
                 "failed_count": failed_count,
             },
@@ -288,30 +286,30 @@ async def backfill_tracks_to_pds(
         return
 
     summary = (
-        f"backfill completed ({backfilled_count} backfilled, {skipped_count} skipped, {failed_count} failed)"
+        f"save completed ({saved_count} saved, {skipped_count} skipped, {failed_count} failed)"
         if failed_count > 0 or skipped_count > 0
-        else "backfill completed"
+        else "save completed"
     )
     await job_service.update_progress(
-        backfill_id,
+        save_id,
         JobStatus.COMPLETED,
         summary,
         progress_pct=100.0,
         result={
             "processed_count": processed_count,
-            "backfilled_count": backfilled_count,
+            "saved_count": saved_count,
             "skipped_count": skipped_count,
             "failed_count": failed_count,
         },
     )
 
 
-async def schedule_pds_backfill(
-    backfill_id: str,
+async def schedule_pds_save(
+    save_id: str,
     session_id: str,
     track_ids: list[int],
 ) -> None:
-    """schedule a PDS audio backfill via docket."""
+    """schedule a PDS audio save via docket."""
     docket = get_docket()
-    await docket.add(backfill_tracks_to_pds)(backfill_id, session_id, track_ids)
-    logfire.info("scheduled pds audio backfill", backfill_id=backfill_id)
+    await docket.add(save_tracks_to_pds)(save_id, session_id, track_ids)
+    logfire.info("scheduled pds audio save", save_id=save_id)

--- a/backend/src/backend/_internal/tasks/__init__.py
+++ b/backend/src/backend/_internal/tasks/__init__.py
@@ -7,7 +7,7 @@ requires DOCKET_URL to be set (Redis is always available).
 """
 
 from backend._internal.export_tasks import process_export
-from backend._internal.pds_backfill_tasks import backfill_tracks_to_pds
+from backend._internal.pds_save_tasks import save_tracks_to_pds
 from backend._internal.tasks.copyright import (
     scan_copyright,
     schedule_copyright_resolution_sync,
@@ -101,7 +101,7 @@ def _build_background_tasks() -> list:
         pds_create_comment,
         pds_delete_comment,
         pds_update_comment,
-        backfill_tracks_to_pds,
+        save_tracks_to_pds,
         move_track_audio,
         generate_embedding,
         classify_genres,

--- a/backend/src/backend/api/__init__.py
+++ b/backend/src/backend/api/__init__.py
@@ -14,7 +14,7 @@ from backend.api.jams import router as jams_router
 from backend.api.moderation import router as moderation_router
 from backend.api.now_playing import router as now_playing_router
 from backend.api.oembed import router as oembed_router
-from backend.api.pds_backfill import router as pds_backfill_router
+from backend.api.pds_save import router as pds_save_router
 from backend.api.preferences import router as preferences_router
 from backend.api.queue import router as queue_router
 from backend.api.search import router as search_router
@@ -38,7 +38,7 @@ __all__ = [
     "moderation_router",
     "now_playing_router",
     "oembed_router",
-    "pds_backfill_router",
+    "pds_save_router",
     "preferences_router",
     "queue_router",
     "search_router",

--- a/backend/src/backend/api/pds_save.py
+++ b/backend/src/backend/api/pds_save.py
@@ -1,4 +1,4 @@
-"""API endpoints for PDS audio backfill."""
+"""API endpoints for saving audio to a user's PDS."""
 
 import asyncio
 import json
@@ -13,39 +13,39 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, require_auth
 from backend._internal.jobs import job_service
-from backend._internal.pds_backfill_tasks import schedule_pds_backfill
+from backend._internal.pds_save_tasks import schedule_pds_save
 from backend.models import Track, get_db
 from backend.models.job import JobStatus, JobType
 
-router = APIRouter(prefix="/pds-backfill", tags=["pds"])
+router = APIRouter(prefix="/pds-save", tags=["pds"])
 logger = logging.getLogger(__name__)
 
 
-class PdsBackfillStartRequest(BaseModel):
-    """optional request body for selective backfill."""
+class PdsSaveStartRequest(BaseModel):
+    """optional request body for selectively saving tracks."""
 
-    track_ids: list[int] | None = None  # if None, backfill all eligible
+    track_ids: list[int] | None = None  # if None, save all eligible
 
 
-class PdsBackfillStartResponse(BaseModel):
-    """response when PDS backfill is queued for processing."""
+class PdsSaveStartResponse(BaseModel):
+    """response when a PDS save is queued for processing."""
 
-    backfill_id: str
+    save_id: str
     status: str
     message: str
     track_count: int
 
 
 @router.post("/audio")
-async def backfill_audio_to_pds(
+async def save_audio_to_pds(
     session: Annotated[Session, Depends(require_auth)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    body: PdsBackfillStartRequest | None = None,
-) -> PdsBackfillStartResponse:
-    """start backfill of existing tracks to the user's PDS.
+    body: PdsSaveStartRequest | None = None,
+) -> PdsSaveStartResponse:
+    """start saving existing tracks' audio to the user's PDS.
 
-    optionally accepts a list of track_ids to selectively backfill.
-    returns a backfill_id for tracking progress via SSE.
+    optionally accepts a list of track_ids to selectively save.
+    returns a save_id for tracking progress via SSE.
     """
     stmt = (
         select(Track.id)
@@ -63,39 +63,39 @@ async def backfill_audio_to_pds(
     track_ids = [row[0] for row in result.all()]
 
     if not track_ids:
-        raise HTTPException(status_code=404, detail="no tracks found to backfill")
+        raise HTTPException(status_code=404, detail="no tracks found to save")
 
-    backfill_id = await job_service.create_job(
-        JobType.PDS_BACKFILL,
+    save_id = await job_service.create_job(
+        JobType.PDS_SAVE,
         session.did,
-        "backfill queued for processing",
+        "save queued for processing",
     )
 
-    await schedule_pds_backfill(backfill_id, session.session_id, track_ids)
+    await schedule_pds_save(save_id, session.session_id, track_ids)
 
-    return PdsBackfillStartResponse(
-        backfill_id=backfill_id,
+    return PdsSaveStartResponse(
+        save_id=save_id,
         status="pending",
-        message="backfill queued for processing",
+        message="save queued for processing",
         track_count=len(track_ids),
     )
 
 
-@router.get("/{backfill_id}/progress")
-async def backfill_progress(backfill_id: str) -> StreamingResponse:
-    """SSE endpoint for PDS backfill progress."""
+@router.get("/{save_id}/progress")
+async def save_progress(save_id: str) -> StreamingResponse:
+    """SSE endpoint for PDS save progress."""
 
     async def event_stream():
         try:
             while True:
-                job = await job_service.get_job(backfill_id)
+                job = await job_service.get_job(save_id)
                 if not job:
                     yield (
                         "data: "
                         + json.dumps(
                             {
                                 "status": "failed",
-                                "message": "backfill job not found",
+                                "message": "save job not found",
                                 "error": "job lost",
                             }
                         )
@@ -104,7 +104,7 @@ async def backfill_progress(backfill_id: str) -> StreamingResponse:
                     break
 
                 payload = {
-                    "backfill_id": job.id,
+                    "save_id": job.id,
                     "status": job.status,
                     "message": job.message,
                     "error": job.error,
@@ -112,9 +112,7 @@ async def backfill_progress(backfill_id: str) -> StreamingResponse:
                     if job.result
                     else 0,
                     "total_count": job.result.get("total_count") if job.result else 0,
-                    "backfilled_count": job.result.get("backfilled_count")
-                    if job.result
-                    else 0,
+                    "saved_count": job.result.get("saved_count") if job.result else 0,
                     "skipped_count": job.result.get("skipped_count")
                     if job.result
                     else 0,
@@ -135,7 +133,7 @@ async def backfill_progress(backfill_id: str) -> StreamingResponse:
                 await asyncio.sleep(1.0)
 
         except Exception as e:
-            logger.error(f"error in backfill progress stream: {e}")
+            logger.error(f"error in pds save progress stream: {e}")
             yield (
                 "data: "
                 + json.dumps(

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -31,7 +31,7 @@ from backend.api import (
     moderation_router,
     now_playing_router,
     oembed_router,
-    pds_backfill_router,
+    pds_save_router,
     preferences_router,
     queue_router,
     search_router,
@@ -178,7 +178,7 @@ app.include_router(migration_router)
 app.include_router(exports_router)
 app.include_router(for_you_router)
 app.include_router(jams_router)
-app.include_router(pds_backfill_router)
+app.include_router(pds_save_router)
 app.include_router(moderation_router)
 app.include_router(oembed_router)
 app.include_router(stats_router)

--- a/backend/src/backend/models/job.py
+++ b/backend/src/backend/models/job.py
@@ -26,7 +26,7 @@ class JobType(str, Enum):
 
     UPLOAD = "upload"
     EXPORT = "export"
-    PDS_BACKFILL = "pds_backfill"
+    PDS_SAVE = "pds_save"
     # deferred MP3 optimization of a track published with the interim WAV
     # rendition. a distinct type so the stuck-upload reaper (which scans
     # type='upload') never reaps a legitimately long encode running here.
@@ -62,7 +62,7 @@ class Job(Base):
     # an upload job row is created so that if the job sits in `processing`
     # past the reaper threshold, we can delete the staged R2 blob from the
     # right bucket (public vs gated) before marking the job failed. nullable
-    # so non-upload job types (export, pds_backfill) don't need them; also
+    # so non-upload job types (export, pds_save) don't need them; also
     # nullable to support upload rows created before this migration.
     file_id: Mapped[str | None] = mapped_column(String, nullable=True)
     file_type: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/frontend/src/lib/components/PdsSaveControl.svelte
+++ b/frontend/src/lib/components/PdsSaveControl.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import PdsMigrationModal from './PdsMigrationModal.svelte';
+	import PdsSaveModal from './PdsSaveModal.svelte';
 	import { API_URL } from '$lib/config';
 	import { toast } from '$lib/toast.svelte';
 	import type { Track } from '$lib/types';
@@ -14,9 +14,9 @@
 	} = $props();
 
 	let showModal = $state(false);
-	let migrating = $state(false);
+	let saving = $state(false);
 
-	let backfillableTrackCount = $derived(
+	let savableTrackCount = $derived(
 		tracks.filter(
 			(track) =>
 				!track.support_gate &&
@@ -25,13 +25,13 @@
 		).length
 	);
 
-	async function handleMigrate(trackIds: number[]) {
-		migrating = true;
+	async function handleSave(trackIds: number[]) {
+		saving = true;
 		const count = trackIds.length;
-		const toastId = toast.info(`migrating ${count} track${count !== 1 ? 's' : ''}...`, 0);
+		const toastId = toast.info(`saving ${count} track${count !== 1 ? 's' : ''}...`, 0);
 
 		try {
-			const res = await fetch(`${API_URL}/pds-backfill/audio`, {
+			const res = await fetch(`${API_URL}/pds-save/audio`, {
 				method: 'POST',
 				credentials: 'include',
 				headers: { 'Content-Type': 'application/json' },
@@ -40,49 +40,49 @@
 
 			if (!res.ok) {
 				const err = await res.json().catch(() => null);
-				migrating = false;
+				saving = false;
 				toast.dismiss(toastId);
-				toast.error(err?.detail || 'failed to start migration');
+				toast.error(err?.detail || 'failed to start saving');
 				return;
 			}
 
 			const data = await res.json();
-			listenToProgress(data.backfill_id, toastId);
+			listenToProgress(data.save_id, toastId);
 		} catch {
-			migrating = false;
+			saving = false;
 			toast.dismiss(toastId);
-			toast.error('failed to start migration');
+			toast.error('failed to start saving');
 		}
 	}
 
-	function listenToProgress(backfillId: string, toastId: string) {
-		const eventSource = new EventSource(`${API_URL}/pds-backfill/${backfillId}/progress`);
+	function listenToProgress(saveId: string, toastId: string) {
+		const eventSource = new EventSource(`${API_URL}/pds-save/${saveId}/progress`);
 
 		eventSource.onmessage = (event) => {
 			try {
 				const data = JSON.parse(event.data);
 
 				if (data.processed_count != null && data.total_count) {
-					toast.update(toastId, `migrating... ${data.processed_count}/${data.total_count}`);
+					toast.update(toastId, `saving... ${data.processed_count}/${data.total_count}`);
 				}
 
 				if (data.status === 'completed') {
 					eventSource.close();
-					migrating = false;
+					saving = false;
 					toast.dismiss(toastId);
 					const parts: string[] = [];
-					if (data.backfilled_count) parts.push(`${data.backfilled_count} migrated`);
+					if (data.saved_count) parts.push(`${data.saved_count} saved`);
 					if (data.skipped_count) parts.push(`${data.skipped_count} skipped`);
 					if (data.failed_count) parts.push(`${data.failed_count} failed`);
-					toast.success(parts.join(', ') || 'migration complete');
+					toast.success(parts.join(', ') || 'saved to your PDS');
 					onComplete?.();
 				}
 
 				if (data.status === 'failed') {
 					eventSource.close();
-					migrating = false;
+					saving = false;
 					toast.dismiss(toastId);
-					toast.error(data.error || 'migration failed');
+					toast.error(data.error || 'save failed');
 				}
 			} catch {
 				/* ignore parse errors */
@@ -91,39 +91,39 @@
 
 		eventSource.onerror = () => {
 			eventSource.close();
-			migrating = false;
+			saving = false;
 			toast.dismiss(toastId);
-			toast.error('migration connection lost');
+			toast.error('save connection lost');
 		};
 	}
 </script>
 
-{#if backfillableTrackCount > 0}
+{#if savableTrackCount > 0}
 	<div class="data-control">
 		<div class="control-info">
-			<h3>migrate audio to your PDS</h3>
+			<h3>save audio to your PDS</h3>
 			<p class="control-description">
-				{backfillableTrackCount === 1
+				{savableTrackCount === 1
 					? 'copy your audio blob to your PDS and keep the CDN fallback'
-					: `copy ${backfillableTrackCount} audio blobs to your PDS and keep the CDN fallback`}
+					: `copy ${savableTrackCount} audio blobs to your PDS and keep the CDN fallback`}
 			</p>
 		</div>
 		<button
-			class="migrate-trigger-btn"
+			class="save-trigger-btn"
 			onclick={() => (showModal = true)}
-			disabled={migrating}
+			disabled={saving}
 		>
-			{migrating ? 'migrating...' : 'choose tracks'}
+			{saving ? 'saving...' : 'choose tracks'}
 		</button>
 	</div>
 {/if}
 
 {#if showModal}
-	<PdsMigrationModal
+	<PdsSaveModal
 		{tracks}
 		bind:open={showModal}
 		onClose={() => (showModal = false)}
-		onMigrate={handleMigrate}
+		onSave={handleSave}
 	/>
 {/if}
 
@@ -158,7 +158,7 @@
 		margin: 0;
 	}
 
-	.migrate-trigger-btn {
+	.save-trigger-btn {
 		background: var(--accent);
 		color: var(--bg-primary);
 		border: none;
@@ -172,12 +172,12 @@
 		white-space: nowrap;
 	}
 
-	.migrate-trigger-btn:hover:not(:disabled) {
+	.save-trigger-btn:hover:not(:disabled) {
 		transform: translateY(-1px);
 		box-shadow: 0 4px 12px color-mix(in srgb, var(--accent) 30%, transparent);
 	}
 
-	.migrate-trigger-btn:disabled {
+	.save-trigger-btn:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
 	}
@@ -188,7 +188,7 @@
 			align-items: stretch;
 		}
 
-		.migrate-trigger-btn {
+		.save-trigger-btn {
 			width: 100%;
 			text-align: center;
 		}

--- a/frontend/src/lib/components/PdsSaveModal.svelte
+++ b/frontend/src/lib/components/PdsSaveModal.svelte
@@ -8,10 +8,10 @@
 		tracks: Track[];
 		open: boolean;
 		onClose: () => void;
-		onMigrate?: (trackIds: number[]) => void;
+		onSave?: (trackIds: number[]) => void;
 	}
 
-	let { tracks, open = $bindable(), onClose, onMigrate }: Props = $props();
+	let { tracks, open = $bindable(), onClose, onSave }: Props = $props();
 
 	let selected = new SvelteSet<number>();
 	let fileSizes = $state<Record<number, number>>({});
@@ -43,9 +43,9 @@
 
 	function trackStatus(
 		track: Track
-	): 'eligible' | 'migrated' | 'gated' | 'optimizing' {
+	): 'eligible' | 'saved' | 'gated' | 'optimizing' {
 		if (track.support_gate) return 'gated';
-		if (track.audio_storage === 'both' || track.pds_blob_cid) return 'migrated';
+		if (track.audio_storage === 'both' || track.pds_blob_cid) return 'saved';
 		if (isOptimizingInterimWav(track)) return 'optimizing';
 		return 'eligible';
 	}
@@ -94,9 +94,9 @@
 		}
 	}
 
-	function startMigration() {
+	function startSave() {
 		if (selected.size === 0) return;
-		onMigrate?.([...selected]);
+		onSave?.([...selected]);
 		onClose();
 	}
 
@@ -106,9 +106,9 @@
 </script>
 
 <div class="pds-backdrop" class:open role="presentation" onclick={handleBackdropClick}>
-	<div class="pds-modal" role="dialog" aria-modal="true" aria-label="migrate tracks to pds">
+	<div class="pds-modal" role="dialog" aria-modal="true" aria-label="save tracks to your PDS">
 		<div class="pds-header">
-			<h2 class="pds-title">migrate to pds</h2>
+			<h2 class="pds-title">save to your PDS</h2>
 			<button class="pds-close-btn" onclick={onClose} aria-label="close">
 				<svg
 					width="18"
@@ -127,7 +127,7 @@
 		</div>
 
 		<p class="pds-description">
-			select tracks to back up to your personal data server. gated, already-migrated, and
+			select tracks to save to your personal data server. gated, already-saved, and
 			currently-optimizing tracks are shown for reference — optimizing tracks land on your
 			PDS automatically once the mp3 rendition is ready.
 		</p>
@@ -162,8 +162,8 @@
 						{#if fileSizes[track.id]}
 							<span class="pds-track-size">{formatBytes(fileSizes[track.id])}</span>
 						{/if}
-						{#if status === 'migrated'}
-							<span class="pds-badge migrated">on pds</span>
+						{#if status === 'saved'}
+							<span class="pds-badge saved">saved to PDS</span>
 						{:else if status === 'gated'}
 							<span class="pds-badge gated">gated</span>
 						{:else if status === 'optimizing'}
@@ -178,8 +178,8 @@
 		</div>
 
 		<div class="pds-footer">
-			<button class="pds-migrate-btn" disabled={selected.size === 0} onclick={startMigration}>
-				migrate {selected.size} track{selected.size !== 1 ? 's' : ''}{#if selectedBytes > 0}
+			<button class="pds-save-btn" disabled={selected.size === 0} onclick={startSave}>
+				save {selected.size} track{selected.size !== 1 ? 's' : ''}{#if selectedBytes > 0}
 					&nbsp;({formatBytes(selectedBytes)}){/if}
 			</button>
 		</div>
@@ -369,7 +369,7 @@
 		font-weight: 500;
 	}
 
-	.pds-badge.migrated {
+	.pds-badge.saved {
 		background: color-mix(in srgb, var(--accent) 15%, transparent);
 		color: var(--accent);
 	}
@@ -389,7 +389,7 @@
 		flex-shrink: 0;
 	}
 
-	.pds-migrate-btn {
+	.pds-save-btn {
 		width: 100%;
 		padding: 0.75rem 1rem;
 		background: var(--accent);
@@ -403,11 +403,11 @@
 		transition: all 0.15s;
 	}
 
-	.pds-migrate-btn:hover:not(:disabled) {
+	.pds-save-btn:hover:not(:disabled) {
 		background: var(--accent-hover);
 	}
 
-	.pds-migrate-btn:disabled {
+	.pds-save-btn:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
 	}

--- a/frontend/src/lib/components/portal/DataSection.svelte
+++ b/frontend/src/lib/components/portal/DataSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import PdsAudioUploadsToggle from '$lib/components/PdsAudioUploadsToggle.svelte';
-	import PdsBackfillControl from '$lib/components/PdsBackfillControl.svelte';
+	import PdsSaveControl from '$lib/components/PdsSaveControl.svelte';
 	import type { Track } from '$lib/types';
 	import { API_URL } from '$lib/config';
 	import { toast } from '$lib/toast.svelte';
@@ -178,7 +178,7 @@
 		<div class="data-control">
 			<PdsAudioUploadsToggle />
 		</div>
-		<PdsBackfillControl tracks={tracks} onComplete={loadMyTracks} />
+		<PdsSaveControl tracks={tracks} onComplete={loadMyTracks} />
 
 		<div class="data-control">
 			<div class="control-info">


### PR DESCRIPTION
Renames the operation that copies a track's audio from plyr's storage into the user's own PDS. It was called **backfill** in code (`/pds-backfill` endpoint, `pds_backfill_tasks`, `JobType.PDS_BACKFILL`) and **migrate** in the UI ("migrate to pds", "migrating…") — two names for one thing, and *both* misleading:

- it's not a "backfill" (data-pipeline jargon for retroactively filling a gap), and
- it's not a "migrate"/move — the audio is **copied**; the result is `audio_storage: 'both'` (stays on R2, now also on your PDS).

Unified on **"save"** — clear to users and accurate to what self-hosting your audio means.

This is internal API surface (only plyr's own frontend calls the endpoint), so the rename is safe — no external consumers, frontend + backend deploy together.

## Changes
<details>
<summary>backend</summary>

- `api/pds_backfill.py` → `api/pds_save.py`; router prefix `/pds-backfill` → `/pds-save`
- endpoints `backfill_audio_to_pds` → `save_audio_to_pds`, `backfill_progress` → `save_progress`
- models `PdsBackfillStart{Request,Response}` → `PdsSaveStart{Request,Response}`
- payload keys `backfill_id` → `save_id`, `backfilled_count` → `saved_count`
- `_internal/pds_backfill_tasks.py` → `pds_save_tasks.py`; `backfill_tracks_to_pds` → `save_tracks_to_pds`, `schedule_pds_backfill` → `schedule_pds_save`
- `JobType.PDS_BACKFILL = "pds_backfill"` → `JobType.PDS_SAVE = "pds_save"`
- wiring updated in `main.py`, `api/__init__.py`, `_internal/tasks/__init__.py`
</details>

<details>
<summary>frontend</summary>

- `PdsBackfillControl.svelte` → `PdsSaveControl.svelte`; `PdsMigrationModal.svelte` → `PdsSaveModal.svelte`
- UI copy: "save audio to your PDS", "saving…", badge "saved to PDS", "save N tracks"
- consumes `/pds-save/*` + `save_id`/`saved_count`
- `DataSection.svelte` import/usage updated
</details>

## Intentionally NOT touched
- The **queue "continuation backfill"** (`queue.svelte.ts`, `types.ts`) — a different mechanism ("keep playing" refill).
- The **lazy image-URL "backfill"** in `_internal/queue.py` — unrelated.
- ATProto **account migration** (`/migration`, `MigrationBanner`) — a different feature.

## Notes
- `JobType` value changed from `"pds_backfill"` to `"pds_save"`. Job rows are transient progress-tracking records read by id (the SSE stream uses the job id, not the type string), so historical/in-flight rows are unaffected as logs. Dispatch is by docket task name, which is renamed in lockstep.

## Verify
- backend: `just backend lint` ✅, app builds + routes wire (`just backend test tests/api/test_track_description.py` 3 passed)
- frontend: `just frontend check` (0/0) ✅, `bun run lint` ✅, `uvx loq` ✅
- staging QA: open portal → data → "save audio to your PDS" → choose tracks → confirm progress toast + "saved to PDS" badge