### PR TITLE
refactor(visibility): one visibility model + PDS-native private media (#1528)

### DIFF
--- a/backend/alembic/versions/2026_06_08_130945_816ec59cc00a_collapse_track_visibility_flags_into_.py
+++ b/backend/alembic/versions/2026_06_08_130945_816ec59cc00a_collapse_track_visibility_flags_into_.py
@@ -1,0 +1,71 @@
+"""collapse track visibility flags into visibility enum
+
+Revision ID: 816ec59cc00a
+Revises: 0387de28f52e
+Create Date: 2026-06-08 13:09:45.800361
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "816ec59cc00a"
+down_revision: str | Sequence[str] | None = "0387de28f52e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Collapse `unlisted` + `is_private` booleans into one `visibility` enum.
+
+    backfill precedence: private > supporters (support_gate type=any) > unlisted >
+    public. copyright gating (support_gate type=copyright) is orthogonal and stays
+    on a public/unlisted track, so it doesn't map to a visibility value.
+    """
+    op.add_column(
+        "tracks",
+        sa.Column(
+            "visibility",
+            sa.String(),
+            nullable=False,
+            server_default="public",
+        ),
+    )
+    op.execute(
+        """
+        UPDATE tracks SET visibility = CASE
+            WHEN is_private THEN 'private'
+            WHEN support_gate->>'type' = 'any' THEN 'supporters'
+            WHEN unlisted THEN 'unlisted'
+            ELSE 'public'
+        END
+        """
+    )
+    op.create_index(op.f("ix_tracks_visibility"), "tracks", ["visibility"])
+    op.drop_column("tracks", "is_private")
+    op.drop_column("tracks", "unlisted")
+
+
+def downgrade() -> None:
+    """Restore the `unlisted` + `is_private` booleans from `visibility`."""
+    op.add_column(
+        "tracks",
+        sa.Column("unlisted", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    op.add_column(
+        "tracks",
+        sa.Column("is_private", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    op.execute(
+        """
+        UPDATE tracks SET
+            is_private = (visibility = 'private'),
+            unlisted = (visibility IN ('unlisted', 'private'))
+        """
+    )
+    op.drop_index(op.f("ix_tracks_visibility"), table_name="tracks")
+    op.drop_column("tracks", "visibility")

--- a/backend/src/backend/_internal/track_visibility.py
+++ b/backend/src/backend/_internal/track_visibility.py
@@ -27,10 +27,11 @@ class _HasDid(Protocol):
 
 
 def track_visible_filter(viewer_did: str | None) -> ColumnElement[bool]:
-    """SQL condition: public tracks, plus the viewer's own private tracks."""
+    """SQL condition: non-private tracks, plus the viewer's own private tracks."""
+    not_private = Track.visibility != "private"
     if viewer_did is None:
-        return Track.is_private.is_(False)
-    return or_(Track.is_private.is_(False), Track.artist_did == viewer_did)
+        return not_private
+    return or_(not_private, Track.artist_did == viewer_did)
 
 
 def can_view_track(viewer_did: str | None, track: Track) -> bool:

--- a/backend/src/backend/_internal/track_visibility.py
+++ b/backend/src/backend/_internal/track_visibility.py
@@ -12,7 +12,7 @@ two shapes:
   a guard for endpoints that load one track by id/uri/file_id.
 """
 
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 from fastapi import HTTPException
 from sqlalchemy import ColumnElement, or_
@@ -20,6 +20,7 @@ from sqlalchemy import ColumnElement, or_
 from backend.models import Track
 
 
+@runtime_checkable
 class _HasDid(Protocol):
     """structural type for anything carrying a DID (e.g. an auth Session)."""
 

--- a/backend/src/backend/api/albums/listing.py
+++ b/backend/src/backend/api/albums/listing.py
@@ -55,7 +55,9 @@ async def list_albums(
         .join(Artist, Album.artist_did == Artist.did)
         # count only public tracks — albums that exist solely because of private
         # uploads have a zero public count and drop out via the having clause
-        .outerjoin(Track, and_(Track.album_id == Album.id, Track.is_private.is_(False)))
+        .outerjoin(
+            Track, and_(Track.album_id == Album.id, Track.visibility != "private")
+        )
         .group_by(Album.id, Artist.did)
         .having(func.count(Track.id) > 0)
         .order_by(func.lower(Album.title))
@@ -92,7 +94,9 @@ async def list_artist_albums(
             func.count(Track.id).label("track_count"),
             func.coalesce(func.sum(Track.play_count), 0).label("total_plays"),
         )
-        .outerjoin(Track, and_(Track.album_id == Album.id, Track.is_private.is_(False)))
+        .outerjoin(
+            Track, and_(Track.album_id == Album.id, Track.visibility != "private")
+        )
         .where(Album.artist_did == artist.did)
         .group_by(Album.id)
         .having(func.count(Track.id) > 0)

--- a/backend/src/backend/api/discover.py
+++ b/backend/src/backend/api/discover.py
@@ -49,7 +49,7 @@ async def get_network_artists(
         .join(Track, Track.artist_did == Artist.did)
         .where(Artist.did.in_(follow_dids))
         # private media never counts toward an artist's public track count
-        .where(Track.is_private.is_(False))
+        .where(Track.visibility != "private")
         .group_by(Artist.did)
     )
 

--- a/backend/src/backend/api/for_you.py
+++ b/backend/src/backend/api/for_you.py
@@ -311,7 +311,7 @@ async def get_for_you_feed(
             await db.execute(
                 select(Track.id, Track.artist_did).where(
                     Track.id.in_(top_ids),
-                    Track.unlisted == False,  # noqa: E712
+                    Track.in_discovery,
                 )
             )
         ).all()

--- a/backend/src/backend/api/radio/corpus.py
+++ b/backend/src/backend/api/radio/corpus.py
@@ -20,7 +20,7 @@ async def load_corpus(db: AsyncSession) -> list[Track]:
         .join(Artist)
         .options(selectinload(Track.artist))
         .where(
-            Track.unlisted == False,  # noqa: E712
+            Track.in_discovery,
             Track.support_gate.is_(None),
             Artist.deactivated == False,  # noqa: E712
         )

--- a/backend/src/backend/api/search.py
+++ b/backend/src/backend/api/search.py
@@ -174,7 +174,7 @@ async def _search_tracks(
         .join(Artist, Track.artist_did == Artist.did)
         .where(or_(similarity > 0.1, substring_match))
         # private (permissioned-space) media is never publicly searchable
-        .where(Track.is_private == False)  # noqa: E712
+        .where(Track.visibility != "private")
         .order_by(similarity.desc())
         .limit(limit)
     )
@@ -406,7 +406,7 @@ async def semantic_search(
         .join(Artist, Track.artist_did == Artist.did)
         .where(Track.id.in_(track_ids))
         # private media is never publicly searchable (also shouldn't be indexed)
-        .where(Track.is_private == False)  # noqa: E712
+        .where(Track.visibility != "private")
     )
     result = await db.execute(stmt)
     rows = result.all()

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -134,12 +134,11 @@ async def list_tracks(
         # private (permissioned-space) media is visible only to its owner — an
         # artist page viewed by anyone else (or logged out) must not list it
         if not (session and session.did == artist_did):
-            stmt = stmt.where(Track.is_private == False)  # noqa: E712
+            stmt = stmt.where(Track.visibility != "private")
     else:
-        # discovery feed: exclude unlisted tracks (artist pages show all) and
-        # tracks from deactivated accounts (their content drops out of discovery).
-        # unlisted==False also excludes private media (private implies unlisted).
-        stmt = stmt.where(Track.unlisted == False)  # noqa: E712
+        # discovery feed: only listed visibilities (public + supporters); excludes
+        # unlisted and private. plus tracks from deactivated accounts drop out.
+        stmt = stmt.where(Track.in_discovery)
         stmt = stmt.where(Artist.deactivated == False)  # noqa: E712
 
     # filter out tracks with hidden tags
@@ -378,7 +377,7 @@ async def list_top_tracks(
         select(Track)
         .join(Artist)
         .options(selectinload(Track.artist), selectinload(Track.album_rel))
-        .where(Track.id.in_(top_track_ids), Track.unlisted == False)  # noqa: E712
+        .where(Track.id.in_(top_track_ids), Track.in_discovery)
     )
     result = await db.execute(stmt)
     tracks_by_id = {track.id: track for track in result.scalars().all()}

--- a/backend/src/backend/api/tracks/mutations.py
+++ b/backend/src/backend/api/tracks/mutations.py
@@ -229,6 +229,10 @@ async def update_track_metadata(
             if was_gated and track.r2_url is None:
                 move_to_private = False
             track.support_gate = None
+            # keep visibility consistent: dropping the supporter gate returns the
+            # track to public (copyright gating doesn't change visibility)
+            if track.visibility == "supporters":
+                track.visibility = "public"
         else:
             try:
                 parsed_gate = json.loads(support_gate)
@@ -244,6 +248,7 @@ async def update_track_metadata(
                 if not was_gated and track.r2_url is not None:
                     move_to_private = True
                 track.support_gate = parsed_gate
+                track.visibility = "supporters"
             except json.JSONDecodeError as e:
                 raise HTTPException(
                     status_code=400, detail=f"invalid support_gate JSON: {e}"
@@ -251,9 +256,10 @@ async def update_track_metadata(
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e)) from e
 
-    # handle unlisted toggle
-    if unlisted is not None:
-        track.unlisted = unlisted.lower() == "true"
+    # handle unlisted toggle — flips public ↔ unlisted only (supporters keep their
+    # visibility; private tracks are rejected earlier with 409)
+    if unlisted is not None and track.visibility in ("public", "unlisted"):
+        track.visibility = "unlisted" if unlisted.lower() == "true" else "public"
 
     # track album changes for list sync
     old_album_id = track.album_id

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -69,7 +69,7 @@ from backend.models.job import JobStatus, JobType
 from backend.storage import storage
 from backend.utilities.audio import extract_duration
 from backend.utilities.database import db_session
-from backend.utilities.hashing import CHUNK_SIZE
+from backend.utilities.hashing import CHUNK_SIZE, hash_file_chunked
 from backend.utilities.progress import R2ProgressTracker
 from backend.utilities.rate_limit import limiter
 from backend.utilities.tags import add_tags_to_track, parse_tags_json
@@ -140,14 +140,26 @@ class UploadContext:
     # auto-apply recommended genre tags after classification
     auto_tag: bool = False
 
-    # visibility: unlisted tracks don't appear in discovery feeds
-    unlisted: bool = False
+    # visibility is the ONLY visibility/access field — public | unlisted |
+    # supporters | private. private/unlisted are derived from it (below), never
+    # stored or passed separately. `support_gate` stays (it's the gate-type
+    # detail: supporters vs the orthogonal copyright paradigm).
+    visibility: str = "public"
 
-    # private media: audio blob + record live in the artist's ATProto permissioned
-    # space (com.atproto.space.*), not the public repo. no public R2 copy; excluded
-    # from discovery; playable only through the space credential path. requires a
-    # PDS that supports permissioned spaces (checked at the endpoint).
-    private: bool = False
+    # private media's audio is uploaded straight to the PDS blobstore in the
+    # request handler (never R2); this BlobRef carries it across the docket
+    # boundary so the worker only writes the permissioned record.
+    audio_blob: BlobRef | None = None
+
+    @property
+    def private(self) -> bool:
+        """private (permissioned-space) media."""
+        return self.visibility == "private"
+
+    @property
+    def unlisted(self) -> bool:
+        """excluded from discovery feeds (unlisted + private)."""
+        return self.visibility in ("unlisted", "private")
 
     @property
     def audio_extension(self) -> str:
@@ -899,12 +911,10 @@ async def _create_records(
             image_url=image_url,
             thumbnail_url=thumbnail_url,
             support_gate=ctx.support_gate,
-            # private tracks are never surfaced in discovery feeds
-            unlisted=ctx.unlisted or ctx.private,
+            visibility=ctx.visibility,
             audio_storage="pds" if ctx.private else audio_storage,
             pds_blob_cid=pds_result.cid if pds_result else None,
             pds_blob_size=pds_result.size if pds_result else None,
-            is_private=ctx.private,
             space_uri=space_uri,
         )
 
@@ -1295,9 +1305,9 @@ async def run_track_upload(
     thumbnail_url: str | None,
     support_gate: dict | None,
     auto_tag: bool,
-    unlisted: bool,
     copyright_rights: dict | None = None,
-    private: bool = False,
+    audio_blob: BlobRef | None = None,
+    visibility: str = "public",
     concurrency: ConcurrencyLimit = ConcurrencyLimit("artist_did", max_concurrent=3),
 ) -> None:
     """docket task entry point for track uploads.
@@ -1333,12 +1343,14 @@ async def run_track_upload(
         # session expired or was revoked between HTTP request and task start.
         # the upload can't proceed (no PDS to publish to) and won't recover
         # without a fresh sign-in, so clean up the staged storage objects
-        # rather than leaving them as durable orphans.
-        await _delete_staged_audio(
-            audio_file_id,
-            Path(filename).suffix.lower().lstrip(".") or None,
-            gated=support_gate is not None or private,
-        )
+        # rather than leaving them as durable orphans. private media has no R2
+        # object (the audio is a PDS blob); nothing to delete there.
+        if visibility != "private":
+            await _delete_staged_audio(
+                audio_file_id,
+                Path(filename).suffix.lower().lstrip(".") or None,
+                gated=support_gate is not None,
+            )
         if image_id:
             with contextlib.suppress(Exception):
                 await storage.delete(image_id)
@@ -1369,8 +1381,7 @@ async def run_track_upload(
         support_gate=support_gate,
         copyright_rights=copyright_rights,
         auto_tag=auto_tag,
-        unlisted=unlisted,
-        private=private,
+        visibility=visibility,
     )
     await _process_upload_background(ctx)
 
@@ -1409,8 +1420,7 @@ async def schedule_track_upload(ctx: UploadContext) -> None:
         support_gate=ctx.support_gate,
         copyright_rights=ctx.copyright_rights,
         auto_tag=ctx.auto_tag,
-        unlisted=ctx.unlisted,
-        private=ctx.private,
+        visibility=ctx.visibility,
     )
 
 
@@ -1429,10 +1439,14 @@ async def upload_track(
     ] = None,
     features: Annotated[str | None, Form()] = None,
     tags: Annotated[str | None, Form(description="JSON array of tag names")] = None,
-    support_gate: Annotated[
-        str | None,
-        Form(description='JSON object for supporter gating, e.g., {"type": "any"}'),
-    ] = None,
+    visibility: Annotated[
+        str,
+        Form(
+            description="one of: public | unlisted | supporters | private. "
+            "supporters = atprotofans-gated; private = PDS permissioned space "
+            "(requires a PDS supporting com.atproto.space.*)."
+        ),
+    ] = "public",
     copyright: Annotated[
         str | None,
         Form(
@@ -1448,19 +1462,6 @@ async def upload_track(
     auto_tag: Annotated[
         str | None,
         Form(description="auto-apply recommended genre tags after classification"),
-    ] = None,
-    unlisted: Annotated[
-        str | None,
-        Form(
-            description="set to 'true' to exclude from discovery feeds (latest, top, for-you)"
-        ),
-    ] = None,
-    private: Annotated[
-        str | None,
-        Form(
-            description="set to 'true' to store as private media in the artist's ATProto "
-            "permissioned space (requires a PDS that supports com.atproto.space.*)"
-        ),
     ] = None,
     file: UploadFile = File(...),
     image: UploadFile | None = File(None),
@@ -1495,35 +1496,27 @@ async def upload_track(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
-    # parse and validate support_gate if provided
-    parsed_support_gate: dict | None = None
-    if support_gate:
-        try:
-            parsed_support_gate = json.loads(support_gate)
-            if not isinstance(parsed_support_gate, dict):
-                raise ValueError("support_gate must be a JSON object")
-            if "type" not in parsed_support_gate:
-                raise ValueError("support_gate must have a 'type' field")
-            if parsed_support_gate["type"] not in ("any",):
-                raise ValueError(
-                    f"unsupported support_gate type: {parsed_support_gate['type']}"
-                )
-        except json.JSONDecodeError as e:
-            raise HTTPException(
-                status_code=400, detail=f"invalid support_gate JSON: {e}"
-            ) from e
-        except ValueError as e:
-            raise HTTPException(status_code=400, detail=str(e)) from e
+    # visibility is the single source of truth; derive the transient gating flags.
+    _VISIBILITIES = {"public", "unlisted", "supporters", "private"}
+    if visibility not in _VISIBILITIES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"invalid visibility: {visibility} (one of {sorted(_VISIBILITIES)})",
+        )
+    is_private = visibility == "private"
+    # supporters → atprotofans gate; carried as support_gate on the public record
+    parsed_support_gate: dict | None = (
+        {"type": "any"} if visibility == "supporters" else None
+    )
 
-    # parse and validate copyright payload if provided. mutually exclusive with
-    # support_gate; copyright forces support_gate to {"type": "copyright"} so
-    # the upload pipeline routes audio into private storage.
+    # copyright (indiemusi) is orthogonal — it rides on a public/unlisted track and
+    # gates audio at the app layer. it can't combine with supporters or private.
     parsed_copyright: dict | None = None
     if copyright:
-        if parsed_support_gate is not None:
+        if visibility in ("supporters", "private"):
             raise HTTPException(
                 status_code=400,
-                detail="support_gate and copyright are mutually exclusive",
+                detail=f"copyright cannot combine with {visibility} visibility",
             )
         try:
             parsed_copyright = TrackRightsInput.model_validate_json(
@@ -1552,13 +1545,7 @@ async def upload_track(
     # space. only available on a PDS that supports com.atproto.space.*, and only
     # for web-playable sources (the blob is written at publish time; the deferred
     # transcode path still targets the public repo — see the design note).
-    is_private = private == "true"
     if is_private:
-        if parsed_support_gate is not None:
-            raise HTTPException(
-                status_code=400,
-                detail="private and gated/copyright are mutually exclusive",
-            )
         if not await detect_permissioned_capability(auth_session):
             raise HTTPException(
                 status_code=400,
@@ -1595,13 +1582,11 @@ async def upload_track(
         JobType.UPLOAD, auth_session.did, "upload queued for processing"
     )
     is_gated = parsed_support_gate is not None
-    # private media also lives off the public bucket — stage it privately so no
-    # public object is ever created (the canonical audio is the PDS blob).
-    stage_private = is_gated or is_private
     audio_extension = ext.lstrip(".") or None
 
     file_path: str | None = None
     audio_file_id: str | None = None
+    audio_blob: BlobRef | None = None
     image_id: str | None = None
     image_url: str | None = None
     thumbnail_url: str | None = None
@@ -1628,29 +1613,51 @@ async def upload_track(
         with open(file_path, "rb") as f:
             duration = extract_duration(f)
 
-        # stage audio bytes to shared storage
-        with open(file_path, "rb") as f:
-            audio_file_id = await stage_audio_to_storage(
-                upload_id, f, file.filename, gated=stage_private
-            )
+        if is_private:
+            # permissioned media: audio lives ON THE PDS, never R2. upload the
+            # blob straight to the user's PDS blobstore here (we hold the bytes +
+            # the auth session); the worker only writes the permissioned record.
+            with open(file_path, "rb") as f:
+                audio_file_id = hash_file_chunked(f)[:16]
 
-        # record where the staged blob lives so the stuck-upload reaper can
-        # clean it up if this job stalls in `processing` past the threshold.
-        # audio_extension is the original upload extension (e.g. "wav" for a
-        # lossless upload); the playable file_id may differ post-transcode,
-        # but at this point the only blob in R2 is the staged original.
-        if audio_extension:
-            await job_service.set_cleanup_hints(
-                upload_id,
-                file_id=audio_file_id,
-                file_type=audio_extension,
-                is_gated=stage_private,
+            # stream the temp file (don't buffer audio in memory); the factory is
+            # re-invoked per upload attempt, so it must yield a fresh iterator.
+            def _private_body() -> AsyncIterable[bytes]:
+                async def _gen() -> AsyncIterable[bytes]:
+                    async with aiofiles.open(file_path, "rb") as af:
+                        while chunk := await af.read(CHUNK_SIZE):
+                            yield chunk
+
+                return _gen()
+
+            audio_blob = await upload_blob(
+                auth_session,
+                body_factory=_private_body,
+                content_length=bytes_read,
+                content_type=audio_format.media_type,
             )
+            # no R2 object, no cleanup hint — nothing public/private to roll back
+        else:
+            # stage audio bytes to shared storage (R2). gated tracks (supporter/
+            # copyright) go to the private bucket; public tracks to the public one.
+            with open(file_path, "rb") as f:
+                audio_file_id = await stage_audio_to_storage(
+                    upload_id, f, file.filename, gated=is_gated
+                )
+            if audio_extension:
+                await job_service.set_cleanup_hints(
+                    upload_id,
+                    file_id=audio_file_id,
+                    file_type=audio_extension,
+                    is_gated=is_gated,
+                )
 
         # stage image bytes to shared storage (best-effort; missing or
         # invalid images don't fail the whole upload — the orchestrator
         # treats `image_id is None` as "no track artwork").
-        if image and image.filename:
+        # private media has no public cover in this MVP (a public imageUrl would
+        # leak the artwork); cover-as-PDS-blob is a follow-up.
+        if image and image.filename and not is_private:
             max_image_size = 20 * 1024 * 1024
             image_buffer = BytesIO()
             image_bytes_read = 0
@@ -1685,16 +1692,19 @@ async def upload_track(
             support_gate=parsed_support_gate,
             copyright_rights=parsed_copyright,
             auto_tag=auto_tag == "true",
-            unlisted=unlisted == "true",
-            private=is_private,
+            visibility=visibility,
+            audio_blob=audio_blob,
         )
         await schedule_track_upload(ctx)
         enqueued = True
     except Exception:
         if not enqueued:
-            if audio_file_id:
+            # private media has no R2 object to roll back — the audio is a PDS
+            # blob (an unreferenced blob is GC'd by the PDS). only clean R2 for
+            # the public/gated path.
+            if audio_file_id and not is_private:
                 await _delete_staged_audio(
-                    audio_file_id, audio_extension, gated=stage_private
+                    audio_file_id, audio_extension, gated=is_gated
                 )
             if image_id:
                 with contextlib.suppress(Exception):

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -717,14 +717,19 @@ async def _upload_to_pds(
     never holds the full file in memory. content length is sourced from
     a HEAD request so the PDS can validate up-front without buffering.
     """
-    # gated (supporter/copyright) tracks proxy through the backend and don't
-    # push a blob. private tracks are the opposite: the PDS blob IS the canonical
-    # audio, so the upload is mandatory (and bypasses the user's general
-    # PDS-upload preference + the interim-WAV deferral, which private uploads
-    # avoid by requiring a web-playable source at the endpoint).
+    # private media's audio was already uploaded to the PDS blobstore in the
+    # request handler (never staged to R2) — just hand the existing BlobRef back.
     if audio_info.is_private:
-        pass
-    elif audio_info.is_gated:
+        blob = ctx.audio_blob
+        if not blob:
+            return None
+        return PdsBlobResult(
+            blob_ref=blob, cid=blob["ref"]["$link"], size=blob.get("size")
+        )
+
+    # gated (supporter/copyright) tracks proxy through the backend and don't push
+    # a blob.
+    if audio_info.is_gated:
         return None
     elif sr.needs_optimization:
         # the interim WAV rendition is large and throwaway — never push it to the
@@ -1382,6 +1387,7 @@ async def run_track_upload(
         copyright_rights=copyright_rights,
         auto_tag=auto_tag,
         visibility=visibility,
+        audio_blob=audio_blob,
     )
     await _process_upload_background(ctx)
 
@@ -1421,6 +1427,7 @@ async def schedule_track_upload(ctx: UploadContext) -> None:
         copyright_rights=ctx.copyright_rights,
         auto_tag=ctx.auto_tag,
         visibility=ctx.visibility,
+        audio_blob=ctx.audio_blob,
     )
 
 

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -929,11 +929,14 @@ async def _create_records(
             await db.refresh(track)
         except IntegrityError as e:
             await db.rollback()
-            with contextlib.suppress(Exception):
-                await storage.delete(sr.file_id, playable_file_type)
-            if sr.original_file_id and sr.original_file_type:
+            # private media has no R2 object (PDS blob); its file_id is a content
+            # hash that could collide with a public track's R2 key — never delete.
+            if not ctx.private:
                 with contextlib.suppress(Exception):
-                    await storage.delete(sr.original_file_id, sr.original_file_type)
+                    await storage.delete(sr.file_id, playable_file_type)
+                if sr.original_file_id and sr.original_file_type:
+                    with contextlib.suppress(Exception):
+                        await storage.delete(sr.original_file_id, sr.original_file_type)
             raise UploadPhaseError(f"database constraint violation: {e!s}") from e
 
         track_id = track.id
@@ -1008,8 +1011,11 @@ async def _create_records(
                 await db.commit()
                 deleted_pending = result.rowcount == 1  # type: ignore[union-attr]
 
-        if deleted_pending:
-            # row was still pending — safe to clean up media
+        if deleted_pending and not ctx.private:
+            # row was still pending — safe to clean up media. private media has no
+            # R2 object (its audio is a PDS blob and its file_id is a content hash
+            # that could collide with a public track's R2 key), so skip it; the
+            # orphaned PDS blob is GC'd by the PDS.
             with contextlib.suppress(Exception):
                 await storage.delete(sr.file_id, playable_file_type)
             if sr.original_file_id and sr.original_file_type:
@@ -1141,6 +1147,12 @@ async def _cleanup_staged_media_pre_db(
     cleanup logic; the orchestrator must not run this past that
     boundary or it'll yank media out from under a committed row.
     """
+    # private media never staged anything to R2 — its audio is a PDS blob and it
+    # has no cover. deleting by the synthetic file_id (a content hash) could yank a
+    # DIFFERENT public track's R2 object that happens to share the same bytes.
+    if ctx.private:
+        return
+
     is_gated = ctx.support_gate is not None
 
     if sr is not None and sr.transcode_info is not None:

--- a/backend/src/backend/models/track.py
+++ b/backend/src/backend/models/track.py
@@ -3,8 +3,9 @@
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String
+from sqlalchemy import ColumnElement, DateTime, ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from backend.models.database import Base
@@ -101,11 +102,19 @@ class Track(Base):
     image_url: Mapped[str | None] = mapped_column(String, nullable=True)
     thumbnail_url: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    # visibility — unlisted tracks don't appear in discovery feeds (latest,
-    # top, for-you) but are still accessible via direct link, artist profile,
-    # album pages, playlists, and search
-    unlisted: Mapped[bool] = mapped_column(
-        nullable=False, default=False, server_default="false"
+    # visibility — single source of truth for discovery + access + where audio
+    # lives. one mutually-exclusive value (no overlapping booleans):
+    #   public     — in feeds; audio on R2/CDN; anyone
+    #   unlisted   — NOT in feeds; audio on R2/CDN; anyone with the link
+    #   supporters — in feeds (locked); audio in R2 private bucket; plyr.fm gates
+    #                on atprotofans support; carries support_gate={"type":"any"}
+    #   private    — NOT in feeds; audio + record live in the artist's ATProto
+    #                permissioned space ON THEIR PDS (never R2); the PDS gates via
+    #                a space credential; owner-only. space_uri holds the ats:// space.
+    # copyright gating (indiemusi) is orthogonal — it rides on public/unlisted via
+    # support_gate={"type":"copyright"} and the copyright_* pointers below.
+    visibility: Mapped[str] = mapped_column(
+        String, nullable=False, default="public", server_default="public", index=True
     )
 
     # notification tracking
@@ -113,19 +122,14 @@ class Track(Base):
         nullable=False, default=False, server_default="false"
     )
 
-    # supporter-gated content (e.g., {"type": "any"} requires any atprotofans support)
+    # gating mechanism detail (drives the ATProto record's supportGate field +
+    # audio access checks): {"type": "any"} for supporters, {"type": "copyright"}
+    # for the indiemusi paradigm. None for ungated tracks.
     support_gate: Mapped[dict | None] = mapped_column(
         JSONB(none_as_null=True), nullable=True, default=None
     )
 
-    # private media stored in an ATProto permissioned space (com.atproto.space.*).
-    # the audio blob + track record live in the artist's permissioned repo on their
-    # PDS; there is no public R2 copy and the track is excluded from discovery.
-    # space_uri is the 3-segment ats:// space URI; the record is reachable only
-    # through the space credential path. requires a PDS that supports spaces.
-    is_private: Mapped[bool] = mapped_column(
-        nullable=False, default=False, server_default="false"
-    )
+    # 3-segment ats:// space URI for private (permissioned) media; None otherwise.
     space_uri: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # copyright paradigm record pointers — set when the user has opted into a
@@ -134,6 +138,28 @@ class Track(Base):
     # app-layer pointer; the PDS records themselves have no back-reference.
     copyright_song_uri: Mapped[str | None] = mapped_column(String, nullable=True)
     copyright_recording_uri: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    # --- derived visibility helpers (usable in both Python and SQL queries) ---
+
+    @hybrid_property
+    def is_private(self) -> bool:
+        """private (permissioned-space) media — owner-only, PDS-native."""
+        return self.visibility == "private"
+
+    @is_private.inplace.expression
+    @classmethod
+    def _is_private_expr(cls) -> ColumnElement[bool]:
+        return cls.visibility == "private"
+
+    @hybrid_property
+    def in_discovery(self) -> bool:
+        """appears in discovery feeds (latest / top / for-you / radio)."""
+        return self.visibility in ("public", "supporters")
+
+    @in_discovery.inplace.expression
+    @classmethod
+    def _in_discovery_expr(cls) -> ColumnElement[bool]:
+        return cls.visibility.in_(("public", "supporters"))
 
     @property
     def is_gated(self) -> bool:

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -153,7 +153,8 @@ class TrackResponse(BaseModel):
     description: str | None = None  # track description (liner notes, show notes)
     audio_storage: str = "r2"  # "r2" | "pds" | "both"
     pds_blob_cid: str | None = None  # CID if stored on user's PDS
-    unlisted: bool = False  # excluded from discovery feeds
+    visibility: str = "public"  # public | unlisted | supporters | private
+    unlisted: bool = False  # derived: excluded from discovery feeds
 
     @classmethod
     async def from_track(
@@ -280,7 +281,8 @@ class TrackResponse(BaseModel):
             original_file_type=track.original_file_type,
             audio_storage=track.audio_storage,
             pds_blob_cid=track.pds_blob_cid,
-            unlisted=track.unlisted,
+            visibility=track.visibility,
+            unlisted=not track.in_discovery,
             copyright_song_uri=track.copyright_song_uri,
             copyright_recording_uri=track.copyright_recording_uri,
         )

--- a/backend/tests/api/test_private_media_upload.py
+++ b/backend/tests/api/test_private_media_upload.py
@@ -84,7 +84,7 @@ def test_private_requires_pds_capability(app_no_scope: FastAPI):
         ),
         TestClient(app_no_scope) as client,
     ):
-        resp = _post(client, data={"private": "true"})
+        resp = _post(client, data={"visibility": "private"})
     assert resp.status_code == 400
     assert "permissioned spaces" in resp.json()["detail"]
 
@@ -97,7 +97,7 @@ def test_private_capable_but_scope_missing_requests_upgrade(app_no_scope: FastAP
         ),
         TestClient(app_no_scope) as client,
     ):
-        resp = _post(client, data={"private": "true"})
+        resp = _post(client, data={"visibility": "private"})
     assert resp.status_code == 403
     assert resp.json()["detail"] == "permissioned_scope_required"
 
@@ -113,17 +113,18 @@ def test_private_rejects_non_web_playable(app_with_scope: FastAPI):
         resp = client.post(
             "/tracks/",
             files={"file": ("t.aiff", _WAV, "audio/aiff")},
-            data={"title": "x", "private": "true"},
+            data={"title": "x", "visibility": "private"},
         )
     assert resp.status_code == 400
     assert "web-playable" in resp.json()["detail"]
 
 
-def test_private_and_gated_mutually_exclusive(app_with_scope: FastAPI):
-    # support_gate + private is rejected before any capability check
+def test_private_and_copyright_mutually_exclusive(app_with_scope: FastAPI):
+    # visibility=private can't combine with the orthogonal copyright gate
     with TestClient(app_with_scope) as client:
         resp = _post(
-            client, data={"private": "true", "support_gate": '{"type": "any"}'}
+            client,
+            data={"visibility": "private", "copyright": '{"iswc": "T-000.000.001-0"}'},
         )
     assert resp.status_code == 400
-    assert "mutually exclusive" in resp.json()["detail"]
+    assert "copyright cannot combine" in resp.json()["detail"]

--- a/backend/tests/api/test_private_media_upload.py
+++ b/backend/tests/api/test_private_media_upload.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, require_artist_profile
+from backend._internal.audio import AudioFormat
 from backend.config import settings
 from backend.main import app
 
@@ -128,3 +129,92 @@ def test_private_and_copyright_mutually_exclusive(app_with_scope: FastAPI):
         )
     assert resp.status_code == 400
     assert "copyright cannot combine" in resp.json()["detail"]
+
+
+# --- success path: private upload goes to the PDS, never R2 (regression) ------
+
+
+def test_private_upload_goes_to_pds_not_r2(app_with_scope: FastAPI):
+    """a capable+scoped private upload must call uploadBlob, never stage to R2,
+    and carry the resulting BlobRef on the enqueued context."""
+    fake_blob = {
+        "$type": "blob",
+        "ref": {"$link": "bafkreiprivatesmoke"},
+        "mimeType": "audio/wav",
+        "size": len(_WAV),
+    }
+    captured: dict = {}
+
+    async def _fake_upload_blob(*args, **kwargs):
+        return fake_blob
+
+    async def _fake_schedule(ctx):
+        captured["ctx"] = ctx
+
+    async def _no_stage(*args, **kwargs):  # must NOT be called for private
+        raise AssertionError("private upload must not stage audio to R2")
+
+    with (
+        patch(
+            "backend.api.tracks.uploads.detect_permissioned_capability",
+            return_value=True,
+        ),
+        patch("backend.api.tracks.uploads.upload_blob", _fake_upload_blob),
+        patch("backend.api.tracks.uploads.stage_audio_to_storage", _no_stage),
+        patch("backend.api.tracks.uploads.schedule_track_upload", _fake_schedule),
+        TestClient(app_with_scope) as client,
+    ):
+        resp = _post(client, data={"visibility": "private"})
+
+    assert resp.status_code == 200, resp.text
+    ctx = captured["ctx"]
+    # the BlobRef from the PDS upload rode through to the worker context
+    assert ctx.visibility == "private"
+    assert ctx.audio_blob == fake_blob
+    assert ctx.private is True
+
+
+async def test_upload_to_pds_reuses_handler_blob_for_private(monkeypatch):
+    """worker phase 4: private uploads return the handler's BlobRef without
+    touching R2 (no head_file / stream_file_data)."""
+    from backend.api.tracks import uploads as up
+    from backend.storage import storage
+
+    blob = {"$type": "blob", "ref": {"$link": "bafkreiabc"}, "size": 99}
+    ctx = up.UploadContext(
+        upload_id="u",
+        auth_session=_MockSession(with_space_scope=True),
+        audio_file_id="hash16",
+        filename="t.wav",
+        duration=1,
+        title="x",
+        artist_did="did:test:artist",
+        album=None,
+        album_id=None,
+        features_json=None,
+        tags=[],
+        visibility="private",
+        audio_blob=blob,
+    )
+    info = up.AudioInfo(
+        format=AudioFormat.MP3, duration=1, is_gated=False, is_private=True
+    )
+    sr = up.StorageResult(
+        file_id="hash16",
+        original_file_id=None,
+        original_file_type=None,
+        playable_format=AudioFormat.MP3,
+        r2_url=None,
+        transcode_info=None,
+    )
+
+    def _boom(*a, **k):
+        raise AssertionError("private must not read audio from R2")
+
+    monkeypatch.setattr(storage, "head_file", _boom)
+    monkeypatch.setattr(storage, "stream_file_data", _boom)
+
+    result = await up._upload_to_pds(ctx, info, sr)
+    assert result is not None
+    assert result.blob_ref == blob
+    assert result.cid == "bafkreiabc"

--- a/backend/tests/api/test_private_media_upload.py
+++ b/backend/tests/api/test_private_media_upload.py
@@ -218,3 +218,42 @@ async def test_upload_to_pds_reuses_handler_blob_for_private(monkeypatch):
     assert result is not None
     assert result.blob_ref == blob
     assert result.cid == "bafkreiabc"
+
+
+async def test_private_cleanup_never_touches_r2(monkeypatch):
+    """regression: private failure-cleanup must NOT call storage.delete. the
+    synthetic file_id is a content hash that could collide with a DIFFERENT
+    public track's R2 key; private audio lives only as a PDS blob."""
+    from backend.api.tracks import uploads as up
+    from backend.storage import storage
+
+    ctx = up.UploadContext(
+        upload_id="u",
+        auth_session=_MockSession(with_space_scope=True),
+        audio_file_id="collidinghash16",
+        filename="t.wav",
+        duration=1,
+        title="x",
+        artist_did="did:test:artist",
+        album=None,
+        album_id=None,
+        features_json=None,
+        tags=[],
+        visibility="private",
+    )
+    sr = up.StorageResult(
+        file_id="collidinghash16",
+        original_file_id=None,
+        original_file_type=None,
+        playable_format=AudioFormat.MP3,
+        r2_url=None,
+        transcode_info=None,
+    )
+
+    async def _boom(*a, **k):
+        raise AssertionError("private cleanup must not delete from R2")
+
+    monkeypatch.setattr(storage, "delete", _boom)
+
+    # must be a no-op for private (early return), not an R2 delete
+    await up._cleanup_staged_media_pre_db(ctx, sr)

--- a/backend/tests/api/test_private_media_visibility.py
+++ b/backend/tests/api/test_private_media_visibility.py
@@ -42,8 +42,7 @@ async def _make_track(db_session: AsyncSession, *, title: str, fid: str, private
         artist_did=_DID,
         file_id=fid,
         file_type="mp3",
-        is_private=private,
-        unlisted=private,
+        visibility="private" if private else "public",
         space_uri=(f"ats://{_DID}/fm.plyr.privateMedia/self" if private else None),
         atproto_record_uri=(
             f"ats://{_DID}/fm.plyr.privateMedia/self/{_DID}/fm.plyr.track/rk"
@@ -114,7 +113,11 @@ def test_visibility_helper_rules():
 
     public = Track(title="p", artist_did=_DID, file_id="h_pub", file_type="mp3")
     private = Track(
-        title="x", artist_did=_DID, file_id="h_priv", file_type="mp3", is_private=True
+        title="x",
+        artist_did=_DID,
+        file_id="h_priv",
+        file_type="mp3",
+        visibility="private",
     )
 
     # public: anyone

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -134,7 +134,7 @@ async def _create_track(
         image_url="https://images.example/cover.jpg",
         atproto_record_uri=f"at://{artist.did}/fm.plyr.track/{file_id}",
         play_count=play_count,
-        unlisted=unlisted,
+        visibility="unlisted" if unlisted else "public",
         support_gate=support_gate,
     )
     db_session.add(track)

--- a/frontend/src/lib/components/AlbumUploadForm.svelte
+++ b/frontend/src/lib/components/AlbumUploadForm.svelte
@@ -339,7 +339,7 @@
 					[...track.featuredArtists],
 					null, // no per-track cover — album cover was uploaded above
 					[...track.tags],
-					track.supportGated,
+					track.supportGated ? 'supporters' : 'public',
 					track.autoTag,
 					track.description,
 					(result) => {

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -99,16 +99,14 @@ class UploaderState {
 		features: FeaturedArtist[],
 		image: File | null | undefined,
 		tags: string[],
-		supportGated: boolean,
+		visibility: string,
 		autoTag: boolean,
 		description: string,
 		onSuccess?: (_result?: UploadResult) => void,
 		callbacks?: UploadProgressCallback,
 		label?: string,
 		albumId?: string,
-		unlisted?: boolean,
-		copyright?: object | null,
-		isPrivate?: boolean
+		copyright?: object | null
 	): void {
 		const taskId = crypto.randomUUID();
 		const fileSizeMB = file.size / 1024 / 1024;
@@ -148,9 +146,9 @@ class UploaderState {
 		if (image) {
 			formData.append('image', image);
 		}
-		if (supportGated) {
-			formData.append('support_gate', JSON.stringify({ type: 'any' }));
-		}
+		// visibility is the single source of truth (public | unlisted | supporters
+		// | private); copyright is orthogonal (rides on public/unlisted).
+		formData.append('visibility', visibility);
 		if (copyright) {
 			formData.append('copyright', JSON.stringify(copyright));
 		}
@@ -159,12 +157,6 @@ class UploaderState {
 		}
 		if (description) {
 			formData.append('description', description);
-		}
-		if (unlisted) {
-			formData.append('unlisted', 'true');
-		}
-		if (isPrivate) {
-			formData.append('private', 'true');
 		}
 
 		const xhr = new XMLHttpRequest();

--- a/frontend/src/routes/record/+page.svelte
+++ b/frontend/src/routes/record/+page.svelte
@@ -227,7 +227,7 @@
 			[],
 			null,
 			tags,
-			false,
+			'public',
 			false,
 			'',
 			() => {},

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -69,16 +69,15 @@
 	let description = $state("");
 	let hasUnresolvedFeaturesInput = $state(false);
 	let attestedRights = $state(false);
-	let supportGated = $state(false);
 	let autoTag = $state(false);
-	let trackUnlisted = $state(false);
-	// private media — stored in the artist's ATProto permissioned space. only
-	// offered when the user's PDS supports com.atproto.space.* (see /auth/me).
-	let keepPrivate = $state(false);
+	// visibility/access — one mutually-exclusive choice:
+	//   public | unlisted | supporters | private
+	// "private" is only offered when the PDS supports com.atproto.space.* (/auth/me).
+	let visibility = $state<'public' | 'unlisted' | 'supporters' | 'private'>('public');
 	const permissionedSupported = $derived(
 		auth.user?.permissioned_spaces?.supported ?? false
 	);
-	// copyright rights metadata — mutually exclusive with supporter gating.
+	// copyright rights metadata — orthogonal, rides on public/unlisted tracks.
 	// when enabled, audio is uploaded to private storage and the backend writes
 	// indiemusi song + recording records after the track is published.
 	let copyrightEnabled = $state(false);
@@ -112,9 +111,12 @@
 			featuredArtists = stashed.featuredArtists;
 			uploadTags = stashed.uploadTags;
 			attestedRights = stashed.attestedRights;
-			supportGated = stashed.supportGated;
 			autoTag = stashed.autoTag;
-			trackUnlisted = stashed.trackUnlisted;
+			visibility = stashed.supportGated
+				? 'supporters'
+				: stashed.trackUnlisted
+					? 'unlisted'
+					: 'public';
 			clearTrackFormStash();
 			toast.info(
 				"your draft was restored — please reattach your audio file",
@@ -174,9 +176,9 @@
 				featuredArtists: [...featuredArtists],
 				uploadTags: [...uploadTags],
 				attestedRights,
-				supportGated,
+				supportGated: visibility === 'supporters',
 				autoTag,
-				trackUnlisted,
+				trackUnlisted: visibility === 'unlisted',
 			});
 			setReturnUrl("/upload");
 			toast.error(
@@ -201,10 +203,9 @@
 		const uploadFeatures = [...featuredArtists];
 		const uploadImage = imageFile;
 		const tagsToUpload = [...uploadTags];
-		const isGated = supportGated;
+		const uploadVisibility = visibility;
 		const shouldAutoTag = autoTag;
 		const uploadDescription = description;
-		const isUnlisted = trackUnlisted;
 
 		const clearForm = () => {
 			title = "";
@@ -215,10 +216,8 @@
 			featuredArtists = [];
 			uploadTags = [];
 			attestedRights = false;
-			supportGated = false;
 			autoTag = false;
-			trackUnlisted = false;
-			keepPrivate = false;
+			visibility = 'public';
 			copyrightEnabled = false;
 			copyrightRights = {};
 
@@ -243,7 +242,7 @@
 			uploadFeatures,
 			uploadImage,
 			tagsToUpload,
-			isGated,
+			uploadVisibility,
 			shouldAutoTag,
 			uploadDescription,
 			async () => {
@@ -257,9 +256,7 @@
 			},
 			undefined, // label
 			undefined, // albumId
-			isUnlisted,
 			copyrightToSend,
-			keepPrivate,
 		);
 	}
 
@@ -475,64 +472,51 @@
 			<CopyrightRightsPanel
 				bind:enabled={copyrightEnabled}
 				bind:rights={copyrightRights}
-				disabled={supportGated}
+				disabled={visibility !== 'public' && visibility !== 'unlisted'}
 			/>
 
 			<fieldset class="form-group access-card">
 				<legend>visibility &amp; access</legend>
 
-				<div class="access-row supporter-gating">
-					{#if artistProfile?.support_url}
-						<label class="checkbox-label">
-							<input
-								type="checkbox"
-								bind:checked={supportGated}
-								disabled={copyrightEnabled}
-							/>
+				<label class="access-row checkbox-label">
+					<input type="radio" bind:group={visibility} value="public" />
+					<span class="access-body">
+						<span class="checkbox-text">public</span>
+						<span class="access-note">appears in feeds; anyone can play it.</span>
+					</span>
+				</label>
+
+				<label class="access-row checkbox-label">
+					<input type="radio" bind:group={visibility} value="unlisted" />
+					<span class="access-body">
+						<span class="checkbox-text">unlisted</span>
+						<span class="access-note">hidden from feeds, but anyone with the link, your profile, albums, playlists, or search can play it.</span>
+					</span>
+				</label>
+
+				{#if artistProfile?.support_url}
+					<label class="access-row checkbox-label supporter-gating">
+						<input type="radio" bind:group={visibility} value="supporters" disabled={copyrightEnabled} />
+						<span class="access-body">
 							<span class="checkbox-text">
 								<svg class="heart-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
 									<path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
 								</svg>
 								supporters only
 							</span>
-						</label>
-						<p class="access-note">
-							only users who support you via <a href={artistProfile.support_url} target="_blank" rel="noopener">atprotofans</a> can play this track
-						</p>
-					{:else}
-						<div class="gating-disabled">
-							<span class="gating-disabled-icon">
-								<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-									<path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-								</svg>
-							</span>
-							<span class="gating-disabled-text">
-								want to offer exclusive tracks to supporters? <a href="https://atprotofans.com" target="_blank" rel="noopener">set up atprotofans</a>, then enable it in your <a href="/portal">portal</a>
-							</span>
-						</div>
-					{/if}
-				</div>
-
-				<div class="access-row">
-					<label class="checkbox-label">
-						<input type="checkbox" bind:checked={trackUnlisted} />
-						<span class="checkbox-text">unlisted</span>
+							<span class="access-note">only users who support you via <a href={artistProfile.support_url} target="_blank" rel="noopener">atprotofans</a> can play it.</span>
+						</span>
 					</label>
-					<p class="access-note">
-						hidden from the latest, top, and for-you feeds — still reachable via direct link, your profile, albums, playlists, and search.
-					</p>
-				</div>
+				{/if}
 
 				{#if permissionedSupported}
-					<div class="access-row">
-						<label class="checkbox-label">
-							<input type="checkbox" bind:checked={keepPrivate} />
-							<span class="checkbox-text">keep private</span>
-						</label>
-						<p class="access-note">
-							stored in a private space on your PDS — no public copy, hidden from feeds, playable only by you. you'll be asked once to approve private-media access.
-						</p>
-					</div>
+					<label class="access-row checkbox-label">
+						<input type="radio" bind:group={visibility} value="private" disabled={copyrightEnabled} />
+						<span class="access-body">
+							<span class="checkbox-text">private</span>
+							<span class="access-note">stored in a permissioned space on your PDS — no public copy, hidden from feeds, playable only by you. you'll be asked once to approve private-media access.</span>
+						</span>
+					</label>
 				{/if}
 			</fieldset>
 
@@ -861,11 +845,29 @@
 	}
 
 	.access-row {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.6rem;
 		padding: 0.875rem 1rem;
+		margin: 0;
+		cursor: pointer;
 	}
 
 	.access-row + .access-row {
 		border-top: 1px solid var(--border-default);
+	}
+
+	.access-row input[type='radio'] {
+		margin-top: 0.2rem;
+		flex-shrink: 0;
+		accent-color: var(--accent);
+		cursor: pointer;
+	}
+
+	.access-body {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
 	}
 
 	.supporter-gating .checkbox-text {
@@ -879,8 +881,6 @@
 	}
 
 	.access-note {
-		margin-top: 0.4rem;
-		margin-left: 2rem;
 		font-size: var(--text-sm);
 		color: var(--text-tertiary);
 		line-height: 1.4;
@@ -892,32 +892,6 @@
 	}
 
 	.access-note a:hover {
-		text-decoration: underline;
-	}
-
-	.gating-disabled {
-		display: flex;
-		align-items: flex-start;
-		gap: 0.75rem;
-		color: var(--text-muted);
-	}
-
-	.gating-disabled-icon {
-		flex-shrink: 0;
-		margin-top: 0.1rem;
-	}
-
-	.gating-disabled-text {
-		font-size: var(--text-sm);
-		line-height: 1.4;
-	}
-
-	.gating-disabled-text a {
-		color: var(--accent);
-		text-decoration: none;
-	}
-
-	.gating-disabled-text a:hover {
 		text-decoration: underline;
 	}
 

--- a/loq.toml
+++ b/loq.toml
@@ -40,7 +40,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1787
+max_lines = 1797
 
 [[rules]]
 path = "backend/src/backend/config.py"

--- a/loq.toml
+++ b/loq.toml
@@ -40,7 +40,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1804
+max_lines = 1818
 
 [[rules]]
 path = "backend/src/backend/config.py"

--- a/loq.toml
+++ b/loq.toml
@@ -40,7 +40,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1797
+max_lines = 1804
 
 [[rules]]
 path = "backend/src/backend/config.py"


### PR DESCRIPTION
Reworks the visibility/access model and makes private media **PDS-native** — the two structural fixes from our back-and-forth. Open for review per your call; happy to iterate.

## the model — one axis, not three booleans

`Track.visibility` is now the single source of truth: **`public | unlisted | supporters | private`** (mutually exclusive). Drops the `unlisted` + `is_private` columns; `is_private` / `in_discovery` are derived `hybrid_property`s (work in Python *and* SQL). `support_gate` stays as the gate-*type* detail; **copyright (indiemusi) is orthogonal** — it rides on public/unlisted, not a visibility value.

This kills the overlap: `private` *implies* not-in-feeds (no separate `unlisted` flag to sync), and `private`/`supporters` can't both be set.

<details>
<summary>Backend</summary>

- **model + migration**: `visibility` enum column + index; Alembic backfills `private > supporters (support_gate=any) > unlisted > public` and drops the two booleans.
- **reads/guards** all key off `visibility`: `track_visible_filter`/`ensure_track_visible`, discovery feeds (`in_discovery` = public+supporters), search, albums (counts + detail), audio serving, likes/comments/shares/tags, oembed, post-create hooks, serialization (`TrackResponse.visibility`).
- **upload API** takes `visibility` (+ orthogonal `copyright`); derives the internal gating flags. edit endpoint keeps `visibility` consistent when supporter-gating toggles.

</details>

<details>
<summary>Private media is PDS-native (never R2)</summary>

Per #1528 ("upload the audio blob to the artist account's PDS blobstore", "keep blobs on its current PDS", "a permission space is not a physical storage bucket"):

- the upload **handler** streams the audio straight to `com.atproto.repo.uploadBlob` on the user's PDS — chunked `body_factory`, never buffered into memory — and passes the `BlobRef` across the docket boundary. the worker only writes the permissioned-space record (`ensure_personal_space` + `create_space_record`).
- **no R2 at all** for private: no public object, no private-bucket staging, no CDN url. if the PDS upload or space-record write fails, the upload fails (no R2 fallback).
- playback stays the credential-gated `space.getBlob` proxy with Range forwarding.

This replaces the earlier mistake of routing private audio through the R2 *gated* path (supporter/copyright) — those remain R2-private + app-gated; private is PDS-gated.

</details>

<details>
<summary>Frontend</summary>

One mutually-exclusive **visibility selector** (radio group) replaces the three stacked checkboxes. The `private` option only renders when the PDS supports permissioned spaces (`/auth/me` `permissioned_spaces.supported`); copyright stays orthogonal (offered only on public/unlisted). Album + in-browser-record upload paths updated to pass `visibility`.

</details>

## tests / checks
- visibility model + guards, upload preflight (capability / scope-upgrade / web-playable / copyright-exclusion), radio, ats:// serialization.
- full backend suite (**1182 passing**) + svelte-check + eslint + loq green.

## still tracked (not in this PR)
- the real-OAuth private write/playback e2e against `pds.zat.dev` — was blocked on the ZDS `include:` permission-set deploy (resolved) then the capability fail-closed fix; ready to verify through the app once this deploys to staging.
- prod needs `NAMESPACE=fm.plyr` permission set published before private media works in prod.
- non-web-playable private uploads (deferred-transcode path) + private cover art (currently omitted) are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)