### PR TITLE
fix(uploads): stop silently dropping PDS blobs under concurrent token rotation

### DIFF
--- a/backend/src/backend/_internal/atproto/client.py
+++ b/backend/src/backend/_internal/atproto/client.py
@@ -1,9 +1,10 @@
 """low-level ATProto PDS client with OAuth and token refresh."""
 
 import asyncio
+import contextlib
 import logging
 import time
-from collections.abc import AsyncIterable, Awaitable, Callable
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any, BinaryIO
 
@@ -13,6 +14,7 @@ from atproto import AtUri
 from atproto_oauth.models import OAuthSession
 from atproto_oauth.security import is_safe_url
 from cachetools import LRUCache
+from redis.exceptions import RedisError
 
 from backend._internal import Session as AuthSession
 from backend._internal import get_oauth_client, get_session, update_session_tokens
@@ -20,6 +22,7 @@ from backend._internal.auth import (
     get_client_auth_method,
     get_refresh_token_lifetime_days,
 )
+from backend.utilities.redis import get_async_redis_client
 
 # factory that produces a fresh async iterator over the request body. used
 # for streaming uploads where the body must be re-emitted on retry (DPoP
@@ -146,6 +149,55 @@ BlobRef = dict[str, Any]
 # 2. TTL expiration could evict a lock while a coroutine holds it, breaking mutual exclusion
 _refresh_locks: LRUCache[str, asyncio.Lock] = LRUCache(maxsize=10_000)
 
+# how long a refresh may hold the lock before it auto-expires, and how long a
+# waiter blocks for it. a refresh is a single token-endpoint round-trip (~1-3s);
+# this leaves generous headroom without stranding waiters if a holder dies.
+_REFRESH_LOCK_TIMEOUT_SECONDS = 15
+
+
+@contextlib.asynccontextmanager
+async def _session_refresh_lock(session_id: str) -> AsyncIterator[None]:
+    """serialize a session's token refresh CLUSTER-WIDE via redis.
+
+    the per-process `_refresh_locks` only serializes within one worker — but
+    uploads for one artist run across worker processes/machines, so without a
+    shared lock each one refreshes on an expired token, rotating the refresh
+    token out from under the others (the failure that silently drops blobs to
+    R2-only). a redis lock keyed by session collapses them to a single refresh.
+
+    degrades to the in-process lock if redis is unavailable, so refresh never
+    breaks outright on a redis blip — single-worker correctness is preserved.
+    """
+    redis_lock = None
+    acquired = False
+    try:
+        redis_lock = get_async_redis_client().lock(
+            f"oauth_refresh:{session_id}",
+            timeout=_REFRESH_LOCK_TIMEOUT_SECONDS,
+            blocking=True,
+            blocking_timeout=_REFRESH_LOCK_TIMEOUT_SECONDS,
+        )
+        acquired = await redis_lock.acquire()
+    except RedisError as exc:
+        logger.warning(
+            f"redis refresh-lock unavailable for {session_id}, "
+            f"falling back to in-process lock: {exc}"
+        )
+        acquired = False
+
+    if acquired and redis_lock is not None:
+        try:
+            yield
+        finally:
+            with contextlib.suppress(Exception):
+                await redis_lock.release()
+        return
+
+    # fallback: in-process serialization
+    proc_lock = _refresh_locks.setdefault(session_id, asyncio.Lock())
+    async with proc_lock:
+        yield
+
 
 def reconstruct_oauth_session(oauth_data: dict[str, Any]) -> OAuthSession:
     """reconstruct OAuthSession from serialized data."""
