### PR TITLE
feat(radio): embeddable radio player at /embed/radio

### DIFF
--- a/frontend/src/lib/components/embed/RadioEmbed.svelte
+++ b/frontend/src/lib/components/embed/RadioEmbed.svelte
@@ -1,0 +1,245 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { API_URL } from '$lib/config';
+	import type { RadioState, RadioTrack } from '$lib/radio.svelte';
+
+	// standalone embed player: this is its own iframe context (not the main app),
+	// so it owns a local <audio> and its own station polling.
+	let audioElement = $state<HTMLAudioElement | null>(null);
+	let radioState = $state<RadioState | null>(null);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let playing = $state(false);
+	let pollTimer: number | null = null;
+
+	let current: RadioTrack | null = $derived(radioState?.current ?? null);
+
+	function stateProgress(fetched: RadioState): number {
+		const generatedAt = Date.parse(fetched.generated_at);
+		const drift = Number.isFinite(generatedAt) ? Math.max(0, (Date.now() - generatedAt) / 1000) : 0;
+		return Math.min(fetched.current?.duration ?? 0, fetched.progress_seconds + drift);
+	}
+
+	function syncAudio(fetched: RadioState) {
+		const el = audioElement;
+		if (!el || !fetched.current) return;
+		const target = stateProgress(fetched);
+		const changed = el.src !== fetched.current.stream_url;
+		if (changed) {
+			el.src = fetched.current.stream_url;
+			el.load();
+		}
+		const seek = () => {
+			if (!el || !fetched.current) return;
+			if (Number.isFinite(target)) el.currentTime = Math.min(target, fetched.current.duration);
+			if (playing) el.play().catch(() => (playing = false));
+		};
+		if (el.readyState >= 1 && !changed) {
+			if (Math.abs(el.currentTime - target) > 5) seek();
+		} else {
+			el.onloadedmetadata = seek;
+		}
+	}
+
+	async function loadState(sync = false) {
+		try {
+			const res = await fetch(`${API_URL}/radio/state`);
+			if (!res.ok) throw new Error(`radio ${res.status}`);
+			radioState = await res.json();
+			error = null;
+			if (sync && radioState) syncAudio(radioState);
+		} catch (e) {
+			console.error('radio embed: failed to load state', e);
+			error = 'radio is off air right now';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function toggle() {
+		const el = audioElement;
+		if (!el || !current) return;
+		if (playing) {
+			el.pause();
+		} else {
+			// user gesture — safe to start audio
+			syncAudio(radioState!);
+			el.play().then(() => (playing = true)).catch(() => (playing = false));
+		}
+	}
+
+	onMount(() => {
+		loadState(false);
+		pollTimer = window.setInterval(() => loadState(playing), 30000);
+		return () => {
+			if (pollTimer) window.clearInterval(pollTimer);
+		};
+	});
+</script>
+
+<audio
+	bind:this={audioElement}
+	preload="metadata"
+	onended={() => loadState(true)}
+	onplay={() => (playing = true)}
+	onpause={() => (playing = false)}
+></audio>
+
+<div class="radio-embed">
+	<a class="brand" href="https://plyr.fm/radio" target="_blank" rel="noopener">
+		<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+			<circle cx="12" cy="12" r="2"></circle>
+			<path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14"></path>
+		</svg>
+		<span>plyr.fm radio</span>
+	</a>
+
+	{#if loading && !radioState}
+		<div class="status">tuning…</div>
+	{:else if error}
+		<div class="status error">{error}</div>
+	{:else if current}
+		<div class="now">
+			{#if current.artwork_url}
+				<img class="art" src={current.artwork_url} alt="" />
+			{:else}
+				<div class="art fallback"></div>
+			{/if}
+			<div class="meta">
+				<span class="label">{playing ? 'on air' : "what's on"}</span>
+				<span class="title">{current.title}</span>
+				<a class="artist" href={`https://plyr.fm/u/${current.artist_handle}`} target="_blank" rel="noopener">@{current.artist_handle}</a>
+			</div>
+			<button class="play" onclick={toggle} aria-label={playing ? 'pause radio' : 'play radio'}>
+				{#if playing}
+					<svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="6" y="5" width="4" height="14" rx="1"></rect><rect x="14" y="5" width="4" height="14" rx="1"></rect></svg>
+				{:else}
+					<svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><polygon points="7 4 20 12 7 20 7 4"></polygon></svg>
+				{/if}
+			</button>
+		</div>
+	{:else}
+		<div class="status">no tracks in rotation yet</div>
+	{/if}
+</div>
+
+<style>
+	.radio-embed {
+		height: 100%;
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		padding: 1rem;
+		background: var(--bg-primary);
+		color: var(--text-primary);
+		font-family:
+			'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', 'Consolas', monospace;
+	}
+
+	.brand {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		color: var(--accent);
+		text-decoration: none;
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
+
+	.brand:hover {
+		text-decoration: underline;
+	}
+
+	.status {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--text-tertiary);
+	}
+
+	.status.error {
+		color: #ef4444;
+	}
+
+	.now {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		min-height: 0;
+	}
+
+	.art {
+		width: 5rem;
+		height: 5rem;
+		border-radius: 8px;
+		object-fit: cover;
+		border: 1px solid var(--border-default);
+		flex-shrink: 0;
+	}
+
+	.art.fallback {
+		background:
+			linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 45%),
+			var(--bg-secondary);
+	}
+
+	.meta {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+	}
+
+	.label {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--text-tertiary);
+	}
+
+	.title {
+		font-size: 1.1rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.artist {
+		font-size: 0.85rem;
+		color: var(--text-secondary);
+		text-decoration: none;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.artist:hover {
+		color: var(--text-primary);
+	}
+
+	.play {
+		flex-shrink: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 3rem;
+		height: 3rem;
+		border-radius: var(--radius-full);
+		border: none;
+		background: var(--accent);
+		color: var(--bg-primary);
+		cursor: pointer;
+		transition: filter 0.15s;
+	}
+
+	.play:hover {
+		filter: brightness(1.1);
+	}
+</style>

--- a/frontend/src/routes/embed/radio/+page.svelte
+++ b/frontend/src/routes/embed/radio/+page.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import RadioEmbed from '$lib/components/embed/RadioEmbed.svelte';
+	import { APP_NAME } from '$lib/branding';
+</script>
+
+<svelte:head>
+	<title>radio • {APP_NAME}</title>
+</svelte:head>
+
+<RadioEmbed />


### PR DESCRIPTION
A compact, standalone **`/embed/radio`** — for dropping plyr.fm radio into an iframe (the existing embeds only cover playlist/track/album/user).

- Own audio element + station polling (it's a separate iframe context, not the main app player — a local element is correct here).
- Shows the on-air track + artwork with a play/pause button; advances with the station; links back to `/radio` and the artist.
- Uses the bare embed layout + embed CSS vars, matching the other embeds.

First consumer: the bottom-left player on my personal site (`zzstoatzz.github.io`), which I'll point at this.

## Verify
- `just frontend check` (0/0) ✅, `bun run lint` ✅, `uvx loq` ✅, `bun run build` ✅
- post-deploy: `plyr.fm/embed/radio` in an iframe → compact player, click play → streams the station.