### PR TITLE
feat(radio): slop station — quarantine ai-tagged tracks

### DIFF
--- a/backend/src/backend/api/radio/state.py
+++ b/backend/src/backend/api/radio/state.py
@@ -49,22 +49,30 @@ async def _select_rotation(
     limit: int,
     now: datetime,
 ) -> tuple[list[Track], dict[int, int]]:
-    """Score the full corpus through the station lens and sample a rotation.
+    """Score the station's eligible corpus through its lens and sample a rotation.
 
-    Returns the chosen tracks plus the corpus-wide like counts (reused for
-    serialization so we only count likes once).
+    Returns the chosen tracks plus their like counts (reused for serialization so
+    we only count likes once).
     """
     corpus = await load_corpus(db)
     if not corpus:
         return [], {}
 
-    like_counts = await get_like_counts(db, [track.id for track in corpus])
-    # corpus is ordered newest-first, so enumeration is the recency rank.
-    recency_rank = {track.id: rank for rank, track in enumerate(corpus)}
+    # a station's corpus_filter decides eligibility from a track's tags (e.g.
+    # `slop` keeps only ai/suno-tagged tracks; every other station excludes them).
+    tag_map = await get_track_tags(db, [track.id for track in corpus])
+    eligible = [t for t in corpus if station.corpus_filter(tag_map.get(t.id, set()))]
+    if not eligible:
+        return [], {}
+
+    like_counts = await get_like_counts(db, [track.id for track in eligible])
+    # eligible keeps the newest-first corpus order, so enumeration is the recency
+    # rank within this station's pool.
+    recency_rank = {track.id: rank for rank, track in enumerate(eligible)}
     ctx = LensContext(like_counts=like_counts, now=now, recency_rank=recency_rank)
-    weights = {track.id: station.lens(track, ctx) for track in corpus}
+    weights = {track.id: station.lens(track, ctx) for track in eligible}
     rotation = build_rotation(
-        corpus,
+        eligible,
         weights,
         station_slug=station.slug,
         day=now.date().isoformat(),

--- a/backend/src/backend/api/radio/stations.py
+++ b/backend/src/backend/api/radio/stations.py
@@ -1,19 +1,36 @@
 """Station registry — the small, curated lineup you flip between.
 
