### PR TITLE
fix(embed): show artist display name in radio embed, not the handle

### DIFF
--- a/frontend/src/lib/components/embed/RadioEmbed.svelte
+++ b/frontend/src/lib/components/embed/RadioEmbed.svelte
@@ -162,7 +162,7 @@
 			<div class="meta">
 				<span class="label">{playing ? 'on air' : "what's on"}</span>
 				<span class="title">{current.title}</span>
-				<a class="artist" href={`https://plyr.fm/u/${current.artist_handle}`} target="_blank" rel="noopener">@{current.artist_handle}</a>
+				<a class="artist" href={`https://plyr.fm/u/${current.artist_handle}`} target="_blank" rel="noopener">{current.artist}</a>
 			</div>
 			<button class="play" onclick={toggle} aria-label={playing ? 'pause radio' : 'play radio'}>
 				{#if playing}


### PR DESCRIPTION
The standalone radio embed (PlayerFM and other iframe embedders) rendered the now-playing artist as `@{artist_handle}` — the atproto handle — instead of the artist's display name. The main radio page already shows the display name (`{current.artist}`) while linking to `/u/{handle}`; this aligns the embed with that.

<details>
<summary>detail</summary>

- `RadioEmbed.svelte`: the `.artist` link's visible text is now `{current.artist}` (display name). The `href` is unchanged — still `/u/{artist_handle}`, since the handle is the routable identity.
- `RadioTrack` already carries both `artist` (display name) and `artist_handle`; this was purely a presentation bug in the embed.
- note: this is plyr's own display name field, not the Bluesky profile display name — handled consistently with the rest of the app.

intentional non-behavior: the link target stays the handle (display names aren't routable / unique).
</details>