### PR TITLE
fix(radio): roll back radio mode when a policy-blocked autoplay tune-in fails

### DIFF
--- a/frontend/src/lib/player-radio.test.ts
+++ b/frontend/src/lib/player-radio.test.ts
@@ -1,0 +1,74 @@
+// a policy-blocked autoplay tune-in (NotAllowedError) must roll the player
+// back out of radio mode — not leave a silent on-air state ("stop" + LIVE
+// with no sound). follow-up to #1592/#1593.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { player, type RadioNowPlaying } from '$lib/player.svelte';
+import type { Track } from '$lib/types';
+
+vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
+vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+const playSpy = vi.spyOn(HTMLMediaElement.prototype, 'play');
+
+function track(id: number): Track {
+	return {
+		id,
+		title: `track ${id}`,
+		artist: 'artist',
+		artist_handle: 'artist.test',
+		file_id: '',
+		file_type: 'mp3',
+		play_count: 0
+	};
+}
+
+function nowPlaying(id: number): RadioNowPlaying {
+	return { track: track(id), stream_url: `https://audio.test/${id}.mp3`, start_at: 0 };
+}
+
+const blocked = () =>
+	new DOMException('The play method is not allowed in the current context', 'NotAllowedError');
+
+beforeEach(() => {
+	playSpy.mockReset();
+	player.audioElement = document.createElement('audio');
+	player.radio = null;
+	player.currentTrack = null;
+	player.paused = true;
+});
+
+describe('playRadio under autoplay policy', () => {
+	it('rolls back out of radio mode when a fresh tune-in is blocked', async () => {
+		playSpy.mockRejectedValueOnce(blocked());
+		player.playRadio(nowPlaying(1));
+		await vi.waitFor(() => expect(player.radio).toBeNull());
+		expect(player.paused).toBe(true);
+	});
+
+	it('restores the previously loaded track on rollback', async () => {
+		const prev = track(7);
+		player.currentTrack = prev;
+		playSpy.mockRejectedValueOnce(blocked());
+		player.playRadio(nowPlaying(1));
+		// $state proxies assigned objects, so compare by id rather than identity
+		await vi.waitFor(() => expect(player.currentTrack?.id).toBe(prev.id));
+		expect(player.radio).toBeNull();
+	});
+
+	it('keeps radio mode when a blocked play happens mid-session', async () => {
+		playSpy.mockResolvedValueOnce(undefined);
+		player.playRadio(nowPlaying(1));
+		expect(player.radio?.track.id).toBe(1);
+
+		playSpy.mockRejectedValueOnce(blocked());
+		player.playRadio(nowPlaying(2));
+		await vi.waitFor(() => expect(player.paused).toBe(true));
+		expect(player.radio?.track.id).toBe(2);
+	});
+
+	it('keeps radio mode on non-policy playback errors', async () => {
+		playSpy.mockRejectedValueOnce(new DOMException('no source', 'NotSupportedError'));
+		player.playRadio(nowPlaying(1));
+		await vi.waitFor(() => expect(player.paused).toBe(true));
+		expect(player.radio?.track.id).toBe(1);
+	});
+});

--- a/frontend/src/lib/player.svelte.ts
+++ b/frontend/src/lib/player.svelte.ts
@@ -80,7 +80,12 @@ class PlayerState {
 	 * call from a user gesture so the play() isn't blocked by autoplay policy. */
 	playRadio(np: RadioNowPlaying, options: RadioPlaybackOptions = {}) {
 		const autoplay = options.autoplay ?? true;
+		const wasActive = this.radio !== null;
+		const previousTrack = this.currentTrack;
 		this.radio = np;
+		// $state proxies the assigned object, so capture the proxy for the
+		// is-this-tune-in-still-current check in the catch below
+		const assigned = this.radio;
 		this.currentTrack = null; // exit track mode; the track loader bails on null
 		this.paused = !autoplay;
 		const el = this.audioElement;
@@ -89,7 +94,21 @@ class PlayerState {
 		el.load();
 		if (autoplay) {
 			// play immediately (preserve the gesture), then align to station position
-			el.play().catch(() => (this.paused = true));
+			el.play().catch((err: unknown) => {
+				this.paused = true;
+				// autoplay policy blocked a fresh tune-in: roll back to the pre-tune
+				// state so the ui reads "tune in" again instead of a silent on-air
+				// state ("stop" + LIVE). mid-session failures (station flips, track
+				// boundaries) keep radio mode — only the entry is rolled back.
+				if (
+					!wasActive &&
+					this.radio === assigned &&
+					(err as { name?: string })?.name === 'NotAllowedError'
+				) {
+					this.radio = null;
+					this.currentTrack = previousTrack;
+				}
+			});
 		} else {
 			el.pause();
 		}


### PR DESCRIPTION
a policy-blocked `?autoplay=1` tune-in left the radio UI in a lying half-state — the page button read "stop" and the footer showed LIVE while nothing played. now a blocked fresh tune-in rolls cleanly back to the "tune in" state. follow-up to #1592/#1593.

## motivation

testing #1592/#1593 in firefox (default autoplay policy, no site permission) surfaced this: `play()` rejects with `NotAllowedError`, but `playRadio` sets `player.radio` *before* calling `play()` and its catch only rolled back `paused`. since `radio.active` derives from `player.radio !== null`, the UI advanced to on-air — "stop" button, LIVE badge, 30s polling running — over a silent player. the documented degrade ("quietly leaves it paused — no error, just no sound") was supposed to look like you never tuned in.

a manual tune-in never hits this because a gesture-backed `play()` succeeds; the autoplay param was the first caller that could fail.

## design

- the rollback lives in `playRadio`'s catch and is deliberately narrow: only when the rejection is `NotAllowedError` **and** radio was not already active before this call. mid-session failures (station flips, track boundaries via `onEnded`, poll-driven rotation) keep radio mode and just pause, exactly as before — tearing down radio mid-listen on a transient failure would be wrong.
- the previously loaded `currentTrack` is restored on rollback, so a hydrated track in the footer isn't silently discarded by a tune-in that never happened.
- a `this.radio === assigned` guard skips the rollback if something else (a track play, another station) took the player while the rejection was in flight. note: `assigned` is captured *after* assignment because `$state` wraps the object in a reactive proxy — comparing against the raw `np` never matches (the first test run caught exactly this).

## intentional non-behaviors

- no change to the polling teardown: `tuneIn()` starts the 30s poll before the rejection lands, but `syncToStation` already self-cleans on its first tick when `player.radio` is null.
- non-policy errors (`NotSupportedError` etc.) still keep radio mode paused — those are stream problems, not consent problems, and the on-air UI with a play button is the right surface for retrying.
- no embed-specific changes: the embed tunes in through the same `radio.tuneIn()` path, so it inherits the rollback.

## testing

new `player-radio.test.ts` (4 tests): fresh-tune-in rollback, prior-track restoration, mid-session blocked play keeps radio mode, non-policy errors keep radio mode. the rollback tests fail against the previous behavior. full suite 51/51, svelte-check, eslint, loq all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)