### PR TITLE
refactor(collections): share one drag-to-reorder module across playlist and album pages

### DIFF
--- a/frontend/src/lib/list-reorder.svelte.ts
+++ b/frontend/src/lib/list-reorder.svelte.ts
@@ -1,0 +1,144 @@
+// list-reorder — shared drag-to-reorder state machine for edit-mode track
+// lists (playlist + album detail). desktop HTML5 drag and touch drag share one
+// instance: the page owns the array and passes an onMove callback; this module
+// owns the gesture state and the drop/hit-testing logic.
+//
+// usage:
+//   const reorder = createListReorder((from, to) => (tracks = moveItem(tracks, from, to)));
+//
+//   <div bind:this={reorder.listElement}
+//        ontouchmove={reorder.handleTouchMove} ontouchend={reorder.handleTouchEnd} ...>
+//     {#each tracks as track, i (track.id)}
+//       <div class="track-row" data-index={i} draggable="true"
+//            class:drag-over={reorder.dragOverIndex === i && reorder.touchDragIndex !== i}
+//            class:is-dragging={reorder.touchDragIndex === i || reorder.draggedIndex === i}
+//            ondragstart={(e) => reorder.handleDragStart(e, i)} ...>
+//         <button ontouchstart={(e) => reorder.handleTouchStart(e, i)}>⠿</button>
+
+export interface ListReorderOptions {
+	/** selector for the reorderable rows inside the list element (default: '.track-row') */
+	rowSelector?: string;
+}
+
+/** return a copy of items with the element at fromIndex moved to toIndex. */
+export function moveItem<T>(items: T[], fromIndex: number, toIndex: number): T[] {
+	if (fromIndex === toIndex) return items;
+	const next = [...items];
+	const [moved] = next.splice(fromIndex, 1);
+	next.splice(toIndex, 0, moved);
+	return next;
+}
+
+export function createListReorder(
+	onMove: (fromIndex: number, toIndex: number) => void,
+	options: ListReorderOptions = {}
+) {
+	const { rowSelector = '.track-row' } = options;
+
+	let draggedIndex = $state<number | null>(null);
+	let dragOverIndex = $state<number | null>(null);
+
+	let touchDragIndex = $state<number | null>(null);
+	let touchStartY = 0;
+	let touchDragElement: HTMLElement | null = null;
+
+	let listElement: HTMLElement | null = null;
+
+	return {
+		get draggedIndex() {
+			return draggedIndex;
+		},
+		get dragOverIndex() {
+			return dragOverIndex;
+		},
+		get touchDragIndex() {
+			return touchDragIndex;
+		},
+		get listElement() {
+			return listElement;
+		},
+		set listElement(el: HTMLElement | null) {
+			listElement = el;
+		},
+
+		// desktop drag and drop
+		handleDragStart(event: DragEvent, index: number) {
+			draggedIndex = index;
+			if (event.dataTransfer) {
+				event.dataTransfer.effectAllowed = 'move';
+			}
+		},
+
+		handleDragOver(event: DragEvent, index: number) {
+			event.preventDefault();
+			dragOverIndex = index;
+		},
+
+		handleDrop(event: DragEvent, index: number) {
+			event.preventDefault();
+			if (draggedIndex !== null && draggedIndex !== index) {
+				onMove(draggedIndex, index);
+			}
+			draggedIndex = null;
+			dragOverIndex = null;
+		},
+
+		handleDragEnd() {
+			draggedIndex = null;
+			dragOverIndex = null;
+		},
+
+		// touch drag and drop
+		handleTouchStart(event: TouchEvent, index: number) {
+			const touch = event.touches[0];
+			touchDragIndex = index;
+			touchStartY = touch.clientY;
+			touchDragElement = event.currentTarget as HTMLElement;
+			touchDragElement.classList.add('touch-dragging');
+		},
+
+		handleTouchMove(event: TouchEvent) {
+			if (touchDragIndex === null || !touchDragElement || !listElement) return;
+
+			event.preventDefault();
+			const touch = event.touches[0];
+			const offset = touch.clientY - touchStartY;
+			touchDragElement.style.transform = `translateY(${offset}px)`;
+
+			const rowElements = listElement.querySelectorAll(rowSelector);
+			for (let i = 0; i < rowElements.length; i++) {
+				const rowEl = rowElements[i] as HTMLElement;
+				const rect = rowEl.getBoundingClientRect();
+				const midY = rect.top + rect.height / 2;
+
+				if (touch.clientY < midY && i > 0) {
+					const targetIndex = parseInt(rowEl.dataset.index || '0');
+					if (targetIndex !== touchDragIndex) {
+						dragOverIndex = targetIndex;
+					}
+					break;
+				} else if (touch.clientY >= midY) {
+					const targetIndex = parseInt(rowEl.dataset.index || '0');
+					if (targetIndex !== touchDragIndex) {
+						dragOverIndex = targetIndex;
+					}
+				}
+			}
+		},
+
+		handleTouchEnd() {
+			if (touchDragIndex !== null && dragOverIndex !== null && touchDragIndex !== dragOverIndex) {
+				onMove(touchDragIndex, dragOverIndex);
+			}
+
+			if (touchDragElement) {
+				touchDragElement.classList.remove('touch-dragging');
+				touchDragElement.style.transform = '';
+			}
+
+			touchDragIndex = null;
+			dragOverIndex = null;
+			touchDragElement = null;
+		}
+	};
+}

