### PR TITLE
fix(track page): owner can open their own private track (no more 404)

### DIFF
--- a/frontend/src/routes/track/[id]/+page.server.ts
+++ b/frontend/src/routes/track/[id]/+page.server.ts
@@ -1,23 +1,22 @@
 import { API_URL } from '$lib/config';
 import type { Track } from '$lib/types';
-import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, fetch }) => {
+	// SSR runs ANONYMOUSLY — the session cookie is scoped to the API host, not
+	// this frontend host, so we can't authenticate here. a public track loads
+	// fine (and gets its SEO/og tags); a private track 404s even for its owner.
+	// in that case return a null track and let the page refetch client-side with
+	// the user's session, which can read an owner's own private track.
 	try {
 		const response = await fetch(`${API_URL}/tracks/${params.id}`);
-
 		if (!response.ok) {
-			throw error(404, 'track not found');
+			return { track: null };
 		}
-
 		const track: Track = await response.json();
-
-		return {
-			track
-		};
+		return { track };
 	} catch (e) {
 		console.error('failed to load track:', e);
-		throw error(404, 'track not found');
+		return { track: null };
 	}
 };

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -39,7 +39,10 @@
 	// receive server-loaded data
 	let { data }: { data: PageData } = $props();
 
-	let track = $state<Track>(data.track);
+	// null when SSR couldn't see it (private track / owner-only); the client
+	// refetch below fills it in for the owner, or flips `notFound`.
+	let track = $state<Track | null>(data.track);
+	let notFound = $state(false);
 
 	// the visible cover and the og:image cascade share the same root rule
 	// (track art → album art); the og:image then fans out to the artist
