### PR TITLE
fix(migrations): unique revision id for private-media migration (unblock staging deploy)

### DIFF
--- a/backend/alembic/versions/2026_06_07_235801_0387de28f52e_add_private_media_columns_to_track.py
+++ b/backend/alembic/versions/2026_06_07_235801_0387de28f52e_add_private_media_columns_to_track.py
@@ -1,20 +1,22 @@
-"""add is_private and space_uri to track for permissioned media
+"""add private media columns to track
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: 0387de28f52e
 Revises: e9ec24f00cd1
-Create Date: 2026-06-07 00:00:00.000000
+Create Date: 2026-06-07 23:58:01.576185
 
 """
+
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "a1b2c3d4e5f6"
-down_revision: str | None = "e9ec24f00cd1"
-branch_labels: str | None = None
-depends_on: str | None = None
+revision: str = "0387de28f52e"
+down_revision: str | Sequence[str] | None = "e9ec24f00cd1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:


### PR DESCRIPTION
The merged #1552 migration hand-authored revision id `a1b2c3d4e5f6`, which **collides** with the existing `2025_12_16_add_ui_settings_jsonb` migration. The duplicate id makes `alembic upgrade head` detect a revision **cycle**, which failed the staging deploy (`release_command` exit 255) — so #1552 never reached staging.

Fix: regenerated the migration via `alembic revision` (proper unique id `0387de28f52e`, `down_revision = e9ec24f00cd1` — the real head). Same `is_private` / `space_uri` columns. Verified single head + no cycle locally. Applies cleanly on staging's current DB head (`e9ec24f00cd1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)