@@ -193,13 +245,7 @@ async def _refresh_session_tokens(
     """
     session_id = auth_session.session_id
 
-    # get or create lock for this session
-    if session_id not in _refresh_locks:
-        _refresh_locks[session_id] = asyncio.Lock()
-
-    lock = _refresh_locks[session_id]
-
-    async with lock:
+    async with _session_refresh_lock(session_id):
         # check if another coroutine already refreshed while we were waiting
         # reload session from DB to get potentially updated tokens
         updated_auth_session = await get_session(session_id)
@@ -538,7 +584,6 @@ async def upload_blob(
         blob_data = data if isinstance(data, bytes) else data.read()
 
     response: httpx.Response | None = None
-    has_refreshed = False
 
     for attempt in range(_PDS_MAX_ATTEMPTS):
         try:
@@ -585,9 +630,14 @@ async def upload_blob(
                 f"blob too large for PDS (limit exceeded): {response.text or '<empty body>'}"
             )
 
-        # 401: refresh once, then retry (same rationale as make_pds_request).
-        if response.status_code == 401 and not has_refreshed:
-            has_refreshed = True
+        # 401: token expired or rotated out from under us by a sibling upload.
+        # refresh on EVERY 401 (not once) — under a concurrent rotation herd a
+        # single refresh isn't enough: the retry can be 401'd again by another
+        # upload's rotation. the redis refresh-lock collapses concurrent
+        # refreshes and the reload picks up the latest token; bounded by
+        # _PDS_MAX_ATTEMPTS so a genuinely dead token still gives up (and an
+        # invalid_grant raises SessionExpiredError, which propagates).
+        if response.status_code == 401 and attempt < _PDS_MAX_ATTEMPTS - 1:
             logger.info(
                 f"access token expired or rejected for {auth_session.did}; refreshing"
             )

--- a/backend/tests/_internal/test_pds_blob_upload_resilience.py
+++ b/backend/tests/_internal/test_pds_blob_upload_resilience.py
@@ -1,0 +1,125 @@
+"""PDS blob upload must survive repeated 401s under concurrent token rotation.
+
+regression for the silent R2-only fallback (prod): when a batch starts with an
+expired access token, every upload 401s and races to refresh; the refresh token
+rotates, so a retry can 401 *again*. the upload must keep refreshing (up to the
+attempt budget) instead of giving up after one — otherwise the blob never lands
+on the PDS and the track silently degrades to R2-only.
+
+also covers the cross-process refresh lock: refreshes are serialized via redis
+(not just an in-process asyncio.Lock), so concurrent uploads across workers
+collapse to a single refresh instead of a rotation thundering-herd.
+"""
+
+from types import SimpleNamespace
+
+import httpx
+from redis.exceptions import RedisError
+
+from backend._internal import Session
+from backend._internal.atproto import client as c
+
+
+def _session() -> Session:
+    s = Session.__new__(Session)
+    s.did = "did:plc:x"
+    s.handle = "x.test"
+    s.session_id = "sess-123"
+    s.oauth_session = {
+        "did": "did:plc:x",
+        "pds_url": "https://pds.test",
+        "access_token": "stale-token",
+        "dpop_private_key_pem": "fake",
+    }
+    return s
+
+
+def _body_factory():
+    async def _gen():
+        yield b"x" * 10
+
+    return _gen()
+
+
+async def test_upload_blob_recovers_from_repeated_401(monkeypatch):
+    """401, 401, then 200 — must recover. today's one-shot refresh gives up
+    after the first retry still 401s, leaving the track R2-only."""
+    attempts = {"n": 0}
+
+    async def fake_streaming_post(
+        oauth_session, url, body_factory, headers, heartbeat=None
+    ):
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            return httpx.Response(401, json={"error": "invalid_token"})
+        return httpx.Response(
+            200,
+            json={"blob": {"$type": "blob", "ref": {"$link": "bafkreiok"}, "size": 10}},
+        )
+
+    refreshes = {"n": 0}
+
+    async def fake_refresh(auth_session, oauth_session):
+        refreshes["n"] += 1
+        return oauth_session
+
+    monkeypatch.setattr(c, "_signed_streaming_post", fake_streaming_post)
+    monkeypatch.setattr(c, "_refresh_session_tokens", fake_refresh)
+    monkeypatch.setattr(
+        c, "reconstruct_oauth_session", lambda data: SimpleNamespace(access_token="t")
+    )
+
+    blob = await c.upload_blob(
+        _session(),
+        body_factory=_body_factory,
+        content_length=10,
+        content_type="audio/wav",
+    )
+    assert blob["ref"]["$link"] == "bafkreiok"
+    # recovered only because it refreshed on the SECOND 401 too
+    assert attempts["n"] == 3
+    assert refreshes["n"] == 2
+
+
+async def test_session_refresh_lock_uses_redis(monkeypatch):
+    """refreshes serialize on a session-scoped REDIS lock (cluster-wide), not
+    just the in-process asyncio.Lock."""
+    acquired: list[str] = []
+
+    class FakeLock:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        async def acquire(self) -> bool:
+            acquired.append(self.name)
+            return True
+
+        async def release(self) -> None:
+            pass
+
+    class FakeRedis:
+        def lock(self, name: str, **kwargs):
+            return FakeLock(name)
+
+    monkeypatch.setattr(c, "get_async_redis_client", lambda: FakeRedis())
+
+    async with c._session_refresh_lock("sess-123"):
+        pass
+
+    assert acquired == ["oauth_refresh:sess-123"]
+
+
+async def test_session_refresh_lock_falls_back_when_redis_down(monkeypatch):
+    """redis unavailable must degrade to in-process serialization, not break
+    refresh entirely."""
+
+    class DeadRedis:
+        def lock(self, name: str, **kwargs):
+            raise RedisError("redis down")
+
+    monkeypatch.setattr(c, "get_async_redis_client", lambda: DeadRedis())
+
+    entered = False
+    async with c._session_refresh_lock("sess-123"):
+        entered = True
+    assert entered

--- a/backend/tests/test_integration_upload.py
+++ b/backend/tests/test_integration_upload.py
@@ -8,6 +8,7 @@ these tests require:
 run with: uv run pytest tests/test_integration_upload.py -m integration -v
 """
 
+import asyncio
 import json
 import os
 import struct
@@ -22,7 +23,28 @@ API_URL = os.getenv("PLYR_API_URL", "http://localhost:8001")
 TOKEN = os.getenv("PLYR_TOKEN") or os.getenv("PLYRFM_API_TOKEN")
 
 
-def generate_wav_file(duration_seconds: float = 1.0, sample_rate: int = 44100) -> bytes:
+async def _resolve_pds(client: httpx.AsyncClient, did: str) -> str:
+    doc = (await client.get(f"https://plc.directory/{did}")).json()
+    return next(
+        s["serviceEndpoint"] for s in doc["service"] if s["id"] == "#atproto_pds"
+    )
+
+
+async def _record_has_blob(client: httpx.AsyncClient, pds: str, at_uri: str) -> bool:
+    """does the published fm.plyr.track record carry an audioBlob?"""
+    # at://<did>/<collection>/<rkey>
+    _, _, did, collection, rkey = at_uri.split("/")
+    r = await client.get(
+        f"{pds}/xrpc/com.atproto.repo.getRecord",
+        params={"repo": did, "collection": collection, "rkey": rkey},
+    )
+    value = json.loads(r.text, strict=False).get("value", {})
+    return value.get("audioBlob") is not None
+
+
+def generate_wav_file(
+    duration_seconds: float = 1.0, sample_rate: int = 44100, noise: bool = False
+) -> bytes:
     """generate a minimal valid WAV file with silence."""
     num_channels = 1
     bits_per_sample = 16
@@ -47,8 +69,8 @@ def generate_wav_file(duration_seconds: float = 1.0, sample_rate: int = 44100) -
         data_size,
     )
 
