### PR TITLE
fix(uploads): never block track creation on transcoding

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"76921554-b9ae-4d92-998c-e8dd472958d8","pid":82842,"procStart":"Sat May 30 23:54:44 2026","acquiredAt":1780204019361}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"76921554-b9ae-4d92-998c-e8dd472958d8","pid":82842,"procStart":"Sat May 30 23:54:44 2026","acquiredAt":1780204019361}

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ simple-build.log
 .gemini/
 .gemini-clipboard/
 .loq_cache
+
+# claude code local runtime state
+.claude/scheduled_tasks.lock

--- a/backend/src/backend/api/tracks/audio_optimize.py
+++ b/backend/src/backend/api/tracks/audio_optimize.py
@@ -1,18 +1,20 @@
-"""deferred MP3 optimization for tracks published with the interim WAV rendition.
+"""deferred MP3 optimization for tracks published with an interim rendition.
 
-a lossless (AIFF) upload publishes immediately with a fast 16-bit WAV
-compatibility rendition (see `uploads._store_audio`) so the track exists in
-seconds and plays in every browser, instead of blocking on a multi-minute,
-single-threaded MP3 encode. this background task then produces the smaller MP3
-streaming rendition from the lossless original, swaps it in as the canonical
-playable file, and writes the single PDS `audioBlob` — all off the upload's
-critical path. nothing here is reaped by the stuck-upload reaper (it runs under
-a distinct `JobType.OPTIMIZE` row) and it uses a generous transcoder timeout
-since no user is waiting.
+a non-web-playable upload (AIFF, and the browser-recorder webm/ogg) publishes
+immediately referencing the raw staged source as its interim playable rendition
+(see `uploads._store_audio`) so the track exists in seconds, instead of blocking
+on the transcoder — a slow or wedged encode of a large file must never fail the
+upload or it produces no track at all (the woody.fm 939 MB AIFF incident). this
+background task then transcodes the lossless original to the MP3 streaming
+rendition, swaps it in as the canonical playable file, and writes the single PDS
+`audioBlob` — all off the upload's critical path. nothing here is reaped by the
+stuck-upload reaper (it runs under a distinct `JobType.OPTIMIZE` row) and it uses
+a generous transcoder timeout since no user is waiting.
 