-A station is just a name + a lens (and, later, an optional corpus filter). Keeping
-the lineup deliberately small is the point: a constrained set you look forward to,
-not an infinite dial. New stations are added here; the default is what existing
-``/radio/state`` consumers see and can be swapped without touching the API shape.
+A station is a name + a lens (what it leans toward) + a corpus filter (what's even
+eligible). Keeping the lineup small is the point: a constrained set you look
+forward to, not an infinite dial. New stations are added here; the default is what
+existing ``/radio/state`` consumers see and can be swapped without touching the
+API shape.
 """
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from backend.api.radio import lenses
 from backend.api.radio.lenses import LensContext
 from backend.models import Track
+from backend.utilities.tags import is_tag_hidden_by_default
 
 Lens = Callable[[Track, LensContext], float]
+# given a track's normalized tags, is it eligible for this station?
+CorpusFilter = Callable[[set[str]], bool]
+
+
+def _has_hidden_tag(tags: set[str]) -> bool:
+    """True if the track carries any default-hidden tag (ai / ai-slop / suno)."""
+    return any(is_tag_hidden_by_default(tag) for tag in tags)
+
+
+def _exclude_slop(tags: set[str]) -> bool:
+    return not _has_hidden_tag(tags)
+
+
+def _only_slop(tags: set[str]) -> bool:
+    return _has_hidden_tag(tags)
 
 
 @dataclass(frozen=True)
@@ -22,6 +39,8 @@ class Station:
     name: str
     description: str
     lens: Lens
+    # default: keep the same ai/suno tracks out that the homepage hides
+    corpus_filter: CorpusFilter = field(default=_exclude_slop)
 
 
 STATIONS: tuple[Station, ...] = (
@@ -42,6 +61,13 @@ STATIONS: tuple[Station, ...] = (
         name="deep cuts",
         description="older, overlooked tracks from the back catalog",
         lens=lenses.deep_cuts,
+    ),
+    Station(
+        slug="slop",
+        name="slop",
+        description="ai-generated tracks — hidden from the other stations",
+        lens=lenses.loved,
+        corpus_filter=_only_slop,
     ),
 )
 

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -280,9 +280,49 @@ async def test_stations_endpoint_lists_lineup(radio_app: FastAPI) -> None:
     data = response.json()
     assert data["default_slug"] == "loved"
     slugs = {s["slug"] for s in data["stations"]}
-    assert slugs == {"loved", "fresh", "deep-cuts"}
+    assert slugs == {"loved", "fresh", "deep-cuts", "slop"}
     default = next(s for s in data["stations"] if s["slug"] == "loved")
     assert default["is_default"] is True
+
+
+async def _tag_track(db_session: AsyncSession, track: Track, tag_name: str) -> None:
+    tag = Tag(name=tag_name, created_by_did=track.artist_did)
+    db_session.add(tag)
+    await db_session.flush()
+    db_session.add(TrackTag(track_id=track.id, tag_id=tag.id))
+
+
+async def test_slop_station_isolates_ai_tagged_tracks(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    """slop holds exactly the ai/suno-tagged tracks; other stations exclude them."""
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
+    ai_track = await _create_track(
+        db_session, radio_artist, title="Slop Jam", file_id="slop", created_at=now
+    )
+    await _tag_track(db_session, ai_track, "ai")
+    clean_track = await _create_track(
+        db_session,
+        radio_artist,
+        title="Real Jam",
+        file_id="clean",
+        created_at=now - timedelta(minutes=1),
+    )
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=radio_app),
+        base_url="https://radio.plyr.fm",
+    ) as client:
+        slop = await client.get("/radio/state.json", params={"station": "slop"})
+        loved = await client.get("/radio/state.json")
+
+    slop_ids = {t["id"] for t in slop.json()["rotation"]}
+    loved_ids = {t["id"] for t in loved.json()["rotation"]}
+    assert slop_ids == {ai_track.id}  # slop = only the ai-tagged track
+    assert loved_ids == {clean_track.id}  # default station excludes it
 
 
 async def test_radio_state_includes_tags_and_up_next(

--- a/frontend/src/lib/components/radio/StationPills.svelte
+++ b/frontend/src/lib/components/radio/StationPills.svelte
@@ -32,39 +32,44 @@
 
 <style>
 	.station-pills {
-		display: inline-flex;
+		display: flex;
+		flex-wrap: wrap;
 		align-self: center;
-		gap: 0.25rem;
-		padding: 0.2rem;
-		background: var(--bg-secondary);
-		border: 1px solid var(--border-subtle);
-		border-radius: var(--radius-full);
+		justify-content: center;
+		gap: 0.35rem;
+		max-width: 100%;
 	}
 
+	/* independent chips (not a fixed segmented bar) so the row wraps cleanly as
+	   the lineup grows and labels vary in width (e.g. "deep cuts") */
 	.pill {
 		appearance: none;
-		border: none;
-		background: transparent;
+		background: var(--bg-secondary);
 		color: var(--text-secondary);
+		border: 1px solid var(--border-subtle);
 		font-family: inherit;
 		font-size: var(--text-sm);
 		font-weight: 600;
 		text-transform: lowercase;
+		white-space: nowrap;
 		padding: 0.3rem 0.85rem;
 		border-radius: var(--radius-full);
 		cursor: pointer;
 		transition:
 			background 0.15s ease,
-			color 0.15s ease;
+			color 0.15s ease,
+			border-color 0.15s ease;
 		-webkit-tap-highlight-color: transparent;
 	}
 
 	.pill:hover {
 		color: var(--text-primary);
+		border-color: var(--border-default);
 	}
 
 	.pill.active {
 		background: var(--accent);
+		border-color: var(--accent);
 		color: var(--bg-primary);
 	}
 </style>


### PR DESCRIPTION
Adds a **`slop`** station holding exactly the ai/suno-tagged tracks, and filters that same set *out* of `loved` / `fresh` / `deep cuts`. So ai-generated audio gets its own dial position instead of leaking into the rest of radio.

## what

- **Stations gain a `corpus_filter`** — a predicate over a track's tags deciding eligibility. Default excludes the hidden set; `slop` is the inverse (only the hidden set).
- **Reuses the homepage's source of truth** — `DEFAULT_HIDDEN_TAGS = ["ai", "ai-slop", "suno"]` + `is_tag_hidden_by_default` from `utilities/tags.py` (the exact set + normalization the homepage track list and for-you feed already hide). So `slop` is precisely the inverse of what's hidden elsewhere, and it tracks any future change to that set with no drift.
- **`_select_rotation`** now fetches corpus tags, applies the station's filter, and ranks recency within the eligible pool.
- **frontend**: `StationPills` are now independent wrapping chips rather than a fixed segmented bar — the lineup is 4 now and "deep cuts" is wide, so it wraps cleanly on narrow screens and scales as the lineup grows. `slop` shows up automatically (stations come from the API).

Lineup: `loved` · `fresh` · `deep cuts` · **`slop`**.

Prod has ~34 `ai` + 8 `suno` + 6 `ai-slop` tagged tracks today, so slop won't be empty.

<details>
<summary>tests</summary>

- `test_slop_station_isolates_ai_tagged_tracks` — an `ai`-tagged track appears in `slop` and *only* `slop`; the default station excludes it.
- lineup slug assertion updated to `{loved, fresh, deep-cuts, slop}`.

10 pass; backend lint, svelte-check, eslint, loq green.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)