### PR TITLE
fix(radio): render radio through the existing player strip

### DIFF
--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -57,7 +57,11 @@
 	// when jam is active, show jam tracks; otherwise show personal queue
 	const tracks = $derived(jam.active ? jam.tracks : queue.tracks);
 	const currentIdx = $derived(jam.active ? jam.currentIndex : queue.currentIndex);
-	const currentTrack = $derived.by<Track | null>(() => tracks[currentIdx] ?? null);
+	// radio is what's actually playing when active — reflect it in the now-playing
+	// card so the panel doesn't claim a queue track is playing.
+	const currentTrack = $derived.by<Track | null>(
+		() => player.radio?.track ?? tracks[currentIdx] ?? null
+	);
 	const upcoming = $derived.by<{ track: Track; index: number }[]>(() => {
 		return tracks
 			.map((track, index) => ({ track, index }))

--- a/frontend/src/lib/components/player/PlaybackControls.svelte
+++ b/frontend/src/lib/components/player/PlaybackControls.svelte
@@ -3,6 +3,9 @@
 	import { player } from '$lib/player.svelte';
 	import { queue } from '$lib/queue.svelte';
 
+	// radio mode: live stream — no prev/next or scrubbing, just play/pause + volume
+	let { radioMode = false }: { radioMode?: boolean } = $props();
+
 	let seekValue = $state(0);
 	let isScrubbing = $state(false);
 	let rafId: number | null = null;
@@ -108,12 +111,14 @@
 	}
 </script>
 
-<div class="player-controls">
-	<button class="control-btn" onclick={handlePrevious} title="previous track / restart">
-		<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-			<path d="M6 4h2v16H6V4zm12 0l-10 8 10 8V4z" />
-		</svg>
-	</button>
+<div class="player-controls" class:radio-mode={radioMode}>
+	{#if !radioMode}
+		<button class="control-btn" onclick={handlePrevious} title="previous track / restart">
+			<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+				<path d="M6 4h2v16H6V4zm12 0l-10 8 10 8V4z" />
+			</svg>
+		</button>
+	{/if}
 
 	<button
 		class="control-btn play-pause"
@@ -132,39 +137,43 @@
 		{/if}
 	</button>
 
-	<button
-		class="control-btn"
-		class:disabled={!queue.hasNext}
-		onclick={() => queue.next()}
-		title="next track"
-		disabled={!queue.hasNext}
-	>
-		<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-			<path d="M16 4h2v16h-2V4zM6 4l10 8-10 8V4z"></path>
-		</svg>
-	</button>
+	{#if !radioMode}
+		<button
+			class="control-btn"
+			class:disabled={!queue.hasNext}
+			onclick={() => queue.next()}
+			title="next track"
+			disabled={!queue.hasNext}
+		>
+			<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+				<path d="M16 4h2v16h-2V4zM6 4l10 8-10 8V4z"></path>
+			</svg>
+		</button>
 
-	<div class="time-control">
-		<span class="time">{formattedCurrentTime}</span>
-		<input
-			type="range"
-			class="seek-bar"
-			min="0"
-			max={player.duration || 0}
-			step="0.01"
-			value={seekValue}
-			oninput={handleSeekInput}
-			onchange={handleSeekChange}
-			onpointerdown={() => (isScrubbing = true)}
-			onpointerup={handleSeekPointerUp}
-			onpointerleave={(event) => {
-				if (isScrubbing) handleSeekPointerCancel(event);
-			}}
-			onpointercancel={handleSeekPointerCancel}
-			style="--progress: {progressPercent}%"
-		/>
-		<span class="time">{formattedDuration}</span>
-	</div>
+		<div class="time-control">
+			<span class="time">{formattedCurrentTime}</span>
+			<input
+				type="range"
+				class="seek-bar"
+				min="0"
+				max={player.duration || 0}
+				step="0.01"
+				value={seekValue}
+				oninput={handleSeekInput}
+				onchange={handleSeekChange}
+				onpointerdown={() => (isScrubbing = true)}
+				onpointerup={handleSeekPointerUp}
+				onpointerleave={(event) => {
+					if (isScrubbing) handleSeekPointerCancel(event);
+				}}
+				onpointercancel={handleSeekPointerCancel}
+				style="--progress: {progressPercent}%"
+			/>
+			<span class="time">{formattedDuration}</span>
+		</div>
+	{:else}
+		<span class="live-pill">live</span>
+	{/if}
 
 	<div class="volume-control">
 		<div class="volume-icon" class:muted={volumeState === 'muted'}>
@@ -208,6 +217,17 @@
 		gap: 1rem;
 		min-width: 0;
 		width: 100%;
+	}
+
+	/* radio: "live" fills the slot the scrubber would occupy, keeping play/pause
+	   left and volume right — same control row, no scrubber/skip */
+	.live-pill {
+		flex: 1;
+		font-size: var(--text-xs);
+		font-weight: 600;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--accent);
 	}
 
 	.control-btn {

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -106,6 +106,9 @@
 	let isOnTrackDetailPage = $derived(
 		player.currentTrack && $page.url.pathname === `/track/${player.currentTrack.id}`
 	);
+	// what the strip shows: the radio on-air track when in radio mode, else the
+	// queue track. radio renders through the SAME strip (TrackInfo + controls).
+	let nowPlayingTrack = $derived(player.radio?.track ?? player.currentTrack);
 	let trackInfoRef = $state<{ recalcOverflow: () => void } | null>(null);
 
 	$effect(() => {
@@ -741,7 +744,7 @@
 
 </script>
 
-{#if player.currentTrack || player.radio}
+{#if nowPlayingTrack}
 	<div class="player" class:jam-active={jam.active} class:is-playing={!player.paused}>
 		<audio
 			bind:this={player.audioElement}
@@ -753,31 +756,7 @@
 			onended={() => (player.radio ? radio.onEnded() : handleTrackEnded())}
 		></audio>
 
-		{#if player.radio}
-			<div class="player-content radio-content">
-				<div class="radio-info">
-					<svg class="radio-tower" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-						<circle cx="12" cy="12" r="2"></circle>
-						<path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14"></path>
-					</svg>
-					<div class="radio-text">
-						<span class="radio-station">radio.plyr.fm</span>
-						<a class="radio-track" href="/u/{player.radio.artist_handle}">{player.radio.title} · @{player.radio.artist_handle}</a>
-					</div>
-				</div>
-				<div class="radio-controls">
-					<button class="radio-toggle" onclick={() => player.togglePlayPause()} aria-label={player.paused ? 'play radio' : 'pause radio'}>
-						{#if player.paused}
-							<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><polygon points="6 4 20 12 6 20 6 4"></polygon></svg>
-						{:else}
-							<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="6" y="5" width="4" height="14" rx="1"></rect><rect x="14" y="5" width="4" height="14" rx="1"></rect></svg>
-						{/if}
-					</button>
-					<button class="radio-stop" onclick={() => radio.stop()}>stop</button>
-				</div>
-			</div>
-		{:else if player.currentTrack}
-		{#if jam.active}
+		{#if jam.active && !player.radio}
 			<div class="jam-stripe-label">
 				<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>{#if jam.isOutputDevice}<path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>{/if}</svg>
 				{#if jam.outputMode === 'everyone'}
@@ -793,13 +772,13 @@
 
 		<div class="player-content">
 			<TrackInfo
-				track={player.currentTrack}
+				track={nowPlayingTrack}
 				isOnTrackDetailPage={Boolean(isOnTrackDetailPage)}
+				radioMode={Boolean(player.radio)}
 				bind:this={trackInfoRef}
 			/>
-			<PlaybackControls />
+			<PlaybackControls radioMode={Boolean(player.radio)} />
 		</div>
-		{/if}
 	</div>
 {/if}
 
@@ -832,93 +811,6 @@
 		grid-template-columns: minmax(200px, 420px) minmax(0, 1fr);
 		align-items: center;
 		gap: 1.5rem;
-	}
-
-	/* radio source — a simple row in the same player, not the track grid */
-	.player-content.radio-content {
-		display: flex;
-		gap: 1rem;
-	}
-
-	.radio-info {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		flex: 1;
-		min-width: 0;
-	}
-
-	.radio-tower {
-		color: var(--accent);
-		flex-shrink: 0;
-	}
-
-	.radio-text {
-		display: flex;
-		flex-direction: column;
-		min-width: 0;
-	}
-
-	.radio-station {
-		font-size: var(--text-xs);
-		color: var(--text-tertiary);
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-	}
-
-	.radio-track {
-		font-size: var(--text-sm);
-		color: var(--text-primary);
-		text-decoration: none;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
-	}
-
-	.radio-track:hover {
-		color: var(--accent);
-	}
-
-	.radio-controls {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		flex-shrink: 0;
-	}
-
-	.radio-toggle {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 40px;
-		height: 40px;
-		border-radius: var(--radius-full);
-		border: none;
-		background: var(--accent);
-		color: var(--bg-primary);
-		cursor: pointer;
-		transition: all 0.15s;
-	}
-
-	.radio-toggle:hover {
-		background: var(--accent-hover);
-	}
-
-	.radio-stop {
-		padding: 0.4rem 0.75rem;
-		border-radius: var(--radius-base);
-		border: 1px solid var(--border-default);
-		background: transparent;
-		color: var(--text-secondary);
-		font-family: inherit;
-		font-size: var(--text-sm);
-		cursor: pointer;
-		transition: all 0.15s;
-	}
-
-	.radio-stop:hover {
-		border-color: var(--text-secondary);
-		color: var(--text-primary);
 	}
 
 	@media (max-width: 1100px) {

--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -6,9 +6,10 @@
 	interface Props {
 		track: Track;
 		isOnTrackDetailPage: boolean;
+		radioMode?: boolean;
 	}
 
-	let { track, isOnTrackDetailPage }: Props = $props();
+	let { track, isOnTrackDetailPage, radioMode = false }: Props = $props();
 
 	let titleEl = $state<HTMLElement | null>(null);
 	let artistEl = $state<HTMLElement | null>(null);
@@ -111,7 +112,15 @@
 				</div>
 			</div>
 			<div class="metadata-line">
-				{#if track.album}
+				{#if radioMode}
+					<span class="metadata-link radio-indicator">
+						<svg class="metadata-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+							<circle cx="12" cy="12" r="2" />
+							<path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14" />
+						</svg>
+						<div class="text-container"><span>radio.plyr.fm</span></div>
+					</span>
+				{:else if track.album}
 					<a
 						href="/u/{track.artist_handle}/album/{track.album.slug}"
 						class="metadata-link"
@@ -273,6 +282,12 @@
 		min-width: 0;
 		white-space: nowrap;
 		line-height: 1.15;
+	}
+
+	/* radio source indicator — sits in the album/single slot, tinted to signal
+	   the player is on the station */
+	.radio-indicator {
+		color: var(--accent);
 	}
 
 	.metadata-link:hover,

--- a/frontend/src/lib/player.svelte.ts
+++ b/frontend/src/lib/player.svelte.ts
@@ -2,12 +2,12 @@ import type { Track } from './types';
 import { API_URL } from './config';
 
 // radio is a distinct *source* on the same player: when set, the one <audio>
-// element plays this stream instead of a queue track. metadata only — no
-// second audio element, no second player.
+// element plays this stream instead of a queue track, and the normal player
+// strip renders `track` (the on-air track) with a radioMode flag. no second
+// audio element, no second strip.
 export interface RadioNowPlaying {
-	title: string;
-	artist_handle: string;
-	artwork_url: string | null;
+	/** the on-air track, rendered in the normal player strip (TrackInfo) */
+	track: Track;
 	stream_url: string;
 	/** station position to resume at (seconds) */
 	start_at: number;

--- a/frontend/src/lib/radio.svelte.ts
+++ b/frontend/src/lib/radio.svelte.ts
@@ -4,6 +4,7 @@
 // single source of truth.
 import { API_URL } from './config';
 import { player, type RadioNowPlaying } from './player.svelte';
+import type { Track } from './types';
 
 export interface RadioTrack {
 	id: number;
@@ -60,10 +61,28 @@ class Radio {
 	}
 
 	private toNowPlaying(c: RadioTrack): RadioNowPlaying {
-		return {
+		// the on-air entry is a real track — reshape it as a Track so the normal
+		// player strip renders it identically to any other track.
+		const track: Track = {
+			id: c.id,
 			title: c.title,
+			artist: c.artist,
 			artist_handle: c.artist_handle,
-			artwork_url: c.artwork_url,
+			artist_did: c.artist_did,
+			file_id: '',
+			file_type: c.file_type,
+			play_count: c.play_count,
+			like_count: c.like_count,
+			image_url: c.artwork_url ?? undefined,
+			thumbnail_url: c.thumbnail_url ?? undefined,
+			created_at: c.created_at,
+			tags: c.tags,
+			atproto_record_uri: c.atproto_record_uri ?? undefined,
+			album: null,
+			features: []
+		};
+		return {
+			track,
 			stream_url: c.stream_url,
 			start_at: this.state ? this.stateProgress(this.state) : 0
 		};


### PR DESCRIPTION
Follow-up to #1487. That still rendered a **separate-looking footer strip** for radio (a bespoke `radio-content` block) — effectively a second player, which is exactly what you flagged. This makes radio render through the **same strip** you already have.

## What changed
- `player.radio` now carries the **on-air `Track`** (radio entries are real tracks). `radio.svelte.ts` reshapes the station's current track into a `Track`.
- `Player.svelte`: **one render path** — `TrackInfo` + `PlaybackControls`, fed the radio track + a `radioMode` flag. The `radio-content` branch and its CSS are gone.
- `TrackInfo` (radioMode): shows a radio-tower **"radio.plyr.fm"** badge in the album/single slot; artwork, title, artist render identically to any track.
- `PlaybackControls` (radioMode): hides prev/next + scrubber (it's a live stream), keeps play/pause + volume, shows a small **"live"** pill.
- **Queue panel** now-playing reflects the radio track when radio is the source (it was wrongly showing the queue track).

One audio element, one strip, one set of controls — radio is just a mode on the player.

## Deferred
- Teal scrobbles for signed-in radio listening.

## Verify
- `just frontend check` (0/0) ✅, `bun run lint` ✅, `uvx loq` ✅, `bun run build` ✅
- staging QA: tune in → the **same** footer strip shows the on-air track (artwork/title/artist) with a "radio.plyr.fm" badge + "live", play/pause + volume only; navigate → persists; open the queue panel → now-playing shows the radio track, not a queue track; play a track → takes over, queue intact.