### PR TITLE
fix(portal): keep the tracks filter box mounted while results load

### DIFF
--- a/frontend/src/lib/components/portal/TracksSection.svelte
+++ b/frontend/src/lib/components/portal/TracksSection.svelte
@@ -402,7 +402,7 @@
 <section class="tracks-section">
 	<h2>your tracks</h2>
 
-	{#if !loadingTracks && (tracks.length > 0 || hasQuery)}
+	{#if tracks.length > 0 || hasQuery}
 		<div class="tracks-toolbar">
 			<input
 				type="search"
@@ -420,14 +420,14 @@
 		</div>
 	{/if}
 
-	{#if loadingTracks}
+	{#if loadingTracks && tracks.length === 0}
 		<div class="loading-container">
 			<WaveLoading size="lg" message="loading tracks..." />
 		</div>
 	{:else if tracks.length === 0}
 		<p class="empty">{hasQuery ? `no tracks match “${searchInput.trim()}”` : 'no tracks uploaded yet'}</p>
 	{:else}
-		<div class="tracks-list">
+		<div class="tracks-list" class:refreshing={loadingTracks}>
 			{#each tracks as track}
 				<div class="track-item" class:editing={editingTrackId === track.id} class:copyright-flagged={track.copyright_flagged}>
 					{#if editingTrackId === track.id}
@@ -1027,6 +1027,13 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.75rem;
+	}
+
+	/* while a filter/sort reload is in flight, dim the prior results instead of
+	   blanking to a spinner — keeps the search box and list in place */
+	.tracks-list.refreshing {
+		opacity: 0.5;
+		transition: opacity 0.15s;
 	}
 
 	.track-item {


### PR DESCRIPTION
Typing in the tracks filter made the **search box itself disappear** mid-keystroke. Cause: the toolbar was gated behind `!loadingTracks`, and typing triggers `loadMyTracks` → `loadingTracks = true` → the toolbar unmounted (losing focus) and the loading spinner took over the whole pane.

Fix:
- Toolbar now renders whenever there are tracks **or** an active query, **independent of loading** — the box stays put and keeps focus while you type.
- The full `WaveLoading` spinner only shows when there's nothing to display yet (initial load, `loadingTracks && tracks.length === 0`). A filter/sort reload keeps the **prior list visible, dimmed** (`.refreshing`) until the new results land — no blank flash on every search.

## Verify
- `just frontend check` (0/0) ✅, `bun run lint` ✅, `uvx loq` ✅
- staging QA: type in "filter your tracks" — the box stays, keeps focus, list dims briefly then updates; clearing the filter restores all; a no-match query shows "no tracks match …" with the box still present.