### PR TITLE
refactor(collections): share play/queue helpers + ConfirmDialog across collection pages

### DIFF
--- a/frontend/src/lib/collection-playback.test.ts
+++ b/frontend/src/lib/collection-playback.test.ts
@@ -1,0 +1,61 @@
+// tests for collection playback: the empty-collection guards and the
+// "toast only when playback actually started" gating around playQueue.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const playQueueMock = vi.hoisted(() => vi.fn());
+const addTracksMock = vi.hoisted(() => vi.fn());
+const toastSuccessMock = vi.hoisted(() => vi.fn());
+
+vi.mock('$lib/playback.svelte', () => ({ playQueue: playQueueMock }));
+vi.mock('$lib/queue.svelte', () => ({ queue: { addTracks: addTracksMock } }));
+vi.mock('$lib/toast.svelte', () => ({ toast: { success: toastSuccessMock } }));
+
+import { playCollection, queueCollection } from './collection-playback';
+import type { Track } from './types';
+
+const TRACKS = [{ id: 1 }, { id: 2 }] as Track[];
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('playCollection', () => {
+	it('plays the tracks and toasts the collection name', async () => {
+		playQueueMock.mockResolvedValueOnce(true);
+
+		await expect(playCollection(TRACKS, 'road mix')).resolves.toBe(true);
+
+		expect(playQueueMock).toHaveBeenCalledWith(TRACKS);
+		expect(toastSuccessMock).toHaveBeenCalledWith('playing road mix', 1800);
+	});
+
+	it('does not toast when playback was blocked (e.g. gated first track)', async () => {
+		playQueueMock.mockResolvedValueOnce(false);
+
+		await expect(playCollection(TRACKS, 'road mix')).resolves.toBe(false);
+
+		expect(toastSuccessMock).not.toHaveBeenCalled();
+	});
+
+	it('is a no-op for an empty collection', async () => {
+		await expect(playCollection([], 'road mix')).resolves.toBe(false);
+
+		expect(playQueueMock).not.toHaveBeenCalled();
+	});
+});
+
+describe('queueCollection', () => {
+	it('appends the tracks and toasts the collection name', () => {
+		queueCollection(TRACKS, 'road mix');
+
+		expect(addTracksMock).toHaveBeenCalledWith(TRACKS);
+		expect(toastSuccessMock).toHaveBeenCalledWith('added road mix to queue', 1800);
+	});
+
+	it('is a no-op for an empty collection', () => {
+		queueCollection([], 'road mix');
+
+		expect(addTracksMock).not.toHaveBeenCalled();
+		expect(toastSuccessMock).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/lib/collection-playback.ts
+++ b/frontend/src/lib/collection-playback.ts
@@ -1,0 +1,30 @@
+// collection playback — play or queue an entire ordered collection (album,
+// playlist) on the shared footer player. this is the seam where a labeled
+// playback context ("next from: <collection>") can attach later.
+import { queue } from '$lib/queue.svelte';
+import { playQueue } from '$lib/playback.svelte';
+import { toast } from '$lib/toast.svelte';
+import type { Track } from '$lib/types';
+
+/**
+ * replace the queue with the collection and start playing from the top.
+ * gated-access on the first track is checked before the queue is touched.
+ * returns whether playback actually started.
+ */
+export async function playCollection(tracks: Track[], name: string): Promise<boolean> {
+	if (tracks.length === 0) return false;
+
+	const played = await playQueue(tracks);
+	if (played) {
+		toast.success(`playing ${name}`, 1800);
+	}
+	return played;
+}
+
+/** append the collection to the current queue. */
+export function queueCollection(tracks: Track[], name: string): void {
+	if (tracks.length === 0) return;
+
+	queue.addTracks(tracks);
+	toast.success(`added ${name} to queue`, 1800);
+}

--- a/frontend/src/routes/playlist/[id]/+page.svelte
+++ b/frontend/src/routes/playlist/[id]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import ConfirmDialog from "$lib/components/ConfirmDialog.svelte";
 	import Header from "$lib/components/Header.svelte";
 	import ShareButton from "$lib/components/ShareButton.svelte";
 	import SensitiveImage from "$lib/components/SensitiveImage.svelte";
@@ -12,7 +13,10 @@
 	import { toast } from "$lib/toast.svelte";
 	import { player } from "$lib/player.svelte";
 	import { queue } from "$lib/queue.svelte";
-	import { playQueue } from "$lib/playback.svelte";
+	import {
+		playCollection,
+		queueCollection,
+	} from "$lib/collection-playback";
 	import { fetchLikedTracks } from "$lib/tracks.svelte";
 	import { createListReorder, moveItem } from "$lib/list-reorder.svelte";
 	import * as playlistActions from "$lib/playlist-actions";
@@ -148,20 +152,11 @@
 	}
 
 	async function playNow() {
-		if (tracks.length > 0) {
-			// use playQueue to check gated access on first track before modifying queue
-			const played = await playQueue(tracks);
-			if (played) {
-				toast.success(`playing ${playlist.name}`, 1800);
-			}
-		}
+		await playCollection(tracks, playlist.name);
 	}
 
 	function addToQueue() {
-		if (tracks.length > 0) {
-			queue.addTracks(tracks);
-			toast.success(`added ${playlist.name} to queue`, 1800);
-		}
+		queueCollection(tracks, playlist.name);
 	}
 
 	async function searchTracks() {
@@ -1223,106 +1218,30 @@
 	</div>
 {/if}
 
-{#if showVisibilityConfirm}
-	<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-	<div
-		class="modal-overlay"
-		role="presentation"
-		onclick={() => (showVisibilityConfirm = false)}
-	>
-		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-		<div
-			class="modal"
-			role="alertdialog"
-			aria-modal="true"
-			aria-labelledby="visibility-confirm-title"
-			tabindex="-1"
-			onclick={(e) => e.stopPropagation()}
-		>
-			<div class="modal-header">
-				<h3 id="visibility-confirm-title">
-					{playlist.is_private ? "make this playlist public?" : "make this playlist private?"}
-				</h3>
-			</div>
-			<div class="modal-body">
-				<p>
-					{#if playlist.is_private}
-						"{playlist.name}" will be published to your PDS as a public list record. anyone with the link will be able to see it.
-					{:else}
-						"{playlist.name}" will be removed from your PDS and only you will be able to see it. it won't appear in search, on your profile, or in the activity feed.
-					{/if}
-				</p>
-			</div>
-			<div class="modal-footer">
-				<button
-					class="cancel-btn"
-					onclick={() => (showVisibilityConfirm = false)}
-					disabled={togglingVisibility}
-				>
-					cancel
-				</button>
-				<button
-					class="confirm-btn"
-					onclick={toggleVisibility}
-					disabled={togglingVisibility}
-				>
-					{#if togglingVisibility}
-						working...
-					{:else if playlist.is_private}
-						make public
-					{:else}
-						make private
-					{/if}
-				</button>
-			</div>
-		</div>
-	</div>
-{/if}
+<ConfirmDialog
+	bind:open={showVisibilityConfirm}
+	title={playlist.is_private
+		? "make this playlist public?"
+		: "make this playlist private?"}
+	body={playlist.is_private
+		? `"${playlist.name}" will be published to your PDS as a public list record. anyone with the link will be able to see it.`
+		: `"${playlist.name}" will be removed from your PDS and only you will be able to see it. it won't appear in search, on your profile, or in the activity feed.`}
+	confirmText={playlist.is_private ? "make public" : "make private"}
+	pending={togglingVisibility}
+	pendingText="working..."
+	onConfirm={toggleVisibility}
+/>
 
-{#if showDeleteConfirm}
-	<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-	<div
-		class="modal-overlay"
-		role="presentation"
-		onclick={() => (showDeleteConfirm = false)}
-	>
-		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-		<div
-			class="modal"
-			role="alertdialog"
-			aria-modal="true"
-			aria-labelledby="delete-confirm-title"
-			tabindex="-1"
-			onclick={(e) => e.stopPropagation()}
-		>
-			<div class="modal-header">
-				<h3 id="delete-confirm-title">delete playlist?</h3>
-			</div>
-			<div class="modal-body">
-				<p>
-					are you sure you want to delete "{playlist.name}"? this
-					action cannot be undone.
-				</p>
-			</div>
-			<div class="modal-footer">
-				<button
-					class="cancel-btn"
-					onclick={() => (showDeleteConfirm = false)}
-					disabled={deleting}
-				>
-					cancel
-				</button>
-				<button
-					class="confirm-btn danger"
-					onclick={deletePlaylist}
-					disabled={deleting}
-				>
-					{deleting ? "deleting..." : "delete"}
-				</button>
-			</div>
-		</div>
-	</div>
-{/if}
+<ConfirmDialog
+	bind:open={showDeleteConfirm}
+	title="delete playlist?"
+	body={`are you sure you want to delete "${playlist.name}"? this action cannot be undone.`}
+	confirmText="delete"
+	variant="danger"
+	pending={deleting}
+	pendingText="deleting..."
+	onConfirm={deletePlaylist}
+/>
 
 <style>
 	.container {
@@ -2028,67 +1947,6 @@
 	}
 
 	.add-result-btn:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-
-	.modal-body {
-		padding: 1.5rem;
-	}
-
-	.modal-body p {
-		margin: 0;
-		color: var(--text-secondary);
-		font-size: var(--text-base);
-		line-height: 1.5;
-	}
-
-	.modal-footer {
-		display: flex;
-		justify-content: flex-end;
-		gap: 0.75rem;
-		padding: 1rem 1.5rem 1.25rem;
-	}
-
-	.cancel-btn,
-	.confirm-btn {
-		padding: 0.625rem 1.25rem;
-		border-radius: var(--radius-md);
-		font-family: inherit;
-		font-size: var(--text-base);
-		font-weight: 500;
-		cursor: pointer;
-		transition: all 0.15s;
-	}
-
-	.cancel-btn {
-		background: var(--bg-secondary);
-		border: 1px solid var(--border-default);
-		color: var(--text-secondary);
-	}
-
-	.cancel-btn:hover:not(:disabled) {
-		background: var(--bg-hover);
-		color: var(--text-primary);
-	}
-
-	.confirm-btn {
-		background: var(--accent);
-		border: 1px solid var(--accent);
-		color: white;
-	}
-
-	.confirm-btn.danger {
-		background: #ef4444;
-		border-color: #ef4444;
-	}
-
-	.confirm-btn:hover:not(:disabled) {
-		opacity: 0.9;
-	}
-
-	.confirm-btn:disabled,
-	.cancel-btn:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
 	}

--- a/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import Header from '$lib/components/Header.svelte';
 	import TrackItem from '$lib/components/TrackItem.svelte';
 	import ShareButton from '$lib/components/ShareButton.svelte';
@@ -7,7 +8,7 @@
 	import { moderation } from '$lib/moderation.svelte';
 	import { player } from '$lib/player.svelte';
 	import { queue } from '$lib/queue.svelte';
-	import { playQueue } from '$lib/playback.svelte';
+	import { playCollection, queueCollection } from '$lib/collection-playback';
 	import { toast } from '$lib/toast.svelte';
 	import { auth } from '$lib/auth.svelte';
 	import { API_URL } from '$lib/config';
@@ -72,20 +73,11 @@
 	}
 
 	async function playNow() {
-		if (tracks.length > 0) {
-			// use playQueue to check gated access on first track before modifying queue
-			const played = await playQueue(tracks);
-			if (played) {
-				toast.success(`playing ${albumMetadata.title}`, 1800);
-			}
-		}
+		await playCollection(tracks, albumMetadata.title);
 	}
 
 	function addToQueue() {
-		if (tracks.length > 0) {
-			queue.addTracks(tracks);
-			toast.success(`added ${albumMetadata.title} to queue`, 1800);
-		}
+		queueCollection(tracks, albumMetadata.title);
 	}
 
 	function toggleEditMode() {
@@ -567,49 +559,16 @@
 	</main>
 </div>
 
-{#if showDeleteConfirm}
-	<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-	<div
-		class="modal-overlay"
-		role="presentation"
-		onclick={() => (showDeleteConfirm = false)}
-	>
-		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-		<div
-			class="modal"
-			role="alertdialog"
-			aria-modal="true"
-			aria-labelledby="delete-confirm-title"
-			tabindex="-1"
-			onclick={(e) => e.stopPropagation()}
-		>
-			<div class="modal-header">
-				<h3 id="delete-confirm-title">delete album?</h3>
-			</div>
-			<div class="modal-body">
-				<p>
-					are you sure you want to delete "{albumMetadata.title}"? the tracks will remain as standalone tracks.
-				</p>
-			</div>
-			<div class="modal-footer">
-				<button
-					class="cancel-btn"
-					onclick={() => (showDeleteConfirm = false)}
-					disabled={deleting}
-				>
-					cancel
-				</button>
-				<button
-					class="confirm-btn danger"
-					onclick={deleteAlbum}
-					disabled={deleting}
-				>
-					{deleting ? 'deleting...' : 'delete'}
-				</button>
-			</div>
-		</div>
-	</div>
-{/if}
+<ConfirmDialog
+	bind:open={showDeleteConfirm}
+	title="delete album?"
+	body={`are you sure you want to delete "${albumMetadata.title}"? the tracks will remain as standalone tracks.`}
+	confirmText="delete"
+	variant="danger"
+	pending={deleting}
+	pendingText="deleting..."
+	onConfirm={deleteAlbum}
+/>
 
 <style>
 	.container {
@@ -1045,96 +1004,4 @@
 		opacity: 0.5;
 	}
 
-	/* modal styles */
-	.modal-overlay {
-		position: fixed;
-		inset: 0;
-		background: rgba(0, 0, 0, 0.7);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		z-index: 1000;
-		backdrop-filter: blur(4px);
-	}
-
-	.modal {
-		background: var(--bg-secondary);
-		border-radius: var(--radius-lg);
-		padding: 1.5rem;
-		max-width: 400px;
-		width: calc(100% - 2rem);
-		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-		border: 1px solid var(--border-subtle);
-	}
-
-	.modal-header {
-		margin-bottom: 1rem;
-	}
-
-	.modal-header h3 {
-		margin: 0;
-		font-size: var(--text-2xl);
-		font-weight: 600;
-		color: var(--text-primary);
-	}
-
-	.modal-body {
-		margin-bottom: 1.5rem;
-	}
-
-	.modal-body p {
-		margin: 0;
-		color: var(--text-secondary);
-		line-height: 1.5;
-	}
-
-	.modal-footer {
-		display: flex;
-		gap: 0.75rem;
-		justify-content: flex-end;
-	}
-
-	.cancel-btn,
-	.confirm-btn {
-		padding: 0.625rem 1.25rem;
-		border-radius: var(--radius-md);
-		font-weight: 500;
-		font-size: var(--text-base);
-		font-family: inherit;
-		cursor: pointer;
-		transition: all 0.2s;
-		border: none;
-	}
-
-	.cancel-btn {
-		background: var(--bg-tertiary);
-		color: var(--text-primary);
-	}
-
-	.cancel-btn:hover {
-		background: var(--bg-hover);
-	}
-
-	.cancel-btn:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-
-	.confirm-btn {
-		background: var(--accent);
-		color: var(--bg-primary);
-	}
-
-	.confirm-btn:hover {
-		filter: brightness(1.1);
-	}
-
-	.confirm-btn.danger {
-		background: var(--error);
-	}
-
-	.confirm-btn:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
 </style>


### PR DESCRIPTION
fourth PR of the #1578 native-readiness arc (after #1579/#1581/#1582). two shared pieces replace duplicated code on the playlist and album detail pages; net −184 lines. no behavior change.

## 1. `$lib/collection-playback.ts`

`playCollection(tracks, name)` and `queueCollection(tracks, name)` wrap the rituals both pages hand-rolled identically: gated-access check via `playQueue` → toast-only-if-it-actually-started, and `queue.addTracks` → toast. each page's `playNow`/`addToQueue` collapse to one-liners.

this is deliberately the seam that **collection-continuity Part B** (STATUS.md "next") will attach to — when a tapped collection becomes a labeled playback context ("next from: \<album/playlist\>"), it threads through here rather than through two separate route components.

## 2. ConfirmDialog reuse

the repo already had a polished `ConfirmDialog` (native `<dialog>` + `showModal()` so it lives in the top layer, `pending`/`pendingText` state, `danger` variant, ESC/backdrop handling) — but only the portal used it. the collection pages had three bespoke `.modal-overlay` + `.modal` blocks (playlist delete, playlist visibility, album delete). those become three `<ConfirmDialog>` instances, and the now-dead modal CSS (~150 lines across the two pages) is deleted.

the visibility dialog keeps its dynamic copy (public↔private title/body/confirm-label) by passing expressions to the props; `pending` wires to the existing `togglingVisibility`/`deleting` flags so the in-flight states are preserved.

## intentional non-behaviors

- the native `<dialog>` is a slightly different element than the old `position:fixed` overlay, but visually matched (same tokens, same backdrop) and strictly better behaved (top-layer stacking, focus trap, ESC). this is the one spot in the series with a real DOM-shape change rather than pure code motion — called out here so the Codex review weighs it.
- drag/touch reorder, the per-track action menus, and the search modal are untouched (the search modal keeps its own `.modal-overlay` CSS, which is why those selectors stay).

## verification

- 6 unit tests for collection-playback: toast-on-success, no-toast-when-`playQueue`-returns-false (gated first track), and empty-collection no-ops for both helpers (mocked queue/playback/toast).
- live in the browser on both pages (chrome devtools MCP, signed-in local dev):
  - playlist: play → "✓ playing \<name\>" + audio actually streams; add-to-queue → "✓ added \<name\> to queue"; visibility toggle opens the native ConfirmDialog with the right private/public copy and confirms (chip flips); delete opens the danger ConfirmDialog and confirms → redirect to /library.
  - album: play/queue toasts fire with the album title; delete opens the danger ConfirmDialog with the correct "tracks will remain as standalone tracks" body and **cancels cleanly** without navigating (cancelled deliberately to preserve dev data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)