### PR TITLE
Show radio rotation through artwork

### DIFF
--- a/backend/src/backend/api/radio.py
+++ b/backend/src/backend/api/radio.py
@@ -1,5 +1,6 @@
 """Public live radio state for simple clients and games."""
 
+import hashlib
 import math
 from datetime import UTC, datetime, timedelta
 from typing import Annotated
@@ -16,8 +17,10 @@ from backend.utilities.aggregations import get_like_counts, get_track_tags
 router = APIRouter(prefix="/radio", tags=["radio"])
 
 DEFAULT_TRACK_SECONDS = 180
-MAX_ROTATION_SIZE = 50
-SOURCE_CANDIDATE_LIMIT = 250
+DEFAULT_ROTATION_SIZE = 40
+MAX_ROTATION_SIZE = 75
+SOURCE_CANDIDATE_LIMIT = 500
+DAILY_VARIETY_WEIGHT = 0.75
 
 
 class RadioTrack(BaseModel):
@@ -76,8 +79,16 @@ def _score_track(track: Track, like_count: int) -> float:
     return (like_count * 3) + math.log1p(track.play_count)
 
 
+def _daily_variety(track: Track, now: datetime) -> float:
+    """Stable daily jitter so the station is weighted, not a hard top-N chart."""
+    day = now.date().isoformat()
+    digest = hashlib.blake2s(f"{day}:{track.id}".encode(), digest_size=4).digest()
+    return int.from_bytes(digest, "big") / 2**32
+
+
 async def _rotation_tracks(db: AsyncSession, limit: int) -> list[Track]:
     """Build the public radio rotation from catalog signals."""
