### PR TITLE
fix(spaces): capability probe must fail closed (#1528)

### DIFF
--- a/backend/src/backend/_internal/atproto/spaces/capability.py
+++ b/backend/src/backend/_internal/atproto/spaces/capability.py
@@ -30,37 +30,37 @@ from backend.utilities.redis import get_async_redis_client
 
 logger = logging.getLogger(__name__)
 
-_CACHE_PREFIX = "permissioned_capability:"
+# bumped to v2 when the classifier flipped to fail-closed — invalidates any stale
+# (overly-permissive) cached results from the prior heuristic.
+_CACHE_PREFIX = "permissioned_capability:v2:"
 _CACHE_TTL_SECONDS = 6 * 60 * 60
-
-# error codes that mean "this PDS does not implement the space surface"
-_UNSUPPORTED_ERROR_CODES = (
-    "MethodNotImplemented",
-    "UnknownMethod",
-    "XRPCNotSupported",
-    "MethodNotSupported",
-)
-_UNSUPPORTED_STATUS = (404, 501)
 
 _STATUS_RE = re.compile(r"PDS request failed:\s*(\d{3})")
 
 
 def _classify_failure(message: str) -> bool | None:
-    """interpret a failed listSpaces probe.
+    """interpret a FAILED listSpaces probe — fail closed.
 
-    returns True (supported), False (definitively unsupported), or None (ambiguous
-    / transient — caller should fail closed without caching).
+    a PDS is treated as supporting permissioned spaces ONLY on an unambiguous
+    positive signal (handled in `_probe`: HTTP 200, or 403 InsufficientScope —
+    ZDS's space-scope check, which proves the route is implemented). every other
+    failure is unsupported; a non-supporting PDS returns auth/method-not-found
+    errors that must NOT be read as "route exists."
+
+    returns True (supported), False (unsupported, cacheable), or None (transient
+    — don't cache, fail closed for this call only).
     """
-    if any(code in message for code in _UNSUPPORTED_ERROR_CODES):
-        return False
+    # the space-scope check ran → the route is implemented → supported
+    if "InsufficientScope" in message:
+        return True
     if match := _STATUS_RE.search(message):
         status = int(match.group(1))
-        if status in _UNSUPPORTED_STATUS:
-            return False
+        if status == 501:
+            return False  # not implemented
         if 500 <= status < 600:
-            return None  # transient upstream failure
-        return True  # 4xx other than 404: the route dispatched (auth/scope/validation)
-    return None
+            return None  # transient upstream failure (500/502/503/504)
+        return False  # 401/400/404/405/other 4xx → not a supporting PDS
+    return None  # opaque / network error
 
 
 async def _probe(auth_session: AuthSession) -> bool | None:

--- a/backend/tests/_internal/test_permissioned_spaces.py
+++ b/backend/tests/_internal/test_permissioned_spaces.py
@@ -51,21 +51,53 @@ def test_parse_space_uri_rejects_malformed(bad):
 @pytest.mark.parametrize(
     "message,expected",
     [
-        ("PDS request failed: 501 MethodNotImplemented", False),
+        # the ONLY supported signal from a failure: ZDS's space-scope check ran
+        ("PDS request failed: 403 InsufficientScope", True),
+        # not-a-supporting-PDS responses — all unsupported (fail closed)
+        ("PDS request failed: 401 AuthMissing", False),  # regression: bsky 401 leak
+        ("PDS request failed: 400 InvalidRequest: bad", False),
         ("PDS request failed: 404 UnknownMethod", False),
-        ("XRPCNotSupported", False),
-        ("PDS request failed: 400 InvalidRequest: Missing space", True),  # route ran
-        ("PDS request failed: 403 InsufficientScope", True),  # route ran
-        (
-            "PDS request failed: 503 upstream",
-            None,
-        ),  # transient -> fail closed, no cache
+        ("PDS request failed: 405 MethodNotAllowed", False),
+        ("PDS request failed: 501 MethodNotImplemented", False),
+        # genuinely transient → don't cache, fail closed for this call
+        ("PDS request failed: 503 upstream", None),
         ("PDS request failed: 502 bad gateway", None),
         ("totally opaque error", None),
     ],
 )
 def test_classify_failure(message, expected):
     assert cap._classify_failure(message) is expected
+
+
+async def test_detect_capability_insufficient_scope_is_supported(monkeypatch):
+    # a capable PDS that hasn't been granted the space scope yet returns 403
+    # InsufficientScope from the space route — that proves the route exists.
+    async def fake_request(*args, **kwargs):
+        raise Exception("PDS request failed: 403 InsufficientScope")
+
+    monkeypatch.setattr(cap, "make_pds_request", fake_request)
+    session = Session(
+        session_id="s",
+        did="did:plc:x",
+        handle="x.test",
+        oauth_session={"pds_url": "https://probe-insufficient.test"},
+    )
+    assert await cap.detect_permissioned_capability(session) is True
+
+
+async def test_detect_capability_401_is_unsupported(monkeypatch):
+    # regression: a non-supporting PDS (e.g. bsky) must NOT be read as supported
+    async def fake_request(*args, **kwargs):
+        raise Exception("PDS request failed: 401 AuthMissing")
+
+    monkeypatch.setattr(cap, "make_pds_request", fake_request)
+    session = Session(
+        session_id="s",
+        did="did:plc:x",
+        handle="x.test",
+        oauth_session={"pds_url": "https://probe-bsky.test"},
+    )
+    assert await cap.detect_permissioned_capability(session) is False
 
 
 async def test_detect_capability_supported(monkeypatch):


### PR DESCRIPTION
**Bug:** the "keep private" toggle showed on accounts whose PDS does **not** support permissioned spaces, and the consent screen rendered an empty permission set.

**Cause:** the capability probe classified "any 4xx that isn't 404/method-not-impl" as *supported* ("the route dispatched"). But a non-supporting PDS (bsky) returns `401 AuthMissing` for `com.atproto.space.listSpaces`, which was read as supported.

**Fix — fail closed.** A PDS is supported **only** on an unambiguous positive:
- `200` from `listSpaces`, or
- `403 InsufficientScope` — ZDS's space-scope check, which only runs if the route is actually implemented (a capable PDS that hasn't been granted the space scope yet).

Everything else (`401`/`400`/`404`/`405`/`501`/method-not-supported) → **unsupported**. Genuine `5xx`/network stays transient (uncached, fail-closed for that call). Cache key bumped to `v2:` so the stale overly-permissive entries on staging redis are dropped immediately.

Regression tests: `401 → unsupported` (the bug), `InsufficientScope → supported`.

After this deploys, the toggle should disappear for non-supporting accounts and only appear for PDSes that genuinely implement the space surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)