### PR TITLE
fix(jetstream): resolve handle on #identity events (they carry no handle)

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -15,6 +15,11 @@ primary_region = 'iad'
 [processes]
   app = "uv run --no-sync uvicorn backend.main:app --host 0.0.0.0 --port 8000"
   worker = "uv run --no-sync python -m backend.worker"
+  # the jetstream consumer runs on its own event loop, isolated from the
+  # worker's blocking tasks that were starving its WebSocket keepalive (the
+  # connection dropped ~every 50s). keep this at a single machine — two
+  # consumers double-process the firehose. see backend/jetstream.py.
+  jetstream = "uv run --no-sync python -m backend.jetstream"
 
 [http_service]
   internal_port = 8000
@@ -53,6 +58,14 @@ primary_region = 'iad'
   cpu_kind = 'shared'
   cpus = 1
 
+# `jetstream` only holds a WebSocket + enqueues ingest tasks — no audio
+# processing, so it needs little memory.
+[[vm]]
+  processes = ['jetstream']
+  memory = '512mb'
+  cpu_kind = 'shared'
+  cpus = 1
+
 # always restart the worker on exit, with no retry budget. fly's default
 # (`on-failure`, max_retries=10) gave up after 10 consecutive OOMs on
 # 2026-05-06 and left the machine `stopped` for ~4 days; see
@@ -65,6 +78,12 @@ primary_region = 'iad'
 [[restart]]
   policy = "always"
   processes = ["worker"]
+
+# the jetstream consumer is a singleton with no health check; a crash should
+# always restart (cursor resume picks up where it left off).
+[[restart]]
+  policy = "always"
+  processes = ["jetstream"]
 
 [env]
   PORT = '8000'