@@ -48,12 +51,12 @@
 	// image, stale client cache).
 	const OG_FALLBACK_IMAGE = `${APP_CANONICAL_URL}/icons/icon-512.png`;
 	const coverUrl = $derived.by(() => {
-		const url = trackCoverUrl(track);
+		const url = track ? trackCoverUrl(track) : undefined;
 		return url && !moderation.isSensitive(url) ? url : undefined;
 	});
 	const previewImage = $derived.by(() => {
 		if (coverUrl) return coverUrl;
-		if (track.artist_avatar_url && !moderation.isSensitive(track.artist_avatar_url)) {
+		if (track?.artist_avatar_url && !moderation.isSensitive(track.artist_avatar_url)) {
 			return track.artist_avatar_url;
 		}
 		return OG_FALLBACK_IMAGE;
@@ -71,7 +74,7 @@
 
 	// reactive check if this track is currently playing
 	let isCurrentlyPlaying = $derived(
-		player.currentTrack?.id === track.id && !player.paused
+		track != null && player.currentTrack?.id === track.id && !player.paused
 	);
 
 	// mobile detection
@@ -112,12 +115,14 @@
 	}
 
 	function handleLikesClick() {
+		if (!track) return;
 		if (isMobile && track.like_count) {
 			likersSheet.open(track.id, track.like_count);
 		}
 	}
 
 	function handleLikesKeydown(event: KeyboardEvent) {
+		if (!track) return;
 		if (event.key === 'Enter' || event.key === ' ') {
 			event.preventDefault();
 			if (isMobile && track.like_count) {
@@ -133,6 +138,7 @@
 
 
 	async function loadLikedState() {
+		if (!track) return;
 		try {
 			const response = await fetch(`${API_URL}/tracks/${track.id}`, {
 				credentials: 'include'
@@ -152,6 +158,7 @@
 	}
 
 	async function handlePlay() {
+		if (!track) return;
 		if (player.currentTrack?.id === track.id) {
 			// this track is already loaded - just toggle play/pause
 			queue.togglePlayPause();
@@ -167,12 +174,14 @@
 	}
 
 	function addToQueue() {
+		if (!track) return;
 		if (!guardGatedTrack(track, auth.isAuthenticated)) return;
 		queue.addTracks([track]);
 		toast.success(`queued ${track.title}`, 1800);
 	}
 
 	async function loadComments() {
+		if (!track) return;
 		loadingComments = true;
 		try {
 			const response = await fetch(`${API_URL}/tracks/${track.id}/comments`);
@@ -191,7 +200,7 @@
 	}
 
 	async function submitComment() {
-		if (!newCommentText.trim() || submittingComment) return;
+		if (!track || !newCommentText.trim() || submittingComment) return;
 
 		// get current playback position (default to 0 if not playing this track)
 		let timestampMs = 0;
@@ -242,6 +251,7 @@
 	}
 
 	async function seekToTimestamp(ms: number) {
+		if (!track) return;
 		const doSeek = () => {
 			queue.seek(ms);
 		};
@@ -277,6 +287,7 @@
 	}
 
 	async function copyCommentLink(timestampMs: number) {
+		if (!track) return;
 		const seconds = Math.floor(timestampMs / 1000);
 		const url = `${window.location.origin}/track/${track.id}?t=${seconds}`;
 		await navigator.clipboard.writeText(url);
@@ -404,11 +415,39 @@ $effect(() => {
 	}
 });
 
-let shareUrl = $derived(`${typeof window !== 'undefined' ? window.location.origin : ''}/track/${track.id}`);
+// SSR loads anonymously, so a private (owner-only) track arrives as null. retry
+// once on the client WITH the session cookie — an owner can read their own
+// private track; anyone else (or logged-out) gets a real 404 → notFound.
+let triedClientFetch = $state(false);
+$effect(() => {
+	if (track || triedClientFetch || !browser) return;
+	triedClientFetch = true;
+	void (async () => {
+		try {
+			const r = await fetch(`${API_URL}/tracks/${$page.params.id}`, {
+				credentials: 'include'
+			});
+			if (r.ok) {
+				track = await r.json();
+				void loadComments();
+			} else {
+				notFound = true;
+			}
+		} catch {
+			notFound = true;
+		}
+	})();
+});
+
+let shareUrl = $derived(`${typeof window !== 'undefined' ? window.location.origin : ''}/track/${track?.id ?? $page.params.id}`);
 
 // handle ?t= timestamp param for deep linking (youtube-style)
 // handle ?ref= param for share link tracking
 onMount(() => {
+	// deep-link seek + share-ref attribution only apply to a track we already
+	// have (public tracks render server-side); private tracks are owner-only and
+	// don't carry these affordances.
+	if (!track) return;
 	const t = $page.url.searchParams.get('t');
 	if (t) {
 		const seconds = parseInt(t, 10);
@@ -443,6 +482,7 @@ onMount(() => {
 $effect(() => {
 	if (
 		pendingSeekMs !== null &&
+		track != null &&
 		player.currentTrack?.id === track.id &&
 		player.audioElement &&
 		player.audioElement.readyState >= 1
@@ -457,6 +497,9 @@ $effect(() => {
 </script>
 
 <svelte:head>
+	{#if !track}
+		<title>{APP_NAME}</title>
+	{:else}
 	{#if !player.currentTrack || player.currentTrack.id === track.id}
 		<title>{track.title} - {track.artist}{track.album ? ` • ${track.album.title}` : ''}</title>
 	{/if}
@@ -515,9 +558,22 @@ $effect(() => {
 		href="{API_URL}/oembed?url={encodeURIComponent(`${APP_CANONICAL_URL}/track/${track.id}`)}"
 		title="{track.title} - {track.artist}"
 	/>
+	{/if}
 </svelte:head>
 
 <div class="page-container">
+	{#if !track}
+		<Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={handleLogout} />
+		<main>
+			<div class="track-detail">
+				{#if notFound}
+					<p class="track-missing">track not found</p>
+				{:else}
+					<p class="track-missing">loading…</p>
+				{/if}
+			</div>
+		</main>
+	{:else}
 	{#if track.tags && track.tags.length > 0}
 		<TagEffects tags={track.tags} trackTitle={track.title} />
 	{/if}
@@ -810,9 +866,17 @@ $effect(() => {
 			</section>
 		{/if}
 	</main>
+	{/if}
 </div>
 
 <style>
+	.track-missing {
+		text-align: center;
+		color: var(--text-muted);
+		padding: 4rem 1rem;
+		font-size: var(--text-lg);
+	}
+
 	.page-container {
 		min-height: 100vh;
 		display: flex;

--- a/loq.toml
+++ b/loq.toml
@@ -337,3 +337,7 @@ max_lines = 525
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"
 max_lines = 502
+
+[[rules]]
+path = "frontend/src/routes/track/[[]id[]]/+page.svelte"
+max_lines = 1721


### PR DESCRIPTION
Clicking a private track 404'd **even for its owner**. The `/track/[id]` page loads the track in a server-side load, which runs **anonymously** — the `plyr_session` cookie is host-scoped to the API (`api-*.plyr.fm`), not the frontend host, so SSR can't authenticate. A private track is owner-only, so SSR got a 404 and the page hard-errored.

**Fix (matches the codebase's SSR-anonymous / client-authed pattern):**
- The server load returns `{ track: null }` instead of throwing on a non-ok response.
- The page refetches once on the client **with `credentials: 'include'`** (where the cookie *is* sent), so an owner reads their own private track. A non-owner / logged-out viewer still gets a real 404 → "track not found".
- Public tracks are unaffected — SSR still loads them, preserving SEO/og tags.

`track` is now nullable; the deriveds and handlers guard the brief null (load) window, and the page shows `loading…` → rendered / `track not found`.

Manually verified the visibility model is already correct everywhere else (the private track is excluded from feed/top/for-you/discover and hidden from non-owners on artist pages) — this was purely the track-detail SSR-auth gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)