### PR TITLE
fix radio page ci checks

### DIFF
--- a/frontend/src/routes/radio/+page.svelte
+++ b/frontend/src/routes/radio/+page.svelte
@@ -44,7 +44,7 @@
 	let audioElement = $state<HTMLAudioElement | null>(null);
 	let progressSeconds = $state(0);
 	let volume = $state(0.72);
-	let pollTimer: ReturnType<typeof setInterval> | null = null;
+	let pollTimer: number | null = null;
 
 	let current = $derived(radioState?.current ?? null);
 	let duration = $derived(current?.duration ?? 0);
@@ -151,12 +151,12 @@
 		const savedVolume = localStorage.getItem('radio_volume');
 		if (savedVolume) volume = Number(savedVolume);
 		fetchRadioState(false);
-		pollTimer = setInterval(() => {
+		pollTimer = window.setInterval(() => {
 			fetchRadioState(playing);
 		}, 30000);
 
 		return () => {
-			if (pollTimer) clearInterval(pollTimer);
+			if (pollTimer) window.clearInterval(pollTimer);
 		};
 	});
 

--- a/loq.toml
+++ b/loq.toml
@@ -325,3 +325,7 @@ max_lines = 561
 [[rules]]
 path = "frontend/src/lib/components/portal/DataSection.svelte"
 max_lines = 612
+
+[[rules]]
+path = "frontend/src/routes/radio/+page.svelte"
+max_lines = 674


### PR DESCRIPTION
## Summary

Fixes the CI failures from the radio page merge.

- uses `window.setInterval` / `window.clearInterval` so eslint no longer reports browser timer globals as undefined
- relaxes the radio page line limit through `just loq-relax`, per repo workflow

## Validation

- `uvx loq`
- `cd frontend && bun run lint`
- `just frontend check`
