### PR TITLE
fix(radio): use the shared WaveLoading loader while tuning

### DIFF
--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -9,6 +9,7 @@
 	import { radio } from '$lib/radio.svelte';
 	import { horizontalSwipe } from '$lib/horizontal-swipe';
 	import TunerDial from '$lib/components/radio/TunerDial.svelte';
+	import WaveLoading from '$lib/components/WaveLoading.svelte';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
 	import LikeButton from '$lib/components/LikeButton.svelte';
 	import type { PageData } from './$types';
@@ -132,7 +133,7 @@
 	<div class="tuner">
 	<section class="station">
 		{#if radio.loading && !radio.state}
-			<div class="status">tuning...</div>
+			<div class="status"><WaveLoading size="lg" message="tuning..." /></div>
 		{:else if radio.error}
 			<div class="status error">{radio.error}</div>
 		{:else if radio.current}

--- a/loq.toml
+++ b/loq.toml
@@ -328,7 +328,7 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/[[][[]station[]][]]/+page.svelte"
-max_lines = 947
+max_lines = 948
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"


### PR DESCRIPTION
Swaps the bare, awkwardly-placed `tuning...` text on `/radio` for the animated `WaveLoading` bars used everywhere else in the app, so the initial-tune state is consistent with the home feed, activity, portal, settings, and costs loaders.

<details>
<summary>details</summary>

- `+page.svelte`: the `radio.loading && !radio.state` branch now renders `<WaveLoading size="lg" message="tuning..." />` instead of a plain `<div class="status">tuning...</div>`. The error branch is unchanged.
- `WaveLoading` centers itself; `.station` is already a centered flex column, so the loader sits centered rather than floating in the corner.
- Relaxed the loq limit for the file by 1 (the added import) — no golfing.

Verified: `just frontend check` (0 errors / 0 warnings), `uvx loq` clean.