### PR TITLE
feat(radio): station lineup over the full corpus with an airtime-fair sampler

### DIFF
--- a/backend/src/backend/api/radio/__init__.py
+++ b/backend/src/backend/api/radio/__init__.py
@@ -1,0 +1,13 @@
+"""Radio API package that exposes the FastAPI router.
+
+Radio carries a fair amount of idiosyncrasy (deterministic seeds, airtime caps,
+per-station lenses) that we deliberately keep walled off in this package rather
+than spread across the rest of the API.
+"""
+
+from backend.api.radio.router import router
+
+# Import route module to register handlers on the shared router.
+from backend.api.radio import state as _state
+
+__all__ = ["router"]

--- a/backend/src/backend/api/radio/corpus.py
+++ b/backend/src/backend/api/radio/corpus.py
@@ -1,0 +1,29 @@
+"""Eligible-track loading for radio.
+
+The whole catalog of public, ungated tracks is the corpus. There is deliberately
+no recency cap here: stations reach the full library and the sampler decides what
+actually rotates. (The previous implementation only ever considered the 500 most
+recent tracks, which made ~40% of the catalog unreachable on radio.)
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from backend.models import Artist, Track
+
+
+async def load_corpus(db: AsyncSession) -> list[Track]:
+    """Load every public, ungated track with its artist eager-loaded."""
+    stmt = (
+        select(Track)
+        .join(Artist)
+        .options(selectinload(Track.artist))
+        .where(
+            Track.unlisted == False,  # noqa: E712
+            Track.support_gate.is_(None),
+        )
+        .order_by(Track.created_at.desc(), Track.id.desc())
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())

--- a/backend/src/backend/api/radio/lenses.py
+++ b/backend/src/backend/api/radio/lenses.py
@@ -1,0 +1,61 @@
+"""Station lenses — the scoring strategies that make stations feel different.
+
+A lens turns a track + context into a non-negative weight. The sampler then draws
+a deterministic, airtime-fair rotation from those weights, so a lens decides
+*flavor* (what this station leans toward) while the sampler decides *fairness and
+rotation* (no one artist hogging the clock, genuine day-to-day variety).
+
+All weights carry a small floor so nothing in the corpus is ever strictly
+impossible — that floor is what keeps a station from collapsing into a fixed
+top-N playlist.
+"""
+
+import math
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from backend.models import Track
+
+WEIGHT_FLOOR = 0.05
+
+
+@dataclass(frozen=True)
+class LensContext:
+    """Per-request signals shared across every track in a lens evaluation."""
+
+    like_counts: dict[int, int]
+    now: datetime
+
+    def likes(self, track: Track) -> int:
+        return self.like_counts.get(track.id, 0)
+
+    def age_days(self, track: Track) -> float:
+        created = track.created_at
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=UTC)
+        return max(0.0, (self.now - created).total_seconds() / 86400.0)
+
+
+def loved(track: Track, ctx: LensContext) -> float:
+    """Genuinely liked + played. Closest to the historical radio behavior."""
+    return WEIGHT_FLOOR + ctx.likes(track) * 3 + math.log1p(track.play_count)
+
+
+def fresh(track: Track, ctx: LensContext) -> float:
+    """Recency-leaning. New uploads surface, engagement is a tiebreak nudge."""
+    # ~2-week half-life so the station keeps turning over toward new material.
+    recency = math.exp(-ctx.age_days(track) / 14.0)
+    nudge = math.log1p(ctx.likes(track) + track.play_count) * 0.15
+    return WEIGHT_FLOOR + recency + nudge
+
+
+def discovery(track: Track, ctx: LensContext) -> float:
+    """Deep cuts — the long tail the other lenses never reach.
+
+    Up-weights low-play tracks so the ~40% of the catalog that the old recency
+    cap made unreachable actually gets airtime. A faint like signal keeps it from
+    being pure noise without re-privileging the already-popular.
+    """
+    obscurity = 1.0 / (1.0 + math.log1p(track.play_count))
+    quality_hint = math.log1p(ctx.likes(track)) * 0.1
+    return WEIGHT_FLOOR + obscurity + quality_hint

--- a/backend/src/backend/api/radio/lenses.py
+++ b/backend/src/backend/api/radio/lenses.py
@@ -6,8 +6,11 @@ a deterministic, airtime-fair rotation from those weights, so a lens decides
 rotation* (no one artist hogging the clock, genuine day-to-day variety).
 
 All weights carry a small floor so nothing in the corpus is ever strictly
-impossible — that floor is what keeps a station from collapsing into a fixed
-top-N playlist.
+impossible, which keeps a station from collapsing into a fixed top-N. The
+tradeoff: as the catalog grows, the summed floor mass of many off-lens tracks
+dilutes a station's identity (most visible on ``fresh``, where lots of old
+tracks can outweigh a few genuinely new ones). The lenses lean the right way;
+they don't hard-partition. Sharpening this is a tuning follow-up.
 """
 
 import math

--- a/backend/src/backend/api/radio/router.py
+++ b/backend/src/backend/api/radio/router.py
@@ -1,0 +1,5 @@
+"""Shared radio router. Route handlers register on it from sibling modules."""
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/radio", tags=["radio"])

--- a/backend/src/backend/api/radio/sampler.py
+++ b/backend/src/backend/api/radio/sampler.py
@@ -1,21 +1,24 @@
-"""Airtime-fair, deterministic rotation sampler.
+"""Deterministic, per-artist-budgeted rotation sampler.
 
-This is the piece that turns a scored corpus into something that behaves like a
-radio station rather than a playlist:
+Turns a scored corpus into a daily rotation that doesn't let one artist stack it:
 
 * **Deterministic per (station, day):** seeded by the station slug + calendar day,
-  so every client computes the same rotation for the same day — a hard requirement
-  for the stateless wall-clock loop that existing consumers depend on. The rotation
-  reshuffles once a day, which is the "reason to tune back in" knob.
+  so every client computes the same rotation for the same day — required by the
+  stateless wall-clock loop that existing consumers depend on. It reshuffles once
+  a day.
 
-* **Airtime-fair:** an artist stops being eligible once they have contributed
-  ``ARTIST_AIRTIME_CAP`` of clock time, so one creator's long-form mixes can't
-  swallow the station. A single over-cap track is allowed (you can't split a
-  90-minute mix), but no *new* tracks from that artist are drawn afterward.
+* **Per-artist airtime budget:** once an artist has contributed
+  ``ARTIST_AIRTIME_CAP_SECONDS`` of clock time they stop being drawn, so a creator
+  with many tracks can't fill the rotation. One budget-crossing track is allowed
+  (we can't split a track), so a single long mix can still be one entry — it just
+  won't be joined by more from the same artist. Note this caps how *often* an
+  artist appears, not the share of any one long track: a 2-hour mix can still be a
+  big slice of a single loop. That's a deliberate v1 tradeoff (popular long-form
+  content should still feature) and a knob to revisit.
 