--- a/backend/src/backend/_internal/jetstream.py
+++ b/backend/src/backend/_internal/jetstream.py
@@ -9,17 +9,16 @@ heavy lifting (DB queries, record resolution) happens in docket tasks.
 """
 
 import asyncio
+import contextlib
 import logging
 import random
 import time
-from datetime import timedelta
 from typing import Any
 
 import logfire
 import orjson
 import websockets
 from atproto_core.nsid import NSID
-from docket import Perpetual
 from sqlalchemy import select
 from websockets.asyncio.client import ClientConnection
 
@@ -71,6 +70,18 @@ class JetstreamConsumer:
         self._last_cursor_flush: float = 0.0
         self._last_did_refresh: float = 0.0
         self._shutdown_event = asyncio.Event()
+
+    def stop(self) -> None:
+        """signal the consumer to shut down and unblock the recv loop.
+
+        closing the socket interrupts the `async for raw in ws` loop so a
+        quiet stream doesn't hold the process open until the next message.
+        """
+        self._shutdown_event.set()
+        ws = self._ws
+        if ws is not None:
+            with contextlib.suppress(Exception):
+                asyncio.get_running_loop().create_task(ws.close())
 
     async def run(self) -> None:
         """main loop with auto-reconnect and exponential backoff."""
@@ -137,15 +148,16 @@ class JetstreamConsumer:
         kind = event.get("kind")
 
         if kind == "identity":
+            # the identity event carries no handle (payload is just
+            # {did, seq, time}) — it's only a signal to re-resolve. the task
+            # fetches the current verified handle/PDS from slingshot.
             did = event.get("did")
-            handle = (event.get("identity") or {}).get("handle")
-            if did and handle and did in self._known_dids:
+            if did and did in self._known_dids:
                 docket = get_docket()
-                await docket.add(ingest_identity_update)(did=did, handle=handle)
+                await docket.add(ingest_identity_update)(did=did)
                 logfire.info(
                     "jetstream dispatched identity update",
                     did=did,
-                    handle=handle,
                 )
             if time_us := event.get("time_us"):
                 self._cursor = time_us
@@ -316,19 +328,3 @@ class JetstreamConsumer:
             >= settings.jetstream.did_refresh_interval_seconds
         ):
             await self._refresh_known_dids()
-
-
-async def consume_jetstream(
-    perpetual: Perpetual = Perpetual(every=timedelta(seconds=0), automatic=True),  # noqa: B008
-) -> None:
-    """perpetual task: run the Jetstream WebSocket consumer.
-
-    docket's Redis lock ensures only one instance runs this across all workers.
-    if the consumer exits (crash, disconnect), Perpetual reschedules immediately.
-    """
-    if not settings.jetstream.enabled:
-        perpetual.cancel()
-        return
-
-    consumer = JetstreamConsumer()
-    await consumer.run()

--- a/backend/src/backend/_internal/slingshot.py
+++ b/backend/src/backend/_internal/slingshot.py
@@ -1,0 +1,67 @@
+"""client for slingshot, microcosm's atproto identity + record edge cache.
+
+we use it for verified DID → handle/PDS resolution. jetstream `#identity`
+events carry no handle — the payload is just `{did, seq, time}` — so on an
+identity change we resolve the current verified miniDoc here rather than
+trusting the event.
+
+public instance: https://slingshot.microcosm.blue
+source: https://github.com/at-microcosm/microcosm-rs/tree/main/slingshot
+"""
+
+import logging
+from typing import TypedDict
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+SLINGSHOT_URL = "https://slingshot.microcosm.blue"
+USER_AGENT = "plyr.fm (zzstoatzz.io)"
+
+
+class MiniDoc(TypedDict):
+    """verified identity summary returned by resolveMiniDoc."""
+
+    did: str
+    handle: str
+    pds: str
+    signing_key: str
+
+
+async def resolve_mini_doc(did: str) -> MiniDoc:
+    """resolve a DID to its current verified handle, PDS, and signing key.
+
+    the miniDoc is bidirectionally verified by slingshot, so the handle is
+    confirmed to resolve back to the DID.
+
+    args:
+        did: the DID to resolve (also accepts a handle as the identifier).
+
+    raises:
+        httpx.HTTPError on transport/status failure; KeyError if the response
+        is missing required fields.
+    """
+    async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}) as client:
+        resp = await client.get(
+            f"{SLINGSHOT_URL}/xrpc/com.bad-example.identity.resolveMiniDoc",
+            params={"identifier": did},
+            timeout=10.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return MiniDoc(
+            did=data["did"],
+            handle=data["handle"],
+            pds=data["pds"],
+            signing_key=data.get("signing_key", ""),
+        )
+
+
+async def resolve_mini_doc_safe(did: str) -> MiniDoc | None:
+    """resolve a miniDoc, returning None instead of raising on any failure."""
+    try:
+        return await resolve_mini_doc(did)
+    except Exception as e:
+        logger.warning(f"slingshot miniDoc resolution failed for {did}: {e}")
+        return None

--- a/backend/src/backend/_internal/tasks/__init__.py
+++ b/backend/src/backend/_internal/tasks/__init__.py
@@ -74,22 +74,25 @@ from backend._internal.tasks.sync import (
 
 
 def _build_background_tasks() -> list:
-    """build the task list, deferring jetstream import to break circular dep.
+    """build the task list of docket worker tasks.
 
-    cycle: jetstream.py → tasks.ingest → tasks/__init__.py → jetstream.py
+    the jetstream consumer is NOT here — it runs in its own process
+    (`backend.jetstream`) so its WebSocket keepalive loop is isolated from
+    the worker's blocking/CPU-heavy tasks. it only enqueues the ingest tasks
+    below; the worker consumes them.
 
-    the upload / audio-replace tasks are also imported lazily because their
-    modules (`api.tracks.uploads`, `api.tracks.audio_replace`) pull in the
-    FastAPI router infrastructure, which we don't want to touch at task-module
-    import time.
+    the upload / audio-replace / audio-optimize tasks are imported here (not
+    at module top) to break a circular import: those modules import back from
+    `backend._internal.tasks` (e.g. `schedule_album_list_sync`,
+    `run_post_track_create_hooks`), so a top-level import would re-enter this
+    module while it's still initializing. by worker startup this function runs,
+    `tasks/__init__` is fully initialized and the import resolves.
     """
