### PR TITLE
fix(migrations): async alembic engine + db-init bootstrap for fresh databases

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,6 +1,9 @@
+import asyncio
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
 
@@ -65,24 +68,33 @@ def run_migrations_offline() -> None:
         context.run_migrations()
 
 
-def run_migrations_online() -> None:
-    """Run migrations in 'online' mode.
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
 
-    In this scenario we need to create an Engine
-    and associate a connection with the context.
+    with context.begin_transaction():
+        context.run_migrations()
 
-    """
-    connectable = engine_from_config(
+
+async def run_async_migrations() -> None:
+    connectable = async_engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )
 
-    with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
 
-        with context.begin_transaction():
-            context.run_migrations()
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    the engine is async so the URL can use any async driver (psycopg or
+    asyncpg) — the database settings only accept async-capable URLs.
+    """
+    asyncio.run(run_async_migrations())
 
 
 if context.is_offline_mode():

--- a/backend/justfile
+++ b/backend/justfile
@@ -31,6 +31,12 @@ migrate MESSAGE:
 migrate-up:
     uv run alembic upgrade head
 
+# create the schema on an EMPTY database and stamp it at alembic head.
+# needed for fresh local databases: the migration chain predates alembic
+# adoption, so `alembic upgrade head` cannot bootstrap from zero.
+db-init:
+    uv run scripts/init_db.py
+
 # show current migration status
 migrate-status:
     uv run alembic current

--- a/backend/scripts/init_db.py
+++ b/backend/scripts/init_db.py
@@ -1,0 +1,48 @@
+"""create the full schema on an empty database and stamp it at alembic head.
+
+the migration chain starts from a snapshot that predates alembic adoption, so
+`alembic upgrade head` cannot bootstrap an empty database. run this once for a
+fresh local database, then use `alembic upgrade head` for later migrations.
+"""
+
+import asyncio
+import sys
+
+import sqlalchemy as sa
+
+from alembic import command
+from alembic.config import Config
+from backend.models import Base
+from backend.utilities.database import get_engine
+
+
+async def create_schema() -> bool:
+    engine = get_engine()
+    try:
+        async with engine.begin() as conn:
+            already_migrated = await conn.run_sync(
+                lambda sync_conn: sa.inspect(sync_conn).has_table("alembic_version")
+            )
+            if already_migrated:
+                return False
+            await conn.run_sync(Base.metadata.create_all)
+            return True
+    finally:
+        await engine.dispose()
+
+
+def main() -> None:
+    if not asyncio.run(create_schema()):
+        print(
+            "database already has an alembic_version table — "
+            "use `uv run alembic upgrade head` instead",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    command.stamp(Config("alembic.ini"), "head")
+    print("schema created and stamped at alembic head")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/internal/local-development/setup.md
+++ b/docs/internal/local-development/setup.md
@@ -92,8 +92,8 @@ python -c "import base64, os; print(base64.b64encode(os.urandom(32)).decode())"
 ### option 1: use neon dev instance (recommended)
 
 1. get dev database URL from neon console or `.env.example`
-2. set `DATABASE_URL` in `.env`
-3. run migrations: `uv run alembic upgrade head`
+2. set `DATABASE_URL` in `backend/.env`
+3. apply any pending migrations: `uv run alembic upgrade head`
 
 ### option 2: local postgres
 
@@ -105,8 +105,10 @@ brew install postgresql@15  # macos
 # create database
 createdb plyr
 
-# run migrations
-DATABASE_URL=postgresql+psycopg://localhost/plyr uv run alembic upgrade head
+# create the schema (from backend/). a FRESH database needs this instead of
+# `alembic upgrade head` — the migration chain predates alembic adoption and
+# cannot bootstrap from zero. later migrations use `alembic upgrade head`.
+just db-init
 ```
 
 ## running services


### PR DESCRIPTION
companion to #1585: the *second* independently-reported local-setup failure, from the contributor working on tangled issue #2 (filter-by-length): `sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called` while setting up a local database. reproduced both layers of the failure and fixed both.

## layer 1: sync alembic engine × async-only driver

`alembic/env.py` used `engine_from_config` — a synchronous engine. asyncpg is async-only, so with the previously documented `postgresql+asyncpg://localhost/plyr` URL, **the documented migration command itself** raised `MissingGreenlet` on every run. nobody on the happy path ever saw it: prod/staging/dev migrate Neon with `+psycopg` (which works sync *and* async), and CI creates schema via `Base.metadata.create_all`, not alembic.

env.py now uses the standard SQLAlchemy asyncio template (`async_engine_from_config` + `connection.run_sync`), so any async driver — psycopg, asyncpg, or a driverless URL normalized by #1585 — migrates identically. offline mode is unchanged.

## layer 2: the chain can't bootstrap an empty database at all

fixing layer 1 exposed the deeper problem: the **root migration** (`aabe82c8f0fb, add features column to tracks`) `ALTER`s tables that no migration creates — alembic was adopted after the schema already existed. so `alembic upgrade head` against a fresh database fails with `relation "tracks" does not exist` under *any* driver, and always has. fresh-contributor setup was impossible by the documented path.

new `just db-init` (from `backend/`; `scripts/init_db.py`) creates the schema from the current models and stamps `alembic_version` at head — the same source of truth the test suite uses. it refuses to run on any database that already has an `alembic_version` table, so it cannot clobber a real, partially-migrated database. setup docs updated to route fresh databases through `db-init` and existing ones through `upgrade head`.

## verification (fresh dockerized postgres, full lifecycle)

- pre-fix repro: `+asyncpg` + `alembic upgrade head` → `MissingGreenlet`, byte-for-byte the reported error
- post-fix: bootstrap succeeds with `+psycopg`, `+asyncpg`, and driverless URLs; `alembic current` shows head; `upgrade head` no-ops; re-running `db-init` aborts with exit 1 and a pointer to `upgrade head`
- guard verified against the real (already-migrated) dev database: correctly refuses
- backend lint + type check clean; the full backend suite was green on this base earlier today and this change touches no application code

## not doing

- no retroactive root migration reconstructing the pre-alembic schema — `db-init` + stamp reaches the same end state from the models without archaeology, and existing databases are untouched
- the asyncpg statement-cache `connect_args` in `utilities/database.py` and CI's `+asyncpg` test path are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)