### PR TITLE
fix(uploads): dead atproto session → 401, not a misleading "connection failed" toast

### DIFF
--- a/backend/src/backend/_internal/atproto/client.py
+++ b/backend/src/backend/_internal/atproto/client.py
@@ -126,6 +126,15 @@ class PayloadTooLargeError(Exception):
     """raised when PDS rejects a blob due to size limits."""
 
 
+class SessionExpiredError(Exception):
+    """raised when an OAuth token refresh fails terminally (the refresh token
+    itself is dead — `invalid_grant`). the only remedy is re-authentication, so
+    callers/handlers should surface a 401, not a 500. distinct from transient
+    refresh failures (network blips), which keep raising ValueError so existing
+    retry/catch logic is unaffected.
+    """
+
+
 # BlobRef uses ATProto's JSON structure with $type, $link keys.
 # TypedDict can't express $ in field names, so we use dict[str, Any] with documentation.
 # Structure: {"$type": "blob", "ref": {"$link": "<CID>"}, "mimeType": str, "size": int}
@@ -277,6 +286,13 @@ async def _refresh_session_tokens(
                     )
                     return retry_oauth_session
 
+            # a dead refresh token (`invalid_grant`) is terminal — the session
+            # can't be saved by a retry, the user must sign in again. surface it
+            # as a distinct type so handlers return 401 instead of 500.
+            if "invalid_grant" in str(e):
+                raise SessionExpiredError(
+                    "atproto session expired — re-authentication required"
+                ) from e
             raise ValueError(f"failed to refresh access token: {e}") from e
 
 

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -15,6 +15,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 
 from backend._internal import jam_service, notification_service, queue_service