+    now = datetime.now(UTC)
     stmt = (
         select(Track)
         .join(Artist)
@@ -98,7 +109,8 @@ async def _rotation_tracks(db: AsyncSession, limit: int) -> list[Track]:
     ranked = sorted(
         candidates,
         key=lambda track: (
-            _score_track(track, like_counts.get(track.id, 0)),
+            _score_track(track, like_counts.get(track.id, 0))
+            + (_daily_variety(track, now) * DAILY_VARIETY_WEIGHT),
             track.created_at,
             track.id,
         ),
@@ -181,7 +193,7 @@ def _up_next(rotation: list[RadioTrack], current_index: int | None) -> list[Radi
 async def radio_state(
     request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],
-    limit: int = Query(25, ge=1, le=MAX_ROTATION_SIZE),
+    limit: int = Query(DEFAULT_ROTATION_SIZE, ge=1, le=MAX_ROTATION_SIZE),
 ) -> RadioStateResponse:
     """Return the live public radio state.
 

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -11,6 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.main import app
 from backend.models import Artist, Tag, Track, TrackLike, TrackTag, get_db
 
+# clear_database only removes timestamped rows created after test start.
+TEST_TIME_OFFSET = timedelta(minutes=10)
+
 
 @pytest.fixture
 def radio_app(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
@@ -75,7 +78,7 @@ async def test_radio_state_returns_live_public_rotation(
     radio_artist: Artist,
 ) -> None:
     """radio state returns one live station with public tracks only."""
-    now = datetime.now(UTC)
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
     visible = await _create_track(
         db_session,
         radio_artist,
@@ -125,7 +128,7 @@ async def test_radio_state_orders_rotation_by_likes_then_plays(
     radio_artist: Artist,
 ) -> None:
     """likes and play counts determine what gets into the radio loop."""
-    now = datetime.now(UTC)
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
     played = await _create_track(
         db_session,
         radio_artist,
@@ -180,7 +183,7 @@ async def test_radio_state_includes_tags_and_up_next(
     radio_artist: Artist,
 ) -> None:
     """radio state includes useful metadata for clients."""
-    now = datetime.now(UTC)
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
     first = await _create_track(
         db_session,
         radio_artist,
@@ -213,6 +216,7 @@ async def test_radio_state_includes_tags_and_up_next(
     assert data["progress_seconds"] >= 0
     assert data["current_started_at"] is not None
     assert data["current_ends_at"] is not None
-    assert data["rotation"][0]["tags"] == ["desert"]
+    tagged_track = next(track for track in data["rotation"] if track["id"] == first.id)
+    assert tagged_track["tags"] == ["desert"]
     assert data["up_next"]
     assert {track["id"] for track in data["up_next"]}.issubset({first.id, second.id})

--- a/frontend/src/routes/radio/+page.svelte
+++ b/frontend/src/routes/radio/+page.svelte
@@ -121,13 +121,17 @@
 
 	{#if radio.state}
 		<section class="station-board" aria-label="station">
-			<div class="station-stat">
-				<span>{radio.state.rotation.length}</span>
-				<p>tracks in rotation</p>
-			</div>
-			<div class="request-card">
-				<h2>requests</h2>
-				<p>coming soon</p>
+			<div class="rotation-card">
+				<div class="rotation-artworks" aria-hidden="true">
+					{#each radio.state.rotation.slice(0, 10) as track (track.id)}
+						{#if track.thumbnail_url || track.artwork_url}
+							<img src={track.thumbnail_url ?? track.artwork_url ?? ''} alt="" />
+						{:else}
+							<div class="rotation-fallback"></div>
+						{/if}
+					{/each}
+				</div>
+				<p>from across plyr.fm</p>
 			</div>
 		</section>
 	{/if}
@@ -380,53 +384,37 @@
 	}
 
 	.station-board {
-		display: flex;
-		align-items: stretch;
-		gap: 1rem;
 		margin-top: 2.25rem;
 	}
 
-	.station-stat,
-	.request-card {
-		min-height: 5rem;
-		border: 1px solid var(--border-subtle);
-		border-radius: var(--radius-md);
-		padding: 0.85rem 1rem;
+	.rotation-card {
+		min-width: 0;
 	}
 
-	.station-stat {
-		width: 9rem;
-		flex-shrink: 0;
+	.rotation-artworks {
+		display: flex;
+		align-items: center;
+		min-width: 0;
+	}
+
+	.rotation-artworks img,
+	.rotation-fallback {
+		width: 3rem;
+		height: 3rem;
+		margin-right: -0.65rem;
+		object-fit: cover;
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-sm);
 		background:
 			linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 45%),
 			var(--bg-secondary);
-		color: var(--text-secondary);
+		box-shadow: 0 0 0 2px var(--bg-primary);
 	}
 
-	.station-stat span {
-		display: block;
-		color: var(--text-primary);
-		font-size: var(--text-2xl);
-		font-weight: 600;
-		line-height: 1;
-	}
-
-	.station-stat p,
-	.request-card p {
-		margin: 0.35rem 0 0;
+	.rotation-card p {
+		margin: 0.6rem 0 0;
 		color: var(--text-tertiary);
 		font-size: var(--text-sm);
-	}
-
-	.request-card {
-		flex: 1;
-		color: var(--text-secondary);
-	}
-
-	.request-card h2 {
-		margin: 0;
-		color: var(--text-primary);
-		font-size: var(--text-lg);
 	}
 
 	.credit {
@@ -483,13 +471,13 @@
 		}
 
 		.station-board {
-			flex-direction: column;
-			gap: 0.75rem;
 			margin-top: 2rem;
 		}
 
-		.station-stat {
-			width: auto;
+		.rotation-artworks img,
+		.rotation-fallback {
+			width: 2.75rem;
+			height: 2.75rem;
 		}
 	}
 </style>


### PR DESCRIPTION
## Summary
- replace the radio page station stat/request placeholder with a compact artwork cluster that hints at the active rotation without exposing a fixed queue
- make the public radio rotation larger and less frozen with a small deterministic daily variety weight
- keep the /radio/state response shape unchanged for existing clients, including rotation and up_next
- fix radio tests that backdated track timestamps before the cleanup watermark, which left tracks behind and broke the test DB fixture state

## Checks
- just frontend check
- cd frontend && bun run lint
- just backend lint
- just backend test tests/api/test_radio.py
- git diff --check
- uvx loq check backend/src/backend/api/radio.py backend/tests/api/test_radio.py frontend/src/routes/radio/+page.svelte