### PR TITLE
docs(lexicons): document fm.plyr.authFullApp permission set

### DIFF
--- a/lexicons/authFullApp.json
+++ b/lexicons/authFullApp.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "permission-set",
-      "description": "OAuth permission set granting full write access to a user's plyr.fm data. Clients request it at sign-in as include:fm.plyr.authFullApp; the user's PDS expands it into granular repo permissions for each collection. Grants create, update, and delete on five collections in the user's repository: fm.plyr.track (uploaded audio tracks), fm.plyr.like (track likes), fm.plyr.comment (timed comments anchored to a playback position), fm.plyr.list (ordered collections of records, used for playlists), and fm.plyr.actor.profile (creator profile). These records are public — reading them requires no permission.",
+      "description": "Write access to a user's plyr.fm data. Clients request include:fm.plyr.authFullApp at sign-in and the PDS expands it into the collections this set currently lists — the set can evolve without clients changing their scope request.",
       "title": "Full plyr.fm Access",
       "detail": "Provides full access to all plyr.fm features including uploading and managing tracks, playlists, likes, and comments.",
       "permissions": [

--- a/lexicons/authFullApp.json
+++ b/lexicons/authFullApp.json
@@ -4,6 +4,7 @@
   "defs": {
     "main": {
       "type": "permission-set",
+      "description": "OAuth permission set granting full write access to a user's plyr.fm data. Clients request it at sign-in as include:fm.plyr.authFullApp; the user's PDS expands it into granular repo permissions for each collection. Grants create, update, and delete on five collections in the user's repository: fm.plyr.track (uploaded audio tracks), fm.plyr.like (track likes), fm.plyr.comment (timed comments anchored to a playback position), fm.plyr.list (ordered collections of records, used for playlists), and fm.plyr.actor.profile (creator profile). These records are public — reading them requires no permission.",
       "title": "Full plyr.fm Access",
       "detail": "Provides full access to all plyr.fm features including uploading and managing tracks, playlists, likes, and comments.",
       "permissions": [

--- a/scripts/publish_permission_set.py
+++ b/scripts/publish_permission_set.py
@@ -1,99 +1,70 @@
 #!/usr/bin/env python
-"""publish permission set lexicon to ATProto repo with specific rkey."""
+"""publish permission set lexicons from lexicons/ to the plyr.fm ATProto repo.
 
+usage: uv run scripts/publish_permission_set.py authFullApp [privateMedia]
+
+publishes to the namespace in NAMESPACE (default: fm.plyr, i.e. production).
+for staging: NAMESPACE=fm.plyr.stg uv run scripts/publish_permission_set.py ...
+"""
+
+import argparse
 import asyncio
+import json
 from pathlib import Path
+from typing import Any
 
 from atproto import AsyncClient
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 ROOT = Path(__file__).parent.parent
+LEXICON_DIR = ROOT / "lexicons"
+PROD_NAMESPACE = "fm.plyr"
+PERMISSION_SETS = ("authFullApp", "privateMedia")
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=str(ROOT / ".env"), extra="ignore")
 
-    plyrfm_handle: str = Field(validation_alias="PLYRFM_HANDLE")
+    plyrfm_handle: str = Field(default="plyr.fm", validation_alias="PLYRFM_HANDLE")
     plyrfm_password: str = Field(validation_alias="PLYRFM_PASSWORD")
-    namespace: str = Field(default="fm.plyr", validation_alias="NAMESPACE")
+    namespace: str = Field(default=PROD_NAMESPACE, validation_alias="NAMESPACE")
 
 
-def _auth_full_app(ns: str) -> dict:
-    return {
-        "type": "permission-set",
-        "title": "Full plyr.fm Access",
-        "detail": "Provides full access to all plyr.fm features including uploading and managing tracks, playlists, likes, and comments.",
-        "permissions": [
-            {
-                "type": "permission",
-                "resource": "repo",
-                "action": ["create", "update", "delete"],
-                "collection": [
-                    f"{ns}.track",
-                    f"{ns}.like",
-                    f"{ns}.comment",
-                    f"{ns}.list",
-                    f"{ns}.actor.profile",
-                ],
-            }
-        ],
-    }
+def _renamespace(value: Any, ns: str) -> Any:
+    if isinstance(value, str):
+        return value.replace(f"{PROD_NAMESPACE}.", f"{ns}.")
+    if isinstance(value, list):
+        return [_renamespace(item, ns) for item in value]
+    if isinstance(value, dict):
+        return {key: _renamespace(item, ns) for key, item in value.items()}
+    return value
 
 
-def _private_media(ns: str) -> dict:
-    """permissioned-space set for artist-owned private media (#1528).
-
-    requested progressively as `include:{ns}.privateMedia` only for accounts on a
-    PDS that supports permissioned spaces; the PDS expands the space permission
-    into `space:{ns}.privateMedia?action=...` scopes on the token.
-    """
-    return {
-        "type": "permission-set",
-        "title": "plyr.fm Private Media",
-        "detail": "Access to your private audio — a permissioned space on your PDS that only you (and apps you grant) can read.",
-        "permissions": [
-            {
-                "type": "permission",
-                "resource": "space",
-                "action": ["read", "create", "update", "delete", "manage"],
-                "space": [f"{ns}.privateMedia"],
-                "skey": ["self"],
-                "did": ["*"],
-                "collection": [f"{ns}.track"],
-            }
-        ],
-    }
-
-
-async def _publish(client: AsyncClient, permission_set_id: str, main_def: dict) -> None:
-    record = {
-        "$type": "com.atproto.lexicon.schema",
-        "lexicon": 1,
-        "id": permission_set_id,
-        "defs": {"main": main_def},
-    }
+async def _publish(client: AsyncClient, name: str, ns: str) -> None:
+    schema = _renamespace(json.loads((LEXICON_DIR / f"{name}.json").read_text()), ns)
     result = await client.com.atproto.repo.put_record(
         {
             "repo": client.me.did,
             "collection": "com.atproto.lexicon.schema",
-            "rkey": permission_set_id,
-            "record": record,
+            "rkey": schema["id"],
+            "record": {"$type": "com.atproto.lexicon.schema", **schema},
         }
     )
-    print(f"published {permission_set_id}: {result.uri} (cid {result.cid})")
+    print(f"published {schema['id']}: {result.uri} (cid {result.cid})")
 
 
-async def main():
+async def main(names: list[str]) -> None:
     settings = Settings()
 
     client = AsyncClient()
     await client.login(settings.plyrfm_handle, settings.plyrfm_password)
 
-    ns = settings.namespace
-    await _publish(client, f"{ns}.authFullApp", _auth_full_app(ns))
-    await _publish(client, f"{ns}.privateMedia", _private_media(ns))
+    for name in names:
+        await _publish(client, name, settings.namespace)
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sets", nargs="+", choices=PERMISSION_SETS)
+    asyncio.run(main(parser.parse_args().sets))


### PR DESCRIPTION
adds a developer-facing `description` to the `fm.plyr.authFullApp` permission set and makes `lexicons/` the single source of truth for the publish script. the documented record is **already published to prod** ([lexicon garden](https://lexicon.garden/lexicon/did:plc:vs3hnzq2daqbszxlysywzy54/fm.plyr.authFullApp) now renders the description on its docs tab).

## motivation

lexicon garden extracts documentation from `description` fields in published schemas. our prod permission set only had `title`/`detail` (the OAuth consent-screen strings), so its docs tab was empty. this is the first step of documenting all our lexicons; record lexicons (`fm.plyr.track` etc.) already have descriptions locally but aren't published yet — deferred to follow-up work.

## design

<details>
<summary>description placement and script refactor</summary>

- the `description` lives only on the permission-set main def, where `@atproto/lexicon` explicitly models it (`lexPermissionSet`). it documents the interface — a stable scope request whose expansion is defined by the set — rather than enumerating the current collections, which the `permissions` array already declares machine-readably and which would drift as the set evolves.
- `scripts/publish_permission_set.py` previously hardcoded both permission-set defs inline, duplicating `lexicons/*.json` (which `docs/public/lexicons/overview.md` declares as the source of truth). it now loads the JSON files and rewrites the `fm.plyr.` namespace prefix recursively for staging — including occurrences inside description prose, so staging docs reference `include:fm.plyr.stg.authFullApp` correctly.
- publishing now requires naming sets explicitly (`publish_permission_set.py authFullApp`). the old script unconditionally published both sets, which would have shipped `fm.plyr.privateMedia` to prod — that set is a staging-only experiment (#1557) and stays unpublished in prod.
- `PLYRFM_HANDLE` gains a `plyr.fm` default since `.env` only carries the password.

</details>

## verification

- updated schema validates via `parseLexiconDoc` from `@atproto/lexicon`
- published with `uv run --project backend scripts/publish_permission_set.py authFullApp`; `getRecord` against the PDS confirms the description landed and the permissions array is unchanged
- staging records (`fm.plyr.stg.*`) intentionally not republished in this pass

## intentional non-behaviors

- no permission/scope changes — the `permissions` array is byte-identical to what was already published
- `fm.plyr.privateMedia` (prod) remains unpublished; `lexicons/privateMedia.json` content untouched (description for it comes with the private-media work)
- record lexicons remain unpublished — later phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