-failure is safe: the track simply stays on its WAV rendition (fully consistent
-— DB row, R2 object, and PDS record all agree), and the orphaned MP3 (if any)
-is cleaned up. docket retries the task.
+failure is safe: the track simply stays on its interim rendition (fully
+consistent — DB row, R2 object, and PDS record all agree; clients that can play
+the source format keep playing, others keep seeing "processing"), and the
+orphaned MP3 (if any) is cleaned up. docket retries the task.
 """
 
 import contextlib
@@ -104,11 +106,17 @@ class _MetadataState:
 
 
 def _needs_optimization(track: Track) -> bool:
-    """a track is optimizable iff it currently serves the interim WAV rendition
-    over a lossless original. an already-swapped (mp3) track is a no-op, which
-    makes the task idempotent under docket retries."""
+    """a track is optimizable iff it still serves a non-mp3 interim rendition
+    over a preserved original. an already-swapped (mp3) track is a no-op, which
+    makes the task idempotent under docket retries.
+
+    the interim is the raw lossless source itself (aiff/webm/ogg) for uploads
+    published after the publish/transcode decoupling, or the legacy 16-bit WAV
+    remux for tracks still in flight from the prior scheme — both are caught by
+    "not yet mp3, and an original exists". a directly-uploaded web-playable
+    track (no `original_file_id`) is never optimized."""
     return (
-        track.file_type == AudioFormat.WAV.value
+        track.file_type != AudioFormat.MP3.value
         and track.original_file_id is not None
         and track.original_file_type is not None
     )
@@ -419,10 +427,15 @@ async def optimize_track_audio(
             )
             raise
 
-        # post-commit: the interim WAV is now orphaned — delete it. best-effort;
-        # a leaked WAV is harmless (no row references it) and cheap to sweep.
-        with contextlib.suppress(Exception):
-            await storage.delete(state.interim_file_id, state.interim_file_type)
+        # post-commit: the interim playable rendition is now orphaned — delete
+        # it. best-effort; a leaked object is harmless (no row references it).
+        # CRITICAL: skip when the interim IS the lossless original (the raw
+        # source published directly as the interim stopgap). that object is
+        # still referenced as `original_file_id` (the archival master) — only
+        # the legacy WAV-remux scheme had a distinct, throwaway interim.
+        if state.interim_file_id != state.original_file_id:
+            with contextlib.suppress(Exception):
+                await storage.delete(state.interim_file_id, state.interim_file_type)
         with contextlib.suppress(Exception):
             await invalidate_tracks_discovery_cache()
 

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -159,10 +159,10 @@ class StorageResult:
     playable_format: AudioFormat
     r2_url: str | None
     transcode_info: "TranscodeInfo | None"
-    # True when this is a fast playable rendition (16-bit WAV remux of a
-    # lossless source) published ahead of the smaller MP3. signals the
-    # pipeline to skip the PDS blob at publish (the deferred optimize task
-    # writes the single canonical MP3 blob) and to enqueue that task.
+    # True when the playable rendition is an interim stopgap (the raw lossless
+    # source itself) published ahead of the mp3. signals the pipeline to skip
+    # the PDS blob at publish (the deferred optimize task writes the single
+    # canonical MP3 blob) and to enqueue that task.
     needs_optimization: bool = False
 
 
@@ -593,74 +593,57 @@ async def _validate_audio(ctx: UploadContext) -> AudioInfo:
 
 
 async def _store_audio(ctx: UploadContext, audio_info: AudioInfo) -> StorageResult:
-    """phase 2: settle on the playable file_id, transcoding if the staged audio is lossless.
+    """phase 2: settle on the playable file_id. NEVER transcodes.
 
-    the staged file_id (already in storage from the HTTP handler) is the
-    starting point. for web-playable formats we use it directly. for
-    lossless formats we keep the staged file as the `original_file_id`
-    and produce a transcoded sibling.
+    track creation is the critical path and must not block on the transcoder
+    (a slow or wedged encode of a large lossless file would otherwise fail the
+    whole upload and produce no track — exactly the woody.fm 939 MB AIFF
+    incident). so this phase only ever points at the already-staged bytes:
+
+    - web-playable formats (mp3, wav, m4a, flac): the staged file IS the
+      playable file. nothing else to do.
+    - non-web-playable formats (aiff, and the browser-recorder webm/ogg): we
+      publish the staged file directly as BOTH the interim playable rendition
+      (a stopgap — it plays for clients that support the source format; others
+      see a "processing" state until the mp3 lands) AND the `original_file_id`
+      (the archival master). the deferred `optimize_track_audio` docket task
+      produces the mp3 streaming rendition off the critical path and swaps it
+      in, writing the single canonical PDS blob.
+
+    the transcode that used to live here moved wholesale into the optimize
+    task; see `audio_optimize.optimize_track_audio`.
     """
-    transcode_info: TranscodeInfo | None = None
+    needs_optimization = not audio_info.format.is_web_playable
 
-    if not audio_info.format.is_web_playable:
-        if audio_info.is_gated:
-            raise UploadPhaseError(
-                "supporter-gated tracks cannot use lossless formats yet"
-            )
+    if needs_optimization and audio_info.is_gated:
+        raise UploadPhaseError("supporter-gated tracks cannot use lossless formats yet")
 
-        # the handler-staged file_id IS the lossless original. we produce a
-        # fast 16-bit WAV compatibility rendition (a near-instant PCM rewrap,
-        # not the slow MP3 encode) so the track can publish immediately and
-        # play in every browser; the smaller MP3 is generated off the critical
-        # path by the deferred optimize task. the staged id becomes
-        # `original_file_id` (the lossless master, preserved untouched).
-        transcode_info = await _transcode_audio(
-            ctx.upload_id,
-            ctx.audio_file_id,
-            ctx.filename,
-            ctx.audio_extension,
-            target_format="wav",
-        )
-        if not transcode_info:
-            raise UploadPhaseError("transcoding failed")
-
-        file_id = transcode_info.transcoded_file_id
-        playable_format = AudioFormat.from_extension(
-            transcode_info.transcoded_file_type
-        )
-        if not playable_format:
-            raise UploadPhaseError("unknown transcoded format")
-    else:
-        # web-playable: staged file_id is already the playable file. for
-        # gated tracks we still need it in the private bucket — gating
-        # is decided at the handler boundary, so the staged file already
-        # lives in the right place.
-        file_id = ctx.audio_file_id
-        playable_format = audio_info.format
-        transcode_info = None
+    # the staged file is the playable file (interim, for lossless). the stored
+    # object carries the RAW upload extension (e.g. ".aif"), so serving + the
+    # record audioUrl must resolve against that, not the canonical enum value.
+    file_id = ctx.audio_file_id
+    playable_format = audio_info.format
+    source_ext = ctx.audio_extension
 
     # public-bucket URL (gated tracks proxy through the auth-protected backend)
     r2_url: str | None = None
     if not audio_info.is_gated:
-        playable_ext = playable_format.value if playable_format else ctx.audio_extension
-        r2_url = await storage.get_url(
-            file_id, file_type="audio", extension=playable_ext
-        )
+        r2_url = await storage.get_url(file_id, file_type="audio", extension=source_ext)
         if not r2_url:
             raise UploadPhaseError("failed to get public audio URL")
 
     return StorageResult(
         file_id=file_id,
-        original_file_id=transcode_info.original_file_id if transcode_info else None,
-        original_file_type=transcode_info.original_file_type
-        if transcode_info
-        else None,
+        # the interim playable rendition IS the lossless master, so they share
+        # one storage object; the optimize task must not delete it as a stale
+        # interim (it's the archival original). web-playable uploads have no
+        # separate original.
+        original_file_id=file_id if needs_optimization else None,
+        original_file_type=source_ext if needs_optimization else None,
         playable_format=playable_format,
         r2_url=r2_url,
-        transcode_info=transcode_info,
-        # a transcode here means we remuxed a lossless source to the interim
-        # WAV rendition, so the smaller MP3 still needs to be produced.
-        needs_optimization=transcode_info is not None,
+        transcode_info=None,
+        needs_optimization=needs_optimization,
     )
 
 

--- a/backend/tests/api/test_audio_optimize.py
+++ b/backend/tests/api/test_audio_optimize.py
@@ -1,18 +1,24 @@
 """tests for the decoupled publish/optimize audio pipeline.
 
-a lossless (AIFF) upload now publishes immediately with a fast 16-bit WAV
-compatibility rendition, then a deferred `optimize_track_audio` task produces
-the smaller MP3 streaming rendition off the critical path. these tests pin:
+a non-web-playable upload (AIFF) now publishes immediately referencing the raw
+staged source as its interim playable rendition — `_store_audio` NEVER
+transcodes, so a slow/wedged transcoder can't fail the upload — then a deferred
+`optimize_track_audio` task produces the MP3 streaming rendition off the
+critical path. these tests pin:
 
-- the publish side: `_store_audio` remuxes AIFF to WAV and flags optimization;
-  `_upload_to_pds` skips the (large, throwaway) WAV blob at publish.
-- the optimize side: the task swaps the playable rendition WAV -> MP3, preserves
-  the lossless original AND the record's createdAt, writes the single canonical
-  PDS blob, and deletes the orphaned interim WAV — and is a safe no-op / leaves
-  the track on WAV when it can't complete.
+- the publish side: `_store_audio` does NOT transcode a lossless source; it
+  flags optimization and reuses the raw source as both the interim playable
+  file and the preserved `original_file_id`. `_upload_to_pds` skips the (large,
+  throwaway) interim blob at publish.
+- the optimize side: the task transcodes the original -> MP3, swaps the playable
+  rendition, preserves the lossless original AND the record's createdAt, writes
+  the single canonical PDS blob, deletes the orphaned interim (but NOT when the
+  interim IS the original) — and is a safe no-op / leaves the track on its
+  interim when it can't complete.
 
-regression for the 2026-05-27 incident where a 939MB AIFF blocked on an
-11-minute MP3 encode, exceeded the transcoder timeout, and produced no track.
+regression for the 2026-05-27 → 2026-05-30 incident where a 939MB AIFF blocked
+on a synchronous transcode (first the MP3 encode, then the WAV remux) on the
+upload critical path and produced no track at all.
 """
 
 from __future__ import annotations
@@ -114,9 +120,12 @@ def _transcode_info(transcoded_file_id: str, target: str) -> TranscodeInfo:
 # --------------------------------------------------------------------------- #
 
 
