### PR TITLE
feat(scripts): coupled traffic report — Cloudflare edge + Logfire app lens

### DIFF
--- a/.claude/skills/traffic-overview/SKILL.md
+++ b/.claude/skills/traffic-overview/SKILL.md
@@ -1,32 +1,50 @@
 ---
-description: Multi-horizon traffic & performance report (24h / 7d / 30d) — Logfire (app-server) and Cloudflare API MCP (edge)
+description: Multi-horizon traffic & performance report (24h / 7d / 30d) — Cloudflare edge + Logfire app-server, coupled in one script
 argument-hint: [optional: single horizon like "7d" or a specific question]
 ---
 
 # traffic-overview
 
-Two lenses:
-- **Logfire** = inside-the-app: per-route p95/p99, errors, user identity
-- **Cloudflare edge** = outside-the-app: total requests, cache %, bytes, threats — sees requests that never hit origin
+Two lenses on the same days:
+- **Cloudflare edge** = outside-the-app: total requests, bandwidth, cache %, unique visitors, threats — sees anonymous CDN traffic that never reaches origin.
+- **Logfire app** = inside-the-app: authenticated requests, distinct signed-in users, uploads, p95/p99, errors, user identity.
 
-## horizons (don't exceed these — both tools have hard ceilings)
+The coupling is the point: the edge serves ~2–3× origin's request count (cache absorbs the rest), and peak unique visitors run ~60× signed-in users (most listening is logged-out). Neither lens shows that gap alone.
+
+## default path: the script
+
+```
+uv run scripts/traffic_report.py            # last 7 days
+uv run scripts/traffic_report.py -d 1        # last 24h
+uv run scripts/traffic_report.py -d 30       # last 30 days (edge retention cap)
+```
+
+Renders a coupled summary table + terminal charts (plotext) for any horizon: two overlay line charts (edge-total vs app-origin requests/day; edge-visitors vs signed-in-users/day), plus edge bandwidth, cache-hit %, uploads, and p95 per day. **The ANSI charts render in the user's terminal — don't try to reproduce them in text; extract the summary numbers and narrate the shape.**
+
+To pull just the summary figures (strip ANSI): `... 2>&1 | sed -n '/summary/,/└/p' | sed 's/\x1b\[[0-9;]*m//g'`.
+
+### credentials (.env, gitignored)
+- `SCRIPT_CF_API_TOKEN` — Cloudflare token with **Zone → Analytics → Read** on the plyr.fm zone. The older script token only had account/RUM read; if zone analytics 403s (`does not have permission 'com.cloudflare.api.account.zone.analytics.read'`), ask the user to add that permission to the token or mint a new one.
+- `LOGFIRE_READ_API_TOKEN` — a Logfire **read** token for the plyr-fm project (Logfire dashboard → project settings → read tokens). Distinct from the write token the backend uses.
+
+Each lens degrades independently — a missing credential or out-of-retention horizon skips that lens with a note instead of failing the whole report. So a partial run still tells you which credential to fix.
+
+## horizons — hard ceilings (the script handles these; respect them in any manual query too)
 
 | horizon | Logfire | Cloudflare |
 |---|---|---|
 | 24h–7d | ✅ | ✅ |
 | 14d | ✅ (max single-query window) | ✅ |
-| 30d | ⚠ chunk into 3× 14d queries | ✅ |
-| **>30d** | ❌ too many chunks | ❌ **CF retention ≈30d** — querying 180d returns ~34 days |
+| 30d | ✅ script auto-chunks into 14+14+2 | ✅ |
+| **>30d** | ❌ too many chunks | ❌ **edge retention ≈30d** — querying 180d returns ~34 days |
 
-If user asks for 90d/180d: say the data isn't accessible. Don't fabricate.
+If asked for 90d/180d: say the data isn't accessible. Don't fabricate.
 
-## prerequisites
+## fallback: query the sources directly
 
-- **Logfire**: pass `project: "plyr-fm"` to every `mcp__logfire__query_run` call.
-- **CF API MCP**: if `mcp__plugin_cloudflare_cloudflare-api__execute` is unavailable, ask user to run `/mcp` to authenticate `plugin:cloudflare:cloudflare-api`. Do NOT call `__authenticate` yourself (see `feedback_mcp_auth.md`).
-- plyr.fm zone ID: `2bfcb9ffe7847604e9febbb62d9649a3` (account `3e9ba01cd687b3c4d29033908177072e` is pre-set in the MCP).
+Use these only if the script is unavailable or you need a cut it doesn't render (e.g. top error route, per-country, a specific trace). The script encodes the same queries — prefer it.
 