+from backend._internal.atproto.client import SessionExpiredError
 from backend._internal.background import docket_client_lifespan
 from backend.api import (
     account_router,
@@ -132,6 +133,19 @@ app = FastAPI(
 # setup rate limiter
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
+
+
+async def _session_expired_handler(request: Request, exc: Exception) -> Response:
+    """a dead atproto refresh token is the user's problem to fix (re-auth), not a
+    server fault — return 401 so the client prompts a fresh sign-in. registered as
+    a typed handler so it runs inside CORSMiddleware (the catch-all 500 handler
+    runs outside it, which strips CORS headers and makes the browser see a opaque
+    network error instead of the real status).
+    """
+    return ORJSONResponse(status_code=401, content={"detail": "session_expired"})
+
+
+app.add_exception_handler(SessionExpiredError, _session_expired_handler)
 
 
 async def _unhandled_exception_handler(request: Request, exc: Exception) -> Response:

--- a/backend/tests/api/test_private_media_upload.py
+++ b/backend/tests/api/test_private_media_upload.py
@@ -257,3 +257,28 @@ async def test_private_cleanup_never_touches_r2(monkeypatch):
 
     # must be a no-op for private (early return), not an R2 delete
     await up._cleanup_staged_media_pre_db(ctx, sr)
+
+
+def test_private_upload_dead_session_returns_401_not_500(app_with_scope: FastAPI):
+    """a dead atproto refresh token during the in-request PDS blob upload must
+    surface as 401 session_expired (so the client re-auths), not a 500 that the
+    browser shows as a misleading 'connection failed' network error."""
+    from backend._internal.atproto.client import SessionExpiredError
+
+    async def _dead_session(*args, **kwargs):
+        raise SessionExpiredError(
+            "atproto session expired — re-authentication required"
+        )
+
+    with (
+        patch(
+            "backend.api.tracks.uploads.detect_permissioned_capability",
+            return_value=True,
+        ),
+        patch("backend.api.tracks.uploads.upload_blob", _dead_session),
+        TestClient(app_with_scope) as client,
+    ):
+        resp = _post(client, data={"visibility": "private"})
+
+    assert resp.status_code == 401, resp.text
+    assert resp.json()["detail"] == "session_expired"

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -1,8 +1,10 @@
 import { browser } from '$app/environment';
+import { goto } from '$app/navigation';
 import { API_URL } from './config';
 import { toast } from './toast.svelte';
 import { tracksCache } from './tracks.svelte';
 import type { FeaturedArtist } from './types';
+import { setReturnUrl } from './utils/return-url';
 
 interface UploadTask {
 	id: string;
@@ -69,6 +71,12 @@ function buildNetworkErrorMessage(progressPercent: number, fileSizeMB: number, i
 
 	if (progressPercent > 0 && progressPercent < 100) {
 		return `upload failed${progressInfo}: connection was interrupted. check your network and try again`;
+	}
+
+	// at 100% the file finished uploading — the failure is on the server while it
+	// processes the file, so don't blame the user's connection.
+	if (progressPercent >= 100) {
+		return `upload failed${progressInfo}: the server had trouble processing your file. please try again in a moment`;
 	}
 
 	return `upload failed${progressInfo}: connection failed. check your internet connection and try again`;
@@ -283,6 +291,16 @@ class UploaderState {
 					// off the one-time opt-in upgrade, then the user retries the upload.
 					if (xhr.status === 403 && error.detail === 'permissioned_scope_required') {
 						void startPermissionedScopeUpgrade();
+						return;
+					}
+					// the atproto session's refresh token died — the upload couldn't
+					// authenticate to the PDS. /auth/me preflight can't catch this (it
+					// doesn't force a token refresh), so handle it at runtime: bounce to
+					// sign-in instead of showing a misleading "connection failed".
+					if (xhr.status === 401 && error.detail === 'session_expired') {
+						toast.error('your session expired — sign in to finish your upload');
+						setReturnUrl('/upload');
+						if (browser) void goto('/login');
 						return;
 					}
 					errorMsg = error.detail || errorMsg;

--- a/loq.toml
+++ b/loq.toml
@@ -284,7 +284,7 @@ max_lines = 2589
 
 [[rules]]
 path = "backend/src/backend/_internal/atproto/client.py"
-max_lines = 617
+max_lines = 633
 
 [[rules]]
 path = "backend/src/backend/_internal/auth/oauth.py"


### PR DESCRIPTION
A private upload that hit a dead OAuth session showed `upload failed (failed at 100%): connection failed. check your internet connection` — blaming the user's wifi when the real cause was server-side.

## Root cause (from staging spans)

`POST /tracks/` → **500** in 2.67s:
```
ValueError: failed to refresh access token: Token refresh failed:
400 {"error":"invalid_grant","error_description":"Invalid refresh token"}
```

A private upload streams the audio blob to the user's PDS *inside the request* — the first thing to exercise the live OAuth token. The session's refresh token was dead (`invalid_grant`), so token refresh raised a bare `ValueError` → unhandled 500. Public uploads never hit this (refresh happens later, in the worker).

Two compounding bugs:
1. A dead session 500s instead of returning a clean 401.
2. The catch-all `Exception` handler runs on Starlette's outermost `ServerErrorMiddleware` — **outside** `CORSMiddleware` — so the 500 response had no CORS headers. The browser treated it as an opaque network error (xhr `status === 0`), and at 100% the uploader's network-error message blames the user's connection.

## Fix

<details>
<summary>backend</summary>

- New typed `SessionExpiredError`, raised when refresh fails terminally (`invalid_grant`). Transient refresh failures still raise `ValueError`, so existing retry/catch logic is unaffected.
- A typed 401 handler returning `{"detail": "session_expired"}`. Because it's a *specific* exception handler it runs inside `ExceptionMiddleware` (inside `CORSMiddleware`), so the browser receives a real 401 with CORS headers — not an opaque status-0. Fixes this for **every** in-request PDS op, not just uploads.
</details>

<details>
<summary>frontend</summary>

- Uploader handles 401 `session_expired` at runtime: clear toast + bounce to `/login` with a return-url. The existing `/auth/me` preflight can't catch this — it doesn't force a token refresh, so it returns `ok` while the actual PDS op fails.
- Reworded the 100%-failure message: at 100% the file finished uploading, so the failure is server-side ("the server had trouble processing your file") — not the user's connection.
</details>

## Intentional non-behaviors
- Transient (non-`invalid_grant`) refresh failures keep raising `ValueError` and surface as 500 — they're not the user's session to fix.
- The runtime 401 path bounces to login but does not auto-stash the draft (the uploader doesn't hold form state); the page-level preflight stash is unchanged.

## Test
`test_private_upload_dead_session_returns_401_not_500` drives the endpoint with the in-request PDS upload raising `SessionExpiredError` and asserts 401 `session_expired` (proves it no longer 500s). Full private-media suite green; backend lint, frontend check, loq all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)