### PR TITLE
fix(config): normalize driverless postgres URLs to async psycopg

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,8 +21,9 @@ FRONTEND_URL=http://localhost:5173
 # VITE_APP_CANONICAL_URL=
 # VITE_APP_BROADCAST_PREFIX=plyr
 
-# database
-DATABASE_URL=postgresql+asyncpg://localhost/plyr
+# database — a plain postgresql:// URL works too; the backend upgrades it to
+# the async psycopg driver automatically
+DATABASE_URL=postgresql+psycopg://localhost/plyr
 
 # storage (cloudflare r2)
 AWS_ACCESS_KEY_ID=your_r2_access_key_id

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -229,11 +229,27 @@ class FrontendSettings(AppSettingsSection):
             return r"^(https://.+|http://localhost:\d+)$"
 
 
+def normalize_postgres_driver(url: str) -> str:
+    """Coerce driverless postgres URLs to the async psycopg dialect.
+
+    SQLAlchemy resolves a plain ``postgresql://`` URL to the synchronous
+    psycopg2 driver, which ``create_async_engine`` cannot use — so the
+    standard connection string every postgres tool hands out crashes the
+    backend. An explicit ``+driver`` in the URL is respected as-is.
+    """
+    if not isinstance(url, str):
+        return url
+    for prefix in ("postgresql://", "postgres://"):
+        if url.startswith(prefix):
+            return f"postgresql+psycopg://{url[len(prefix) :]}"
+    return url
+
+
 class DatabaseSettings(AppSettingsSection):
     """Database configuration."""
 
