### PR TITLE
fix(embed): radio embed can pin and switch stations

### DIFF
--- a/frontend/src/lib/components/embed/RadioEmbed.svelte
+++ b/frontend/src/lib/components/embed/RadioEmbed.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
 	import { API_URL } from '$lib/config';
-	import type { RadioState, RadioTrack } from '$lib/radio.svelte';
+	import TunerDial from '$lib/components/radio/TunerDial.svelte';
+	import type { RadioState, RadioStation, RadioTrack } from '$lib/radio.svelte';
 
 	// standalone embed player: this is its own iframe context (not the main app),
 	// so it owns a local <audio> and its own station polling.
@@ -10,9 +12,15 @@
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 	let playing = $state(false);
+	let stations = $state<RadioStation[]>([]);
+	/** selected station slug; null defers to the server default. seeded from
+	 * the iframe url's ?station= so embedders can pin a station. */
+	let station = $state<string | null>(null);
+	let switching = $state(false);
 	let pollTimer: number | null = null;
 
 	let current: RadioTrack | null = $derived(radioState?.current ?? null);
+	let activeSlug = $derived(radioState?.station_slug ?? station);
 
 	function stateProgress(fetched: RadioState): number {
 		const generatedAt = Date.parse(fetched.generated_at);
@@ -41,9 +49,26 @@
 		}
 	}
 
