### PR TITLE
fix(jetstream): correct VM memory (1gb) + add the process group to staging

### DIFF
--- a/backend/fly.staging.toml
+++ b/backend/fly.staging.toml
@@ -30,6 +30,9 @@ primary_region = 'iad'
 [processes]
   app = "uv run --no-sync uvicorn backend.main:app --host 0.0.0.0 --port 8000"
   worker = "uv run --no-sync python -m backend.worker"
+  # mirrors backend/fly.toml — the jetstream consumer runs on its own event
+  # loop, isolated from the worker's blocking tasks. keep at a single machine.
+  jetstream = "uv run --no-sync python -m backend.jetstream"
 
 [http_service]
   internal_port = 8000
@@ -63,6 +66,14 @@ primary_region = 'iad'
   cpu_kind = 'shared'
   cpus = 1
 
+# the docket client registers the full task collection at startup, pulling in
+# the whole backend import graph (~400MB RSS) — 512mb OOM-crash-loops, so 1gb.
+[[vm]]
+  processes = ['jetstream']
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+
 # always restart the worker on exit, with no retry budget. mirrors prod
 # fly.toml — staging needs the same restart policy so the silence /
 # crash-loop alerts can be smoke-tested against staging before going to
@@ -70,6 +81,10 @@ primary_region = 'iad'
 [[restart]]
   policy = "always"
   processes = ["worker"]
+
+[[restart]]
+  policy = "always"
+  processes = ["jetstream"]
 
 # secrets to set via: fly secrets set KEY=value -a relay-api-staging
 # - DATABASE_URL (neon postgres connection string)

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -58,11 +58,13 @@ primary_region = 'iad'
   cpu_kind = 'shared'
   cpus = 1
 
-# `jetstream` only holds a WebSocket + enqueues ingest tasks — no audio
-# processing, so it needs little memory.
+# `jetstream` only holds a WebSocket + enqueues ingest tasks at runtime, but
+# the docket client registers the full task collection at startup, which pulls
+# in the whole backend import graph (~400MB RSS) — same reason `app` needs 1gb.
+# 512mb OOM-crash-looped on first deploy (2026-06-20).
 [[vm]]
   processes = ['jetstream']
-  memory = '512mb'
+  memory = '1gb'
   cpu_kind = 'shared'
   cpus = 1
 


### PR DESCRIPTION
Follow-up to #1603, fixing two deploy-config gaps found while shipping it to prod.

**1. 512mb OOM-crash-looped (prod).** The dedicated `jetstream` process OOM-killed on first deploy — the docket client registers the full task collection at startup, pulling in the whole backend (~400MB RSS), the same reason `app` runs at 1gb. Already mitigated live via `fly scale memory 1024 --group jetstream` (consumer is now stable — connected once, no reconnect churn); this makes 1gb durable so the next deploy doesn't reset it.

**2. staging had no jetstream group at all.** #1603 removed `consume_jetstream` from the worker but only added the process group to prod `fly.toml`. `fly.staging.toml` never got it, so on staging the consumer ran nowhere and firehose ingest silently stopped. This adds the mirrored group (1gb, always-restart, singleton).

Both fly configs now define `jetstream` consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)