### PR TITLE
feat(radio): radio as a source on the existing player

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -2,6 +2,7 @@
 	import { untrack } from 'svelte';
 	import { player } from '$lib/player.svelte';
 	import { queue } from '$lib/queue.svelte';
+	import { radio } from '$lib/radio.svelte';
 	import { jam } from '$lib/jam.svelte';
 	import { nowPlaying } from '$lib/now-playing.svelte';
 	import { moderation } from '$lib/moderation.svelte';
@@ -522,6 +523,9 @@
 	let shouldAutoPlay = $state(false);
 
 	$effect(() => {
+		// radio owns the player while active — don't let passive queue syncs
+		// (cross-tab, refetch, hydration) pull a track in underneath it.
+		if (player.radio) return;
 		// in jam mode, jam state drives the player directly
 		if (jam.active && jam.currentTrack) {
 			const trackChanged = jam.currentTrack.id !== player.currentTrack?.id;
@@ -737,7 +741,7 @@
 
 </script>
 
-{#if player.currentTrack}
+{#if player.currentTrack || player.radio}
 	<div class="player" class:jam-active={jam.active} class:is-playing={!player.paused}>
 		<audio
 			bind:this={player.audioElement}
@@ -746,9 +750,33 @@
 			bind:volume={player.volume}
 			onplay={() => { if (!jam.active) player.paused = false; }}
 			onpause={() => { if (!jam.active) player.paused = true; }}
-			onended={handleTrackEnded}
+			onended={() => (player.radio ? radio.onEnded() : handleTrackEnded())}
 		></audio>
 
+		{#if player.radio}
+			<div class="player-content radio-content">
+				<div class="radio-info">
+					<svg class="radio-tower" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+						<circle cx="12" cy="12" r="2"></circle>
+						<path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14"></path>
+					</svg>
+					<div class="radio-text">
+						<span class="radio-station">radio.plyr.fm</span>
+						<a class="radio-track" href="/u/{player.radio.artist_handle}">{player.radio.title} · @{player.radio.artist_handle}</a>
+					</div>
+				</div>
+				<div class="radio-controls">
+					<button class="radio-toggle" onclick={() => player.togglePlayPause()} aria-label={player.paused ? 'play radio' : 'pause radio'}>
+						{#if player.paused}
+							<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><polygon points="6 4 20 12 6 20 6 4"></polygon></svg>
+						{:else}
+							<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="6" y="5" width="4" height="14" rx="1"></rect><rect x="14" y="5" width="4" height="14" rx="1"></rect></svg>
+						{/if}
+					</button>
+					<button class="radio-stop" onclick={() => radio.stop()}>stop</button>
+				</div>
+			</div>
+		{:else if player.currentTrack}
 		{#if jam.active}
 			<div class="jam-stripe-label">
 				<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>{#if jam.isOutputDevice}<path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>{/if}</svg>
@@ -771,6 +799,7 @@
 			/>
 			<PlaybackControls />
 		</div>
+		{/if}
 	</div>
 {/if}
 
@@ -803,6 +832,93 @@
 		grid-template-columns: minmax(200px, 420px) minmax(0, 1fr);
 		align-items: center;
 		gap: 1.5rem;
+	}
+
+	/* radio source — a simple row in the same player, not the track grid */
+	.player-content.radio-content {
+		display: flex;
+		gap: 1rem;
+	}
+
+	.radio-info {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		flex: 1;
+		min-width: 0;
+	}
+
+	.radio-tower {
+		color: var(--accent);
+		flex-shrink: 0;
+	}
+
+	.radio-text {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+	}
+
+	.radio-station {
+		font-size: var(--text-xs);
+		color: var(--text-tertiary);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.radio-track {
+		font-size: var(--text-sm);
+		color: var(--text-primary);
+		text-decoration: none;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.radio-track:hover {
+		color: var(--accent);
+	}
+
+	.radio-controls {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		flex-shrink: 0;
+	}
+
+	.radio-toggle {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 40px;
+		height: 40px;
+		border-radius: var(--radius-full);
+		border: none;
+		background: var(--accent);
+		color: var(--bg-primary);
+		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.radio-toggle:hover {
+		background: var(--accent-hover);
+	}
+
+	.radio-stop {
+		padding: 0.4rem 0.75rem;
+		border-radius: var(--radius-base);
+		border: 1px solid var(--border-default);
+		background: transparent;
+		color: var(--text-secondary);
+		font-family: inherit;
+		font-size: var(--text-sm);
+		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.radio-stop:hover {
+		border-color: var(--text-secondary);
+		color: var(--text-primary);
 	}
 
 	@media (max-width: 1100px) {

--- a/frontend/src/lib/player.svelte.ts
+++ b/frontend/src/lib/player.svelte.ts
@@ -1,6 +1,18 @@
 import type { Track } from './types';
 import { API_URL } from './config';
 
+// radio is a distinct *source* on the same player: when set, the one <audio>
+// element plays this stream instead of a queue track. metadata only — no
+// second audio element, no second player.
+export interface RadioNowPlaying {
+	title: string;
+	artist_handle: string;
+	artwork_url: string | null;
+	stream_url: string;
+	/** station position to resume at (seconds) */
+	start_at: number;
+}
+
 // natural timeupdate steps are sub-second; a larger jump is a seek, scrub, or a
 // restored hydration position — none of which is listened time.
 const PLAY_PROGRESS_SEEK_THRESHOLD_S = 5;
@@ -8,6 +20,8 @@ const PLAY_PROGRESS_SEEK_THRESHOLD_S = 5;
 // global player state using Svelte 5 runes
 class PlayerState {
 	currentTrack = $state<Track | null>(null);
+	// when non-null, the player is in radio mode (overrides currentTrack)
+	radio = $state<RadioNowPlaying | null>(null);
 	audioElement = $state<HTMLAudioElement | undefined>(undefined);
 	paused = $state(true);
 
@@ -56,6 +70,33 @@ class PlayerState {
 
 	togglePlayPause() {
 		this.paused = !this.paused;
+	}
+
+	/** start (or switch) radio playback through the shared audio element.
+	 * call from a user gesture so the play() isn't blocked by autoplay policy. */
+	playRadio(np: RadioNowPlaying) {
+		this.radio = np;
+		this.currentTrack = null; // exit track mode; the track loader bails on null
+		this.paused = false;
+		const el = this.audioElement;
+		if (!el) return;
+		el.src = np.stream_url;
+		el.load();
+		// play immediately (preserve the gesture), then align to station position
+		el.play().catch(() => (this.paused = true));
+		const seek = () => {
+			if (np.start_at > 0 && Number.isFinite(el.duration)) {
+				el.currentTime = Math.min(np.start_at, el.duration);
+			}
+		};
+		if (el.readyState >= 1) seek();
+		else el.onloadedmetadata = seek;
+	}
+
+	stopRadio() {
+		this.radio = null;
+		this.paused = true;
+		this.audioElement?.pause();
 	}
 
 	incrementPlayCount() {

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -538,6 +538,7 @@ class Queue {
 				: insertAt + tracks.length;
 
 		if (playNow) {
+			player.radio = null; // playing a track leaves radio mode
 			this.currentIndex = insertAt;
 		}
 
@@ -606,6 +607,7 @@ class Queue {
 	}
 
 	playNow(track: Track, autoPlay = true) {
+		player.radio = null; // playing a track leaves radio mode
 		this.lastUpdateWasLocal = autoPlay;
 		this.suppressContinuation = false;
 		// keep explicitly-queued up-next, but drop the stale "next from" tail —
@@ -631,6 +633,7 @@ class Queue {
 	goTo(index: number) {
 		if (index < 0 || index >= this.tracks.length) return;
 
+		player.radio = null; // playing a queue item leaves radio mode
 		this.lastUpdateWasLocal = true;
 		this.currentIndex = index;
 		this.syncState();

--- a/frontend/src/lib/radio.svelte.ts
+++ b/frontend/src/lib/radio.svelte.ts
@@ -1,0 +1,130 @@
+// radio data + control. this does NOT own an audio element or a player — it
+// fetches the shared station state and drives the global player's radio source
+// (player.playRadio / player.stopRadio). "active" is read from the player, the
+// single source of truth.
+import { API_URL } from './config';
+import { player, type RadioNowPlaying } from './player.svelte';
+
+export interface RadioTrack {
+	id: number;
+	title: string;
+	artist: string;
+	artist_handle: string;
+	artist_did: string;
+	stream_url: string;
+	file_type: string;
+	duration: number;
+	artwork_url: string | null;
+	thumbnail_url: string | null;
+	atproto_record_uri: string | null;
+	created_at: string;
+	tags: string[];
+	like_count: number;
+	play_count: number;
+}
+
+export interface RadioState {
+	station: string;
+	generated_at: string;
+	loop_duration_seconds: number;
+	current_index: number | null;
+	current_started_at: string | null;
+	current_ends_at: string | null;
+	progress_seconds: number;
+	current: RadioTrack | null;
+	up_next: RadioTrack[];
+	rotation: RadioTrack[];
+}
+
+const POLL_INTERVAL_MS = 30000;
+
+class Radio {
+	state = $state<RadioState | null>(null);
+	loading = $state(true);
+	error = $state<string | null>(null);
+	private pollTimer: number | null = null;
+
+	get current(): RadioTrack | null {
+		return this.state?.current ?? null;
+	}
+
+	/** whether radio is the active player source (single source of truth) */
+	get active(): boolean {
+		return player.radio !== null;
+	}
+
+	private stateProgress(fetched: RadioState): number {
+		const generatedAt = Date.parse(fetched.generated_at);
+		const drift = Number.isFinite(generatedAt) ? Math.max(0, (Date.now() - generatedAt) / 1000) : 0;
+		return Math.min(fetched.current?.duration ?? 0, fetched.progress_seconds + drift);
+	}
+
+	private toNowPlaying(c: RadioTrack): RadioNowPlaying {
+		return {
+			title: c.title,
+			artist_handle: c.artist_handle,
+			artwork_url: c.artwork_url,
+			stream_url: c.stream_url,
+			start_at: this.state ? this.stateProgress(this.state) : 0
+		};
+	}
+
+	async loadState(): Promise<void> {
+		try {
+			const response = await fetch(`${API_URL}/radio/state`);
+			if (!response.ok) throw new Error(`radio returned ${response.status}`);
+			this.state = await response.json();
+			this.error = null;
+		} catch (e) {
+			console.error('failed to load radio state:', e);
+			this.error = 'radio is off air right now';
+		} finally {
+			this.loading = false;
+		}
+	}
+
+	/** start radio. synchronous (no await) so the caller's gesture is preserved
+	 * for autoplay — call once `current` is loaded (the page gates on it). */
+	tuneIn(): void {
+		const c = this.current;
+		if (!c) return;
+		player.playRadio(this.toNowPlaying(c));
+		this.startPolling();
+	}
+
+	stop(): void {
+		player.stopRadio();
+		this.stopPolling();
+	}
+
+	/** the current stream ended — pull the station's now-current track */
+	async onEnded(): Promise<void> {
+		await this.loadState();
+		const c = this.current;
+		if (c && player.radio) player.playRadio(this.toNowPlaying(c));
+	}
+
+	/** poll: follow the shared station when it rotates to a new track */
+	private async syncToStation(): Promise<void> {
+		await this.loadState();
+		const c = this.current;
+		if (!c || !player.radio) return;
+		if (player.radio.stream_url !== c.stream_url) {
+			player.playRadio(this.toNowPlaying(c));
+		}
+	}
+
+	private startPolling(): void {
+		this.stopPolling();
+		this.pollTimer = window.setInterval(() => this.syncToStation(), POLL_INTERVAL_MS);
+	}
+
+	private stopPolling(): void {
+		if (this.pollTimer) {
+			window.clearInterval(this.pollTimer);
+			this.pollTimer = null;
+		}
+	}
+}
+
+export const radio = new Radio();

--- a/frontend/src/routes/radio/+page.svelte
+++ b/frontend/src/routes/radio/+page.svelte
@@ -4,142 +4,10 @@
 	import { API_URL } from '$lib/config';
 	import { APP_NAME } from '$lib/branding';
 	import { auth } from '$lib/auth.svelte';
+	import { radio } from '$lib/radio.svelte';
 
-	interface RadioTrack {
-		id: number;
-		title: string;
-		artist: string;
-		artist_handle: string;
-		artist_did: string;
-		stream_url: string;
-		file_type: string;
-		duration: number;
-		artwork_url: string | null;
-		thumbnail_url: string | null;
-		atproto_record_uri: string | null;
-		created_at: string;
-		tags: string[];
-		like_count: number;
-		play_count: number;
-	}
-
-	interface RadioState {
-		station: string;
-		generated_at: string;
-		loop_duration_seconds: number;
-		current_index: number | null;
-		current_started_at: string | null;
-		current_ends_at: string | null;
-		progress_seconds: number;
-		current: RadioTrack | null;
-		up_next: RadioTrack[];
-		rotation: RadioTrack[];
-	}
-
-	let radioState = $state<RadioState | null>(null);
-	let loading = $state(true);
-	let error = $state<string | null>(null);
-	let playing = $state(false);
 	let helpOpen = $state(false);
-	let audioElement = $state<HTMLAudioElement | null>(null);
-	let progressSeconds = $state(0);
-	let volume = $state(0.72);
-	let pollTimer: number | null = null;
-
-	let current = $derived(radioState?.current ?? null);
-	let duration = $derived(current?.duration ?? 0);
-	let progressPercent = $derived(duration > 0 ? Math.min(100, (progressSeconds / duration) * 100) : 0);
-	let endpoint = $derived(`${API_URL}/radio/state`);
-
-	function formatTime(seconds: number): string {
-		const safe = Math.max(0, Math.floor(seconds));
-		const minutes = Math.floor(safe / 60);
-		const remainder = safe % 60;
-		return `${minutes}:${remainder.toString().padStart(2, '0')}`;
-	}
-
-	function stateProgress(fetched: RadioState): number {
-		const generatedAt = Date.parse(fetched.generated_at);
-		const drift = Number.isFinite(generatedAt) ? Math.max(0, (Date.now() - generatedAt) / 1000) : 0;
-		return Math.min(fetched.current?.duration ?? 0, fetched.progress_seconds + drift);
-	}
-
-	function syncAudioToState(fetched: RadioState) {
-		if (!audioElement || !fetched.current) return;
-
-		const targetProgress = stateProgress(fetched);
-		const sourceChanged = audioElement.src !== fetched.current.stream_url;
-
-		if (sourceChanged) {
-			audioElement.src = fetched.current.stream_url;
-			audioElement.load();
-		}
-
-		const seek = () => {
-			if (!audioElement || !fetched.current) return;
-			if (Number.isFinite(targetProgress)) {
-				audioElement.currentTime = Math.min(targetProgress, fetched.current.duration);
-				progressSeconds = audioElement.currentTime;
-			}
-			if (playing) audioElement.play().catch(() => (playing = false));
-		};
-
-		if (audioElement.readyState >= HTMLMediaElement.HAVE_METADATA && !sourceChanged) {
-			if (Math.abs(audioElement.currentTime - targetProgress) > 5) {
-				seek();
-			}
-		} else {
-			audioElement.onloadedmetadata = seek;
-		}
-	}
-
-	async function fetchRadioState(syncAudio = true) {
-		try {
-			const response = await fetch(endpoint);
-			if (!response.ok) {
-				throw new Error(`radio returned ${response.status}`);
-			}
-			const nextState: RadioState = await response.json();
-			radioState = nextState;
-			progressSeconds = stateProgress(nextState);
-			error = null;
-			if (syncAudio) syncAudioToState(nextState);
-		} catch (e) {
-			console.error('failed to load radio state:', e);
-			error = 'radio is off air right now';
-		} finally {
-			loading = false;
-		}
-	}
-
-	async function tuneIn() {
-		if (!audioElement || !radioState?.current) return;
-		audioElement.volume = volume;
-		syncAudioToState(radioState);
-		try {
-			await audioElement.play();
-			playing = true;
-		} catch (e) {
-			console.error('failed to play radio:', e);
-			playing = false;
-		}
-	}
-
-	function handleVolumeInput(event: Event) {
-		const input = event.currentTarget as HTMLInputElement;
-		volume = Number(input.value);
-		if (audioElement) audioElement.volume = volume;
-		if (!playing) tuneIn();
-	}
-
-	function handleTimeUpdate() {
-		if (!audioElement) return;
-		progressSeconds = audioElement.currentTime;
-	}
-
-	function handleEnded() {
-		fetchRadioState(true);
-	}
+	const endpoint = `${API_URL}/radio/state`;
 
 	async function handleLogout() {
 		await auth.logout();
@@ -148,21 +16,8 @@
 
 	onMount(() => {
 		auth.initialize();
-		const savedVolume = localStorage.getItem('radio_volume');
-		if (savedVolume) volume = Number(savedVolume);
-		fetchRadioState(false);
-		pollTimer = window.setInterval(() => {
-			fetchRadioState(playing);
-		}, 30000);
-
-		return () => {
-			if (pollTimer) window.clearInterval(pollTimer);
-		};
-	});
-
-	$effect(() => {
-		localStorage.setItem('radio_volume', volume.toString());
-		if (audioElement) audioElement.volume = volume;
+		// populate "what's on" for display without starting playback
+		if (!radio.state) radio.loadState();
 	});
 </script>
 
@@ -175,15 +30,6 @@
 </svelte:head>
 
 <Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={handleLogout} />
-
-<audio
-	bind:this={audioElement}
-	preload="metadata"
-	ontimeupdate={handleTimeUpdate}
-	onended={handleEnded}
-	onpause={() => (playing = false)}
-	onplay={() => (playing = true)}
-></audio>
 
 <main class="radio-page">
 	<div class="help-corner">
@@ -213,78 +59,49 @@
 			<p class="subtitle">plyr.fm, on air</p>
 		</div>
 
-		{#if loading}
+		{#if radio.loading && !radio.state}
 			<div class="status">tuning...</div>
-		{:else if error}
-			<div class="status error">{error}</div>
-		{:else if current}
-			<div class="now">
-				<div class="radio-face">
-					<div class="speaker">
-						{#if current.artwork_url}
-							<img src={current.artwork_url} alt="" class="art" />
-						{:else}
-							<div class="art fallback"></div>
-						{/if}
-					</div>
-					<div class="receiver">
-						<div class="signal-row">
-							<span class:active={playing}></span>
-							<span class:active={playing}></span>
-							<span class:active={playing}></span>
-							<span class:active={playing}></span>
-						</div>
-						<div class="frequency">radio.plyr.fm</div>
-						<div class="needle-track" aria-label="radio progress">
-							<div class="needle" style={`left: ${progressPercent}%`}></div>
-						</div>
-					</div>
+		{:else if radio.error}
+			<div class="status error">{radio.error}</div>
+		{:else if radio.current}
+			<div class="now-card">
+				{#if radio.current.artwork_url}
+					<img src={radio.current.artwork_url} alt="" class="art" />
+				{:else}
+					<div class="art fallback"></div>
+				{/if}
+				<div class="now-meta">
+					<p class="label">{radio.active ? 'on air' : "what's on"}</p>
+					<h2>{radio.current.title}</h2>
+					<a class="artist" href={`/u/${radio.current.artist_handle}`}>@{radio.current.artist_handle}</a>
 				</div>
-
-				<div class="track-panel">
-					<div class="track-meta">
-						<p class="label">{playing ? 'on air' : 'standby'}</p>
-						<h2>{current.title}</h2>
-						<a class="artist" href={`/u/${current.artist_handle}`}>@{current.artist_handle}</a>
-					</div>
-
-					<div class="progress-row">
-						<span>{formatTime(progressSeconds)}</span>
-						<div class="progress" aria-label="radio progress">
-							<div class="progress-fill" style={`width: ${progressPercent}%`}></div>
-						</div>
-						<span>{formatTime(duration)}</span>
-					</div>
-
-					<div class="volume-control">
-						<label for="radio-volume">volume</label>
-						<input
-							id="radio-volume"
-							type="range"
-							min="0"
-							max="1"
-							step="0.01"
-							value={volume}
-							oninput={handleVolumeInput}
-							onpointerdown={tuneIn}
-							aria-label="radio volume"
-						/>
-					</div>
-				</div>
+				{#if radio.active}
+					<button class="tune-btn stop" onclick={() => radio.stop()}>stop</button>
+				{:else}
+					<button class="tune-btn" onclick={() => radio.tuneIn()}>
+						<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+							<polygon points="6 4 20 12 6 20 6 4"></polygon>
+						</svg>
+						tune in
+					</button>
+				{/if}
 			</div>
+			{#if radio.active}
+				<p class="now-hint">playing in your player — keep browsing, it follows you.</p>
+			{/if}
 		{:else}
 			<div class="status">no tracks in rotation yet</div>
 		{/if}
 	</section>
 
-	{#if radioState && radioState.up_next.length > 0}
+	{#if radio.state && radio.state.up_next.length > 0}
 		<section class="queue-strip" aria-label="up next">
 			<div class="section-heading">
 				<h2>up next</h2>
-				<span>{radioState.rotation.length} in rotation</span>
+				<span>{radio.state.rotation.length} in rotation</span>
 			</div>
 			<div class="up-next">
-				{#each radioState.up_next as track (track.id)}
+				{#each radio.state.up_next as track (track.id)}
 					<a class="next-track" href={`/track/${track.id}`}>
 						{#if track.thumbnail_url || track.artwork_url}
 							<img src={track.thumbnail_url ?? track.artwork_url ?? ''} alt="" />
@@ -373,14 +190,12 @@
 		color: var(--text-tertiary);
 		font-size: var(--text-xs);
 		text-transform: uppercase;
-		letter-spacing: 0;
 	}
 
 	h1 {
 		margin: 0;
 		font-size: clamp(3rem, 13vw, 7rem);
 		line-height: 0.9;
-		letter-spacing: 0;
 	}
 
 	.subtitle {
@@ -391,68 +206,43 @@
 		line-height: 1.45;
 	}
 
-	.now {
-		display: grid;
-		grid-template-columns: minmax(15rem, 0.78fr) minmax(0, 1fr);
-		gap: 2rem;
-		align-items: end;
-	}
-
-	.radio-face {
-		width: 100%;
-		max-width: 28rem;
-		border: 1px solid var(--border-default);
-		background: var(--bg-secondary);
-	}
-
-	.speaker {
-		aspect-ratio: 1;
-		margin: 1rem;
-		overflow: hidden;
-		border: 1px solid var(--border-default);
-		background:
-			repeating-linear-gradient(
-				90deg,
-				rgba(255, 255, 255, 0.08) 0,
-				rgba(255, 255, 255, 0.08) 1px,
-				transparent 1px,
-				transparent 8px
-			),
-			var(--bg-primary);
+	.now-card {
+		display: flex;
+		align-items: center;
+		gap: 1.5rem;
+		flex-wrap: wrap;
 	}
 
 	.art {
-		width: 100%;
-		height: 100%;
+		width: 8rem;
+		height: 8rem;
 		object-fit: cover;
-		display: block;
+		border: 1px solid var(--border-default);
+		flex-shrink: 0;
 	}
 
 	.art.fallback,
 	.thumb-fallback {
-		width: 100%;
-		height: 100%;
 		background:
 			linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 45%),
 			var(--bg-secondary);
 	}
 
-	.track-panel {
-		min-width: 0;
-		padding-bottom: 0.25rem;
+	.now-meta {
+		flex: 1;
+		min-width: 12rem;
 	}
 
-	.track-meta h2 {
+	.now-meta h2 {
 		margin: 0;
-		font-size: clamp(2rem, 6vw, 4rem);
+		font-size: clamp(1.75rem, 5vw, 3rem);
 		line-height: 1;
-		letter-spacing: 0;
 		overflow-wrap: anywhere;
 	}
 
 	.artist {
 		display: inline-block;
-		margin-top: 0.75rem;
+		margin-top: 0.6rem;
 		color: var(--text-secondary);
 		text-decoration: none;
 		font-size: var(--text-lg);
@@ -463,115 +253,44 @@
 		color: var(--text-primary);
 	}
 
-	.progress-row {
-		display: grid;
-		grid-template-columns: 3.25rem minmax(0, 1fr) 3.25rem;
+	.tune-btn {
+		display: inline-flex;
 		align-items: center;
-		gap: 0.75rem;
-		margin-top: 2rem;
-		color: var(--text-tertiary);
-		font-variant-numeric: tabular-nums;
-		font-size: var(--text-sm);
-	}
-
-	.progress {
-		height: 0.45rem;
-		border-radius: 999px;
-		background: var(--bg-secondary);
-		overflow: hidden;
-	}
-
-	.progress-fill {
-		height: 100%;
-		border-radius: inherit;
-		background: var(--text-primary);
-	}
-
-	.receiver {
-		display: grid;
-		gap: 0.75rem;
-		padding: 0 1rem 1rem;
-	}
-
-	.signal-row {
-		display: flex;
-		align-items: end;
-		gap: 0.35rem;
-	}
-
-	.signal-row span {
-		width: 0.35rem;
-		height: 0.55rem;
-		background: var(--text-tertiary);
-		opacity: 0.35;
-	}
-
-	.signal-row span:nth-child(2) {
-		height: 0.8rem;
-	}
-
-	.signal-row span:nth-child(3) {
-		height: 1.05rem;
-	}
-
-	.signal-row span:nth-child(4) {
-		height: 1.3rem;
-	}
-
-	.signal-row span.active {
-		background: var(--text-primary);
-		opacity: 1;
-	}
-
-	.frequency {
-		color: var(--text-secondary);
-		font-size: var(--text-sm);
-		font-variant-numeric: tabular-nums;
-	}
-
-	.needle-track {
-		position: relative;
-		height: 1.8rem;
-		border-top: 1px solid var(--border-default);
-		border-bottom: 1px solid var(--border-default);
-		background:
-			repeating-linear-gradient(
-				90deg,
-				var(--border-default) 0,
-				var(--border-default) 1px,
-				transparent 1px,
-				transparent 10%
-			),
-			var(--bg-primary);
-	}
-
-	.needle {
-		position: absolute;
-		top: -0.25rem;
-		bottom: -0.25rem;
-		width: 2px;
-		background: var(--text-primary);
-		transform: translateX(-1px);
-	}
-
-	.volume-control {
-		display: grid;
-		grid-template-columns: 4.5rem minmax(0, 1fr);
-		align-items: center;
-		gap: 0.85rem;
-		margin-top: 1.5rem;
-		color: var(--text-secondary);
-	}
-
-	.volume-control label {
-		font-size: var(--text-sm);
-		font-weight: 700;
-	}
-
-	.volume-control input {
-		width: 100%;
-		accent-color: var(--text-primary);
+		gap: 0.5rem;
+		padding: 0.7rem 1.4rem;
+		border: none;
+		border-radius: var(--radius-full);
+		background: var(--accent);
+		color: var(--bg-primary);
+		font-family: inherit;
+		font-size: var(--text-base);
+		font-weight: 600;
 		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.tune-btn:hover {
+		background: var(--accent-hover);
+		transform: translateY(-1px);
+	}
+
+	.tune-btn.stop {
+		background: transparent;
+		border: 1px solid var(--border-default);
+		color: var(--text-secondary);
+	}
+
+	.tune-btn.stop:hover {
+		background: transparent;
+		border-color: var(--text-secondary);
+		color: var(--text-primary);
+		transform: none;
+	}
+
+	.now-hint {
+		margin: 1rem 0 0;
+		color: var(--text-tertiary);
+		font-size: var(--text-sm);
 	}
 
 	.status {
@@ -598,7 +317,6 @@
 	.section-heading h2 {
 		margin: 0;
 		font-size: var(--text-lg);
-		letter-spacing: 0;
 	}
 
 	.section-heading span {
@@ -656,19 +374,6 @@
 
 		.station {
 			padding-top: 2.25rem;
-		}
-
-		.now {
-			grid-template-columns: 1fr;
-			gap: 1.25rem;
-		}
-
-		.radio-face {
-			max-width: none;
-		}
-
-		.progress-row {
-			grid-template-columns: 2.75rem minmax(0, 1fr) 2.75rem;
 		}
 	}
 </style>

--- a/loq.toml
+++ b/loq.toml
@@ -124,7 +124,7 @@ max_lines = 622
 
 [[rules]]
 path = "frontend/src/lib/components/player/Player.svelte"
-max_lines = 906
+max_lines = 987
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"


### PR DESCRIPTION
Redo of the reverted #1485 — the **right** way this time. #1485 added a second `<audio>` element and a clone footer (a parallel mini-player). This makes radio a **source on the one player** instead: same audio element, same footer, same play/pause.

## How it works
- **`player.svelte.ts`** — `radio: RadioNowPlaying | null` + `playRadio()` / `stopRadio()`. `playRadio` drives the **existing** `player.audioElement` (no second element), plays synchronously to preserve the tune-in gesture, then seeks to the station position. Setting `radio` nulls `currentTrack` (so the track loader, which already no-ops on null, stays out of the way).
- **`Player.svelte`** — the existing footer renders a radio branch when `player.radio` is set (radio-tower icon + station + current track), reusing the existing **play/pause** (`player.togglePlayPause`) and **volume**. The queue→player sync effect bails while radio is active; `onended` advances the station instead of the queue.
- **`queue.svelte.ts`** — `playNow` / `goTo` / `addTracks(playNow)` clear `player.radio`, so starting a track cleanly takes over the shared audio output.
- **`radio.svelte.ts`** — data/poll only (no audio element). Drives `player.playRadio`, follows the shared station as it rotates; `active` is read from `player.radio` (single source of truth).
- **radio page** — explicit **"tune in"** button (the gesture browsers require), no local `<audio>`, no tuner dial. Playback now lives in the real player and **persists across navigation**.

One audio element, one player, one set of controls — radio is just a source on it.

## Deferred
- Teal scrobbles for signed-in radio listening.

## Verify
- `just frontend check` (0/0) ✅, `bun run lint` ✅, `uvx loq` ✅, `bun run build` ✅
- staging QA: `/radio` → tune in plays immediately; footer shows tower + station + track using the normal controls; navigate anywhere → keeps playing; play a normal track → radio hands off, queue intact; stop → playback stops. No second player.