### PR TITLE
fix(radio): drop the domain label in the player — just "radio"

### DIFF
--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -118,7 +118,7 @@
 							<circle cx="12" cy="12" r="2" />
 							<path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14" />
 						</svg>
-						<div class="text-container"><span>radio.plyr.fm</span></div>
+						<div class="text-container"><span>radio</span></div>
 					</a>
 				{:else if track.album}
 					<a


### PR DESCRIPTION
The footer badge said **radio.plyr.fm**, but the page lives at `/radio` and there's no radio subdomain (decided not to set one up). Label it just **radio** — still links to `/radio`. No DNS needed.