### PR TITLE
fix(radio): distribute page vertically instead of centering

### DIFF
--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -224,7 +224,10 @@
 		display: flex;
 		flex-direction: column;
 		align-items: stretch;
-		justify-content: center;
+		/* distribute through the available height instead of centering — pins the
+		   tuner under the header and the footer above the player, so the top space
+		   isn't wasted and everything (incl. the deck) fits without scrolling */
+		justify-content: space-between;
 		gap: clamp(0.7rem, 1.8vh, 1.25rem);
 		overflow: hidden;
 	}

--- a/loq.toml
+++ b/loq.toml
@@ -328,4 +328,4 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/[[][[]station[]][]]/+page.svelte"
-max_lines = 799
+max_lines = 802


### PR DESCRIPTION
Per feedback: the tuner was centered in the available height, so all the slack collected as a big empty band between the header and "live radio" while the footer crowded the player. Switch `.radio-page` to `justify-content: space-between` — the tuner pins under the header, the footer sits just above the player, the top space gets used, and the rotation deck fits without scrolling (no need to drop it). Frontend/CSS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)