-    url: str = Field(
-        default="postgresql+asyncpg://localhost/plyr",
+    url: Annotated[str, BeforeValidator(normalize_postgres_driver)] = Field(
+        default="postgresql+psycopg://localhost/plyr",
         validation_alias="DATABASE_URL",
         description="PostgreSQL connection string",
     )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -29,6 +29,11 @@ from backend.models import Base
 from backend.storage.r2 import R2Storage
 from backend.utilities.redis import clear_client_cache
 
+# the suite's scope/collection assertions are written against the production
+# namespace; pin it so a developer's backend/.env (e.g. fm.plyr.dev) can't
+# leak in. CI runs with no .env and is unaffected.
+settings.atproto.app_namespace = "fm.plyr"
+
 
 class MockStorage(R2Storage):
     """Mock storage for tests - no R2 credentials needed."""

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -80,3 +80,41 @@ def test_settings_supports_nested_env(monkeypatch):
     assert settings.frontend.url == "https://cdn.example.com"
     assert settings.atproto.client_id == "https://new/meta.json"
     assert settings.atproto.scope_override == "custom scope"
+
+
+@pytest.mark.parametrize(
+    ("env_url", "expected"),
+    [
+        # driverless URLs — what `createdb` workflows and managed-postgres
+        # consoles hand out — must be upgraded to the async psycopg dialect,
+        # otherwise create_async_engine resolves them to sync psycopg2 and
+        # crashes (#1584)
+        (
+            "postgresql://localhost/plyr",
+            "postgresql+psycopg://localhost/plyr",
+        ),
+        (
+            "postgres://user:pass@host:5432/db",
+            "postgresql+psycopg://user:pass@host:5432/db",
+        ),
+        (
+            "postgresql://u:p@host/db?sslmode=require&channel_binding=require",
+            "postgresql+psycopg://u:p@host/db?sslmode=require&channel_binding=require",
+        ),
+        # explicit drivers are respected as-is
+        (
+            "postgresql+asyncpg://localhost/plyr",
+            "postgresql+asyncpg://localhost/plyr",
+        ),
+        (
+            "postgresql+psycopg://u:p@host/db?sslmode=require",
+            "postgresql+psycopg://u:p@host/db?sslmode=require",
+        ),
+    ],
+)
+def test_database_url_driver_normalization(monkeypatch, env_url, expected):
+    monkeypatch.setenv("DATABASE_URL", env_url)
+
+    settings = Settings()
+
+    assert settings.database.url == expected

--- a/docs/internal/local-development/setup.md
+++ b/docs/internal/local-development/setup.md
@@ -41,21 +41,28 @@ visit http://localhost:5173 to see the app.
 
 ### required environment variables
 
-create a `.env` file in the project root:
+create the env file at `backend/.env` (the backend reads it from there, not the repo root):
 
 ```bash
-# database (use neon dev instance or local postgres)
-DATABASE_URL=postgresql+asyncpg://localhost/plyr  # local
+# database (use neon dev instance or local postgres).
+# any standard postgresql:// URL works — the backend upgrades driverless URLs
+# to the async psycopg driver automatically.
+DATABASE_URL=postgresql+psycopg://localhost/plyr  # local
 # DATABASE_URL=<neon-dev-connection-string>        # neon dev
 
-# oauth (uses client metadata discovery - no registration required)
+# oauth (uses client metadata discovery - no registration required).
+# note: real PDSes reject localhost redirect URIs (RFC 8252), so signing in
+# against a real account requires exposing the backend over a public https
+# tunnel (e.g. ngrok) and pointing ATPROTO_CLIENT_ID / ATPROTO_REDIRECT_URI
+# at the tunnel hostname. anonymous browsing works without this.
 ATPROTO_CLIENT_ID=http://localhost:8001/oauth-client-metadata.json
 ATPROTO_CLIENT_SECRET=<your-client-secret>
 ATPROTO_REDIRECT_URI=http://localhost:5173/auth/callback
 OAUTH_ENCRYPTION_KEY=<base64-encoded-32-byte-key>
 
-# storage (r2 or filesystem)
-STORAGE_BACKEND=filesystem  # or "r2" for cloudflare r2
+# storage (cloudflare r2). R2 credentials are required for uploads and
+# cover-image changes; without them those endpoints return 500. playback of
+# existing tracks works without credentials (public bucket URLs).
 R2_BUCKET=audio-dev
 R2_PRIVATE_BUCKET=audio-private-dev  # for supporter-gated content
 R2_IMAGE_BUCKET=images-dev
@@ -99,7 +106,7 @@ brew install postgresql@15  # macos
 createdb plyr
 
 # run migrations
-DATABASE_URL=postgresql+asyncpg://localhost/plyr uv run alembic upgrade head
+DATABASE_URL=postgresql+psycopg://localhost/plyr uv run alembic upgrade head
 ```
 
 ## running services
@@ -341,13 +348,9 @@ echo $R2_BUCKET
 
 # test r2 connectivity
 uv run python -c "
-from backend.storage import get_storage_backend
-storage = get_storage_backend()
-print(storage.bucket_name)
+from backend.storage.r2 import R2Storage
+print(R2Storage().audio_bucket_name)
 "
-
-# or use filesystem backend for local development
-STORAGE_BACKEND=filesystem uv run uvicorn backend.main:app --reload
 ```
 
 ## useful commands

--- a/loq.toml
+++ b/loq.toml
@@ -44,7 +44,7 @@ max_lines = 1818
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 1114
+max_lines = 1130
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
@@ -260,7 +260,7 @@ max_lines = 836
 
 [[rules]]
 path = "backend/tests/conftest.py"
-max_lines = 515
+max_lines = 518
 
 [[rules]]
 path = "backend/tests/api/track_audio_replace/test_pipeline.py"


### PR DESCRIPTION
closes #1584. a contributor reported on bluesky that local plyr.fm setup fails with "some error about async" when pointing at a local Postgres. reproduced and fixed, along with the adjacent doc traps on the same onboarding path.

## the bug

`DatabaseSettings.url` fed `create_async_engine` unmodified. SQLAlchemy resolves a driverless `postgresql://` URL — the standard string every postgres tool hands out (`createdb` workflows, Supabase/Neon consoles) — to the **synchronous psycopg2** driver. so a fresh contributor gets:

1. `ModuleNotFoundError: No module named 'psycopg2'` (not a dependency), and
2. if they "fix" that by installing psycopg2: `InvalidRequestError: The asyncio extension requires an async driver to be used` — the reported error.

## the fix

a `BeforeValidator` on `DatabaseSettings.url` coerces `postgresql://` and `postgres://` to `postgresql+psycopg://`. psycopg (3, async mode) is the driver production/staging/dev already run per `docs/internal/backend/database/neon.md`, and it handles Neon-style `channel_binding=require` URLs, which asyncpg cannot — so any pasted managed-postgres URL now just works. **explicit `+driver` schemes pass through untouched**, so CI's `postgresql+asyncpg://` test path is unchanged. the config default flips from `+asyncpg` to `+psycopg` for consistency (only affects local dev with no DATABASE_URL set; either driver works against plain local postgres).

verified end-to-end: `DATABASE_URL=postgresql://localhost/plyr` now boots a psycopg engine (`engine.dialect.driver == "psycopg"`); 5 parametrized regression tests cover both coerced schemes, query-param preservation, and both explicit-driver passthroughs.

## doc traps fixed in the same path (`docs/internal/local-development/setup.md`)

- said to create the `.env` at the **project root**; the backend reads `backend/.env`
- documented `STORAGE_BACKEND=filesystem`, which no longer exists (storage is R2-only; the doc now states uploads/cover changes need R2 credentials while playback of existing tracks works without)
- no mention that real PDSes reject localhost redirect URIs (RFC 8252) — sign-in against a real account needs a public https tunnel; noted
- a stale troubleshooting snippet imported a `get_storage_backend` that no longer exists

## test hermeticity fix

running the suite locally with a populated `backend/.env` failed one scope assertion (`ATPROTO_APP_NAMESPACE=fm.plyr.dev` leaked into settings — CI never sees this because it runs with no `.env`). conftest now pins the namespace the suite's assertions are written against, matching the established `settings.database.url` mutation pattern already in conftest.

full backend suite green locally with a populated `backend/.env` in place (1197 passed, 24 skipped). loq limits relaxed for conftest.py/config.py via `just loq-relax`.

## intentional non-behaviors

- asyncpg stays a dependency and its statement-cache `connect_args` path in `utilities/database.py` is untouched (CI uses it).
- no attempt to make the whole test suite hermetic to arbitrary `.env` values — only the namespace, which is what the suite actually asserts against. broader env-file isolation for tests is a separate design question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)