### PR TITLE
refactor(radio): make fresh & deep-cuts genuinely distinct stations

### DIFF
--- a/backend/src/backend/api/radio/lenses.py
+++ b/backend/src/backend/api/radio/lenses.py
@@ -5,12 +5,19 @@ a deterministic, airtime-fair rotation from those weights, so a lens decides
 *flavor* (what this station leans toward) while the sampler decides *fairness and
 rotation* (no one artist hogging the clock, genuine day-to-day variety).
 
+The three lenses are deliberately spread across orthogonal axes so flipping
+between stations means something:
+
+* ``loved``     — popularity (likes + plays), any age
+* ``fresh``     — the *new* end of the catalog (most-recent uploads)
+* ``deep_cuts`` — the *old* end (older tracks that stayed underplayed)
+
+``fresh`` and ``deep_cuts`` sit at opposite ends of the recency axis on purpose,
+so they don't surface the same brand-new-and-unplayed tracks.
+
 All weights carry a small floor so nothing in the corpus is ever strictly
-impossible, which keeps a station from collapsing into a fixed top-N. The
-tradeoff: as the catalog grows, the summed floor mass of many off-lens tracks
-dilutes a station's identity (most visible on ``fresh``, where lots of old
-tracks can outweigh a few genuinely new ones). The lenses lean the right way;
-they don't hard-partition. Sharpening this is a tuning follow-up.
+impossible, which keeps a station from collapsing into a fixed top-N. The lenses
+lean the right way; they don't hard-partition.
 """
 
 import math
@@ -20,6 +27,12 @@ from datetime import UTC, datetime
 from backend.models import Track
 
 WEIGHT_FLOOR = 0.05
+# how fast `fresh` falls off down the newest-first ordering; ~the newest two
+# dozen uploads carry the station regardless of how fast they arrived.
+FRESH_RANK_SCALE = 12.0
+# wall-clock days over which a track "matures" into deep-cut eligibility, so a
+# just-uploaded track belongs to `fresh`, not here.
+DEEP_CUT_MATURITY_DAYS = 30.0
 
 
 @dataclass(frozen=True)
@@ -28,6 +41,8 @@ class LensContext:
 
     like_counts: dict[int, int]
     now: datetime
+    # track id -> 0-based position in the newest-first ordering of the corpus.
+    recency_rank: dict[int, int]
 
     def likes(self, track: Track) -> int:
         return self.like_counts.get(track.id, 0)
@@ -38,6 +53,10 @@ class LensContext:
             created = created.replace(tzinfo=UTC)
         return max(0.0, (self.now - created).total_seconds() / 86400.0)
 
+    def recency_position(self, track: Track) -> int:
+        """0 = newest upload; unknown tracks rank at the back of the catalog."""
+        return self.recency_rank.get(track.id, len(self.recency_rank))
+
 
 def loved(track: Track, ctx: LensContext) -> float:
     """Genuinely liked + played. Closest to the historical radio behavior."""
@@ -45,20 +64,27 @@ def loved(track: Track, ctx: LensContext) -> float:
 
 
 def fresh(track: Track, ctx: LensContext) -> float:
-    """Recency-leaning. New uploads surface, engagement is a tiebreak nudge."""
-    # ~2-week half-life so the station keeps turning over toward new material.
-    recency = math.exp(-ctx.age_days(track) / 14.0)
+    """The leading edge of uploads.
+
+    Recency is measured by *position* in the newest-first ordering, not wall-clock
+    age, so "fresh" tracks whatever just landed whether uploads are pouring in or
+    trickling — a quiet week doesn't surface stale tracks and a busy week doesn't
+    flatten everything to the same weight.
+    """
+    recency = math.exp(-ctx.recency_position(track) / FRESH_RANK_SCALE)
     nudge = math.log1p(ctx.likes(track) + track.play_count) * 0.15
     return WEIGHT_FLOOR + recency + nudge
 
 
-def discovery(track: Track, ctx: LensContext) -> float:
-    """Deep cuts — the long tail the other lenses never reach.
+def deep_cuts(track: Track, ctx: LensContext) -> float:
+    """The old end of the catalog — tracks that aged without getting played.
 
-    Up-weights low-play tracks so the ~40% of the catalog that the old recency
-    cap made unreachable actually gets airtime. A faint like signal keeps it from
-    being pure noise without re-privileging the already-popular.
+    Up-weights low-play tracks (the long tail the recency cap used to hide), but
+    only once they've had wall-clock time to be discovered: a brand-new unplayed
+    track belongs to ``fresh``, not here, so newness is multiplied out. A faint
+    like signal keeps it from being pure noise without re-privileging the popular.
     """
     obscurity = 1.0 / (1.0 + math.log1p(track.play_count))
