### PR TITLE
fix(portal): sticky tab bar + search bar use glass bg on live theme

### DIFF
--- a/frontend/src/lib/components/PagerTabs.svelte
+++ b/frontend/src/lib/components/PagerTabs.svelte
@@ -86,7 +86,11 @@
 		display: flex;
 		gap: 0.25rem;
 		margin-bottom: 1.5rem;
-		background: var(--bg-primary);
+		/* glass (not opaque --bg-primary) so the sticky bar blends with the live
+		   theme's ambient gradient, matching the app header */
+		background: var(--glass-bg, var(--bg-primary));
+		backdrop-filter: var(--glass-blur, none);
+		-webkit-backdrop-filter: var(--glass-blur, none);
 		border-bottom: 1px solid var(--border-subtle);
 	}
 

--- a/frontend/src/lib/components/portal/TracksSection.svelte
+++ b/frontend/src/lib/components/portal/TracksSection.svelte
@@ -990,7 +990,10 @@
 		gap: 0.5rem;
 		padding: 0.5rem 0 0.75rem;
 		margin-bottom: 0.5rem;
-		background: var(--bg-primary);
+		/* glass so it blends with the live-theme gradient like the tab bar/header */
+		background: var(--glass-bg, var(--bg-primary));
+		backdrop-filter: var(--glass-blur, none);
+		-webkit-backdrop-filter: var(--glass-blur, none);
 	}
 
 	.track-search {

--- a/loq.toml
+++ b/loq.toml
@@ -312,7 +312,7 @@ max_lines = 610
 
 [[rules]]
 path = "frontend/src/lib/components/portal/TracksSection.svelte"
-max_lines = 1830
+max_lines = 1833
 
 [[rules]]
 path = "frontend/src/lib/components/portal/SharesSection.svelte"


### PR DESCRIPTION
Follow-up to the portal redesign. On the **live (ambient gradient) theme**, the sticky pager tab bar and the tracks search/sort toolbar rendered as opaque dark bands over the gradient (see staging).

Cause: both used `var(--bg-primary)`, which the ambient theme does **not** tint (it overrides `--glass-bg`/`--bg-tertiary` but leaves `--bg-primary` opaque). The app header avoids this by using the glass tokens.

Fix: both sticky bars now use `var(--glass-bg, var(--bg-primary))` + `--glass-blur`, matching the header — so they blend with the gradient on live and are unchanged on dark/light (the fallback resolves to the same values).

## Verify
- `just frontend check` (0/0) ✅, `bun run lint` ✅, `uvx loq` ✅
- staging QA: switch to the live theme, open `/portal` — the tab bar + filter bar should blend with the gradient (translucent/blurred like the header), not show as dark rectangles.