### PR TITLE
fix(meta): real link-preview image for homepage + default

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -450,7 +450,11 @@
 		/>
 		<meta property="og:site_name" content={APP_NAME} />
 		<meta property="og:url" content={APP_CANONICAL_URL} />
-		<meta property="og:image" content={logo} />
+		<!-- absolute URL — scrapers can't resolve the relative hashed asset path -->
+		<meta property="og:image" content={`${APP_CANONICAL_URL}/icons/icon-512.png`} />
+		<meta property="og:image:secure_url" content={`${APP_CANONICAL_URL}/icons/icon-512.png`} />
+		<meta property="og:image:width" content="512" />
+		<meta property="og:image:height" content="512" />
 
 		<!-- Twitter -->
 		<meta name="twitter:card" content="summary" />
@@ -459,7 +463,7 @@
 			name="twitter:description"
 			content={`discover and stream audio on the AT Protocol with ${APP_NAME}`}
 		/>
-		<meta name="twitter:image" content={logo} />
+		<meta name="twitter:image" content={`${APP_CANONICAL_URL}/icons/icon-512.png`} />
 	{/if}
 
 	<script>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -257,11 +257,17 @@
 	<meta property="og:description" content={APP_TAGLINE} />
 	<meta property="og:url" content={APP_CANONICAL_URL} />
 	<meta property="og:site_name" content={APP_NAME} />
+	<meta property="og:image" content={`${APP_CANONICAL_URL}/icons/icon-512.png`} />
+	<meta property="og:image:secure_url" content={`${APP_CANONICAL_URL}/icons/icon-512.png`} />
+	<meta property="og:image:width" content="512" />
+	<meta property="og:image:height" content="512" />
+	<meta property="og:image:alt" content={APP_NAME} />
 
 	<!-- Twitter -->
 	<meta name="twitter:card" content="summary" />
 	<meta name="twitter:title" content={APP_NAME} />
 	<meta name="twitter:description" content={APP_TAGLINE} />
+	<meta name="twitter:image" content={`${APP_CANONICAL_URL}/icons/icon-512.png`} />
 </svelte:head>
 
 <Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={logout} />

--- a/loq.toml
+++ b/loq.toml
@@ -132,7 +132,7 @@ max_lines = 897
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"
-max_lines = 831
+max_lines = 835
 
 [[rules]]
 path = "frontend/src/routes/costs/+page.svelte"


### PR DESCRIPTION
`https://plyr.fm` previewed with **no image**: the homepage head had no `og:image`/`twitter:image` at all, and the layout's default block used a *relative* hashed asset path (`logo` → `/_app/immutable/...`) that scrapers can't resolve.

Both now point at the **absolute** brand icon (`/icons/icon-512.png`) with dimensions + alt, matching the track pages.

`just frontend check` ✅ · `bun run lint` ✅ · `uvx loq` ✅

After deploy, re-scrape (or `?x=1`) to bust the card cache.