### PR TITLE
docs(neon): replace real dev connection string with placeholder

### DIFF
--- a/docs/internal/tools/neon.md
+++ b/docs/internal/tools/neon.md
@@ -329,9 +329,9 @@ returns a postgres connection string for use with `psql`, database clients, or a
 - `databaseName` - specific database (defaults to neondb)
 - `roleName` - specific role (defaults to neondb_owner)
 
-**example output:**
+**example output** (placeholder values — never commit a real connection string):
 ```
-postgresql://neondb_owner:npg_6CNUVfgtz8bY@ep-flat-haze-aefjvcba-pooler.c-2.us-east-2.aws.neon.tech/neondb?channel_binding=require&sslmode=require
+postgresql://<role>:<password>@<endpoint>.<region>.aws.neon.tech/<database>?channel_binding=require&sslmode=require
 ```
 
 ## database environment mapping


### PR DESCRIPTION
The "example output" block in the Neon MCP guide was a **real, valid dev connection string**, not a sanitized example. Swapped it for an obvious placeholder and rotated the credential.

## what happened
- `docs/internal/tools/neon.md:334` contained a live `neondb_owner` connection string for the dev project (`muddy-flower-98795112`).
- It was committed in #184 (Nov 12 2025) under an "example output" heading, then carried forward by the #203 rename (`docs/neon-mcp-guide.md` → `docs/internal/tools/neon.md`) — so it was still in the working tree at HEAD.
- An external reporter flagged it; verified the leaked password matched the current live password byte-for-byte.

## actions taken
- **Rotated** the `neondb_owner` password out of band. Confirmed end-to-end: the leaked password now fails auth, the new one works.
- Replaced the string with `<role>:<password>@<endpoint>...` placeholder text plus a "never commit a real connection string" note.

<details>
<summary>scope notes</summary>

- Only the **dev** DB was exposed — prod (`cold-butterfly-11920742`) and staging credentials were not in this file.
- Inspected the dev DB for tampering: no rogue tables, `api_keys`/`pending_dev_tokens` empty, no suspicious recent writes. No evidence of misuse (reads leave no trace, so rotation is still the right call).
- The string remains in git history (commits `507b068f`, `aec7cae7`); it's now invalid, so history rewrite is optional.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)