### PR TITLE
fix(#1408): thread gated context through transcode save path for lossless uploads

### DIFF
--- a/backend/src/backend/api/tracks/audio_optimize.py
+++ b/backend/src/backend/api/tracks/audio_optimize.py
@@ -21,6 +21,7 @@ import contextlib
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from urllib.parse import urljoin
 
 import logfire
 from docket import ConcurrencyLimit, ExponentialRetry
@@ -88,6 +89,7 @@ class _AudioState:
     interim_file_id: str
     interim_file_type: str
     created_at: datetime
+    is_gated: bool
 
 
 @dataclass
@@ -156,6 +158,7 @@ async def _load_audio_state(track_id: int) -> _AudioState | None:
             interim_file_id=track.file_id,
             interim_file_type=track.file_type,
             created_at=track.created_at,
+            is_gated=track.support_gate is not None,
         )
 
 
@@ -307,6 +310,7 @@ async def optimize_track_audio(
                 f"track.{state.original_file_type}",
                 state.original_file_type,
                 target_format=OPTIMIZE_TARGET_FORMAT,
+                gated=state.is_gated,
                 timeout_seconds=settings.transcoder.optimize_timeout_seconds,
             )
             if not transcode_info:
@@ -318,26 +322,32 @@ async def optimize_track_audio(
                 raise RuntimeError("transcode to mp3 failed; see job error detail")
             new_mp3_file_id = transcode_info.transcoded_file_id
 
-            mp3_url = await storage.get_url(
-                new_mp3_file_id, file_type="audio", extension=OPTIMIZE_TARGET_FORMAT
-            )
-            if not mp3_url:
-                # transient R2 hiccup; retry rather than give up on the track.
-                raise RuntimeError(
-                    f"failed to resolve mp3 url for file_id={new_mp3_file_id}"
+            if state.is_gated:
+                backend_url = settings.atproto.redirect_uri.rsplit("/", 2)[0]
+                mp3_url = urljoin(backend_url + "/", f"audio/{new_mp3_file_id}")
+            else:
+                mp3_url = await storage.get_url(
+                    new_mp3_file_id,
+                    file_type="audio",
+                    extension=OPTIMIZE_TARGET_FORMAT,
                 )
+                if not mp3_url:
+                    # transient R2 hiccup; retry rather than give up on the track.
+                    raise RuntimeError(
+                        f"failed to resolve mp3 url for file_id={new_mp3_file_id}"
+                    )
 
             sr = StorageResult(
                 file_id=new_mp3_file_id,
                 original_file_id=state.original_file_id,
                 original_file_type=state.original_file_type,
                 playable_format=AudioFormat.MP3,
-                r2_url=mp3_url,
+                r2_url=None if state.is_gated else mp3_url,
                 transcode_info=transcode_info,
                 needs_optimization=False,
             )
             audio_info = AudioInfo(
-                format=AudioFormat.MP3, duration=None, is_gated=False
+                format=AudioFormat.MP3, duration=None, is_gated=state.is_gated
             )
             phase_ctx = UploadContext(
                 upload_id=job_id,
@@ -402,7 +412,10 @@ async def optimize_track_audio(
             # using it.
             if new_mp3_file_id and not pds_published:
                 with contextlib.suppress(Exception):
-                    await storage.delete(new_mp3_file_id, OPTIMIZE_TARGET_FORMAT)
+                    delete_fn = (
+                        storage.delete_gated if state.is_gated else storage.delete
+                    )
+                    await delete_fn(new_mp3_file_id, OPTIMIZE_TARGET_FORMAT)
             await job_service.update_progress(
                 job_id, JobStatus.FAILED, "optimization aborted", error=str(e)
             )
@@ -414,7 +427,10 @@ async def optimize_track_audio(
             # mp3 if PDS already references it; the next attempt will reconcile.
             if new_mp3_file_id and not pds_published:
                 with contextlib.suppress(Exception):
-                    await storage.delete(new_mp3_file_id, OPTIMIZE_TARGET_FORMAT)
+                    delete_fn = (
+                        storage.delete_gated if state.is_gated else storage.delete
+                    )
+                    await delete_fn(new_mp3_file_id, OPTIMIZE_TARGET_FORMAT)
             await job_service.update_progress(
                 job_id,
                 JobStatus.FAILED,
@@ -435,7 +451,8 @@ async def optimize_track_audio(
         # the legacy WAV-remux scheme had a distinct, throwaway interim.
         if state.interim_file_id != state.original_file_id:
             with contextlib.suppress(Exception):
-                await storage.delete(state.interim_file_id, state.interim_file_type)
+                delete_fn = storage.delete_gated if state.is_gated else storage.delete
+                await delete_fn(state.interim_file_id, state.interim_file_type)
         with contextlib.suppress(Exception):
             await invalidate_tracks_discovery_cache()
 

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -386,6 +386,7 @@ async def _transcode_audio(
     source_format: str,
     *,
     target_format: str,
+    gated: bool = False,
     timeout_seconds: int | None = None,
 ) -> TranscodeInfo | None:
     """transcode an already-staged audio file to a web-playable format.
@@ -405,6 +406,8 @@ async def _transcode_audio(
         target_format: format to produce — "wav" for the fast compatibility
             remux on the upload critical path, "mp3" for the deferred
             optimization pass.
+        gated: if True, read the source from private storage and save the
+            transcoded result back to private storage.
         timeout_seconds: per-request transcoder timeout override. the WAV
             remux is seconds, so the default (settings) is fine; the MP3
             optimization runs off the critical path and passes a generous
@@ -449,7 +452,7 @@ async def _transcode_audio(
         last_heartbeat = 0.0
         async with aiofiles.open(source_path, "wb") as source_file:
             async for chunk in storage.stream_file_data(
-                original_file_id, source_format
+                original_file_id, source_format, private=gated
             ):
                 await source_file.write(chunk)
                 bytes_streamed += len(chunk)
@@ -523,7 +526,8 @@ async def _transcode_audio(
             phase="upload_transcoded",
         ) as tracker:
             with open(result.output_path, "rb") as transcoded_file:
-                transcoded_file_id = await storage.save(
+                save_fn = storage.save_gated if gated else storage.save
+                transcoded_file_id = await save_fn(
                     transcoded_file,
                     transcoded_filename,
                     progress_callback=tracker.on_progress,
@@ -614,9 +618,6 @@ async def _store_audio(ctx: UploadContext, audio_info: AudioInfo) -> StorageResu
     task; see `audio_optimize.optimize_track_audio`.
     """
     needs_optimization = not audio_info.format.is_web_playable
-
-    if needs_optimization and audio_info.is_gated:
-        raise UploadPhaseError("supporter-gated tracks cannot use lossless formats yet")
 
     # the staged file is the playable file (interim, for lossless). the stored
     # object carries the RAW upload extension (e.g. ".aif"), so serving + the
@@ -1062,15 +1063,14 @@ async def _cleanup_staged_media_pre_db(
     is_gated = ctx.support_gate is not None
 
     if sr is not None and sr.transcode_info is not None:
-        # transcode produced a new sibling. the playable sibling lives
-        # in the public bucket (gated lossless is rejected upstream),
-        # and the staged source is now `original_file_id` (also public).
+        # transcode produced a new sibling. both sibling and staged source
+        # live in the bucket selected at handler-staging time.
         playable_ext = sr.playable_format.value if sr.playable_format else None
-        with contextlib.suppress(Exception):
-            await storage.delete(sr.file_id, playable_ext)
+        await _delete_staged_audio(sr.file_id, playable_ext, gated=is_gated)
         if sr.original_file_id:
-            with contextlib.suppress(Exception):
-                await storage.delete(sr.original_file_id, sr.original_file_type)
+            await _delete_staged_audio(
+                sr.original_file_id, sr.original_file_type, gated=is_gated
+            )
     else:
         # `_store_audio` either didn't run, or returned the staged file
         # as-is (web-playable). either way, only ctx.audio_file_id is

--- a/backend/src/backend/storage/protocol.py
+++ b/backend/src/backend/storage/protocol.py
@@ -41,6 +41,7 @@ class StorageProtocol(Protocol):
         file_type: str,
         *,
         chunk_size: int = 1024 * 1024,
+        private: bool = False,
     ) -> AsyncIterator[bytes]:
         """async-iterate over the file body in `chunk_size` chunks.
 

--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -358,6 +358,7 @@ class R2Storage:
         file_type: str,
         *,
         chunk_size: int = STREAM_CHUNK_SIZE,
+        private: bool = False,
     ) -> AsyncIterator[bytes]:
         """stream the audio body in fixed-size chunks.
 
@@ -381,14 +382,26 @@ class R2Storage:
             file_id=file_id,
             file_type=file_type,
             chunk_size=chunk_size,
+            private=private,
         ):
+            bucket = (
+                self.private_audio_bucket_name if private else self.audio_bucket_name
+            )
+            if not bucket:
+                logfire.warning(
+                    "R2 stream_file_data: private bucket not configured",
+                    file_id=file_id,
+                    file_type=file_type,
+                )
+                return
+
             async with self._s3_client() as client:
                 try:
-                    response = await client.get_object(
-                        Bucket=self.audio_bucket_name, Key=key
-                    )
+                    response = await client.get_object(Bucket=bucket, Key=key)
                 except client.exceptions.NoSuchKey:
-                    logfire.warning("R2 file not found", file_id=file_id, key=key)
+                    logfire.warning(
+                        "R2 file not found", file_id=file_id, key=key, bucket=bucket
+                    )
                     return
                 except ClientError as e:
                     if e.response.get("Error", {}).get("Code") == "404":

--- a/backend/tests/api/test_audio_optimize.py
+++ b/backend/tests/api/test_audio_optimize.py
@@ -24,6 +24,7 @@ upload critical path and produced no track at all.
 from __future__ import annotations
 
 import contextlib
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -41,6 +42,7 @@ from backend.api.tracks.uploads import (
     UploadPhaseError,
     _check_duplicate,
     _store_audio,
+    _transcode_audio,
     _upload_to_pds,
 )
 from backend.config import settings
@@ -164,6 +166,47 @@ async def test_store_audio_publishes_lossless_raw_and_flags_optimization() -> No
     assert sr.needs_optimization is True
 
 
+async def test_store_audio_allows_gated_lossless_without_public_url() -> None:
+    """regression for #1408: gated lossless uploads should publish the staged
+    private object as the interim/original and queue optimization, without
+    requiring a public R2 URL."""
+    ctx = UploadContext(
+        upload_id="job-gated",
+        auth_session=_MockSession(),
+        audio_file_id="GATEDAIFF",
+        filename="members-only.aiff",
+        duration=300,
+        title="Members Only",
+        artist_did=OWNER_DID,
+        album=None,
+        album_id=None,
+        features_json=None,
+        tags=[],
+        support_gate={"type": "any"},
+    )
+    audio_info = AudioInfo(format=AudioFormat.AIFF, duration=300, is_gated=True)
+
+    with (
+        patch(
+            "backend.api.tracks.uploads._transcode_audio",
+            new_callable=AsyncMock,
+        ) as mock_transcode,
+        patch(
+            "backend.api.tracks.uploads.storage.get_url",
+            new_callable=AsyncMock,
+        ) as mock_get_url,
+    ):
+        sr = await _store_audio(ctx, audio_info)
+
+    mock_transcode.assert_not_awaited()
+    mock_get_url.assert_not_awaited()
+    assert sr.file_id == "GATEDAIFF"
+    assert sr.original_file_id == "GATEDAIFF"
+    assert sr.original_file_type == "aiff"
+    assert sr.r2_url is None
+    assert sr.needs_optimization is True
+
+
 async def test_store_audio_web_playable_does_not_need_optimization() -> None:
     """an already web-playable upload (mp3) is served as-is, no transcode, no
     optimization."""
@@ -236,6 +279,64 @@ async def test_upload_to_pds_skips_when_optimization_pending() -> None:
 
     assert result is None
     mock_upload_blob.assert_not_awaited()
+
+
+async def test_transcode_gated_reads_and_writes_private_storage() -> None:
+    """gated optimization must never read from or write to the public bucket."""
+
+    async def source_chunks(*args, **kwargs):
+        yield b"private-audio"
+
+    class FakeTranscoder:
+        async def transcode_file(
+            self,
+            source_path: str,
+            source_format: str,
+            *,
+            output_path: str,
+            target_format: str,
+            heartbeat,
+        ):
+            await heartbeat()
+            Path(output_path).write_bytes(Path(source_path).read_bytes() + b"-mp3")
+            return type("Result", (), {"success": True, "output_path": output_path})()
+
+    job_service_mock = AsyncMock()
+
+    with (
+        patch("backend.api.tracks.uploads.job_service", job_service_mock),
+        patch(
+            "backend.api.tracks.uploads.storage.stream_file_data",
+            side_effect=source_chunks,
+        ) as mock_stream,
+        patch(
+            "backend.api.tracks.uploads.storage.save_gated",
+            new_callable=AsyncMock,
+            return_value="GATEDMP3",
+        ) as mock_save_gated,
+        patch(
+            "backend.api.tracks.uploads.storage.save",
+            new_callable=AsyncMock,
+        ) as mock_save,
+        patch(
+            "backend.api.tracks.uploads.get_transcoder_client",
+            return_value=FakeTranscoder(),
+        ),
+    ):
+        result = await _transcode_audio(
+            "job-gated-transcode",
+            "GATEDAIFF",
+            "members-only.aiff",
+            "aiff",
+            target_format="mp3",
+            gated=True,
+        )
+
+    assert result is not None
+    assert result.transcoded_file_id == "GATEDMP3"
+    assert mock_stream.call_args.kwargs["private"] is True
+    mock_save_gated.assert_awaited_once()
+    mock_save.assert_not_awaited()
 
 
 async def test_check_duplicate_matches_lossless_original(
@@ -324,7 +425,7 @@ def _patch_optimize(
             "backend.api.tracks.audio_optimize.storage.get_url",
             new_callable=AsyncMock,
             return_value="https://audio.example/MP3NEW.mp3",
-        ),
+        ) as mock_get_url,
         patch(
             "backend.api.tracks.audio_optimize._upload_to_pds",
             new_callable=AsyncMock,
@@ -343,7 +444,12 @@ def _patch_optimize(
             "backend.api.tracks.audio_optimize.storage.delete",
             new_callable=AsyncMock,
             side_effect=fake_delete,
-        ),
+        ) as mock_delete,
+        patch(
+            "backend.api.tracks.audio_optimize.storage.delete_gated",
+            new_callable=AsyncMock,
+            side_effect=fake_delete,
+        ) as mock_delete_gated,
         patch(
             "backend.api.tracks.audio_optimize.invalidate_tracks_discovery_cache",
             new_callable=AsyncMock,
@@ -352,9 +458,12 @@ def _patch_optimize(
     ):
         yield {
             "transcode": mock_transcode,
+            "get_url": mock_get_url,
             "upload_to_pds": mock_upload_to_pds,
             "build_record": mock_build_record,
             "update_record": mock_update_record,
+            "delete": mock_delete,
+            "delete_gated": mock_delete_gated,
         }
 
 
@@ -680,3 +789,52 @@ async def test_optimize_raw_interim_does_not_delete_the_lossless_original(
 
     # CRUCIAL: the raw source/original was NOT deleted as a stale interim
     assert "AIFFID" not in deleted
+
+
+async def test_optimize_gated_lossless_uses_private_storage_and_backend_audio_url(
+    db_session: AsyncSession, owner: Artist
+) -> None:
+    """for gated lossless tracks, the deferred MP3 stays private and the PDS
+    record points at the auth-protected backend audio endpoint."""
+    track = _raw_interim_track(
+        file_id="GATEDAIFF",
+        file_type="aiff",
+        original_file_id="GATEDAIFF",
+        original_file_type="aiff",
+        r2_url=None,
+        support_gate={"type": "any"},
+    )
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+    track_id = track.id
+
+    with _patch_optimize(
+        transcode=TranscodeInfo(
+            original_file_id="GATEDAIFF",
+            original_file_type="aiff",
+            transcoded_file_id="GATEDMP3",
+            transcoded_file_type="mp3",
+        ),
+        pds=None,
+    ) as mocks:
+        await optimize_track_audio(track_id, "session-id")
+
+    transcode_call = mocks["transcode"].await_args
+    assert transcode_call.args[1] == "GATEDAIFF"
+    assert transcode_call.kwargs["gated"] is True
+    mocks["get_url"].assert_not_awaited()
+
+    upload_call = mocks["upload_to_pds"].await_args
+    assert upload_call.args[1].is_gated is True
+
+    record_kwargs = mocks["build_record"].await_args.kwargs
+    assert record_kwargs["audio_url"].endswith("/audio/GATEDMP3")
+    assert record_kwargs["support_gate"] == {"type": "any"}
+
+    await db_session.refresh(track)
+    assert track.file_id == "GATEDMP3"
+    assert track.file_type == "mp3"
+    assert track.r2_url is None
+    assert track.audio_storage == "r2"
+    assert track.pds_blob_cid is None

--- a/loq.toml
+++ b/loq.toml
@@ -48,7 +48,7 @@ max_lines = 1085
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
-max_lines = 903
+max_lines = 905
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"
@@ -308,7 +308,7 @@ max_lines = 505
 
 [[rules]]
 path = "backend/tests/api/test_audio_optimize.py"
-max_lines = 682
+max_lines = 840
 
 [[rules]]
 path = "frontend/src/lib/components/portal/TracksSection.svelte"


### PR DESCRIPTION
## Problem

Lossless (FLAC/AIFF) uploads for gated (supporter-only) tracks were blocked with:

> supporter-gated tracks cannot use lossless formats yet

The guard existed because `_transcode_audio` saved the transcoded output to the **public** R2 bucket via `storage.save()`, which would leak gated content. The original lossless file correctly landed in the private bucket (the HTTP handler passes `gated=True` to `stage_audio_to_storage`), but the transcoded sibling bypassed the gate.

## Changes

### `uploads.py` — `_transcode_audio`
- Added `gated: bool = False` parameter
- When `gated=True\`, uses `storage.save_gated()` instead of `storage.save()`

### `uploads.py` — `_store_audio`
- Removed the guard that blocked gated lossless uploads
- Passes `gated=audio_info.is_gated` to `_transcode_audio`

### `audio_optimize.py` (deferred MP3 optimization)
- Added `is_gated: bool` to `_AudioState` dataclass
- `_load_audio_state` reads `track.support_gate` to populate it
- Passes `gated=state.is_gated` to `_transcode_audio`
- For gated tracks: uses auth-proxied backend URL (`{backend}/audio/{file_id}`) instead of `storage.get_url()` (private bucket has no public URL)
- Sets `AudioInfo(is_gated=state.is_gated)` so `_upload_to_pds` is correctly skipped for gated tracks

Closes #1408