### PR TITLE
fix(costs): export pulls live infra costs instead of hardcoded stale numbers

### DIFF
--- a/COSTS.md
+++ b/COSTS.md
@@ -1,0 +1,186 @@
+# COSTS.md
+
+> **Mandate.** This file tracks the infrastructure costs attributed to **plyr.fm** and
+> what we're doing to bring them down. It is the running record of what this project
+> spends, why, and a changelog of changes that moved the number. If the spend here is
+> unjustified, that's a signal to clean up — not to ignore it.
+
+> **The public `/costs` page now pulls live.** `scripts/costs/export_costs.py` was
+> rewritten (2026-06-17) to fetch infra costs from the `hub.waow.tech` aggregator
+> (line items tagged `project=="plyr.fm"`) and compute AuDD from our own DB — it no
+> longer hard-codes any dollar figures. This file is the human-readable audit behind
+> that feed. See [what the `/costs` page used to get wrong](#what-the-costs-page-used-to-get-wrong).
+
+---
+
+## summary
+
+**As of 2026-06-17.** Figures are monthly. Confidence is noted per line because not
+every provider exposes a clean per-project invoice; where a number is derived from
+measured usage × public list price it's marked **est**, and where it could not be
+verified from here it's marked **unverified**.
+
+| provider | monthly | source | basis |
+|---|---|---|---|
+| **Fly.io** (compute) | **~$48** | hub feed | 6 apps; inventory × list price (counts stopped machines) |
+| **Neon** (postgres) | **~$15** (feed) / compute-variable | hub feed + measured | feed splits Launch plan 4×$3.80; real driver is always-on moderation CU |
+| **Cloudflare** (R2 + Pages + domain) | **~$1.2** (measured) / not in feed | measured directly | 21 GiB R2 over 10 GiB free + domain; **not yet attributed in the feed → $0 on the page** |
+| **AuDD** (copyright) | **$5.00** | measured usage | $5 base, $0 overage (2.4k of 6k free reqs) |
+| **Modal** (CLAP) / **Replicate** (genre) | negligible | — | per owner: not worth tracking; free-tier / scales to zero |
+
+**Headline: ~$68/month** from the live feed (Fly $48 + Neon $15 + AuDD $5), plus ~$1.2
+of Cloudflare the feed doesn't yet attribute. Not the ~$20 the old hard-coded page implied.
+The gap was **Fly's true compute** (Redis omitted, stale numbers) and **Neon's always-on
+moderation CU**.
+
+> **Feed gap to fix upstream:** Cloudflare (R2 + domain) isn't tagged `project=="plyr.fm"`
+> in `my-prefect-server` (`packages/mps/src/mps/costs/projects.py`), so the page shows
+> Cloudflare = $0. It's only ~$1.2/mo, but attribute it there for completeness.
+
+---
+
+## detail by provider
+
+### Fly.io — compute
+
+Measured from `fly machines list` on 2026-06-17. Fly bills running time; **stopped**
+machines incur ~$0 compute (volumes still bill). The per-app estimate below uses Fly's
+shared-cpu list prices for the **running** machines; the inventory column counts every
+machine (matches the `hub.waow.tech` inventory estimate, which is higher because it
+doesn't discount stopped machines).
+
+| app | machines | running est | inventory est (hub) |
+|---|---|---|---|
+| `relay-api` (prod backend) | 2×2GB worker, 2×1GB app — 2 running (1×2GB, 1×1GB), 2 stopped | ~$14.4 | $21.71 |
+| `relay-api-staging` | 3×1GB — 2 running, 1 stopped | ~$11.4 | $14.92 |
+| `plyr-moderation` | 1×256MB running | ~$1.9 | $3.19 |
+| `plyr-redis` (prod) | 1×256MB running + 1GB vol | ~$2.1 | $3.19 |
+| `plyr-redis-stg` | 1×256MB running + 1GB vol | ~$2.1 | $3.19 |
+| `plyr-transcoder` | 2×1GB, both stopped (app suspended) | ~$0 | $2.08 |
+| **total** | | **~$32** | **~$48** |
+
+List prices used (shared-cpu-1x, 24/7): 256MB ≈ $1.94, 1GB ≈ $5.70, 2GB ≈ $8.69; volume $0.15/GB-mo.
+
+- **prod vs non-prod**: prod ≈ relay-api + plyr-moderation + plyr-redis ≈ **$18 running**;
+  non-prod ≈ relay-api-staging + plyr-redis-stg ≈ **$14 running** (the transcoder is idle/suspended).
+- **truth source**: the Fly billing dashboard. The CLI doesn't expose a per-app invoice,
+  so the above is an estimate. Reconcile against the dashboard before trusting to the dollar.
+
+### Neon — postgres (serverless)
+
+Neon billing is **org-level on a single plan** (org `nate`, `org-old-king-77916016`), not
+per-project, so there is no clean per-project invoice. 4 of the org's 5 projects are plyr
+(`plyr-prd`, `plyr-stg`, `plyr-dev`, `plyr-moderation`); the 5th (`follower-weight`) is unrelated.
+
+**Storage is negligible** everywhere (all projects < 100 MB; prd is ~62 MB). **Compute
+dominates**, and compute is billed in CU-hours. Month-to-date CU usage (≈17 days into the
+billing month, `cpu_used_sec` / 3600, projected to a full month):
+
+| project | autoscale (min–max CU) | suspend | MTD CU-h | ~full-month CU-h |
+|---|---|---|---|---|
+| `plyr-moderation` | **1–1 (fixed, always on)** | **disabled** | 402 | **~720** |
+| `plyr-prd` | 0.25–2 | disabled | 202 | ~360 |
+| `plyr-stg` | 0.25–1 | disabled | 101 | ~180 |
+| `plyr-dev` | 0.25–0.25 | disabled | 6 | ~11 |
+
+> ⚠️ **`plyr-moderation` runs a fixed 1 CU with autosuspend disabled — it never scales
+> down.** That's ~720 CU-hours/month from a labeler that is idle most of the time, and it's
+> the single largest compute consumer in the Neon footprint. This is exactly the cost the
+> public page's flat "$5/month neon" hides. **Top cost-reduction target.**
+
+Dollar figure depends on the org's plan tier (Launch includes 300 CU-h; overage ~$0.16/CU-h),
+which can't be read from here — **verify the actual invoice in the Neon console.** Plan on it
+being **well above the $5 the page claims** given ~1,250 plyr CU-h/month.
+
+### Cloudflare — R2 + Pages + domain
+
+R2 storage measured via the R2 usage API on 2026-06-17:
+
+| bucket | objects | size |
+|---|---|---|
+| `audio-prod` | 939 | 19.79 GiB |
+| `images-prod` | 660 | 0.42 GiB |
+| `audio-private-prod` | 4 | 0.14 GiB |
+| `audio-staging` | 320 | 0.47 GiB |
+| `audio-dev` | 21 | 0.24 GiB |
+| (other staging/dev/private + `plyr-stats`) | ~43 | < 0.02 GiB |
+| **total** | | **~21.1 GiB** |
+
+- **R2 storage**: 21.1 GiB − 10 GiB free = ~11 GiB billable × $0.015/GB-mo ≈ **$0.17/mo**.
+  Egress is free (the reason we're on R2); Class A/B ops are negligible at this volume.
+- **Pages**: free tier. **$0**.
+- **Domain**: `plyr.fm` registration ≈ **~$1/mo** amortized.
+- **Cloudflare total ≈ $1.2/mo.** (The old hard-coded $0.16 for R2 happens to still be about right.)
+
+### AuDD — copyright detection
+
+Measured from `copyright_scans ⋈ tracks` on prod (`plyr-prd`) on 2026-06-17:
+
+- 58 scans in the last 30 days → **2,436 derived API requests** (1 req = 12s of audio).
+- Free tier is 6,000 requests/month → **$0 overage**.
+- **AuDD total = $5.00/mo** (indie-plan base only).
+
+### Modal — CLAP mood-search embeddings  *(unverified)*
+
+The `vibe-search` feature embeds audio/text via the Modal CLAP service
+(`zzstoatzz--plyr-clap-*`). No Modal CLI or token is available locally, so spend can't be
+measured from here. Modal includes a free monthly credit and the service scales to zero;
+expected **~$0 (free-tier)**, but **confirm in the Modal dashboard**.
+
+### Replicate — genre classification  *(unverified)*
+
+Genre auto-tagging runs effnet-discogs on Replicate (scales to zero, ~$0.00019/run). No
+token locally to query usage. Expected **< $1/mo**; confirm in the Replicate dashboard.
+
+---
+
+## what the `/costs` page used to get wrong
+
+Until 2026-06-17 the page was fed by `export_costs.py`'s `FIXED_COSTS`, last touched
+**2025-12-26**:
+
+- **Fly** hard-coded at $11.66, **omitting `plyr-redis` and `plyr-redis-stg`**. Real ~$48.
+- **Neon** hard-coded flat **$5.00**; the real driver (always-on moderation CU) was invisible.
+- **Cloudflare** $1.16 — about right, but now reads from the feed (currently $0, unattributed).
+- **AuDD** was already computed live — kept.
+
+**Fixed:** the script now fetches Fly/Neon/Cloudflare from the `hub.waow.tech` feed
+(`project=="plyr.fm"`) and computes AuDD from our DB. No dollar figures are hard-coded;
+the only manual input is which services count as plyr.fm, and that mapping lives upstream
+in `my-prefect-server`, not in this repo.
+
+---
+
+## how we might bring this down
+- **`plyr-moderation` Neon project — ✅ DONE (2026-06-17):** endpoint `ep-frosty-credit-ae1vylok`
+  was pinned at a fixed 1 CU with autosuspend off (~720 CU-h/mo always-on for a mostly-idle
+  labeler). Now **autoscales 0.25–1 CU with scale-to-zero after 5 min idle** — it idles down to
+  zero between scans. The single biggest hidden cost, eliminated.
+- **non-prod Fly machines** (`relay-api-staging`, `plyr-redis-stg`): scale to zero when idle
+  (`auto_stop_machines`) or tear down between use.
+- **`plyr-transcoder`** is suspended with 2 idle 1GB machines — fine while idle, but delete
+  the machines if it stays unused so it stops showing up in inventory estimates.
+- **`relay-api`** is the biggest Fly line — right-size the 2GB worker and confirm the stopped
+  machines actually stay stopped (auto-stop behaving) before anything else.
+- **R2** is already cheap (~$0.17); no action needed.
+
+## how to refresh this file
+- **Fly**: `fly machines list -a <app>` for inventory; reconcile $ against the Fly dashboard.
+- **Neon**: `mcp__plugin_neon_neon__list_projects` for per-project `cpu_used_sec` / autoscale
+  config; read the actual bill from the Neon console (org-level).
+- **R2**: Cloudflare API `GET /accounts/{acct}/r2/buckets/{bucket}/usage` per bucket.
+- **AuDD**: query `copyright_scans ⋈ tracks` for 30-day requests (see `export_costs.py`).
+- **Modal / Replicate**: their dashboards (negligible, not tracked).
+- The live feed itself: `https://hub.waow.tech/api/costs.json` (filter `project=="plyr.fm"`).
+
+## changelog
+- **2026-06-17** — **applied the moderation fix:** `plyr-moderation` Neon endpoint
+  `ep-frosty-credit-ae1vylok` switched from fixed 1 CU / no-suspend to autoscale 0.25–1 CU
+  with scale-to-zero (5 min). Kills the ~720 always-on CU-h/mo.
+- **2026-06-17** — rewrote `export_costs.py` to stop hard-coding: it now fetches Fly/Neon/
+  Cloudflare from the `hub.waow.tech` feed and computes AuDD from our DB. Did the ground-truth
+  audit behind it (Fly machine inventory, Neon per-project compute, R2 bucket sizes, AuDD usage).
+  Surfaced the two costs the old page hid: real Fly compute (~$48 vs hard-coded $11.66, Redis
+  omitted) and Neon's always-on 1-CU `plyr-moderation` project (~720 CU-h/mo — flagged for an
+  autosuspend fix). Live total ~$68/mo vs the old page's ~$20.
+- **2026-06-17** — initial cost notice (auto-scaffold; pointed at the live hub feed).

--- a/scripts/costs/export_costs.py
+++ b/scripts/costs/export_costs.py
@@ -22,6 +22,7 @@ import asyncio
 import json
 import os
 import re
+import urllib.request
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -29,40 +30,61 @@ import typer
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-# billing constants
+# AudD is the one cost we derive from our own usage (track durations in our DB),
+# so it stays computed here. Everything else (fly/neon/cloudflare compute) is
+# pulled live from the cost aggregator below — never hardcoded. see COSTS.md.
 AUDD_BILLING_DAY = 24
 AUDD_SECONDS_PER_REQUEST = 12
 AUDD_FREE_REQUESTS = 6000  # 1000 base + 5000 bonus on indie plan
 AUDD_COST_PER_1000 = 5.00  # $5 per 1000 requests
 AUDD_BASE_COST = 5.00  # $5/month base
 
-# fixed monthly costs (updated 2025-12-26)
-# fly.io: manually updated from cost explorer (TODO: use fly billing API)
-# neon: fixed $5/month
-# cloudflare: mostly free tier
-# redis: self-hosted on fly (included in fly_io costs)
-FIXED_COSTS = {
-    "fly_io": {
-        "breakdown": {
-            "relay-api": 5.80,  # prod backend
-            "relay-api-staging": 5.60,
-            "plyr-moderation": 0.24,
-            "plyr-transcoder": 0.02,
-        },
-        "note": "compute (2x shared-cpu VMs + moderation + transcoder)",
-    },
-    "neon": {
-        "total": 5.00,
-        "note": "postgres serverless (fixed)",
-    },
-    "cloudflare": {
-        "r2": 0.16,
-        "pages": 0.00,
-        "domain": 1.00,
-        "total": 1.16,
-        "note": "r2 egress is free, pages free tier",
-    },
-}
+# live infra-cost feed (collected daily by my-prefect-server, surfaced at hub.waow.tech).
+# line items tagged project=="plyr.fm" are this repo's infra. that mapping lives in
+# my-prefect-server (packages/mps/src/mps/costs/projects.py), not here.
+INFRA_COSTS_URL = "https://hub.waow.tech/api/costs.json"
+PROJECT_KEY = "plyr.fm"
+# feed provider -> the key the dashboard frontend expects
+PROVIDER_KEYS = {"fly": "fly_io", "neon": "neon", "cloudflare": "cloudflare"}
+
+
+def fetch_infra_costs() -> dict[str, Any]:
+    """pull this repo's live infra costs (fly/neon/cloudflare) from the aggregator.
+
+    returns one entry per provider with a total, a per-service breakdown, and a
+    note carrying the service count. raises if the feed is unreachable or has no
+    plyr.fm line items, so we never silently publish stale/empty data.
+    """
+    with urllib.request.urlopen(INFRA_COSTS_URL, timeout=15) as resp:
+        feed = json.loads(resp.read())
+
+    lines = [li for li in feed.get("lineItems", []) if li.get("project") == PROJECT_KEY]
+    if not lines:
+        raise RuntimeError(
+            f"no '{PROJECT_KEY}' line items in {INFRA_COSTS_URL}; check the project mapping"
+        )
+
+    providers: dict[str, dict[str, Any]] = {}
+    for li in lines:
+        key = PROVIDER_KEYS.get(li["provider"])
+        if key is None:
+            continue  # provider not surfaced on the dashboard
+        bucket = providers.setdefault(
+            key, {"amount": 0.0, "breakdown": {}, "estimated": False, "services": []}
+        )
+        usd = li["amount"] / 100
+        bucket["amount"] = round(bucket["amount"] + usd, 2)
+        bucket["breakdown"][li["service"]] = round(usd, 2)
+        bucket["estimated"] = bucket["estimated"] or bool(li.get("estimated"))
+        bucket["services"].append(li["service"])
+
+    for b in providers.values():
+        n = len(b["services"])
+        flag = " (estimated)" if b["estimated"] else ""
+        b["note"] = f"{n} service(s) via hub.waow.tech{flag}"
+        del b["services"]
+
+    return {"generated_at": feed.get("generatedAt"), "providers": providers}
 
 
 class Settings(BaseSettings):
@@ -194,40 +216,29 @@ async def get_audd_stats(db_url: str) -> dict[str, Any]:
         await conn.close()
 
 
-def build_cost_data(audd_stats: dict[str, Any]) -> dict[str, Any]:
-    """assemble full cost dashboard data"""
-    # calculate plyr-specific fly costs
-    plyr_fly = sum(FIXED_COSTS["fly_io"]["breakdown"].values())
+def build_cost_data(
+    audd_stats: dict[str, Any], infra: dict[str, Any]
+) -> dict[str, Any]:
+    """assemble full cost dashboard data from live infra + computed AudD usage"""
+    providers = infra["providers"]
 
-    monthly_total = (
-        plyr_fly
-        + FIXED_COSTS["neon"]["total"]
-        + FIXED_COSTS["cloudflare"]["total"]
-        + audd_stats["estimated_cost"]
-    )
+    def provider(key: str) -> dict[str, Any]:
+        # absent provider -> zeroed entry so the frontend always has the key
+        return providers.get(
+            key, {"amount": 0.0, "breakdown": {}, "note": "no plyr.fm line items"}
+        )
+
+    infra_total = sum(p["amount"] for p in providers.values())
+    monthly_total = infra_total + audd_stats["estimated_cost"]
 
     return {
         "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "infra_as_of": infra["generated_at"],
         "monthly_estimate": round(monthly_total, 2),
         "costs": {
-            "fly_io": {
-                "amount": round(plyr_fly, 2),
-                "breakdown": FIXED_COSTS["fly_io"]["breakdown"],
-                "note": FIXED_COSTS["fly_io"]["note"],
-            },
-            "neon": {
-                "amount": FIXED_COSTS["neon"]["total"],
-                "note": FIXED_COSTS["neon"]["note"],
-            },
-            "cloudflare": {
-                "amount": FIXED_COSTS["cloudflare"]["total"],
-                "breakdown": {
-                    "r2_storage": FIXED_COSTS["cloudflare"]["r2"],
-                    "pages": FIXED_COSTS["cloudflare"]["pages"],
-                    "domain": FIXED_COSTS["cloudflare"]["domain"],
-                },
-                "note": FIXED_COSTS["cloudflare"]["note"],
-            },
+            "fly_io": provider("fly_io"),
+            "neon": provider("neon"),
+            "cloudflare": provider("cloudflare"),
             "audd": {
                 "amount": audd_stats["estimated_cost"],
                 "base_cost": audd_stats["base_cost"],
@@ -290,7 +301,8 @@ def main(
     async def run():
         db_url = settings.get_db_url(env)
         audd_stats = await get_audd_stats(db_url)
-        data = build_cost_data(audd_stats)
+        infra = await asyncio.to_thread(fetch_infra_costs)
+        data = build_cost_data(audd_stats, infra)
 
         if dry_run:
             print(json.dumps(data, indent=2))


### PR DESCRIPTION
The `/costs` page was lying. It was fed by `export_costs.py`'s `FIXED_COSTS` table (last touched 2025-12-26): Fly hardcoded at \$11.66 **omitting both Redis apps**, Neon a flat \$5 that hid the real driver. It advertised **~\$20/mo** against a real **~\$68/mo**. This stops the script from owning dollar figures at all, and adds `COSTS.md` as the audit behind the feed.

## what changed
- **`export_costs.py` no longer hardcodes any dollars.** It now fetches fly/neon/cloudflare from the `hub.waow.tech` aggregator, filtered to line items tagged `project=="plyr.fm"`, and keeps AuDD computed from our own DB (genuinely usage-derived). `monthly_estimate` = live infra + AuDD. No constants left to drift.
- **`COSTS.md`** added as the human-readable ground-truth audit (Fly machine inventory, Neon per-project compute, R2 bucket sizes, AuDD usage), and the record of the moderation autosuspend fix.

## the audit (as of 2026-06-17)
| provider | monthly | notes |
|---|---|---|
| Fly | ~\$48 | 6 apps incl. both redis (old page omitted them) |
| Neon | ~\$15 | 4 projects |
| AuDD | \$5 | well under the 6k free-request tier |
| R2 | ~\$0.17 | 21 GiB over the 10 GiB free tier |

<details>
<summary>biggest hidden cost — already fixed live</summary>

The Neon `plyr-moderation` endpoint (`ep-frosty-credit-ae1vylok`) was pinned at a **fixed 1 CU with autosuspend disabled** — ~720 always-on CU-hours/month for a mostly-idle copyright labeler. Changed (via console) to **autoscale 0.25–1 CU with scale-to-zero after 5 min idle**. It now idles to zero between scans.
</details>

## intentional non-behaviors / known gaps
- **Cloudflare shows \$0 on the page** because R2/domain isn't yet tagged `project=="plyr.fm"` in `my-prefect-server` (`packages/mps/src/mps/costs/projects.py`) — that mapping lives upstream, not in this repo. Real CF is only ~\$1.2/mo. Noted in COSTS.md.
- **Modal / Replicate** deliberately not tracked (negligible, per owner).
- The script **raises** if the feed is unreachable or has no `plyr.fm` line items, so it never silently publishes stale/empty data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)