### PR TITLE
fix(auth): surface the real OAuth-start exception instead of an empty error

### DIFF
--- a/backend/src/backend/_internal/auth/oauth.py
+++ b/backend/src/backend/_internal/auth/oauth.py
@@ -208,6 +208,24 @@ def _bsky_edge_block_error(exc: Exception, handle: str) -> HTTPException | None:
     )
 
 
+def _oauth_start_failure(e: Exception, handle: str) -> HTTPException:
+    """turn an OAuth-start failure into a surfaced HTTPException.
+
+    PAR failures from the authserver can arrive as exceptions whose `str()` is
+    empty (notably `httpx.RemoteProtocolError` when the PDS aborts the PAR
+    connection) — which produced an opaque "failed to start OAuth flow: " with
+    no cause. include the exception type + repr in the detail, and log the full
+    traceback so the real cause is always captured.
+    """
+    if friendly := _bsky_edge_block_error(e, handle):
+        return friendly
+    logger.exception("failed to start OAuth flow for %s", handle)
+    detail = str(e).strip() or f"{type(e).__name__}: {e!r}"
+    return HTTPException(
+        status_code=400, detail=f"failed to start OAuth flow: {detail}"
+    )
+
+
 async def start_oauth_flow(
     handle: str, prompt: PromptType | None = None
 ) -> tuple[str, str]:
@@ -243,12 +261,7 @@ async def start_oauth_flow(
     except HTTPException:
         raise
     except Exception as e:
-        if friendly := _bsky_edge_block_error(e, handle):
-            raise friendly from e
-        raise HTTPException(
-            status_code=400,
-            detail=f"failed to start OAuth flow: {e}",
-        ) from e
+        raise _oauth_start_failure(e, handle) from e
 
 
 async def start_oauth_flow_with_scopes(
@@ -275,12 +288,7 @@ async def start_oauth_flow_with_scopes(
     except HTTPException:
         raise
     except Exception as e:
-        if friendly := _bsky_edge_block_error(e, handle):
-            raise friendly from e
-        raise HTTPException(
-            status_code=400,
-            detail=f"failed to start OAuth flow: {e}",
-        ) from e
+        raise _oauth_start_failure(e, handle) from e
 
 
 async def start_oauth_flow_for_pds(pds_url: str) -> tuple[str, str]:

--- a/loq.toml
+++ b/loq.toml
@@ -288,7 +288,7 @@ max_lines = 633
 
 [[rules]]
 path = "backend/src/backend/_internal/auth/oauth.py"
-max_lines = 560
+max_lines = 568
 
 [[rules]]
 path = "frontend/src/lib/components/CopyrightSection.svelte"


### PR DESCRIPTION
Login failures were showing `failed to start OAuth flow: ` with **no cause** — because the PAR step can raise an exception whose `str()` is empty (notably `httpx.RemoteProtocolError` when the PDS aborts the PAR connection), and the handler interpolated the empty `str(e)` straight into the detail.

`_oauth_start_failure` now:
- logs the full traceback via `logger.exception` (so the exact type + stack land in logfire), and
- includes `type(e).__name__: repr(e)` in the surfaced detail when `str(e)` is empty.

Applied across `start_oauth_flow` + `start_oauth_flow_with_scopes` (the account-creation `start_oauth_flow_for_pds` path is left alone).

**Context, not fixed here:** a `bufo.uk` login (pds.zat.dev / ZDS) is currently failing at PAR while `zzstoatzz.io` (a different PDS) succeeds — a ZDS-side `/oauth/par` issue (its logs show `InvalidPermissionSet` for plyr's `include:` permission sets). This PR just makes the cause visible so the next failed login is diagnosable instead of blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)