### PR TITLE
fix(radio): keep plyr.fm account's own tracks out of slop

### DIFF
--- a/backend/src/backend/api/radio/state.py
+++ b/backend/src/backend/api/radio/state.py
@@ -61,7 +61,7 @@ async def _select_rotation(
     # a station's corpus_filter decides eligibility from a track's tags (e.g.
     # `slop` keeps only ai/suno-tagged tracks; every other station excludes them).
     tag_map = await get_track_tags(db, [track.id for track in corpus])
-    eligible = [t for t in corpus if station.corpus_filter(tag_map.get(t.id, set()))]
+    eligible = [t for t in corpus if station.corpus_filter(t, tag_map.get(t.id, set()))]
     if not eligible:
         return [], {}
 

--- a/backend/src/backend/api/radio/stations.py
+++ b/backend/src/backend/api/radio/stations.py
@@ -16,8 +16,12 @@ from backend.models import Track
 from backend.utilities.tags import is_tag_hidden_by_default
 
 Lens = Callable[[Track, LensContext], float]
-# given a track's normalized tags, is it eligible for this station?
-CorpusFilter = Callable[[set[str]], bool]
+# given a track and its normalized tags, is it eligible for this station?
+CorpusFilter = Callable[[Track, set[str]], bool]
+
+# the plyr.fm app account, whose ai-tagged changelog/update posts we keep out of
+# the slop station for now (they're not music).
+PLYR_FM_ACCOUNT_HANDLE = "plyr.fm"
 
 
 def _has_hidden_tag(tags: set[str]) -> bool:
@@ -25,12 +29,12 @@ def _has_hidden_tag(tags: set[str]) -> bool:
     return any(is_tag_hidden_by_default(tag) for tag in tags)
 
 
-def _exclude_slop(tags: set[str]) -> bool:
+def _exclude_slop(track: Track, tags: set[str]) -> bool:
     return not _has_hidden_tag(tags)
 
 
-def _only_slop(tags: set[str]) -> bool:
-    return _has_hidden_tag(tags)
+def _only_slop(track: Track, tags: set[str]) -> bool:
+    return _has_hidden_tag(tags) and track.artist.handle != PLYR_FM_ACCOUNT_HANDLE
 
 
 @dataclass(frozen=True)

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.api.radio import lenses
@@ -286,10 +287,14 @@ async def test_stations_endpoint_lists_lineup(radio_app: FastAPI) -> None:
 
 
 async def _tag_track(db_session: AsyncSession, track: Track, tag_name: str) -> None:
-    tag = Tag(name=tag_name, created_by_did=track.artist_did)
-    db_session.add(tag)
-    await db_session.flush()
-    db_session.add(TrackTag(track_id=track.id, tag_id=tag.id))
+    existing = (
+        await db_session.execute(select(Tag).where(Tag.name == tag_name))
+    ).scalar_one_or_none()
+    if existing is None:
+        existing = Tag(name=tag_name, created_by_did=track.artist_did)
+        db_session.add(existing)
+        await db_session.flush()
+    db_session.add(TrackTag(track_id=track.id, tag_id=existing.id))
 
 
 async def test_slop_station_isolates_ai_tagged_tracks(
@@ -323,6 +328,38 @@ async def test_slop_station_isolates_ai_tagged_tracks(
     loved_ids = {t["id"] for t in loved.json()["rotation"]}
     assert slop_ids == {ai_track.id}  # slop = only the ai-tagged track
     assert loved_ids == {clean_track.id}  # default station excludes it
+
+
+async def test_slop_excludes_plyr_fm_account_tracks(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    """the plyr.fm account's ai-tagged update posts are kept out of slop."""
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
+    plyr = await _create_artist(db_session, "did:plc:plyrfm", "plyr.fm")
+    plyr_track = await _create_track(
+        db_session, plyr, title="plyr.fm update", file_id="update", created_at=now
+    )
+    await _tag_track(db_session, plyr_track, "ai")
+    other_slop = await _create_track(
+        db_session,
+        radio_artist,
+        title="Real Slop",
+        file_id="realslop",
+        created_at=now - timedelta(minutes=1),
+    )
+    await _tag_track(db_session, other_slop, "ai")
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=radio_app),
+        base_url="https://radio.plyr.fm",
+    ) as client:
+        slop = await client.get("/radio/state.json", params={"station": "slop"})
+
+    slop_ids = {t["id"] for t in slop.json()["rotation"]}
+    assert slop_ids == {other_slop.id}  # plyr.fm's ai track excluded
 
 
 async def test_radio_state_includes_tags_and_up_next(


### PR DESCRIPTION
The plyr.fm app account's changelog/update posts are all `ai`-tagged, so they were dominating the **slop** station (the current track on prod was literally "plyr.fm update - December 17, 2025"). They're not music — exclude them for now.

- widens `Station.corpus_filter` from `(tags)` → `(track, tags)` so a station can filter on artist, not just tags.
- `slop` now additionally excludes the `plyr.fm` account (by handle). The account has 18 tracks, all ai-tagged, so this clears them from slop; they were already excluded from loved/fresh/deep-cuts by the ai tag, so they simply won't appear on radio.

Regression test: a `plyr.fm`-account ai track is kept out of slop while another artist's ai track remains. 11 tests pass; backend lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)