### PR TITLE
feat(spaces): private media on ATProto permissioned spaces (#1528)

### DIFF
--- a/backend/alembic/versions/2026_06_07_000000_a1b2c3d4e5f6_add_private_media_to_track.py
+++ b/backend/alembic/versions/2026_06_07_000000_a1b2c3d4e5f6_add_private_media_to_track.py
@@ -1,0 +1,39 @@
+"""add is_private and space_uri to track for permissioned media
+
+Revision ID: a1b2c3d4e5f6
+Revises: e9ec24f00cd1
+Create Date: 2026-06-07 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | None = "e9ec24f00cd1"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    """Add permissioned private-media columns to tracks.
+
+    private tracks store their audio blob + record in the artist's permissioned
+    space on their PDS; space_uri is the 3-segment ats:// space URI.
+    """
+    op.add_column(
+        "tracks",
+        sa.Column("is_private", sa.Boolean(), server_default="false", nullable=False),
+    )
+    op.add_column(
+        "tracks",
+        sa.Column("space_uri", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove permissioned private-media columns from tracks."""
+    op.drop_column("tracks", "space_uri")
+    op.drop_column("tracks", "is_private")

--- a/backend/src/backend/_internal/atproto/spaces/__init__.py
+++ b/backend/src/backend/_internal/atproto/spaces/__init__.py
@@ -1,0 +1,22 @@
+"""permissioned-data spaces (com.atproto.space.*).
+
+experimental ATProto permissioned-data surface. all of this engages only for
+sessions whose PDS actually implements the space methods — see
+[capability.detect_permissioned_capability][backend._internal.atproto.spaces.capability.detect_permissioned_capability].
+"""
+
+from backend._internal.atproto.spaces.capability import (
+    detect_permissioned_capability,
+)
+from backend._internal.atproto.spaces.uris import (
+    build_record_uri,
+    build_space_uri,
+    parse_space_uri,
+)
+
+__all__ = [
+    "build_record_uri",
+    "build_space_uri",
+    "detect_permissioned_capability",
+    "parse_space_uri",
+]

--- a/backend/src/backend/_internal/atproto/spaces/capability.py
+++ b/backend/src/backend/_internal/atproto/spaces/capability.py
@@ -1,0 +1,108 @@
+"""detect whether a PDS implements the permissioned-data space surface.
+
+no PDS advertises this declaratively (not describeServer, not .well-known, not
+OAuth metadata; ZDS's openapi.json is vendor-specific). so we **probe**: call a
+`com.atproto.space.*` method with the user's auth and branch on the response.
+
+    supported   -> the method dispatches for real (2xx, or a genuine
+                   InvalidRequest / InsufficientScope / auth error proving the
+                   route exists and ran)
+    unsupported -> HTTP 404/501 or an error in {MethodNotImplemented,
+                   UnknownMethod, XRPCNotSupported} (identical across a
+                   ZDS with the flag off and a vanilla PDS like bsky/tranquil)
+
+ambiguous results (transient 5xx, network) fail **closed** and are not cached, so a
+blip never pins a capable PDS to "unsupported" for the cache lifetime.
+
+the probe is authenticated: an unauthenticated call can't distinguish a supporting
+PDS from a vanilla one, because PDS auth middleware returns 401 before method routing.
+"""
+
+import logging
+import re
+
+from redis.exceptions import RedisError
+
+from backend._internal import Session as AuthSession
+from backend._internal.atproto.client import make_pds_request
+from backend.config import settings
+from backend.utilities.redis import get_async_redis_client
+
+logger = logging.getLogger(__name__)
+
+_CACHE_PREFIX = "permissioned_capability:"
+_CACHE_TTL_SECONDS = 6 * 60 * 60
+
+# error codes that mean "this PDS does not implement the space surface"
+_UNSUPPORTED_ERROR_CODES = (
+    "MethodNotImplemented",
+    "UnknownMethod",
+    "XRPCNotSupported",
+    "MethodNotSupported",
+)
+_UNSUPPORTED_STATUS = (404, 501)
+
+_STATUS_RE = re.compile(r"PDS request failed:\s*(\d{3})")
+
+
+def _classify_failure(message: str) -> bool | None:
+    """interpret a failed listSpaces probe.
+
+    returns True (supported), False (definitively unsupported), or None (ambiguous
+    / transient — caller should fail closed without caching).
+    """
+    if any(code in message for code in _UNSUPPORTED_ERROR_CODES):
+        return False
+    if match := _STATUS_RE.search(message):
+        status = int(match.group(1))
+        if status in _UNSUPPORTED_STATUS:
+            return False
+        if 500 <= status < 600:
+            return None  # transient upstream failure
+        return True  # 4xx other than 404: the route dispatched (auth/scope/validation)
+    return None
+
+
+async def _probe(auth_session: AuthSession) -> bool | None:
+    """probe listSpaces. True/False = definitive; None = ambiguous (don't cache)."""
+    try:
+        await make_pds_request(
+            auth_session,
+            "GET",
+            "com.atproto.space.listSpaces",
+            params={
+                "did": auth_session.did,
+                "type": settings.atproto.private_media_space_type,
+            },
+        )
+        return True
+    except Exception as exc:  # make_pds_request raises a bare Exception on non-2xx
+        return _classify_failure(str(exc))
+
+
+async def detect_permissioned_capability(auth_session: AuthSession) -> bool:
+    """whether the session's PDS implements permissioned spaces (cached per PDS)."""
+    pds_url = (auth_session.oauth_session or {}).get("pds_url")
+    cache_key = f"{_CACHE_PREFIX}{pds_url}" if pds_url else None
+
+    redis = None
+    if cache_key:
+        try:
+            redis = get_async_redis_client()
+            if (cached := await redis.get(cache_key)) is not None:
+                return cached == "1"
+        except RedisError as exc:
+            logger.debug("permissioned capability cache read failed: %s", exc)
+            redis = None
+
+    result = await _probe(auth_session)
+    if result is None:
+        return False  # ambiguous: fail closed, do not cache
+
+    if redis is not None and cache_key:
+        try:
+            await redis.set(cache_key, "1" if result else "0", ex=_CACHE_TTL_SECONDS)
+        except RedisError as exc:
+            logger.debug("permissioned capability cache write failed: %s", exc)
+
+    return result

--- a/backend/src/backend/_internal/atproto/spaces/client.py
+++ b/backend/src/backend/_internal/atproto/spaces/client.py
@@ -1,0 +1,220 @@
+"""client for the permissioned-data space surface (com.atproto.space.*).
+
+owner/author writes go through the DPoP-protected OAuth path
+([make_pds_request][backend._internal.atproto.client.make_pds_request]); the
+credential exchange and credential-gated reads use plain Bearer tokens (member
+grants and space credentials are JWTs, not DPoP-bound), so those go through a
+small raw-bearer helper.
+
+read path (per permissioned-data diary 6):
+
+    user OAuth -> getMemberGrant (member PDS, DPoP) -> getSpaceCredential
+    (space owner, plain Bearer grant) -> getRecord / getBlob (plain Bearer credential)
+"""
+
+import logging
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+from atproto_oauth.security import is_safe_url
+
+from backend._internal import Session as AuthSession
+from backend._internal.atproto.client import make_pds_request
+from backend._internal.atproto.spaces.uris import build_space_uri
+from backend.config import settings
+
+logger = logging.getLogger(__name__)
+
+# space credentials are "a couple of hours"; refresh well under that and renew
+# eagerly on a read rejection.
+_CREDENTIAL_TTL_SECONDS = 50 * 60
+
+
+class SpaceAccessError(Exception):
+    """the space owner refused a credential (AppNotPermitted, NotAMember, ...)."""
+
+
+def _pds_url(auth_session: AuthSession) -> str:
+    pds_url = (auth_session.oauth_session or {}).get("pds_url")
+    if not pds_url:
+        raise ValueError(f"no pds_url on session for {auth_session.did}")
+    return pds_url
+
+
+async def _raw_bearer_request(
+    pds_url: str,
+    method: str,
+    endpoint: str,
+    bearer: str,
+    *,
+    json: dict[str, Any] | None = None,
+    params: dict[str, Any] | None = None,
+) -> httpx.Response:
+    """call an XRPC method with a plain Bearer token (member grant / space credential)."""
+    url = f"{pds_url}/xrpc/{endpoint}"
+    if not is_safe_url(url):
+        raise ValueError(f"unsafe PDS URL: {url}")
+    async with httpx.AsyncClient(timeout=30) as http:
+        return await http.request(
+            method,
+            url,
+            headers={"authorization": f"Bearer {bearer}"},
+            json=json,
+            params=params,
+        )
+
+
+# --- space lifecycle + record writes (owner/author, DPoP OAuth) ---------------
+
+
+async def ensure_personal_space(
+    auth_session: AuthSession,
+    *,
+    space_type: str | None = None,
+    skey: str = "self",
+) -> str:
+    """create (or find) the caller's artist-owned personal space; return its URI.
+
+    owner DID = the artist's DID, single-member (the artist is auto-added).
+    `appAccessMode:"allow"` + empty exceptions leaves plyr.fm's OAuth client
+    default-allowed for credential exchange.
+    """
+    space_type = space_type or settings.atproto.private_media_space_type
+    space_uri = build_space_uri(auth_session.did, space_type, skey)
+    try:
+        await make_pds_request(
+            auth_session,
+            "POST",
+            "com.atproto.space.createSpace",
+            payload={
+                "did": auth_session.did,
+                "type": space_type,
+                "skey": skey,
+                "managingApp": settings.atproto.client_id,
+                "isPublic": False,
+                "appAccessMode": "allow",
+                "appExceptions": [],
+            },
+        )
+    except Exception as exc:
+        if "SpaceAlreadyExists" not in str(exc):
+            raise
+    return space_uri
+
+
+async def create_space_record(
+    auth_session: AuthSession,
+    *,
+    space: str,
+    collection: str,
+    record: dict[str, Any],
+    rkey: str | None = None,
+) -> tuple[str, str]:
+    """write a record into the caller's permissioned repo within `space`.
+
+    uses putRecord when an rkey is supplied (idempotent), else createRecord.
+    returns (record_uri, cid).
+    """
+    payload: dict[str, Any] = {
+        "space": space,
+        "repo": auth_session.did,
+        "collection": collection,
+        "record": record,
+    }
+    if rkey:
+        payload["rkey"] = rkey
+        endpoint = "com.atproto.space.putRecord"
+    else:
+        endpoint = "com.atproto.space.createRecord"
+    result = await make_pds_request(auth_session, "POST", endpoint, payload=payload)
+    return result["uri"], result["cid"]
+
+
+# --- credential exchange (diary-6 read path) ----------------------------------
+
+# per-process cache: space credentials are owner-signed and client-id-bound, so
+# they're reusable across reads of the same space until they expire.
+_credential_cache: dict[str, tuple[str, float]] = {}
+
+
+async def _mint_credential(auth_session: AuthSession, space: str) -> str:
+    pds_url = _pds_url(auth_session)
+    grant_resp = await make_pds_request(
+        auth_session,
+        "GET",
+        "com.atproto.space.getMemberGrant",
+        params={"space": space},
+    )
+    grant = grant_resp["grant"]
+
+    # exchange the grant (plain Bearer) for an owner-signed space credential
+    cred_resp = await _raw_bearer_request(
+        pds_url,
+        "POST",
+        "com.atproto.space.getSpaceCredential",
+        grant,
+        json={"space": space},
+    )
+    if cred_resp.status_code != 200:
+        body = cred_resp.text
+        if any(e in body for e in ("AppNotPermitted", "NotAMember", "SpaceDeleted")):
+            raise SpaceAccessError(f"space owner refused credential: {body}")
+        raise Exception(f"getSpaceCredential failed: {cred_resp.status_code} {body}")
+    return cred_resp.json()["credential"]
+
+
+async def get_space_credential(
+    auth_session: AuthSession, space: str, *, force_refresh: bool = False
+) -> str:
+    """obtain a space credential for `space`, minting+caching or renewing as needed."""
+    now = time.monotonic()
+    if not force_refresh and (cached := _credential_cache.get(space)):
+        credential, expires_at = cached
+        if expires_at > now:
+            return credential
+    credential = await _mint_credential(auth_session, space)
+    _credential_cache[space] = (credential, now + _CREDENTIAL_TTL_SECONDS)
+    return credential
+
+
+@asynccontextmanager
+async def open_space_blob(
+    auth_session: AuthSession,
+    *,
+    space: str,
+    repo: str,
+    cid: str,
+    range_header: str | None = None,
+) -> AsyncIterator[httpx.Response]:
+    """stream a blob through the permissioned-space path using a space credential.
+
+    yields the upstream streaming response (status, headers, body) so the caller
+    can relay Range/206 semantics. renews the credential once on a 401/InvalidToken.
+    """
+    pds_url = _pds_url(auth_session)
+    url = f"{pds_url}/xrpc/com.atproto.space.getBlob"
+    if not is_safe_url(url):
+        raise ValueError(f"unsafe PDS URL: {url}")
+    params = {"space": space, "repo": repo, "cid": cid}
+
+    async with httpx.AsyncClient(timeout=httpx.Timeout(None)) as http:
+        for attempt in range(2):
+            credential = await get_space_credential(
+                auth_session, space, force_refresh=attempt > 0
+            )
+            headers = {"authorization": f"Bearer {credential}"}
+            if range_header:
+                headers["range"] = range_header
+            req = http.build_request("GET", url, headers=headers, params=params)
+            resp = await http.send(req, stream=True)
+            if resp.status_code == 401 and attempt == 0:
+                await resp.aclose()
+                continue  # stale credential — renew and retry once
+            try:
+                yield resp
+            finally:
+                await resp.aclose()
+            return

--- a/backend/src/backend/_internal/atproto/spaces/uris.py
+++ b/backend/src/backend/_internal/atproto/spaces/uris.py
@@ -1,0 +1,41 @@
+"""ats:// URI helpers for permissioned-data spaces.
+
+a *space* URI has 3 segments and a *record* URI has 6 (space-first), per Daniel
+Holmgren's permissioned-data diary 5:
+
+    space:  ats://<spaceDid>/<spaceType>/<spaceKey>
+    record: ats://<spaceDid>/<spaceType>/<spaceKey>/<authorDid>/<collection>/<rkey>
+"""
+
+from typing import NamedTuple
+
+ATS_SCHEME = "ats://"
+
+
+class SpaceUri(NamedTuple):
+    owner_did: str
+    space_type: str
+    skey: str
+
+
+def build_space_uri(owner_did: str, space_type: str, skey: str) -> str:
+    return f"{ATS_SCHEME}{owner_did}/{space_type}/{skey}"
+
+
+def build_record_uri(
+    space_uri: str, author_did: str, collection: str, rkey: str
+) -> str:
+    return f"{space_uri}/{author_did}/{collection}/{rkey}"
+
+
+def parse_space_uri(uri: str) -> SpaceUri:
+    """parse the 3-segment space portion of an ats:// URI.
+
+    accepts either a bare space URI or a full record URI (extra segments ignored).
+    """
+    if not uri.startswith(ATS_SCHEME):
+        raise ValueError(f"not an ats:// URI: {uri!r}")
+    segments = uri[len(ATS_SCHEME) :].split("/")
+    if len(segments) < 3 or not all(segments[:3]):
+        raise ValueError(f"space URI needs 3 non-empty segments: {uri!r}")
+    return SpaceUri(owner_did=segments[0], space_type=segments[1], skey=segments[2])

--- a/backend/src/backend/_internal/auth/oauth.py
+++ b/backend/src/backend/_internal/auth/oauth.py
@@ -127,7 +127,9 @@ def get_public_jwks() -> dict | None:
 
 
 def get_oauth_client(
-    include_teal: bool = False, include_indiemusi: bool = False
+    include_teal: bool = False,
+    include_indiemusi: bool = False,
+    include_permissioned: bool = False,
 ) -> OAuthClient:
     """create an OAuth client with the appropriate scopes.
 
@@ -140,6 +142,7 @@ def get_oauth_client(
         indiemusi_tokens=(
             settings.indiemusi.scope_tokens() if include_indiemusi else None
         ),
+        permissioned_spaces=include_permissioned,
     )
 
     # load confidential client key if configured
@@ -168,8 +171,12 @@ def get_oauth_client_for_scope(scope: str) -> OAuthClient:
     include_indiemusi = scopes.matches(
         "repo", collection=settings.indiemusi.song_collection, action="create"
     )
+    # ScopesSet doesn't model the experimental space: token, so match on the string
+    include_permissioned = settings.atproto.private_media_space_scope in scope
     return get_oauth_client(
-        include_teal=include_teal, include_indiemusi=include_indiemusi
+        include_teal=include_teal,
+        include_indiemusi=include_indiemusi,
+        include_permissioned=include_permissioned,
     )
 
 
@@ -247,16 +254,20 @@ async def start_oauth_flow_with_scopes(
     handle: str,
     include_teal: bool = False,
     include_indiemusi: bool = False,
+    include_permissioned: bool = False,
     prompt: PromptType | None = None,
 ) -> tuple[str, str]:
     """start OAuth flow with explicit scope selection (used for scope upgrades)."""
     try:
         client = get_oauth_client(
-            include_teal=include_teal, include_indiemusi=include_indiemusi
+            include_teal=include_teal,
+            include_indiemusi=include_indiemusi,
+            include_permissioned=include_permissioned,
         )
         logger.info(
             f"starting scope upgrade OAuth for {handle} "
-            f"(teal={include_teal}, indiemusi={include_indiemusi})"
+            f"(teal={include_teal}, indiemusi={include_indiemusi}, "
+            f"permissioned={include_permissioned})"
         )
         auth_url, state = await client.start_authorization(handle, prompt=prompt)
         return auth_url, state

--- a/backend/src/backend/_internal/tasks/hooks.py
+++ b/backend/src/backend/_internal/tasks/hooks.py
@@ -81,6 +81,19 @@ async def run_post_track_create_hooks(
     this is the SINGLE place to add new post-creation behavior.
     both the API upload path and Jetstream ingest call this function.
     """
+    # private (permissioned-space) media must not trigger any public/external
+    # side effect: no follower notification, no turbopuffer embedding, no
+    # copyright scan or genre classification (the audio is credential-gated and
+    # the track is owner-only). mark notification sent so it's never retried.
+    async with db_session() as db:
+        is_private = await db.scalar(
+            select(Track.is_private).where(Track.id == track_id)
+        )
+    if is_private:
+        await _mark_notification_sent(track_id)
+        await invalidate_tracks_discovery_cache()
+        return
+
     if audio_url is None:
         audio_url = await resolve_audio_url(track_id)
 

--- a/backend/src/backend/_internal/track_visibility.py
+++ b/backend/src/backend/_internal/track_visibility.py
@@ -1,0 +1,53 @@
+"""private (permissioned-space) track visibility — one place, applied everywhere.
+
+a private track (`Track.is_private`) lives in the artist's permissioned space and
+must be invisible and inert to everyone except its owner: no metadata reads, no
+listing/counting, no likes/comments/shares/embeds. public, unlisted, and gated
+tracks are unaffected (unlisted is still searchable/listable by design).
+
+two shapes:
+- [track_visible_filter][backend._internal.track_visibility.track_visible_filter]:
+  a SQLAlchemy condition for queries that list/count tracks.
+- [ensure_track_visible][backend._internal.track_visibility.ensure_track_visible]:
+  a guard for endpoints that load one track by id/uri/file_id.
+"""
+
+from typing import Protocol
+
+from fastapi import HTTPException
+from sqlalchemy import ColumnElement, or_
+
+from backend.models import Track
+
+
+class _HasDid(Protocol):
+    """structural type for anything carrying a DID (e.g. an auth Session)."""
+
+    did: str
+
+
+def track_visible_filter(viewer_did: str | None) -> ColumnElement[bool]:
+    """SQL condition: public tracks, plus the viewer's own private tracks."""
+    if viewer_did is None:
+        return Track.is_private.is_(False)
+    return or_(Track.is_private.is_(False), Track.artist_did == viewer_did)
+
+
+def can_view_track(viewer_did: str | None, track: Track) -> bool:
+    """whether `viewer_did` may see/interact with `track` (owner-only when private)."""
+    return not track.is_private or viewer_did == track.artist_did
+
+
+def ensure_track_visible(track: Track, viewer_did: str | None) -> None:
+    """404 when a private track is accessed by anyone but its owner.
+
+    404 (not 403) so a private track is indistinguishable from a missing one —
+    sequential ids must not let a non-owner probe for private uploads.
+    """
+    if not can_view_track(viewer_did, track):
+        raise HTTPException(status_code=404, detail="track not found")
+
+
+def viewer_did(session: _HasDid | None) -> str | None:
+    """extract the DID from an optional session for the helpers above."""
+    return session.did if session is not None else None

--- a/backend/src/backend/api/albums/listing.py
+++ b/backend/src/backend/api/albums/listing.py
@@ -5,13 +5,14 @@ import logging
 from typing import Annotated
 
 from fastapi import Depends, HTTPException
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session
 from backend._internal.atproto.records import fetch_list_item_uris
+from backend._internal.track_visibility import track_visible_filter, viewer_did
 from backend.models import Album, Artist, Track, TrackLike, get_db
 from backend.schemas import TrackResponse
 from backend.utilities.aggregations import (
@@ -52,7 +53,9 @@ async def list_albums(
             func.coalesce(func.sum(Track.play_count), 0).label("total_plays"),
         )
         .join(Artist, Album.artist_did == Artist.did)
-        .outerjoin(Track, Track.album_id == Album.id)
+        # count only public tracks — albums that exist solely because of private
+        # uploads have a zero public count and drop out via the having clause
+        .outerjoin(Track, and_(Track.album_id == Album.id, Track.is_private.is_(False)))
         .group_by(Album.id, Artist.did)
         .having(func.count(Track.id) > 0)
         .order_by(func.lower(Album.title))
@@ -89,7 +92,7 @@ async def list_artist_albums(
             func.count(Track.id).label("track_count"),
             func.coalesce(func.sum(Track.play_count), 0).label("total_plays"),
         )
-        .outerjoin(Track, Track.album_id == Album.id)
+        .outerjoin(Track, and_(Track.album_id == Album.id, Track.is_private.is_(False)))
         .where(Album.artist_did == artist.did)
         .group_by(Album.id)
         .having(func.count(Track.id) > 0)
@@ -147,6 +150,8 @@ async def get_album(
         select(Track)
         .options(selectinload(Track.artist), selectinload(Track.album_rel))
         .where(Track.album_id == album.id)
+        # a private track in an album is visible only to the album's owner
+        .where(track_visible_filter(viewer_did(session)))
     )
     track_result = await db.execute(track_stmt)
     all_tracks = list(track_result.scalars().all())

--- a/backend/src/backend/api/audio.py
+++ b/backend/src/backend/api/audio.py
@@ -2,15 +2,20 @@
 
 import logfire
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import or_, select
 
 from backend._internal import Session, get_optional_session, validate_supporter
 from backend._internal.atproto.client import pds_blob_url
+from backend._internal.atproto.spaces.client import SpaceAccessError, open_space_blob
+from backend.config import settings
 from backend.models import Artist, Track
 from backend.storage import storage
 from backend.utilities.database import db_session
+
+# headers worth relaying from the upstream getBlob response so range/seek works
+_PROXY_HEADERS = ("content-type", "content-length", "content-range", "accept-ranges")
 
 router = APIRouter(prefix="/audio", tags=["audio"])
 
@@ -64,6 +69,8 @@ async def stream_audio(
                 Track.artist_did,
                 Track.audio_storage,
                 Track.pds_blob_cid,
+                Track.is_private,
+                Track.space_uri,
             )
             .where(or_(Track.file_id == file_id, Track.original_file_id == file_id))
             .order_by(Track.r2_url.is_not(None).desc(), Track.created_at.desc())
@@ -84,7 +91,21 @@ async def stream_audio(
             artist_did,
             audio_storage,
             pds_blob_cid,
+            is_private,
+            space_uri,
         ) = track_data
+
+    # private media lives in a permissioned space — proxy the bytes through the
+    # owner's space credential (can't redirect: the browser has no credential).
+    if is_private:
+        return await _handle_private_audio(
+            session=session,
+            artist_did=artist_did,
+            space_uri=space_uri,
+            pds_blob_cid=pds_blob_cid,
+            request=request,
+            is_head_request=is_head_request,
+        )
 
     # determine if we're serving the original lossless file
     serving_original = file_id == original_file_id and original_file_type is not None
@@ -230,6 +251,8 @@ async def get_audio_url(
                 Track.artist_did,
                 Track.audio_storage,
                 Track.pds_blob_cid,
+                Track.is_private,
+                Track.space_uri,
             )
             .where(or_(Track.file_id == file_id, Track.original_file_id == file_id))
             .order_by(Track.r2_url.is_not(None).desc(), Track.created_at.desc())
@@ -250,7 +273,22 @@ async def get_audio_url(
             artist_did,
             audio_storage,
             pds_blob_cid,
+            is_private,
+            _space_uri,
         ) = track_data
+
+    # private media is proxied through the permissioned-space credential path,
+    # so the cacheable "url" is this backend's own stream endpoint (which holds
+    # the credential), not a presigned/CDN URL the client could fetch directly.
+    if is_private:
+        if session is None or session.did != artist_did:
+            raise HTTPException(status_code=404, detail="audio file not found")
+        backend_url = settings.atproto.redirect_uri.rsplit("/", 2)[0]
+        return AudioUrlResponse(
+            url=f"{backend_url}/audio/{file_id}",
+            file_id=file_id,
+            file_type=file_type,
+        )
 
     # determine if we're serving the original lossless file
     serving_original = file_id == original_file_id and original_file_type is not None
@@ -301,3 +339,58 @@ async def get_audio_url(
         raise HTTPException(status_code=404, detail="audio file not found")
 
     return AudioUrlResponse(url=url, file_id=serve_file_id, file_type=serve_file_type)
+
+
+def _relay_headers(resp) -> dict[str, str]:
+    return {k: resp.headers[k] for k in _PROXY_HEADERS if k in resp.headers}
+
+
+async def _handle_private_audio(
+    *,
+    session: Session | None,
+    artist_did: str,
+    space_uri: str | None,
+    pds_blob_cid: str | None,
+    request: Request,
+    is_head_request: bool,
+) -> Response:
+    """proxy a private track's audio through the permissioned-space credential path.
+
+    only the owner can play their own private media in this single-member-space MVP,
+    so a non-owner (or anonymous) request gets a 404 — the same response as a missing
+    file, so private tracks don't leak their existence. Range is passed through so the
+    206/seek semantics survive the proxy.
+    """
+    if session is None or session.did != artist_did:
+        raise HTTPException(status_code=404, detail="audio file not found")
+    if not (space_uri and pds_blob_cid):
+        raise HTTPException(status_code=404, detail="audio file not found")
+
+    cm = open_space_blob(
+        session,
+        space=space_uri,
+        repo=artist_did,
+        cid=pds_blob_cid,
+        range_header=request.headers.get("range"),
+    )
+    try:
+        resp = await cm.__aenter__()
+    except SpaceAccessError as exc:
+        raise HTTPException(
+            status_code=403, detail="permissioned access denied"
+        ) from exc
+
+    headers = _relay_headers(resp)
+    if is_head_request:
+        status = resp.status_code
+        await cm.__aexit__(None, None, None)
+        return Response(status_code=status, headers=headers)
+
+    async def body():
+        try:
+            async for chunk in resp.aiter_bytes():
+                yield chunk
+        finally:
+            await cm.__aexit__(None, None, None)
+
+    return StreamingResponse(body(), status_code=resp.status_code, headers=headers)

--- a/backend/src/backend/api/auth.py
+++ b/backend/src/backend/api/auth.py
@@ -39,6 +39,7 @@ from backend._internal import (
     start_oauth_flow_with_scopes,
     switch_active_account,
 )
+from backend._internal.atproto.spaces import detect_permissioned_capability
 from backend._internal.auth import get_refresh_token_lifetime_days
 from backend._internal.copyright import complete_indiemusi_setup
 from backend._internal.tasks import schedule_atproto_sync
@@ -59,6 +60,12 @@ class LinkedAccountResponse(BaseModel):
     avatar_url: str | None
 
 
+class PermissionedSpacesStatus(BaseModel):
+    """whether the user's PDS implements the experimental permissioned-space surface."""
+
+    supported: bool = False
+
+
 class CurrentUserResponse(BaseModel):
     """response model for current user endpoint."""
 
@@ -66,6 +73,7 @@ class CurrentUserResponse(BaseModel):
     handle: str
     linked_accounts: list[LinkedAccountResponse] = []
     enabled_flags: list[str] = []
+    permissioned_spaces: PermissionedSpacesStatus = PermissionedSpacesStatus()
 
 
 class DeveloperTokenInfo(BaseModel):
@@ -482,6 +490,15 @@ async def get_current_user(
     # get feature flags for current user from dedicated table
     current_user_flags = await get_user_flags(db, session.did)
 
+    # permissioned-spaces capability is the gate for the private-media feature;
+    # cached per-PDS in redis so this probe is cheap after the first call. never
+    # let it break /auth/me.
+    try:
+        spaces_supported = await detect_permissioned_capability(session)
+    except Exception as exc:
+        logger.debug(f"permissioned capability probe failed: {exc}")
+        spaces_supported = False
+
     return CurrentUserResponse(
         did=session.did,
         handle=session.handle,
@@ -494,6 +511,7 @@ async def get_current_user(
             for account in linked
         ],
         enabled_flags=current_user_flags,
+        permissioned_spaces=PermissionedSpacesStatus(supported=spaces_supported),
     )
 
 
@@ -607,8 +625,9 @@ async def start_developer_token_flow(
 class ScopeUpgradeStartRequest(BaseModel):
     """request model for starting scope upgrade OAuth flow."""
 
-    # for now, only teal scopes are supported
     include_teal: bool = True
+    # private-media permissioned-space scope (opt-in, capable PDS only)
+    include_permissioned: bool = False
 
 
 class ScopeUpgradeStartResponse(BaseModel):
@@ -635,13 +654,30 @@ async def start_scope_upgrade_flow(
 
     returns the authorization URL that the frontend should redirect to.
     """
-    # start OAuth flow with the requested scopes
+    # a scope upgrade replaces the session's whole scope set, so preserve whatever
+    # the user already granted and only ADD what's requested.
+    current_scope = (session.oauth_session or {}).get("scope", "")
+    include_teal = body.include_teal or (
+        f"repo:{settings.teal.play_collection}" in current_scope
+    )
+    include_indiemusi = settings.indiemusi.song_collection in current_scope
+    include_permissioned = body.include_permissioned or (
+        settings.atproto.private_media_space_scope in current_scope
+    )
+
     auth_url, state = await start_oauth_flow_with_scopes(
-        session.handle, include_teal=body.include_teal
+        session.handle,
+        include_teal=include_teal,
+        include_indiemusi=include_indiemusi,
+        include_permissioned=include_permissioned,
     )
 
     # build the requested scopes string for logging/tracking
-    requested_scopes = "teal" if body.include_teal else "base"
+    requested_scopes = (
+        "permissioned"
+        if body.include_permissioned
+        else ("teal" if include_teal else "base")
+    )
 
     # save pending scope upgrade metadata keyed by state
     await save_pending_scope_upgrade(

--- a/backend/src/backend/api/discover.py
+++ b/backend/src/backend/api/discover.py
@@ -48,6 +48,8 @@ async def get_network_artists(
         select(Artist, func.count(Track.id).label("track_count"))
         .join(Track, Track.artist_did == Artist.did)
         .where(Artist.did.in_(follow_dids))
+        # private media never counts toward an artist's public track count
+        .where(Track.is_private.is_(False))
         .group_by(Artist.did)
     )
 

--- a/backend/src/backend/api/lists/hydration.py
+++ b/backend/src/backend/api/lists/hydration.py
@@ -4,6 +4,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from backend._internal.track_visibility import track_visible_filter
 from backend.models import Track, TrackLike
 from backend.schemas import TrackResponse
 from backend.utilities.aggregations import get_comment_counts, get_like_counts
@@ -26,6 +27,8 @@ async def hydrate_tracks_from_uris(
         select(Track)
         .options(selectinload(Track.artist), selectinload(Track.album_rel))
         .where(Track.atproto_record_uri.in_(track_uris))
+        # a private track referenced by a list hydrates only for its owner
+        .where(track_visible_filter(session_did))
     )
     all_tracks = track_result.scalars().all()
     track_by_uri = {t.atproto_record_uri: t for t in all_tracks}

--- a/backend/src/backend/api/meta.py
+++ b/backend/src/backend/api/meta.py
@@ -69,6 +69,7 @@ async def client_metadata() -> dict[str, Any]:
                 if settings.indiemusi.enabled
                 else None
             ),
+            permissioned_spaces=True,
         ),
         "grant_types": ["authorization_code", "refresh_token"],
         "response_types": ["code"],

--- a/backend/src/backend/api/oembed.py
+++ b/backend/src/backend/api/oembed.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from typing_extensions import TypedDict
 
+from backend._internal.track_visibility import ensure_track_visible
 from backend.config import settings
 from backend.models import Album, Artist, Playlist, Track, get_db
 
@@ -80,6 +81,8 @@ async def _build_track_oembed(
     )
     if not (track := result.scalar_one_or_none()):
         raise HTTPException(status_code=404, detail="track not found")
+    # oEmbed is an unauthenticated public-embed surface — private media never embeds
+    ensure_track_visible(track, None)
 
     return OEmbedResponse(
         title=f"{track.title} - {track.artist.display_name}",

--- a/backend/src/backend/api/search.py
+++ b/backend/src/backend/api/search.py
@@ -173,6 +173,8 @@ async def _search_tracks(
         select(Track, Artist, similarity.label("relevance"))
         .join(Artist, Track.artist_did == Artist.did)
         .where(or_(similarity > 0.1, substring_match))
+        # private (permissioned-space) media is never publicly searchable
+        .where(Track.is_private == False)  # noqa: E712
         .order_by(similarity.desc())
         .limit(limit)
     )

--- a/backend/src/backend/api/search.py
+++ b/backend/src/backend/api/search.py
@@ -405,6 +405,8 @@ async def semantic_search(
         select(Track, Artist)
         .join(Artist, Track.artist_did == Artist.did)
         .where(Track.id.in_(track_ids))
+        # private media is never publicly searchable (also shouldn't be indexed)
+        .where(Track.is_private == False)  # noqa: E712
     )
     result = await db.execute(stmt)
     rows = result.all()

--- a/backend/src/backend/api/tracks/audio_replace.py
+++ b/backend/src/backend/api/tracks/audio_replace.py
@@ -711,17 +711,28 @@ async def replace_track_audio(
     async with db_session() as db:
         result = await db.execute(
             select(
-                Track.artist_did, Track.atproto_record_uri, Track.support_gate
+                Track.artist_did,
+                Track.atproto_record_uri,
+                Track.support_gate,
+                Track.is_private,
             ).where(Track.id == track_id)
         )
         row = result.first()
         if not row:
             raise HTTPException(status_code=404, detail="track not found")
-        artist_did, atproto_uri, support_gate = row
+        artist_did, atproto_uri, support_gate, is_private = row
         if artist_did != auth_session.did:
             raise HTTPException(
                 status_code=403,
                 detail="you can only replace audio on your own tracks",
+            )
+        # the replace pipeline builds a public/gated upload context; replacing
+        # audio in a permissioned space isn't implemented yet, so reject rather
+        # than drift a private track toward public storage.
+        if is_private:
+            raise HTTPException(
+                status_code=409,
+                detail="replacing audio on private tracks isn't supported yet",
             )
         if not atproto_uri:
             raise HTTPException(

--- a/backend/src/backend/api/tracks/comments.py
+++ b/backend/src/backend/api/tracks/comments.py
@@ -10,12 +10,13 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session as AuthSession
-from backend._internal import require_auth
+from backend._internal import get_optional_session, require_auth
 from backend._internal.tasks import (
     schedule_pds_create_comment,
     schedule_pds_delete_comment,
     schedule_pds_update_comment,
 )
+from backend._internal.track_visibility import ensure_track_visible, viewer_did
 from backend.models import Artist, Track, TrackComment, UserPreferences, get_db
 from backend.schemas import DeletedResponse
 
@@ -66,10 +67,11 @@ class CommentsListResponse(BaseModel):
 async def get_track_comments(
     track_id: int,
     db: Annotated[AsyncSession, Depends(get_db)],
+    session: AuthSession | None = Depends(get_optional_session),
 ) -> CommentsListResponse:
     """get all comments for a track, ordered by timestamp.
 
-    public endpoint - no auth required.
+    public for normal tracks; a private track is owner-only (else 404).
     """
     # check track exists and get artist's allow_comments setting
     track_result = await db.execute(select(Track).where(Track.id == track_id))
@@ -77,6 +79,7 @@ async def get_track_comments(
 
     if not track:
         raise HTTPException(status_code=404, detail="track not found")
+    ensure_track_visible(track, viewer_did(session))
 
     # check if artist allows comments
     prefs_result = await db.execute(
@@ -136,6 +139,7 @@ async def create_comment(
 
     if not track:
         raise HTTPException(status_code=404, detail="track not found")
+    ensure_track_visible(track, auth_session.did)
 
     if not track.atproto_record_uri or not track.atproto_record_cid:
         raise HTTPException(

--- a/backend/src/backend/api/tracks/likes.py
+++ b/backend/src/backend/api/tracks/likes.py
@@ -11,10 +11,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from backend._internal import Session as AuthSession
-from backend._internal import require_auth
+from backend._internal import get_optional_session, require_auth
 from backend._internal.tasks import (
     schedule_pds_create_like,
     schedule_pds_delete_like,
+)
+from backend._internal.track_visibility import (
+    ensure_track_visible,
+    track_visible_filter,
+    viewer_did,
 )
 from backend.models import Artist, Track, TrackLike, get_db
 from backend.schemas import LikedResponse, TrackResponse
@@ -60,6 +65,9 @@ async def list_liked_tracks(
         .join(Artist)
         .options(selectinload(Track.artist), selectinload(Track.album_rel))
         .where(TrackLike.user_did == auth_session.did)
+        # a user may have liked their own private track; never surface a private
+        # track owned by someone else (shouldn't exist, but defense in depth)
+        .where(track_visible_filter(auth_session.did))
         .order_by(TrackLike.created_at.desc())
     )
 
@@ -104,6 +112,7 @@ async def like_track(
 
     if not track:
         raise HTTPException(status_code=404, detail="track not found")
+    ensure_track_visible(track, auth_session.did)
 
     if not track.atproto_record_uri or not track.atproto_record_cid:
         raise HTTPException(
@@ -185,15 +194,23 @@ async def unlike_track(
 async def get_track_likes(
     track_id: int,
     db: Annotated[AsyncSession, Depends(get_db)],
+    session: AuthSession | None = Depends(get_optional_session),
 ) -> TrackLikersResponse:
     """Public endpoint returning users who liked a track.
 
     Returns a list of user display info (handle, display name, avatar, liked_at
-    timestamp). This endpoint is public—no authentication required to see who
-    liked a track.
+    timestamp). Public for normal tracks; a private track's likers are visible
+    only to its owner (otherwise it 404s like a missing track).
     """
-    track_exists = await db.scalar(select(Track.id).where(Track.id == track_id))
-    if not track_exists:
+    row = (
+        await db.execute(
+            select(Track.is_private, Track.artist_did).where(Track.id == track_id)
+        )
+    ).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="track not found")
+    is_private, artist_did = row
+    if is_private and viewer_did(session) != artist_did:
         raise HTTPException(status_code=404, detail="track not found")
 
     stmt = (

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -131,9 +131,14 @@ async def list_tracks(
     # filter by artist if provided
     if artist_did:
         stmt = stmt.where(Track.artist_did == artist_did)
+        # private (permissioned-space) media is visible only to its owner — an
+        # artist page viewed by anyone else (or logged out) must not list it
+        if not (session and session.did == artist_did):
+            stmt = stmt.where(Track.is_private == False)  # noqa: E712
     else:
         # discovery feed: exclude unlisted tracks (artist pages show all) and
-        # tracks from deactivated accounts (their content drops out of discovery)
+        # tracks from deactivated accounts (their content drops out of discovery).
+        # unlisted==False also excludes private media (private implies unlisted).
         stmt = stmt.where(Track.unlisted == False)  # noqa: E712
         stmt = stmt.where(Artist.deactivated == False)  # noqa: E712
 

--- a/backend/src/backend/api/tracks/mutations.py
+++ b/backend/src/backend/api/tracks/mutations.py
@@ -200,6 +200,15 @@ async def update_track_metadata(
             detail="you can only edit your own tracks",
         )
 
+    # editing private (permissioned-space) media would route through the public
+    # at:// rebuild path; space record update isn't implemented yet, so reject it
+    # rather than corrupt the record or write to the public repo.
+    if track.is_private:
+        raise HTTPException(
+            status_code=409,
+            detail="editing private tracks isn't supported yet",
+        )
+
     title_changed = False
     if title is not None:
         track.title = title

--- a/backend/src/backend/api/tracks/playback.py
+++ b/backend/src/backend/api/tracks/playback.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import selectinload
 
 from backend._internal import Session, get_optional_session
 from backend._internal.tasks import schedule_teal_scrobble
+from backend._internal.track_visibility import ensure_track_visible, viewer_did
 from backend.config import settings
 from backend.models import (
     Artist,
@@ -135,6 +136,7 @@ async def get_track_by_uri(
     )
     if not (track := result.scalar_one_or_none()):
         raise HTTPException(status_code=404, detail="track not found")
+    ensure_track_visible(track, viewer_did(session))
 
     return await _resolve_track(db, track, session)
 
@@ -154,6 +156,7 @@ async def get_track(
     )
     if not (track := result.scalar_one_or_none()):
         raise HTTPException(status_code=404, detail="track not found")
+    ensure_track_visible(track, viewer_did(session))
 
     return await _resolve_track(db, track, session)
 
@@ -187,6 +190,7 @@ async def increment_play_count(
 
     if not (track := result.scalar_one_or_none()):
         raise HTTPException(status_code=404, detail="track not found")
+    ensure_track_visible(track, viewer_did(session))
 
     ttl = max(
         _PLAY_DEDUP_MIN_TTL_S,

--- a/backend/src/backend/api/tracks/shares.py
+++ b/backend/src/backend/api/tracks/shares.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import selectinload
 
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session, require_auth
+from backend._internal.track_visibility import ensure_track_visible
 from backend.config import settings
 from backend.models import Artist, ShareLink, ShareLinkEvent, Track, get_db
 from backend.schemas import OkResponse, TrackResponse
@@ -86,6 +87,9 @@ async def create_share_link(
     track = await db.scalar(select(Track).where(Track.id == track_id))
     if not track:
         raise HTTPException(status_code=404, detail="track not found")
+    ensure_track_visible(track, auth_session.did)  # non-owner → 404
+    if track.is_private:
+        raise HTTPException(status_code=409, detail="private tracks can't be shared")
 
     code = await generate_unique_share_code(db)
 

--- a/backend/src/backend/api/tracks/tags.py
+++ b/backend/src/backend/api/tracks/tags.py
@@ -12,6 +12,11 @@ from sqlalchemy.orm import selectinload
 
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session
+from backend._internal.track_visibility import (
+    ensure_track_visible,
+    track_visible_filter,
+    viewer_did,
+)
 from backend.config import settings
 from backend.models import Artist, Tag, Track, TrackLike, TrackTag, get_db
 from backend.schemas import TrackResponse
@@ -76,6 +81,8 @@ async def get_tracks_by_tag(
         .join(Artist, Track.artist_did == Artist.did)
         .join(TrackTag, Track.id == TrackTag.track_id)
         .where(TrackTag.tag_id == tag.id)
+        # private media isn't tag-discoverable by anyone but its owner
+        .where(track_visible_filter(viewer_did(session)))
         .options(selectinload(Track.artist), selectinload(Track.album_rel))
         .order_by(Track.created_at.desc())
     )
@@ -183,6 +190,7 @@ async def get_recommended_tags(
     track_id: int,
     db: Annotated[AsyncSession, Depends(get_db)],
     limit: Annotated[int, Query(ge=1, le=20)] = 5,
+    session: AuthSession | None = Depends(get_optional_session),
 ) -> RecommendedTagsResponse:
     """recommend tags for a track based on ML genre classification.
 
@@ -194,6 +202,7 @@ async def get_recommended_tags(
     track = result.scalar_one_or_none()
     if not track:
         raise HTTPException(status_code=404, detail="track not found")
+    ensure_track_visible(track, viewer_did(session))
 
     # check for stored predictions (invalidate if audio file changed)
     extra = track.extra or {}

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -40,6 +40,15 @@ from backend._internal.atproto.handles import (
     InvalidFeaturesError,
     resolve_featured_artists,
 )
+from backend._internal.atproto.records.fm_plyr.track import build_track_record
+from backend._internal.atproto.spaces import (
+    build_record_uri,
+    detect_permissioned_capability,
+)
+from backend._internal.atproto.spaces.client import (
+    create_space_record,
+    ensure_personal_space,
+)
 from backend._internal.audio import AudioFormat
 from backend._internal.background import get_docket
 from backend._internal.clients.transcoder import (
@@ -134,6 +143,12 @@ class UploadContext:
     # visibility: unlisted tracks don't appear in discovery feeds
     unlisted: bool = False
 
+    # private media: audio blob + record live in the artist's ATProto permissioned
+    # space (com.atproto.space.*), not the public repo. no public R2 copy; excluded
+    # from discovery; playable only through the space credential path. requires a
+    # PDS that supports permissioned spaces (checked at the endpoint).
+    private: bool = False
+
     @property
     def audio_extension(self) -> str:
         """source-format extension, normalized (lowercase, no leading dot)."""
@@ -147,6 +162,7 @@ class AudioInfo:
     format: AudioFormat
     duration: int | None
     is_gated: bool
+    is_private: bool = False
 
 
 @dataclass
@@ -593,7 +609,12 @@ async def _validate_audio(ctx: UploadContext) -> AudioInfo:
                     "supporter gating requires atprotofans to be enabled in settings"
                 )
 
-    return AudioInfo(format=audio_format, duration=ctx.duration, is_gated=is_gated)
+    return AudioInfo(
+        format=audio_format,
+        duration=ctx.duration,
+        is_gated=is_gated,
+        is_private=ctx.private,
+    )
 
 
 async def _store_audio(ctx: UploadContext, audio_info: AudioInfo) -> StorageResult:
@@ -626,9 +647,11 @@ async def _store_audio(ctx: UploadContext, audio_info: AudioInfo) -> StorageResu
     playable_format = audio_info.format
     source_ext = ctx.audio_extension
 
-    # public-bucket URL (gated tracks proxy through the auth-protected backend)
+    # public-bucket URL — omitted for gated tracks (proxied through the
+    # auth-protected backend) and for private tracks (no public copy at all;
+    # the canonical audio is the PDS blob in the permissioned space).
     r2_url: str | None = None
-    if not audio_info.is_gated:
+    if not audio_info.is_gated and not audio_info.is_private:
         r2_url = await storage.get_url(file_id, file_type="audio", extension=source_ext)
         if not r2_url:
             raise UploadPhaseError("failed to get public audio URL")
@@ -682,20 +705,26 @@ async def _upload_to_pds(
     never holds the full file in memory. content length is sourced from
     a HEAD request so the PDS can validate up-front without buffering.
     """
-    if audio_info.is_gated:
+    # gated (supporter/copyright) tracks proxy through the backend and don't
+    # push a blob. private tracks are the opposite: the PDS blob IS the canonical
+    # audio, so the upload is mandatory (and bypasses the user's general
+    # PDS-upload preference + the interim-WAV deferral, which private uploads
+    # avoid by requiring a web-playable source at the endpoint).
+    if audio_info.is_private:
+        pass
+    elif audio_info.is_gated:
         return None
-
-    # the interim WAV rendition is large and throwaway — never push it to the
-    # user's PDS. the deferred optimize task writes the single canonical blob
-    # (the MP3) once. publishing now with audioUrl-only is an already-supported
-    # record shape (it's the same shape as the large-file R2-only fallback).
-    if sr.needs_optimization:
+    elif sr.needs_optimization:
+        # the interim WAV rendition is large and throwaway — never push it to the
+        # user's PDS. the deferred optimize task writes the single canonical blob
+        # (the MP3) once. publishing now with audioUrl-only is an already-supported
+        # record shape (it's the same shape as the large-file R2-only fallback).
         return None
-
-    async with db_session() as db:
-        allow_pds_upload = await _should_upload_pds_blob(db, ctx.artist_did)
-    if not allow_pds_upload:
-        return None
+    else:
+        async with db_session() as db:
+            allow_pds_upload = await _should_upload_pds_blob(db, ctx.artist_did)
+        if not allow_pds_upload:
+            return None
 
     content_type = sr.playable_format.media_type
     playable_ext = sr.playable_format.value
@@ -762,21 +791,32 @@ async def _create_records(
     ext = Path(ctx.filename).suffix.lower()
     playable_file_type = sr.playable_format.value if sr.playable_format else ext[1:]
 
-    # compute audio URL for ATProto record
-    if audio_info.is_gated:
+    created_at = datetime.now(UTC)
+    rkey = datetime_to_tid(created_at)
+    collection = settings.atproto.track_collection
+
+    # resolve where the record lives + its audio URL.
+    # private: record goes into the artist's permissioned space (ats:// URI, no
+    # public audio URL — the canonical audio is the PDS blob, required).
+    # gated: public repo record, audio proxied through the auth-protected backend.
+    # default: public repo record pointing at the public R2 URL.
+    space_uri: str | None = None
+    if ctx.private:
+        if not (pds_result and pds_result.blob_ref):
+            raise UploadPhaseError("private upload requires the audio blob on the PDS")
+        space_uri = await ensure_personal_space(ctx.auth_session)
+        audio_url_for_record = None
+        uri = build_record_uri(space_uri, ctx.artist_did, collection, rkey)
+    elif audio_info.is_gated:
         from urllib.parse import urljoin
 
         backend_url = settings.atproto.redirect_uri.rsplit("/", 2)[0]
         audio_url_for_record = urljoin(backend_url + "/", f"audio/{sr.file_id}")
+        uri = f"at://{ctx.artist_did}/{collection}/{rkey}"
     else:
         assert sr.r2_url is not None
         audio_url_for_record = sr.r2_url
-
-    # generate deterministic rkey and AT URI
-    created_at = datetime.now(UTC)
-    rkey = datetime_to_tid(created_at)
-    collection = settings.atproto.track_collection
-    uri = f"at://{ctx.artist_did}/{collection}/{rkey}"
+        uri = f"at://{ctx.artist_did}/{collection}/{rkey}"
 
     # step 1: reserve DB row as pending
     await job_service.update_progress(
@@ -859,10 +899,13 @@ async def _create_records(
             image_url=image_url,
             thumbnail_url=thumbnail_url,
             support_gate=ctx.support_gate,
-            unlisted=ctx.unlisted,
-            audio_storage=audio_storage,
+            # private tracks are never surfaced in discovery feeds
+            unlisted=ctx.unlisted or ctx.private,
+            audio_storage="pds" if ctx.private else audio_storage,
             pds_blob_cid=pds_result.cid if pds_result else None,
             pds_blob_size=pds_result.size if pds_result else None,
+            is_private=ctx.private,
+            space_uri=space_uri,
         )
 
         db.add(track)
@@ -888,25 +931,48 @@ async def _create_records(
         phase="atproto",
     )
     try:
-        atproto_result = await create_track_record(
-            auth_session=ctx.auth_session,
-            title=ctx.title,
-            artist=artist_display_name,
-            audio_url=audio_url_for_record,
-            file_type=playable_file_type,
-            album=ctx.album,
-            duration=audio_info.duration,
-            features=featured_artists or None,
-            image_url=image_url,
-            support_gate=ctx.support_gate,
-            audio_blob=pds_result.blob_ref if pds_result else None,
-            description=ctx.description,
-            rkey=rkey,
-            created_at=created_at,
-        )
-        if not atproto_result:
-            raise ValueError("PDS returned no record data")
-        _, atproto_cid = atproto_result
+        if ctx.private:
+            assert space_uri is not None and pds_result is not None
+            record = await build_track_record(
+                title=ctx.title,
+                artist=artist_display_name,
+                audio_url=None,
+                file_type=playable_file_type,
+                album=ctx.album,
+                duration=audio_info.duration,
+                features=featured_artists or None,
+                image_url=image_url,
+                audio_blob=pds_result.blob_ref,
+                description=ctx.description,
+                created_at=created_at,
+            )
+            _, atproto_cid = await create_space_record(
+                ctx.auth_session,
+                space=space_uri,
+                collection=collection,
+                record=record,
+                rkey=rkey,
+            )
+        else:
+            atproto_result = await create_track_record(
+                auth_session=ctx.auth_session,
+                title=ctx.title,
+                artist=artist_display_name,
+                audio_url=audio_url_for_record,
+                file_type=playable_file_type,
+                album=ctx.album,
+                duration=audio_info.duration,
+                features=featured_artists or None,
+                image_url=image_url,
+                support_gate=ctx.support_gate,
+                audio_blob=pds_result.blob_ref if pds_result else None,
+                description=ctx.description,
+                rkey=rkey,
+                created_at=created_at,
+            )
+            if not atproto_result:
+                raise ValueError("PDS returned no record data")
+            _, atproto_cid = atproto_result
     except Exception as e:
         # always include the exception type in the surfaced message — some
         # exception classes (notably httpx.RemoteProtocolError with an empty
@@ -1231,6 +1297,7 @@ async def run_track_upload(
     auto_tag: bool,
     unlisted: bool,
     copyright_rights: dict | None = None,
+    private: bool = False,
     concurrency: ConcurrencyLimit = ConcurrencyLimit("artist_did", max_concurrent=3),
 ) -> None:
     """docket task entry point for track uploads.
@@ -1267,11 +1334,10 @@ async def run_track_upload(
         # the upload can't proceed (no PDS to publish to) and won't recover
         # without a fresh sign-in, so clean up the staged storage objects
         # rather than leaving them as durable orphans.
-        is_gated = support_gate is not None
         await _delete_staged_audio(
             audio_file_id,
             Path(filename).suffix.lower().lstrip(".") or None,
-            gated=is_gated,
+            gated=support_gate is not None or private,
         )
         if image_id:
             with contextlib.suppress(Exception):
@@ -1304,6 +1370,7 @@ async def run_track_upload(
         copyright_rights=copyright_rights,
         auto_tag=auto_tag,
         unlisted=unlisted,
+        private=private,
     )
     await _process_upload_background(ctx)
 
@@ -1343,6 +1410,7 @@ async def schedule_track_upload(ctx: UploadContext) -> None:
         copyright_rights=ctx.copyright_rights,
         auto_tag=ctx.auto_tag,
         unlisted=ctx.unlisted,
+        private=ctx.private,
     )
 
 
@@ -1385,6 +1453,13 @@ async def upload_track(
         str | None,
         Form(
             description="set to 'true' to exclude from discovery feeds (latest, top, for-you)"
+        ),
+    ] = None,
+    private: Annotated[
+        str | None,
+        Form(
+            description="set to 'true' to store as private media in the artist's ATProto "
+            "permissioned space (requires a PDS that supports com.atproto.space.*)"
         ),
     ] = None,
     file: UploadFile = File(...),
@@ -1473,6 +1548,37 @@ async def upload_track(
             f"supported: {AudioFormat.supported_extensions_str()}",
         )
 
+    # private media: audio + record live in the artist's ATProto permissioned
+    # space. only available on a PDS that supports com.atproto.space.*, and only
+    # for web-playable sources (the blob is written at publish time; the deferred
+    # transcode path still targets the public repo — see the design note).
+    is_private = private == "true"
+    if is_private:
+        if parsed_support_gate is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="private and gated/copyright are mutually exclusive",
+            )
+        if not await detect_permissioned_capability(auth_session):
+            raise HTTPException(
+                status_code=400,
+                detail="your PDS does not support permissioned spaces (private media)",
+            )
+        # writing to a space needs the granted space scope (the capability probe
+        # passes without it). signal the frontend to run the opt-in scope upgrade.
+        if settings.atproto.private_media_space_scope not in (
+            auth_session.oauth_session or {}
+        ).get("scope", ""):
+            raise HTTPException(status_code=403, detail="permissioned_scope_required")
+        if not audio_format.is_web_playable:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"private media currently supports web-playable audio only "
+                    f"({ext} needs transcoding); convert to mp3/wav/m4a/flac first"
+                ),
+            )
+
     # stage audio + image to shared object storage BEFORE enqueueing the
     # docket task. only stable file_ids travel over Redis to the worker —
     # docket workers are not co-located with the request handler in
@@ -1487,6 +1593,9 @@ async def upload_track(
         JobType.UPLOAD, auth_session.did, "upload queued for processing"
     )
     is_gated = parsed_support_gate is not None
+    # private media also lives off the public bucket — stage it privately so no
+    # public object is ever created (the canonical audio is the PDS blob).
+    stage_private = is_gated or is_private
     audio_extension = ext.lstrip(".") or None
 
     file_path: str | None = None
@@ -1520,7 +1629,7 @@ async def upload_track(
         # stage audio bytes to shared storage
         with open(file_path, "rb") as f:
             audio_file_id = await stage_audio_to_storage(
-                upload_id, f, file.filename, gated=is_gated
+                upload_id, f, file.filename, gated=stage_private
             )
 
         # record where the staged blob lives so the stuck-upload reaper can
@@ -1533,7 +1642,7 @@ async def upload_track(
                 upload_id,
                 file_id=audio_file_id,
                 file_type=audio_extension,
-                is_gated=is_gated,
+                is_gated=stage_private,
             )
 
         # stage image bytes to shared storage (best-effort; missing or
@@ -1575,6 +1684,7 @@ async def upload_track(
             copyright_rights=parsed_copyright,
             auto_tag=auto_tag == "true",
             unlisted=unlisted == "true",
+            private=is_private,
         )
         await schedule_track_upload(ctx)
         enqueued = True
@@ -1582,7 +1692,7 @@ async def upload_track(
         if not enqueued:
             if audio_file_id:
                 await _delete_staged_audio(
-                    audio_file_id, audio_extension, gated=is_gated
+                    audio_file_id, audio_extension, gated=stage_private
                 )
             if image_id:
                 with contextlib.suppress(Exception):

--- a/backend/src/backend/api/users.py
+++ b/backend/src/backend/api/users.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from backend._internal import Session, get_optional_session
+from backend._internal.track_visibility import track_visible_filter, viewer_did
 from backend.models import Artist, Track, TrackLike, get_db
 from backend.schemas import TrackResponse
 from backend.utilities.aggregations import get_comment_counts, get_like_counts
@@ -59,6 +60,8 @@ async def get_user_liked_tracks(
         .join(Artist, Artist.did == Track.artist_did)
         .options(selectinload(Track.artist), selectinload(Track.album_rel))
         .where(TrackLike.user_did == artist.did)
+        # a private track this user liked is shown only to that track's owner
+        .where(track_visible_filter(viewer_did(session)))
         .order_by(TrackLike.created_at.desc())
     )
 
@@ -90,11 +93,13 @@ async def get_user_liked_tracks(
         ]
     )
 
-    # get total like count for this user
+    # total like count — match the visible list (exclude others' private tracks)
     count_stmt = (
         select(func.count())
         .select_from(TrackLike)
+        .join(Track, Track.id == TrackLike.track_id)
         .where(TrackLike.user_did == artist.did)
+        .where(track_visible_filter(viewer_did(session)))
     )
     total_count = await db.scalar(count_stmt)
 

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -463,6 +463,24 @@ class AtprotoSettings(AppSettingsSection):
 
     @computed_field
     @property
+    def private_media_space_type(self) -> str:
+        """Permissioned-space type NSID for artist-owned private media.
+
+        the OAuth consent boundary for the permissioned-spaces private-media
+        feature; records inside reuse the public track collection lexicon.
+        """
+
+        return f"{self.app_namespace}.privateMedia"
+
+    @computed_field
+    @property
+    def private_media_space_scope(self) -> str:
+        """granular OAuth scope token granting access to the private-media space."""
+
+        return f"space:{self.private_media_space_type}"
+
+    @computed_field
+    @property
     def old_track_collection(self) -> str | None:
         """Collection name for old namespace, if migration is active."""
 
@@ -516,6 +534,7 @@ class AtprotoSettings(AppSettingsSection):
         teal_play: str | None = None,
         teal_status: str | None = None,
         indiemusi_tokens: list[str] | None = None,
+        permissioned_spaces: bool = False,
     ) -> str:
         """OAuth scope composed with optional integration extras.
 
@@ -523,6 +542,9 @@ class AtprotoSettings(AppSettingsSection):
             teal_play: teal.fm play collection NSID, present iff teal scopes wanted
             teal_status: teal.fm status collection NSID, present iff teal scopes wanted
             indiemusi_tokens: indiemusi paradigm scope tokens, present iff requested
+            permissioned_spaces: include the private-media space scope. only ever
+                requested as an opt-in upgrade for accounts on a PDS that supports
+                permissioned spaces (never in a base login).
 
         either teal pair must both be set or both be None.
         """
@@ -531,6 +553,8 @@ class AtprotoSettings(AppSettingsSection):
             parts.extend([f"repo:{teal_play}", f"repo:{teal_status}"])
         if indiemusi_tokens:
             parts.extend(indiemusi_tokens)
+        if permissioned_spaces:
+            parts.append(self.private_media_space_scope)
         return " ".join(parts)
 
 

--- a/backend/src/backend/models/track.py
+++ b/backend/src/backend/models/track.py
@@ -118,6 +118,16 @@ class Track(Base):
         JSONB(none_as_null=True), nullable=True, default=None
     )
 
+    # private media stored in an ATProto permissioned space (com.atproto.space.*).
+    # the audio blob + track record live in the artist's permissioned repo on their
+    # PDS; there is no public R2 copy and the track is excluded from discovery.
+    # space_uri is the 3-segment ats:// space URI; the record is reachable only
+    # through the space credential path. requires a PDS that supports spaces.
+    is_private: Mapped[bool] = mapped_column(
+        nullable=False, default=False, server_default="false"
+    )
+    space_uri: Mapped[str | None] = mapped_column(String, nullable=True)
+
     # copyright paradigm record pointers — set when the user has opted into a
     # copyright paradigm and filled out the rights form on upload/edit. AT-URIs
     # of records on the user's PDS (e.g. ch.indiemusi.alpha.song). pure

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -203,9 +203,15 @@ class TrackResponse(BaseModel):
                 artist_avatar_url=track.artist.avatar_url,
             )
 
-        # construct atproto record URL
+        # construct atproto record URL — only for public at:// records. private
+        # media uses an ats:// permissioned-space URI that parse_at_uri can't read
+        # and that has no public getRecord endpoint, so it has no record URL.
         atproto_record_url: str | None = None
-        if track.atproto_record_uri and pds_url:
+        if (
+            track.atproto_record_uri
+            and pds_url
+            and track.atproto_record_uri.startswith("at://")
+        ):
             from backend.config import settings
 
             _, _, rkey = parse_at_uri(track.atproto_record_uri)

--- a/backend/tests/_internal/test_permissioned_spaces.py
+++ b/backend/tests/_internal/test_permissioned_spaces.py
@@ -1,0 +1,157 @@
+"""unit tests for the permissioned-data spaces foundation (#1528).
+
+pure-logic + mocked-PDS-boundary tests for capability detection, ats:// URI
+helpers, the OAuth scope composition, and space-credential caching/renewal. the
+full data path is exercised against a live ZDS by scripts/permissioned_smoke.py.
+"""
+
+import pytest
+
+from backend._internal import Session
+from backend._internal.atproto.spaces import capability as cap
+from backend._internal.atproto.spaces import client as space_client
+from backend._internal.atproto.spaces.uris import (
+    build_record_uri,
+    build_space_uri,
+    parse_space_uri,
+)
+from backend.config import settings
+
+# --- ats:// URI helpers -------------------------------------------------------
+
+
+def test_space_and_record_uri_roundtrip():
+    space = build_space_uri("did:plc:abc", "fm.plyr.privateMedia", "self")
+    assert space == "ats://did:plc:abc/fm.plyr.privateMedia/self"
+
+    record = build_record_uri(space, "did:plc:abc", "fm.plyr.track", "rkey1")
+    assert record == (
+        "ats://did:plc:abc/fm.plyr.privateMedia/self/did:plc:abc/fm.plyr.track/rkey1"
+    )
+
+    # parse_space_uri returns the 3-segment space portion from either form
+    for uri in (space, record):
+        parsed = parse_space_uri(uri)
+        assert parsed.owner_did == "did:plc:abc"
+        assert parsed.space_type == "fm.plyr.privateMedia"
+        assert parsed.skey == "self"
+
+
+@pytest.mark.parametrize(
+    "bad", ["at://did:plc:abc/x/y", "ats://did:plc:abc", "ats://did:plc:abc//self", ""]
+)
+def test_parse_space_uri_rejects_malformed(bad):
+    with pytest.raises(ValueError):
+        parse_space_uri(bad)
+
+
+# --- capability probe interpretation -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        ("PDS request failed: 501 MethodNotImplemented", False),
+        ("PDS request failed: 404 UnknownMethod", False),
+        ("XRPCNotSupported", False),
+        ("PDS request failed: 400 InvalidRequest: Missing space", True),  # route ran
+        ("PDS request failed: 403 InsufficientScope", True),  # route ran
+        (
+            "PDS request failed: 503 upstream",
+            None,
+        ),  # transient -> fail closed, no cache
+        ("PDS request failed: 502 bad gateway", None),
+        ("totally opaque error", None),
+    ],
+)
+def test_classify_failure(message, expected):
+    assert cap._classify_failure(message) is expected
+
+
+async def test_detect_capability_supported(monkeypatch):
+    async def fake_request(*args, **kwargs):
+        return {"spaces": []}
+
+    monkeypatch.setattr(cap, "make_pds_request", fake_request)
+
+    session = Session(
+        session_id="s",
+        did="did:plc:x",
+        handle="x.test",
+        oauth_session={"pds_url": "https://probe-supported.test"},
+    )
+    assert await cap.detect_permissioned_capability(session) is True
+
+
+async def test_detect_capability_unsupported(monkeypatch):
+    async def fake_request(*args, **kwargs):
+        raise Exception("PDS request failed: 501 MethodNotImplemented")
+
+    monkeypatch.setattr(cap, "make_pds_request", fake_request)
+
+    session = Session(
+        session_id="s",
+        did="did:plc:x",
+        handle="x.test",
+        oauth_session={"pds_url": "https://probe-unsupported.test"},
+    )
+    assert await cap.detect_permissioned_capability(session) is False
+
+
+async def test_detect_capability_transient_fails_closed(monkeypatch):
+    async def fake_request(*args, **kwargs):
+        raise Exception("PDS request failed: 503 upstream")
+
+    monkeypatch.setattr(cap, "make_pds_request", fake_request)
+
+    session = Session(
+        session_id="s",
+        did="did:plc:x",
+        handle="x.test",
+        oauth_session={"pds_url": "https://probe-transient.test"},
+    )
+    assert await cap.detect_permissioned_capability(session) is False
+
+
+# --- OAuth scope composition --------------------------------------------------
+
+
+def test_permissioned_scope_opt_in_only():
+    base = settings.atproto.resolved_scope_with_extras()
+    assert settings.atproto.private_media_space_scope not in base
+
+    with_perm = settings.atproto.resolved_scope_with_extras(permissioned_spaces=True)
+    assert settings.atproto.private_media_space_scope in with_perm
+    assert settings.atproto.private_media_space_scope == "space:fm.plyr.privateMedia"
+
+
+# --- space credential caching + renewal ---------------------------------------
+
+
+async def test_space_credential_cache_and_force_refresh(monkeypatch):
+    space_client._credential_cache.clear()
+    calls = {"n": 0}
+
+    async def fake_mint(auth_session, space):
+        calls["n"] += 1
+        return f"cred-{calls['n']}"
+
+    monkeypatch.setattr(space_client, "_mint_credential", fake_mint)
+    session = Session(
+        session_id="s",
+        did="did:plc:x",
+        handle="x.test",
+        oauth_session={"pds_url": "https://x"},
+    )
+    space = "ats://did:plc:x/fm.plyr.privateMedia/self"
+
+    first = await space_client.get_space_credential(session, space)
+    cached = await space_client.get_space_credential(session, space)
+    assert first == cached == "cred-1"
+    assert calls["n"] == 1  # second call served from cache
+
+    renewed = await space_client.get_space_credential(
+        session, space, force_refresh=True
+    )
+    assert renewed == "cred-2"
+    assert calls["n"] == 2

