### PR TITLE
docs: developer tokens are created in settings, not the portal

### DIFF
--- a/docs/internal/authentication.md
+++ b/docs/internal/authentication.md
@@ -380,7 +380,7 @@ for scripts, CLIs, and automated workflows, create a long-lived developer token:
 ### creating a token
 
 **via UI (recommended)**:
-1. go to portal → "your data" → "developer tokens" section
+1. go to [settings → "developer tokens"](https://plyr.fm/settings#developer)
 2. optionally enter a name (e.g., "upload-script", "ci-pipeline")
 3. select expiration (30/90/180/365 days or never)
 4. click "create token"
@@ -404,13 +404,13 @@ const { auth_url } = await response.json();
 ### managing tokens
 
 **list active tokens**:
-the portal shows all your active developer tokens with:
+the settings page shows all your active developer tokens with:
 - token name (or auto-generated identifier)
 - creation date
 - expiration date
 
 **revoke a token**:
-1. go to portal → "your data" → "developer tokens"
+1. go to [settings → "developer tokens"](https://plyr.fm/settings#developer)
 2. find the token in the list
 3. click "revoke" to immediately invalidate it
 
@@ -475,7 +475,7 @@ developer tokens are **scoped to plyr.fm's lexicon namespace** via ATProto OAuth
 
 the PDS enforces these scopes at the protocol level — not just plyr.fm's API. rather than app passwords (full repo access, coupled to Bluesky), plyr.fm issues OAuth grants scoped to the minimum permissions needed.
 
-**security notes**: tokens grant full access to plyr.fm features, but are namespace-scoped at the protocol level. each token is independent — revoke individually via the portal or API.
+**security notes**: tokens grant full access to plyr.fm features, but are namespace-scoped at the protocol level. each token is independent — revoke individually via [settings](https://plyr.fm/settings#developer) or API.
 
 ## OAuth client types: public vs confidential
 

--- a/docs/internal/testing/integration-tests.md
+++ b/docs/internal/testing/integration-tests.md
@@ -25,7 +25,7 @@ uv run pytest tests/integration -m integration -v
 | `PLYR_TEST_TOKEN_2` | plyr.fm | secondary user - cross-user interaction tests |
 | `PLYR_TEST_TOKEN_3` | zzstoatzzdevlog.bsky.social | tertiary user - reserved for future tests |
 
-tokens are developer tokens created at [plyr.fm/portal](https://plyr.fm/portal) → "developer tokens".
+tokens are developer tokens created at [plyr.fm/settings#developer](https://plyr.fm/settings#developer) → "developer tokens".
 
 ## github actions
 

--- a/docs/internal/tools/plyrfm.md
+++ b/docs/internal/tools/plyrfm.md
@@ -23,7 +23,7 @@ some operations work without auth (listing public tracks, getting a track by ID)
 
 for authenticated operations:
 
-1. go to [plyr.fm/portal](https://plyr.fm/portal) -> "your data" -> "developer tokens"
+1. go to [plyr.fm/settings#developer](https://plyr.fm/settings#developer) -> "developer tokens"
 2. create a token
 3. `export PLYR_TOKEN="your_token"`
 

--- a/docs/public/developers/api-reference/index.md
+++ b/docs/public/developers/api-reference/index.md
@@ -4,7 +4,7 @@ description: "plyr.fm REST API — endpoints, request/response examples, error c
 ---
 
 the plyr.fm REST API. public endpoints need no auth; authenticated endpoints
-take a [developer token](/developers/auth/) from plyr.fm/portal. the OpenAPI
+take a [developer token](/developers/auth/) from plyr.fm/settings#developer. the OpenAPI
 spec is live at [api.plyr.fm/docs](https://api.plyr.fm/docs).
 
 new here? start with the [quickstart](/developers/quickstart/) — a track player in 30 lines.

--- a/docs/public/developers/auth.md
+++ b/docs/public/developers/auth.md
@@ -7,7 +7,7 @@ plyr.fm uses ATProto OAuth 2.1 for authentication. there are two ways to authent
 
 ## developer tokens
 
-the simplest way to authenticate. generate a token at [plyr.fm/portal](https://plyr.fm/portal) and pass it as a Bearer token:
+the simplest way to authenticate. generate a token at [plyr.fm/settings#developer](https://plyr.fm/settings#developer) and pass it as a Bearer token:
 
 ```bash
 curl -H "Authorization: Bearer your_token" https://api.plyr.fm/tracks/liked
@@ -20,12 +20,12 @@ client = PlyrClient(token="your_token")
 my_tracks = client.my_tracks()
 ```
 
-tokens are scoped to your account and have independent OAuth credentials — refreshing your browser session won't invalidate them. revoke tokens at any time from the portal.
+tokens are scoped to your account and have independent OAuth credentials — refreshing your browser session won't invalidate them. revoke tokens at any time from settings.
 
 ### creating tokens
 
-1. go to [plyr.fm/portal](https://plyr.fm/portal)
-2. click "developer tokens"
+1. go to [plyr.fm/settings#developer](https://plyr.fm/settings#developer)
+2. find the "developer tokens" section
 3. name your token and choose an expiry (default: 180 days)
 4. you'll be redirected through an OAuth flow to authorize the token
 5. copy the token — it won't be shown again

--- a/docs/public/developers/index.md
+++ b/docs/public/developers/index.md
@@ -18,7 +18,7 @@ https://api.plyr.fm/docs. the Python SDK is `plyrfm` (uv add plyrfm).
 
 public endpoints (no auth): search, list tracks, stream audio, top tracks,
 tags, albums, playlists, RSS feeds, oEmbed. authenticated endpoints require
-a developer token from plyr.fm/portal.
+a developer token from plyr.fm/settings#developer.
 ```
 
 ## get started

--- a/docs/public/developers/quickstart.md
+++ b/docs/public/developers/quickstart.md
@@ -8,7 +8,7 @@ this guide walks through building a minimal track player using the plyr.fm API. 
 ## prerequisites
 
 - Python 3.11+ with [uv](https://docs.astral.sh/uv/)
-- a [developer token](/developers/auth/) from [plyr.fm/portal](https://plyr.fm/portal) (for authenticated operations)
+- a [developer token](/developers/auth/) from [plyr.fm/settings#developer](https://plyr.fm/settings#developer) (for authenticated operations)
 
 ## install the SDK
 
@@ -38,7 +38,7 @@ no authentication needed — search, listing, and streaming are public.
 
 ## authenticated operations
 
-generate a developer token at [plyr.fm/portal](https://plyr.fm/portal), then:
+generate a developer token at [plyr.fm/settings#developer](https://plyr.fm/settings#developer), then:
 
 ```python
 authed = PlyrClient(token="your_token")

--- a/docs/public/glossary.md
+++ b/docs/public/glossary.md
@@ -75,7 +75,7 @@ a reference to a specific version of a record, consisting of a URI (`at://did/co
 
 ### developer token
 
-an API authentication token generated at [plyr.fm/portal](https://plyr.fm/portal). tokens have their own OAuth credentials and don't expire when your browser session refreshes. used for scripts, bots, and integrations. see [auth guide](/developers/auth/).
+an API authentication token generated at [plyr.fm/settings#developer](https://plyr.fm/settings#developer). tokens have their own OAuth credentials and don't expire when your browser session refreshes. used for scripts, bots, and integrations. see [auth guide](/developers/auth/).
 
 ### jam
 
@@ -87,7 +87,7 @@ semantic search powered by [CLAP](https://github.com/LAION-AI/CLAP) audio embedd
 
 ### portal
 
-the artist dashboard at [plyr.fm/portal](https://plyr.fm/portal). manage your tracks, albums, playlists, developer tokens, and account settings.
+the artist dashboard at [plyr.fm/portal](https://plyr.fm/portal). manage your tracks, albums, and playlists. (developer tokens and account settings live in [settings](https://plyr.fm/settings).)
 
 ### supporter-gated content
 

--- a/docs/public/troubleshooting.md
+++ b/docs/public/troubleshooting.md
@@ -29,7 +29,7 @@ description: "common issues and solutions for plyr.fm"
 
 **cause**: developer tokens rely on OAuth credentials that refresh automatically. if the refresh fails, the token becomes invalid.
 
-**solution**: generate a new token at [plyr.fm/portal](https://plyr.fm/portal). you can revoke the old one from the same page.
+**solution**: generate a new token at [plyr.fm/settings#developer](https://plyr.fm/settings#developer). you can revoke the old one from the same page.
 
 ## uploads
 

--- a/docs/site/public/llms-full.txt
+++ b/docs/site/public/llms-full.txt
@@ -41,7 +41,7 @@ for track in client.discover.top_tracks(limit=5):
     print(f"{track.title} — {track.play_count} plays")
 
 # authenticated: like a track (requires developer token)
-authed = PlyrClient(token="your_token_from_plyr.fm/portal")
+authed = PlyrClient(token="your_token_from_plyr.fm/settings")
 authed.tracks.like(42)
 ```
 
@@ -58,7 +58,7 @@ Tools: search, list_tracks, top_tracks, tracks_by_tag, get_track, liked_tracks, 
 ## API reference
 
 Base URL: `https://api.plyr.fm`
-Auth: `Authorization: Bearer <developer_token>` (get tokens at plyr.fm/portal)
+Auth: `Authorization: Bearer <developer_token>` (get tokens at plyr.fm/settings#developer)
 
 ### public endpoints (no auth)
 
@@ -164,7 +164,7 @@ GET /tracks/?limit=20
 
 ### developer tokens (simplest)
 
-1. Go to plyr.fm/portal → "developer tokens"
+1. Go to plyr.fm/settings#developer → "developer tokens"
 2. Name token, choose expiry (default: 180 days)
 3. Authorize via OAuth flow
 4. Use as Bearer token: `Authorization: Bearer <token>`
@@ -340,5 +340,5 @@ At least one of `audioUrl` or `audioBlob` must be present.
 - **strongRef**: reference to a specific record version (URI + CID content hash)
 - **Jetstream**: real-time ATProto firehose for record change events
 - **AppView**: application service that indexes records from the network
-- **developer token**: API auth token from plyr.fm/portal
+- **developer token**: API auth token from plyr.fm/settings#developer
 - **jam**: shared listening room with real-time sync

--- a/docs/site/public/llms.txt
+++ b/docs/site/public/llms.txt
@@ -19,7 +19,7 @@
 
 - [OpenAPI spec](https://api.plyr.fm/docs): interactive API documentation
 - Base URL: `https://api.plyr.fm`
-- Auth: Bearer token via developer tokens from [plyr.fm/portal](https://plyr.fm/portal)
+- Auth: Bearer token via developer tokens from [plyr.fm/settings#developer](https://plyr.fm/settings#developer)
 - Public endpoints (no auth): search, list tracks, stream audio, stats, oEmbed, RSS feeds
 - Authenticated endpoints: upload, like, comment, playlist management, account settings
 

--- a/docs/site/templates/api-reference-index.md
+++ b/docs/site/templates/api-reference-index.md
@@ -4,7 +4,7 @@ description: "plyr.fm REST API — endpoints, request/response examples, error c
 ---
 
 the plyr.fm REST API. public endpoints need no auth; authenticated endpoints
-take a [developer token](/developers/auth/) from plyr.fm/portal. the OpenAPI
+take a [developer token](/developers/auth/) from plyr.fm/settings#developer. the OpenAPI
 spec is live at [api.plyr.fm/docs](https://api.plyr.fm/docs).
 
 new here? start with the [quickstart](/developers/quickstart/) — a track player in 30 lines.


### PR DESCRIPTION
Token creation lives on the **settings** page now, but the docs still told people to go to the portal. Every reference now points at the deep-linkable `/settings#developer` anchor (the slugged section header from #1447).

<details>
<summary>files touched (12)</summary>

**public docs** (docs.plyr.fm):
- `developers/auth.md` — generate/creating/revoke copy
- `developers/quickstart.md` — prereqs + authed-ops
- `developers/index.md` — coding-assistant blurb
- `developers/api-reference/index.md` (+ `docs/site/templates/api-reference-index.md`, the `cp` source for it)
- `troubleshooting.md` — "token stopped working"
- `glossary.md` — developer-token term; also dropped "developer tokens" from the **portal** definition and noted they live in settings
- `docs/site/public/llms.txt` + `llms-full.txt` — the public LLM-facing surface

**internal docs**:
- `authentication.md` — create/manage/revoke + security-notes line
- `tools/plyrfm.md`, `testing/integration-tests.md`

</details>

Left untouched: portal references unrelated to tokens (ZIP export, delete account, metadata editing, OAuth `?exchange_token` redirects). `docs/site/dist/` is build output (untracked) and regenerates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)