-    # silence (zeros)
-    audio_data = b"\x00" * data_size
+    # silence (zeros), or random samples when a unique file is needed
+    audio_data = os.urandom(data_size) if noise else b"\x00" * data_size
 
     return header + audio_data
 
@@ -158,3 +180,84 @@ async def test_upload_and_delete_track(test_audio_file: Path):
         verify_response = await client.get(f"{API_URL}/tracks/{track_id}")
         assert verify_response.status_code == 404, "track should be deleted"
         print("verified track no longer exists")
+
+
+async def _upload_one(client: httpx.AsyncClient, idx: int) -> tuple[int, str | None]:
+    """upload one unique WAV, poll to completion, return (track_id, atproto_uri)."""
+    # unique bytes per upload AND per run so duplicate-detection (file-hash based)
+    # never collapses the batch or collides with leftovers from a prior run
+    wav = generate_wav_file(duration_seconds=1.0 + idx * 0.05, noise=True)
+    files = {"file": (f"concurrent_{idx}.wav", wav, "audio/wav")}
+    data = {"title": f"Concurrent PDS-blob Test {idx} (DELETE ME)"}
+    resp = await client.post(
+        f"{API_URL}/tracks/",
+        headers={"Authorization": f"Bearer {TOKEN}"},
+        files=files,
+        data=data,
+    )
+    assert resp.status_code == 200, f"[{idx}] upload start failed: {resp.text}"
+    upload_id = resp.json()["upload_id"]
+    async with client.stream(
+        "GET",
+        f"{API_URL}/tracks/uploads/{upload_id}/progress",
+        headers={"Authorization": f"Bearer {TOKEN}"},
+    ) as response:
+        async for line in response.aiter_lines():
+            if not line.startswith("data: "):
+                continue
+            evt = json.loads(line[6:])
+            if evt.get("status") == "completed":
+                return evt.get("track_id"), evt.get("atproto_uri")
+            if evt.get("status") == "failed":
+                pytest.fail(f"[{idx}] upload failed: {evt.get('error')}")
+    pytest.fail(f"[{idx}] progress stream ended without completion")
+
+
+@pytest.mark.integration
+async def test_concurrent_uploads_all_get_pds_blob(request: pytest.FixtureRequest):
+    """reproduce the R2-only fallback: upload N tracks concurrently and assert
+    every published record ends up with an audioBlob on the PDS. under the bug,
+    some uploads 401 on the PDS uploadBlob and silently fall back to R2-only.
+
+    N defaults to 8 (above the per-artist concurrency cap of 3); override with
+    `--upload-count`.
+    """
+    if not TOKEN:
+        pytest.skip("PLYR_TOKEN or PLYRFM_API_TOKEN not set")
+
+    n = int(os.getenv("UPLOAD_COUNT", "8"))
+    async with httpx.AsyncClient(timeout=180.0) as client:
+        me = await client.get(
+            f"{API_URL}/auth/me", headers={"Authorization": f"Bearer {TOKEN}"}
+        )
+        if me.status_code != 200:
+            pytest.skip(f"token invalid: {me.status_code}")
+        did = me.json()["did"]
+        pds = await _resolve_pds(client, did)
+        print(f"\nuploading {n} tracks concurrently as {me.json()['handle']} ({pds})")
+
+        results = await asyncio.gather(*[_upload_one(client, i) for i in range(n)])
+
+        missing: list[int] = []
+        try:
+            for track_id, at_uri in results:
+                if not at_uri or not at_uri.startswith("at://"):
+                    missing.append(track_id)
+                    print(f"  track {track_id}: NO at:// record uri")
+                    continue
+                has_blob = await _record_has_blob(client, pds, at_uri)
+                print(f"  track {track_id}: audioBlob={'YES' if has_blob else 'NO'}")
+                if not has_blob:
+                    missing.append(track_id)
+        finally:
+            for track_id, _ in results:
+                await client.delete(
+                    f"{API_URL}/tracks/{track_id}",
+                    headers={"Authorization": f"Bearer {TOKEN}"},
+                )
+            print(f"cleaned up {len(results)} tracks")
+
+        assert not missing, (
+            f"{len(missing)}/{n} concurrent uploads fell back to R2-only "
+            f"(no PDS blob): track ids {missing}"
+        )

