### PR TITLE
fix(radio): build stream_url from configured base, not request scheme

### DIFF
--- a/backend/loq.toml
+++ b/backend/loq.toml
@@ -1,0 +1,11 @@
+default_max_lines = 500
+respect_gitignore = true
+exclude = []
+
+[[rules]]
+path = "tests/api/test_radio.py"
+max_lines = 535
+
+[[rules]]
+path = "src/backend/config.py"
+max_lines = 1142

--- a/backend/src/backend/api/radio/state.py
+++ b/backend/src/backend/api/radio/state.py
@@ -8,8 +8,9 @@ owns only the HTTP surface and the loop arithmetic.
 
 from datetime import UTC, datetime, timedelta
 from typing import Annotated
+from urllib.parse import urljoin
 
-from fastapi import Depends, HTTPException, Query, Request
+from fastapi import Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session as AuthSession
@@ -25,6 +26,7 @@ from backend.api.radio.schemas import (
     StationsResponse,
     StationSummary,
 )
+from backend.config import settings
 from backend.models import Track, get_db
 from backend.utilities.aggregations import (
     get_like_counts,
@@ -42,9 +44,14 @@ MAX_ROTATION_SIZE = 75
 RANK_DECAY = 12.0
 
 
-def _stream_url(request: Request, track: Track) -> str:
-    """Return the existing audio redirect endpoint as an absolute URL."""
-    return str(request.url_for("stream_audio", file_id=track.file_id))
+def _stream_url(track: Track) -> str:
+    """Return the existing audio redirect endpoint as an absolute URL.
+
+    Built from the configured public base URL rather than the request scheme,
+    which is ``http`` behind Fly's TLS termination and would emit mixed-content
+    URLs to https pages and embedders.
+    """
+    return urljoin(settings.atproto.base_url + "/", f"audio/{track.file_id}")
 
 
 def _duration_seconds(track: Track) -> int:
@@ -95,7 +102,6 @@ async def _select_rotation(
 
 
 async def _to_radio_tracks(
-    request: Request,
     db: AsyncSession,
     tracks: list[Track],
     like_counts: dict[int, int],
@@ -111,7 +117,7 @@ async def _to_radio_tracks(
             artist=track.artist.display_name,
             artist_handle=track.artist.handle,
             artist_did=track.artist_did,
-            stream_url=_stream_url(request, track),
+            stream_url=_stream_url(track),
             file_type=track.file_type,
             duration=_duration_seconds(track),
             artwork_url=track.image_url or track.artist.avatar_url,
@@ -185,7 +191,6 @@ async def list_stations() -> StationsResponse:
 @router.get("/state")
 @router.get("/state.json")
 async def radio_state(
-    request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],
     limit: int = Query(DEFAULT_ROTATION_SIZE, ge=1, le=MAX_ROTATION_SIZE),
     station: str | None = Query(None, description="station slug; omit for default"),
@@ -208,7 +213,7 @@ async def radio_state(
         if session
         else set()
     )
-    rotation = await _to_radio_tracks(request, db, tracks, like_counts, liked_ids)
+    rotation = await _to_radio_tracks(db, tracks, like_counts, liked_ids)
     current_index, progress, started_at, ends_at = _live_window(now, rotation)
     current = rotation[current_index] if current_index is not None else None
 

--- a/backend/src/backend/api/tracks/revisions.py
+++ b/backend/src/backend/api/tracks/revisions.py
@@ -111,8 +111,7 @@ def _audio_url_for_record(revision: TrackRevision) -> str:
     directly.
     """
     if revision.was_gated:
-        backend_url = settings.atproto.redirect_uri.rsplit("/", 2)[0]
-        return urljoin(backend_url + "/", f"audio/{revision.file_id}")
+        return urljoin(settings.atproto.base_url + "/", f"audio/{revision.file_id}")
     if not revision.audio_url:
         # public revision missing a CDN url — this shouldn't happen for any
         # revision created post-CDN-cutover, but guard the assertion anyway

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -827,8 +827,9 @@ async def _create_records(
     elif audio_info.is_gated:
         from urllib.parse import urljoin
 
-        backend_url = settings.atproto.redirect_uri.rsplit("/", 2)[0]
-        audio_url_for_record = urljoin(backend_url + "/", f"audio/{sr.file_id}")
+        audio_url_for_record = urljoin(
+            settings.atproto.base_url + "/", f"audio/{sr.file_id}"
+        )
         uri = f"at://{ctx.artist_did}/{collection}/{rkey}"
     else:
         assert sr.r2_url is not None

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -444,6 +444,18 @@ class AtprotoSettings(AppSettingsSection):
 
     @computed_field
     @property
+    def base_url(self) -> str:
+        """Public base URL of the backend (e.g. ``https://api.plyr.fm``).
+
+        Derived from the OAuth ``redirect_uri`` so it always reflects the
+        configured public scheme/host — never the request scheme, which is
+        ``http`` behind Fly's TLS termination.
+        """
+
+        return self.redirect_uri.rsplit("/", 2)[0]
+
+    @computed_field
+    @property
     def track_collection(self) -> str:
         """Collection name for plyr audio records."""
 

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -13,6 +13,7 @@ from backend._internal import Session, get_optional_session
 from backend.api.radio import lenses
 from backend.api.radio.lenses import LensContext
 from backend.api.radio.sampler import rank_decay_weights
+from backend.config import settings
 from backend.main import app
 from backend.models import Artist, Tag, Track, TrackLike, TrackTag, get_db
 
@@ -146,8 +147,15 @@ async def test_default_station_returns_public_tracks_only(
     radio_app: FastAPI,
     db_session: AsyncSession,
     radio_artist: Artist,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """default station serves the loved station; unlisted/gated are excluded."""
+    # regression (#1594): stream_url must come from the configured public base
+    # URL, not the request scheme — behind Fly's TLS termination the request is
+    # plain http, which leaked http:// URLs onto https pages/embedders.
+    monkeypatch.setattr(
+        settings.atproto, "redirect_uri", "https://api.plyr.fm/auth/callback"
+    )
     now = datetime.now(UTC) + TEST_TIME_OFFSET
     visible = await _create_track(
         db_session, radio_artist, title="Visible", file_id="visible", created_at=now
@@ -170,9 +178,11 @@ async def test_default_station_returns_public_tracks_only(
     )
     await db_session.commit()
 
+    # request over plain http (as Fly's proxy presents it internally) to prove
+    # the response URL ignores the request scheme.
     async with AsyncClient(
         transport=ASGITransport(app=radio_app),
-        base_url="https://radio.plyr.fm",
+        base_url="http://radio.internal",
     ) as client:
         response = await client.get("/radio/state")
 
@@ -183,7 +193,7 @@ async def test_default_station_returns_public_tracks_only(
     assert data["station"] == "loved"
     assert data["current"]["title"] == "Visible"
     assert data["current"]["stream_url"] == (
-        f"https://radio.plyr.fm/audio/{visible.file_id}"
+        f"https://api.plyr.fm/audio/{visible.file_id}"
     )
     assert data["current"]["duration"] == 123
     assert data["current"]["artwork_url"] == "https://images.example/cover.jpg"

--- a/loq.toml
+++ b/loq.toml
@@ -44,7 +44,7 @@ max_lines = 1818
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 1130
+max_lines = 1142
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
@@ -332,7 +332,7 @@ max_lines = 947
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"
-max_lines = 525
+max_lines = 535
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"


### PR DESCRIPTION
`/radio/state` emitted `http://api.plyr.fm/audio/...` because it built `stream_url` from `request.url_for`, and behind Fly's TLS termination the request scheme is plain `http` — so every https page and embedder got a mixed-content URL (chromium auto-upgrades `<audio src>` with a console warning; `fetch()` of the URL is hard-blocked). Fixes #1594.

The fix derives the URL from the configured public base instead of the request, mirroring what `uploads.py`/`revisions.py` already do.

<details>
<summary>design</summary>

- new `AtprotoSettings.base_url` computed property (e.g. `https://api.plyr.fm`), derived from the OAuth `redirect_uri` so it always reflects the configured public scheme/host. it replaces the copy-pasted `redirect_uri.rsplit("/", 2)[0]` pattern that lived in `uploads.py` and `revisions.py`.
- `radio/state.py` `_stream_url` now builds `{base_url}/audio/{file_id}` and no longer threads `request` through `_to_radio_tracks` / the endpoint.
- regression test: `/radio/state` is requested over **http** (`base_url="http://radio.internal"`) with `redirect_uri` patched to an https host; it asserts the response `stream_url` stays https. verified it fails on the old code. the prior test passed only because the ASGI client used an https base_url — it never exercised the proxy condition.
</details>

<details>
<summary>incidental</summary>

- fixes a pre-existing import-sort lint error in `scripts/init_db.py` (introduced by #1586) so `just backend lint` is green on this branch.
- `loq` limits relaxed for `config.py` and `test_radio.py` (added lines, not golf).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)