--- a/backend/tests/api/test_private_media_upload.py
+++ b/backend/tests/api/test_private_media_upload.py
@@ -1,0 +1,126 @@
+"""upload-endpoint preflight gating for private (permissioned-space) media (#1528).
+
+these assertions all trip BEFORE any audio staging / docket enqueue, so they
+exercise the real endpoint gating without the full pipeline. the end-to-end space
+write/read is covered against a live ZDS by scripts/permissioned_smoke.py.
+"""
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import Session, require_artist_profile
+from backend.config import settings
+from backend.main import app
+
+PERM_SCOPE = settings.atproto.private_media_space_scope
+
+
+class _MockSession(Session):
+    def __init__(self, *, with_space_scope: bool = False) -> None:
+        self.did = "did:test:artist"
+        self.handle = "artist.test"
+        self.session_id = "test_session_private_media"
+        scopes = ["atproto", "transition:generic"]
+        if with_space_scope:
+            scopes.append(PERM_SCOPE)
+        self.oauth_session = {
+            "did": self.did,
+            "handle": self.handle,
+            "pds_url": "https://test.pds",
+            "scope": " ".join(scopes),
+            "access_token": "t",
+            "refresh_token": "r",
+            "dpop_private_key_pem": "fake",
+            "dpop_authserver_nonce": "",
+            "dpop_pds_nonce": "",
+        }
+
+
+def _auth_app(*, with_space_scope: bool) -> Generator[FastAPI, None, None]:
+    async def _profile() -> Session:
+        return _MockSession(with_space_scope=with_space_scope)
+
+    app.dependency_overrides[require_artist_profile] = _profile
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def app_no_scope(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
+    yield from _auth_app(with_space_scope=False)
+
+
+@pytest.fixture
+def app_with_scope(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
+    yield from _auth_app(with_space_scope=True)
+
+
+# minimal RIFF/WAVE header — web-playable; enough to pass extension routing
+_WAV = b"RIFF\x24\x00\x00\x00WAVEfmt private-media-test"
+
+
+def _post(client: TestClient, *, filename: str = "t.wav", data: dict) -> httpx.Response:
+    return client.post(
+        "/tracks/",
+        files={"file": (filename, _WAV, "audio/wav")},
+        data={"title": "private test", **data},
+    )
+
+
+def test_private_requires_pds_capability(app_no_scope: FastAPI):
+    with (
+        patch(
+            "backend.api.tracks.uploads.detect_permissioned_capability",
+            return_value=False,
+        ),
+        TestClient(app_no_scope) as client,
+    ):
+        resp = _post(client, data={"private": "true"})
+    assert resp.status_code == 400
+    assert "permissioned spaces" in resp.json()["detail"]
+
+
+def test_private_capable_but_scope_missing_requests_upgrade(app_no_scope: FastAPI):
+    with (
+        patch(
+            "backend.api.tracks.uploads.detect_permissioned_capability",
+            return_value=True,
+        ),
+        TestClient(app_no_scope) as client,
+    ):
+        resp = _post(client, data={"private": "true"})
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "permissioned_scope_required"
+
+
+def test_private_rejects_non_web_playable(app_with_scope: FastAPI):
+    with (
+        patch(
+            "backend.api.tracks.uploads.detect_permissioned_capability",
+            return_value=True,
+        ),
+        TestClient(app_with_scope) as client,
+    ):
+        resp = client.post(
+            "/tracks/",
+            files={"file": ("t.aiff", _WAV, "audio/aiff")},
+            data={"title": "x", "private": "true"},
+        )
+    assert resp.status_code == 400
+    assert "web-playable" in resp.json()["detail"]
+
+
+def test_private_and_gated_mutually_exclusive(app_with_scope: FastAPI):
+    # support_gate + private is rejected before any capability check
+    with TestClient(app_with_scope) as client:
+        resp = _post(
+            client, data={"private": "true", "support_gate": '{"type": "any"}'}
+        )
+    assert resp.status_code == 400
+    assert "mutually exclusive" in resp.json()["detail"]

--- a/backend/tests/api/test_private_media_visibility.py
+++ b/backend/tests/api/test_private_media_visibility.py
@@ -1,0 +1,104 @@
+"""private (permissioned-space) media must not leak through public surfaces (#1528).
+
+private tracks set is_private=True (and unlisted=True). they must be excluded from
+public search and from an artist page viewed by anyone but the owner, and must
+serialize without tripping over their ats:// record URI.
+"""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from backend._internal import Session
+from backend.api.search import _search_tracks
+from backend.api.tracks.listing import list_tracks
+from backend.models import Artist, Track
+from backend.schemas import TrackResponse
+
+_DID = "did:test:private-vis"
+
+
+def _session(did: str) -> Session:
+    s = Session.__new__(Session)
+    s.did = did
+    s.handle = "owner.test"
+    s.session_id = "sess"
+    s.oauth_session = {"did": did, "pds_url": "https://test.pds"}
+    return s
+
+
+@pytest.fixture
+async def artist(db_session: AsyncSession) -> Artist:
+    artist = Artist(did=_DID, handle="privvis.test", display_name="Priv Vis")
+    db_session.add(artist)
+    await db_session.commit()
+    return artist
+
+
+async def _make_track(db_session: AsyncSession, *, title: str, fid: str, private: bool):
+    track = Track(
+        title=title,
+        artist_did=_DID,
+        file_id=fid,
+        file_type="mp3",
+        is_private=private,
+        unlisted=private,
+        space_uri=(f"ats://{_DID}/fm.plyr.privateMedia/self" if private else None),
+        atproto_record_uri=(
+            f"ats://{_DID}/fm.plyr.privateMedia/self/{_DID}/fm.plyr.track/rk"
+            if private
+            else f"at://{_DID}/fm.plyr.track/rk"
+        ),
+    )
+    db_session.add(track)
+    await db_session.commit()
+    return track
+
+
+async def test_search_excludes_private(db_session: AsyncSession, artist: Artist):
+    await _make_track(db_session, title="ztitle public", fid="pv_pub", private=False)
+    await _make_track(db_session, title="ztitle private", fid="pv_priv", private=True)
+
+    results = await _search_tracks(db_session, "ztitle", 20)
+    titles = {r.title for r in results}
+    assert "ztitle public" in titles
+    assert "ztitle private" not in titles
+
+
+async def test_artist_page_hides_private_from_non_owner(
+    db_session: AsyncSession, artist: Artist
+):
+    await _make_track(db_session, title="ypublic", fid="ap_pub", private=False)
+    await _make_track(db_session, title="yprivate", fid="ap_priv", private=True)
+
+    # anonymous / other viewer: private excluded
+    anon = await list_tracks(db_session, artist_did=_DID, session=None)
+    assert "yprivate" not in {t.title for t in anon.tracks}
+    assert "ypublic" in {t.title for t in anon.tracks}
+
+    other = await list_tracks(
+        db_session, artist_did=_DID, session=_session("did:test:someone-else")
+    )
+    assert "yprivate" not in {t.title for t in other.tracks}
+
+    # owner sees their own private track
+    owner = await list_tracks(db_session, artist_did=_DID, session=_session(_DID))
+    assert "yprivate" in {t.title for t in owner.tracks}
+
+
+async def test_private_track_serializes_without_at_uri_crash(
+    db_session: AsyncSession, artist: Artist
+):
+    await _make_track(db_session, title="serial", fid="ser_priv", private=True)
+    # reload with relationships the way the real list/serialize paths do
+    track = (
+        await db_session.execute(
+            select(Track)
+            .options(selectinload(Track.artist), selectinload(Track.album_rel))
+            .where(Track.file_id == "ser_priv")
+        )
+    ).scalar_one()
+    # passing a pds_url used to push the ats:// URI through parse_at_uri and raise
+    resp = await TrackResponse.from_track(track, pds_url="https://test.pds")
+    assert resp.atproto_record_url is None

--- a/backend/tests/api/test_private_media_visibility.py
+++ b/backend/tests/api/test_private_media_visibility.py
@@ -102,3 +102,61 @@ async def test_private_track_serializes_without_at_uri_crash(
     # passing a pds_url used to push the ats:// URI through parse_at_uri and raise
     resp = await TrackResponse.from_track(track, pds_url="https://test.pds")
     assert resp.atproto_record_url is None
+
+
+# --- centralized helper (the chokepoint every endpoint routes through) --------
+
+
+def test_visibility_helper_rules():
+    from fastapi import HTTPException
+
+    from backend._internal.track_visibility import can_view_track, ensure_track_visible
+
+    public = Track(title="p", artist_did=_DID, file_id="h_pub", file_type="mp3")
+    private = Track(
+        title="x", artist_did=_DID, file_id="h_priv", file_type="mp3", is_private=True
+    )
+
+    # public: anyone
+    assert can_view_track(None, public)
+    assert can_view_track("did:test:other", public)
+    # private: owner only
+    assert can_view_track(_DID, private)
+    assert not can_view_track(None, private)
+    assert not can_view_track("did:test:other", private)
+
+    ensure_track_visible(private, _DID)  # owner: no raise
+    for did in (None, "did:test:other"):
+        with pytest.raises(HTTPException) as exc:
+            ensure_track_visible(private, did)
+        assert exc.value.status_code == 404
+
+
+# --- endpoint proof: GET /tracks/{id} is the headline leak --------------------
+
+
+async def test_track_detail_endpoint_owner_only_for_private(
+    db_session: AsyncSession, artist: Artist
+):
+    from fastapi.testclient import TestClient
+
+    from backend._internal import get_optional_session
+    from backend.main import app
+
+    track = await _make_track(db_session, title="detail", fid="det_priv", private=True)
+
+    async def _anon() -> Session | None:
+        return None
+
+    async def _owner() -> Session | None:
+        return _session(_DID)
+
+    app.dependency_overrides[get_optional_session] = _anon
+    try:
+        with TestClient(app) as client:
+            assert client.get(f"/tracks/{track.id}").status_code == 404
+        app.dependency_overrides[get_optional_session] = _owner
+        with TestClient(app) as client:
+            assert client.get(f"/tracks/{track.id}").status_code == 200
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/api/test_scope_upgrade.py
+++ b/backend/tests/api/test_scope_upgrade.py
@@ -71,7 +71,14 @@ async def test_start_scope_upgrade_flow(test_app: FastAPI, db_session: AsyncSess
         data = response.json()
         assert "auth_url" in data
         assert data["auth_url"].startswith("https://auth.example.com")
-        mock_oauth.assert_called_once_with("testuser.bsky.social", include_teal=True)
+        # a scope upgrade preserves every scope the session already has; this
+        # session has neither indiemusi nor the permissioned-space scope.
+        mock_oauth.assert_called_once_with(
+            "testuser.bsky.social",
+            include_teal=True,
+            include_indiemusi=False,
+            include_permissioned=False,
+        )
 
 
 async def test_start_scope_upgrade_default_includes_teal(
@@ -92,7 +99,14 @@ async def test_start_scope_upgrade_default_includes_teal(
             )
 
         assert response.status_code == 200
-        mock_oauth.assert_called_once_with("testuser.bsky.social", include_teal=True)
+        # a scope upgrade preserves every scope the session already has; this
+        # session has neither indiemusi nor the permissioned-space scope.
+        mock_oauth.assert_called_once_with(
+            "testuser.bsky.social",
+            include_teal=True,
+            include_indiemusi=False,
+            include_permissioned=False,
+        )
 
 
 async def test_scope_upgrade_requires_auth(db_session: AsyncSession):

--- a/docs/internal/architecture/permissioned-private-media.md
+++ b/docs/internal/architecture/permissioned-private-media.md
@@ -1,0 +1,119 @@
+# private media on permissioned spaces (design note)
+
+resolves #1528. proves a minimum-viable **private-media** workflow on the experimental
+ATProto permissioned-data surface (`com.atproto.space.*`), engaging only for accounts
+whose PDS implements it. ports cleanly from today's public track flow: the record body
+is the same `fm.plyr.track` lexicon — only the write target (a permissioned space repo)
+and the read auth (a space credential) differ.
+
+## the first space type, and why it's the smallest meaningful one
+
+`fm.plyr.privateMedia` (env-aware: `fm.plyr.dev.privateMedia` in dev). One artist-owned
+personal space, `skey = "self"`. It holds **only** private audio — nothing else.
+
+This narrowness is the point: per diary 6, granting an app a credential grants
+**whole-space** read access, not per-record. So the space type *is* the privacy boundary.
+Bundling drafts, proofs, DMs, or analytics into one space would mean one plyr.fm grant
+exposes all of them. Private audio is the smallest slice that proves the end-to-end flow
+(discover → space → blob → record → credential → playback) while keeping the blast radius
+of a grant to exactly "this artist's private tracks."
+
+## capability check (now, and the standards-shaped replacement)
+
+No PDS advertises permissioned-space support declaratively — not `describeServer`, not
+`.well-known`, not OAuth metadata. ZDS's `openapi.json` (with `x-zds-experimental: true`)
+is vendor-specific and brittle, and the issue explicitly says not to lock onto it.
+
+**Now:** an authenticated *method probe* — `com.atproto.space.listSpaces`. The method
+dispatching for real (`200`, or a genuine `InvalidRequest`/`InsufficientScope`/auth error)
+means supported; `404`/`501` or `MethodNotImplemented`/`UnknownMethod`/`XRPCNotSupported`
+means unsupported. The probe must be authenticated: an unauthenticated call can't tell a
+supporting PDS from a vanilla one, because PDS auth middleware returns `401` before method
+routing (verified: `bsky.social` and a permissioned ZDS both `401` unauthenticated).
+Result is cached per-PDS in Redis (6h) and surfaced on `/auth/me` as
+`permissioned_spaces.supported`, which gates all UI. Code:
+`backend/_internal/atproto/spaces/capability.py`.
+
+**Later:** when the protocol defines a declarative capability (likely a `describeServer`
+field), swap it in behind the same `detect_permissioned_capability()` function — the one
+isolation point.
+
+## owner model, initial members, and plyr.fm's client ID
+
+- **Owner DID = artist DID.** Personal namespaces use the user's own DID (diary 5); no
+  dedicated space DID is needed until ownership must transfer (shared/gated spaces).
+- **Members:** exactly one — the artist, auto-added as the owner. The member list is the
+  read ACL; write legitimacy is app policy (below).
+- **plyr.fm's OAuth client ID is default-allowed.** The space is created with
+  `appAccessMode: "allow"` and empty `appExceptions`, so any OAuth client (including
+  plyr.fm) may obtain a credential. A future shared-space pass can flip to an allow-list.
+  ZDS binds the issued credential to the requesting client ID and enforces
+  `spaceAllowsClient` at `getSpaceCredential` time.
+
+## the read path: OAuth → member grant → space credential (with renewal/errors)
+
+1. `getMemberGrant?space=<uri>` — authenticated with the user's **OAuth (DPoP)** token via
+   `make_pds_request`. Returns a short-lived, one-use grant signed by the member's PDS,
+   bound to plyr.fm's client ID.
+2. `getSpaceCredential` (POST) — authenticated with the grant as a **plain Bearer** token
+   (grants/credentials are JWTs, *not* DPoP-bound, so they bypass `make_pds_request`'s DPoP
+   path via a raw-bearer helper). Returns an owner-signed space credential (~hours TTL,
+   client-ID-bound), verifiable offline by any member PDS.
+3. reads (`getRecord`/`listRecords`/`getBlob`) accept the credential as a plain Bearer
+   token.
+
+**Renewal:** credentials are cached per `(space, client_id)` for ~50 min; a read that gets
+`401`/`InvalidToken` triggers one re-mint (grant → credential) and retry.
+**Errors:** `AppNotPermitted` / `NotAMember` / `SpaceDeleted` surface as a typed
+`SpaceAccessError`; `getSpaceCredential` requires the member DID to be PLC-resolvable (the
+owner's PDS verifies the grant signature). Code: `backend/_internal/atproto/spaces/client.py`.
+
+## the record, and how it references the blob
+
+The audio blob is uploaded to the artist's PDS blobstore with the standard
+`com.atproto.repo.uploadBlob`. The record reuses the **existing `fm.plyr.track` lexicon**
+body (`build_track_record`) with `audioBlob` set and `audioUrl` omitted (no public URL
+exists for private media), written into the space repo via `com.atproto.space.createRecord`
+(`putRecord` for idempotent retries). The resulting record URI is the 6-segment
+`ats://<ownerDid>/<spaceType>/<skey>/<authorDid>/fm.plyr.track/<rkey>`.
+
+## playback via getBlob / range
+
+Private tracks have no CDN URL. The backend stream endpoint obtains a space credential and
+proxies `com.atproto.space.getBlob?space=&repo=&cid=`, **passing the client's `Range`
+header through** and relaying the `206`/`Content-Range`/`Content-Type`/`Content-Length` so
+seeking works (verified `206` ranged reads against a live ZDS).
+
+## app-layer write legitimacy
+
+The protocol no longer encodes write access (diary 6) — only a read member list. So
+plyr.fm enforces, in app/indexer logic, that **only the record's author DID (== the signed-in
+artist) may publish, edit, or delete** records in their private-media space. For this
+single-member personal space that's simply "owner only." Shared/gated spaces will need
+richer write/role policy.
+
+## ZDS endpoints plyr.fm depends on (MVP)
+
+`createSpace`, `getSpace`/`listSpaces` (capability probe + idempotent ensure),
+`com.atproto.repo.uploadBlob`, `space.createRecord`/`putRecord`, `space.getRecord`,
+`space.listRecords`, `space.getMemberGrant`, `space.getSpaceCredential`, `space.getBlob`
+(with Range). All exist in the current ZDS source; the data path
+(`createSpace`→`uploadBlob`→`createRecord`→`getRecord`/`listRecords`→`getBlob` ranged) is
+verified against a local `ZDS_PERMISSIONED_DATA=true` build by `scripts/permissioned_smoke.py`.
+
+## why shared/gated follow-ups need their own model
+
+Supporter-gated, label-managed, or community spaces are **not** this MVP scaled up. They
+need: a **dedicated space DID** (so ownership can transfer without breaking references), an
+**arbiter / space host** (e.g. atprotofans) to manage membership, and **app-layer write/role
+rules** above the protocol. They must not reuse the personal-space MVP unchanged. Tracked
+alongside #564 (supporter gating) and #642 (time-release) on the permissioned-data substrate
+(#1384).
+
+## deferred (this PR)
+
+- Non-web-playable private uploads: today's pipeline defers the canonical MP3 to the
+  `optimize_track_audio` task, which writes the blob to the *public* repo. Routing that
+  deferred write into the space is a follow-up; the MVP path covers web-playable audio
+  (mp3/wav/m4a/flac), where the blob is written at publish time.
+- Multi-member sync (member/repo oplogs, SetHash) — single-member spaces don't need it.

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -80,6 +80,8 @@ export interface User {
 	handle: string;
 	linked_accounts: LinkedAccount[];
 	enabled_flags: string[];
+	// whether the user's PDS supports ATProto permissioned spaces (private media)
+	permissioned_spaces?: { supported: boolean };
 }
 
 export interface Artist {

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -36,6 +36,30 @@ function isMobileDevice(): boolean {
 
 const MOBILE_LARGE_FILE_THRESHOLD_MB = 50;
 
+/**
+ * Start the one-time OAuth scope upgrade that grants the permissioned-space
+ * (private media) scope, then redirect to the authorization URL. After the user
+ * returns, they retry the upload with the scope granted.
+ */
+async function startPermissionedScopeUpgrade(): Promise<void> {
+	toast.info('one-time approval needed to store private media on your PDS...', 6000);
+	try {
+		const res = await fetch(`${API_URL}/auth/scope-upgrade/start`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			credentials: 'include',
+			// include_teal:false → the backend re-derives existing scopes from the
+			// current session and only ADDS permissioned (doesn't force teal on).
+			body: JSON.stringify({ include_teal: false, include_permissioned: true })
+		});
+		if (!res.ok) throw new Error(`scope upgrade failed (${res.status})`);
+		const data = await res.json();
+		if (browser && data.auth_url) window.location.href = data.auth_url;
+	} catch {
+		toast.error('could not start the approval needed for private media');
+	}
+}
+
 function buildNetworkErrorMessage(progressPercent: number, fileSizeMB: number, isMobile: boolean): string {
 	const progressInfo = progressPercent > 0 ? ` (failed at ${progressPercent}%)` : '';
 
@@ -83,7 +107,8 @@ class UploaderState {
 		label?: string,
 		albumId?: string,
 		unlisted?: boolean,
-		copyright?: object | null
+		copyright?: object | null,
+		isPrivate?: boolean
 	): void {
 		const taskId = crypto.randomUUID();
 		const fileSizeMB = file.size / 1024 / 1024;
@@ -137,6 +162,9 @@ class UploaderState {
 		}
 		if (unlisted) {
 			formData.append('unlisted', 'true');
+		}
+		if (isPrivate) {
+			formData.append('private', 'true');
 		}
 
 		const xhr = new XMLHttpRequest();
@@ -259,6 +287,12 @@ class UploaderState {
 				let errorMsg = `upload failed (${xhr.status} ${xhr.statusText})`;
 				try {
 					const error = JSON.parse(xhr.responseText);
+					// private media needs the permissioned-space scope granted — kick
+					// off the one-time opt-in upgrade, then the user retries the upload.
+					if (xhr.status === 403 && error.detail === 'permissioned_scope_required') {
+						void startPermissionedScopeUpgrade();
+						return;
+					}
 					errorMsg = error.detail || errorMsg;
 				} catch {
 					if (xhr.status === 0) {

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -72,6 +72,12 @@
 	let supportGated = $state(false);
 	let autoTag = $state(false);
 	let trackUnlisted = $state(false);
+	// private media — stored in the artist's ATProto permissioned space. only
+	// offered when the user's PDS supports com.atproto.space.* (see /auth/me).
+	let keepPrivate = $state(false);
+	const permissionedSupported = $derived(
+		auth.user?.permissioned_spaces?.supported ?? false
+	);
 	// copyright rights metadata — mutually exclusive with supporter gating.
 	// when enabled, audio is uploaded to private storage and the backend writes
 	// indiemusi song + recording records after the track is published.
@@ -212,6 +218,7 @@
 			supportGated = false;
 			autoTag = false;
 			trackUnlisted = false;
+			keepPrivate = false;
 			copyrightEnabled = false;
 			copyrightRights = {};
 
@@ -252,6 +259,7 @@
 			undefined, // albumId
 			isUnlisted,
 			copyrightToSend,
+			keepPrivate,
 		);
 	}
 
@@ -516,6 +524,20 @@
 					</p>
 				{/if}
 			</div>
+
+			{#if permissionedSupported}
+				<div class="form-group">
+					<label class="checkbox-label">
+						<input type="checkbox" bind:checked={keepPrivate} />
+						<span class="checkbox-text">keep private — store in your permissioned space</span>
+					</label>
+					{#if keepPrivate}
+						<p class="field-hint">
+							the audio and its record live in a private space on your PDS — no public copy, not shown in feeds, and playable only by you. your PDS supports this experimental ATProto feature. you'll be asked once to approve private-media access.
+						</p>
+					{/if}
+				</div>
+			{/if}
 
 			<div class="form-group attestation">
 				<label class="checkbox-label">

--- a/lexicons/privateMedia.json
+++ b/lexicons/privateMedia.json
@@ -1,0 +1,19 @@
+{
+  "lexicon": 1,
+  "id": "fm.plyr.privateMedia",
+  "defs": {
+    "main": {
+      "type": "permission-set",
+      "title": "plyr.fm Private Media",
+      "detail": "An artist-owned permissioned-data space for private audio. Granting plyr.fm access lets it read and sync the WHOLE space (every record and blob in it), so this space is kept narrow: it holds only private media records. Records reuse the fm.plyr.track lexicon; the audio blob lives in the artist's permissioned repo on their PDS, not in public storage.",
+      "permissions": [
+        {
+          "type": "permission",
+          "resource": "space",
+          "action": ["read", "create", "update", "delete"],
+          "collection": ["fm.plyr.track"]
+        }
+      ]
+    }
+  }
+}

--- a/loq.toml
+++ b/loq.toml
@@ -28,7 +28,7 @@ max_lines = 896
 
 [[rules]]
 path = "backend/src/backend/api/auth.py"
-max_lines = 826
+max_lines = 862
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
@@ -44,7 +44,7 @@ max_lines = 1692
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 1085
+max_lines = 1109
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
@@ -288,7 +288,7 @@ max_lines = 617
 
 [[rules]]
 path = "backend/src/backend/_internal/auth/oauth.py"
-max_lines = 549
+max_lines = 559
 
 [[rules]]
 path = "frontend/src/lib/components/CopyrightSection.svelte"

--- a/loq.toml
+++ b/loq.toml
@@ -32,7 +32,7 @@ max_lines = 862
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
-max_lines = 596
+max_lines = 601
 
 [[rules]]
 path = "backend/src/backend/api/tracks/mutations.py"
@@ -256,7 +256,7 @@ max_lines = 1050
 
 [[rules]]
 path = "backend/src/backend/api/tracks/audio_replace.py"
-max_lines = 825
+max_lines = 836
 
 [[rules]]
 path = "backend/tests/conftest.py"

--- a/loq.toml
+++ b/loq.toml
@@ -40,7 +40,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1692
+max_lines = 1787
 
 [[rules]]
 path = "backend/src/backend/config.py"
@@ -176,7 +176,7 @@ max_lines = 1299
 
 [[rules]]
 path = "frontend/src/routes/upload/+page.svelte"
-max_lines = 905
+max_lines = 927
 
 [[rules]]
 path = "services/moderation/src/admin.rs"

--- a/scripts/permissioned_smoke.py
+++ b/scripts/permissioned_smoke.py
@@ -1,0 +1,202 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["httpx", "python-dotenv"]
+# ///
+"""end-to-end smoke for the permissioned-spaces private-media flow against a live PDS.
+
+exercises the exact com.atproto.space.* request/response shapes the plyr.fm space
+client uses, proving private records + blobs actually store and read back through the
+permissioned-space access path. uses a plain createSession bearer (scope
+com.atproto.access bypasses ZDS granular space-scope checks) so it can run without the
+full OAuth/DPoP plumbing.
+
+run: uv run scripts/permissioned_smoke.py
+needs ZAT_TEST_HANDLE / ZAT_TEST_PASSWORD / ZAT_TEST_PDS in .env (a test account on a
+ZDS_PERMISSIONED_DATA=true instance).
+"""
+
+import os
+import sys
+
+import httpx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+PDS = os.environ["ZAT_TEST_PDS"].rstrip("/")
+HANDLE = os.environ["ZAT_TEST_HANDLE"]
+PASSWORD = os.environ["ZAT_TEST_PASSWORD"]
+
+# dev namespace — mirrors ATPROTO_APP_NAMESPACE=fm.plyr.dev locally
+SPACE_TYPE = "fm.plyr.dev.privateMedia"
+COLLECTION = "fm.plyr.dev.track"
+SKEY = "self"
+CLIENT_ID = "did:web:plyr.fm"
+
+
+def xrpc(
+    client: httpx.Client, method: str, name: str, *, token: str, **kw
+) -> httpx.Response:
+    headers = {"authorization": f"Bearer {token}"}
+    url = f"{PDS}/xrpc/{name}"
+    if method == "GET":
+        return client.get(url, headers=headers, params=kw.get("params"))
+    return client.post(url, headers=headers, json=kw.get("json"))
+
+
+def main() -> int:
+    c = httpx.Client(timeout=30)
+
+    session = c.post(
+        f"{PDS}/xrpc/com.atproto.server.createSession",
+        json={"identifier": HANDLE, "password": PASSWORD},
+    )
+    session.raise_for_status()
+    did = session.json()["did"]
+    token = session.json()["accessJwt"]
+    print(f"✓ session  did={did}")
+
+    space_uri = f"ats://{did}/{SPACE_TYPE}/{SKEY}"
+
+    # capability probe: listSpaces should dispatch for real
+    probe = xrpc(
+        c,
+        "GET",
+        "com.atproto.space.listSpaces",
+        token=token,
+        params={"did": did, "type": SPACE_TYPE},
+    )
+    assert probe.status_code == 200, (
+        f"capability probe failed: {probe.status_code} {probe.text}"
+    )
+    print("✓ capability probe → supported")
+
+    # upload a tiny audio blob to the account blobstore (standard repo.uploadBlob)
+    audio = b"RIFF\x24\x00\x00\x00WAVEfmt private-media smoke"
+    blob = c.post(
+        f"{PDS}/xrpc/com.atproto.repo.uploadBlob",
+        headers={"authorization": f"Bearer {token}", "content-type": "audio/wav"},
+        content=audio,
+    )
+    blob.raise_for_status()
+    blob_ref = blob.json()["blob"]
+    blob_cid = blob_ref["ref"]["$link"]
+    print(f"✓ uploadBlob  cid={blob_cid}")
+
+    # create (or find) the personal private-media space
+    created = xrpc(
+        c,
+        "POST",
+        "com.atproto.space.createSpace",
+        token=token,
+        json={
+            "did": did,
+            "type": SPACE_TYPE,
+            "skey": SKEY,
+            "managingApp": CLIENT_ID,
+            "isPublic": False,
+            "appAccessMode": "allow",
+            "appExceptions": [],
+        },
+    )
+    if created.status_code == 400 and "SpaceAlreadyExists" in created.text:
+        print("✓ createSpace → already exists (idempotent)")
+    else:
+        created.raise_for_status()
+        assert created.json()["uri"] == space_uri, created.text
+        print(f"✓ createSpace  uri={space_uri}")
+
+    # write the private track record (reuses the fm.plyr track lexicon body)
+    record = {
+        "$type": COLLECTION,
+        "title": "private smoke",
+        "artist": HANDLE,
+        "fileType": "wav",
+        "createdAt": "2026-06-07T00:00:00Z",
+        "audioBlob": blob_ref,
+    }
+    rec = xrpc(
+        c,
+        "POST",
+        "com.atproto.space.createRecord",
+        token=token,
+        json={
+            "space": space_uri,
+            "repo": did,
+            "collection": COLLECTION,
+            "rkey": "smoke-one",
+            "record": record,
+        },
+    )
+    rec.raise_for_status()
+    rec_uri = rec.json()["uri"]
+    assert rec_uri == f"{space_uri}/{did}/{COLLECTION}/smoke-one", rec.text
+    print(f"✓ createRecord  uri={rec_uri}")
+
+    got = xrpc(
+        c,
+        "GET",
+        "com.atproto.space.getRecord",
+        token=token,
+        params={
+            "space": space_uri,
+            "repo": did,
+            "collection": COLLECTION,
+            "rkey": "smoke-one",
+        },
+    )
+    got.raise_for_status()
+    assert "private smoke" in got.text, got.text
+    print("✓ getRecord round-trips")
+
+    listed = xrpc(
+        c,
+        "GET",
+        "com.atproto.space.listRecords",
+        token=token,
+        params={"space": space_uri, "repo": did, "collection": COLLECTION, "limit": 10},
+    )
+    listed.raise_for_status()
+    print(f"✓ listRecords  {listed.text[:120]}")
+
+    # credential flow: OAuth-ish bearer -> member grant -> space credential
+    grant_resp = xrpc(
+        c,
+        "GET",
+        "com.atproto.space.getMemberGrant",
+        token=token,
+        params={"space": space_uri},
+    )
+    grant_resp.raise_for_status()
+    grant = grant_resp.json()["grant"]
+    print("✓ getMemberGrant")
+
+    cred_resp = c.post(
+        f"{PDS}/xrpc/com.atproto.space.getSpaceCredential",
+        headers={"authorization": f"Bearer {grant}"},
+        json={"space": space_uri},
+    )
+    cred_resp.raise_for_status()
+    credential = cred_resp.json()["credential"]
+    print("✓ getSpaceCredential")
+
+    # read the blob THROUGH the permissioned path using the space credential + Range
+    blob_get = c.get(
+        f"{PDS}/xrpc/com.atproto.space.getBlob",
+        headers={"authorization": f"Bearer {credential}", "range": "bytes=0-3"},
+        params={"space": space_uri, "repo": did, "cid": blob_cid},
+    )
+    assert blob_get.status_code == 206, (
+        f"getBlob (credential, range) → {blob_get.status_code} {blob_get.text}"
+    )
+    assert len(blob_get.content) == 4, blob_get.content
+    print(f"✓ getBlob via space credential (206, {len(blob_get.content)} bytes)")
+
+    print(
+        "\nPASS — private media stored and read back through the permissioned-space path"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1528. Adds an artist-owned **private-media** flow on ATProto permissioned spaces (`com.atproto.space.*`): a "keep private" toggle at upload (shown only when your PDS supports spaces) stores the audio blob + track record in your permissioned space repo — no public copy, excluded from discovery, playable only through the space-credential path. Reuses the [`fm.plyr.track`](https://github.com/zzstoatzz/plyr.fm/blob/feat/permissioned-private-media/lexicons/track.json) lexicon; only the write target and read auth differ.

Verified end-to-end against the live `pds.zat.dev` ZDS — including the credential exchange — via [`scripts/permissioned_smoke.py`](https://github.com/zzstoatzz/plyr.fm/blob/feat/permissioned-private-media/scripts/permissioned_smoke.py).

Full design rationale (every #1528 acceptance criterion): [`docs/internal/architecture/permissioned-private-media.md`](https://github.com/zzstoatzz/plyr.fm/blob/feat/permissioned-private-media/docs/internal/architecture/permissioned-private-media.md).

<details>
<summary>How it works</summary>

- **Capability gate** — [`spaces/capability.py`](https://github.com/zzstoatzz/plyr.fm/blob/feat/permissioned-private-media/backend/src/backend/_internal/atproto/spaces/capability.py): authenticated `listSpaces` method-probe (no PDS advertises spaces declaratively; unauth probes can't tell a supporting PDS from a vanilla one). Cached per-PDS; surfaced on `/auth/me` as `permissioned_spaces.supported`, which gates the UI.
- **Space client + credential flow** — [`spaces/client.py`](https://github.com/zzstoatzz/plyr.fm/blob/feat/permissioned-private-media/backend/src/backend/_internal/atproto/spaces/client.py): owner writes via DPoP OAuth (`ensure_personal_space`, `create_space_record`); reads via `OAuth → getMemberGrant → getSpaceCredential → getBlob` with a plain-bearer helper (grants/credentials are JWTs, not DPoP-bound), credential cache + renew-on-401.
- **Upload** — [`tracks/uploads.py`](https://github.com/zzstoatzz/plyr.fm/blob/feat/permissioned-private-media/backend/src/backend/api/tracks/uploads.py): `private` field; preflight (capability + granted `space:` scope else `403 permissioned_scope_required`, web-playable only, no gate+private); audio staged privately (no public R2), PDS blob mandatory; `_create_records` branches into the space; `Track.is_private`/`space_uri` persisted; author-only write legitimacy.
- **Playback** — [`audio.py`](https://github.com/zzstoatzz/plyr.fm/blob/feat/permissioned-private-media/backend/src/backend/api/audio.py): private tracks proxied through the owner's space credential with `Range` passthrough (→ 206); can't redirect (browser has no credential); non-owner → 404.
- **Frontend** — capability-gated toggle on [`/upload`](https://github.com/zzstoatzz/plyr.fm/blob/feat/permissioned-private-media/frontend/src/routes/upload/+page.svelte); on `403 permissioned_scope_required` runs the one-time opt-in scope upgrade (preserving existing scopes) via [`uploader.svelte.ts`](https://github.com/zzstoatzz/plyr.fm/blob/feat/permissioned-private-media/frontend/src/lib/uploader.svelte.ts), then retries.
- **OAuth scope** `space:fm.plyr.privateMedia` (env-aware): opt-in only, never in a base login; threaded through the three scope-coupling points ([config](https://github.com/zzstoatzz/plyr.fm/blob/feat/permissioned-private-media/backend/src/backend/config.py), [oauth.py](https://github.com/zzstoatzz/plyr.fm/blob/feat/permissioned-private-media/backend/src/backend/_internal/auth/oauth.py), [meta.py](https://github.com/zzstoatzz/plyr.fm/blob/feat/permissioned-private-media/backend/src/backend/api/meta.py)).
</details>

<details>
<summary>Verification</summary>

- Live contract: [`scripts/permissioned_smoke.py`](https://github.com/zzstoatzz/plyr.fm/blob/feat/permissioned-private-media/scripts/permissioned_smoke.py) against `pds.zat.dev` — `createSpace → uploadBlob → createRecord → getRecord/listRecords → getMemberGrant → getSpaceCredential → ranged getBlob (206)`.
- Unit: [`test_permissioned_spaces.py`](https://github.com/zzstoatzz/plyr.fm/blob/feat/permissioned-private-media/backend/tests/_internal/test_permissioned_spaces.py) (probe interpretation, ats:// roundtrip, scope opt-in, credential renewal).
- Endpoint preflight: [`test_private_media_upload.py`](https://github.com/zzstoatzz/plyr.fm/blob/feat/permissioned-private-media/backend/tests/api/test_private_media_upload.py) (capability / scope / web-playable / mutual exclusion).
- Full backend suite (1174) + frontend check + loq clean.
</details>

<details>
<summary>Deferred / out of scope (intentional)</summary>

- **Through-the-app pass before merge**: sign in as a `pds.zat.dev` account (e.g. bufo.uk), upload "keep private", confirm the space record + credential-gated playback in the running app. Contract + gating are verified; this is the UI/OAuth round-trip. Draft until then.
- **Non-web-playable private uploads**: today's pipeline defers the canonical MP3 to the optimize task (writes the public repo); private MVP requires web-playable sources. Routing the deferred write into the space is a follow-up.
- **Shared/supporter/label spaces**: need a dedicated space DID + arbiter (#564/#642), not this single-member personal-space MVP scaled up.

Protocol context: Daniel Holmgren's permissioned-data diaries, esp. [diary 5 (URIs)](https://dholms.leaflet.pub/3mlegohgtps2k) and [diary 6 (auth)](https://dholms.leaflet.pub/3mnkrxp7rt22i).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)