### PR TITLE
[codex] add public radio state endpoint

### DIFF
--- a/backend/src/backend/api/__init__.py
+++ b/backend/src/backend/api/__init__.py
@@ -17,6 +17,7 @@ from backend.api.oembed import router as oembed_router
 from backend.api.pds_save import router as pds_save_router
 from backend.api.preferences import router as preferences_router
 from backend.api.queue import router as queue_router
+from backend.api.radio import router as radio_router
 from backend.api.search import router as search_router
 from backend.api.stats import router as stats_router
 from backend.api.tracks import router as tracks_router
@@ -41,6 +42,7 @@ __all__ = [
     "pds_save_router",
     "preferences_router",
     "queue_router",
+    "radio_router",
     "search_router",
     "stats_router",
     "tracks_router",

--- a/backend/src/backend/api/radio.py
+++ b/backend/src/backend/api/radio.py
@@ -1,0 +1,209 @@
+"""Public live radio state for simple clients and games."""
+
+import math
+from datetime import UTC, datetime, timedelta
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, Request
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from backend.models import Artist, Track, get_db
+from backend.utilities.aggregations import get_like_counts, get_track_tags
+
+router = APIRouter(prefix="/radio", tags=["radio"])
+
+DEFAULT_TRACK_SECONDS = 180
+MAX_ROTATION_SIZE = 50
+SOURCE_CANDIDATE_LIMIT = 250
+
+
+class RadioTrack(BaseModel):
+    """Small public track shape for radio clients."""
+
+    id: int
+    title: str
+    artist: str
+    artist_handle: str
+    artist_did: str
+    stream_url: str
+    file_type: str
+    duration: int
+    artwork_url: str | None
+    thumbnail_url: str | None
+    atproto_record_uri: str | None
+    created_at: str
+    tags: list[str]
+    like_count: int
+    play_count: int
+
+
+class RadioStateResponse(BaseModel):
+    """Live radio state response."""
+
+    station: str
+    generated_at: str
+    loop_duration_seconds: int
+    current_index: int | None
+    current_started_at: str | None
+    current_ends_at: str | None
+    progress_seconds: int
+    current: RadioTrack | None
+    up_next: list[RadioTrack]
+    rotation: list[RadioTrack]
+
+
+def _stream_url(request: Request, track: Track) -> str:
+    """Return the existing audio redirect endpoint as an absolute URL."""
+    return str(request.url_for("stream_audio", file_id=track.file_id))
+
+
+def _duration_seconds(track: Track) -> int:
+    """Return a usable duration for scheduling."""
+    if track.duration and track.duration > 0:
+        return int(track.duration)
+    return DEFAULT_TRACK_SECONDS
+
+
+def _score_track(track: Track, like_count: int) -> float:
+    """Rank tracks for the station rotation.
+
+    Likes are explicit taste signals. Plays are weaker implicit signals and are
+    log-scaled so old high-volume tracks do not permanently swallow the station.
+    """
+    return (like_count * 3) + math.log1p(track.play_count)
+
+
+async def _rotation_tracks(db: AsyncSession, limit: int) -> list[Track]:
+    """Build the public radio rotation from catalog signals."""
+    stmt = (
+        select(Track)
+        .join(Artist)
+        .options(selectinload(Track.artist))
+        .where(
+            Track.unlisted == False,  # noqa: E712
+            Track.support_gate.is_(None),
+        )
+        .order_by(Track.created_at.desc(), Track.id.desc())
+        .limit(SOURCE_CANDIDATE_LIMIT)
+    )
+    result = await db.execute(stmt)
+    candidates = list(result.scalars().all())
+    if not candidates:
+        return []
+
+    like_counts = await get_like_counts(db, [track.id for track in candidates])
+    ranked = sorted(
+        candidates,
+        key=lambda track: (
+            _score_track(track, like_counts.get(track.id, 0)),
+            track.created_at,
+            track.id,
+        ),
+        reverse=True,
+    )
+    return ranked[:limit]
+
+
+async def _to_radio_tracks(
+    request: Request,
+    db: AsyncSession,
+    tracks: list[Track],
+) -> list[RadioTrack]:
+    """Serialize tracks for public radio consumers."""
+    track_ids = [track.id for track in tracks]
+    like_counts = await get_like_counts(db, track_ids)
+    tag_map = await get_track_tags(db, track_ids)
+    return [
+        RadioTrack(
+            id=track.id,
+            title=track.title,
+            artist=track.artist.display_name,
+            artist_handle=track.artist.handle,
+            artist_did=track.artist_did,
+            stream_url=_stream_url(request, track),
+            file_type=track.file_type,
+            duration=_duration_seconds(track),
+            artwork_url=track.image_url or track.artist.avatar_url,
+            thumbnail_url=track.thumbnail_url,
+            atproto_record_uri=track.atproto_record_uri,
+            created_at=track.created_at.isoformat(),
+            tags=sorted(tag_map.get(track.id, set())),
+            like_count=like_counts.get(track.id, 0),
+            play_count=track.play_count,
+        )
+        for track in tracks
+    ]
+
+
+def _live_window(
+    now: datetime,
+    rotation: list[RadioTrack],
+) -> tuple[int | None, int, datetime | None, datetime | None]:
+    """Locate the current track in the deterministic station loop."""
+    if not rotation:
+        return None, 0, None, None
+
+    durations = [track.duration for track in rotation]
+    loop_duration = sum(durations)
+    if loop_duration <= 0:
+        return None, 0, None, None
+
+    epoch_seconds = int(now.timestamp())
+    loop_offset = epoch_seconds % loop_duration
+    cursor = 0
+    for index, duration in enumerate(durations):
+        next_cursor = cursor + duration
+        if loop_offset < next_cursor:
+            progress = loop_offset - cursor
+            started_at = now - timedelta(seconds=progress)
+            ends_at = started_at + timedelta(seconds=duration)
+            return index, progress, started_at, ends_at
+        cursor = next_cursor
+
+    return 0, 0, now, now + timedelta(seconds=durations[0])
+
+
+def _up_next(rotation: list[RadioTrack], current_index: int | None) -> list[RadioTrack]:
+    """Return the next few tracks after the current one."""
+    if current_index is None or not rotation:
+        return []
+    return [
+        rotation[(current_index + offset) % len(rotation)]
+        for offset in range(1, min(len(rotation), 5))
+    ]
+
+
+@router.get("/state")
+@router.get("/state.json")
+async def radio_state(
+    request: Request,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: int = Query(25, ge=1, le=MAX_ROTATION_SIZE),
+) -> RadioStateResponse:
+    """Return the live public radio state.
+
+    The MVP station is stateless and deterministic: every client gets the same
+    current track for a given wall-clock time. Rotation order is selected from
+    public, ungated tracks using likes plus log-scaled play counts.
+    """
+    now = datetime.now(UTC)
+    tracks = await _rotation_tracks(db, limit)
+    rotation = await _to_radio_tracks(request, db, tracks)
+    current_index, progress, started_at, ends_at = _live_window(now, rotation)
+    current = rotation[current_index] if current_index is not None else None
+
+    return RadioStateResponse(
+        station="plyr.fm radio",
+        generated_at=now.isoformat(),
+        loop_duration_seconds=sum(track.duration for track in rotation),
+        current_index=current_index,
+        current_started_at=started_at.isoformat() if started_at else None,
+        current_ends_at=ends_at.isoformat() if ends_at else None,
+        progress_seconds=progress,
+        current=current,
+        up_next=_up_next(rotation, current_index),
+        rotation=rotation,
+    )

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -34,6 +34,7 @@ from backend.api import (
     pds_save_router,
     preferences_router,
     queue_router,
+    radio_router,
     search_router,
     stats_router,
     tracks_router,
@@ -173,6 +174,7 @@ app.include_router(audio_router)
 app.include_router(search_router)
 app.include_router(preferences_router)
 app.include_router(queue_router)
+app.include_router(radio_router)
 app.include_router(now_playing_router)
 app.include_router(migration_router)
 app.include_router(exports_router)

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -1,0 +1,218 @@
+"""tests for public radio state."""
+
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.main import app
+from backend.models import Artist, Tag, Track, TrackLike, TrackTag, get_db
+
+
+@pytest.fixture
+def radio_app(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
+    """test app using the test db session."""
+
+    async def mock_get_db() -> AsyncSession:  # type: ignore[misc]
+        yield db_session
+
+    app.dependency_overrides[get_db] = mock_get_db
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def radio_artist(db_session: AsyncSession) -> Artist:
+    """create a radio test artist."""
+    artist = Artist(
+        did="did:plc:radio",
+        handle="radio.plyr.fm",
+        display_name="Radio Artist",
+        avatar_url="https://images.example/avatar.jpg",
+    )
+    db_session.add(artist)
+    await db_session.commit()
+    await db_session.refresh(artist)
+    return artist
+
+
+async def _create_track(
+    db_session: AsyncSession,
+    artist: Artist,
+    *,
+    title: str,
+    file_id: str,
+    created_at: datetime,
+    play_count: int = 0,
+    unlisted: bool = False,
+    support_gate: dict | None = None,
+) -> Track:
+    """Create a track for radio tests."""
+    track = Track(
+        title=title,
+        artist_did=artist.did,
+        file_id=file_id,
+        file_type="mp3",
+        created_at=created_at,
+        extra={"duration": 123},
+        image_url="https://images.example/cover.jpg",
+        atproto_record_uri=f"at://{artist.did}/fm.plyr.track/{file_id}",
+        play_count=play_count,
+        unlisted=unlisted,
+        support_gate=support_gate,
+    )
+    db_session.add(track)
+    await db_session.flush()
+    return track
+
+
+async def test_radio_state_returns_live_public_rotation(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    """radio state returns one live station with public tracks only."""
+    now = datetime.now(UTC)
+    visible = await _create_track(
+        db_session,
+        radio_artist,
+        title="Visible",
+        file_id="visible",
+        created_at=now,
+    )
+    await _create_track(
+        db_session,
+        radio_artist,
+        title="Unlisted",
+        file_id="unlisted",
+        created_at=now - timedelta(minutes=1),
+        unlisted=True,
+    )
+    await _create_track(
+        db_session,
+        radio_artist,
+        title="Gated",
+        file_id="gated",
+        created_at=now - timedelta(minutes=2),
+        support_gate={"type": "any"},
+    )
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=radio_app),
+        base_url="https://radio.plyr.fm",
+    ) as client:
+        response = await client.get("/radio/state")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["station"] == "plyr.fm radio"
+    assert data["current"]["title"] == "Visible"
+    assert data["current"]["stream_url"] == (
+        f"https://radio.plyr.fm/audio/{visible.file_id}"
+    )
+    assert data["current"]["duration"] == 123
+    assert data["current"]["artwork_url"] == "https://images.example/cover.jpg"
+    assert [track["title"] for track in data["rotation"]] == ["Visible"]
+
+
+async def test_radio_state_orders_rotation_by_likes_then_plays(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    """likes and play counts determine what gets into the radio loop."""
+    now = datetime.now(UTC)
+    played = await _create_track(
+        db_session,
+        radio_artist,
+        title="Played",
+        file_id="played",
+        created_at=now,
+        play_count=50,
+    )
+    liked = await _create_track(
+        db_session,
+        radio_artist,
+        title="Liked",
+        file_id="liked",
+        created_at=now - timedelta(minutes=1),
+        play_count=1,
+    )
+    latest = await _create_track(
+        db_session,
+        radio_artist,
+        title="Latest",
+        file_id="latest",
+        created_at=now - timedelta(minutes=2),
+    )
+
+    for index in range(2):
+        db_session.add(
+            TrackLike(
+                track_id=liked.id,
+                user_did=f"did:test:liker{index}",
+                atproto_like_uri=f"at://did:test:liker{index}/fm.plyr.like/liked",
+            )
+        )
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=radio_app),
+        base_url="https://radio.plyr.fm",
+    ) as client:
+        response = await client.get("/radio/state.json")
+
+    assert response.status_code == 200
+    rotation = response.json()["rotation"]
+    assert [track["title"] for track in rotation] == ["Liked", "Played", "Latest"]
+    assert rotation[0]["like_count"] == 2
+    assert rotation[1]["play_count"] == played.play_count
+    assert rotation[2]["id"] == latest.id
+
+
+async def test_radio_state_includes_tags_and_up_next(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    """radio state includes useful metadata for clients."""
+    now = datetime.now(UTC)
+    first = await _create_track(
+        db_session,
+        radio_artist,
+        title="First",
+        file_id="first",
+        created_at=now,
+    )
+    second = await _create_track(
+        db_session,
+        radio_artist,
+        title="Second",
+        file_id="second",
+        created_at=now - timedelta(minutes=1),
+    )
+    tag = Tag(name="desert", created_by_did=radio_artist.did)
+    db_session.add(tag)
+    await db_session.flush()
+    db_session.add(TrackTag(track_id=first.id, tag_id=tag.id))
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=radio_app),
+        base_url="https://radio.plyr.fm",
+    ) as client:
+        response = await client.get("/radio/state.json")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["loop_duration_seconds"] == 246
+    assert data["progress_seconds"] >= 0
+    assert data["current_started_at"] is not None
+    assert data["current_ends_at"] is not None
+    assert data["rotation"][0]["tags"] == ["desert"]
+    assert data["up_next"]
+    assert {track["id"] for track in data["up_next"]}.issubset({first.id, second.id})