-## Logfire query (≤14d)
+### Logfire (≤14d per query, pass `project: "plyr-fm"`)
 
 ```sql
 SELECT
@@ -47,7 +65,9 @@ WHERE deployment_environment = 'production'
 
 For day-by-day or top-route breakdowns, swap the SELECT but keep the WHERE. `GROUP BY date_trunc('day', start_timestamp)` — the expression verbatim, not by alias.
 
-## Cloudflare query (any horizon up to 30d)
+### Cloudflare edge (via the `mcp__plugin_cloudflare_cloudflare-api__execute` MCP)
+
+The MCP is OAuth'd and must be on the **personal** account (`3e9ba01cd687b3c4d29033908177072e`), where plyr.fm lives — not the work/prefect one, or zone queries return `not authorized for that account`. zone ID: `2bfcb9ffe7847604e9febbb62d9649a3`. If unavailable, ask the user to run `/mcp` (don't call `__authenticate` yourself — see `feedback_mcp_auth.md`).
 
 ```js
 async () => {
@@ -74,10 +94,11 @@ async () => {
 1. **CF GraphQL is unwrapped** — `r.result.viewer.zones`, NOT `r.result.data.viewer.zones`. Miss this → silent empty result.
 2. **`date_geq`, not `date_gt`** — `date_gt` skips the boundary day.
 3. **CF retention ≈ 30 days** — `limit:200` doesn't help past that. Verified empirically.
-4. **Logfire 14d cap** — `Time range N days exceeds max 14 days`.
+4. **Logfire 14d cap** — `Time range N days exceeds max 14 days`. The script chunks; a manual query must not exceed it.
 5. **`approx_percentile_cont(duration, 0.95) * 1000`** = p95 in ms (duration is seconds).
 6. **`service_name = 'plyr-api'` for all envs** — filter by `deployment_environment`, never `service_name`.
+7. **Two different denominators** — CF "unique visitors" is a unique-IP estimate; Logfire "users" is DID-tagged auth'd activity. The gap between them is signal (logged-out reach), not an error.
 
 ## what to report
 
-For each horizon: numbers (side-by-side Logfire + CF), shape (day-by-day, flag >2× median outliers), one concrete thing (top error route, slowest endpoint, spike correlation). Lead with the punchline (healthy / one concern / multiple concerns). Concrete numbers, not adjectives.
+Lead with the punchline (healthy / one concern / multiple concerns), then concrete numbers — not adjectives. For each horizon: the coupled figures (edge + app side by side), the shape (day-by-day, flag >2× median outliers), and one concrete thing (top error route, slowest endpoint, spike correlation, the origin-vs-edge gap). Always surface the edge-vs-origin and visitors-vs-signed-in gaps — they're the reason both lenses exist.

--- a/scripts/traffic_report.py
+++ b/scripts/traffic_report.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["httpx", "rich", "plotext", "pydantic-settings", "typer"]
+# ///
+"""coupled traffic report — Cloudflare edge + Logfire app-server, side by side.
+
+two lenses on the same days:
+  - Cloudflare (edge):  total requests, bytes, cache-hit %, unique visitors,
+    threats — sees anonymous CDN traffic that never reaches origin.
+  - Logfire (app):      authenticated requests, distinct signed-in users,
+    uploads, p95 latency, error rate — what the backend actually handled.
+
+usage:
+    uv run scripts/traffic_report.py            # last 7 days
+    uv run scripts/traffic_report.py -d 30       # last 30 days (CF retention cap)
+    uv run scripts/traffic_report.py -d 1        # last 24h
+
+credentials (.env):
+    SCRIPT_CF_API_TOKEN   — needs Zone Analytics: Read on the plyr.fm zone
+    LOGFIRE_READ_API_TOKEN    — a Logfire *read* token for the plyr-fm project
+                            (Logfire dashboard → project → settings → read tokens)
+
+both halves degrade independently: if one credential is missing or a horizon
+exceeds a tool's retention, that lens is skipped with a note rather than
+failing the whole report.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+import plotext as plt
+import typer
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from rich.console import Console
+from rich.table import Table
+
+ZONE_ID = "2bfcb9ffe7847604e9febbb62d9649a3"
+CF_GRAPHQL = "https://api.cloudflare.com/client/v4/graphql"
+LOGFIRE_QUERY_URL = "https://logfire-api.pydantic.dev/v1/query"
+
+# Logfire caps a single query at 14 days; chunk longer windows.
+LOGFIRE_MAX_WINDOW_DAYS = 14
+# Cloudflare httpRequests1dGroups retention is ~30 days regardless of limit.
+CF_RETENTION_DAYS = 30
+
+console = Console()
+app = typer.Typer(add_completion=False)
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    script_cf_api_token: str | None = None
+    logfire_read_api_token: str | None = None
+
+
+# --------------------------------------------------------------------------- #
+# Cloudflare (edge lens)
+# --------------------------------------------------------------------------- #
+
+
+def fetch_cloudflare(token: str, days: int) -> list[dict[str, Any]]:
+    """daily edge stats from the zone's httpRequests1dGroups."""
+    since = (datetime.now(UTC).date() - timedelta(days=days)).isoformat()
+    query = """
+    query($zone: String!, $since: Date!) {
+      viewer { zones(filter: {zoneTag: $zone}) {
+        httpRequests1dGroups(filter: {date_geq: $since}, orderBy: [date_ASC], limit: 200) {
+          dimensions { date }
+          sum { requests bytes cachedBytes threats }
+          uniq { uniques }
+        }
+      } }
+    }
+    """
+    resp = httpx.post(
+        CF_GRAPHQL,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        json={"query": query, "variables": {"zone": ZONE_ID, "since": since}},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    payload = resp.json()
+    if payload.get("errors"):
+        raise RuntimeError(f"Cloudflare GraphQL: {payload['errors']}")
+    # NOTE: the API unwraps to result under "data", not "data.data"
+    groups = payload["data"]["viewer"]["zones"][0]["httpRequests1dGroups"]
+    rows = []
+    for g in groups:
+        b, cb = g["sum"]["bytes"], g["sum"]["cachedBytes"]
+        rows.append(
+            {
+                "date": g["dimensions"]["date"],
+                "requests": g["sum"]["requests"],
+                "bytes": b,
+                "cache_pct": (cb / b * 100) if b else 0.0,
+                "threats": g["sum"]["threats"],
+                "visitors": g["uniq"]["uniques"],
+            }
+        )
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# Logfire (app lens)
+# --------------------------------------------------------------------------- #
+
+
+def _logfire_query(
+    token: str, sql: str, min_ts: datetime, max_ts: datetime
+) -> list[dict[str, Any]]:
+    resp = httpx.get(
+        LOGFIRE_QUERY_URL,
+        headers={"Authorization": f"Bearer {token}"},
+        params={
+            "sql": sql,
+            "min_timestamp": min_ts.isoformat(),
+            "max_timestamp": max_ts.isoformat(),
+        },
+        timeout=60,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    cols = [c["name"] for c in data["columns"]]
+    # columns-of-arrays → list-of-dicts
+    series = {c["name"]: c["values"] for c in data["columns"]}
+    n = len(next(iter(series.values()))) if series else 0
+    return [{c: series[c][i] for c in cols} for i in range(n)]
+
+
+def fetch_logfire(token: str, days: int) -> list[dict[str, Any]]:
+    """daily app-server stats, chunked to respect the 14-day query cap."""
+    now = datetime.now(UTC)
+    sql = """
+    SELECT
+      date_trunc('day', start_timestamp) AS day,
+      COUNT(*) FILTER (WHERE http_method IS NOT NULL AND http_route != '/health' AND kind='span') AS requests,
+      COUNT(DISTINCT attributes->>'user.did') AS users,
+      COUNT(*) FILTER (WHERE span_name='process upload background') AS uploads,
+      ROUND((approx_percentile_cont(duration, 0.95) FILTER (WHERE http_route != '/health') * 1000)::numeric, 0) AS p95_ms,
+      COUNT(*) FILTER (WHERE http_response_status_code >= 500) AS server_errors
+    FROM records
+    WHERE deployment_environment='production'
+      AND (
+        (http_method IS NOT NULL AND http_route != '/health' AND kind='span')
+        OR span_name='process upload background'
+      )
+    GROUP BY date_trunc('day', start_timestamp)
+    ORDER BY day ASC
+    """
+    by_day: dict[str, dict[str, Any]] = {}
+    remaining = days
+    window_end = now
+    while remaining > 0:
+        chunk = min(remaining, LOGFIRE_MAX_WINDOW_DAYS)
+        window_start = window_end - timedelta(days=chunk)
+        for r in _logfire_query(token, sql, window_start, window_end):
+            day = str(r["day"])[:10]
+            by_day[day] = {
+                "date": day,
+                "requests": int(r["requests"] or 0),
+                "users": int(r["users"] or 0),
+                "uploads": int(r["uploads"] or 0),
+                "p95_ms": int(r["p95_ms"] or 0),
+                "server_errors": int(r["server_errors"] or 0),
+            }
+        window_end = window_start
+        remaining -= chunk
+    return [by_day[d] for d in sorted(by_day)]
+
+
+# --------------------------------------------------------------------------- #
+# rendering
+# --------------------------------------------------------------------------- #
+
+
+def _fmt_bytes(b: float) -> str:
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if b < 1024:
+            return f"{b:.1f} {unit}"
+        b /= 1024
+    return f"{b:.1f} PB"
+
+
+def _bar(title: str, labels: list[str], values: list[float], color: str) -> None:
+    plt.clear_figure()
+    plt.theme("dark")
+    plt.title(title)
+    plt.bar(labels, values, color=color)
+    plt.plotsize(90, 14)
+    plt.show()
+    print()
+
+
+def _dual_line(
+    title: str,
+    labels: list[str],
+    a: tuple[str, list[float]],
+    b: tuple[str, list[float]],
+) -> None:
+    plt.clear_figure()
+    plt.theme("dark")
+    plt.title(title)
+    x = list(range(len(labels)))
+    plt.plot(x, a[1], label=a[0], color="cyan", marker="braille")
+    plt.plot(x, b[1], label=b[0], color="magenta", marker="braille")
+    plt.xticks(x, labels)
+    plt.plotsize(90, 14)
+    plt.show()
+    print()
+
+
+def render(
+    days: int, cf: list[dict] | None, lf: list[dict] | None, cf_err, lf_err
+) -> None:
+    console.print(
+        f"\n[bold cyan]plyr.fm traffic[/] — last {days} days  "
+        "[dim](edge=Cloudflare · app=Logfire)[/]\n"
+    )
+
+    # ---- summary table (coupled) ----
+    t = Table(title="summary", title_style="bold")
+    t.add_column("lens", style="dim")
+    t.add_column("metric")
+    t.add_column("total", justify="right", style="bold green")
+    if cf:
+        req = sum(r["requests"] for r in cf)
+        byt = sum(r["bytes"] for r in cf)
+        cab = sum(r["bytes"] * r["cache_pct"] / 100 for r in cf)
+        t.add_row("edge", "total requests", f"{req:,}")
+        t.add_row(
+            "edge", "unique visitors (peak day)", f"{max(r['visitors'] for r in cf):,}"
+        )
+        t.add_row("edge", "bandwidth", _fmt_bytes(byt))
+        t.add_row("edge", "cache hit %", f"{(cab / byt * 100) if byt else 0:.1f}%")
+        t.add_row("edge", "threats blocked", f"{sum(r['threats'] for r in cf):,}")
+    else:
+        t.add_row("edge", "—", f"[red]unavailable: {cf_err}[/]")
+    if lf:
+        t.add_row("app", "authed requests", f"{sum(r['requests'] for r in lf):,}")
+        t.add_row(
+            "app",
+            "distinct signed-in users",
+            f"{max(r['users'] for r in lf):,} (peak day)",
+        )
+        t.add_row("app", "uploads", f"{sum(r['uploads'] for r in lf):,}")
+        t.add_row("app", "5xx errors", f"{sum(r['server_errors'] for r in lf):,}")
+    else:
+        t.add_row("app", "—", f"[red]unavailable: {lf_err}[/]")
+    console.print(t)
+    print()
+
+    # ---- coupled requests: edge vs origin ----
+    if cf and lf:
+        # align on the intersection of dates so the two series line up
+        cf_by = {r["date"]: r for r in cf}
+        lf_by = {r["date"]: r for r in lf}
+        days_x = sorted(set(cf_by) & set(lf_by))
+        if days_x:
+            short = [d[5:] for d in days_x]
+            _dual_line(
+                "requests/day — edge (total) vs app (origin, authed)",
+                short,
+                ("edge", [cf_by[d]["requests"] for d in days_x]),
+                ("app", [lf_by[d]["requests"] for d in days_x]),
+            )
+            _dual_line(
+                "audience/day — edge visitors vs app signed-in users",
+                short,
+                ("edge visitors", [cf_by[d]["visitors"] for d in days_x]),
+                ("app users", [lf_by[d]["users"] for d in days_x]),
+            )
+
+    # ---- edge-only charts ----
+    if cf:
+        labels = [r["date"][5:] for r in cf]
+        _bar(
+            "edge: bandwidth/day (GB)",
+            labels,
+            [r["bytes"] / 1024**3 for r in cf],
+            "cyan",
+        )
+        _bar(
+            "edge: cache hit %/day",
+            labels,
+            [round(r["cache_pct"], 1) for r in cf],
+            "green",
+        )
+
+    # ---- app-only charts ----
+    if lf:
+        labels = [r["date"][5:] for r in lf]
+        _bar("app: uploads/day", labels, [r["uploads"] for r in lf], "magenta")
+        if any(r["p95_ms"] for r in lf):
+            _bar(
+                "app: p95 latency/day (ms)", labels, [r["p95_ms"] for r in lf], "yellow"
+            )
+
+    console.print()
+
+
+@app.command()
+def main(
+    days: int = typer.Option(7, "-d", "--days", help="lookback window in days"),
+) -> None:
+    s = Settings()
+    if days > CF_RETENTION_DAYS:
+        console.print(
+            f"[yellow]note:[/] Cloudflare retention is ~{CF_RETENTION_DAYS}d; "
+            f"edge data will be truncated."
+        )
+
+    cf = lf = None
+    cf_err = lf_err = None
+
+    if s.script_cf_api_token:
+        try:
+            cf = fetch_cloudflare(s.script_cf_api_token, days)
+        except Exception as e:  # noqa: BLE001
+            cf_err = str(e)[:200]
+    else:
+        cf_err = "SCRIPT_CF_API_TOKEN not set"
+
+    if s.logfire_read_api_token:
+        try:
+            lf = fetch_logfire(s.logfire_read_api_token, days)
+        except Exception as e:  # noqa: BLE001
+            lf_err = str(e)[:200]
+    else:
+        lf_err = "LOGFIRE_READ_API_TOKEN not set"
+
+    if not cf and not lf:
+        console.print(
+            f"[red]both lenses unavailable.[/] edge: {cf_err} · app: {lf_err}"
+        )
+        raise typer.Exit(1)
+
+    render(days, cf, lf, cf_err, lf_err)
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/traffic_report.py
+++ b/scripts/traffic_report.py
@@ -229,32 +229,47 @@ def render(
     t = Table(title="summary", title_style="bold")
     t.add_column("lens", style="dim")
     t.add_column("metric")
-    t.add_column("total", justify="right", style="bold green")
+    t.add_column("value", justify="right", style="bold green")
+    # `kind` makes the math honest: "window" rows are true sums over the
+    # horizon; "daily" rows are per-day stats (peak / avg) because the source
+    # only dedups within a day — there's no cross-window unique to sum.
+    t.add_column("kind", style="dim", justify="right")
+
+    def _daily(values: list[float]) -> str:
+        return f"peak {max(values):,.0f} · avg {sum(values) / len(values):,.0f}"
+
     if cf:
-        req = sum(r["requests"] for r in cf)
         byt = sum(r["bytes"] for r in cf)
         cab = sum(r["bytes"] * r["cache_pct"] / 100 for r in cf)
-        t.add_row("edge", "total requests", f"{req:,}")
+        t.add_row("edge", "requests", f"{sum(r['requests'] for r in cf):,}", "window")
+        t.add_row("edge", "bandwidth", _fmt_bytes(byt), "window")
         t.add_row(
-            "edge", "unique visitors (peak day)", f"{max(r['visitors'] for r in cf):,}"
+            "edge", "cache hit %", f"{(cab / byt * 100) if byt else 0:.1f}%", "window"
         )
-        t.add_row("edge", "bandwidth", _fmt_bytes(byt))
-        t.add_row("edge", "cache hit %", f"{(cab / byt * 100) if byt else 0:.1f}%")
-        t.add_row("edge", "threats blocked", f"{sum(r['threats'] for r in cf):,}")
+        t.add_row(
+            "edge", "threats blocked", f"{sum(r['threats'] for r in cf):,}", "window"
+        )
+        t.add_row(
+            "edge", "unique visitors", _daily([r["visitors"] for r in cf]), "daily"
+        )
     else:
-        t.add_row("edge", "—", f"[red]unavailable: {cf_err}[/]")
+        t.add_row("edge", "—", f"[red]unavailable: {cf_err}[/]", "")
     if lf:
-        t.add_row("app", "authed requests", f"{sum(r['requests'] for r in lf):,}")
         t.add_row(
-            "app",
-            "distinct signed-in users",
-            f"{max(r['users'] for r in lf):,} (peak day)",
+            "app", "authed requests", f"{sum(r['requests'] for r in lf):,}", "window"
         )
-        t.add_row("app", "uploads", f"{sum(r['uploads'] for r in lf):,}")
-        t.add_row("app", "5xx errors", f"{sum(r['server_errors'] for r in lf):,}")
+        t.add_row("app", "uploads", f"{sum(r['uploads'] for r in lf):,}", "window")
+        t.add_row(
+            "app", "5xx errors", f"{sum(r['server_errors'] for r in lf):,}", "window"
+        )
+        t.add_row("app", "signed-in users", _daily([r["users"] for r in lf]), "daily")
     else:
-        t.add_row("app", "—", f"[red]unavailable: {lf_err}[/]")
+        t.add_row("app", "—", f"[red]unavailable: {lf_err}[/]", "")
     console.print(t)
+    console.print(
+        "[dim]window = true total over the horizon · daily = per-day stat "
+        "(no cross-day dedup available for unique counts)[/]"
+    )
     print()
 
     # ---- coupled requests: edge vs origin ----


### PR DESCRIPTION
`scripts/traffic_report.py` renders **both** traffic lenses side by side across any horizon (`-d 1` / `-d 7` / `-d 30`), so you can see the gap between what the edge serves and what the backend actually handles.

- **edge (Cloudflare zone analytics):** total requests, bandwidth, cache-hit %, unique visitors, threats — includes anonymous CDN listening that never reaches origin.
- **app (Logfire):** authenticated requests, distinct signed-in users, uploads, p95 latency, 5xx — what the backend processed.

A coupled summary table plus terminal charts (plotext, matching `cf_analytics.py`'s style), including two overlay line charts: **edge-total vs app-origin requests/day** and **edge-visitors vs signed-in-users/day**. Those two make the headline legible at a glance — e.g. last 7d the edge served 81.7k requests but origin only saw 36.5k (~55% absorbed by the 81% cache), and 1,106 peak unique visitors vs 16 signed-in users/day (most listening is logged-out).

<details>
<summary>credentials &amp; design notes</summary>

- Reads `SCRIPT_CF_API_TOKEN` (needs **Zone Analytics: Read** on the plyr.fm zone — the prior token lacked it) and `LOGFIRE_READ_API_TOKEN` (a Logfire read token for the plyr-fm project). Both from `.env`, which is gitignored.
- **Lenses degrade independently:** a missing/under-permissioned credential or an out-of-retention horizon skips that lens with a note rather than failing the whole report.
- **Documented ceilings baked in:** Logfire caps a single query at 14 days (the script chunks longer windows); Cloudflare `httpRequests1dGroups` retention is ~30 days. `-d 30` is the practical max for the edge lens.
- Encodes the gotchas from the `traffic-overview` skill: CF GraphQL unwraps to `data.viewer.zones` (not `data.data`), `date_geq` not `date_gt`, p95 = `approx_percentile_cont(duration,0.95)*1000` ms, filter Logfire by `deployment_environment` and exclude `/health`.

Verified end-to-end on all three horizons against production.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)