-* **Weighted, not top-N:** tracks are sampled without replacement proportional to
-  their lens weight, so the long tail genuinely rotates instead of the same chart
-  replaying forever.
+* **Weighted draw without replacement:** tracks are sampled in proportion to their
+  lens weight, so the rotation isn't a fixed top-N chart and the long tail turns
+  over.
 """
 
 import hashlib

--- a/backend/src/backend/api/radio/sampler.py
+++ b/backend/src/backend/api/radio/sampler.py
@@ -1,0 +1,101 @@
+"""Airtime-fair, deterministic rotation sampler.
+
+This is the piece that turns a scored corpus into something that behaves like a
+radio station rather than a playlist:
+
+* **Deterministic per (station, day):** seeded by the station slug + calendar day,
+  so every client computes the same rotation for the same day — a hard requirement
+  for the stateless wall-clock loop that existing consumers depend on. The rotation
+  reshuffles once a day, which is the "reason to tune back in" knob.
+
+* **Airtime-fair:** an artist stops being eligible once they have contributed
+  ``ARTIST_AIRTIME_CAP`` of clock time, so one creator's long-form mixes can't
+  swallow the station. A single over-cap track is allowed (you can't split a
+  90-minute mix), but no *new* tracks from that artist are drawn afterward.
+
+* **Weighted, not top-N:** tracks are sampled without replacement proportional to
+  their lens weight, so the long tail genuinely rotates instead of the same chart
+  replaying forever.
+"""
+
+import hashlib
+import random
+
+from backend.models import Track
+
+DEFAULT_TRACK_SECONDS = 180
+ARTIST_AIRTIME_CAP_SECONDS = 20 * 60  # an artist is done once past ~20 min of airtime
+TARGET_ROTATION_SECONDS = 4 * 60 * 60  # aim for ~4 hours of programming per rotation
+
+
+def _seed(station_slug: str, day: str) -> int:
+    digest = hashlib.blake2s(f"{station_slug}:{day}".encode(), digest_size=8).digest()
+    return int.from_bytes(digest, "big")
+
+
+def _track_seconds(track: Track) -> int:
+    if track.duration and track.duration > 0:
+        return int(track.duration)
+    return DEFAULT_TRACK_SECONDS
+
+
+def build_rotation(
+    candidates: list[Track],
+    weights: dict[int, float],
+    *,
+    station_slug: str,
+    day: str,
+    max_tracks: int,
+    target_seconds: int = TARGET_ROTATION_SECONDS,
+    artist_airtime_cap_seconds: int = ARTIST_AIRTIME_CAP_SECONDS,
+) -> list[Track]:
+    """Draw a deterministic, airtime-fair rotation from scored candidates.
+
+    Args:
+        candidates: the eligible corpus (already filtered for this station).
+        weights: track id -> non-negative lens weight.
+        station_slug: identifies the station for the daily seed.
+        day: ISO calendar day (UTC); rotation is stable within it.
+        max_tracks: hard ceiling on rotation length (the API ``limit``).
+        target_seconds: stop once the rotation reaches roughly this much airtime.
+        artist_airtime_cap_seconds: per-artist airtime budget before they drop out.
+    """
+    pool = [t for t in candidates if weights.get(t.id, 0.0) > 0.0]
+    if not pool:
+        return []
+
+    rng = random.Random(_seed(station_slug, day))
+    remaining = pool[:]
+    remaining_weights = [weights[t.id] for t in remaining]
+
+    rotation: list[Track] = []
+    artist_airtime: dict[str, int] = {}
+    total_seconds = 0
+
+    while remaining and len(rotation) < max_tracks and total_seconds < target_seconds:
+        chosen_idx = _weighted_pick(rng, remaining_weights)
+        track = remaining.pop(chosen_idx)
+        remaining_weights.pop(chosen_idx)
+
+        if artist_airtime.get(track.artist_did, 0) >= artist_airtime_cap_seconds:
+            continue  # this artist has already used their airtime budget
+
+        seconds = _track_seconds(track)
+        rotation.append(track)
+        artist_airtime[track.artist_did] = (
+            artist_airtime.get(track.artist_did, 0) + seconds
+        )
+        total_seconds += seconds
+
+    return rotation
+
+
+def _weighted_pick(rng: random.Random, weights: list[float]) -> int:
+    """Index of a weighted random draw. ``weights`` is assumed non-empty/positive."""
+    target = rng.random() * sum(weights)
+    cumulative = 0.0
+    for idx, weight in enumerate(weights):
+        cumulative += weight
+        if target < cumulative:
+            return idx
+    return len(weights) - 1

--- a/backend/src/backend/api/radio/schemas.py
+++ b/backend/src/backend/api/radio/schemas.py
@@ -1,0 +1,60 @@
+"""Public radio response shapes.
+
+The RadioTrack / RadioStateResponse shapes are the existing public API contract
+(consumed by external clients and games) and must stay stable. Station summaries
+are additive.
+"""
+
+from pydantic import BaseModel
+
+
+class RadioTrack(BaseModel):
+    """Small public track shape for radio clients."""
+
+    id: int
+    title: str
+    artist: str
+    artist_handle: str
+    artist_did: str
+    stream_url: str
+    file_type: str
+    duration: int
+    artwork_url: str | None
+    thumbnail_url: str | None
+    atproto_record_uri: str | None
+    created_at: str
+    tags: list[str]
+    like_count: int
+    play_count: int
+
+
+class RadioStateResponse(BaseModel):
+    """Live radio state response (one station's deterministic loop)."""
+
+    station: str
+    station_slug: str
+    generated_at: str
+    loop_duration_seconds: int
+    current_index: int | None
+    current_started_at: str | None
+    current_ends_at: str | None
+    progress_seconds: int
+    current: RadioTrack | None
+    up_next: list[RadioTrack]
+    rotation: list[RadioTrack]
+
+
+class StationSummary(BaseModel):
+    """One tunable station in the lineup."""
+
+    slug: str
+    name: str
+    description: str
+    is_default: bool
+
+
+class StationsResponse(BaseModel):
+    """The current station lineup for the flip UI."""
+
+    default_slug: str
+    stations: list[StationSummary]

--- a/backend/src/backend/api/radio/state.py
+++ b/backend/src/backend/api/radio/state.py
@@ -1,61 +1,34 @@
-"""Public live radio state for simple clients and games."""
+"""Public live radio state for simple clients and games.
 
-import hashlib
-import math
+The response is a stateless, deterministic wall-clock loop: every client gets the
+same current track for a given instant, per station. Station selection (which
+tracks, in what order) lives in ``corpus`` / ``lenses`` / ``sampler``; this module
+owns only the HTTP surface and the loop arithmetic.
+"""
+
 from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query, Request
-from pydantic import BaseModel
-from sqlalchemy import select
+from fastapi import Depends, HTTPException, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
-from backend.models import Artist, Track, get_db
+from backend.api.radio import stations
+from backend.api.radio.corpus import load_corpus
+from backend.api.radio.lenses import LensContext
+from backend.api.radio.router import router
+from backend.api.radio.sampler import build_rotation
+from backend.api.radio.schemas import (
+    RadioStateResponse,
+    RadioTrack,
+    StationsResponse,
+    StationSummary,
+)
+from backend.models import Track, get_db
 from backend.utilities.aggregations import get_like_counts, get_track_tags
-
-router = APIRouter(prefix="/radio", tags=["radio"])
 
 DEFAULT_TRACK_SECONDS = 180
 DEFAULT_ROTATION_SIZE = 40
 MAX_ROTATION_SIZE = 75
-SOURCE_CANDIDATE_LIMIT = 500
-DAILY_VARIETY_WEIGHT = 0.75
-
-
-class RadioTrack(BaseModel):
-    """Small public track shape for radio clients."""
-
-    id: int
-    title: str
-    artist: str
-    artist_handle: str
-    artist_did: str
-    stream_url: str
-    file_type: str
-    duration: int
-    artwork_url: str | None
-    thumbnail_url: str | None
-    atproto_record_uri: str | None
-    created_at: str
-    tags: list[str]
-    like_count: int
-    play_count: int
-
-
-class RadioStateResponse(BaseModel):
-    """Live radio state response."""
-
-    station: str
-    generated_at: str
-    loop_duration_seconds: int
-    current_index: int | None
-    current_started_at: str | None
-    current_ends_at: str | None
-    progress_seconds: int
-    current: RadioTrack | None
-    up_next: list[RadioTrack]
-    rotation: list[RadioTrack]
 
 
 def _stream_url(request: Request, track: Track) -> str:
@@ -70,63 +43,42 @@ def _duration_seconds(track: Track) -> int:
     return DEFAULT_TRACK_SECONDS
 
 
-def _score_track(track: Track, like_count: int) -> float:
-    """Rank tracks for the station rotation.
+async def _select_rotation(
+    db: AsyncSession,
+    station: stations.Station,
+    limit: int,
+    now: datetime,
+) -> tuple[list[Track], dict[int, int]]:
+    """Score the full corpus through the station lens and sample a rotation.
 
-    Likes are explicit taste signals. Plays are weaker implicit signals and are
-    log-scaled so old high-volume tracks do not permanently swallow the station.
+    Returns the chosen tracks plus the corpus-wide like counts (reused for
+    serialization so we only count likes once).
     """
-    return (like_count * 3) + math.log1p(track.play_count)
+    corpus = await load_corpus(db)
+    if not corpus:
+        return [], {}
 
-
-def _daily_variety(track: Track, now: datetime) -> float:
-    """Stable daily jitter so the station is weighted, not a hard top-N chart."""
-    day = now.date().isoformat()
-    digest = hashlib.blake2s(f"{day}:{track.id}".encode(), digest_size=4).digest()
-    return int.from_bytes(digest, "big") / 2**32
-
-
-async def _rotation_tracks(db: AsyncSession, limit: int) -> list[Track]:
-    """Build the public radio rotation from catalog signals."""
-    now = datetime.now(UTC)
-    stmt = (
-        select(Track)
-        .join(Artist)
-        .options(selectinload(Track.artist))
-        .where(
-            Track.unlisted == False,  # noqa: E712
-            Track.support_gate.is_(None),
-        )
-        .order_by(Track.created_at.desc(), Track.id.desc())
-        .limit(SOURCE_CANDIDATE_LIMIT)
+    like_counts = await get_like_counts(db, [track.id for track in corpus])
+    ctx = LensContext(like_counts=like_counts, now=now)
+    weights = {track.id: station.lens(track, ctx) for track in corpus}
+    rotation = build_rotation(
+        corpus,
+        weights,
+        station_slug=station.slug,
+        day=now.date().isoformat(),
+        max_tracks=limit,
     )
-    result = await db.execute(stmt)
-    candidates = list(result.scalars().all())
-    if not candidates:
-        return []
-
-    like_counts = await get_like_counts(db, [track.id for track in candidates])
-    ranked = sorted(
-        candidates,
-        key=lambda track: (
-            _score_track(track, like_counts.get(track.id, 0))
-            + (_daily_variety(track, now) * DAILY_VARIETY_WEIGHT),
-            track.created_at,
-            track.id,
-        ),
-        reverse=True,
-    )
-    return ranked[:limit]
+    return rotation, like_counts
 
 
 async def _to_radio_tracks(
     request: Request,
     db: AsyncSession,
     tracks: list[Track],
+    like_counts: dict[int, int],
 ) -> list[RadioTrack]:
     """Serialize tracks for public radio consumers."""
     track_ids = [track.id for track in tracks]
-    like_counts = await get_like_counts(db, track_ids)
     tag_map = await get_track_tags(db, track_ids)
     return [
         RadioTrack(
@@ -188,27 +140,50 @@ def _up_next(rotation: list[RadioTrack], current_index: int | None) -> list[Radi
     ]
 
 
+@router.get("/stations")
+async def list_stations() -> StationsResponse:
+    """List the current station lineup for the flip UI."""
+    return StationsResponse(
+        default_slug=stations.DEFAULT_STATION_SLUG,
+        stations=[
+            StationSummary(
+                slug=station.slug,
+                name=station.name,
+                description=station.description,
+                is_default=station.slug == stations.DEFAULT_STATION_SLUG,
+            )
+            for station in stations.STATIONS
+        ],
+    )
+
+
 @router.get("/state")
 @router.get("/state.json")
 async def radio_state(
     request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],
     limit: int = Query(DEFAULT_ROTATION_SIZE, ge=1, le=MAX_ROTATION_SIZE),
+    station: str | None = Query(None, description="station slug; omit for default"),
 ) -> RadioStateResponse:
-    """Return the live public radio state.
+    """Return the live public radio state for a station.
 
-    The MVP station is stateless and deterministic: every client gets the same
-    current track for a given wall-clock time. Rotation order is selected from
-    public, ungated tracks using likes plus log-scaled play counts.
+    Stateless and deterministic per (station, day): every client gets the same
+    current track for a given wall-clock time. Omitting ``station`` serves the
+    default station, preserving the historical single-station contract.
     """
+    resolved = stations.get_station(station)
+    if resolved is None:
+        raise HTTPException(status_code=404, detail=f"unknown station: {station}")
+
     now = datetime.now(UTC)
-    tracks = await _rotation_tracks(db, limit)
-    rotation = await _to_radio_tracks(request, db, tracks)
+    tracks, like_counts = await _select_rotation(db, resolved, limit, now)
+    rotation = await _to_radio_tracks(request, db, tracks, like_counts)
     current_index, progress, started_at, ends_at = _live_window(now, rotation)
     current = rotation[current_index] if current_index is not None else None
 
     return RadioStateResponse(
-        station="plyr.fm radio",
+        station=resolved.name,
+        station_slug=resolved.slug,
         generated_at=now.isoformat(),
         loop_duration_seconds=sum(track.duration for track in rotation),
         current_index=current_index,

--- a/backend/src/backend/api/radio/stations.py
+++ b/backend/src/backend/api/radio/stations.py
@@ -1,0 +1,57 @@
+"""Station registry — the small, curated lineup you flip between.
+
+A station is just a name + a lens (and, later, an optional corpus filter). Keeping
+the lineup deliberately small is the point: a constrained set you look forward to,
+not an infinite dial. New stations are added here; the default is what existing
+``/radio/state`` consumers see and can be swapped without touching the API shape.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from backend.api.radio import lenses
+from backend.api.radio.lenses import LensContext
+from backend.models import Track
+
+Lens = Callable[[Track, LensContext], float]
+
+
+@dataclass(frozen=True)
+class Station:
+    slug: str
+    name: str
+    description: str
+    lens: Lens
+
+
+STATIONS: tuple[Station, ...] = (
+    Station(
+        slug="loved",
+        name="loved",
+        description="the most-liked, most-played tracks across plyr.fm",
+        lens=lenses.loved,
+    ),
+    Station(
+        slug="fresh",
+        name="fresh",
+        description="newly uploaded — what just landed on plyr.fm",
+        lens=lenses.fresh,
+    ),
+    Station(
+        slug="discovery",
+        name="discovery",
+        description="deep cuts and overlooked tracks from across the catalog",
+        lens=lenses.discovery,
+    ),
+)
+
+DEFAULT_STATION_SLUG = "loved"
+
+_BY_SLUG = {station.slug: station for station in STATIONS}
+
+
+def get_station(slug: str | None) -> Station | None:
+    """Resolve a station by slug; ``None`` slug yields the default station."""
+    if slug is None:
+        return _BY_SLUG[DEFAULT_STATION_SLUG]
+    return _BY_SLUG.get(slug)

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -8,11 +8,44 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from backend.api.radio import lenses
+from backend.api.radio.lenses import LensContext
 from backend.main import app
 from backend.models import Artist, Tag, Track, TrackLike, TrackTag, get_db
 
 # clear_database only removes timestamped rows created after test start.
 TEST_TIME_OFFSET = timedelta(minutes=10)
+
+
+# --- lens semantics (pure functions, no sampler randomness) -----------------
+
+
+def _lens_track(track_id: int, *, play_count: int, created_at: datetime) -> Track:
+    return Track(id=track_id, play_count=play_count, created_at=created_at)
+
+
+def test_loved_lens_prefers_liked() -> None:
+    now = datetime.now(UTC)
+    liked = _lens_track(1, play_count=0, created_at=now)
+    unliked = _lens_track(2, play_count=0, created_at=now)
+    ctx = LensContext(like_counts={liked.id: 5}, now=now)
+    assert lenses.loved(liked, ctx) > lenses.loved(unliked, ctx)
+
+
+def test_fresh_lens_prefers_newer() -> None:
+    now = datetime.now(UTC)
+    newer = _lens_track(1, play_count=0, created_at=now)
+    older = _lens_track(2, play_count=0, created_at=now - timedelta(days=120))
+    ctx = LensContext(like_counts={}, now=now)
+    assert lenses.fresh(newer, ctx) > lenses.fresh(older, ctx)
+
+
+def test_discovery_lens_prefers_lower_play() -> None:
+    now = datetime.now(UTC)
+    obscure = _lens_track(1, play_count=2, created_at=now)
+    popular = _lens_track(2, play_count=5000, created_at=now)
+    ctx = LensContext(like_counts={}, now=now)
+    assert lenses.discovery(obscure, ctx) > lenses.discovery(popular, ctx)
 
 
 @pytest.fixture

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -1,4 +1,4 @@
-"""tests for public radio state."""
+"""tests for public radio state and the station lineup."""
 
 from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
@@ -42,6 +42,13 @@ async def radio_artist(db_session: AsyncSession) -> Artist:
     return artist
 
 
+async def _create_artist(db_session: AsyncSession, did: str, handle: str) -> Artist:
+    artist = Artist(did=did, handle=handle, display_name=handle)
+    db_session.add(artist)
+    await db_session.flush()
+    return artist
+
+
 async def _create_track(
     db_session: AsyncSession,
     artist: Artist,
@@ -50,6 +57,7 @@ async def _create_track(
     file_id: str,
     created_at: datetime,
     play_count: int = 0,
+    duration: int = 123,
     unlisted: bool = False,
     support_gate: dict | None = None,
 ) -> Track:
@@ -60,7 +68,7 @@ async def _create_track(
         file_id=file_id,
         file_type="mp3",
         created_at=created_at,
-        extra={"duration": 123},
+        extra={"duration": duration},
         image_url="https://images.example/cover.jpg",
         atproto_record_uri=f"at://{artist.did}/fm.plyr.track/{file_id}",
         play_count=play_count,
@@ -72,19 +80,15 @@ async def _create_track(
     return track
 
 
-async def test_radio_state_returns_live_public_rotation(
+async def test_default_station_returns_public_tracks_only(
     radio_app: FastAPI,
     db_session: AsyncSession,
     radio_artist: Artist,
 ) -> None:
-    """radio state returns one live station with public tracks only."""
+    """default station serves the loved station; unlisted/gated are excluded."""
     now = datetime.now(UTC) + TEST_TIME_OFFSET
     visible = await _create_track(
-        db_session,
-        radio_artist,
-        title="Visible",
-        file_id="visible",
-        created_at=now,
+        db_session, radio_artist, title="Visible", file_id="visible", created_at=now
     )
     await _create_track(
         db_session,
@@ -112,7 +116,9 @@ async def test_radio_state_returns_live_public_rotation(
 
     assert response.status_code == 200
     data = response.json()
-    assert data["station"] == "plyr.fm radio"
+    # back-compat: omitting ?station serves the default (loved) station, same shape.
+    assert data["station_slug"] == "loved"
+    assert data["station"] == "loved"
     assert data["current"]["title"] == "Visible"
     assert data["current"]["stream_url"] == (
         f"https://radio.plyr.fm/audio/{visible.file_id}"
@@ -122,45 +128,59 @@ async def test_radio_state_returns_live_public_rotation(
     assert [track["title"] for track in data["rotation"]] == ["Visible"]
 
 
-async def test_radio_state_orders_rotation_by_likes_then_plays(
+async def test_rotation_is_deterministic_per_day(
     radio_app: FastAPI,
     db_session: AsyncSession,
     radio_artist: Artist,
 ) -> None:
-    """likes and play counts determine what gets into the radio loop."""
+    """same (station, day) yields the same rotation for every client."""
     now = datetime.now(UTC) + TEST_TIME_OFFSET
-    played = await _create_track(
-        db_session,
-        radio_artist,
-        title="Played",
-        file_id="played",
-        created_at=now,
-        play_count=50,
-    )
-    liked = await _create_track(
-        db_session,
-        radio_artist,
-        title="Liked",
-        file_id="liked",
-        created_at=now - timedelta(minutes=1),
-        play_count=1,
-    )
-    latest = await _create_track(
-        db_session,
-        radio_artist,
-        title="Latest",
-        file_id="latest",
-        created_at=now - timedelta(minutes=2),
-    )
-
-    for index in range(2):
-        db_session.add(
-            TrackLike(
-                track_id=liked.id,
-                user_did=f"did:test:liker{index}",
-                atproto_like_uri=f"at://did:test:liker{index}/fm.plyr.like/liked",
-            )
+    for index in range(8):
+        await _create_track(
+            db_session,
+            radio_artist,
+            title=f"t{index}",
+            file_id=f"t{index}",
+            created_at=now - timedelta(minutes=index),
+            play_count=index,
         )
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=radio_app),
+        base_url="https://radio.plyr.fm",
+    ) as client:
+        first = await client.get("/radio/state.json")
+        second = await client.get("/radio/state.json")
+
+    assert first.status_code == 200
+    order_a = [t["id"] for t in first.json()["rotation"]]
+    order_b = [t["id"] for t in second.json()["rotation"]]
+    assert order_a == order_b
+    assert len(order_a) == 8
+
+
+async def test_airtime_cap_prevents_single_artist_domination(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    """one artist's long tracks can't swallow the whole rotation."""
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
+    # hog: five 10-minute tracks (cap is ~20 min, so at most two get in).
+    for index in range(5):
+        await _create_track(
+            db_session,
+            radio_artist,
+            title=f"hog{index}",
+            file_id=f"hog{index}",
+            created_at=now - timedelta(minutes=index),
+            duration=600,
+        )
+    other = await _create_artist(db_session, "did:plc:other", "other.plyr.fm")
+    await _create_track(
+        db_session, other, title="other", file_id="other", created_at=now, duration=180
+    )
     await db_session.commit()
 
     async with AsyncClient(
@@ -169,12 +189,51 @@ async def test_radio_state_orders_rotation_by_likes_then_plays(
     ) as client:
         response = await client.get("/radio/state.json")
 
-    assert response.status_code == 200
     rotation = response.json()["rotation"]
-    assert [track["title"] for track in rotation] == ["Liked", "Played", "Latest"]
-    assert rotation[0]["like_count"] == 2
-    assert rotation[1]["play_count"] == played.play_count
-    assert rotation[2]["id"] == latest.id
+    hog_count = sum(1 for t in rotation if t["artist_did"] == radio_artist.did)
+    assert hog_count <= 2  # capped despite five eligible tracks
+    assert any(t["artist_did"] == other.did for t in rotation)  # other artist surfaces
+
+
+async def test_station_param_and_404(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    """?station selects a named station; unknown slugs 404."""
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
+    await _create_track(
+        db_session, radio_artist, title="t", file_id="t", created_at=now
+    )
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=radio_app),
+        base_url="https://radio.plyr.fm",
+    ) as client:
+        fresh = await client.get("/radio/state.json", params={"station": "fresh"})
+        unknown = await client.get("/radio/state.json", params={"station": "nope"})
+
+    assert fresh.status_code == 200
+    assert fresh.json()["station_slug"] == "fresh"
+    assert unknown.status_code == 404
+
+
+async def test_stations_endpoint_lists_lineup(radio_app: FastAPI) -> None:
+    """the lineup endpoint exposes the flippable stations + the default."""
+    async with AsyncClient(
+        transport=ASGITransport(app=radio_app),
+        base_url="https://radio.plyr.fm",
+    ) as client:
+        response = await client.get("/radio/stations")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["default_slug"] == "loved"
+    slugs = {s["slug"] for s in data["stations"]}
+    assert slugs == {"loved", "fresh", "discovery"}
+    default = next(s for s in data["stations"] if s["slug"] == "loved")
+    assert default["is_default"] is True
 
 
 async def test_radio_state_includes_tags_and_up_next(
@@ -185,11 +244,7 @@ async def test_radio_state_includes_tags_and_up_next(
     """radio state includes useful metadata for clients."""
     now = datetime.now(UTC) + TEST_TIME_OFFSET
     first = await _create_track(
-        db_session,
-        radio_artist,
-        title="First",
-        file_id="first",
-        created_at=now,
+        db_session, radio_artist, title="First", file_id="first", created_at=now
     )
     second = await _create_track(
         db_session,
@@ -202,6 +257,14 @@ async def test_radio_state_includes_tags_and_up_next(
     db_session.add(tag)
     await db_session.flush()
     db_session.add(TrackTag(track_id=first.id, tag_id=tag.id))
+    # a like so the loved lens has signal to work with
+    db_session.add(
+        TrackLike(
+            track_id=first.id,
+            user_did="did:test:liker",
+            atproto_like_uri="at://did:test:liker/fm.plyr.like/first",
+        )
+    )
     await db_session.commit()
 
     async with AsyncClient(

--- a/frontend/src/lib/components/radio/StationPills.svelte
+++ b/frontend/src/lib/components/radio/StationPills.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import type { RadioStation } from '$lib/radio.svelte';
+
+	let {
+		stations,
+		activeSlug,
+		onSelect
+	}: {
+		stations: RadioStation[];
+		activeSlug: string | null;
+		onSelect: (slug: string) => void;
+	} = $props();
+</script>
+
+{#if stations.length > 1}
+	<div class="station-pills" role="tablist" aria-label="radio stations">
+		{#each stations as s (s.slug)}
+			<button
+				type="button"
+				role="tab"
+				aria-selected={s.slug === activeSlug}
+				class="pill"
+				class:active={s.slug === activeSlug}
+				title={s.description}
+				onclick={() => onSelect(s.slug)}
+			>
+				{s.name}
+			</button>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.station-pills {
+		display: inline-flex;
+		align-self: center;
+		gap: 0.25rem;
+		padding: 0.2rem;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-full);
+	}
+
+	.pill {
+		appearance: none;
+		border: none;
+		background: transparent;
+		color: var(--text-secondary);
+		font-family: inherit;
+		font-size: var(--text-sm);
+		font-weight: 600;
+		text-transform: lowercase;
+		padding: 0.3rem 0.85rem;
+		border-radius: var(--radius-full);
+		cursor: pointer;
+		transition:
+			background 0.15s ease,
+			color 0.15s ease;
+		-webkit-tap-highlight-color: transparent;
+	}
+
+	.pill:hover {
+		color: var(--text-primary);
+	}
+
+	.pill.active {
+		background: var(--accent);
+		color: var(--bg-primary);
+	}
+</style>

--- a/frontend/src/lib/horizontal-swipe.ts
+++ b/frontend/src/lib/horizontal-swipe.ts
@@ -1,0 +1,82 @@
+// horizontal-swipe attachment — flip left/right between radio stations.
+//
+// touch/pen only; mouse users get the pills + arrow keys. activates once motion
+// is horizontal-dominant and past the noise floor, so it never steals a tap on
+// the artwork link or a vertical page scroll. fires onSwipe('left'|'right') once
+// per gesture when released past the distance threshold.
+//
+// usage:
+//   <div {@attach horizontalSwipe((dir) => radio.flip(dir))}>...</div>
+
+import type { Attachment } from 'svelte/attachments';
+
+interface HorizontalSwipeOptions {
+	/** distance in px past which release fires (default: 60) */
+	swipeDeltaPx?: number;
+	/** minimum horizontal delta (px) before activation, suppresses taps (default: 10) */
+	activationDeltaPx?: number;
+}
+
+export function horizontalSwipe(
+	onSwipe: (direction: 'left' | 'right') => void,
+	options: HorizontalSwipeOptions = {}
+): Attachment<HTMLElement> {
+	const { swipeDeltaPx = 60, activationDeltaPx = 10 } = options;
+
+	return (node) => {
+		let tracking = false;
+		let active = false;
+		let startX = 0;
+		let startY = 0;
+		let dx = 0;
+		let pointerId = -1;
+
+		function down(event: PointerEvent) {
+			if (event.pointerType === 'mouse') return;
+			tracking = true;
+			active = false;
+			startX = event.clientX;
+			startY = event.clientY;
+			dx = 0;
+			pointerId = event.pointerId;
+		}
+
+		function move(event: PointerEvent) {
+			if (!tracking || event.pointerId !== pointerId) return;
+			dx = event.clientX - startX;
+			const dy = event.clientY - startY;
+
+			if (!active) {
+				if (Math.abs(dx) < activationDeltaPx) return; // below noise floor
+				if (Math.abs(dy) > Math.abs(dx)) {
+					// vertical-dominant: leave it to the page scroll
+					tracking = false;
+					return;
+				}
+				active = true;
+			}
+		}
+
+		function up(event: PointerEvent) {
+			if (!tracking || event.pointerId !== pointerId) return;
+			const wasActive = active;
+			tracking = false;
+			active = false;
+			pointerId = -1;
+			if (!wasActive) return;
+			if (Math.abs(dx) > swipeDeltaPx) onSwipe(dx < 0 ? 'left' : 'right');
+		}
+
+		node.addEventListener('pointerdown', down);
+		node.addEventListener('pointermove', move);
+		node.addEventListener('pointerup', up);
+		node.addEventListener('pointercancel', up);
+
+		return () => {
+			node.removeEventListener('pointerdown', down);
+			node.removeEventListener('pointermove', move);
+			node.removeEventListener('pointerup', up);
+			node.removeEventListener('pointercancel', up);
+		};
+	};
+}

--- a/frontend/src/lib/radio.svelte.ts
+++ b/frontend/src/lib/radio.svelte.ts
@@ -24,8 +24,16 @@ export interface RadioTrack {
 	play_count: number;
 }
 
+export interface RadioStation {
+	slug: string;
+	name: string;
+	description: string;
+	is_default: boolean;
+}
+
 export interface RadioState {
 	station: string;
+	station_slug: string;
 	generated_at: string;
 	loop_duration_seconds: number;
 	current_index: number | null;
@@ -38,15 +46,72 @@ export interface RadioState {
 }
 
 const POLL_INTERVAL_MS = 30000;
+const STATION_STORAGE_KEY = 'plyr_radio_station';
 
 class Radio {
 	state = $state<RadioState | null>(null);
 	loading = $state(true);
 	error = $state<string | null>(null);
+	stations = $state<RadioStation[]>([]);
+	/** selected station slug; null defers to the server default */
+	station = $state<string | null>(null);
+	/** brief flag while a station flip is in flight, for the tuning transition */
+	switching = $state(false);
 	private pollTimer: number | null = null;
 
 	get current(): RadioTrack | null {
 		return this.state?.current ?? null;
+	}
+
+	/** the resolved station metadata for the loaded state */
+	get activeStation(): RadioStation | null {
+		const slug = this.state?.station_slug;
+		return this.stations.find((s) => s.slug === slug) ?? null;
+	}
+
+	/** load the lineup + restore the listener's last station, then pull state */
+	async init(): Promise<void> {
+		if (this.station === null && typeof localStorage !== 'undefined') {
+			this.station = localStorage.getItem(STATION_STORAGE_KEY);
+		}
+		await Promise.all([this.loadStations(), this.loadState()]);
+	}
+
+	async loadStations(): Promise<void> {
+		try {
+			const response = await fetch(`${API_URL}/radio/stations`);
+			if (!response.ok) return;
+			const data = await response.json();
+			this.stations = data.stations;
+			if (this.station === null) this.station = data.default_slug;
+		} catch (e) {
+			console.error('failed to load radio stations:', e);
+		}
+	}
+
+	/** flip to the next/previous station in the lineup (wraps around) */
+	flip(direction: 'next' | 'prev'): void {
+		if (this.stations.length < 2) return;
+		const slug = this.state?.station_slug ?? this.station;
+		const i = this.stations.findIndex((s) => s.slug === slug);
+		const step = direction === 'next' ? 1 : -1;
+		const next = this.stations[(i + step + this.stations.length) % this.stations.length];
+		void this.setStation(next.slug);
+	}
+
+	/** switch stations: reload state and, if tuned in, follow the audio across */
+	async setStation(slug: string): Promise<void> {
+		if (slug === this.state?.station_slug) return;
+		this.station = slug;
+		if (typeof localStorage !== 'undefined') localStorage.setItem(STATION_STORAGE_KEY, slug);
+		this.switching = true;
+		try {
+			await this.loadState();
+		} finally {
+			this.switching = false;
+		}
+		const c = this.current;
+		if (c && player.radio) player.playRadio(this.toNowPlaying(c), { autoplay: !player.paused });
 	}
 
 	/** whether radio is the active player source (single source of truth) */
@@ -97,9 +162,11 @@ class Radio {
 
 	async loadState(): Promise<void> {
 		try {
-			const response = await fetch(`${API_URL}/radio/state`);
+			const query = this.station ? `?station=${encodeURIComponent(this.station)}` : '';
+			const response = await fetch(`${API_URL}/radio/state${query}`);
 			if (!response.ok) throw new Error(`radio returned ${response.status}`);
 			this.state = await response.json();
+			this.station = this.state?.station_slug ?? this.station;
 			this.error = null;
 		} catch (e) {
 			console.error('failed to load radio state:', e);

--- a/frontend/src/routes/radio/+page.svelte
+++ b/frontend/src/routes/radio/+page.svelte
@@ -5,8 +5,21 @@
 	import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
 	import { auth } from '$lib/auth.svelte';
 	import { radio } from '$lib/radio.svelte';
+	import { horizontalSwipe } from '$lib/horizontal-swipe';
+	import StationPills from '$lib/components/radio/StationPills.svelte';
 
 	const endpoint = `${API_URL}/radio/state`;
+
+	let activeSlug = $derived(radio.state?.station_slug ?? radio.station);
+
+	function onKeydown(event: KeyboardEvent) {
+		if (event.metaKey || event.ctrlKey || event.altKey) return;
+		const target = event.target as HTMLElement | null;
+		if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable))
+			return;
+		if (event.key === 'ArrowRight') radio.flip('next');
+		else if (event.key === 'ArrowLeft') radio.flip('prev');
+	}
 
 	// link preview — a stable station identity, not a per-moment "now playing"
 	// (the on-air track changes constantly and scrapers cache the snapshot).
@@ -31,8 +44,9 @@
 	}
 
 	onMount(() => {
-		// populate "what's on" for display without starting playback
-		if (!radio.state) radio.loadState();
+		// populate "what's on" + station lineup for display without starting playback
+		if (!radio.state) radio.init();
+		else if (radio.stations.length === 0) radio.loadStations();
 	});
 </script>
 
@@ -59,6 +73,8 @@
 	<meta name="twitter:image" content={RADIO_OG_IMAGE} />
 </svelte:head>
 
+<svelte:window onkeydown={onKeydown} />
+
 <Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={handleLogout} />
 
 <main class="radio-page">
@@ -68,7 +84,7 @@
 		{:else if radio.error}
 			<div class="status error">{radio.error}</div>
 		{:else if radio.current}
-			<div class="radio-player">
+			<div class="radio-player" {@attach horizontalSwipe((dir) => radio.flip(dir === 'left' ? 'next' : 'prev'))}>
 				<div class="station-title">
 					<span>live radio</span>
 					<span class="radio-mark" aria-hidden="true">
@@ -81,6 +97,12 @@
 						<span class="source-state">listening here</span>
 					{/if}
 				</div>
+				<StationPills
+					stations={radio.stations}
+					{activeSlug}
+					onSelect={(slug) => radio.setStation(slug)}
+				/>
+				<div class="now-block" class:tuning={radio.switching}>
 				<a class="art-link" href={`/track/${radio.current.id}`} aria-label={`view ${radio.current.title}`}>
 					{#if radio.current.artwork_url}
 						<img src={radio.current.artwork_url} alt="" class="art" />
@@ -94,6 +116,7 @@
 						<a href={`/track/${radio.current.id}`}>{radio.current.title}</a>
 					</h2>
 					<a class="artist" href={`/u/${radio.current.artist_handle}`}>{radio.current.artist}</a>
+				</div>
 				</div>
 				{#if radio.active}
 					<button class="tune-btn stop" onclick={() => radio.stop()} aria-label="stop listening to radio">stop</button>
@@ -143,7 +166,7 @@
 						</a>
 					{/each}
 				</div>
-				<p>from across plyr.fm</p>
+				<p>{radio.activeStation?.description ?? 'from across plyr.fm'}</p>
 			</div>
 		</section>
 	{/if}
@@ -250,6 +273,34 @@
 		border-left: 1px solid var(--border-subtle);
 		color: var(--text-tertiary);
 		font-size: var(--text-sm);
+	}
+
+	/* the swappable station content — artwork + title — fades while tuning */
+	.now-block {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: clamp(0.5rem, 1.35vh, 0.85rem);
+		width: 100%;
+		transition:
+			opacity 0.22s ease,
+			filter 0.22s ease;
+	}
+
+	.now-block.tuning {
+		opacity: 0.35;
+		filter: blur(2px);
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.now-block {
+			transition: none;
+		}
+
+		.now-block.tuning {
+			opacity: 0.6;
+			filter: none;
+		}
 	}
 
 	.label {

--- a/loq.toml
+++ b/loq.toml
@@ -328,4 +328,4 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/+page.svelte"
-max_lines = 687
+max_lines = 738


### PR DESCRIPTION
A first pass at turning radio from one "well-liked + recent" rotation into a small lineup of **stations you flip between** — `loved` / `fresh` / `discovery` — at fixing the structural reason one creator's long mixes dominate, and at the radio-page UI to flip between stations. This isn't meant to be the final shape of radio; it's the first thing worth trying, built so we can swap stations and tune the selection without breaking existing consumers. `GET /radio/state` keeps its response shape and now serves the default station.

```mermaid
flowchart LR
  Q["GET /radio/state<br/>?station=loved"] --> C["load_corpus<br/>(all public ungated tracks)"]
  C --> L["lens scores each track<br/>loved · fresh · discovery"]
  L --> S["sampler<br/>seeded per (station, day)<br/>+ per-artist airtime budget"]
  S --> W["wall-clock loop<br/>epoch % loop_duration"]
  W --> R["RadioStateResponse"]
```

The sampler is what keeps a station from just being a fixed chart: it draws a daily, seeded, weighted rotation and stops drawing from an artist once they've used their airtime budget.

```mermaid
flowchart TD
  A["scored corpus"] --> P["weighted random pick<br/>seed = station + day"]
  P --> Cap{"artist already past<br/>~20 min airtime?"}
  Cap -- yes --> Skip["skip (drop from pool)"] --> Cont{"tracks left &<br/>under ~4h target?"}
  Cap -- no --> Add["add to rotation<br/>artist airtime += duration"] --> Cont
  Cont -- yes --> P
  Cont -- no --> Done["daily rotation"]
```

<details>
<summary><b>why — the prod numbers</b></summary>

Looked into this after a listener noted radio plays one artist's long DJ mixes most of the time. It's structural, not a ranking bug:

| | |
|---|---|
| public ungated tracks in catalog | **861** |
| tracks the old rule could ever reach | 500 (most-recent only) |
| **tracks radio could never play** | **361 (~42%)** |
| one creator's share of rotation **airtime** | **>80%** off 5 long mixes |

The old rule ranked by `likes×3 + log(plays)`, took the top N, and had no artist/airtime diversity — so five 60–140-minute mixes were each "1 slot" but ate the whole clock.

Likes, plays, and teal.fm scrobbles (by *distinct* listeners) all agree that creator is genuinely the most-listened artist on the platform — so the goal here is to stop her appearing five times in one rotation, not to push her down. She still shows up on `loved`.
</details>

<details>
<summary><b>what shipped</b></summary>

Moved radio into its own package `backend/api/radio/` (same layout as `api/tracks/`) so its specifics — seeds, caps, lenses — stay in one place. `api/radio.py` → `api/radio/state.py`; `__init__.py` re-exports `router`, so `from backend.api.radio import router` is unchanged.

```
backend/api/radio/
  __init__.py    re-exports router; registers route module
  router.py      the shared APIRouter
  state.py       endpoints + wall-clock loop arithmetic
  corpus.py      eligibility = full public ungated catalog (no recency cap)
  lenses.py      scoring strategies: loved / fresh / discovery
  sampler.py     deterministic + per-artist-budgeted + weighted rotation builder
  stations.py    station registry; DEFAULT_STATION_SLUG = "loved"
  schemas.py     RadioTrack / RadioStateResponse / station summaries
```

**The three lenses** lean a station one way; they don't hard-partition the catalog (each weight has a small floor — see the caveat below):
- `loved` — `likes×3 + log(plays)`, closest to the old behavior
- `fresh` — recency, ~2-week half-life
- `discovery` — up-weights low-play tracks so the long tail (incl. the ~42% the recency cap hid) gets airtime

**API:**
- `GET /radio/state[.json]?station=<slug>` — omit `station` → default. Unknown slug → `404`.
- `GET /radio/stations` — lists `{slug, name, description, is_default}` for a flip UI.
- `RadioStateResponse` gains a `station_slug` field (see compatibility note).
</details>

<details>
<summary><b>backwards compatibility</b></summary>

What external consumers (Apex's tuner, games) depend on is the **response shape** and the **stateless wall-clock loop** (`epoch_seconds % loop_duration` → same now-playing for every client at a given instant). Both preserved.

- `GET /radio/state` with no params serves the `loved` default and is shape-compatible.
- The response is **additive, not byte-identical**: it gains a `station_slug` field. Existing clients that read known fields are unaffected; calling it "exactly the same shape" would be imprecise.
- `station` (was hardcoded `"plyr.fm radio"`) now carries the station name. The frontend doesn't render it (hardcodes "live radio"), so no UI change.
- Track **ordering** intentionally changes (top-N → seeded weighted sample). Tests assert per-day determinism rather than a fixed order.
- The default station is swappable later without touching the contract.
</details>

<details>
<summary><b>known limitations (deliberate for v1)</b></summary>

- **The per-artist budget caps how *often* an artist appears, not the share of one long track.** One budget-crossing pick is allowed (we can't split a track), so a single 2-hour mix can still be a large slice of one loop. Popular long-form content should still feature, so this is intentional for now — but it means "fairness" is about frequency, not airtime share. A per-track or per-loop ceiling is a follow-up if it turns out to matter.
- **The weight floor dilutes station identity as the catalog grows.** Because no track is ever strictly impossible, the summed floor mass of many off-lens tracks can outweigh a few on-lens ones — most visible on `fresh`. The lenses lean the right way (tests pin the direction) but don't hard-partition. Sharpening this is tuning, not a redesign.
</details>

<details>
<summary><b>station-flip UI (radio page)</b></summary>

Switching is built as car-radio presets, not a menu:
- **segmented pills** (`StationPills.svelte`) where the "live radio" eyebrow sits — always visible, tap to switch.
- **swipe ←/→** on mobile (`horizontalSwipe` attachment, touch/pen only so it never steals a tap or a vertical scroll); **←/→ arrow keys** on desktop.
- a brief **"tuning" fade/blur** on the artwork + title while a flip loads (`prefers-reduced-motion` aware).
- the rotation-deck caption now shows the **active station's description**.
- when you're **tuned in**, flipping follows the audio to the new station's current track; when just previewing, it only updates the display.
- last station is remembered in `localStorage` (a public radio choice, not account-scoped, so a global key is fine).
</details>

<details>
<summary><b>tests</b></summary>

Rewrote `tests/api/test_radio.py` for the new contract:
- public-only filtering (unlisted / gated excluded)
- per-day determinism — same request → identical rotation
- per-artist budget — five 10-min tracks from one artist → ≤2 in rotation, and a second artist surfaces
- `?station=` switching + `404` on unknown slug
- `/radio/stations` lineup + default flag
- existing tags / up-next / loop-math invariants
- **lens direction** (pure unit tests): `fresh` prefers newer, `discovery` prefers lower-play, `loved` prefers liked

9 pass; lint, type-check, loq green.
</details>

<details>
<summary><b>follow-ups</b></summary>

- **teal.fm distinct-listener signal** — strong (2,735 plyr-origin plays across 28 scrobblers, cross-user) but lives only on PDSes; folding it into `loved` needs a local index of teal plays.
- **embedding-based selection** (turbopuffer) for `discovery` — later; v1 uses play-count obscurity.
- **per-request corpus load** — `/radio/state` scans the full corpus + like counts each call (was capped at 500). Negligible at 861 tracks; deterministic per (station, day), so cacheable when it matters.
- the `docs.plyr.fm/developers/api-reference/` 404 flagged separately is unrelated.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