--- a/frontend/src/lib/list-reorder.test.ts
+++ b/frontend/src/lib/list-reorder.test.ts
@@ -1,0 +1,158 @@
+// tests for the shared list-reorder state machine: the pure move helper, the
+// desktop drag lifecycle (incl. drop-on-self no-op and state reset), and the
+// touch lifecycle with mocked row geometry for the hit-testing scan.
+import { describe, it, expect, vi } from 'vitest';
+
+import { createListReorder, moveItem } from './list-reorder.svelte';
+
+function dragEvent(): DragEvent {
+	return new Event('dragstart', { cancelable: true }) as DragEvent;
+}
+
+function touchEvent(clientY: number, target?: HTMLElement): TouchEvent {
+	const event = new Event('touchstart', { cancelable: true }) as TouchEvent;
+	Object.defineProperty(event, 'touches', { value: [{ clientY }] });
+	if (target) {
+		Object.defineProperty(event, 'currentTarget', { value: target });
+	}
+	return event;
+}
+
+/** a list element whose rows report fixed 50px-tall stacked rects. */
+function listWithRows(count: number): { list: HTMLElement; rows: HTMLElement[] } {
+	const list = document.createElement('div');
+	const rows: HTMLElement[] = [];
+	for (let i = 0; i < count; i++) {
+		const row = document.createElement('div');
+		row.className = 'track-row';
+		row.dataset.index = String(i);
+		row.getBoundingClientRect = () => ({ top: i * 50, height: 50, bottom: i * 50 + 50 }) as DOMRect;
+		list.appendChild(row);
+		rows.push(row);
+	}
+	return { list, rows };
+}
+
+describe('moveItem', () => {
+	it('moves an element and returns a new array', () => {
+		const items = ['a', 'b', 'c', 'd'];
+
+		const moved = moveItem(items, 0, 2);
+
+		expect(moved).toEqual(['b', 'c', 'a', 'd']);
+		expect(items).toEqual(['a', 'b', 'c', 'd']);
+	});
+
+	it('returns the same array when from equals to', () => {
+		const items = ['a', 'b'];
+
+		expect(moveItem(items, 1, 1)).toBe(items);
+	});
+});
+
+describe('desktop drag', () => {
+	it('fires onMove with the dragged and dropped indices, then resets', () => {
+		const onMove = vi.fn();
+		const reorder = createListReorder(onMove);
+
+		reorder.handleDragStart(dragEvent(), 0);
+		expect(reorder.draggedIndex).toBe(0);
+
+		reorder.handleDragOver(dragEvent(), 2);
+		expect(reorder.dragOverIndex).toBe(2);
+
+		reorder.handleDrop(dragEvent(), 2);
+		expect(onMove).toHaveBeenCalledWith(0, 2);
+		expect(reorder.draggedIndex).toBeNull();
+		expect(reorder.dragOverIndex).toBeNull();
+	});
+
+	it('does not fire onMove when dropping on the dragged row', () => {
+		const onMove = vi.fn();
+		const reorder = createListReorder(onMove);
+
+		reorder.handleDragStart(dragEvent(), 1);
+		reorder.handleDrop(dragEvent(), 1);
+
+		expect(onMove).not.toHaveBeenCalled();
+		expect(reorder.draggedIndex).toBeNull();
+	});
+
+	it('resets state on dragend without firing onMove', () => {
+		const onMove = vi.fn();
+		const reorder = createListReorder(onMove);
+
+		reorder.handleDragStart(dragEvent(), 0);
+		reorder.handleDragOver(dragEvent(), 1);
+		reorder.handleDragEnd();
+
+		expect(onMove).not.toHaveBeenCalled();
+		expect(reorder.draggedIndex).toBeNull();
+		expect(reorder.dragOverIndex).toBeNull();
+	});
+});
+
+describe('touch drag', () => {
+	it('tracks the dragged row, hit-tests rows on move, and fires onMove on release', () => {
+		const onMove = vi.fn();
+		const reorder = createListReorder(onMove);
+		const { list, rows } = listWithRows(3);
+		reorder.listElement = list;
+
+		reorder.handleTouchStart(touchEvent(25, rows[0]), 0);
+		expect(reorder.touchDragIndex).toBe(0);
+		expect(rows[0].classList.contains('touch-dragging')).toBe(true);
+
+		// drag down past the midpoint of row 2 (midY = 125)
+		reorder.handleTouchMove(touchEvent(130));
+		expect(reorder.dragOverIndex).toBe(2);
+		expect(rows[0].style.transform).toBe('translateY(105px)');
+
+		reorder.handleTouchEnd();
+		expect(onMove).toHaveBeenCalledWith(0, 2);
+		expect(reorder.touchDragIndex).toBeNull();
+		expect(rows[0].classList.contains('touch-dragging')).toBe(false);
+		expect(rows[0].style.transform).toBe('');
+	});
+
+	it('does not fire onMove on a tap (release without any move)', () => {
+		const onMove = vi.fn();
+		const reorder = createListReorder(onMove);
+		const { list, rows } = listWithRows(3);
+		reorder.listElement = list;
+
+		reorder.handleTouchStart(touchEvent(25, rows[0]), 0);
+		reorder.handleTouchEnd();
+
+		expect(onMove).not.toHaveBeenCalled();
+		expect(rows[0].classList.contains('touch-dragging')).toBe(false);
+	});
+
+	// legacy quirk, preserved verbatim from the page handlers: the hit-test
+	// scan marks a neighboring row as the drop target for ANY movement, even
+	// one that stays within the dragged row's own bounds — so a micro-wiggle
+	// reorders by one position on release.
+	it('marks a neighbor as drop target even for movement within the dragged row', () => {
+		const onMove = vi.fn();
+		const reorder = createListReorder(onMove);
+		const { list, rows } = listWithRows(3);
+		reorder.listElement = list;
+
+		reorder.handleTouchStart(touchEvent(25, rows[0]), 0);
+		reorder.handleTouchMove(touchEvent(30));
+		reorder.handleTouchEnd();
+
+		expect(onMove).toHaveBeenCalledWith(0, 1);
+	});
+
+	it('ignores touch moves without an active drag or list element', () => {
+		const onMove = vi.fn();
+		const reorder = createListReorder(onMove);
+
+		// no touchstart, no list element — must be a no-op
+		reorder.handleTouchMove(touchEvent(100));
+
+		expect(reorder.dragOverIndex).toBeNull();
+		expect(onMove).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/routes/playlist/[id]/+page.svelte
+++ b/frontend/src/routes/playlist/[id]/+page.svelte
@@ -14,6 +14,7 @@
 	import { queue } from "$lib/queue.svelte";
 	import { playQueue } from "$lib/playback.svelte";
 	import { fetchLikedTracks } from "$lib/tracks.svelte";
+	import { createListReorder, moveItem } from "$lib/list-reorder.svelte";
 	import * as playlistActions from "$lib/playlist-actions";
 	import type { PlaylistTrackCandidate } from "$lib/playlist-actions";
 	import type { PageData } from "./$types";
@@ -132,15 +133,10 @@
 	let loadingRecommendations = $state(false);
 	let recommendationsAvailable = $state(true);
 
-	// drag state
-	let draggedIndex = $state<number | null>(null);
-	let dragOverIndex = $state<number | null>(null);
-
-	// touch drag state
-	let touchDragIndex = $state<number | null>(null);
-	let touchStartY = $state(0);
-	let touchDragElement = $state<HTMLElement | null>(null);
-	let tracksListElement = $state<HTMLElement | null>(null);
+	// drag-to-reorder (desktop + touch)
+	const reorder = createListReorder((from, to) => {
+		tracks = moveItem(tracks, from, to);
+	});
 
 	async function handleLogout() {
 		await auth.logout();
@@ -421,100 +417,6 @@
 		} finally {
 			isSavingOrder = false;
 		}
-	}
-
-	// move track from one index to another
-	function moveTrack(fromIndex: number, toIndex: number) {
-		if (fromIndex === toIndex) return;
-		const newTracks = [...tracks];
-		const [moved] = newTracks.splice(fromIndex, 1);
-		newTracks.splice(toIndex, 0, moved);
-		tracks = newTracks;
-	}
-
-	// desktop drag and drop
-	function handleDragStart(event: DragEvent, index: number) {
-		draggedIndex = index;
-		if (event.dataTransfer) {
-			event.dataTransfer.effectAllowed = "move";
-		}
-	}
-
-	function handleDragOver(event: DragEvent, index: number) {
-		event.preventDefault();
-		dragOverIndex = index;
-	}
-
-	function handleDrop(event: DragEvent, index: number) {
-		event.preventDefault();
-		if (draggedIndex !== null && draggedIndex !== index) {
-			moveTrack(draggedIndex, index);
-		}
-		draggedIndex = null;
-		dragOverIndex = null;
-	}
-
-	function handleDragEnd() {
-		draggedIndex = null;
-		dragOverIndex = null;
-	}
-
-	// touch drag and drop
-	function handleTouchStart(event: TouchEvent, index: number) {
-		const touch = event.touches[0];
-		touchDragIndex = index;
-		touchStartY = touch.clientY;
-		touchDragElement = event.currentTarget as HTMLElement;
-		touchDragElement.classList.add("touch-dragging");
-	}
-
-	function handleTouchMove(event: TouchEvent) {
-		if (touchDragIndex === null || !touchDragElement || !tracksListElement)
-			return;
-
-		event.preventDefault();
-		const touch = event.touches[0];
-		const offset = touch.clientY - touchStartY;
-		touchDragElement.style.transform = `translateY(${offset}px)`;
-
-		const trackElements = tracksListElement.querySelectorAll(".track-row");
-		for (let i = 0; i < trackElements.length; i++) {
-			const trackEl = trackElements[i] as HTMLElement;
-			const rect = trackEl.getBoundingClientRect();
-			const midY = rect.top + rect.height / 2;
-
-			if (touch.clientY < midY && i > 0) {
-				const targetIndex = parseInt(trackEl.dataset.index || "0");
-				if (targetIndex !== touchDragIndex) {
-					dragOverIndex = targetIndex;
-				}
-				break;
-			} else if (touch.clientY >= midY) {
-				const targetIndex = parseInt(trackEl.dataset.index || "0");
-				if (targetIndex !== touchDragIndex) {
-					dragOverIndex = targetIndex;
-				}
-			}
-		}
-	}
-
-	function handleTouchEnd() {
-		if (
-			touchDragIndex !== null &&
-			dragOverIndex !== null &&
-			touchDragIndex !== dragOverIndex
-		) {
-			moveTrack(touchDragIndex, dragOverIndex);
-		}
-
-		if (touchDragElement) {
-			touchDragElement.classList.remove("touch-dragging");
-			touchDragElement.style.transform = "";
-		}
-
-		touchDragIndex = null;
-		dragOverIndex = null;
-		touchDragElement = null;
 	}
 
 	async function deletePlaylist() {
@@ -975,30 +877,36 @@
 				<div
 					class="tracks-list"
 					class:edit-mode={isEditMode}
-					bind:this={tracksListElement}
-					ontouchmove={isEditMode ? handleTouchMove : undefined}
-					ontouchend={isEditMode ? handleTouchEnd : undefined}
-					ontouchcancel={isEditMode ? handleTouchEnd : undefined}
+					bind:this={reorder.listElement}
+					ontouchmove={isEditMode
+						? reorder.handleTouchMove
+						: undefined}
+					ontouchend={isEditMode ? reorder.handleTouchEnd : undefined}
+					ontouchcancel={isEditMode
+						? reorder.handleTouchEnd
+						: undefined}
 				>
 					{#each tracks as track, i (track.id)}
 						{#if isEditMode}
 							<div
 								class="track-row"
-								class:drag-over={dragOverIndex === i &&
-									touchDragIndex !== i}
-								class:is-dragging={touchDragIndex === i ||
-									draggedIndex === i}
+								class:drag-over={reorder.dragOverIndex === i &&
+									reorder.touchDragIndex !== i}
+								class:is-dragging={reorder.touchDragIndex ===
+									i || reorder.draggedIndex === i}
 								data-index={i}
 								role="listitem"
 								draggable="true"
-								ondragstart={(e) => handleDragStart(e, i)}
-								ondragover={(e) => handleDragOver(e, i)}
-								ondrop={(e) => handleDrop(e, i)}
-								ondragend={handleDragEnd}
+								ondragstart={(e) =>
+									reorder.handleDragStart(e, i)}
+								ondragover={(e) => reorder.handleDragOver(e, i)}
+								ondrop={(e) => reorder.handleDrop(e, i)}
+								ondragend={reorder.handleDragEnd}
 							>
 								<button
 									class="drag-handle"
-									ontouchstart={(e) => handleTouchStart(e, i)}
+									ontouchstart={(e) =>
+										reorder.handleTouchStart(e, i)}
 									onclick={(e) => e.stopPropagation()}
 									aria-label="drag to reorder"
 									title="drag to reorder"

--- a/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
@@ -12,6 +12,7 @@
 	import { auth } from '$lib/auth.svelte';
 	import { API_URL } from '$lib/config';
 	import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
+	import { createListReorder, moveItem } from '$lib/list-reorder.svelte';
 	import * as albumActions from '$lib/album-actions';
 	import type { Track } from '$lib/types';
 	import type { PageData } from './$types';
@@ -61,15 +62,10 @@
 	// track removal
 	let removingTrackId = $state<number | null>(null);
 
-	// drag state
-	let draggedIndex = $state<number | null>(null);
-	let dragOverIndex = $state<number | null>(null);
-
-	// touch drag state
-	let touchDragIndex = $state<number | null>(null);
-	let touchStartY = $state(0);
-	let touchDragElement = $state<HTMLElement | null>(null);
-	let tracksListElement = $state<HTMLElement | null>(null);
+	// drag-to-reorder (desktop + touch)
+	const reorder = createListReorder((from, to) => {
+		tracks = moveItem(tracks, from, to);
+	});
 
 	function playTrack(track: Track) {
 		queue.playNow(track);
@@ -228,95 +224,6 @@
 		} finally {
 			isSaving = false;
 		}
-	}
-
-	// move track from one index to another
-	function moveTrack(fromIndex: number, toIndex: number) {
-		if (fromIndex === toIndex) return;
-		const newTracks = [...tracks];
-		const [moved] = newTracks.splice(fromIndex, 1);
-		newTracks.splice(toIndex, 0, moved);
-		tracks = newTracks;
-	}
-
-	// desktop drag and drop
-	function handleDragStart(event: DragEvent, index: number) {
-		draggedIndex = index;
-		if (event.dataTransfer) {
-			event.dataTransfer.effectAllowed = 'move';
-		}
-	}
-
-	function handleDragOver(event: DragEvent, index: number) {
-		event.preventDefault();
-		dragOverIndex = index;
-	}
-
-	function handleDrop(event: DragEvent, index: number) {
-		event.preventDefault();
-		if (draggedIndex !== null && draggedIndex !== index) {
-			moveTrack(draggedIndex, index);
-		}
-		draggedIndex = null;
-		dragOverIndex = null;
-	}
-
-	function handleDragEnd() {
-		draggedIndex = null;
-		dragOverIndex = null;
-	}
-
-	// touch drag and drop
-	function handleTouchStart(event: TouchEvent, index: number) {
-		const touch = event.touches[0];
-		touchDragIndex = index;
-		touchStartY = touch.clientY;
-		touchDragElement = event.currentTarget as HTMLElement;
-		touchDragElement.classList.add('touch-dragging');
-	}
-
-	function handleTouchMove(event: TouchEvent) {
-		if (touchDragIndex === null || !touchDragElement || !tracksListElement) return;
-
-		event.preventDefault();
-		const touch = event.touches[0];
-		const offset = touch.clientY - touchStartY;
-		touchDragElement.style.transform = `translateY(${offset}px)`;
-
-		const trackElements = tracksListElement.querySelectorAll('.track-row');
-		for (let i = 0; i < trackElements.length; i++) {
-			const trackEl = trackElements[i] as HTMLElement;
-			const rect = trackEl.getBoundingClientRect();
-			const midY = rect.top + rect.height / 2;
-
-			if (touch.clientY < midY && i > 0) {
-				const targetIndex = parseInt(trackEl.dataset.index || '0');
-				if (targetIndex !== touchDragIndex) {
-					dragOverIndex = targetIndex;
-				}
-				break;
-			} else if (touch.clientY >= midY) {
-				const targetIndex = parseInt(trackEl.dataset.index || '0');
-				if (targetIndex !== touchDragIndex) {
-					dragOverIndex = targetIndex;
-				}
-			}
-		}
-	}
-
-	function handleTouchEnd() {
-		if (touchDragIndex !== null && dragOverIndex !== null && touchDragIndex !== dragOverIndex) {
-			moveTrack(touchDragIndex, dragOverIndex);
-		}
-
-		if (touchDragElement) {
-			touchDragElement.classList.remove('touch-dragging');
-			touchDragElement.style.transform = '';
-		}
-
-		touchDragIndex = null;
-		dragOverIndex = null;
-		touchDragElement = null;
 	}
 
 	let shareUrl = $state('');
@@ -571,29 +478,29 @@
 			<div
 				class="tracks-list"
 				class:edit-mode={isEditMode}
-				bind:this={tracksListElement}
-				ontouchmove={isEditMode ? handleTouchMove : undefined}
-				ontouchend={isEditMode ? handleTouchEnd : undefined}
-				ontouchcancel={isEditMode ? handleTouchEnd : undefined}
+				bind:this={reorder.listElement}
+				ontouchmove={isEditMode ? reorder.handleTouchMove : undefined}
+				ontouchend={isEditMode ? reorder.handleTouchEnd : undefined}
+				ontouchcancel={isEditMode ? reorder.handleTouchEnd : undefined}
 			>
 				{#each tracks as track, i (track.id)}
 					{#if isEditMode}
 						<div
 							class="track-row"
-							class:drag-over={dragOverIndex === i && touchDragIndex !== i}
-							class:is-dragging={touchDragIndex === i || draggedIndex === i}
+							class:drag-over={reorder.dragOverIndex === i && reorder.touchDragIndex !== i}
+							class:is-dragging={reorder.touchDragIndex === i || reorder.draggedIndex === i}
 							data-index={i}
 							role="listitem"
 							draggable="true"
-							ondragstart={(e) => handleDragStart(e, i)}
-							ondragover={(e) => handleDragOver(e, i)}
-							ondrop={(e) => handleDrop(e, i)}
-							ondragend={handleDragEnd}
+							ondragstart={(e) => reorder.handleDragStart(e, i)}
+							ondragover={(e) => reorder.handleDragOver(e, i)}
+							ondrop={(e) => reorder.handleDrop(e, i)}
+							ondragend={reorder.handleDragEnd}
 						>
 							{#if canReorder}
 								<button
 									class="drag-handle"
-									ontouchstart={(e) => handleTouchStart(e, i)}
+									ontouchstart={(e) => reorder.handleTouchStart(e, i)}
 									onclick={(e) => e.stopPropagation()}
 									aria-label="drag to reorder"
 									title="drag to reorder"


### PR DESCRIPTION
third PR of the #1578 native-readiness arc (after #1579/#1581): the desktop-drag + touch-drag reorder handlers that existed byte-for-byte in both collection pages (~190 duplicated lines) collapse into one runes-based module, `$lib/list-reorder.svelte.ts`. behavior preserved verbatim. no visual changes.

## design

- `createListReorder(onMove)` returns a gesture state machine: reactive `draggedIndex` / `dragOverIndex` / `touchDragIndex` for the pages' class bindings, a settable `listElement` the pages wire with `bind:this={reorder.listElement}`, and the seven handlers the markup already bound — pages swap `handleDragStart` for `reorder.handleDragStart` and delete their local copies.
- the page owns its array; the module calls `onMove(from, to)` and the page applies it with the exported pure `moveItem` helper (extracted from the duplicated `moveTrack`).
- follows the repo's existing interaction-module idiom (`horizontal-swipe.ts`, `swipe-to-dismiss.ts`): documented usage header, page-agnostic, options for the row selector (default `.track-row` matches both pages).

## a legacy quirk, deliberately preserved

writing tests for the touch path surfaced a quirk in the (pre-existing) hit-test scan: **any** touch movement marks a neighboring row as the drop target — even movement that stays within the dragged row's own bounds — so a micro-wiggle reorders by one position on release. this PR copies that logic verbatim (behavior-preserving is the contract of this series) and pins it with an explicitly-labeled test so a future fix is a conscious decision rather than an accident. happy to file a follow-up issue if we want to fix it (the fix is small: only set `dragOverIndex` when the touch actually leaves the dragged row's bounds).

## verification

- 8 unit tests: `moveItem` purity, the desktop drag lifecycle (drop fires `onMove`, drop-on-self is a no-op, dragend resets), and the touch lifecycle against mocked row geometry (hit-testing, transform follow, cleanup on release, tap is a no-op, plus the pinned quirk).
- live in the browser on both pages (chrome devtools MCP, signed-in local dev): playlist — created a scratch playlist, added 3 tracks, dragged row 0 → row 2 via synthetic DragEvents through the real handlers, saved on done-editing (`PUT /lists/playlists/{id}/reorder` 200), **order persisted across reload**, then deleted the scratch. album — swapped the two rows and back (`PUT /lists/{rkey}/reorder` 200 on save), original order preserved.
- touch path is unit-tested rather than live-driven (CDP touch emulation doesn't reach these handlers reliably); the bindings are identical to the desktop ones that were live-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)