### PR TITLE
fix(radio): stable-width tuner dial + needle indicator + heart under controls

### DIFF
--- a/frontend/src/lib/components/radio/TunerDial.svelte
+++ b/frontend/src/lib/components/radio/TunerDial.svelte
@@ -78,21 +78,26 @@
 		transition: color 0.15s ease;
 	}
 
-	/* the tick sits on the line; active is a lit dot (the needle) */
+	/* inactive stop: a short flat tick on the line. active: a tall accent "needle"
+	   that rises above the line with a glowing tip (a tuner pointer, not a dot) */
 	.tick {
-		width: 0.55rem;
-		height: 0.55rem;
-		border-radius: 999px;
-		background: var(--bg-primary);
-		box-shadow: inset 0 0 0 2px var(--border-default);
+		width: 2px;
+		height: 0.5rem;
+		border-radius: 2px;
+		background: var(--border-default);
 		transition:
-			background 0.15s ease,
-			box-shadow 0.15s ease,
-			transform 0.15s ease;
+			height 0.18s ease,
+			margin-top 0.18s ease,
+			background 0.18s ease,
+			box-shadow 0.18s ease;
 	}
 
 	.stop:hover {
 		color: var(--text-secondary);
+	}
+
+	.stop:hover .tick {
+		background: var(--text-tertiary);
 	}
 
 	.stop.active {
@@ -101,10 +106,9 @@
 	}
 
 	.stop.active .tick {
+		height: 1.15rem;
+		margin-top: -0.32rem;
 		background: var(--accent);
-		box-shadow:
-			inset 0 0 0 2px var(--accent),
-			0 0 0 4px color-mix(in srgb, var(--accent) 30%, transparent);
-		transform: scale(1.15);
+		box-shadow: 0 0 7px 1px color-mix(in srgb, var(--accent) 65%, transparent);
 	}
 </style>

--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -155,26 +155,26 @@
 					<h2>
 						<a href={`/track/${radio.current.id}`}>{radio.current.title}</a>
 					</h2>
-					<div class="now-by">
-						<a class="artist" href={`/u/${radio.current.artist_handle}`}>{radio.current.artist}</a>
-						{#if auth.isAuthenticated}
-							{#key radio.current.id}
-								<LikeButton trackId={radio.current.id} trackTitle={radio.current.title} />
-							{/key}
-						{/if}
-					</div>
+					<a class="artist" href={`/u/${radio.current.artist_handle}`}>{radio.current.artist}</a>
 				</div>
 				</div>
-				{#if radio.active}
-					<button class="tune-btn stop" onclick={() => radio.stop()} aria-label="stop listening to radio">stop</button>
-				{:else}
-					<button class="tune-btn" onclick={() => radio.tuneIn()} aria-label="tune in to radio">
-						<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-							<polygon points="6 4 20 12 6 20 6 4"></polygon>
-						</svg>
-						tune in
-					</button>
-				{/if}
+				<div class="controls">
+					{#if radio.active}
+						<button class="tune-btn stop" onclick={() => radio.stop()} aria-label="stop listening to radio">stop</button>
+					{:else}
+						<button class="tune-btn" onclick={() => radio.tuneIn()} aria-label="tune in to radio">
+							<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+								<polygon points="6 4 20 12 6 20 6 4"></polygon>
+							</svg>
+							tune in
+						</button>
+					{/if}
+					{#if auth.isAuthenticated}
+						{#key radio.current.id}
+							<LikeButton trackId={radio.current.id} trackTitle={radio.current.title} />
+						{/key}
+					{/if}
+				</div>
 				<div class="progress-wrap">
 					<div class="progress" aria-label="track progress">
 						<div class="progress-fill" style={`width: ${progressPercent}%`}></div>
@@ -215,7 +215,6 @@
 						</a>
 					{/each}
 				</div>
-				<p>{radio.activeStation?.description ?? 'from across plyr.fm'}</p>
 			</div>
 		</section>
 	{/if}
@@ -321,6 +320,10 @@
 	.station {
 		flex: 1 1 auto;
 		min-height: 0;
+		/* fixed-width column so the dial + controls never resize with the
+		   (height-driven) artwork — the artwork is capped to this width too */
+		width: min(100%, 30rem);
+		align-self: center;
 		display: flex;
 		flex-direction: column;
 		padding-top: 0;
@@ -454,16 +457,11 @@
 		border: 1px solid rgba(255, 255, 255, 0.08);
 	}
 
-	.now-by {
+	.controls {
 		display: flex;
+		flex-direction: column;
 		align-items: center;
-		justify-content: center;
-		gap: 0.6rem;
-		margin-top: 0.35rem;
-	}
-
-	.now-by .artist {
-		margin-top: 0;
+		gap: clamp(0.4rem, 1.2vh, 0.7rem);
 	}
 
 	.art {
@@ -795,12 +793,6 @@
 	.rotation-artwork:focus-visible .rotation-tooltip {
 		opacity: 1;
 		transform: translate(-50%, 0);
-	}
-
-	.rotation-card p {
-		margin: 0.25rem 0 0;
-		color: var(--text-tertiary);
-		font-size: var(--text-sm);
 	}
 
 	.credit {


### PR DESCRIPTION
Per feedback:
- **Dial no longer resizes with the artwork** — root cause was the player column having no fixed width, so the dial's `min(100%,30rem)` tracked the height-driven artwork width. Pinned the column to 30rem (artwork capped to it too); the dial is now stable.
- **Better indicator** — replaced the glowing dot with a tall accent **needle** that rises above the line with a glowing tip (a tuner pointer).
- **Heart moved** out from beside the artist to **under the tune-in/stop button** (centered controls group).
- **Removed the deck caption** (clutter) + its dead CSS.

Verified at 1440px and 390px against a local dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)