-async def test_store_audio_remuxes_aiff_to_wav_and_flags_optimization() -> None:
-    """a lossless source produces the fast WAV rendition (not MP3) and marks the
-    result as still needing the deferred MP3 optimization."""
+async def test_store_audio_publishes_lossless_raw_and_flags_optimization() -> None:
+    """a lossless source is NEVER transcoded on the publish path. it's published
+    directly: the raw staged file is both the interim playable rendition and the
+    preserved `original_file_id`, and the result is flagged for the deferred MP3
+    optimization. this is the load-bearing invariant — track creation must not
+    block on (or fail with) the transcoder."""
     ctx = UploadContext(
         upload_id="job-1",
         auth_session=_MockSession(),
@@ -136,22 +145,22 @@ async def test_store_audio_remuxes_aiff_to_wav_and_flags_optimization() -> None:
         patch(
             "backend.api.tracks.uploads._transcode_audio",
             new_callable=AsyncMock,
-            return_value=_transcode_info("WAVID", "wav"),
         ) as mock_transcode,
         patch(
             "backend.api.tracks.uploads.storage.get_url",
             new_callable=AsyncMock,
-            return_value="https://audio.example/WAVID.wav",
+            return_value="https://audio.example/AIFFID.aiff",
         ),
     ):
         sr = await _store_audio(ctx, audio_info)
 
-    # remuxed to the WAV compatibility rendition, lossless kept as the original
-    assert mock_transcode.await_args.kwargs["target_format"] == "wav"
-    assert sr.playable_format == AudioFormat.WAV
-    assert sr.file_id == "WAVID"
+    # the publish path must NOT touch the transcoder at all
+    mock_transcode.assert_not_awaited()
+    # interim playable == the raw source == the preserved original
+    assert sr.file_id == "AIFFID"
     assert sr.original_file_id == "AIFFID"
     assert sr.original_file_type == "aiff"
+    assert sr.playable_format == AudioFormat.AIFF
     assert sr.needs_optimization is True
 
 
@@ -193,12 +202,12 @@ async def test_store_audio_web_playable_does_not_need_optimization() -> None:
 
 
 async def test_upload_to_pds_skips_when_optimization_pending() -> None:
-    """the interim WAV must never be pushed to the user's PDS — the deferred
-    optimize task writes the single canonical MP3 blob instead."""
+    """the interim rendition must never be pushed to the user's PDS — the
+    deferred optimize task writes the single canonical MP3 blob instead."""
     ctx = UploadContext(
         upload_id="job-3",
         auth_session=_MockSession(),
-        audio_file_id="WAVID",
+        audio_file_id="AIFFID",
         filename="mix.aiff",
         duration=5400,
         title="Long Mix",
@@ -208,13 +217,13 @@ async def test_upload_to_pds_skips_when_optimization_pending() -> None:
         features_json=None,
         tags=[],
     )
-    audio_info = AudioInfo(format=AudioFormat.WAV, duration=5400, is_gated=False)
+    audio_info = AudioInfo(format=AudioFormat.AIFF, duration=5400, is_gated=False)
     sr = StorageResult(
-        file_id="WAVID",
+        file_id="AIFFID",
         original_file_id="AIFFID",
         original_file_type="aiff",
-        playable_format=AudioFormat.WAV,
-        r2_url="https://audio.example/WAVID.wav",
+        playable_format=AudioFormat.AIFF,
+        r2_url="https://audio.example/AIFFID.aiff",
         transcode_info=None,
         needs_optimization=True,
     )
