### PR TITLE
fix(frontend): keep client logos transparent with a theme-aware contrast halo

### DIFF
--- a/frontend/src/lib/components/ClientLogo.svelte
+++ b/frontend/src/lib/components/ClientLogo.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import type { AtClient } from '$lib/atclients';
+
+	let { client, size = 20 }: { client: AtClient; size?: number } = $props();
+</script>
+
+<!--
+	external client logos ship as transparent marks in arbitrary colors. instead of
+	flattening them onto an opaque white tile (looks bad, and breaks at rounded edges),
+	we keep them transparent and give each mark a theme-aware halo so it always clears
+	the WCAG 1.4.11 non-text contrast bar (3:1) against the surface — a light halo on
+	dark, a dark halo on light. handles the hard case (blacksky's black mark on dark).
+-->
+<img
+	class="client-logo"
+	src={client.iconUrl}
+	alt=""
+	width={size}
+	height={size}
+	loading="lazy"
+/>
+
+<style>
+	.client-logo {
+		object-fit: contain;
+		/* dark theme (default): light halo */
+		filter: drop-shadow(0 0 0.5px rgba(255, 255, 255, 0.9))
+			drop-shadow(0 0 1.5px rgba(255, 255, 255, 0.55));
+	}
+
+	:global(:root.theme-light) .client-logo {
+		/* light theme: dark halo */
+		filter: drop-shadow(0 0 0.5px rgba(0, 0, 0, 0.75))
+			drop-shadow(0 0 1.5px rgba(0, 0, 0, 0.4));
+	}
+</style>

--- a/frontend/src/lib/components/LinksMenu.svelte
+++ b/frontend/src/lib/components/LinksMenu.svelte
@@ -3,6 +3,7 @@
 	import PlatformStats from './PlatformStats.svelte';
 	import { feedback } from '$lib/feedback.svelte';
 	import { getPreferredClient } from '$lib/atclients';
+	import ClientLogo from './ClientLogo.svelte';
 
 	let showMenu = $state(false);
 	let client = $derived(getPreferredClient());
@@ -83,7 +84,7 @@
 					rel="noopener noreferrer"
 					class="menu-link"
 				>
-					<img src={client.iconUrl} alt="" width="24" height="24" class="menu-icon-img" />
+					<ClientLogo {client} size={24} />
 					<div class="link-info">
 						<span class="link-title">profile</span>
 						<span class="link-subtitle">@plyr.fm on {client.label}</span>
@@ -320,19 +321,6 @@
 
 	.menu-link:hover svg {
 		color: var(--accent);
-	}
-
-	.menu-icon-img {
-		/* light tile so any client logo (e.g. blacksky's black mark) stays legible */
-		border-radius: var(--radius-sm);
-		background: #fff;
-		padding: 2px;
-		box-sizing: border-box;
-		transition: box-shadow 0.2s;
-	}
-
-	.menu-link:hover .menu-icon-img {
-		box-shadow: 0 0 0 2px var(--accent);
 	}
 
 	.link-info {

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -9,6 +9,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 	import { auth } from '$lib/auth.svelte';
 	import { preferences, FONT_OPTIONS, type Theme, type FontFamily } from '$lib/preferences.svelte';
 	import { AT_CLIENTS, DEFAULT_AT_CLIENT } from '$lib/atclients';
+	import ClientLogo from '$lib/components/ClientLogo.svelte';
 	import { ambient } from '$lib/ambient.svelte';
 	import { getReturnUrl, clearReturnUrl } from '$lib/utils/return-url';
 
@@ -739,7 +740,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 								onclick={() => selectClient(client.value)}
 								title={client.label}
 							>
-								<img src={client.iconUrl} alt="" width="20" height="20" loading="lazy" />
+								<ClientLogo {client} size={20} />
 								<span>{client.label}</span>
 							</button>
 						{/each}
@@ -1249,18 +1250,6 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		background: color-mix(in srgb, var(--accent) 15%, transparent);
 		border-color: var(--accent);
 		color: var(--accent);
-	}
-
-	.client-btn img {
-		/* external client logos have arbitrary/transparent backgrounds (blacksky's
-		   mark is black and vanishes on dark) — sit them on a constant light tile so
-		   they stay legible in every theme */
-		width: 24px;
-		height: 24px;
-		padding: 2px;
-		box-sizing: border-box;
-		border-radius: var(--radius-sm);
-		background: #fff;
 	}
 
 	.client-btn span {


### PR DESCRIPTION
The client logos in the "open links in" picker (and the links-menu profile card) sat on an opaque white tile so dark marks stayed legible — but the white box looks bad in both themes and clips at the rounded corners. This keeps the marks transparent and gives each one a theme-aware contrast halo instead.

![logos in both themes](N/A)

## what changed
- new shared `ClientLogo.svelte` — renders the mark transparent with a theme-aware `drop-shadow` halo (light halo on dark, dark halo on light). Used by both the settings picker (20px) and the links-menu profile card (24px), so the treatment is consistent anywhere a client logo shows.
- removed the `background: #fff` tile + hover box-shadow from both call sites.

## why a halo
The marks are external raster icons in arbitrary colors (mid-tone butterfly, black starburst, red star, …), so we can't recolor them. A halo is the only treatment that keeps full transparency while guaranteeing the mark separates from the surface regardless of its intrinsic luminance — it targets **WCAG 1.4.11 non-text contrast (3:1)** for graphical objects, the standard the white tile was crudely approximating.

<details>
<summary>verification + deferred scope</summary>

- Validated all five marks (bluesky / blacksky / witchsky / red dwarf / pdsls) against the **live icon URLs** in a standalone harness, dark + light. blacksky's solid-black starburst on dark is the hard case and reads cleanly with the light halo. The shipped CSS uses the same filter values.
- `svelte-check`, `eslint`, `loq` all clean.
- **Deferred (intentional)**: a broad, tokenized contrast pass across the rest of the app is out of scope — this fixes the one surface where intrinsic-color logos meet the theme background. Calling that out per the "punt broadly, fix it properly here" framing.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)