### PR TITLE
fix(radio): hide deactivated accounts from discovery + handle long titles

### DIFF
--- a/backend/alembic/versions/2026_06_04_015653_e9ec24f00cd1_add_artist_deactivated_flag.py
+++ b/backend/alembic/versions/2026_06_04_015653_e9ec24f00cd1_add_artist_deactivated_flag.py
@@ -1,0 +1,34 @@
+"""add artist deactivated flag
+
+Revision ID: e9ec24f00cd1
+Revises: 2ff28fd69210
+Create Date: 2026-06-04 01:56:53.818917
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e9ec24f00cd1"
+down_revision: str | None = "2ff28fd69210"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    """Add deactivated flag to artists (set from #account firehose events)."""
+    op.add_column(
+        "artists",
+        sa.Column("deactivated", sa.Boolean(), server_default="false", nullable=False),
+    )
+    op.create_index(
+        op.f("ix_artists_deactivated"), "artists", ["deactivated"], unique=False
+    )
+
+
+def downgrade() -> None:
+    """Remove deactivated flag from artists."""
+    op.drop_index(op.f("ix_artists_deactivated"), table_name="artists")
+    op.drop_column("artists", "deactivated")

--- a/backend/src/backend/_internal/tasks/ingest.py
+++ b/backend/src/backend/_internal/tasks/ingest.py
@@ -817,7 +817,8 @@ async def ingest_account_status_change(
     the CDN URL goes dead during deactivation.
 
     on deactivation (active=False): clear the avatar URL so the frontend
-    doesn't show a broken image pointing at a dead CDN URL.
+    doesn't show a broken image pointing at a dead CDN URL, and mark the artist
+    deactivated so their content drops out of discovery (radio / home / for-you).
     """
     from backend._internal.atproto.profile import fetch_user_avatar
 
@@ -826,6 +827,12 @@ async def ingest_account_status_change(
         if not artist:
             logger.debug("ingest_account_status_change: unknown artist %s", did)
             return
+
+        # persist liveness so discovery queries can exclude deactivated accounts
+        if artist.deactivated == active:
+            artist.deactivated = not active
+            await db.commit()
+            logfire.info("ingest: account status changed", did=did, active=active)
 
         if active:
             # re-fetch avatar on reactivation

--- a/backend/src/backend/api/for_you.py
+++ b/backend/src/backend/api/for_you.py
@@ -343,6 +343,19 @@ async def get_for_you_feed(
         if hidden_set:
             track_ids = [tid for tid in track_ids if tid not in hidden_set]
 
+    # drop tracks from deactivated accounts (their content is hidden from discovery)
+    if track_ids:
+        deactivated_rows = (
+            await db.execute(
+                select(Track.id)
+                .join(Artist)
+                .where(Track.id.in_(track_ids), Artist.deactivated == True)  # noqa: E712
+            )
+        ).all()
+        deactivated_set = {r.id for r in deactivated_rows}
+        if deactivated_set:
+            track_ids = [tid for tid in track_ids if tid not in deactivated_set]
+
     # apply active tag filter (inclusive — keep only tracks with at least one matching tag)
     if tags and track_ids:
         tagged_rows = (

--- a/backend/src/backend/api/radio/corpus.py
+++ b/backend/src/backend/api/radio/corpus.py
@@ -22,6 +22,7 @@ async def load_corpus(db: AsyncSession) -> list[Track]:
         .where(
             Track.unlisted == False,  # noqa: E712
             Track.support_gate.is_(None),
+            Artist.deactivated == False,  # noqa: E712
         )
         .order_by(Track.created_at.desc(), Track.id.desc())
     )

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -132,8 +132,10 @@ async def list_tracks(
     if artist_did:
         stmt = stmt.where(Track.artist_did == artist_did)
     else:
-        # discovery feed: exclude unlisted tracks (artist pages show all)
+        # discovery feed: exclude unlisted tracks (artist pages show all) and
+        # tracks from deactivated accounts (their content drops out of discovery)
         stmt = stmt.where(Track.unlisted == False)  # noqa: E712
+        stmt = stmt.where(Artist.deactivated == False)  # noqa: E712
 
     # filter out tracks with hidden tags
     # when filter_hidden_tags is None (default), auto-decide:

--- a/backend/src/backend/models/artist.py
+++ b/backend/src/backend/models/artist.py
@@ -3,7 +3,7 @@
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, Index, String
+from sqlalchemy import Boolean, DateTime, Index, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from backend.models.database import Base
@@ -30,6 +30,13 @@ class Artist(Base):
 
     # cached PDS URL (for performance)
     pds_url: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    # atproto account deactivated (or suspended): set from #account firehose
+    # events. deactivated accounts' content is hidden from discovery surfaces
+    # (radio, the home feed, for-you) and their PDS blobs / audio go dead.
+    deactivated: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false", default=False, index=True
+    )
 
     # metadata
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -378,6 +378,38 @@ async def test_slop_excludes_plyr_fm_account_tracks(
     assert slop_ids == {other_slop.id}  # plyr.fm's ai track excluded
 
 
+async def test_radio_excludes_deactivated_artists(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    """tracks from deactivated accounts drop out of radio (their audio is dead)."""
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
+    live = await _create_track(
+        db_session, radio_artist, title="Live", file_id="live", created_at=now
+    )
+    gone = await _create_artist(db_session, "did:plc:gone", "gone.plyr.fm")
+    gone.deactivated = True
+    gone_track = await _create_track(
+        db_session,
+        gone,
+        title="Gone",
+        file_id="gone",
+        created_at=now - timedelta(minutes=1),
+    )
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=radio_app),
+        base_url="https://radio.plyr.fm",
+    ) as client:
+        response = await client.get("/radio/state.json")
+
+    ids = {t["id"] for t in response.json()["rotation"]}
+    assert live.id in ids
+    assert gone_track.id not in ids
+
+
 async def test_radio_state_includes_tags_and_up_next(
     radio_app: FastAPI,
     db_session: AsyncSession,

--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -402,10 +402,16 @@
 
 	.now-meta h2 {
 		margin: 0;
-		font-size: clamp(1.75rem, 4.6vw, 2.65rem);
-		line-height: 1.05;
-		overflow-wrap: normal;
-		text-wrap: balance;
+		font-size: clamp(1.5rem, 4.6vw, 2.65rem);
+		line-height: 1.1;
+		/* long titles (e.g. DJ-set names with dates) must not blow up the
+		   fixed-height layout: wrap hard, then clamp to two lines with an ellipsis */
+		overflow-wrap: anywhere;
+		display: -webkit-box;
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		overflow: hidden;
 	}
 
 	.now-meta h2 a {
@@ -421,11 +427,15 @@
 	}
 
 	.artist {
-		display: inline-block;
+		display: block;
+		max-width: 100%;
 		margin-top: 0.35rem;
 		color: var(--text-secondary);
 		text-decoration: none;
 		font-size: var(--text-base);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.artist:hover {

--- a/loq.toml
+++ b/loq.toml
@@ -32,7 +32,7 @@ max_lines = 826
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
-max_lines = 594
+max_lines = 596
 
 [[rules]]
 path = "backend/src/backend/api/tracks/mutations.py"
@@ -328,4 +328,4 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/[[][[]station[]][]]/+page.svelte"
-max_lines = 768
+max_lines = 778

--- a/scripts/backfill_account_status.py
+++ b/scripts/backfill_account_status.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env -S uv run --script --quiet
+"""backfill Artist.deactivated by checking each account's PDS status.
+
+going forward, #account firehose events keep Artist.deactivated current (see
+ingest_account_status_change). but accounts that deactivated *before* that flag
+existed won't emit a new event, so their content (incl. dead audio) keeps showing
+up in discovery. this script resolves each artist's PDS and asks
+com.atproto.sync.getRepoStatus whether the account is active, then sets the flag.
+
+usage:
+    uv run scripts/backfill_account_status.py --dry-run
+    uv run scripts/backfill_account_status.py --concurrency 8
+    uv run scripts/backfill_account_status.py --did did:plc:6r5lmfugglmlsgvundyzt6z4
+"""
+
+import argparse
+import asyncio
+import logging
+
+import httpx
+from sqlalchemy import select
+
+from backend.models import Artist
+from backend.utilities.database import db_session
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("backfill_account_status")
+
+
+async def _resolve_pds(client: httpx.AsyncClient, did: str) -> str | None:
+    try:
+        r = await client.get(f"https://plc.directory/{did}")
+        r.raise_for_status()
+        for svc in r.json().get("service", []):
+            if svc.get("id") == "#atproto_pds":
+                return svc["serviceEndpoint"]
+    except Exception as e:
+        logger.warning("  resolve pds failed %s: %s", did, e)
+    return None
+
+
+async def _is_deactivated(
+    client: httpx.AsyncClient, did: str, pds_url: str | None
+) -> bool | None:
+    """True/False if known, None if we couldn't determine (left unchanged)."""
+    pds = pds_url or await _resolve_pds(client, did)
+    if not pds:
+        return None
+    try:
+        r = await client.get(
+            f"{pds}/xrpc/com.atproto.sync.getRepoStatus", params={"did": did}
+        )
+        if r.status_code != 200:
+            return None
+        return not r.json().get("active", True)
+    except Exception as e:
+        logger.warning("  getRepoStatus failed %s: %s", did, e)
+        return None
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--concurrency", type=int, default=8)
+    parser.add_argument("--did", help="check a single DID")
+    parser.add_argument("--limit", type=int)
+    args = parser.parse_args()
+
+    async with db_session() as db:
+        stmt = select(Artist.did, Artist.pds_url, Artist.deactivated)
+        if args.did:
+            stmt = stmt.where(Artist.did == args.did)
+        if args.limit:
+            stmt = stmt.limit(args.limit)
+        rows = (await db.execute(stmt)).all()
+
+    logger.info("checking %d artists (concurrency=%d)", len(rows), args.concurrency)
+    sem = asyncio.Semaphore(args.concurrency)
+    changed: list[tuple[str, bool]] = []
+
+    async with httpx.AsyncClient(timeout=20) as client:
+
+        async def check(did: str, pds_url: str | None, current: bool) -> None:
+            async with sem:
+                deactivated = await _is_deactivated(client, did, pds_url)
+            if deactivated is not None and deactivated != current:
+                changed.append((did, deactivated))
+                logger.info("  %s: deactivated %s -> %s", did, current, deactivated)
+
+        await asyncio.gather(*(check(d, p, bool(c)) for d, p, c in rows))
+
+    logger.info("%d artists need updating", len(changed))
+    if args.dry_run or not changed:
+        return
+
+    async with db_session() as db:
+        for did, deactivated in changed:
+            artist = await db.get(Artist, did)
+            if artist:
+                artist.deactivated = deactivated
+        await db.commit()
+    logger.info("updated %d artists", len(changed))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Reported: radio served an **unplayable track from a deactivated account** (BlueCat / fpst.uk) — and long track titles blew up the radio layout.

## the deactivated-account bug (multiple levels)

- The account is **deactivated** (PDS `getRepoStatus` → `active: false`), and its R2 audio is **404** — so radio served a dead track.
- Root cause: plyr **already consumes `#account` firehose events** (`ingest_account_status_change`) but only cleared the avatar — it never recorded that the account deactivated, so the user's content stayed in every discovery surface.

**Fix:**
- New `Artist.deactivated` flag (migration `e9ec24f00cd1` — autogenerated against neon dev, then trimmed of unrelated drift). `ingest_account_status_change` now **persists** it (deactivate sets, reactivate clears).
- Exclude deactivated accounts from **radio** (corpus), the **home discovery feed** (`listing.py`), and **for-you**.
- `scripts/backfill_account_status.py` — flags accounts that deactivated *before* the flag existed by checking `com.atproto.sync.getRepoStatus` per PDS. Run once post-deploy; `#account` events keep it current after.

## long titles

"Matthew Balaam - Warm up at Renae in Manchester on 2025-08-11" overflowed the fixed-height radio layout. Titles now wrap hard (`overflow-wrap: anywhere`) and **clamp to two lines with an ellipsis**; long artist names ellipsize too.

<details>
<summary>notes</summary>

- The dead-audio-but-row-persists case (R2 object gone, `r2_url` still set → raw 404) is a broader orphan-availability concern (#1368 class); this PR hides the deactivated-account case from discovery, which covers the report. Direct links to such tracks still 404 on play — separate follow-up.
- migration was generated via `alembic revision --autogenerate` against the neon **dev** DB (this env's `.env` has no `DATABASE_URL`, so the local default can't reach a DB — used the Neon dev connection directly), then hand-trimmed to just the column + index.
- regression test: radio excludes a deactivated artist's track. 13 radio tests + discovery/listing tests pass; lint, svelte-check, loq green.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)