--- a/frontend/src/routes/radio/+page.svelte
+++ b/frontend/src/routes/radio/+page.svelte
@@ -1,0 +1,674 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import Header from '$lib/components/Header.svelte';
+	import { API_URL } from '$lib/config';
+	import { APP_NAME } from '$lib/branding';
+	import { auth } from '$lib/auth.svelte';
+
+	interface RadioTrack {
+		id: number;
+		title: string;
+		artist: string;
+		artist_handle: string;
+		artist_did: string;
+		stream_url: string;
+		file_type: string;
+		duration: number;
+		artwork_url: string | null;
+		thumbnail_url: string | null;
+		atproto_record_uri: string | null;
+		created_at: string;
+		tags: string[];
+		like_count: number;
+		play_count: number;
+	}
+
+	interface RadioState {
+		station: string;
+		generated_at: string;
+		loop_duration_seconds: number;
+		current_index: number | null;
+		current_started_at: string | null;
+		current_ends_at: string | null;
+		progress_seconds: number;
+		current: RadioTrack | null;
+		up_next: RadioTrack[];
+		rotation: RadioTrack[];
+	}
+
+	let radioState = $state<RadioState | null>(null);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let playing = $state(false);
+	let helpOpen = $state(false);
+	let audioElement = $state<HTMLAudioElement | null>(null);
+	let progressSeconds = $state(0);
+	let volume = $state(0.72);
+	let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+	let current = $derived(radioState?.current ?? null);
+	let duration = $derived(current?.duration ?? 0);
+	let progressPercent = $derived(duration > 0 ? Math.min(100, (progressSeconds / duration) * 100) : 0);
+	let endpoint = $derived(`${API_URL}/radio/state`);
+
+	function formatTime(seconds: number): string {
+		const safe = Math.max(0, Math.floor(seconds));
+		const minutes = Math.floor(safe / 60);
+		const remainder = safe % 60;
+		return `${minutes}:${remainder.toString().padStart(2, '0')}`;
+	}
+
+	function stateProgress(fetched: RadioState): number {
+		const generatedAt = Date.parse(fetched.generated_at);
+		const drift = Number.isFinite(generatedAt) ? Math.max(0, (Date.now() - generatedAt) / 1000) : 0;
+		return Math.min(fetched.current?.duration ?? 0, fetched.progress_seconds + drift);
+	}
+
+	function syncAudioToState(fetched: RadioState) {
+		if (!audioElement || !fetched.current) return;
+
+		const targetProgress = stateProgress(fetched);
+		const sourceChanged = audioElement.src !== fetched.current.stream_url;
+
+		if (sourceChanged) {
+			audioElement.src = fetched.current.stream_url;
+			audioElement.load();
+		}
+
+		const seek = () => {
+			if (!audioElement || !fetched.current) return;
+			if (Number.isFinite(targetProgress)) {
+				audioElement.currentTime = Math.min(targetProgress, fetched.current.duration);
+				progressSeconds = audioElement.currentTime;
+			}
+			if (playing) audioElement.play().catch(() => (playing = false));
+		};
+
+		if (audioElement.readyState >= HTMLMediaElement.HAVE_METADATA && !sourceChanged) {
+			if (Math.abs(audioElement.currentTime - targetProgress) > 5) {
+				seek();
+			}
+		} else {
+			audioElement.onloadedmetadata = seek;
+		}
+	}
+
+	async function fetchRadioState(syncAudio = true) {
+		try {
+			const response = await fetch(endpoint);
+			if (!response.ok) {
+				throw new Error(`radio returned ${response.status}`);
+			}
+			const nextState: RadioState = await response.json();
+			radioState = nextState;
+			progressSeconds = stateProgress(nextState);
+			error = null;
+			if (syncAudio) syncAudioToState(nextState);
+		} catch (e) {
+			console.error('failed to load radio state:', e);
+			error = 'radio is off air right now';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function tuneIn() {
+		if (!audioElement || !radioState?.current) return;
+		audioElement.volume = volume;
+		syncAudioToState(radioState);
+		try {
+			await audioElement.play();
+			playing = true;
+		} catch (e) {
+			console.error('failed to play radio:', e);
+			playing = false;
+		}
+	}
+
+	function handleVolumeInput(event: Event) {
+		const input = event.currentTarget as HTMLInputElement;
+		volume = Number(input.value);
+		if (audioElement) audioElement.volume = volume;
+		if (!playing) tuneIn();
+	}
+
+	function handleTimeUpdate() {
+		if (!audioElement) return;
+		progressSeconds = audioElement.currentTime;
+	}
+
+	function handleEnded() {
+		fetchRadioState(true);
+	}
+
+	async function handleLogout() {
+		await auth.logout();
+		window.location.href = '/';
+	}
+
+	onMount(() => {
+		auth.initialize();
+		const savedVolume = localStorage.getItem('radio_volume');
+		if (savedVolume) volume = Number(savedVolume);
+		fetchRadioState(false);
+		pollTimer = setInterval(() => {
+			fetchRadioState(playing);
+		}, 30000);
+
+		return () => {
+			if (pollTimer) clearInterval(pollTimer);
+		};
+	});
+
+	$effect(() => {
+		localStorage.setItem('radio_volume', volume.toString());
+		if (audioElement) audioElement.volume = volume;
+	});
+</script>
+
+<svelte:head>
+	<title>radio • {APP_NAME}</title>
+	<meta
+		name="description"
+		content="live public radio state from plyr.fm for listeners, games, and lightweight clients"
+	/>
+</svelte:head>
+
+<Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={handleLogout} />
+
+<audio
+	bind:this={audioElement}
+	preload="metadata"
+	ontimeupdate={handleTimeUpdate}
+	onended={handleEnded}
+	onpause={() => (playing = false)}
+	onplay={() => (playing = true)}
+></audio>
+
+<main class="radio-page">
+	<div class="help-corner">
+		<button
+			class="help-button"
+			type="button"
+			aria-label="radio integration details"
+			aria-expanded={helpOpen}
+			onclick={() => (helpOpen = !helpOpen)}
+		>
+			?
+		</button>
+		{#if helpOpen}
+			<div class="help-panel" role="tooltip">
+				<strong>integration</strong>
+				<p>poll <code>{endpoint}</code> for the shared station state.</p>
+				<p>play <code>current.stream_url</code> and seek to <code>progress_seconds</code>.</p>
+				<p>refresh when <code>current_ends_at</code> passes, or poll every 30s.</p>
+			</div>
+		{/if}
+	</div>
+
+	<section class="station">
+		<div class="station-copy">
+			<p class="eyebrow">live station</p>
+			<h1>radio</h1>
+			<p class="subtitle">one public plyr.fm signal for clients, games, and late-night tabs</p>
+		</div>
+
+		{#if loading}
+			<div class="status">tuning...</div>
+		{:else if error}
+			<div class="status error">{error}</div>
+		{:else if current}
+			<div class="now">
+				<div class="radio-face">
+					<div class="speaker">
+						{#if current.artwork_url}
+							<img src={current.artwork_url} alt="" class="art" />
+						{:else}
+							<div class="art fallback"></div>
+						{/if}
+					</div>
+					<div class="receiver">
+						<div class="signal-row">
+							<span class:active={playing}></span>
+							<span class:active={playing}></span>
+							<span class:active={playing}></span>
+							<span class:active={playing}></span>
+						</div>
+						<div class="frequency">radio.plyr.fm</div>
+						<div class="needle-track" aria-label="radio progress">
+							<div class="needle" style={`left: ${progressPercent}%`}></div>
+						</div>
+					</div>
+				</div>
+
+				<div class="track-panel">
+					<div class="track-meta">
+						<p class="label">{playing ? 'on air' : 'standby'}</p>
+						<h2>{current.title}</h2>
+						<a class="artist" href={`/u/${current.artist_handle}`}>@{current.artist_handle}</a>
+					</div>
+
+					<div class="progress-row">
+						<span>{formatTime(progressSeconds)}</span>
+						<div class="progress" aria-label="radio progress">
+							<div class="progress-fill" style={`width: ${progressPercent}%`}></div>
+						</div>
+						<span>{formatTime(duration)}</span>
+					</div>
+
+					<div class="volume-control">
+						<label for="radio-volume">volume</label>
+						<input
+							id="radio-volume"
+							type="range"
+							min="0"
+							max="1"
+							step="0.01"
+							value={volume}
+							oninput={handleVolumeInput}
+							onpointerdown={tuneIn}
+							aria-label="radio volume"
+						/>
+					</div>
+				</div>
+			</div>
+		{:else}
+			<div class="status">no tracks in rotation yet</div>
+		{/if}
+	</section>
+
+	{#if radioState && radioState.up_next.length > 0}
+		<section class="queue-strip" aria-label="up next">
+			<div class="section-heading">
+				<h2>up next</h2>
+				<span>{radioState.rotation.length} in rotation</span>
+			</div>
+			<div class="up-next">
+				{#each radioState.up_next as track (track.id)}
+					<a class="next-track" href={`/track/${track.id}`}>
+						{#if track.thumbnail_url || track.artwork_url}
+							<img src={track.thumbnail_url ?? track.artwork_url ?? ''} alt="" />
+						{:else}
+							<div class="thumb-fallback"></div>
+						{/if}
+						<div>
+							<strong>{track.title}</strong>
+							<span>@{track.artist_handle}</span>
+						</div>
+					</a>
+				{/each}
+			</div>
+		</section>
+	{/if}
+</main>
+
+<style>
+	.radio-page {
+		position: relative;
+		max-width: 980px;
+		margin: 0 auto;
+		padding: 0 1rem calc(var(--player-height, 0px) + 3rem + env(safe-area-inset-bottom, 0px));
+		min-height: 100vh;
+	}
+
+	.help-corner {
+		position: fixed;
+		top: calc(1rem + env(safe-area-inset-top, 0px));
+		right: 1rem;
+		z-index: 20;
+	}
+
+	.help-button {
+		width: 2rem;
+		height: 2rem;
+		border-radius: 999px;
+		border: 1px solid var(--border-default);
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+		font-weight: 700;
+		cursor: help;
+	}
+
+	.help-panel {
+		position: absolute;
+		top: calc(100% + 0.5rem);
+		right: 0;
+		width: min(21rem, calc(100vw - 2rem));
+		padding: 0.85rem;
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-sm);
+		background: var(--bg-primary);
+		box-shadow: 0 12px 32px rgba(0, 0, 0, 0.32);
+		color: var(--text-secondary);
+		font-size: var(--text-sm);
+		line-height: 1.45;
+	}
+
+	.help-panel strong {
+		display: block;
+		margin-bottom: 0.35rem;
+		color: var(--text-primary);
+	}
+
+	.help-panel p {
+		margin: 0.35rem 0;
+	}
+
+	code {
+		font-size: 0.85em;
+		color: var(--text-primary);
+	}
+
+	.station {
+		padding-top: 3.5rem;
+	}
+
+	.station-copy {
+		margin-bottom: 2rem;
+	}
+
+	.eyebrow,
+	.label {
+		margin: 0 0 0.35rem;
+		color: var(--text-tertiary);
+		font-size: var(--text-xs);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	h1 {
+		margin: 0;
+		font-size: clamp(3rem, 13vw, 7rem);
+		line-height: 0.9;
+		letter-spacing: 0;
+	}
+
+	.subtitle {
+		max-width: 38rem;
+		margin: 1rem 0 0;
+		color: var(--text-secondary);
+		font-size: var(--text-lg);
+		line-height: 1.45;
+	}
+
+	.now {
+		display: grid;
+		grid-template-columns: minmax(15rem, 0.78fr) minmax(0, 1fr);
+		gap: 2rem;
+		align-items: end;
+	}
+
+	.radio-face {
+		width: 100%;
+		max-width: 28rem;
+		border: 1px solid var(--border-default);
+		background: var(--bg-secondary);
+	}
+
+	.speaker {
+		aspect-ratio: 1;
+		margin: 1rem;
+		overflow: hidden;
+		border: 1px solid var(--border-default);
+		background:
+			repeating-linear-gradient(
+				90deg,
+				rgba(255, 255, 255, 0.08) 0,
+				rgba(255, 255, 255, 0.08) 1px,
+				transparent 1px,
+				transparent 8px
+			),
+			var(--bg-primary);
+	}
+
+	.art {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	.art.fallback,
+	.thumb-fallback {
+		width: 100%;
+		height: 100%;
+		background:
+			linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 45%),
+			var(--bg-secondary);
+	}
+
+	.track-panel {
+		min-width: 0;
+		padding-bottom: 0.25rem;
+	}
+
+	.track-meta h2 {
+		margin: 0;
+		font-size: clamp(2rem, 6vw, 4rem);
+		line-height: 1;
+		letter-spacing: 0;
+		overflow-wrap: anywhere;
+	}
+
+	.artist {
+		display: inline-block;
+		margin-top: 0.75rem;
+		color: var(--text-secondary);
+		text-decoration: none;
+		font-size: var(--text-lg);
+	}
+
+	.artist:hover,
+	.next-track:hover strong {
+		color: var(--text-primary);
+	}
+
+	.progress-row {
+		display: grid;
+		grid-template-columns: 3.25rem minmax(0, 1fr) 3.25rem;
+		align-items: center;
+		gap: 0.75rem;
+		margin-top: 2rem;
+		color: var(--text-tertiary);
+		font-variant-numeric: tabular-nums;
+		font-size: var(--text-sm);
+	}
+
+	.progress {
+		height: 0.45rem;
+		border-radius: 999px;
+		background: var(--bg-secondary);
+		overflow: hidden;
+	}
+
+	.progress-fill {
+		height: 100%;
+		border-radius: inherit;
+		background: var(--text-primary);
+	}
+
+	.receiver {
+		display: grid;
+		gap: 0.75rem;
+		padding: 0 1rem 1rem;
+	}
+
+	.signal-row {
+		display: flex;
+		align-items: end;
+		gap: 0.35rem;
+	}
+
+	.signal-row span {
+		width: 0.35rem;
+		height: 0.55rem;
+		background: var(--text-tertiary);
+		opacity: 0.35;
+	}
+
+	.signal-row span:nth-child(2) {
+		height: 0.8rem;
+	}
+
+	.signal-row span:nth-child(3) {
+		height: 1.05rem;
+	}
+
+	.signal-row span:nth-child(4) {
+		height: 1.3rem;
+	}
+
+	.signal-row span.active {
+		background: var(--text-primary);
+		opacity: 1;
+	}
+
+	.frequency {
+		color: var(--text-secondary);
+		font-size: var(--text-sm);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.needle-track {
+		position: relative;
+		height: 1.8rem;
+		border-top: 1px solid var(--border-default);
+		border-bottom: 1px solid var(--border-default);
+		background:
+			repeating-linear-gradient(
+				90deg,
+				var(--border-default) 0,
+				var(--border-default) 1px,
+				transparent 1px,
+				transparent 10%
+			),
+			var(--bg-primary);
+	}
+
+	.needle {
+		position: absolute;
+		top: -0.25rem;
+		bottom: -0.25rem;
+		width: 2px;
+		background: var(--text-primary);
+		transform: translateX(-1px);
+	}
+
+	.volume-control {
+		display: grid;
+		grid-template-columns: 4.5rem minmax(0, 1fr);
+		align-items: center;
+		gap: 0.85rem;
+		margin-top: 1.5rem;
+		color: var(--text-secondary);
+	}
+
+	.volume-control label {
+		font-size: var(--text-sm);
+		font-weight: 700;
+	}
+
+	.volume-control input {
+		width: 100%;
+		accent-color: var(--text-primary);
+		cursor: pointer;
+	}
+
+	.status {
+		padding: 3rem 0;
+		color: var(--text-secondary);
+	}
+
+	.status.error {
+		color: var(--error);
+	}
+
+	.queue-strip {
+		margin-top: 3rem;
+	}
+
+	.section-heading {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 0.85rem;
+	}
+
+	.section-heading h2 {
+		margin: 0;
+		font-size: var(--text-lg);
+		letter-spacing: 0;
+	}
+
+	.section-heading span {
+		color: var(--text-tertiary);
+		font-size: var(--text-sm);
+	}
+
+	.up-next {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+		gap: 0.75rem;
+	}
+
+	.next-track {
+		display: grid;
+		grid-template-columns: 3.25rem minmax(0, 1fr);
+		align-items: center;
+		gap: 0.75rem;
+		min-height: 4rem;
+		color: var(--text-secondary);
+		text-decoration: none;
+	}
+
+	.next-track img,
+	.thumb-fallback {
+		width: 3.25rem;
+		height: 3.25rem;
+		object-fit: cover;
+		border: 1px solid var(--border-default);
+	}
+
+	.next-track strong,
+	.next-track span {
+		display: block;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.next-track strong {
+		color: var(--text-primary);
+		font-size: var(--text-sm);
+	}
+
+	.next-track span {
+		margin-top: 0.15rem;
+		color: var(--text-tertiary);
+		font-size: var(--text-xs);
+	}
+
+	@media (max-width: 720px) {
+		.radio-page {
+			padding-top: 0;
+		}
+
+		.station {
+			padding-top: 2.25rem;
+		}
+
+		.now {
+			grid-template-columns: 1fr;
+			gap: 1.25rem;
+		}
+
+		.radio-face {
+			max-width: none;
+		}
+
+		.progress-row {
+			grid-template-columns: 2.75rem minmax(0, 1fr) 2.75rem;
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary

Adds an MVP public radio endpoint at `GET /radio/state.json`.

The endpoint exposes one live station state rather than separate feed menus. It returns the current track, progress, current start/end times, upcoming tracks, and the full deterministic rotation so external clients and little game experiments can consume plyr.fm as a radio source.

## How the MVP decides what is on radio

The rotation is built from public, ungated, listed tracks only. Tracks are ranked by explicit likes plus log-scaled play counts, so likes act like stronger votes while plays still help surface songs people actually listen to without letting old high-play tracks dominate forever.

The station is stateless: track durations define a loop, and wall-clock time determines what is currently playing. That means every client polling the endpoint sees the same current track without needing a scheduler or persistent radio worker yet.

## Validation

- `just backend lint` passes; existing unrelated `ty` warnings remain in older tests.
- Smoke imported the app with a test `OAUTH_ENCRYPTION_KEY` and confirmed `/radio/state.json` is mounted.
- `just backend test backend/tests/api/test_radio.py` could not start because the local Docker/OrbStack socket is unavailable at `/Users/nate/.orbstack/run/docker.sock`.