--- a/loq.toml
+++ b/loq.toml
@@ -284,7 +284,7 @@ max_lines = 2589
 
 [[rules]]
 path = "backend/src/backend/_internal/atproto/client.py"
-max_lines = 633
+max_lines = 683
 
 [[rules]]
 path = "backend/src/backend/_internal/auth/oauth.py"


### PR DESCRIPTION
## Punchline
Tracks uploaded since the Mar-6 default-on flip sometimes published with **no `audioBlob` on the user's PDS** (`audio_storage='r2'`, null cid) — the audio lived only in plyr's R2, not the user's repo. Root cause: the PDS blob upload silently degrades to R2-only when token refresh can't keep up under concurrent uploads.

## Evidence (not theory)
- Read the actual records off the PDS: `both` tracks have an `audioBlob`, the `r2` ones genuinely don't.
- Traced a real failing batch in prod (a 6-track album, in retention): **every `uploadBlob` 401'd at batch start** (expired access token); some recovered, some didn't.
- Confirmed fresh-token concurrent uploads all succeed — so the trigger is specifically *an expired token at batch start*.

## Two causes, both fixed
<details>
<summary>1. one-shot refresh gives up under rotation</summary>

`upload_blob` refreshed only once per 401 (`has_refreshed`). When a batch starts expired, N uploads refresh concurrently and rotate the refresh token; a retry can be 401'd *again* by a sibling's rotation, hit the one-shot guard, and give up → silent R2-only. Now refreshes on **every** 401 up to `_PDS_MAX_ATTEMPTS`, reloading the latest token each time. A genuinely dead token still gives up, and `invalid_grant` still raises `SessionExpiredError`.
</details>

<details>
<summary>2. in-process refresh lock can't coordinate across workers</summary>

The refresh lock was an in-process `asyncio.Lock`, so it couldn't serialize refreshes across worker processes/machines (the per-artist concurrency cap allows 3 concurrent). Replaced with a **redis distributed lock** keyed by `oauth_refresh:<session_id>` (blocking, 15s), keeping the existing double-check (reload → return-if-already-rotated). Degrades to the in-process lock if redis is unavailable, so a redis blip never breaks refresh outright.
</details>

## Tests
- `tests/_internal/test_pds_blob_upload_resilience.py` — deterministic: `401, 401, 200` must recover (red on the one-shot code); the refresh lock acquires a session-scoped redis lock and falls back when redis is down.
- Integration harness gains `test_concurrent_uploads_all_get_pds_blob` — N concurrent uploads, every published record must carry an `audioBlob` (the end-to-end invariant). Run: `just backend integration` with `PLYR_TOKEN`/`PLYR_API_URL`.

## Deferred (intentional)
Repairing the **existing** r2-only backlog (the pre-flip bulk is expected — PDS upload was off by default before Mar 6; the post-flip set is the genuine-failure subset) via the existing PDS-backfill machinery is a follow-up, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)