### PR TITLE
docs(private-media): align with ZDS member-list removal (#1573); owner-only by app policy

### DIFF
--- a/backend/src/backend/_internal/atproto/spaces/client.py
+++ b/backend/src/backend/_internal/atproto/spaces/client.py
@@ -78,9 +78,12 @@ async def ensure_personal_space(
 ) -> str:
     """create (or find) the caller's artist-owned personal space; return its URI.
 
-    owner DID = the artist's DID, single-member (the artist is auto-added).
-    `appAccessMode:"allow"` + empty exceptions leaves plyr.fm's OAuth client
-    default-allowed for credential exchange.
+    owner DID = the artist's DID. the space is owner-only: the protocol no longer
+    has a reader member list (#1573), and private-space credentials are owner-only
+    by default, so for this MVP the owner is the sole reader. any broader access
+    (label/supporter rosters) is plyr.fm app-layer state, not a PDS member list.
+    `appAccessMode:"allow"` + empty exceptions is the app-access policy that leaves
+    plyr.fm's OAuth client default-allowed for the credential exchange.
     """
     space_type = space_type or settings.atproto.private_media_space_type
     space_uri = build_space_uri(auth_session.did, space_type, skey)

--- a/backend/src/backend/api/audio.py
+++ b/backend/src/backend/api/audio.py
@@ -356,10 +356,13 @@ async def _handle_private_audio(
 ) -> Response:
     """proxy a private track's audio through the permissioned-space credential path.
 
-    only the owner can play their own private media in this single-member-space MVP,
-    so a non-owner (or anonymous) request gets a 404 — the same response as a missing
-    file, so private tracks don't leak their existence. Range is passed through so the
-    206/seek semantics survive the proxy.
+    access is owner-only by plyr.fm's APP-LAYER policy: the protocol no longer
+    enumerates readers (ZDS dropped member-list semantics, #1573), so reader/group
+    access is the app's concern, not the PDS's. for this MVP the only reader is the
+    space owner, so a non-owner (or anonymous) request gets a 404 — the same as a
+    missing file, so private tracks don't leak their existence. broader access
+    (label rosters, supporter tiers) would be a future app-layer roster, not a PDS
+    member list. Range is passed through so the 206/seek semantics survive the proxy.
     """
     if session is None or session.did != artist_did:
         raise HTTPException(status_code=404, detail="audio file not found")

--- a/docs/internal/architecture/permissioned-private-media.md
+++ b/docs/internal/architecture/permissioned-private-media.md
@@ -6,6 +6,19 @@ whose PDS implements it. ports cleanly from today's public track flow: the recor
 is the same `fm.plyr.track` lexicon — only the write target (a permissioned space repo)
 and the read auth (a space credential) differ.
 
+> **update (#1573): the protocol no longer has a reader member list.** ZDS removed the
+> member-list routes (`addMember`/`removeMember`/`getMembers`/`getMemberState`/
+> `getMemberOplog`/`notifyMembership`) and `getSpace`/`listSpaces` no longer expose
+> `members`/`isMember`. the **space credential is the substrate**; reader/group semantics
+> live **above** it, in the app. private-space credentials are owner-only by default.
+> plyr.fm does not depend on any of the removed surface (audited: we never read
+> `members`/`isMember` and never called a member-list route). access for this MVP is
+> **owner-only by plyr's app-layer policy** — see the owner-model section. broader access
+> (label rosters, artist-catalog membership, supporter tiers) is future plyr.fm app-layer
+> state — ideally records in the relevant permissioned space — never a PDS member list.
+> sections below that say "member list" describe the original (now-removed) protocol shape
+> and are kept for history; the binding model is owner-only-by-app-policy.
+
 ## the first space type, and why it's the smallest meaningful one
 
 `fm.plyr.privateMedia` (env-aware: `fm.plyr.dev.privateMedia` in dev). One artist-owned
@@ -38,12 +51,13 @@ Result is cached per-PDS in Redis (6h) and surfaced on `/auth/me` as
 field), swap it in behind the same `detect_permissioned_capability()` function — the one
 isolation point.
 
-## owner model, initial members, and plyr.fm's client ID
+## owner model, access, and plyr.fm's client ID
 
 - **Owner DID = artist DID.** Personal namespaces use the user's own DID (diary 5); no
   dedicated space DID is needed until ownership must transfer (shared/gated spaces).
-- **Members:** exactly one — the artist, auto-added as the owner. The member list is the
-  read ACL; write legitimacy is app policy (below).
+- **Access: owner-only.** Post-#1573 the protocol has no reader member list — private-space
+  credentials are owner-only by default, and any wider read ACL is plyr's app-layer concern.
+  for this MVP the owner is the sole reader; write legitimacy is also app policy (below).
 - **plyr.fm's OAuth client ID is default-allowed.** The space is created with
   `appAccessMode: "allow"` and empty `appExceptions`, so any OAuth client (including
   plyr.fm) may obtain a credential. A future shared-space pass can flip to an allow-list.


### PR DESCRIPTION
Course-correction for #1573 — ZDS removed protocol-level member-list semantics from `com.atproto.space.*` (the credential is the substrate; reader/group access lives above it, in the app; private-space credentials are owner-only by default).

**Audit result: plyr depends on none of the removed surface.** We never read `members`/`isMember` and never call a member-list route (`addMember`/`getMembers`/etc.) — confirmed by grep. We call only the **retained** substrate: `createSpace`, `create/putRecord`, `getBlob`, `getMemberGrant`/`getSpaceCredential`, `listSpaces`. So nothing breaks against the new ZDS, and prod is unaffected (no prod PDS even has the surface).

**No behavior change.** This reframes the *already-enforced* owner-only access as plyr's explicit **app-layer** policy (rather than a "single-member" protocol member list):
- `_handle_private_audio` + `ensure_personal_space` docstrings updated.
- Design note (`docs/internal/architecture/permissioned-private-media.md`) gets a prominent #1573 update banner + the owner-model section reworded; "member list" passages kept for history but flagged.
- Records that broader access (label rosters, artist-catalog membership, supporter tiers) is now future plyr **app-layer state** — ideally records in the permissioned space — not a PDS member list.

Owner-only is enforced in code (`session.did != artist_did → 404`); this just makes the *why* explicit now that the protocol no longer enumerates readers. Capability detection already uses only retained substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)