-    from backend._internal.jetstream import consume_jetstream
     from backend.api.tracks.audio_optimize import optimize_track_audio
     from backend.api.tracks.audio_replace import run_track_audio_replace
     from backend.api.tracks.uploads import run_track_upload
 
     return [
-        consume_jetstream,
         scan_copyright,
         sync_copyright_resolutions,
         process_export,
@@ -137,10 +140,6 @@ def __getattr__(name: str):
         if _background_tasks is None:
             _background_tasks = _build_background_tasks()
         return _background_tasks
-    if name == "consume_jetstream":
-        from backend._internal.jetstream import consume_jetstream
-
-        return consume_jetstream
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -148,7 +147,6 @@ __all__ = [
     "SubjectNotFoundError",
     "background_tasks",
     "classify_genres",
-    "consume_jetstream",
     "generate_embedding",
     "ingest_account_status_change",
     "ingest_comment_create",

--- a/backend/src/backend/_internal/tasks/ingest.py
+++ b/backend/src/backend/_internal/tasks/ingest.py
@@ -743,18 +743,17 @@ async def ingest_profile_update(
 
 async def ingest_identity_update(
     did: str,
-    handle: str,
 ) -> None:
-    """update artist handle, PDS URL, and avatar when an identity event arrives.
+    """refresh artist handle, PDS URL, and avatar from a verified resolution.
 
-    identity events fire on handle changes, PDS migrations, and account
-    reactivation. resolving the DID gives us the current PDS URL, and
-    re-fetching the profile refreshes the avatar (which may have gone
-    stale during account deactivation).
+    jetstream `#identity` events fire on handle changes, PDS migrations, and
+    account reactivation but carry no handle — only the DID. we resolve the
+    current verified miniDoc (handle + PDS) from slingshot, then re-fetch the
+    profile to refresh the avatar (which may have gone stale during account
+    deactivation).
     """
-    from atproto_identity.did.resolver import AsyncDidResolver
-
     from backend._internal.atproto.profile import fetch_user_avatar
+    from backend._internal.slingshot import resolve_mini_doc_safe
 
     async with db_session() as db:
         artist = await db.get(Artist, did)
@@ -764,25 +763,27 @@ async def ingest_identity_update(
 
         changes: dict[str, tuple[str | None, str | None]] = {}
 
-        if artist.handle != handle:
-            changes["handle"] = (artist.handle, handle)
-            artist.handle = handle
+        # resolve the current verified handle + PDS (the event has neither)
+        if mini_doc := await resolve_mini_doc_safe(did):
+            new_handle = mini_doc["handle"]
+            if new_handle and artist.handle != new_handle:
+                changes["handle"] = (artist.handle, new_handle)
+                artist.handle = new_handle
 
-            # update active sessions so session handles stay current
-            await db.execute(
-                update(UserSession).where(UserSession.did == did).values(handle=handle)
-            )
+                # update active sessions so session handles stay current
+                await db.execute(
+                    update(UserSession)
+                    .where(UserSession.did == did)
+                    .values(handle=new_handle)
+                )
 
-        # resolve DID to get current PDS URL
-        try:
-            atproto_data = await AsyncDidResolver().resolve_atproto_data(did)
-            resolved_pds = atproto_data.pds
-            if resolved_pds and resolved_pds != artist.pds_url:
-                changes["pds_url"] = (artist.pds_url, resolved_pds)
-                artist.pds_url = resolved_pds
-        except Exception as e:
+            new_pds = mini_doc["pds"]
+            if new_pds and artist.pds_url != new_pds:
+                changes["pds_url"] = (artist.pds_url, new_pds)
+                artist.pds_url = new_pds
+        else:
             logger.warning(
-                "ingest_identity_update: DID resolution failed for %s: %s", did, e
+                "ingest_identity_update: miniDoc resolution failed for %s", did
             )
 
         # refresh avatar from Bluesky profile

--- a/backend/src/backend/jetstream.py
+++ b/backend/src/backend/jetstream.py
@@ -1,0 +1,73 @@
+"""dedicated jetstream consumer process.
+
+run via:
+    uv run --no-sync python -m backend.jetstream
+
+this runs the Jetstream WebSocket consumer ISOLATED from the docket worker's
+task-execution event loop. when the consumer ran as a docket task inside the
+`worker` process, CPU/blocking tasks (copyright scans, genre classification,
+exports) starved the WebSocket keepalive coroutine and the connection dropped
+roughly every ~50s. on its own quiet event loop it stays connected.
+
+this process opens a docket *client* only — it enqueues ingest tasks; the
+`worker` process consumes them. matches the `jetstream` process group in
+`backend/fly.toml`. run a single instance: two consumers would double-process
+the firehose (the ingest tasks are idempotent, so it's wasteful, not unsafe).
+
+observability is app-owned, same as `backend/worker.py`: `configure_observability()`
+must run before any task module is imported.
+"""
+
+import asyncio
+import logging
+import signal
+
+from backend._internal.background import docket_client_lifespan
+from backend._internal.jetstream import JetstreamConsumer
+from backend.config import settings
+from backend.utilities.observability import (
+    configure_observability,
+    suppress_warnings,
+)
+
+# matches the order in main.py: suppress pydantic warnings before any
+# atproto-touching task module gets imported, then configure logfire.
+suppress_warnings()
+configure_observability(settings)
+
+logger = logging.getLogger(__name__)
+
+
+async def _run() -> None:
+    """run the jetstream consumer until SIGINT/SIGTERM."""
+    if not settings.jetstream.enabled:
+        logger.info("jetstream disabled, exiting")
+        return
+
+    loop = asyncio.get_running_loop()
+    consumer = JetstreamConsumer()
+
+    def request_stop(sig_name: str) -> None:
+        logger.info("received %s, stopping jetstream consumer", sig_name)
+        consumer.stop()
+
+    loop.add_signal_handler(signal.SIGTERM, lambda: request_stop("SIGTERM"))
+    loop.add_signal_handler(signal.SIGINT, lambda: request_stop("SIGINT"))
+
+    try:
+        # a docket client (no Worker) so the consumer can enqueue ingest
+        # tasks; the dedicated `worker` process runs the Worker that drains them.
+        async with docket_client_lifespan():
+            logger.info("jetstream process ready")
+            await consumer.run()
+    finally:
+        loop.remove_signal_handler(signal.SIGTERM)
+        loop.remove_signal_handler(signal.SIGINT)
+
+
+def main() -> None:
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_jetstream.py
+++ b/backend/tests/test_jetstream.py
@@ -1,15 +1,14 @@
 """tests for Jetstream consumer and ingest tasks."""
 
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from docket import Perpetual
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from backend._internal.jetstream import JetstreamConsumer, consume_jetstream
+from backend._internal.jetstream import JetstreamConsumer
 from backend._internal.tasks.ingest import (
     SubjectNotFoundError,
     _write_tombstone,
@@ -212,6 +211,13 @@ class TestJetstreamConsumer:
         mock_docket.add.assert_not_called()
 
     async def test_dispatches_identity_event(self) -> None:
+        """a real (handle-less) identity event dispatches on DID alone.
+
+        regression for the bug where dispatch was gated on `identity.handle`:
+        jetstream `#identity` events carry only `{did, seq, time}` — no handle —
+        so the gate was always false and `ingest_identity_update` never ran.
+        the shape below matches a live jetstream payload.
+        """
         consumer = JetstreamConsumer()
         consumer._known_dids = {"did:plc:jetstream_test"}
 
@@ -227,15 +233,14 @@ class TestJetstreamConsumer:
             "kind": "identity",
             "did": "did:plc:jetstream_test",
             "time_us": 2000000,
-            "identity": {"handle": "new.handle.example"},
+            "identity": {"seq": 31115825625, "time": "2026-06-20T18:11:39.496Z"},
         }
 
         with patch("backend._internal.jetstream.get_docket", return_value=mock_docket):
             await consumer._process_event(event)
 
         assert len(dispatched) == 1
-        assert dispatched[0]["did"] == "did:plc:jetstream_test"
-        assert dispatched[0]["handle"] == "new.handle.example"
+        assert dispatched[0] == {"did": "did:plc:jetstream_test"}
         assert consumer._cursor == 2000000
 
     async def test_identity_event_skips_unknown_did(self) -> None:
@@ -248,7 +253,7 @@ class TestJetstreamConsumer:
         event = {
             "kind": "identity",
             "did": "did:plc:unknown",
-            "identity": {"handle": "new.handle"},
+            "identity": {"seq": 1, "time": "2026-06-20T18:11:39.496Z"},
         }
 
         with patch("backend._internal.jetstream.get_docket", return_value=mock_docket):
@@ -321,24 +326,6 @@ class TestJetstreamConsumer:
         """passing collections explicitly bypasses settings."""
         consumer = JetstreamConsumer(collections=["fm.plyr.dev.track"])
         assert consumer._collections == ["fm.plyr.dev.track"]
-
-
-class TestConsumeJetstreamPerpetual:
-    async def test_cancels_perpetual_when_disabled(self) -> None:
-        perpetual = Perpetual(every=timedelta(seconds=0))
-        with patch("backend._internal.jetstream.settings") as mock_settings:
-            mock_settings.jetstream.enabled = False
-            await consume_jetstream(perpetual=perpetual)
-        assert perpetual.cancelled
-
-    async def test_runs_consumer_when_enabled(self) -> None:
-        with (
-            patch("backend._internal.jetstream.settings") as mock_settings,
-            patch.object(JetstreamConsumer, "run", new_callable=AsyncMock) as mock_run,
-        ):
-            mock_settings.jetstream.enabled = True
-            await consume_jetstream()
-            mock_run.assert_called_once()
 
 
 # --- track ingestion tests ---
@@ -1690,27 +1677,39 @@ class TestGhostTrackPrevention:
 # --- identity update tests ---
 
 
-def _mock_did_resolver(pds_url: str = "https://pds.example.com") -> AsyncMock:
-    """create a mock AsyncDidResolver that returns the given PDS URL."""
-    mock_resolver = AsyncMock()
-    mock_data = MagicMock()
-    mock_data.pds = pds_url
-    mock_resolver.resolve_atproto_data = AsyncMock(return_value=mock_data)
-    return mock_resolver
-
-
 def _patch_identity_update(
-    pds_url: str = "https://pds.example.com",
+    *,
+    handle: str | None = None,
+    pds: str = "https://pds.example.com",
     avatar_url: str | None = None,
+    mini_doc_none: bool = False,
 ):
-    """context manager stack for patching DID resolution + avatar fetch."""
+    """context manager stack for patching slingshot resolution + avatar fetch.
+
+    by default the resolved miniDoc keeps the artist's current handle (caller
+    overrides `handle` to simulate a change). `mini_doc_none=True` simulates a
+    slingshot failure (the safe resolver returns None).
+    """
     from contextlib import ExitStack
 
+    from backend._internal.slingshot import MiniDoc
+
     stack = ExitStack()
+    mini_doc = (
+        None
+        if mini_doc_none
+        else MiniDoc(
+            did="did:plc:ignored",
+            handle=handle or "",
+            pds=pds,
+            signing_key="zkey",
+        )
+    )
     stack.enter_context(
         patch(
-            "atproto_identity.did.resolver.AsyncDidResolver",
-            return_value=_mock_did_resolver(pds_url=pds_url),
+            "backend._internal.slingshot.resolve_mini_doc_safe",
+            new_callable=AsyncMock,
+            return_value=mini_doc,
         )
     )
     stack.enter_context(
@@ -1728,8 +1727,8 @@ class TestIngestIdentityUpdate:
         self, db_session: AsyncSession, artist: Artist
     ) -> None:
         new_handle = "updated.handle.example"
-        with _patch_identity_update():
-            await ingest_identity_update(did=artist.did, handle=new_handle)
+        with _patch_identity_update(handle=new_handle):
+            await ingest_identity_update(did=artist.did)
 
         await db_session.refresh(artist)
         assert artist.handle == new_handle
@@ -1747,8 +1746,8 @@ class TestIngestIdentityUpdate:
         await db_session.commit()
 
         new_handle = "updated.handle.example"
-        with _patch_identity_update():
-            await ingest_identity_update(did=artist.did, handle=new_handle)
+        with _patch_identity_update(handle=new_handle):
+            await ingest_identity_update(did=artist.did)
 
         await db_session.refresh(session)
         assert session.handle == new_handle
@@ -1756,10 +1755,10 @@ class TestIngestIdentityUpdate:
     async def test_updates_pds_url(
         self, db_session: AsyncSession, artist: Artist
     ) -> None:
-        """PDS migration updates the cached pds_url via DID resolution."""
+        """PDS migration updates the cached pds_url via slingshot resolution."""
         new_pds = "https://new-pds.example.com"
-        with _patch_identity_update(pds_url=new_pds):
-            await ingest_identity_update(did=artist.did, handle=artist.handle)
+        with _patch_identity_update(handle=artist.handle, pds=new_pds):
+            await ingest_identity_update(did=artist.did)
 
         await db_session.refresh(artist)
         assert artist.pds_url == new_pds
@@ -1769,8 +1768,8 @@ class TestIngestIdentityUpdate:
     ) -> None:
         """identity event refreshes avatar from Bluesky profile."""
         new_avatar = "https://cdn.bsky.app/img/avatar/plain/did:plc:test/newcid@jpeg"
-        with _patch_identity_update(avatar_url=new_avatar):
-            await ingest_identity_update(did=artist.did, handle=artist.handle)
+        with _patch_identity_update(handle=artist.handle, avatar_url=new_avatar):
+            await ingest_identity_update(did=artist.did)
 
         await db_session.refresh(artist)
         assert artist.avatar_url == new_avatar
@@ -1783,10 +1782,11 @@ class TestIngestIdentityUpdate:
         original_pds = artist.pds_url
         original_avatar = artist.avatar_url
         with _patch_identity_update(
-            pds_url=original_pds or "",
+            handle=original_handle,
+            pds=original_pds or "",
             avatar_url=original_avatar,
         ):
-            await ingest_identity_update(did=artist.did, handle=original_handle)
+            await ingest_identity_update(did=artist.did)
 
         await db_session.refresh(artist)
         assert artist.handle == original_handle
@@ -1794,33 +1794,22 @@ class TestIngestIdentityUpdate:
         assert artist.avatar_url == original_avatar
 
     async def test_noop_for_unknown_did(self, db_session: AsyncSession) -> None:
-        """unknown DID is silently skipped (no DID resolution attempted)."""
-        await ingest_identity_update(did="did:plc:nonexistent", handle="ghost.handle")
+        """unknown DID is silently skipped (no resolution attempted)."""
+        await ingest_identity_update(did="did:plc:nonexistent")
 
-    async def test_did_resolution_failure_still_updates_handle(
+    async def test_resolution_failure_still_refreshes_avatar(
         self, db_session: AsyncSession, artist: Artist
     ) -> None:
-        """if DID resolution fails, handle and avatar are still updated."""
-        new_handle = "updated.handle.example"
-        mock_resolver = AsyncMock()
-        mock_resolver.resolve_atproto_data = AsyncMock(
-            side_effect=Exception("resolution failed")
-        )
-        with (
-            patch(
-                "atproto_identity.did.resolver.AsyncDidResolver",
-                return_value=mock_resolver,
-            ),
-            patch(
-                "backend._internal.atproto.profile.fetch_user_avatar",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-        ):
-            await ingest_identity_update(did=artist.did, handle=new_handle)
+        """if slingshot resolution fails, handle/PDS are left alone but the
+        avatar still refreshes — a partial failure doesn't block the rest."""
+        new_avatar = "https://cdn.bsky.app/img/avatar/plain/did:plc:test/fresh@jpeg"
+        original_handle = artist.handle
+        with _patch_identity_update(mini_doc_none=True, avatar_url=new_avatar):
+            await ingest_identity_update(did=artist.did)
 
         await db_session.refresh(artist)
-        assert artist.handle == new_handle
+        assert artist.handle == original_handle
+        assert artist.avatar_url == new_avatar
 
 
 class TestIngestAccountStatusChange:

--- a/backend/tests/test_slingshot.py
+++ b/backend/tests/test_slingshot.py
@@ -1,0 +1,86 @@
+"""tests for the slingshot identity-resolution client."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend._internal.slingshot import resolve_mini_doc, resolve_mini_doc_safe
+
+# a real resolveMiniDoc response shape (verified against the live service).
+_MINI_DOC = {
+    "did": "did:plc:ygja2cua5eieiepwctxyopcx",
+    "handle": "herbs.teal.town",
+    "pds": "https://teal.town",
+    "signing_key": "zQ3shrePBffzGZv3tEbDyRrBuget7ReqrsEQqRNSQadpkGKsP",
+}
+
+
+class TestResolveMiniDoc:
+    async def test_parses_response(self) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = _MINI_DOC
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("backend._internal.slingshot.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            doc = await resolve_mini_doc(_MINI_DOC["did"])
+
+        assert doc["handle"] == "herbs.teal.town"
+        assert doc["pds"] == "https://teal.town"
+
+    async def test_calls_resolvemini_doc_endpoint_with_identifier(self) -> None:
+        """guards the endpoint contract: the NSID path and `identifier` param.
+
+        slingshot rejects `did=` — the param must be `identifier`.
+        """
+        mock_response = MagicMock()
+        mock_response.json.return_value = _MINI_DOC
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("backend._internal.slingshot.httpx.AsyncClient") as mock_client:
+            mock_get = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.get = mock_get
+            await resolve_mini_doc(_MINI_DOC["did"])
+
+        args, kwargs = mock_get.call_args
+        assert args[0] == (
+            "https://slingshot.microcosm.blue"
+            "/xrpc/com.bad-example.identity.resolveMiniDoc"
+        )
+        assert kwargs["params"] == {"identifier": _MINI_DOC["did"]}
+
+    async def test_raises_on_http_error(self) -> None:
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = Exception("500 error")
+
+        with patch("backend._internal.slingshot.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            with pytest.raises(Exception, match="500 error"):
+                await resolve_mini_doc(_MINI_DOC["did"])
+
+
+class TestResolveMiniDocSafe:
+    async def test_returns_doc_on_success(self) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = _MINI_DOC
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("backend._internal.slingshot.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            doc = await resolve_mini_doc_safe(_MINI_DOC["did"])
+
+        assert doc is not None
+        assert doc["handle"] == "herbs.teal.town"
+
+    async def test_returns_none_on_error(self) -> None:
+        with patch("backend._internal.slingshot.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                side_effect=Exception("connection failed")
+            )
+            assert await resolve_mini_doc_safe(_MINI_DOC["did"]) is None

--- a/docs/internal/runbooks/worker-silence-alert.md
+++ b/docs/internal/runbooks/worker-silence-alert.md
@@ -24,8 +24,11 @@ the worker is unhealthy if **both** of these are true in the same window:
 1. the HTTP API is alive (so we know the system isn't fully down) — at
    least one successful `POST /tracks/` in the window
 2. the worker emitted zero task-execution spans
-   (`run_track_upload`, `consume_jetstream`, `sync_copyright_resolutions`,
+   (`run_track_upload`, `sync_copyright_resolutions`,
    `scrobble_to_teal`, `warm_follow_graph`)
+
+   (the jetstream consumer no longer runs on the worker — it has its own
+   `jetstream` process group; see `backend/jetstream.py`.)
 
 condition (1) prevents the alert from firing during a planned full-stack
 deploy. condition (2) is the actual silence we care about. when nobody
@@ -57,7 +60,6 @@ SELECT
   COUNT(*) FILTER (
     WHERE attributes->>'docket.task' IN (
       'run_track_upload',
-      'consume_jetstream',
       'sync_copyright_resolutions',
       'scrobble_to_teal',
       'warm_follow_graph'


### PR DESCRIPTION
Handle changes never propagated. A user who renamed their atproto handle kept the **old** handle on their public plyr profile while the portal showed the **new** one — because jetstream `#identity` events carry no handle, and the consumer was gating dispatch on a handle field the firehose never sends. Reported in [tangled issue #5](https://tangled.org/zzstoatzz.io/plyr.fm/issues/5) (`luminousherbs.bsky.social` → `herbs.teal.town`).

## root cause

`#identity` events are only a signal to re-resolve — the payload is just `{did, seq, time}` (verified against the live firehose). The consumer gated dispatch on `identity.handle` being truthy:

```python
handle = (event.get("identity") or {}).get("handle")   # always None
if did and handle and did in self._known_dids:          # always False
```

So `ingest_identity_update` **had never run for anyone** — 0 dispatches in 2 weeks of telemetry while commit events flowed normally. The portal looked correct only because the *session* handle refreshes at login; `Artist.handle` (which `/u/<handle>` → `/artists/by-handle` is keyed on) only ever updated via this dead firehose path.

<details>
<summary>how the asymmetry produces the exact symptom</summary>

- public profile `/u/<handle>` resolves via `/artists/by-handle/{handle}` → `Artist.handle` (stale → old handle works, new 404s)
- portal reads `auth.user.handle` ← `UserSession.handle` (refreshed at login → new handle)
- DB confirmed: row still had old handle **and** old PDS; PLC directory + slingshot both confirm current identity is `herbs.teal.town` / `teal.town`.
</details>

## fix

- **jetstream**: dispatch identity events on `did in known_dids` alone.
- **`ingest_identity_update(did)`**: resolve the current **verified** handle + PDS from microcosm **slingshot** (`com.bad-example.identity.resolveMiniDoc`, bidirectionally verified) instead of trusting the event. Drops the `handle` param and the separate `AsyncDidResolver` PDS lookup (slingshot returns both).
- new `_internal/slingshot.py` client, mirroring the existing `constellation.py` microcosm client.
- **regression test**: feeds a real handle-less identity event through `_process_event` and asserts it dispatches. The previous test fabricated `identity.handle` — a value the firehose never sends — so it passed against a fiction. Verified the new test fails when the gate is reintroduced.

## also: jetstream consumer → its own process group

The consumer ran as a docket task inside the `worker` process, sharing one event loop with blocking/CPU-heavy tasks (copyright scans, genre classification, exports). When those starved the WebSocket keepalive, the connection dropped — **median lifetime 52s, ~590 reconnects/week**. On its own quiet loop it stays connected (verified standalone: survives indefinitely under the same `wantedCollections` config).

- new `backend/jetstream.py` entrypoint (docket **client** only — it enqueues ingest tasks; the `worker` drains them) + `jetstream` fly process group (512mb, always-restart).
- removed the `consume_jetstream` perpetual task from the worker registry; updated the worker-silence runbook.

**Intentional non-behaviors / deploy notes:**
- Run a **single** jetstream machine. Two consumers would double-process the firehose — ingest tasks are idempotent, so it's wasteful, not unsafe.
- The pre-existing reporter's row self-heals on their next `#identity` event (or login-triggered identity activity); no unilateral backfill of their data.
- Slingshot is the same microcosm ecosystem we already depend on (constellation). If it's down, `resolve_mini_doc_safe` logs and no-ops that refresh (handle stays as-is until the next event).

## test
- `just backend test` — 1203 passed, 24 skipped.
- new `tests/test_slingshot.py` guards the endpoint/param contract (`identifier=`, not `did=`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)