### PR TITLE
feat(radio): make the radio page reachable

### DIFF
--- a/frontend/src/lib/components/LinksMenu.svelte
+++ b/frontend/src/lib/components/LinksMenu.svelte
@@ -58,6 +58,25 @@
 				</button>
 			</div>
 			<nav class="menu-links">
+				<a href="/radio" class="menu-link" onclick={closeMenu}>
+					<svg
+						width="24"
+						height="24"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<circle cx="12" cy="12" r="2"></circle>
+						<path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14"></path>
+					</svg>
+					<div class="link-info">
+						<span class="link-title">radio</span>
+						<span class="link-subtitle">live station</span>
+					</div>
+				</a>
 				<a
 					href={client.profileUrl('plyr.fm')}
 					target="_blank"

--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -113,13 +113,13 @@
 			</div>
 			<div class="metadata-line">
 				{#if radioMode}
-					<span class="metadata-link radio-indicator">
+					<a href="/radio" class="metadata-link radio-indicator">
 						<svg class="metadata-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
 							<circle cx="12" cy="12" r="2" />
 							<path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14" />
 						</svg>
 						<div class="text-container"><span>radio.plyr.fm</span></div>
-					</span>
+					</a>
 				{:else if track.album}
 					<a
 						href="/u/{track.artist_handle}/album/{track.album.slug}"


### PR DESCRIPTION
Two ways to get to `/radio` (you couldn't before):

- **Top-left links menu** ("more" / asterisk) gets a **radio** entry (live station). Internal link → client-side nav, doesn't reload or interrupt playback.
- The **footer "radio.plyr.fm" badge** (shown while radio plays) is now a link to `/radio` — client-side nav, playback continues.

Kept the header itself untouched (didn't want to muddy it), per your call.

## Verify
- `just frontend check` (0/0) ✅, `bun run lint` ✅, `uvx loq` ✅
- staging QA: open the top-left menu → "radio" → lands on /radio; while radio plays, click "radio.plyr.fm" in the footer → /radio without stopping playback.