### PR TITLE
feat(portal): move config to /portal/manage drill-in + identity header

### DIFF
--- a/frontend/src/lib/components/portal/PortalIdentity.svelte
+++ b/frontend/src/lib/components/portal/PortalIdentity.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { API_URL } from '$lib/config';
+	import { auth } from '$lib/auth.svelte';
+	import type { Artist } from '$lib/types';
+
+	let { trackCount, albumCount }: { trackCount: number; albumCount: number } = $props();
+
+	let artist = $state<Artist | null>(null);
+
+	const handle = $derived(auth.user?.handle ?? '');
+	const displayName = $derived(artist?.display_name || handle);
+	const initial = $derived((displayName || '?').trim().charAt(0).toUpperCase());
+
+	onMount(async () => {
+		try {
+			const res = await fetch(`${API_URL}/artists/me`, { credentials: 'include' });
+			if (res.ok) artist = await res.json();
+		} catch {
+			// fall back to handle-only display
+		}
+	});
+</script>
+
+<div class="identity">
+	<div class="avatar">
+		{#if artist?.avatar_url}
+			<img src={artist.avatar_url} alt={displayName} />
+		{:else}
+			<span class="avatar-fallback">{initial}</span>
+		{/if}
+	</div>
+	<div class="meta">
+		<span class="name">{displayName}</span>
+		{#if handle}<span class="handle">@{handle}</span>{/if}
+		<span class="counts">
+			{trackCount} {trackCount === 1 ? 'track' : 'tracks'} · {albumCount}
+			{albumCount === 1 ? 'album' : 'albums'}
+		</span>
+	</div>
+	{#if handle}
+		<a class="view-profile" href="/u/{handle}">view public profile →</a>
+	{/if}
+</div>
+
+<style>
+	.identity {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		margin-bottom: 1.5rem;
+	}
+
+	.avatar {
+		width: 56px;
+		height: 56px;
+		flex-shrink: 0;
+		border-radius: var(--radius-full);
+		overflow: hidden;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-default);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.avatar img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	.avatar-fallback {
+		font-size: var(--text-xl);
+		font-weight: 600;
+		color: var(--text-tertiary);
+	}
+
+	.meta {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+	}
+
+	.name {
+		font-size: var(--text-lg);
+		font-weight: 600;
+		color: var(--text-primary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.handle {
+		font-size: var(--text-sm);
+		color: var(--text-tertiary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.counts {
+		font-size: var(--text-sm);
+		color: var(--text-secondary);
+		margin-top: 0.15rem;
+	}
+
+	.view-profile {
+		flex-shrink: 0;
+		align-self: flex-start;
+		color: var(--text-secondary);
+		text-decoration: none;
+		font-size: var(--text-sm);
+		padding: 0.35rem 0.6rem;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-sm);
+		transition: all 0.15s;
+		white-space: nowrap;
+	}
+
+	.view-profile:hover {
+		border-color: var(--accent);
+		color: var(--accent);
+		background: var(--bg-hover);
+	}
+
+	@media (max-width: 600px) {
+		.identity {
+			flex-wrap: wrap;
+			gap: 0.75rem;
+			margin-bottom: 1.25rem;
+		}
+
+		.avatar {
+			width: 48px;
+			height: 48px;
+		}
+
+		.view-profile {
+			order: 3;
+			width: 100%;
+			text-align: center;
+		}
+	}
+</style>

--- a/frontend/src/lib/utils/atprotofans.ts
+++ b/frontend/src/lib/utils/atprotofans.ts
@@ -1,0 +1,28 @@
+import { AtpAgent } from '@atproto/api';
+
+/**
+ * Whether the given DID has published an atprotofans profile that is accepting
+ * supporters. `com.atprotofans.profile` isn't indexed by the Bluesky appview,
+ * so we resolve the DID to its PDS and read the record directly.
+ */
+export async function checkAtprotofansEligibility(did: string | undefined): Promise<boolean> {
+	if (!did) return false;
+	try {
+		const didDoc = await fetch(`https://plc.directory/${did}`).then((r) => r.json());
+		const pdsService = didDoc?.service?.find((s: { id: string }) => s.id === '#atproto_pds');
+		const pdsUrl = pdsService?.serviceEndpoint;
+		if (!pdsUrl) return false;
+
+		const agent = new AtpAgent({ service: pdsUrl });
+		const response = await agent.com.atproto.repo.getRecord({
+			repo: did,
+			collection: 'com.atprotofans.profile',
+			rkey: 'self'
+		});
+		const value = response.data.value as { acceptingSupporters?: boolean } | undefined;
+		return value?.acceptingSupporters === true;
+	} catch {
+		// record doesn't exist or other error — not eligible
+		return false;
+	}
+}

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -1,22 +1,19 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { invalidateAll, replaceState } from '$app/navigation';
-	import { AtpAgent } from '@atproto/api';
 	import Header from '$lib/components/Header.svelte';
 	import WaveLoading from '$lib/components/WaveLoading.svelte';
 	import MigrationBanner from '$lib/components/MigrationBanner.svelte';
 	import BrokenTracks from '$lib/components/BrokenTracks.svelte';
-	import CopyrightSection from '$lib/components/CopyrightSection.svelte';
+	import PortalIdentity from '$lib/components/portal/PortalIdentity.svelte';
 	import PlaylistsSection from '$lib/components/portal/PlaylistsSection.svelte';
-	import ProfileSection from '$lib/components/portal/ProfileSection.svelte';
 	import TracksSection from '$lib/components/portal/TracksSection.svelte';
 	import AlbumsSection from '$lib/components/portal/AlbumsSection.svelte';
-	import SharesSection from '$lib/components/portal/SharesSection.svelte';
-	import DataSection from '$lib/components/portal/DataSection.svelte';
 	import type { Track, AlbumSummary } from '$lib/types';
 	import { API_URL } from '$lib/config';
 	import { toast } from '$lib/toast.svelte';
 	import { auth } from '$lib/auth.svelte';
+	import { checkAtprotofansEligibility } from '$lib/utils/atprotofans';
 	import { preferences } from '$lib/preferences.svelte'; import { getReturnUrl, clearReturnUrl } from '$lib/utils/return-url';
 
 	let loading = $state(true);
@@ -26,9 +23,8 @@
 	let tracksHasMore = $state(false);
 	let loadingTracks = $state(false);
 	let loadingMoreTracks = $state(false);
-	// atprotofans eligibility - checked on mount; shared with TracksSection + ProfileSection
+	// atprotofans eligibility - checked on mount; gates the supporter toggle in TracksSection
 	let atprotofansEligible = $state(false);
-	let checkingAtprotofans = $state(false);
 
 	// album management state
 	let albums = $state<AlbumSummary[]>([]);
@@ -93,7 +89,7 @@
 		try {
 			await Promise.all([
 				loadMyTracks(),
-				checkAtprotofansEligibility(),
+				loadAtprotofansEligibility(),
 				loadMyAlbums()
 			]);
 		} catch (_e) {
@@ -133,36 +129,8 @@
 		}
 	}
 
-	async function checkAtprotofansEligibility() {
-		if (!auth.user?.did) return;
-		checkingAtprotofans = true;
-		try {
-			// resolve DID to find user's PDS (com.atprotofans.profile isn't indexed by Bluesky appview)
-			const didDoc = await fetch(`https://plc.directory/${auth.user.did}`).then((r) => r.json());
-			const pdsService = didDoc?.service?.find(
-				(s: { id: string }) => s.id === '#atproto_pds'
-			);
-			const pdsUrl = pdsService?.serviceEndpoint;
-			if (!pdsUrl) {
-				atprotofansEligible = false;
-				return;
-			}
-
-			// use SDK agent pointed at user's PDS to fetch the record
-			const agent = new AtpAgent({ service: pdsUrl });
-			const response = await agent.com.atproto.repo.getRecord({
-				repo: auth.user.did,
-				collection: 'com.atprotofans.profile',
-				rkey: 'self'
-			});
-			const value = response.data.value as { acceptingSupporters?: boolean } | undefined;
-			atprotofansEligible = value?.acceptingSupporters === true;
-		} catch (_e) {
-			// record doesn't exist or other error - not eligible
-			atprotofansEligible = false;
-		} finally {
-			checkingAtprotofans = false;
-		}
+	async function loadAtprotofansEligibility() {
+		atprotofansEligible = await checkAtprotofansEligibility(auth.user?.did);
 	}
 
 	async function loadMyAlbums() {
@@ -211,9 +179,7 @@
 			<h2>artist portal</h2>
 		</div>
 
-		<ProfileSection {atprotofansEligible} {checkingAtprotofans} />
-
-		<CopyrightSection />
+		<PortalIdentity trackCount={tracksTotal} albumCount={albums.length} />
 
 		<a href="/upload" class="upload-card">
 			<div class="upload-card-icon">
@@ -226,6 +192,29 @@
 			<div class="upload-card-text">
 				<span class="upload-card-title">upload track</span>
 				<span class="upload-card-subtitle">add new music</span>
+			</div>
+			<svg class="upload-card-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+				<polyline points="9 18 15 12 9 6"></polyline>
+			</svg>
+		</a>
+
+		<a href="/portal/manage" class="upload-card">
+			<div class="upload-card-icon">
+				<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+					<line x1="4" y1="21" x2="4" y2="14"></line>
+					<line x1="4" y1="10" x2="4" y2="3"></line>
+					<line x1="12" y1="21" x2="12" y2="12"></line>
+					<line x1="12" y1="8" x2="12" y2="3"></line>
+					<line x1="20" y1="21" x2="20" y2="16"></line>
+					<line x1="20" y1="12" x2="20" y2="3"></line>
+					<line x1="1" y1="14" x2="7" y2="14"></line>
+					<line x1="9" y1="8" x2="15" y2="8"></line>
+					<line x1="17" y1="16" x2="23" y2="16"></line>
+				</svg>
+			</div>
+			<div class="upload-card-text">
+				<span class="upload-card-title">manage</span>
+				<span class="upload-card-subtitle">profile, rights, sharing, data</span>
 			</div>
 			<svg class="upload-card-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 				<polyline points="9 18 15 12 9 6"></polyline>
@@ -247,10 +236,6 @@
 		<AlbumsSection albums={albums} loadingAlbums={loadingAlbums} />
 
 		<PlaylistsSection />
-
-		<SharesSection />
-
-		<DataSection tracks={tracks} tracksTotal={tracksTotal} loadMyTracks={loadMyTracks} />
 	</main>
 {/if}
 

--- a/frontend/src/routes/portal/manage/+page.svelte
+++ b/frontend/src/routes/portal/manage/+page.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import Header from '$lib/components/Header.svelte';
+	import WaveLoading from '$lib/components/WaveLoading.svelte';
+	import ProfileSection from '$lib/components/portal/ProfileSection.svelte';
+	import SharesSection from '$lib/components/portal/SharesSection.svelte';
+	import DataSection from '$lib/components/portal/DataSection.svelte';
+	import CopyrightSection from '$lib/components/CopyrightSection.svelte';
+	import type { Track } from '$lib/types';
+	import { API_URL } from '$lib/config';
+	import { auth } from '$lib/auth.svelte';
+	import { checkAtprotofansEligibility } from '$lib/utils/atprotofans';
+
+	let loading = $state(true);
+	let atprotofansEligible = $state(false);
+	let checkingAtprotofans = $state(false);
+
+	// own, unfiltered track source — kept independent of the portal's library
+	// list (which can be search/sort filtered) so PDS-save candidate detection
+	// in DataSection always sees the full set.
+	let tracks = $state<Track[]>([]);
+	let tracksTotal = $state(0);
+
+	async function loadTracks() {
+		try {
+			const res = await fetch(`${API_URL}/tracks/me?limit=100`, { credentials: 'include' });
+			if (res.ok) {
+				const data = await res.json();
+				tracks = data.tracks;
+				tracksTotal = data.total;
+			}
+		} catch (_e) {
+			console.error('failed to load tracks:', _e);
+		}
+	}
+
+	async function checkEligibility() {
+		checkingAtprotofans = true;
+		try {
+			atprotofansEligible = await checkAtprotofansEligibility(auth.user?.did);
+		} finally {
+			checkingAtprotofans = false;
+		}
+	}
+
+	async function logout() {
+		await auth.logout();
+		window.location.href = '/';
+	}
+
+	onMount(async () => {
+		while (auth.loading) {
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
+		if (!auth.isAuthenticated) {
+			window.location.href = '/login';
+			return;
+		}
+		await Promise.all([loadTracks(), checkEligibility()]);
+		loading = false;
+	});
+</script>
+
+{#if loading}
+	<div class="loading">
+		<WaveLoading size="lg" message="loading..." />
+	</div>
+{:else if auth.user}
+	<Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={logout} />
+	<main>
+		<div class="manage-header">
+			<a href="/portal" class="back-link">← portal</a>
+			<h2>manage</h2>
+			<p class="manage-subtitle">profile, rights, sharing, and data</p>
+		</div>
+
+		<ProfileSection {atprotofansEligible} {checkingAtprotofans} />
+
+		<CopyrightSection />
+
+		<SharesSection />
+
+		<DataSection {tracks} {tracksTotal} loadMyTracks={loadTracks} />
+	</main>
+{/if}
+
+<style>
+	.loading {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		min-height: 100vh;
+		color: var(--text-tertiary);
+		gap: 1rem;
+	}
+
+	main {
+		max-width: 800px;
+		margin: 0 auto;
+		padding: 0 1rem calc(var(--player-height, 120px) + 2rem + env(safe-area-inset-bottom, 0px));
+	}
+
+	.manage-header {
+		margin-bottom: 2rem;
+	}
+
+	.back-link {
+		display: inline-block;
+		color: var(--text-secondary);
+		text-decoration: none;
+		font-size: var(--text-sm);
+		margin-bottom: 0.75rem;
+		transition: color 0.15s;
+	}
+
+	.back-link:hover {
+		color: var(--accent);
+	}
+
+	.manage-header h2 {
+		font-size: var(--text-page-heading);
+		margin: 0;
+	}
+
+	.manage-subtitle {
+		margin: 0.35rem 0 0;
+		font-size: var(--text-sm);
+		color: var(--text-tertiary);
+	}
+
+	@media (max-width: 600px) {
+		main {
+			padding: 0 0.75rem calc(var(--player-height, 120px) + 1.5rem + env(safe-area-inset-bottom, 0px));
+		}
+
+		.manage-header {
+			margin-bottom: 1.25rem;
+		}
+
+		.manage-header h2 {
+			font-size: var(--text-2xl);
+		}
+	}
+</style>


### PR DESCRIPTION
First structural step of the portal de-scroll redesign ([plan approved with @zzstoatzz]). The artist portal stacked **9 sections** into one punishing mobile scroll; this pulls the occasional-config sections off the browse path into a dedicated drill-in, and replaces the heavy profile *form* at the top with a light identity *summary*.

Borrows bluesky's split: Profile-style content stays on the main surface; Settings-style config drills into its own screen.

## What changed
- **New `/portal/manage` route** — profile, copyright/rights, sharing, and data grouped on their own page, reached via a "manage" card on the portal. (Config is occasional setup, not browsing.)
- **New `PortalIdentity` header** — read-only summary: avatar, display name, `@handle`, track/album counts, "view public profile →". Replaces `ProfileSection` (a fetch/save form) at the top of the portal, preserving the recent section-extraction boundary.
- **Extracted `lib/utils/atprotofans.ts`** — `checkAtprotofansEligibility(did)`, shared by the portal (TracksSection supporter gate) and the manage page (ProfileSection). Logic is verbatim from the old inline portal copy.
- **Decoupled PDS-save candidates from the visible list** — on `/portal/manage`, `DataSection` fetches its *own* unfiltered tracks (`limit=100`) for `PdsBackfillControl`'s candidate detection, so the upcoming library search/sort can never poison the candidate set.

Portal now reads: **identity → upload → manage → tracks · albums · playlists**.

## Deferred to the next PRs (per plan)
- Tracks/Albums become a sticky tabbed pager; **PlaylistsSection stays for now**, removed when tabs land (playlists are curation → they live in `/library`).
- Server-side track search/sort UI.

## Relationship to #1475
Independent — no file overlap. #1475 renames the PDS-save internals (incl. `DataSection`'s import); this PR adds the manage route that *renders* `DataSection` but doesn't touch its PDS import. Merge in either order.

## Verify
- `just frontend check` (0 errors / 0 warnings) ✅, `bun run lint` ✅, `uvx loq` ✅
- staging QA (mobile): portal is shorter; "manage" card → `/portal/manage` shows profile/copyright/sharing/data and all four flows work; identity header renders avatar/name/counts; "view public profile" link works; back-to-portal link works; PDS-save candidate count on manage is unaffected by anything on the portal.