### PR TITLE
fix(radio): stop mobile reload loop + accidental station switching

### DIFF
--- a/frontend/src/lib/horizontal-swipe.ts
+++ b/frontend/src/lib/horizontal-swipe.ts
@@ -21,7 +21,10 @@ export function horizontalSwipe(
 	onSwipe: (direction: 'left' | 'right') => void,
 	options: HorizontalSwipeOptions = {}
 ): Attachment<HTMLElement> {
-	const { swipeDeltaPx = 60, activationDeltaPx = 10 } = options;
+	// require a deliberate, sustained-horizontal flick. these thresholds are
+	// intentionally conservative: an accidental station switch is far worse than
+	// a swipe that didn't register.
+	const { swipeDeltaPx = 72, activationDeltaPx = 12 } = options;
 
 	return (node) => {
 		let tracking = false;
@@ -29,32 +32,38 @@ export function horizontalSwipe(
 		let startX = 0;
 		let startY = 0;
 		let dx = 0;
+		let dy = 0;
 		let pointerId = -1;
 
 		function down(event: PointerEvent) {
 			if (event.pointerType === 'mouse') return;
+			// buttons (pills, tune-in) own their taps — never start a swipe on them
+			const el = event.target as HTMLElement | null;
+			if (el && el.closest('button')) return;
 			tracking = true;
 			active = false;
 			startX = event.clientX;
 			startY = event.clientY;
 			dx = 0;
+			dy = 0;
 			pointerId = event.pointerId;
 		}
 
 		function move(event: PointerEvent) {
 			if (!tracking || event.pointerId !== pointerId) return;
 			dx = event.clientX - startX;
-			const dy = event.clientY - startY;
+			dy = event.clientY - startY;
 
-			if (!active) {
-				if (Math.abs(dx) < activationDeltaPx) return; // below noise floor
-				if (Math.abs(dy) > Math.abs(dx)) {
-					// vertical-dominant: leave it to the page scroll
+			// any time the gesture is vertical-dominant, bail for good — a swipe
+			// that curves into a scroll must not still fire on release.
+			if (Math.abs(dy) >= Math.abs(dx)) {
+				if (active || Math.abs(dy) >= activationDeltaPx) {
 					tracking = false;
-					return;
+					active = false;
 				}
-				active = true;
+				return;
 			}
+			if (Math.abs(dx) >= activationDeltaPx) active = true;
 		}
 
 		function up(event: PointerEvent) {
@@ -64,7 +73,11 @@ export function horizontalSwipe(
 			active = false;
 			pointerId = -1;
 			if (!wasActive) return;
-			if (Math.abs(dx) > swipeDeltaPx) onSwipe(dx < 0 ? 'left' : 'right');
+			// fire only on a clear horizontal flick: past the distance threshold
+			// AND clearly more horizontal than vertical.
+			if (Math.abs(dx) > swipeDeltaPx && Math.abs(dx) > 2 * Math.abs(dy)) {
+				onSwipe(dx < 0 ? 'left' : 'right');
+			}
 		}
 
 		node.addEventListener('pointerdown', down);

--- a/frontend/src/lib/radio.svelte.ts
+++ b/frontend/src/lib/radio.svelte.ts
@@ -100,7 +100,10 @@ class Radio {
 	 * if tuned in, follows the audio across. */
 	async show(slug: string | null): Promise<void> {
 		const target = slug ?? this.remembered();
-		if (this.state && target === this.state.station_slug) return;
+		// already showing the requested station — or showing *anything* when no
+		// specific station was asked for (bare /radio). a null target must NOT
+		// fall through, or it never matches station_slug and reloads endlessly.
+		if (this.state && (target === null || target === this.state.station_slug)) return;
 		this.station = target;
 		if (slug && typeof localStorage !== 'undefined') {
 			localStorage.setItem(STATION_STORAGE_KEY, slug);

--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 	import Header from '$lib/components/Header.svelte';
@@ -20,8 +20,11 @@
 	let stationParam = $derived($page.params.station ?? null);
 	let activeSlug = $derived(radio.state?.station_slug ?? radio.station);
 
+	// react ONLY to the URL param. untrack so reads of radio.state inside show()
+	// don't subscribe this effect (that would re-fire on every state reload).
 	$effect(() => {
-		radio.show(stationParam);
+		const slug = stationParam;
+		untrack(() => radio.show(slug));
 	});
 
 	/** select a station by navigating, so the URL (and bookmarks/back) stay in sync */

--- a/loq.toml
+++ b/loq.toml
@@ -328,4 +328,4 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/[[][[]station[]][]]/+page.svelte"
-max_lines = 778
+max_lines = 781


### PR DESCRIPTION
Radio was badly broken on mobile — didn't play and randomly switched stations. Two distinct bugs from the station-flip work:

## 1. Infinite reload loop (→ "doesn't play")

The page's `$effect` called `radio.show(stationParam)`, and `show()` reads `radio.state` synchronously — so the effect **subscribed to `radio.state`**. On a bare `/radio` with no remembered station, `target` was `null`, which never equals `state.station_slug`, so the guard never returned: `loadState()` ran → `state` changed → effect re-fired → forever. Constant reloads (and a `playRadio()` restart every iteration). It specifically hit the **mobile first-visit path** (no `localStorage`).

**Fix:** `untrack` the `show()` call so the effect depends only on the URL param; and short-circuit `show()` when `target` is null and state is already loaded.

## 2. Accidental station switches (→ "randomly switches")

`horizontalSwipe` set `active` after one horizontal move and fired on release even if the gesture then curved vertical — so a scroll/flail could trigger `flip()` → `goto` (the only thing that changes stations). 

**Fix:** bail permanently on any vertical-dominant movement, ignore gestures that start on a `<button>` (pills/tune-in own their taps), and fire only on a clear horizontal flick (`>72px` **and** `|dx| > 2·|dy|`).

<details>
<summary>verification honesty</summary>

No browser-automation MCP is connected to this session, so I could not drive a real device here. Rather than eyeball it, I made each fix safe **by construction**: the effect can no longer self-trigger (single dependency, untracked body + early-return guard), and the swipe requires a deliberate sustained-horizontal gesture that a tap/scroll can't produce. Please re-check on a phone once this deploys; if the swipe still feels wrong I'll remove it entirely (pills + arrow keys already cover switching).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)