### PR TITLE
fix(portal): drop the boxed-in band around the tracks filter bar

### DIFF
--- a/frontend/src/lib/components/PagerTabs.svelte
+++ b/frontend/src/lib/components/PagerTabs.svelte
@@ -22,15 +22,6 @@
 
 	let tablistEl = $state<HTMLDivElement>();
 
-	// publish the tab-bar height so a pane's own sticky toolbar (e.g. the tracks
-	// search/sort bar) can sit just beneath it: top = header + tab-bar.
-	let tabbarHeight = $state(0);
-	$effect(() => {
-		if (typeof document !== 'undefined') {
-			document.documentElement.style.setProperty('--pager-tabbar-height', `${tabbarHeight}px`);
-		}
-	});
-
 	function onKeydown(event: KeyboardEvent) {
 		const idx = tabs.findIndex((t) => t.id === active);
 		if (idx === -1) return;
@@ -48,7 +39,7 @@
 	<div class="pager-header">{@render header()}</div>
 {/if}
 
-<div class="pager-tabbar" bind:this={tablistEl} bind:clientHeight={tabbarHeight} role="tablist">
+<div class="pager-tabbar" bind:this={tablistEl} role="tablist">
 	{#each tabs as tab (tab.id)}
 		<button
 			role="tab"

--- a/frontend/src/lib/components/portal/TracksSection.svelte
+++ b/frontend/src/lib/components/portal/TracksSection.svelte
@@ -980,20 +980,12 @@
 		margin-bottom: 1.5rem;
 	}
 
-	/* search + sort bar — sticks just beneath the pager tab bar so you can
-	   filter a long catalog without scrolling back to the top. */
+	/* search + sort row — inline above the list, no surrounding surface; the
+	   input/select are the only chrome (they match the track cards below) */
 	.tracks-toolbar {
-		position: sticky;
-		top: calc(var(--header-height, 0px) + var(--pager-tabbar-height, 0px));
-		z-index: 15;
 		display: flex;
 		gap: 0.5rem;
-		padding: 0.5rem 0 0.75rem;
-		margin-bottom: 0.5rem;
-		/* glass so it blends with the live-theme gradient like the tab bar/header */
-		background: var(--glass-bg, var(--bg-primary));
-		backdrop-filter: var(--glass-blur, none);
-		-webkit-backdrop-filter: var(--glass-blur, none);
+		margin-bottom: 1rem;
 	}
 
 	.track-search {


### PR DESCRIPTION
The tracks search/sort toolbar wrapped the input in its own full-width background band (sticky + glass). On the live (gradient) theme that read as an ugly raw rectangle floating over the gradient — a boxed-in `<div>` around the input that matched nothing else.

Fix: make the toolbar a **plain inline row** — no background, no blur, no sticky. The input + sort `<select>` are now the only chrome, and they already match the track cards below (translucent surface + border + radius), so the row sits cleanly on the page in every theme.

Also removed the now-unused `--pager-tabbar-height` publish from `PagerTabs` (it only existed to offset the sticky toolbar).

Tradeoff: the filter row no longer sticks while scrolling. It scrolls away with the list — cleaner look, and you scroll up to refine. If we want sticky back later, it'll need a proper treatment that doesn't read as a band.

## Verify
- `just frontend check` (0/0) ✅, `bun run lint` ✅, `uvx loq` ✅
- staging QA: `/portal` tracks tab on the live theme — the filter input + sort sit cleanly with no surrounding rectangle.