### PR TITLE
fix(docs): add API reference landing page so /developers/api-reference/ stops 404ing

### DIFF
--- a/docs/public/developers/api-reference/index.md
+++ b/docs/public/developers/api-reference/index.md
@@ -1,0 +1,33 @@
+---
+title: API reference
+description: "plyr.fm REST API — endpoints, request/response examples, error codes"
+---
+
+the plyr.fm REST API. public endpoints need no auth; authenticated endpoints
+take a [developer token](/developers/auth/) from plyr.fm/portal. the OpenAPI
+spec is live at [api.plyr.fm/docs](https://api.plyr.fm/docs).
+
+new here? start with the [quickstart](/developers/quickstart/) — a track player in 30 lines.
+
+## endpoints
+
+- [tracks](/developers/api-reference/tracks/overview/) — list, upload, stream, edit, delete
+- [search](/developers/api-reference/search/) — keyword + mood search
+- [discover](/developers/api-reference/discover/) — surfaced tracks
+- [for you](/developers/api-reference/for_you/) — personalized feed
+- [albums](/developers/api-reference/albums/) — album CRUD
+- [lists](/developers/api-reference/lists/) — playlists
+- [artists](/developers/api-reference/artists/) — artist profiles
+- [users](/developers/api-reference/users/) — user lookups
+- [account](/developers/api-reference/account/) — your account
+- [preferences](/developers/api-reference/preferences/) — settings
+- [queue](/developers/api-reference/queue/) — playback queue
+- [now playing](/developers/api-reference/now_playing/) — now-playing reports
+- [jams](/developers/api-reference/jams/) — shared listening rooms
+- [activity](/developers/api-reference/activity/) — listen receipts + stats
+- [stats](/developers/api-reference/stats/) — platform stats
+- [audio](/developers/api-reference/audio/) — audio serving
+- [exports](/developers/api-reference/exports/) — media export
+- [moderation](/developers/api-reference/moderation/) — content moderation
+- [oembed](/developers/api-reference/oembed/) — oEmbed
+- [meta](/developers/api-reference/meta/) — metadata

--- a/docs/site/justfile
+++ b/docs/site/justfile
@@ -36,3 +36,6 @@ api-ref:
         mkdir -p tracks && \
         for f in tracks-*.md; do mv "$f" "tracks/${f#tracks-}"; done && \
         mv tracks/__init__.md tracks/overview.md
+    # mdxify emits no directory landing page; restore the curated index so
+    # /developers/api-reference/ doesn't 404
+    cp templates/api-reference-index.md ../public/developers/api-reference/index.md

--- a/docs/site/templates/api-reference-index.md
+++ b/docs/site/templates/api-reference-index.md
@@ -1,0 +1,33 @@
+---
+title: API reference
+description: "plyr.fm REST API — endpoints, request/response examples, error codes"
+---
+
+the plyr.fm REST API. public endpoints need no auth; authenticated endpoints
+take a [developer token](/developers/auth/) from plyr.fm/portal. the OpenAPI
+spec is live at [api.plyr.fm/docs](https://api.plyr.fm/docs).
+
+new here? start with the [quickstart](/developers/quickstart/) — a track player in 30 lines.
+
+## endpoints
+
+- [tracks](/developers/api-reference/tracks/overview/) — list, upload, stream, edit, delete
+- [search](/developers/api-reference/search/) — keyword + mood search
+- [discover](/developers/api-reference/discover/) — surfaced tracks
+- [for you](/developers/api-reference/for_you/) — personalized feed
+- [albums](/developers/api-reference/albums/) — album CRUD
+- [lists](/developers/api-reference/lists/) — playlists
+- [artists](/developers/api-reference/artists/) — artist profiles
+- [users](/developers/api-reference/users/) — user lookups
+- [account](/developers/api-reference/account/) — your account
+- [preferences](/developers/api-reference/preferences/) — settings
+- [queue](/developers/api-reference/queue/) — playback queue
+- [now playing](/developers/api-reference/now_playing/) — now-playing reports
+- [jams](/developers/api-reference/jams/) — shared listening rooms
+- [activity](/developers/api-reference/activity/) — listen receipts + stats
+- [stats](/developers/api-reference/stats/) — platform stats
+- [audio](/developers/api-reference/audio/) — audio serving
+- [exports](/developers/api-reference/exports/) — media export
+- [moderation](/developers/api-reference/moderation/) — content moderation
+- [oembed](/developers/api-reference/oembed/) — oEmbed
+- [meta](/developers/api-reference/meta/) — metadata


### PR DESCRIPTION
The **API reference** link in the developers "get started" list ([screenshot context](https://docs.plyr.fm/developers/)) 404s. So do the quickstart link, the coding-assistant prompt URL, and the `llms.txt` entry — all point at `/developers/api-reference/`, which had no page.

**Root cause:** `just api-ref` runs `mdxify` over `backend.api` to emit one page per router (`search.md`, `tracks/overview.md`, …) but no directory landing page, so Starlight 404'd the route root. The sub-pages always worked; only the index didn't. Dead since the developers landing page was first built (#1035, consolidated in #1247).

**Fix:** keep a curated landing page that links out to each endpoint group. Because the recipe `rm -rf`'s the whole directory on every regeneration, the canonical copy lives in `docs/site/templates/api-reference-index.md` and the `api-ref` recipe `cp`s it back after mdxify runs — so it survives future regens.

<details>
<summary>verification</summary>

Ran a real `bun run build`; `dist/developers/api-reference/index.html` is now produced (44 pages, no errors).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)