### PR TITLE
simplify radio tagline

### DIFF
--- a/frontend/src/routes/radio/+page.svelte
+++ b/frontend/src/routes/radio/+page.svelte
@@ -210,7 +210,7 @@
 		<div class="station-copy">
 			<p class="eyebrow">live station</p>
 			<h1>radio</h1>
-			<p class="subtitle">one public plyr.fm signal for clients, games, and late-night tabs</p>
+			<p class="subtitle">plyr.fm, on air</p>
 		</div>
 
 		{#if loading}


### PR DESCRIPTION
## Summary

Simplifies the radio page subtitle from the long integration-flavored line to: `plyr.fm, on air`.

## Validation

- `just frontend check`