@@ -608,3 +617,66 @@ async def test_optimize_skips_when_session_gone(
     mock_transcode.assert_not_awaited()
     await db_session.refresh(track)
     assert track.file_id == "WAVID"
+
+
+def _raw_interim_track(**overrides) -> Track:
+    """a track published under the decoupled scheme: the raw lossless source IS
+    the interim playable rendition, so `file_id == original_file_id` (one shared
+    storage object). this is what `_store_audio` now produces for AIFF."""
+    defaults = {
+        "title": "Long Mix",
+        "artist_did": OWNER_DID,
+        "file_id": "AIFFID",
+        "file_type": "aiff",
+        "original_file_id": "AIFFID",
+        "original_file_type": "aiff",
+        "atproto_record_uri": TRACK_URI,
+        "atproto_record_cid": "bafyAIFF",
+        "r2_url": "https://audio.example/AIFFID.aiff",
+        "audio_storage": "r2",
+        "extra": {"duration": 5400},
+    }
+    defaults.update(overrides)
+    return Track(**defaults)
+
+
+async def test_optimize_raw_interim_does_not_delete_the_lossless_original(
+    db_session: AsyncSession, owner: Artist
+) -> None:
+    """the load-bearing post-decoupling invariant: when the interim playable
+    rendition IS the raw lossless source (`file_id == original_file_id`), the
+    swap to MP3 must NOT delete that object — it's still referenced as the
+    archival `original_file_id`. deleting it would strip the master AND break
+    any client still streaming the interim.
+
+    (contrast `test_optimize_swaps_wav_to_mp3_...`, where a distinct legacy WAV
+    interim IS correctly deleted.)"""
+    track = _raw_interim_track()
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+    track_id = track.id
+
+    deleted: list[str] = []
+    pds = PdsBlobResult(
+        blob_ref={"$type": "blob", "ref": {"$link": "bafyMP3BLOB"}, "size": 216},
+        cid="bafyMP3BLOB",
+        size=216,
+    )
+    with _patch_optimize(
+        transcode=_transcode_info("MP3NEW", "mp3"), pds=pds, deleted=deleted
+    ) as mocks:
+        await optimize_track_audio(track_id, "session-id")
+
+    # transcoded the lossless ORIGINAL (the shared raw object) to mp3
+    assert mocks["transcode"].await_args.args[1] == "AIFFID"
+
+    # swapped to the mp3 rendition; the lossless original is preserved
+    await db_session.refresh(track)
+    assert track.file_id == "MP3NEW"
+    assert track.file_type == "mp3"
+    assert track.original_file_id == "AIFFID"
+    assert track.original_file_type == "aiff"
+
+    # CRUCIAL: the raw source/original was NOT deleted as a stale interim
+    assert "AIFFID" not in deleted

--- a/frontend/src/lib/audio-source.ts
+++ b/frontend/src/lib/audio-source.ts
@@ -1,6 +1,7 @@
 import { API_URL } from '$lib/config';
 import { getCachedAudioUrl } from '$lib/storage';
-import { hasPlayableLossless } from '$lib/audio-support';
+import { canPlayFormat, hasPlayableLossless } from '$lib/audio-support';
+import { isOptimizing } from '$lib/utils/track-audio';
 import type { Track } from '$lib/types';
 
 /**
@@ -27,6 +28,7 @@ export type ResolvedSource =
 			artistDid: string;
 			artistHandle: string;
 	  }
+	| { kind: 'processing'; trackId: number }
 	| { kind: 'failed'; trackId: number; error: unknown };
 
 /**
@@ -55,6 +57,21 @@ export function pickFileIdForTrack(track: Track): string {
 }
 
 /**
+ * True when a track is still on its interim rendition (the raw lossless source,
+ * published immediately so track creation never blocks on transcoding) AND this
+ * browser can't play that source format natively — so there is nothing
+ * playable to hand `<audio>` until the deferred optimize task swaps in the MP3.
+ *
+ * Safari/WebKit plays AIFF/FLAC, so it streams the interim directly and this is
+ * false. Chrome/Firefox can't, so they show a "processing" state instead of
+ * being handed an unplayable file. Once optimization lands (`file_type` → mp3)
+ * `isOptimizing` is false and this is false everywhere.
+ */
+export function isAwaitingPlayableRendition(track: Track): boolean {
+	return isOptimizing(track) && !canPlayFormat(track.file_type);
+}
+
+/**
  * Resolve a track's audio source URL.
  *
  * Returns a structured result so callers don't have to differentiate
@@ -66,6 +83,14 @@ export async function resolveAudioSource(
 	track: Track,
 	fileIdUsed: string
 ): Promise<ResolvedSource> {
+	// the interim raw source isn't playable in this browser yet — surface a
+	// "processing" outcome rather than handing `<audio>` a file it can't decode.
+	// checked before the cache lookup: a cached interim blob is just as
+	// undecodable as a fresh fetch would be.
+	if (isAwaitingPlayableRendition(track)) {
+		return { kind: 'processing', trackId: track.id };
+	}
+
 	try {
 		const cachedUrl = await getCachedAudioUrl(fileIdUsed);
 		if (cachedUrl) {

--- a/frontend/src/lib/components/PdsSaveControl.svelte
+++ b/frontend/src/lib/components/PdsSaveControl.svelte
@@ -3,7 +3,7 @@
 	import { API_URL } from '$lib/config';
 	import { toast } from '$lib/toast.svelte';
 	import type { Track } from '$lib/types';
-	import { isOptimizingInterimWav } from '$lib/utils/track-audio';
+	import { isOptimizing } from '$lib/utils/track-audio';
 
 	let {
 		tracks,
@@ -21,7 +21,7 @@
 			(track) =>
 				!track.support_gate &&
 				(track.audio_storage ?? 'r2') !== 'both' &&
-				!isOptimizingInterimWav(track)
+				!isOptimizing(track)
 		).length
 	);
 

--- a/frontend/src/lib/components/PdsSaveModal.svelte
+++ b/frontend/src/lib/components/PdsSaveModal.svelte
@@ -2,7 +2,7 @@
 	import { SvelteSet } from 'svelte/reactivity';
 	import { API_URL } from '$lib/config';
 	import type { Track } from '$lib/types';
-	import { isOptimizingInterimWav } from '$lib/utils/track-audio';
+	import { isOptimizing } from '$lib/utils/track-audio';
 
 	interface Props {
 		tracks: Track[];
@@ -22,7 +22,7 @@
 				!t.support_gate &&
 				!t.pds_blob_cid &&
 				t.file_id &&
-				!isOptimizingInterimWav(t)
+				!isOptimizing(t)
 		)
 	);
 
@@ -46,7 +46,7 @@
 	): 'eligible' | 'saved' | 'gated' | 'optimizing' {
 		if (track.support_gate) return 'gated';
 		if (track.audio_storage === 'both' || track.pds_blob_cid) return 'saved';
-		if (isOptimizingInterimWav(track)) return 'optimizing';
+		if (isOptimizing(track)) return 'optimizing';
 		return 'eligible';
 	}
 

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -10,6 +10,7 @@
 	import { toast } from '$lib/toast.svelte';
 	import {
 		gatedErrorFromResolution,
+		isAwaitingPlayableRendition,
 		pickFileIdForTrack,
 		resolveAudioSource,
 		type GatedError,
@@ -425,6 +426,28 @@
 		}
 	}
 
+	function handleProcessing(): void {
+		toast.info('this track is still processing — its playable version will be ready shortly');
+
+		// skip to the next track that's actually playable now (not gated, not
+		// still awaiting its transcoded rendition in this browser). mirrors
+		// handleGatedDenial so auto-advance never dead-airs on a processing track.
+		let nextPlayable = -1;
+		for (let i = queue.currentIndex + 1; i < queue.tracks.length; i++) {
+			const t = queue.tracks[i];
+			if (!t.gated && !isAwaitingPlayableRendition(t)) {
+				nextPlayable = i;
+				break;
+			}
+		}
+		if (nextPlayable >= 0) {
+			shouldAutoPlay = true;
+			queue.goTo(nextPlayable);
+		} else {
+			player.paused = true;
+		}
+	}
+
 	$effect(() => {
 		if (!player.currentTrack || !player.audioElement) return;
 
@@ -473,6 +496,11 @@
 				handleGatedDenial(gatedErrorFromResolution(cached));
 				return;
 			}
+			if (cached.kind === 'processing') {
+				isLoadingTrack = false;
+				handleProcessing();
+				return;
+			}
 			// stale fileId or `failed` → fall through to fresh fetch below
 		}
 
@@ -494,6 +522,10 @@
 			isLoadingTrack = false;
 			if (resolved.kind === 'gated-denied') {
 				handleGatedDenial(gatedErrorFromResolution(resolved));
+				return;
+			}
+			if (resolved.kind === 'processing') {
+				handleProcessing();
 				return;
 			}
 			console.error('failed to load audio:', resolved.error);

--- a/frontend/src/lib/components/portal/TracksSection.svelte
+++ b/frontend/src/lib/components/portal/TracksSection.svelte
@@ -12,7 +12,7 @@
 	import { toast } from '$lib/toast.svelte';
 	import { uploader } from '$lib/uploader.svelte';
 	import { player } from '$lib/player.svelte';
-	import { isOptimizingInterimWav } from '$lib/utils/track-audio';
+	import { isOptimizing } from '$lib/utils/track-audio';
 
 	// supported audio formats — matches backend AudioFormat enum + AlbumUploadForm
 	const AUDIO_FILE_INPUT_ACCEPT = '.mp3,.wav,.m4a,.aiff,.aif,.flac,audio/mpeg,audio/wav,audio/mp4,audio/aiff,audio/x-aiff,audio/flac';
@@ -647,7 +647,7 @@
 										{:else}
 											<div class="audio-current">
 												<span class="audio-current-label">
-													current: {track.file_type}{track.original_file_type && track.original_file_type !== track.file_type ? ` (transcoded from ${track.original_file_type})` : ''}{isOptimizingInterimWav(track) ? ' · optimizing — mp3 will land on your PDS shortly' : track.audio_storage === 'both' || track.audio_storage === 'pds' ? ' · stored on your PDS' : ' · stored on plyr.fm'}
+													current: {track.file_type}{track.original_file_type && track.original_file_type !== track.file_type ? ` (transcoded from ${track.original_file_type})` : ''}{isOptimizing(track) ? ' · optimizing — mp3 will land on your PDS shortly' : track.audio_storage === 'both' || track.audio_storage === 'pds' ? ' · stored on your PDS' : ' · stored on plyr.fm'}
 												</span>
 											</div>
 											<label class="audio-upload-btn">

--- a/frontend/src/lib/utils/track-audio.ts
+++ b/frontend/src/lib/utils/track-audio.ts
@@ -1,25 +1,30 @@
 import type { Track } from '$lib/types';
 
 /**
- * a track is in the "optimizing" state when it was published with the interim
- * 16-bit WAV compatibility rendition from a lossless source (e.g. AIFF), and
- * the deferred MP3 optimization task is still in flight or pending. once the
+ * a track is in the "optimizing" state when it was published with an interim
+ * playable rendition (the raw lossless source — e.g. AIFF — published directly
+ * so the track exists immediately without blocking on a transcode), and the
+ * deferred MP3 optimization task is still in flight or pending. once the
  * optimize task completes the swap, `file_type` becomes 'mp3' and the canonical
  * PDS `audioBlob` is written — at which point this returns false again.
  *
+ * (tracks still in flight from the prior scheme carry a 16-bit WAV interim
+ * instead of the raw source; both are "not yet mp3, with an original" and are
+ * caught here.)
+ *
  * relevant in the PDS-migration UI: optimizing tracks should NOT be offered
  * for manual migration, because the optimize task will write the canonical
- * (much smaller) MP3 PDS blob automatically. uploading the interim WAV in
- * the meantime would race the optimization and leak a redundant ~hundreds-of-
- * MB blob on the user's PDS.
+ * (much smaller) MP3 PDS blob automatically. uploading the interim in the
+ * meantime would race the optimization and leak a redundant blob on the
+ * user's PDS.
  *
- * directly-uploaded WAV tracks (no lossless original) are NOT in this state
- * and remain eligible for manual migration — the `original_file_id` check is
- * what distinguishes a transcoded interim from a real WAV upload.
+ * directly-uploaded web-playable tracks (no lossless original) are NOT in this
+ * state and remain eligible for manual migration — the `original_file_id` check
+ * is what distinguishes a transcoded interim from a real direct upload.
  */
-export function isOptimizingInterimWav(track: Track): boolean {
+export function isOptimizing(track: Track): boolean {
 	return (
-		track.file_type === 'wav' &&
+		track.file_type !== 'mp3' &&
 		!!track.original_file_id &&
 		!!track.original_file_type
 	);

--- a/loq.toml
+++ b/loq.toml
@@ -308,7 +308,7 @@ max_lines = 505
 
 [[rules]]
 path = "backend/tests/api/test_audio_optimize.py"
-max_lines = 610
+max_lines = 682
 
 [[rules]]
 path = "frontend/src/lib/components/portal/TracksSection.svelte"


### PR DESCRIPTION
**Track creation must never depend on a transcode succeeding.** A lossless upload now publishes *immediately* — the track exists in seconds referencing the raw source as an interim playable rendition — and **all** transcoding happens in the deferred `optimize_track_audio` docket job. `_store_audio` no longer calls the transcoder at all, so a slow, wedged, or OOMing transcoder can no longer fail an upload and leave the user with no track.

## why

woody.fm's ~939 MB / 90-min AIFF failed repeatedly with `"transcoding failed"` and **produced no track** — most recently a `502 Bad Gateway` from `plyr-transcoder.fly.dev` (1 GB / 1 shared CPU) on the WAV remux. Confirmed in production spans (trace `019e7b0b…`, `size_mb=938.9`, `target=wav`, `transcode failed`).

This is the *second* time this objective was missed. The intent — "create the track, serve the raw file / show 'processing', transcode in the background" — was the whole point of the docket job paradigm, and it's already a stated codebase principle (#1213: *"track creation is the critical path… ancillary operations should degrade gracefully, never block or fail the track"*). That principle was applied to the PDS-blob step but **never to the transcode step**. #1461 ("decouple publish from MP3 optimization") deferred the *MP3 encode* to a docket job but kept a **synchronous WAV remux** as a new, smaller prerequisite on the publish path — and explicitly accepted the residual risk ("the WAV remux still runs synchronously… a truly enormous file could still stall"). It stalled.

This PR removes the block entirely rather than making it cheaper. No memory bump — the transcoder simply isn't on the critical path anymore.

## what changed

<details>
<summary>backend</summary>

- **`_store_audio` never transcodes.** For a non-web-playable upload (AIFF; and the browser-recorder webm/ogg) it publishes the **raw staged source** as both the interim playable rendition (`file_id`) and the preserved archival master (`original_file_id`) — one shared storage object — and flags `needs_optimization`. Web-playable uploads (mp3/wav/m4a/flac) are unchanged: stored directly, no optimization.
- **`optimize_track_audio` is now the only place a transcode happens** for these uploads. It already transcodes `original_file_id → MP3`, writes the single canonical PDS blob, swaps the rendition (CAS), and preserves `createdAt` — all unchanged. Two adjustments:
  - `_needs_optimization` now matches "`file_type != mp3` **and** an original exists" (was hardcoded to `file_type == wav`), so it covers both the new raw-source interim and any legacy WAV-remux track still mid-flight.
  - **interim cleanup is guarded:** the post-swap delete is skipped when `interim_file_id == original_file_id` — the raw source is still referenced as the archival master, so deleting it would strip the original *and* break any client still streaming the interim. (The legacy distinct-WAV interim is still correctly deleted.)
- The existing audio-serving endpoint already serves `original_file_id` when the playable rendition is unavailable, so the interim state needs no endpoint changes.
</details>

<details>
<summary>frontend</summary>

- `isOptimizingInterimWav` → `isOptimizing`: the "optimizing" state is now "`file_type !== 'mp3'` with an `original_file_id`" (covers raw-source interim *and* legacy WAV). Same three callsites (PDS-save modal/control eligibility + portal per-track status) — optimizing tracks still aren't offered for manual PDS migration, since the optimize task writes the canonical MP3 blob automatically.
</details>

## intentional non-behaviors / scope

- **The interim plays for clients that support the source format; others see "processing" until the MP3 lands.** That's the explicit objective ("serve the raw file to those who can see it, or say we're waiting"). AIFF plays in Safari/WebKit; other browsers fall through to the existing processing affordance. The window is short (one deferred docket job) and was always the intended tradeoff.
- **No transcoder memory bump / infra change.** The transcoder being undersized for ~1 GB files is now irrelevant to whether a track is created.
- **PDS blob is still written exactly once, as MP3**, by the optimize task — unchanged from #1461.
- **`audio_replace` is unchanged** beyond inheriting the new `_store_audio` behavior (it already enqueues `optimize_track_audio` when the replacement is lossless). Race-safety (pre-publish guard + CAS swap) is untouched.
- Did **not** rename `needs_optimization` / `TranscodeInfo`; the mechanism names still fit.

## testing

- Rewrote the publish-side unit tests to assert `_store_audio` **does not** call the transcoder and reuses the raw source as interim+original; added `test_optimize_raw_interim_does_not_delete_the_lossless_original` pinning the guarded-cleanup invariant.
- Updated the AIFF/AIF lossless integration tests: an AIFF upload now completes as `aiff` (interim) and is polled until the deferred task swaps it to `mp3`.
- `just backend lint` clean (ruff), `just frontend check` 0/0, `uvx loq` clean (test file limit relaxed per convention).
- Targeted suites green: `test_audio_optimize`, `test_audio`, `track_audio_replace`, `test_upload_storage_cleanup`, `test_upload_copyright_gate`, `test_upload_session_reload`, `test_stuck_upload_reaper` (88 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)