### PR TITLE
feat(embed): honor ?autoplay=1 in the radio embed + document embed params

### DIFF
--- a/docs/public/artists.md
+++ b/docs/public/artists.md
@@ -54,7 +54,7 @@ album and playlist covers accept the same formats except GIF.
 
 ## embeds
 
-share your audio anywhere with embed iframes. plyr.fm supports track, playlist, and album embeds.
+share your audio anywhere with embed iframes. plyr.fm supports track, playlist, album, and radio embeds.
 
 ### track embed
 
@@ -81,6 +81,51 @@ share your audio anywhere with embed iframes. plyr.fm supports track, playlist, 
   loading="lazy"
 ></iframe>
 ```
+
+### album embed
+
+```html
+<iframe
+  src="https://plyr.fm/embed/album/{handle}/{album_slug}"
+  width="100%"
+  height="352"
+  frameborder="0"
+  allow="autoplay; encrypted-media"
+  loading="lazy"
+></iframe>
+```
+
+### radio embed
+
+a live widget for [plyr.fm radio](https://plyr.fm/radio) with a tuner dial for flipping stations:
+
+```html
+<iframe
+  src="https://plyr.fm/embed/radio"
+  width="100%"
+  height="220"
+  frameborder="0"
+  allow="autoplay; encrypted-media"
+  loading="lazy"
+></iframe>
+```
+
+add `?station={slug}` (e.g. `?station=fresh`) to pin the initial station — an unknown slug falls back to the default station. iframes shorter than ~184px hide the tuner dial but keep the pinned station.
+
+### autoplay
+
+every embed accepts `?autoplay=1` to start playback as soon as it loads:
+
+```
+https://plyr.fm/embed/radio?station=fresh&autoplay=1
+```
+
+two caveats:
+
+- the embedding page must grant permission with `allow="autoplay"` on the iframe (all the examples above do).
+- browsers may still block audible autoplay until the visitor has interacted with the embedding site. when blocked, the embed stays paused — no error, just the normal click-to-play state.
+
+the full [radio page](https://plyr.fm/radio) also accepts `?autoplay=1`, useful for browser-source overlays (e.g. OBS) where nothing can click play.
 
 ### oEmbed
 

--- a/frontend/src/lib/components/embed/RadioEmbed.svelte
+++ b/frontend/src/lib/components/embed/RadioEmbed.svelte
@@ -108,9 +108,16 @@
 	}
 
 	onMount(() => {
-		station = $page.url.searchParams.get('station');
+		const params = $page.url.searchParams;
+		station = params.get('station');
+		const autoplay = params.get('autoplay') === '1';
 		loadStations();
-		loadState(false);
+		// ?autoplay=1 tunes in once the on-air track arrives (same convention as
+		// the other embeds). without a prior gesture, autoplay policy blocks the
+		// play() and toggle's catch leaves the widget in its normal paused state.
+		loadState(false).then(() => {
+			if (autoplay && !playing) toggle();
+		});
 		pollTimer = window.setInterval(() => loadState(playing), 30000);
 		return () => {
 			if (pollTimer) window.clearInterval(pollTimer);

--- a/frontend/src/lib/components/embed/RadioEmbed.test.ts
+++ b/frontend/src/lib/components/embed/RadioEmbed.test.ts
@@ -1,10 +1,26 @@
-// regression test for sensitive artwork in the radio embed: embeds are
-// unauthenticated contexts, so flagged artwork must always render blurred.
+// radio embed tests: flagged artwork must always render blurred (embeds are
+// unauthenticated contexts), and ?autoplay=1 tunes in once state loads.
 import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
 import { mount, unmount } from 'svelte';
 
 const prefs = vi.hoisted(() => ({ showSensitiveArtwork: false }));
 vi.mock('$lib/preferences.svelte', () => ({ preferences: prefs }));
+
+// the shared $app/stores stub pins the url to http://localhost/ — the embed
+// reads ?station= and ?autoplay= from it, so tests need a controllable url
+const pageUrl = vi.hoisted(() => ({ value: 'http://localhost/' }));
+vi.mock('$app/stores', () => ({
+	page: {
+		subscribe(run: (value: { url: URL }) => void) {
+			run({ url: new URL(pageUrl.value) });
+			return () => {};
+		}
+	}
+}));
+
+// jsdom doesn't implement media playback
+const playSpy = vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
 
 const SENSITIVE_ART = 'https://images.test/images/sens123.webp';
 const SAFE_ART = 'https://images.test/images/safe456.webp';
@@ -76,6 +92,8 @@ afterEach(() => {
 		component = null;
 	}
 	document.body.innerHTML = '';
+	pageUrl.value = 'http://localhost/';
+	playSpy.mockClear();
 });
 
 describe('RadioEmbed sensitive artwork', () => {
@@ -89,5 +107,20 @@ describe('RadioEmbed sensitive artwork', () => {
 		artworkUrl = SAFE_ART;
 		const img = await mountRadioEmbed();
 		expect(img.closest('.sensitive-wrapper.blur')).toBeNull();
+	});
+});
+
+describe('RadioEmbed autoplay', () => {
+	it('tunes in automatically with ?autoplay=1', async () => {
+		artworkUrl = SAFE_ART;
+		pageUrl.value = 'http://localhost/?autoplay=1';
+		await mountRadioEmbed();
+		await vi.waitFor(() => expect(playSpy).toHaveBeenCalled());
+	});
+
+	it('stays paused without the param', async () => {
+		artworkUrl = SAFE_ART;
+		await mountRadioEmbed();
+		expect(playSpy).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -154,6 +154,7 @@
 							<p>play <code>current.stream_url</code>, seek to <code>progress_seconds</code>.</p>
 							<p>refresh when <code>current_ends_at</code> passes, or poll every 30s.</p>
 							<p>embedding this page? add <code>?autoplay=1</code> to start playback automatically.</p>
+							<p>or use the compact widget: <code>/embed/radio</code> takes <code>?station=</code> and <code>?autoplay=1</code> too.</p>
 						</div>
 					</details>
 				</div>

--- a/loq.toml
+++ b/loq.toml
@@ -328,7 +328,7 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/[[][[]station[]][]]/+page.svelte"
-max_lines = 929
+max_lines = 947
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"


### PR DESCRIPTION
follow-up to #1592, which added `?autoplay=1` to the full radio page but not to `/embed/radio` — the dedicated iframe widget from #1571 — while the new integration-popover hint told embedders the param exists. the widget now honors `?autoplay=1`, the embed docs finally document autoplay (it has existed on track/playlist/album embeds all along but appeared nowhere in `docs/public/`), and the loq violation #1592 introduced on main is resolved.

<details>
<summary>design</summary>

- **`RadioEmbed` autoplay reuses the play-button path**: on mount it reads `?autoplay=1` alongside the existing `?station=`, and once the initial `/radio/state` load resolves it calls the same `toggle()` a user click would. that path already syncs the `<audio>` to live progress and `catch`es a policy-blocked `play()` into the normal paused state — no error UI, the visitor just clicks play like before. no retry, no loop: it fires once after the first state load.
- **`?station=` and `?autoplay=1` compose** — the autoplay attempt happens after the station pin is folded into the state fetch, so a pinned embed tunes into the pinned station.
- **docs (`docs/public/artists.md`)**: adds the album embed snippet (the section intro already claimed album support but never showed it), a radio embed section (`?station=` pinning, the ~184px dial-hiding threshold from #1571, 220px suggested height), and an `### autoplay` section: the param applies to every embed, requires `allow="autoplay"` on the iframe, and browsers may still silently block it without prior engagement. also notes the full radio page accepts the param for browser-source overlays (the OBS use case that motivated #1592).
- **radio page integration popover** gains one line pointing at the compact widget, so the #1592 hint no longer steers iframe embedders exclusively to the full page.
- **loq**: #1592 pushed the radio page past its 929-line limit, leaving the `pre_commit` check red on main. relaxed via `just loq-relax` (947). a real decomposition of the radio page can ride the #1578 design-system audit wave instead.

</details>

<details>
<summary>intentional non-behaviors</summary>

- **no autoplay retry after a policy block** — matching the track/collection embeds: one attempt, then the normal paused state. retrying against autoplay policy is futile and the play button is right there.
- **no `?autoplay` on other values** — only the literal `1` triggers it, same convention as every other embed surface.
- **no artist-catalog embed docs** — `/embed/u/{handle}` exists (it uses `CollectionEmbed`, so it already honors autoplay) but isn't documented anywhere today; whether to advertise it is a separate call.

</details>

<details>
<summary>verification</summary>

- new vitest coverage in `RadioEmbed.test.ts`: `?autoplay=1` calls `play()` once state loads; no param stays paused. the shared `$app/stores` test stub pins the URL, so the test mocks it with a controllable URL (and stubs `HTMLMediaElement.play/load`, which jsdom doesn't implement).
- `just frontend check`, `bun run lint`, `bun run test` (47 passed), and `uvx loq` all pass locally.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)