### PR TITLE
fix(radio): /radio OG card was losing to the default (duplicate tags)

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -35,6 +35,7 @@
 		$page.url.pathname === '/' || // homepage
 		$page.url.pathname === '/activity' || // activity feed
 		$page.url.pathname === '/record' || // in-browser recording
+		$page.url.pathname === '/radio' || // radio station
 		$page.url.pathname.startsWith('/track/') || // track detail
 		$page.url.pathname.startsWith('/playlist/') || // playlist detail
 		$page.url.pathname.startsWith('/tag/') || // tag detail


### PR DESCRIPTION
Shared `plyr.fm/radio` links showed the **default** site card ("plyr.fm - audio streaming app") instead of the radio card I added in #1491.

Cause: `/radio` wasn't in the layout's `hasPageMetadata` allowlist, so the layout emitted its **default** OG/Twitter tags *in addition* to the radio page's tags. Both ended up in `<head>`; scrapers take the **first** `og:*`, which was the default. (Track/playlist/etc. pages work because they're already in that list.)

Fix: add `/radio` to `hasPageMetadata` so the layout suppresses its defaults there and only the radio tags render. Verified the dupes via `curl https://plyr.fm/radio`.

After deploy, re-paste the link (or bust the scraper cache, e.g. `plyr.fm/radio?x=1`) — Bluesky's card service caches the old fetch.

## Verify
- `just frontend check` (0/0) ✅, `bun run lint` ✅, `uvx loq` ✅
- post-deploy: `curl -s https://plyr.fm/radio | grep og:title` → only `radio · plyr.fm`.