### PR TITLE
fix(spaces): private-media OAuth via include:<permission-set> (#1528)

### DIFF
--- a/backend/src/backend/_internal/auth/oauth.py
+++ b/backend/src/backend/_internal/auth/oauth.py
@@ -171,8 +171,9 @@ def get_oauth_client_for_scope(scope: str) -> OAuthClient:
     include_indiemusi = scopes.matches(
         "repo", collection=settings.indiemusi.song_collection, action="create"
     )
-    # ScopesSet doesn't model the experimental space: token, so match on the string
-    include_permissioned = settings.atproto.private_media_space_scope in scope
+    # match on the private-media NSID — present whether the scope is the requested
+    # `include:<nsid>` form or the granted, expanded `space:<nsid>?...` form
+    include_permissioned = settings.atproto.private_media_space_type in scope
     return get_oauth_client(
         include_teal=include_teal,
         include_indiemusi=include_indiemusi,

--- a/backend/src/backend/api/auth.py
+++ b/backend/src/backend/api/auth.py
@@ -662,7 +662,7 @@ async def start_scope_upgrade_flow(
     )
     include_indiemusi = settings.indiemusi.song_collection in current_scope
     include_permissioned = body.include_permissioned or (
-        settings.atproto.private_media_space_scope in current_scope
+        settings.atproto.private_media_space_type in current_scope
     )
 
     auth_url, state = await start_oauth_flow_with_scopes(

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -1565,8 +1565,10 @@ async def upload_track(
                 detail="your PDS does not support permissioned spaces (private media)",
             )
         # writing to a space needs the granted space scope (the capability probe
-        # passes without it). signal the frontend to run the opt-in scope upgrade.
-        if settings.atproto.private_media_space_scope not in (
+        # passes without it). the granted token carries the expanded
+        # `space:<nsid>?...` scopes, so match on the NSID. absent → tell the
+        # frontend to run the opt-in scope upgrade (which requests include:<nsid>).
+        if settings.atproto.private_media_space_type not in (
             auth_session.oauth_session or {}
         ).get("scope", ""):
             raise HTTPException(status_code=403, detail="permissioned_scope_required")

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -466,18 +466,23 @@ class AtprotoSettings(AppSettingsSection):
     def private_media_space_type(self) -> str:
         """Permissioned-space type NSID for artist-owned private media.
 
-        the OAuth consent boundary for the permissioned-spaces private-media
-        feature; records inside reuse the public track collection lexicon.
+        also the id of the permission-set lexicon that grants access to it (same
+        NSID). records inside the space reuse the public track collection lexicon.
         """
 
         return f"{self.app_namespace}.privateMedia"
 
     @computed_field
     @property
-    def private_media_space_scope(self) -> str:
-        """granular OAuth scope token granting access to the private-media space."""
+    def private_media_include_scope(self) -> str:
+        """OAuth scope REQUESTED for private-media access.
 
-        return f"space:{self.private_media_space_type}"
+        a permission-set include, not a bare `space:` scope — PDS OAuth servers
+        grant space access only via a published permission set, which the PDS
+        expands into the concrete `space:<type>?action=...` scopes on the token.
+        """
+
+        return f"include:{self.private_media_space_type}"
 
     @computed_field
     @property
@@ -554,7 +559,7 @@ class AtprotoSettings(AppSettingsSection):
         if indiemusi_tokens:
             parts.extend(indiemusi_tokens)
         if permissioned_spaces:
-            parts.append(self.private_media_space_scope)
+            parts.append(self.private_media_include_scope)
         return " ".join(parts)
 
 

--- a/backend/tests/_internal/test_permissioned_spaces.py
+++ b/backend/tests/_internal/test_permissioned_spaces.py
@@ -117,12 +117,16 @@ async def test_detect_capability_transient_fails_closed(monkeypatch):
 
 
 def test_permissioned_scope_opt_in_only():
+    # the private-media scope is requested as a permission-set include, not a bare
+    # `space:` scope (PDS OAuth grants space access only via a published set).
     base = settings.atproto.resolved_scope_with_extras()
-    assert settings.atproto.private_media_space_scope not in base
+    assert settings.atproto.private_media_include_scope not in base
 
     with_perm = settings.atproto.resolved_scope_with_extras(permissioned_spaces=True)
-    assert settings.atproto.private_media_space_scope in with_perm
-    assert settings.atproto.private_media_space_scope == "space:fm.plyr.privateMedia"
+    assert settings.atproto.private_media_include_scope in with_perm
+    assert (
+        settings.atproto.private_media_include_scope == "include:fm.plyr.privateMedia"
+    )
 
 
 # --- space credential caching + renewal ---------------------------------------

--- a/backend/tests/api/test_private_media_upload.py
+++ b/backend/tests/api/test_private_media_upload.py
@@ -18,7 +18,10 @@ from backend._internal import Session, require_artist_profile
 from backend.config import settings
 from backend.main import app
 
-PERM_SCOPE = settings.atproto.private_media_space_scope
+# the granted token carries the expanded space scope (what the preflight checks for),
+# not the requested `include:` form
+_TYPE = settings.atproto.private_media_space_type
+PERM_SCOPE = f"space:{_TYPE}?action=create&did=*&skey=self&collection={_TYPE}"
 
 
 class _MockSession(Session):

--- a/lexicons/privateMedia.json
+++ b/lexicons/privateMedia.json
@@ -5,12 +5,15 @@
     "main": {
       "type": "permission-set",
       "title": "plyr.fm Private Media",
-      "detail": "An artist-owned permissioned-data space for private audio. Granting plyr.fm access lets it read and sync the WHOLE space (every record and blob in it), so this space is kept narrow: it holds only private media records. Records reuse the fm.plyr.track lexicon; the audio blob lives in the artist's permissioned repo on their PDS, not in public storage.",
+      "detail": "Access to your private audio — a permissioned space on your PDS that only you (and apps you grant) can read. Granting this lets plyr.fm create, read, and manage private tracks in this space. The audio and records never leave your PDS as public data.",
       "permissions": [
         {
           "type": "permission",
           "resource": "space",
-          "action": ["read", "create", "update", "delete"],
+          "action": ["read", "create", "update", "delete", "manage"],
+          "space": ["fm.plyr.privateMedia"],
+          "skey": ["self"],
+          "did": ["*"],
           "collection": ["fm.plyr.track"]
         }
       ]

--- a/loq.toml
+++ b/loq.toml
@@ -44,7 +44,7 @@ max_lines = 1787
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 1109
+max_lines = 1114
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
@@ -288,7 +288,7 @@ max_lines = 617
 
 [[rules]]
 path = "backend/src/backend/_internal/auth/oauth.py"
-max_lines = 559
+max_lines = 560
 
 [[rules]]
 path = "frontend/src/lib/components/CopyrightSection.svelte"

--- a/scripts/publish_permission_set.py
+++ b/scripts/publish_permission_set.py
@@ -19,41 +19,60 @@ class Settings(BaseSettings):
     namespace: str = Field(default="fm.plyr", validation_alias="NAMESPACE")
 
 
-async def main():
-    settings = Settings()
+def _auth_full_app(ns: str) -> dict:
+    return {
+        "type": "permission-set",
+        "title": "Full plyr.fm Access",
+        "detail": "Provides full access to all plyr.fm features including uploading and managing tracks, playlists, likes, and comments.",
+        "permissions": [
+            {
+                "type": "permission",
+                "resource": "repo",
+                "action": ["create", "update", "delete"],
+                "collection": [
+                    f"{ns}.track",
+                    f"{ns}.like",
+                    f"{ns}.comment",
+                    f"{ns}.list",
+                    f"{ns}.actor.profile",
+                ],
+            }
+        ],
+    }
 
-    client = AsyncClient()
-    await client.login(settings.plyrfm_handle, settings.plyrfm_password)
 
-    permission_set_id = f"{settings.namespace}.authFullApp"
+def _private_media(ns: str) -> dict:
+    """permissioned-space set for artist-owned private media (#1528).
 
+    requested progressively as `include:{ns}.privateMedia` only for accounts on a
+    PDS that supports permissioned spaces; the PDS expands the space permission
+    into `space:{ns}.privateMedia?action=...` scopes on the token.
+    """
+    return {
+        "type": "permission-set",
+        "title": "plyr.fm Private Media",
+        "detail": "Access to your private audio — a permissioned space on your PDS that only you (and apps you grant) can read.",
+        "permissions": [
+            {
+                "type": "permission",
+                "resource": "space",
+                "action": ["read", "create", "update", "delete", "manage"],
+                "space": [f"{ns}.privateMedia"],
+                "skey": ["self"],
+                "did": ["*"],
+                "collection": [f"{ns}.track"],
+            }
+        ],
+    }
+
+
+async def _publish(client: AsyncClient, permission_set_id: str, main_def: dict) -> None:
     record = {
         "$type": "com.atproto.lexicon.schema",
         "lexicon": 1,
         "id": permission_set_id,
-        "defs": {
-            "main": {
-                "type": "permission-set",
-                "title": "Full plyr.fm Access",
-                "detail": "Provides full access to all plyr.fm features including uploading and managing tracks, playlists, likes, and comments.",
-                "permissions": [
-                    {
-                        "type": "permission",
-                        "resource": "repo",
-                        "action": ["create", "update", "delete"],
-                        "collection": [
-                            f"{settings.namespace}.track",
-                            f"{settings.namespace}.like",
-                            f"{settings.namespace}.comment",
-                            f"{settings.namespace}.list",
-                            f"{settings.namespace}.actor.profile",
-                        ],
-                    }
-                ],
-            }
-        },
+        "defs": {"main": main_def},
     }
-
     result = await client.com.atproto.repo.put_record(
         {
             "repo": client.me.did,
@@ -62,9 +81,18 @@ async def main():
             "record": record,
         }
     )
+    print(f"published {permission_set_id}: {result.uri} (cid {result.cid})")
 
-    print(f"created: {result.uri}")
-    print(f"cid: {result.cid}")
+
+async def main():
+    settings = Settings()
+
+    client = AsyncClient()
+    await client.login(settings.plyrfm_handle, settings.plyrfm_password)
+
+    ns = settings.namespace
+    await _publish(client, f"{ns}.authFullApp", _auth_full_app(ns))
+    await _publish(client, f"{ns}.privateMedia", _private_media(ns))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The progressive scope upgrade for private media was requesting a **bare `space:` scope**, which ZDS's OAuth authorizer can't grant (`space:*` isn't in `scopes_supported`; space access is granted only by expanding a published permission set's `resource:"space"` permission, which ZDS now supports). So toggling "keep private" failed with *"your PDS did not grant the permissions plyr.fm needs."*

This switches the request to `include:fm.plyr.<env>.privateMedia` and publishes that permission set.

<details>
<summary>Changes</summary>

- **config**: `private_media_include_scope` = `include:<nsid>` (was a bare `space:` scope); composed into the requested scope when permissioned.
- **detection** (upload preflight, scope-upgrade scope-preserve, callback client match): match on the private-media **NSID substring** — present in both the requested `include:fm.plyr.stg.privateMedia` form and the granted, *expanded* `space:fm.plyr.stg.privateMedia?action=…` form the token actually carries.
- **`lexicons/privateMedia.json`**: real `resource:"space"` permission shape ZDS's `buildExpandedScope` expands — `space:[<type>]`, `skey:["self"]`, `did:["*"]`, `collection:[<track>]`, actions `read/create/update/delete/manage` (covers manage=createSpace, create+update=putRecord, read=play).
- **`publish_permission_set.py`**: also emits the namespace-aware private-media set.

</details>

<details>
<summary>Published + verified</summary>

`NAMESPACE=fm.plyr.stg` published `fm.plyr.stg.privateMedia` to the `plyr.fm` authority account (`did:plc:vs3hnzq2daqbszxlysywzy54`). Verified: `_lexicon.stg.plyr.fm` TXT → that DID, and the record is fetchable from the account's PDS with the expected permission shape. So `include:fm.plyr.stg.privateMedia` resolves + expands on ZDS cross-PDS.

(Prod will need `NAMESPACE=fm.plyr` published the same way before private media works in prod.)

</details>

Once this deploys to staging, the through-the-app pass should work end-to-end: toggle keep-private → `403 permissioned_scope_required` → one-time consent for the private-media permission set → upload stores in the space + plays back via the credential path. That's the real-OAuth verification the ZDS dev flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)