### PR TITLE
Revert radio layout tightening

### DIFF
--- a/frontend/src/routes/radio/+page.svelte
+++ b/frontend/src/routes/radio/+page.svelte
@@ -163,12 +163,12 @@
 		position: relative;
 		max-width: 980px;
 		margin: 0 auto;
-		padding: 0 1rem calc(var(--player-height, 0px) + 2rem + env(safe-area-inset-bottom, 0px));
+		padding: 0 1rem calc(var(--player-height, 0px) + 3rem + env(safe-area-inset-bottom, 0px));
 		min-height: 100vh;
 	}
 
 	.radio-footer {
-		margin-top: 1.5rem;
+		margin-top: 2.5rem;
 		display: flex;
 		flex-wrap: wrap;
 		align-items: baseline;
@@ -212,11 +212,11 @@
 	}
 
 	.station {
-		padding-top: 2rem;
+		padding-top: 3.5rem;
 	}
 
 	.station-copy {
-		margin-bottom: 1.5rem;
+		margin-bottom: 2.75rem;
 	}
 
 	.station-kicker {
@@ -254,8 +254,8 @@
 
 	h1 {
 		margin: 0;
-		font-size: clamp(2.75rem, 7vw, 4.25rem);
-		line-height: 0.95;
+		font-size: clamp(3rem, 11vw, 5.75rem);
+		line-height: 0.9;
 	}
 
 	.now-card {
@@ -396,7 +396,7 @@
 	}
 
 	.queue-strip {
-		margin-top: 2rem;
+		margin-top: 3rem;
 	}
 
 	.section-heading {
@@ -498,38 +498,7 @@
 		}
 
 		.station {
-			padding-top: 1.5rem;
-		}
-	}
-
-	@media (max-height: 820px) and (min-width: 721px) {
-		.radio-page {
-			padding-bottom: calc(var(--player-height, 0px) + 1.25rem + env(safe-area-inset-bottom, 0px));
-		}
-
-		.station {
-			padding-top: 1.25rem;
-		}
-
-		.station-copy {
-			margin-bottom: 1rem;
-		}
-
-		h1 {
-			font-size: clamp(2.5rem, 6vw, 3.5rem);
-		}
-
-		.art {
-			width: clamp(9.5rem, 20vw, 12rem);
-			height: clamp(9.5rem, 20vw, 12rem);
-		}
-
-		.queue-strip {
-			margin-top: 1.5rem;
-		}
-
-		.radio-footer {
-			margin-top: 1rem;
+			padding-top: 2.25rem;
 		}
 	}
 


### PR DESCRIPTION
## Summary
- revert #1506 / 405b1d17 only
- keep the newer API reference landing page fix from #1507 intact

## Checks
- just frontend check
- cd frontend && bun run lint
- uvx loq check frontend/src/routes/radio/+page.svelte
- git diff --check