-	async function loadState(sync = false) {
+	async function loadStations() {
 		try {
-			const res = await fetch(`${API_URL}/radio/state`);
+			const res = await fetch(`${API_URL}/radio/stations`);
+			if (!res.ok) return;
+			stations = (await res.json()).stations;
+		} catch (e) {
+			console.error('radio embed: failed to load stations', e);
+		}
+	}
+
+	async function loadState(sync = false): Promise<void> {
+		try {
+			const query = station ? `?station=${encodeURIComponent(station)}` : '';
+			const res = await fetch(`${API_URL}/radio/state${query}`);
+			if (res.status === 404 && station) {
+				// unknown station slug (bad embed param or a renamed station) —
+				// fall back to the server default rather than going "off air"
+				station = null;
+				return loadState(sync);
+			}
 			if (!res.ok) throw new Error(`radio ${res.status}`);
 			radioState = await res.json();
 			error = null;
@@ -53,6 +78,19 @@
 			error = 'radio is off air right now';
 		} finally {
 			loading = false;
+		}
+	}
+
+	async function selectStation(slug: string) {
+		if (slug === activeSlug) return;
+		station = slug;
+		switching = true;
+		try {
+			// sync so a tuned-in listener follows the audio across the flip;
+			// while paused this just preloads the new station's track
+			await loadState(true);
+		} finally {
+			switching = false;
 		}
 	}
 
@@ -69,6 +107,8 @@
 	}
 
 	onMount(() => {
+		station = $page.url.searchParams.get('station');
+		loadStations();
 		loadState(false);
 		pollTimer = window.setInterval(() => loadState(playing), 30000);
 		return () => {
@@ -86,7 +126,7 @@
 ></audio>
 
 <div class="radio-embed">
-	<a class="brand" href="https://plyr.fm/radio" target="_blank" rel="noopener">
+	<a class="brand" href={`https://plyr.fm/radio${activeSlug ? `/${activeSlug}` : ''}`} target="_blank" rel="noopener">
 		<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 			<circle cx="12" cy="12" r="2"></circle>
 			<path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14"></path>
@@ -94,12 +134,16 @@
 		<span>plyr.fm radio</span>
 	</a>
 
+	<div class="dial-row">
+		<TunerDial {stations} {activeSlug} onSelect={selectStation} />
+	</div>
+
 	{#if loading && !radioState}
 		<div class="status">tuning…</div>
 	{:else if error}
 		<div class="status error">{error}</div>
 	{:else if current}
-		<div class="now">
+		<div class="now" class:tuning={switching}>
 			{#if current.artwork_url}
 				<img class="art" src={current.artwork_url} alt="" />
 			{:else}
@@ -152,6 +196,19 @@
 		text-decoration: underline;
 	}
 
+	.dial-row {
+		display: flex;
+		justify-content: center;
+	}
+
+	/* iframes sized for the pre-dial layout are too short for an extra row —
+	   keep them uncropped and let ?station= still pin the station */
+	@media (max-height: 11.5rem) {
+		.dial-row {
+			display: none;
+		}
+	}
+
 	.status {
 		flex: 1;
 		display: flex;
@@ -170,6 +227,26 @@
 		align-items: center;
 		gap: 1rem;
 		min-height: 0;
+		transition:
+			opacity 0.22s ease,
+			filter 0.22s ease;
+	}
+
+	/* the swappable station content fades while tuning, same as the radio page */
+	.now.tuning {
+		opacity: 0.35;
+		filter: blur(2px);
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.now {
+			transition: none;
+		}
+
+		.now.tuning {
+			opacity: 0.6;
+			filter: none;
+		}
 	}
 
 	.art {

--- a/frontend/src/routes/embed/+layout@.svelte
+++ b/frontend/src/routes/embed/+layout@.svelte
@@ -34,6 +34,9 @@
 		/* accent */
 		--accent: #6a9fff;
 
+		/* type */
+		--text-sm: 0.85rem;
+
 		/* radii */
 		--radius-full: 9999px;
 	}


### PR DESCRIPTION
the standalone radio embed was permanently tuned to the default station — it fetched `/radio/state` with no station param and rendered no switcher, so `?station=` on the iframe url was silently ignored. now the embed reads `?station=` to pin a station and renders the same `TunerDial` the main radio page uses, so visitors can flip stations inside the widget. closes #1570.

<details>
<summary>design</summary>

- **reuses `TunerDial` directly** (it's self-contained: `stations` / `activeSlug` / `onSelect` props, design-token CSS). the embed layout defines its own minimal token set, so it gains the one token the dial needs (`--text-sm: 0.85rem`, same value as the app layout).
- **`?station=` is read once on mount** and folded into every `/radio/state` poll. an unknown slug (bad embed param or a renamed station) gets a 404 from the backend and falls back to the server default instead of going "off air" — same recovery the main page's `Radio.loadState` does.
- **station flips sync the local `<audio>` across**: a tuned-in listener keeps playing on the new station; while paused, the flip just preloads the new station's track so the next play gesture starts in the right place. the now-playing block gets the same tuning fade (`opacity` + `blur`, reduced-motion aware) as the radio page.
- **the brand link follows the active station** — clicking through from an embed pinned to `fresh` lands on `plyr.fm/radio/fresh`.
- **short iframes keep working**: iframes sized for the pre-dial layout (< 11.5rem ≈ 184px tall) hide the dial row via a height media query so nothing clips (`overflow: hidden` on the embed body would otherwise crop it). `?station=` still pins the station there.

</details>

<details>
<summary>intentional non-behaviors</summary>

- **no localStorage persistence** of the picked station (unlike the main page's remembered pick) — the embed is a third-party iframe where storage is partitioned and an embedder's `?station=` pin should stay authoritative on reload.
- **no url rewriting inside the iframe** on flip — the iframe url isn't user-visible and rewriting it would fight the embedder's param.
- **poll cadence unchanged** (30s) — a station flip refetches immediately but doesn't reset or alter the polling loop.

</details>

<details>
<summary>verification (local frontend against the staging api)</summary>

- dial renders the 4-station lineup with the active needle; flipping to `fresh` swaps state + audio src and updates the brand link
- `?station=deep-cuts` pins deep cuts on load; `?station=bogus` falls back to the default station
- a 420×150 iframe hides the dial with no overflow; 420×220 shows it without overflow
- `just frontend check` and `uvx loq` pass

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)