+    maturity = 1.0 - math.exp(-ctx.age_days(track) / DEEP_CUT_MATURITY_DAYS)
     quality_hint = math.log1p(ctx.likes(track)) * 0.1
-    return WEIGHT_FLOOR + obscurity + quality_hint
+    return WEIGHT_FLOOR + obscurity * maturity + quality_hint

--- a/backend/src/backend/api/radio/state.py
+++ b/backend/src/backend/api/radio/state.py
@@ -59,7 +59,9 @@ async def _select_rotation(
         return [], {}
 
     like_counts = await get_like_counts(db, [track.id for track in corpus])
-    ctx = LensContext(like_counts=like_counts, now=now)
+    # corpus is ordered newest-first, so enumeration is the recency rank.
+    recency_rank = {track.id: rank for rank, track in enumerate(corpus)}
+    ctx = LensContext(like_counts=like_counts, now=now, recency_rank=recency_rank)
     weights = {track.id: station.lens(track, ctx) for track in corpus}
     rotation = build_rotation(
         corpus,

--- a/backend/src/backend/api/radio/stations.py
+++ b/backend/src/backend/api/radio/stations.py
@@ -34,14 +34,14 @@ STATIONS: tuple[Station, ...] = (
     Station(
         slug="fresh",
         name="fresh",
-        description="newly uploaded — what just landed on plyr.fm",
+        description="just landed — the newest uploads on plyr.fm",
         lens=lenses.fresh,
     ),
     Station(
-        slug="discovery",
-        name="discovery",
-        description="deep cuts and overlooked tracks from across the catalog",
-        lens=lenses.discovery,
+        slug="deep-cuts",
+        name="deep cuts",
+        description="older, overlooked tracks from the back catalog",
+        lens=lenses.deep_cuts,
     ),
 )
 

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -24,28 +24,44 @@ def _lens_track(track_id: int, *, play_count: int, created_at: datetime) -> Trac
     return Track(id=track_id, play_count=play_count, created_at=created_at)
 
 
+def _ctx(
+    *, like_counts: dict[int, int], now: datetime, order: list[int]
+) -> LensContext:
+    """LensContext with `order` listed newest-first (0-based recency rank)."""
+    return LensContext(
+        like_counts=like_counts,
+        now=now,
+        recency_rank={track_id: rank for rank, track_id in enumerate(order)},
+    )
+
+
 def test_loved_lens_prefers_liked() -> None:
     now = datetime.now(UTC)
     liked = _lens_track(1, play_count=0, created_at=now)
     unliked = _lens_track(2, play_count=0, created_at=now)
-    ctx = LensContext(like_counts={liked.id: 5}, now=now)
+    ctx = _ctx(like_counts={liked.id: 5}, now=now, order=[1, 2])
     assert lenses.loved(liked, ctx) > lenses.loved(unliked, ctx)
 
 
-def test_fresh_lens_prefers_newer() -> None:
+def test_fresh_lens_prefers_newer_by_rank() -> None:
     now = datetime.now(UTC)
     newer = _lens_track(1, play_count=0, created_at=now)
-    older = _lens_track(2, play_count=0, created_at=now - timedelta(days=120))
-    ctx = LensContext(like_counts={}, now=now)
+    older = _lens_track(2, play_count=0, created_at=now)
+    # recency is by position, not wall-clock: newer ranks ahead of older
+    ctx = _ctx(like_counts={}, now=now, order=[newer.id, older.id])
     assert lenses.fresh(newer, ctx) > lenses.fresh(older, ctx)
 
 
-def test_discovery_lens_prefers_lower_play() -> None:
+def test_deep_cuts_prefers_older_underplayed() -> None:
     now = datetime.now(UTC)
-    obscure = _lens_track(1, play_count=2, created_at=now)
-    popular = _lens_track(2, play_count=5000, created_at=now)
-    ctx = LensContext(like_counts={}, now=now)
-    assert lenses.discovery(obscure, ctx) > lenses.discovery(popular, ctx)
+    buried = _lens_track(1, play_count=2, created_at=now - timedelta(days=200))
+    brand_new = _lens_track(2, play_count=2, created_at=now)
+    popular_old = _lens_track(3, play_count=5000, created_at=now - timedelta(days=200))
+    ctx = _ctx(like_counts={}, now=now, order=[2, 1, 3])
+    # older + underplayed beats both a brand-new unplayed track (that's `fresh`)
+    # and an old-but-popular track (that's `loved`)
+    assert lenses.deep_cuts(buried, ctx) > lenses.deep_cuts(brand_new, ctx)
+    assert lenses.deep_cuts(buried, ctx) > lenses.deep_cuts(popular_old, ctx)
 
 
 @pytest.fixture
@@ -264,7 +280,7 @@ async def test_stations_endpoint_lists_lineup(radio_app: FastAPI) -> None:
     data = response.json()
     assert data["default_slug"] == "loved"
     slugs = {s["slug"] for s in data["stations"]}
-    assert slugs == {"loved", "fresh", "discovery"}
+    assert slugs == {"loved", "fresh", "deep-cuts"}
     default = next(s for s in data["stations"] if s["slug"] == "loved")
     assert default["is_default"] is True
 

--- a/frontend/src/lib/radio.svelte.ts
+++ b/frontend/src/lib/radio.svelte.ts
@@ -164,6 +164,13 @@ class Radio {
 		try {
 			const query = this.station ? `?station=${encodeURIComponent(this.station)}` : '';
 			const response = await fetch(`${API_URL}/radio/state${query}`);
+			if (response.status === 404 && this.station) {
+				// a persisted station slug no longer exists (e.g. renamed) — drop it
+				// and fall back to the server default rather than going "off air".
+				this.station = null;
+				if (typeof localStorage !== 'undefined') localStorage.removeItem(STATION_STORAGE_KEY);
+				return this.loadState();
+			}
 			if (!response.ok) throw new Error(`radio returned ${response.status}`);
 			this.state = await response.json();
 			this.station = this.state?.station_slug ?? this.station;


### PR DESCRIPTION
Follow-up to #1525. `fresh` and `discovery` weren't distinct enough — and the overlap was mechanical, not just naming.

## the problem

A brand-new track has **low play count**, so it scored high on *both* `fresh` (recent) and `discovery` (low-play) — the two stations surfaced overlapping tracks, and "fresh"/"discovery" both read as "new to you." Same idea twice.

Separately: `fresh` measured recency by **absolute wall-clock** (`exp(-age_days/14)`), which ignores upload volume — a busy week flattens everything to ~the same weight while a quiet week surfaces stale two-week-old tracks.

## what changed

Three orthogonal axes now, so flipping between stations means something:

| station | axis | surfaces |
|---|---|---|
| `loved` | popularity | most liked + played, any age |
| `fresh` | **new** end of time | the leading edge of uploads |
| `deep cuts` (`deep-cuts`) | **old** end + overlooked | aged tracks that stayed underplayed |

- **`discovery` → `deep cuts`** (slug `deep-cuts`): the lens now multiplies obscurity by a wall-clock **maturity** factor (`1 - exp(-age/30d)`), so a brand-new unplayed track scores ~0 here — it belongs to `fresh`. Deep cuts is explicitly the *back catalog*, the opposite end of the recency axis from fresh. (This is what it was always *for* — surfacing the older tracks the old 500-most-recent cap hid.)
- **`fresh` is now rank-based**: recency = position in the newest-first ordering (`exp(-rank/12)`), not absolute days. It tracks "what just landed" whether uploads pour in or trickle. `LensContext` carries a `recency_rank` map built from the corpus ordering.
- **frontend**: a persisted station slug that no longer exists (the `discovery`→`deep-cuts` rename) now falls back to the default instead of going "off air".

<details>
<summary>tests</summary>

- `test_fresh_lens_prefers_newer_by_rank` — recency by position, not wall-clock
- `test_deep_cuts_prefers_older_underplayed` — older+underplayed beats both a brand-new unplayed track (that's fresh) and an old-but-popular one (that's loved)
- lineup slug assertion updated to `{loved, fresh, deep-cuts}`

9 pass; backend lint, svelte-check, eslint, loq green.
</details>

<details>
<summary>note: slug rename of an already-shipped station</summary>

`discovery` shipped to prod ~an hour before this (release `2026.0604.041624`), so `?station=discovery` will 404 after this deploys. Blast radius is ~nil (live <1h, niche), and the frontend now self-heals a stale persisted slug. Flagging for completeness.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)