### PR TITLE
fix radio cold start audio

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -757,18 +757,18 @@
 
 </script>
 
+<audio
+	bind:this={player.audioElement}
+	bind:currentTime={player.currentTime}
+	bind:duration={player.duration}
+	bind:volume={player.volume}
+	onplay={() => { if (!jam.active) player.paused = false; }}
+	onpause={() => { if (!jam.active) player.paused = true; }}
+	onended={() => (player.radio ? radio.onEnded() : handleTrackEnded())}
+></audio>
+
 {#if nowPlayingTrack}
 	<div class="player" class:jam-active={jam.active} class:is-playing={!player.paused}>
-		<audio
-			bind:this={player.audioElement}
-			bind:currentTime={player.currentTime}
-			bind:duration={player.duration}
-			bind:volume={player.volume}
-			onplay={() => { if (!jam.active) player.paused = false; }}
-			onpause={() => { if (!jam.active) player.paused = true; }}
-			onended={() => (player.radio ? radio.onEnded() : handleTrackEnded())}
-		></audio>
-
 		{#if jam.active && !player.radio}
 			<div class="jam-stripe-label">
 				<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>{#if jam.isOutputDevice}<path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>{/if}</svg>


### PR DESCRIPTION
## Summary

Fixes the cold-start radio playback bug where `/radio` could show `on air` after clicking **tune in**, but no audio source was attached.

## Root cause

The shared `<audio>` element lived inside `{#if nowPlayingTrack}`. On a cold radio page there is no current track/player footer yet. `radio.tuneIn()` calls `player.playRadio()`, but `player.audioElement` was still undefined, so `playRadio()` returned before setting `src`. The footer mounted immediately afterward because `player.radio` was now set, leaving UI state active but audio state empty.

## Fix

Mount the shared `<audio>` element outside the conditional footer UI. The element is now available before the first radio click, while the visible player strip still only renders when there is a queue track or radio track to show.

## Validation

- `uvx loq`
- `cd frontend && bun run lint`
- `just frontend check`
- commit hooks also ran `loq`, `svelte check`, and `eslint`
