### PR TITLE
chore(loq): fix main — relax +layout.svelte limit

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -132,7 +132,7 @@ max_lines = 897
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"
-max_lines = 830
+max_lines = 831
 
 [[rules]]
 path = "frontend/src/routes/costs/+page.svelte"


### PR DESCRIPTION
main went red on loq: #1493's one-line addition to `+layout.svelte` pushed it to 831 > 830. Relax the limit. (#1493 merged before the loq check finished — no required-status gate.)