### PR TITLE
fix(radio): blur sensitive cover art + don't die on track end

### DIFF
--- a/frontend/src/lib/radio.svelte.ts
+++ b/frontend/src/lib/radio.svelte.ts
@@ -136,7 +136,7 @@ class Radio {
 		return Math.min(fetched.current?.duration ?? 0, fetched.progress_seconds + drift);
 	}
 
-	private toNowPlaying(c: RadioTrack): RadioNowPlaying {
+	private toNowPlaying(c: RadioTrack, startAt?: number): RadioNowPlaying {
 		// the on-air entry is a real track — reshape it as a Track so the normal
 		// player strip renders it identically to any other track.
 		const track: Track = {
@@ -160,7 +160,7 @@ class Radio {
 		return {
 			track,
 			stream_url: c.stream_url,
-			start_at: this.state ? this.stateProgress(this.state) : 0
+			start_at: startAt ?? (this.state ? this.stateProgress(this.state) : 0)
 		};
 	}
 
@@ -201,11 +201,20 @@ class Radio {
 		this.stopPolling();
 	}
 
-	/** the current stream ended — pull the station's now-current track */
-	async onEnded(): Promise<void> {
-		await this.loadState();
-		const c = this.current;
-		if (c && player.radio) player.playRadio(this.toNowPlaying(c));
+	/** the current stream ended — advance to the next track.
+	 *
+	 * MUST be synchronous: iOS only keeps autoplay alive across tracks if the
+	 * audio src is swapped within the `ended` handler with no `await` in between.
+	 * Awaiting a /radio/state fetch first (the old behavior) let iOS block the
+	 * play() and radio silently died on every track boundary. So we play the
+	 * already-loaded next track now and refresh station state in the background.
+	 */
+	onEnded(): void {
+		const next = this.state?.up_next[0];
+		if (next && player.radio) player.playRadio(this.toNowPlaying(next, 0));
+		// keep the rotation / up_next current for the next boundary (no await on
+		// the play path above)
+		void this.loadState();
 	}
 
 	/** poll: follow the shared station when it rotates to a new track */

--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -9,6 +9,7 @@
 	import { radio } from '$lib/radio.svelte';
 	import { horizontalSwipe } from '$lib/horizontal-swipe';
 	import StationPills from '$lib/components/radio/StationPills.svelte';
+	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
@@ -134,13 +135,15 @@
 					onSelect={tuneToStation}
 				/>
 				<div class="now-block" class:tuning={radio.switching}>
-				<a class="art-link" href={`/track/${radio.current.id}`} aria-label={`view ${radio.current.title}`}>
-					{#if radio.current.artwork_url}
-						<img src={radio.current.artwork_url} alt="" class="art" />
-					{:else}
-						<div class="art fallback"></div>
-					{/if}
-				</a>
+				<SensitiveImage src={radio.current.artwork_url} tooltipPosition="center">
+					<a class="art-link" href={`/track/${radio.current.id}`} aria-label={`view ${radio.current.title}`}>
+						{#if radio.current.artwork_url}
+							<img src={radio.current.artwork_url} alt="" class="art" />
+						{:else}
+							<div class="art fallback"></div>
+						{/if}
+					</a>
+				</SensitiveImage>
 				<div class="now-meta">
 					<p class="label">{radio.active ? 'on air' : "what's on"}</p>
 					<h2>
@@ -185,11 +188,13 @@
 							aria-label={`view ${track.title} by ${track.artist}`}
 							title={`${track.title} by ${track.artist}`}
 						>
-							{#if track.thumbnail_url || track.artwork_url}
-								<img src={track.thumbnail_url ?? track.artwork_url ?? ''} alt="" />
-							{:else}
-								<div class="rotation-fallback"></div>
-							{/if}
+							<SensitiveImage src={track.thumbnail_url ?? track.artwork_url} compact>
+								{#if track.thumbnail_url || track.artwork_url}
+									<img src={track.thumbnail_url ?? track.artwork_url ?? ''} alt="" />
+								{:else}
+									<div class="rotation-fallback"></div>
+								{/if}
+							</SensitiveImage>
 							<span class="rotation-tooltip" aria-hidden="true">
 								<strong>{track.title}</strong>
 								<span>{track.artist}</span>

--- a/loq.toml
+++ b/loq.toml
@@ -328,4 +328,4 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/[[][[]station[]][]]/+page.svelte"
-max_lines = 813
+max_lines = 818


### PR DESCRIPTION
Two issues from Alex's testing.

## 1. Sensitive cover art rendered raw
Radio showed NSFW/sensitive artwork unblurred (both the hero artwork and the rotation deck), bypassing the `SensitiveImage` blur the rest of the app uses. Now both are wrapped in `SensitiveImage` (centered tooltip for the hero, `compact` for deck thumbs). Sensitivity resolves client-side by URL via the moderation store — no backend/schema change.

## 2. Continuation: radio stopped when a track ended
`radio.onEnded()` did `await loadState()` **before** swapping the audio src. iOS only keeps autoplay alive across tracks if the src swap happens synchronously in the `ended` handler — the await let iOS block the `play()`, so playback silently died at every track boundary. (Switching stations worked because that's a user gesture.) Now `onEnded` plays the already-loaded `up_next[0]` synchronously and refreshes state in the background.

Verified the deep-cuts streams themselves return 206 (playable) — it wasn't dead audio.

_Not addressed here: "add to liked from radio" — Alex clarified he wasn't logged in, so that's the logged-out state, not a bug._

Follow-up: this page is ~815 lines and trips loq on every change — I'll extract a `RotationDeck` component next to stop that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)