### PR TITLE
feat(private-media): request space scope at login; derive capability from granted scope

### DIFF
--- a/backend/src/backend/_internal/atproto/spaces/__init__.py
+++ b/backend/src/backend/_internal/atproto/spaces/__init__.py
@@ -1,12 +1,12 @@
 """permissioned-data spaces (com.atproto.space.*).
 
 experimental ATProto permissioned-data surface. all of this engages only for
-sessions whose PDS actually implements the space methods — see
-[capability.detect_permissioned_capability][backend._internal.atproto.spaces.capability.detect_permissioned_capability].
+sessions whose PDS granted the private-media space scope at login — see
+[capability.session_has_permissioned_scope][backend._internal.atproto.spaces.capability.session_has_permissioned_scope].
 """
 
 from backend._internal.atproto.spaces.capability import (
-    detect_permissioned_capability,
+    session_has_permissioned_scope,
 )
 from backend._internal.atproto.spaces.uris import (
     build_record_uri,
@@ -17,6 +17,6 @@ from backend._internal.atproto.spaces.uris import (
 __all__ = [
     "build_record_uri",
     "build_space_uri",
-    "detect_permissioned_capability",
     "parse_space_uri",
+    "session_has_permissioned_scope",
 ]

--- a/backend/src/backend/_internal/atproto/spaces/capability.py
+++ b/backend/src/backend/_internal/atproto/spaces/capability.py
@@ -1,108 +1,28 @@
-"""detect whether a PDS implements the permissioned-data space surface.
+"""whether a session may access private (permissioned-space) media.
 
-no PDS advertises this declaratively (not describeServer, not .well-known, not
-OAuth metadata; ZDS's openapi.json is vendor-specific). so we **probe**: call a
-`com.atproto.space.*` method with the user's auth and branch on the response.
+private media lives in the artist's `com.atproto.space.*` repo on their PDS. a
+PDS exposes that surface to plyr ONLY if it can grant the private-media
+permission set during OAuth — so capability is simply "the granted token carries
+the space scope." we request that scope at login (falling back when the PDS
+rejects it with `invalid_scope`), which makes the granted scope itself the
+capability signal.
 
-    supported   -> the method dispatches for real (2xx, or a genuine
-                   InvalidRequest / InsufficientScope / auth error proving the
-                   route exists and ran)
-    unsupported -> HTTP 404/501 or an error in {MethodNotImplemented,
-                   UnknownMethod, XRPCNotSupported} (identical across a
-                   ZDS with the flag off and a vanilla PDS like bsky/tranquil)
-
-ambiguous results (transient 5xx, network) fail **closed** and are not cached, so a
-blip never pins a capable PDS to "unsupported" for the cache lifetime.
-
-the probe is authenticated: an unauthenticated call can't distinguish a supporting
-PDS from a vanilla one, because PDS auth middleware returns 401 before method routing.
+deliberately NOT a runtime probe: an authenticated `com.atproto.space.listSpaces`
+call needs the very space scope we're trying to detect (a valid-but-unscoped
+token gets `403 InsufficientScope`), and a scopeless probe only ever surfaces a
+`401` that's indistinguishable from an expired token — which made the old probe
+both a deadlock and a source of pointless token-refresh churn.
 """
 
-import logging
-import re
-
-from redis.exceptions import RedisError
-
 from backend._internal import Session as AuthSession
-from backend._internal.atproto.client import make_pds_request
 from backend.config import settings
-from backend.utilities.redis import get_async_redis_client
-
-logger = logging.getLogger(__name__)
-
-# bumped to v2 when the classifier flipped to fail-closed — invalidates any stale
-# (overly-permissive) cached results from the prior heuristic.
-_CACHE_PREFIX = "permissioned_capability:v2:"
-_CACHE_TTL_SECONDS = 6 * 60 * 60
-
-_STATUS_RE = re.compile(r"PDS request failed:\s*(\d{3})")
 
 
-def _classify_failure(message: str) -> bool | None:
-    """interpret a FAILED listSpaces probe — fail closed.
+def session_has_permissioned_scope(auth_session: AuthSession) -> bool:
+    """whether the session's granted OAuth scope includes private-media space access.
 
-    a PDS is treated as supporting permissioned spaces ONLY on an unambiguous
-    positive signal (handled in `_probe`: HTTP 200, or 403 InsufficientScope —
-    ZDS's space-scope check, which proves the route is implemented). every other
-    failure is unsupported; a non-supporting PDS returns auth/method-not-found
-    errors that must NOT be read as "route exists."
-
-    returns True (supported), False (unsupported, cacheable), or None (transient
-    — don't cache, fail closed for this call only).
+    matches the private-media NSID, which is present whether the scope is the
+    requested `include:<nsid>` form or the granted, expanded `space:<nsid>?...` form.
     """
-    # the space-scope check ran → the route is implemented → supported
-    if "InsufficientScope" in message:
-        return True
-    if match := _STATUS_RE.search(message):
-        status = int(match.group(1))
-        if status == 501:
-            return False  # not implemented
-        if 500 <= status < 600:
-            return None  # transient upstream failure (500/502/503/504)
-        return False  # 401/400/404/405/other 4xx → not a supporting PDS
-    return None  # opaque / network error
-
-
-async def _probe(auth_session: AuthSession) -> bool | None:
-    """probe listSpaces. True/False = definitive; None = ambiguous (don't cache)."""
-    try:
-        await make_pds_request(
-            auth_session,
-            "GET",
-            "com.atproto.space.listSpaces",
-            params={
-                "did": auth_session.did,
-                "type": settings.atproto.private_media_space_type,
-            },
-        )
-        return True
-    except Exception as exc:  # make_pds_request raises a bare Exception on non-2xx
-        return _classify_failure(str(exc))
-
-
-async def detect_permissioned_capability(auth_session: AuthSession) -> bool:
-    """whether the session's PDS implements permissioned spaces (cached per PDS)."""
-    pds_url = (auth_session.oauth_session or {}).get("pds_url")
-    cache_key = f"{_CACHE_PREFIX}{pds_url}" if pds_url else None
-
-    redis = None
-    if cache_key:
-        try:
-            redis = get_async_redis_client()
-            if (cached := await redis.get(cache_key)) is not None:
-                return cached == "1"
-        except RedisError as exc:
-            logger.debug("permissioned capability cache read failed: %s", exc)
-            redis = None
-
-    result = await _probe(auth_session)
-    if result is None:
-        return False  # ambiguous: fail closed, do not cache
-
-    if redis is not None and cache_key:
-        try:
-            await redis.set(cache_key, "1" if result else "0", ex=_CACHE_TTL_SECONDS)
-        except RedisError as exc:
-            logger.debug("permissioned capability cache write failed: %s", exc)
-
-    return result
+    scope = (auth_session.oauth_session or {}).get("scope", "")
+    return settings.atproto.private_media_space_type in scope

--- a/backend/src/backend/_internal/auth/oauth.py
+++ b/backend/src/backend/_internal/auth/oauth.py
@@ -219,27 +219,44 @@ async def start_oauth_flow(
     from backend._internal.atproto.handles import resolve_handle
 
     try:
-        # resolve handle to DID to check preferences
-        resolved = await resolve_handle(handle)
-        if resolved:
+        # resolve handle to DID to check preferences (best-effort: the OAuth flow
+        # resolves the handle again internally if this fails)
+        wants_teal = wants_indiemusi = False
+        if resolved := await resolve_handle(handle):
             did = resolved["did"]
             wants_teal = await _check_teal_preference(did)
             wants_indiemusi = await _check_copyright_paradigm(did)
-            client = get_oauth_client(
-                include_teal=wants_teal, include_indiemusi=wants_indiemusi
-            )
-            logger.info(
-                f"starting OAuth for {handle} (did={did}, "
-                f"teal={wants_teal}, indiemusi={wants_indiemusi})"
-            )
-        else:
-            # fallback to base client if resolution fails
-            # (OAuth flow will resolve handle again internally)
-            client = get_oauth_client()
-            logger.info(f"starting OAuth for {handle} (resolution failed, using base)")
 
-        auth_url, state = await client.start_authorization(handle, prompt=prompt)
-        return auth_url, state
+        # request the private-media space scope by default. capability can't be
+        # probed before the scope is granted (a scopeless space call just 401s), so
+        # OAuth itself is the discovery: a PDS that can't resolve the permission set
+        # rejects PAR with `invalid_scope`, and we retry without it (that account
+        # simply won't see private media). a capable PDS grants it up front, so the
+        # granted scope becomes the capability signal — see spaces.capability.
+        try:
+            auth_url, state = await get_oauth_client(
+                include_teal=wants_teal,
+                include_indiemusi=wants_indiemusi,
+                include_permissioned=True,
+            ).start_authorization(handle, prompt=prompt)
+            logger.info(
+                f"starting OAuth for {handle} "
+                f"(teal={wants_teal}, indiemusi={wants_indiemusi}, permissioned=True)"
+            )
+            return auth_url, state
+        except Exception as e:
+            if "invalid_scope" not in str(e):
+                raise
+            logger.info(
+                f"{handle}'s PDS rejected the private-media scope (invalid_scope); "
+                f"retrying login without it"
+            )
+            auth_url, state = await get_oauth_client(
+                include_teal=wants_teal,
+                include_indiemusi=wants_indiemusi,
+                include_permissioned=False,
+            ).start_authorization(handle, prompt=prompt)
+            return auth_url, state
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/src/backend/api/auth.py
+++ b/backend/src/backend/api/auth.py
@@ -39,7 +39,7 @@ from backend._internal import (
     start_oauth_flow_with_scopes,
     switch_active_account,
 )
-from backend._internal.atproto.spaces import detect_permissioned_capability
+from backend._internal.atproto.spaces import session_has_permissioned_scope
 from backend._internal.auth import get_refresh_token_lifetime_days
 from backend._internal.copyright import complete_indiemusi_setup
 from backend._internal.tasks import schedule_atproto_sync
@@ -490,14 +490,10 @@ async def get_current_user(
     # get feature flags for current user from dedicated table
     current_user_flags = await get_user_flags(db, session.did)
 
-    # permissioned-spaces capability is the gate for the private-media feature;
-    # cached per-PDS in redis so this probe is cheap after the first call. never
-    # let it break /auth/me.
-    try:
-        spaces_supported = await detect_permissioned_capability(session)
-    except Exception as exc:
-        logger.debug(f"permissioned capability probe failed: {exc}")
-        spaces_supported = False
+    # private-media capability == the PDS granted the space scope at login (we
+    # request it with a fallback for PDSes that can't). derived from the granted
+    # scope, never a runtime probe (a scopeless listSpaces probe just 401s).
+    spaces_supported = session_has_permissioned_scope(session)
 
     return CurrentUserResponse(
         did=session.did,

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -43,7 +43,7 @@ from backend._internal.atproto.handles import (
 from backend._internal.atproto.records.fm_plyr.track import build_track_record
 from backend._internal.atproto.spaces import (
     build_record_uri,
-    detect_permissioned_capability,
+    session_has_permissioned_scope,
 )
 from backend._internal.atproto.spaces.client import (
     create_space_record,
@@ -1565,18 +1565,12 @@ async def upload_track(
     # for web-playable sources (the blob is written at publish time; the deferred
     # transcode path still targets the public repo — see the design note).
     if is_private:
-        if not await detect_permissioned_capability(auth_session):
-            raise HTTPException(
-                status_code=400,
-                detail="your PDS does not support permissioned spaces (private media)",
-            )
-        # writing to a space needs the granted space scope (the capability probe
-        # passes without it). the granted token carries the expanded
-        # `space:<nsid>?...` scopes, so match on the NSID. absent → tell the
-        # frontend to run the opt-in scope upgrade (which requests include:<nsid>).
-        if settings.atproto.private_media_space_type not in (
-            auth_session.oauth_session or {}
-        ).get("scope", ""):
+        # writing to a space needs the granted space scope. we request it at login
+        # on capable PDSes, so its presence IS the capability signal — absent means
+        # either the PDS can't grant it or the session predates the ask. tell the
+        # frontend to run the scope upgrade; if the PDS can't grant it, that flow's
+        # PAR fails with invalid_scope and the user learns it's unsupported.
+        if not session_has_permissioned_scope(auth_session):
             raise HTTPException(status_code=403, detail="permissioned_scope_required")
         if not audio_format.is_web_playable:
             raise HTTPException(

--- a/backend/tests/_internal/test_oauth_login_scope.py
+++ b/backend/tests/_internal/test_oauth_login_scope.py
@@ -1,0 +1,89 @@
+"""login requests the private-media space scope, with a fallback (#1528).
+
+capability can't be probed before the scope is granted, so OAuth itself is the
+discovery: request `include:<privateMedia>` at login; if the PDS can't resolve
+the permission set it rejects PAR with `invalid_scope`, and we retry without it.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend._internal.auth import oauth
+
+
+class _FakeClient:
+    """stand-in OAuth client whose start_authorization is scripted per attempt."""
+
+    def __init__(self, *, raise_invalid_scope: bool) -> None:
+        self._raise = raise_invalid_scope
+
+    async def start_authorization(self, handle: str, prompt=None):
+        if self._raise:
+            raise Exception("invalid_scope: Failed to resolve requested permission set")
+        return ("https://pds.test/authorize?x=1", "state-token")
+
+
+@pytest.fixture(autouse=True)
+def _stub_prefs():
+    # isolate start_oauth_flow from handle resolution + preference lookups.
+    # resolve_handle is imported lazily inside the function, so patch it at source.
+    with (
+        patch(
+            "backend._internal.atproto.handles.resolve_handle",
+            AsyncMock(return_value={"did": "did:plc:x"}),
+        ),
+        patch.object(oauth, "_check_teal_preference", AsyncMock(return_value=False)),
+        patch.object(oauth, "_check_copyright_paradigm", AsyncMock(return_value=False)),
+    ):
+        yield
+
+
+async def test_login_requests_permissioned_scope_first():
+    calls: list[bool] = []
+
+    def fake_get_client(*, include_permissioned=False, **kwargs):
+        calls.append(include_permissioned)
+        return _FakeClient(raise_invalid_scope=False)
+
+    with patch.object(oauth, "get_oauth_client", fake_get_client):
+        auth_url, state = await oauth.start_oauth_flow("user.test")
+
+    assert auth_url.startswith("https://pds.test/authorize")
+    assert state == "state-token"
+    # the FIRST (and only) attempt asked for the private-media scope
+    assert calls == [True]
+
+
+async def test_login_falls_back_when_pds_rejects_scope():
+    calls: list[bool] = []
+
+    def fake_get_client(*, include_permissioned=False, **kwargs):
+        calls.append(include_permissioned)
+        # a PDS that can't grant the permission set rejects the scoped attempt
+        return _FakeClient(raise_invalid_scope=include_permissioned)
+
+    with patch.object(oauth, "get_oauth_client", fake_get_client):
+        auth_url, state = await oauth.start_oauth_flow("user.test")
+
+    # tried with the scope, then retried without it — login still succeeds
+    assert calls == [True, False]
+    assert auth_url.startswith("https://pds.test/authorize")
+    assert state == "state-token"
+
+
+async def test_login_does_not_swallow_unrelated_errors():
+    def fake_get_client(*, include_permissioned=False, **kwargs):
+        return _FakeClient(raise_invalid_scope=False)
+
+    async def _boom(handle, prompt=None):
+        raise Exception("network exploded")
+
+    # a non-invalid_scope failure is a real error, surfaced (not retried into a
+    # fallback that hides it)
+    with (
+        patch.object(oauth, "get_oauth_client", fake_get_client),
+        patch.object(_FakeClient, "start_authorization", _boom),
+        pytest.raises(Exception, match="failed to start OAuth flow"),
+    ):
+        await oauth.start_oauth_flow("user.test")

--- a/backend/tests/_internal/test_permissioned_spaces.py
+++ b/backend/tests/_internal/test_permissioned_spaces.py
@@ -45,104 +45,40 @@ def test_parse_space_uri_rejects_malformed(bad):
         parse_space_uri(bad)
 
 
-# --- capability probe interpretation -----------------------------------------
+# --- capability == granted scope ----------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "message,expected",
-    [
-        # the ONLY supported signal from a failure: ZDS's space-scope check ran
-        ("PDS request failed: 403 InsufficientScope", True),
-        # not-a-supporting-PDS responses — all unsupported (fail closed)
-        ("PDS request failed: 401 AuthMissing", False),  # regression: bsky 401 leak
-        ("PDS request failed: 400 InvalidRequest: bad", False),
-        ("PDS request failed: 404 UnknownMethod", False),
-        ("PDS request failed: 405 MethodNotAllowed", False),
-        ("PDS request failed: 501 MethodNotImplemented", False),
-        # genuinely transient → don't cache, fail closed for this call
-        ("PDS request failed: 503 upstream", None),
-        ("PDS request failed: 502 bad gateway", None),
-        ("totally opaque error", None),
-    ],
-)
-def test_classify_failure(message, expected):
-    assert cap._classify_failure(message) is expected
-
-
-async def test_detect_capability_insufficient_scope_is_supported(monkeypatch):
-    # a capable PDS that hasn't been granted the space scope yet returns 403
-    # InsufficientScope from the space route — that proves the route exists.
-    async def fake_request(*args, **kwargs):
-        raise Exception("PDS request failed: 403 InsufficientScope")
-
-    monkeypatch.setattr(cap, "make_pds_request", fake_request)
-    session = Session(
+def _session_with_scope(scope: str) -> Session:
+    return Session(
         session_id="s",
         did="did:plc:x",
         handle="x.test",
-        oauth_session={"pds_url": "https://probe-insufficient.test"},
+        oauth_session={"pds_url": "https://x.test", "scope": scope},
     )
-    assert await cap.detect_permissioned_capability(session) is True
 
 
-async def test_detect_capability_401_is_unsupported(monkeypatch):
-    # regression: a non-supporting PDS (e.g. bsky) must NOT be read as supported
-    async def fake_request(*args, **kwargs):
-        raise Exception("PDS request failed: 401 AuthMissing")
-
-    monkeypatch.setattr(cap, "make_pds_request", fake_request)
-    session = Session(
-        session_id="s",
-        did="did:plc:x",
-        handle="x.test",
-        oauth_session={"pds_url": "https://probe-bsky.test"},
+def test_capability_true_when_scope_granted():
+    # the granted token carries the expanded `space:<nsid>?...` form
+    nsid = settings.atproto.private_media_space_type
+    granted = f"atproto blob:*/* space:{nsid}?action=create&did=*&skey=self"
+    assert cap.session_has_permissioned_scope(_session_with_scope(granted)) is True
+    # the requested `include:<nsid>` form also counts
+    assert (
+        cap.session_has_permissioned_scope(
+            _session_with_scope(f"atproto include:{nsid}")
+        )
+        is True
     )
-    assert await cap.detect_permissioned_capability(session) is False
 
 
-async def test_detect_capability_supported(monkeypatch):
-    async def fake_request(*args, **kwargs):
-        return {"spaces": []}
-
-    monkeypatch.setattr(cap, "make_pds_request", fake_request)
-
-    session = Session(
-        session_id="s",
-        did="did:plc:x",
-        handle="x.test",
-        oauth_session={"pds_url": "https://probe-supported.test"},
+def test_capability_false_without_scope():
+    base = "atproto blob:*/* include:fm.plyr.stg.authFullApp"
+    assert cap.session_has_permissioned_scope(_session_with_scope(base)) is False
+    # a session with no scope key must not crash and must read as unsupported
+    no_scope = Session(
+        session_id="s", did="did:plc:x", handle="x.test", oauth_session={}
     )
-    assert await cap.detect_permissioned_capability(session) is True
-
-
-async def test_detect_capability_unsupported(monkeypatch):
-    async def fake_request(*args, **kwargs):
-        raise Exception("PDS request failed: 501 MethodNotImplemented")
-
-    monkeypatch.setattr(cap, "make_pds_request", fake_request)
-
-    session = Session(
-        session_id="s",
-        did="did:plc:x",
-        handle="x.test",
-        oauth_session={"pds_url": "https://probe-unsupported.test"},
-    )
-    assert await cap.detect_permissioned_capability(session) is False
-
-
-async def test_detect_capability_transient_fails_closed(monkeypatch):
-    async def fake_request(*args, **kwargs):
-        raise Exception("PDS request failed: 503 upstream")
-
-    monkeypatch.setattr(cap, "make_pds_request", fake_request)
-
-    session = Session(
-        session_id="s",
-        did="did:plc:x",
-        handle="x.test",
-        oauth_session={"pds_url": "https://probe-transient.test"},
-    )
-    assert await cap.detect_permissioned_capability(session) is False
+    assert cap.session_has_permissioned_scope(no_scope) is False
 
 
 # --- OAuth scope composition --------------------------------------------------

--- a/backend/tests/api/test_private_media_upload.py
+++ b/backend/tests/api/test_private_media_upload.py
@@ -77,40 +77,18 @@ def _post(client: TestClient, *, filename: str = "t.wav", data: dict) -> httpx.R
     )
 
 
-def test_private_requires_pds_capability(app_no_scope: FastAPI):
-    with (
-        patch(
-            "backend.api.tracks.uploads.detect_permissioned_capability",
-            return_value=False,
-        ),
-        TestClient(app_no_scope) as client,
-    ):
-        resp = _post(client, data={"visibility": "private"})
-    assert resp.status_code == 400
-    assert "permissioned spaces" in resp.json()["detail"]
-
-
-def test_private_capable_but_scope_missing_requests_upgrade(app_no_scope: FastAPI):
-    with (
-        patch(
-            "backend.api.tracks.uploads.detect_permissioned_capability",
-            return_value=True,
-        ),
-        TestClient(app_no_scope) as client,
-    ):
+def test_private_without_granted_scope_requests_upgrade(app_no_scope: FastAPI):
+    # capability == the PDS granted the space scope at login. a session without it
+    # (PDS can't grant it, or it predates the ask) gets 403 → frontend runs the
+    # scope upgrade. there's no separate runtime capability probe anymore.
+    with TestClient(app_no_scope) as client:
         resp = _post(client, data={"visibility": "private"})
     assert resp.status_code == 403
     assert resp.json()["detail"] == "permissioned_scope_required"
 
 
 def test_private_rejects_non_web_playable(app_with_scope: FastAPI):
-    with (
-        patch(
-            "backend.api.tracks.uploads.detect_permissioned_capability",
-            return_value=True,
-        ),
-        TestClient(app_with_scope) as client,
-    ):
+    with TestClient(app_with_scope) as client:
         resp = client.post(
             "/tracks/",
             files={"file": ("t.aiff", _WAV, "audio/aiff")},
@@ -155,10 +133,6 @@ def test_private_upload_goes_to_pds_not_r2(app_with_scope: FastAPI):
         raise AssertionError("private upload must not stage audio to R2")
 
     with (
-        patch(
-            "backend.api.tracks.uploads.detect_permissioned_capability",
-            return_value=True,
-        ),
         patch("backend.api.tracks.uploads.upload_blob", _fake_upload_blob),
         patch("backend.api.tracks.uploads.stage_audio_to_storage", _no_stage),
         patch("backend.api.tracks.uploads.schedule_track_upload", _fake_schedule),
@@ -271,10 +245,6 @@ def test_private_upload_dead_session_returns_401_not_500(app_with_scope: FastAPI
         )
 
     with (
-        patch(
-            "backend.api.tracks.uploads.detect_permissioned_capability",
-            return_value=True,
-        ),
         patch("backend.api.tracks.uploads.upload_blob", _dead_session),
         TestClient(app_with_scope) as client,
     ):

--- a/loq.toml
+++ b/loq.toml
@@ -288,7 +288,7 @@ max_lines = 633
 
 [[rules]]
 path = "backend/src/backend/_internal/auth/oauth.py"
-max_lines = 560
+max_lines = 577
 
 [[rules]]
 path = "frontend/src/lib/components/CopyrightSection.svelte"


### PR DESCRIPTION
Fixes why private media never engaged on a capable PDS: the consent screen didn't list it, the upload page only offered "unlisted", and `/auth/me` reported `supported:false`.

## Root cause (from staging spans, bufo.uk on pds.zat.dev)

Capability was gated on an authenticated `com.atproto.space.listSpaces` probe — but that call needs the **space scope we were trying to detect**. ZDS correctly returns `403 InsufficientScope` for a *valid-but-unscoped* token, but the probe ran on a scopeless session and saw a `401`, which `make_pds_request` reads as "token expired" → a doomed refresh (→ `400 invalid_grant`) and `supported:false`. A deadlock: no scope → no probe → no scope-upgrade UI → no scope.

Per the permissioned-data spec owner: **OAuth itself is the discovery mechanism** for "can this PDS grant the permission set." Don't probe — request the scope and observe.

## Change

<details>
<summary>login requests the scope, with fallback</summary>

`start_oauth_flow` now requests `include:<privateMedia>` by default. A PDS that can't resolve the permission set rejects PAR with `invalid_scope`; we catch that and retry login without it (that account simply won't see private media). A capable PDS grants it up front — so the consent screen lists "plyr.fm Private Media" as expected. Non-`invalid_scope` failures are surfaced, not swallowed.
</details>

<details>
<summary>capability is scope-derived</summary>

New `session_has_permissioned_scope(session)` checks the granted scope for the private-media NSID (matches both the requested `include:<nsid>` and granted expanded `space:<nsid>?...` forms). `/auth/me` and the upload preflight both use it. The deadlocked `listSpaces` probe + its fail-closed classifier + redis cache are deleted — `capability.py` is now a pure scope check.
</details>

## Intentional non-behaviors
- The upload preflight still returns `403 permissioned_scope_required` when the scope is absent (old sessions / PDSes that lost the fallback), so the existing frontend scope-upgrade flow still recovers.
- Published client metadata already advertises the private-media include (`api/meta.py`), so PAR stays within the universe — the `oauth scope universe` pre-commit check passes.

## Tests
`test_oauth_login_scope.py`: requests the scope first / falls back on `invalid_scope` / doesn't swallow unrelated errors. `test_permissioned_spaces.py`: capability true-with-scope / false-without (replaces the deleted probe tests). `test_private_media_upload.py`: preflight 403s without the granted scope. Full suite: 1176 passed.

## ⚠️ Does NOT fix the upload itself
Separate, independent blocker still open: bufo.uk's session is rejected by `pds.zat.dev` on **every** xrpc call (`listSpaces` and `uploadBlob` both `401`) with refresh `400 invalid_grant`, even right after a fresh login. That's a token/session-validity issue (DPoP/refresh/ZDS-side), not scope. This PR makes the scope + capability + UX correct; the token rejection is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)