### PR TITLE
Polish radio playback surfaces

### DIFF
--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -62,6 +62,7 @@
 	const currentTrack = $derived.by<Track | null>(
 		() => player.radio?.track ?? tracks[currentIdx] ?? null
 	);
+	const currentSourceLabel = $derived(player.radio ? 'radio' : jam.active ? 'jam' : 'queue');
 	const upcoming = $derived.by<{ track: Track; index: number }[]>(() => {
 		return tracks
 			.map((track, index) => ({ track, index }))
@@ -415,7 +416,16 @@
 		<div class="queue-body">
 			{#if currentTrack}
 				<section class="now-playing">
-					<div class="section-label">now playing{#if player.radio} · radio{/if}</div>
+					<div class="section-label">
+						<span>now playing</span>
+						{#if player.radio}
+							<a class="source-chip radio-source" href="/radio">{currentSourceLabel}</a>
+						{:else if jam.active && jam.code}
+							<a class="source-chip" href={`/jam/${jam.code}`}>{currentSourceLabel}</a>
+						{:else}
+							<span class="source-chip">{currentSourceLabel}</span>
+						{/if}
+					</div>
 					<div class="now-playing-card">
 						{@render media(currentTrack)}
 					</div>
@@ -751,11 +761,41 @@
 	}
 
 	.section-label {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
 		font-size: var(--text-xs);
 		text-transform: uppercase;
 		letter-spacing: 0.08em;
 		color: var(--text-tertiary);
 		margin-bottom: 0.5rem;
+	}
+
+	.source-chip {
+		display: inline-flex;
+		align-items: center;
+		max-width: 45%;
+		padding: 0.1rem 0.45rem;
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-full);
+		color: var(--text-tertiary);
+		text-decoration: none;
+		font-size: var(--text-xs);
+		letter-spacing: 0.04em;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.source-chip.radio-source {
+		color: var(--accent);
+		border-color: color-mix(in srgb, var(--accent) 35%, var(--border-subtle));
+	}
+
+	.source-chip:hover {
+		color: var(--text-secondary);
+		border-color: var(--border-default);
 	}
 
 	.now-playing-card {

--- a/frontend/src/lib/components/player/PlaybackControls.svelte
+++ b/frontend/src/lib/components/player/PlaybackControls.svelte
@@ -113,13 +113,7 @@
 
 <div class="player-controls" class:radio-mode={radioMode}>
 	{#if radioMode}
-		<!-- live stream: a static ∞ marker holds play/pause in its normal slot
-		     instead of letting it jump left where the prev button used to be -->
-		<button class="control-btn infinity" disabled aria-hidden="true" title="continuous — radio doesn't skip">
-			<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-				<path d="M18.6 6.62c-1.44 0-2.8.56-3.77 1.53L7.8 14.39c-.64.64-1.49.99-2.4.99-1.87 0-3.39-1.51-3.39-3.38S3.53 8.62 5.4 8.62c.91 0 1.76.35 2.44 1.03l1.13 1 1.51-1.34L9.22 8.2C8.2 7.18 6.84 6.62 5.4 6.62 2.42 6.62 0 9.04 0 12s2.42 5.38 5.4 5.38c1.44 0 2.8-.56 3.77-1.53l7.43-6.57c.64-.64 1.49-.99 2.4-.99 1.87 0 3.39 1.51 3.39 3.38s-1.52 3.38-3.39 3.38c-.9 0-1.76-.35-2.44-1.03l-1.14-1.01-1.51 1.34 1.27 1.12c1.02 1.01 2.37 1.57 3.82 1.57 2.98 0 5.4-2.42 5.4-5.38s-2.42-5.37-5.4-5.37z" />
-			</svg>
-		</button>
+		<span class="control-spacer" aria-hidden="true"></span>
 	{:else}
 		<button class="control-btn" onclick={handlePrevious} title="previous track / restart">
 			<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -180,7 +174,7 @@
 			<span class="time">{formattedDuration}</span>
 		</div>
 	{:else}
-		<span class="live-pill">live</span>
+		<a class="live-pill" href="/radio">radio live</a>
 	{/if}
 
 	<div class="volume-control">
@@ -236,6 +230,7 @@
 		letter-spacing: 0.08em;
 		text-transform: uppercase;
 		color: var(--accent);
+		text-decoration: none;
 	}
 
 	.control-btn {
@@ -270,16 +265,10 @@
 		pointer-events: none;
 	}
 
-	/* radio: static, non-interactive marker that holds play/pause in place */
-	.control-btn.infinity {
-		color: var(--text-tertiary);
-		opacity: 0.55;
-		cursor: default;
-	}
-
-	.control-btn.infinity:hover {
-		color: var(--text-tertiary);
-		background: transparent;
+	.control-spacer {
+		width: 40px;
+		height: 40px;
+		flex-shrink: 0;
 	}
 
 	.time-control {
@@ -438,6 +427,13 @@
 			grid-column: 5;
 		}
 
+		.control-spacer {
+			grid-row: 1;
+			grid-column: 4;
+			width: 44px;
+			height: 44px;
+		}
+
 		.control-btn:nth-of-type(3) {
 			grid-column: 6;
 		}
@@ -462,6 +458,11 @@
 			grid-row: 2;
 			grid-column: 1 / 7;
 			text-align: center;
+			color: var(--text-tertiary);
+			text-decoration: none;
+			font-size: var(--text-xs);
+			text-transform: uppercase;
+			letter-spacing: 0.08em;
 		}
 
 		.time {

--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -118,7 +118,7 @@
 							<circle cx="12" cy="12" r="2" />
 							<path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14" />
 						</svg>
-						<div class="text-container"><span>radio</span></div>
+						<div class="text-container"><span>radio live</span></div>
 					</a>
 				{:else if track.album}
 					<a

--- a/frontend/src/routes/radio/+page.svelte
+++ b/frontend/src/routes/radio/+page.svelte
@@ -63,10 +63,15 @@
 
 <main class="radio-page">
 	<section class="station">
-		<div class="station-copy">
-			<p class="eyebrow">live station</p>
-			<h1>radio</h1>
-			<p class="subtitle">plyr.fm, on air</p>
+		<div class="station-header">
+			<div>
+				<p class="eyebrow">plyr.fm</p>
+				<h1>radio</h1>
+			</div>
+			<span class="station-status" class:active={radio.active}>
+				<span></span>
+				{radio.active ? 'live' : 'on air'}
+			</span>
 		</div>
 
 		{#if radio.loading && !radio.state}
@@ -81,12 +86,12 @@
 					<div class="art fallback"></div>
 				{/if}
 				<div class="now-meta">
-					<p class="label">{radio.active ? 'on air' : "what's on"}</p>
+					<p class="label">{radio.active ? 'now playing from radio' : "what's on radio"}</p>
 					<h2>{radio.current.title}</h2>
 					<a class="artist" href={`/u/${radio.current.artist_handle}`}>@{radio.current.artist_handle}</a>
 				</div>
 				{#if radio.active}
-					<button class="tune-btn stop" onclick={() => radio.stop()}>stop</button>
+					<button class="tune-btn stop" onclick={() => radio.stop()}>stop radio</button>
 				{:else}
 					<button class="tune-btn" onclick={() => radio.tuneIn()}>
 						<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -148,14 +153,14 @@
 <style>
 	.radio-page {
 		position: relative;
-		max-width: 980px;
+		max-width: 760px;
 		margin: 0 auto;
-		padding: 0 1rem calc(var(--player-height, 0px) + 3rem + env(safe-area-inset-bottom, 0px));
+		padding: 0 1rem calc(var(--player-height, 0px) + 2.5rem + env(safe-area-inset-bottom, 0px));
 		min-height: 100vh;
 	}
 
 	.radio-footer {
-		margin-top: 2.5rem;
+		margin-top: 2rem;
 		display: flex;
 		flex-wrap: wrap;
 		align-items: baseline;
@@ -199,11 +204,15 @@
 	}
 
 	.station {
-		padding-top: 3.5rem;
+		padding-top: 2.25rem;
 	}
 
-	.station-copy {
-		margin-bottom: 2rem;
+	.station-header {
+		display: flex;
+		align-items: flex-end;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 1.25rem;
 	}
 
 	.eyebrow,
@@ -216,31 +225,47 @@
 
 	h1 {
 		margin: 0;
-		font-size: clamp(3rem, 13vw, 7rem);
-		line-height: 0.9;
+		font-size: var(--text-2xl);
+		line-height: 1;
+		text-transform: lowercase;
 	}
 
-	.subtitle {
-		max-width: 38rem;
-		margin: 1rem 0 0;
-		color: var(--text-secondary);
-		font-size: var(--text-lg);
-		line-height: 1.45;
+	.station-status {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		margin-bottom: 0.1rem;
+		color: var(--text-tertiary);
+		font-size: var(--text-xs);
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		white-space: nowrap;
+	}
+
+	.station-status span {
+		width: 0.45rem;
+		height: 0.45rem;
+		border-radius: var(--radius-full);
+		background: var(--text-muted);
+	}
+
+	.station-status.active span {
+		background: var(--accent);
 	}
 
 	.now-card {
-		display: flex;
-		align-items: center;
-		gap: 1.5rem;
-		flex-wrap: wrap;
+		display: grid;
+		grid-template-columns: minmax(6.5rem, 9rem) minmax(0, 1fr);
+		align-items: end;
+		gap: 1rem;
 	}
 
 	.art {
-		width: 8rem;
-		height: 8rem;
+		width: 100%;
+		aspect-ratio: 1;
 		object-fit: cover;
+		border-radius: var(--radius-md);
 		border: 1px solid var(--border-default);
-		flex-shrink: 0;
 	}
 
 	.art.fallback,
@@ -251,20 +276,19 @@
 	}
 
 	.now-meta {
-		flex: 1;
-		min-width: 12rem;
+		min-width: 0;
 	}
 
 	.now-meta h2 {
 		margin: 0;
-		font-size: clamp(1.75rem, 5vw, 3rem);
-		line-height: 1;
+		font-size: clamp(1.8rem, 7vw, 3.25rem);
+		line-height: 0.98;
 		overflow-wrap: anywhere;
 	}
 
 	.artist {
 		display: inline-block;
-		margin-top: 0.6rem;
+		margin-top: 0.5rem;
 		color: var(--text-secondary);
 		text-decoration: none;
 		font-size: var(--text-lg);
@@ -279,9 +303,10 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.5rem;
-		padding: 0.7rem 1.4rem;
+		margin-top: 1rem;
+		padding: 0.65rem 1rem;
 		border: none;
-		border-radius: var(--radius-full);
+		border-radius: var(--radius-base);
 		background: var(--accent);
 		color: var(--bg-primary);
 		font-family: inherit;
@@ -310,7 +335,7 @@
 	}
 
 	.progress {
-		margin: 1.25rem 0 0;
+		margin: 1rem 0 0;
 		height: 4px;
 		border-radius: 999px;
 		background: var(--bg-secondary);
@@ -343,7 +368,7 @@
 	}
 
 	.queue-strip {
-		margin-top: 3rem;
+		margin-top: 2.25rem;
 	}
 
 	.section-heading {
@@ -356,7 +381,10 @@
 
 	.section-heading h2 {
 		margin: 0;
-		font-size: var(--text-lg);
+		color: var(--text-secondary);
+		font-size: var(--text-sm);
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
 	}
 
 	.section-heading span {
@@ -365,26 +393,37 @@
 	}
 
 	.up-next {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
-		gap: 0.75rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
 	}
 
 	.next-track {
 		display: grid;
-		grid-template-columns: 3.25rem minmax(0, 1fr);
+		grid-template-columns: 48px minmax(0, 1fr);
 		align-items: center;
-		gap: 0.75rem;
-		min-height: 4rem;
+		gap: 0.7rem;
+		min-height: 64px;
+		padding: 0.45rem;
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-md);
+		background: var(--bg-secondary);
 		color: var(--text-secondary);
 		text-decoration: none;
+		transition: background 0.15s ease, border-color 0.15s ease;
+	}
+
+	.next-track:hover {
+		background: var(--bg-hover);
+		border-color: var(--border-default);
 	}
 
 	.next-track img,
 	.thumb-fallback {
-		width: 3.25rem;
-		height: 3.25rem;
+		width: 48px;
+		height: 48px;
 		object-fit: cover;
+		border-radius: var(--radius-sm);
 		border: 1px solid var(--border-default);
 	}
 
@@ -398,7 +437,7 @@
 
 	.next-track strong {
 		color: var(--text-primary);
-		font-size: var(--text-sm);
+		font-size: var(--text-base);
 	}
 
 	.next-track span {
@@ -423,33 +462,27 @@
 		color: var(--text-primary);
 	}
 
-	@media (max-width: 720px) {
-		.radio-page {
-			padding-top: 0;
-		}
-
-		.station {
-			padding-top: 2.25rem;
-		}
-	}
-
 	@media (max-width: 520px) {
+		.station {
+			padding-top: 1.5rem;
+		}
+
 		.now-card {
-			gap: 1rem;
+			grid-template-columns: 5rem minmax(0, 1fr);
+			align-items: center;
 		}
 
-		.art {
-			width: 5.5rem;
-			height: 5.5rem;
+		.now-meta h2 {
+			font-size: var(--text-2xl);
+			line-height: 1.05;
 		}
 
-		/* let the meta shrink next to the art; the button wraps full-width below */
-		.now-meta {
-			min-width: 0;
-			flex-basis: calc(100% - 6.5rem);
+		.artist {
+			font-size: var(--text-base);
 		}
 
 		.tune-btn {
+			grid-column: 1 / -1;
 			width: 100%;
 			justify-content: center;
 		}

--- a/loq.toml
+++ b/loq.toml
@@ -104,7 +104,7 @@ max_lines = 1186
 
 [[rules]]
 path = "frontend/src/lib/components/Queue.svelte"
-max_lines = 1073
+max_lines = 1112
 
 [[rules]]
 path = "frontend/src/lib/components/SearchModal.svelte"


### PR DESCRIPTION
## Summary
- make /radio feel more app-native with a compact station header, artwork-led now-playing section, and mobile-first up-next list rows
- label the queue now-playing source as radio/jam/queue instead of blending radio into queue text
- replace the visible infinity placeholder in radio controls with an invisible layout spacer and quieter radio live source text

## Checks
- just frontend check
- cd frontend && bun run lint
- uvx loq check frontend/src/routes/radio/+page.svelte frontend/src/lib/components/Queue.svelte frontend/src/lib/components/player/PlaybackControls.svelte frontend/src/lib/components/player/TrackInfo.svelte
- git diff --check