### PR TITLE
fix(radio): send session cookie when loading radio state

### DIFF
--- a/frontend/src/lib/radio.svelte.ts
+++ b/frontend/src/lib/radio.svelte.ts
@@ -168,7 +168,11 @@ class Radio {
 	async loadState(): Promise<void> {
 		try {
 			const query = this.station ? `?station=${encodeURIComponent(this.station)}` : '';
-			const response = await fetch(`${API_URL}/radio/state${query}`);
+			// send the session cookie so the server can flag `liked` per track for
+			// signed-in listeners (anonymous requests are unaffected).
+			const response = await fetch(`${API_URL}/radio/state${query}`, {
+				credentials: 'include'
+			});
 			if (response.status === 404 && this.station) {
 				// a persisted station slug no longer exists (e.g. renamed) — drop it
 				// and fall back to the server default rather than going "off air".


### PR DESCRIPTION
The radio like button still showed un-liked on tracks the signed-in listener had already liked (#1546 added the `liked` field but it always came back `false`).

Root cause: `loadState()` fetched `/radio/state` **without** `credentials: 'include'`, so the HttpOnly `session_id` cookie never reached the backend. `get_optional_session` was therefore always `None` and `liked` defaulted to `false` for every track. Anonymous requests were unaffected (and still are).

The fix adds `credentials: 'include'`, matching every other authenticated fetch in the frontend.

<details>
<summary>Why the #1546 test missed it</summary>

The backend regression test overrides `get_optional_session` directly to inject a session, so it validated the query + serialization but never exercised real cookie propagation from the client. The gap was entirely on the fetch call, which that test can't see.
</details>

Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)