### PR TITLE
fix(frontend): soften client-logo halo to a thin keyline (no glow)

### DIFF
--- a/frontend/src/lib/components/ClientLogo.svelte
+++ b/frontend/src/lib/components/ClientLogo.svelte
@@ -7,9 +7,11 @@
 <!--
 	external client logos ship as transparent marks in arbitrary colors. instead of
 	flattening them onto an opaque white tile (looks bad, and breaks at rounded edges),
-	we keep them transparent and give each mark a theme-aware halo so it always clears
-	the WCAG 1.4.11 non-text contrast bar (3:1) against the surface — a light halo on
-	dark, a dark halo on light. handles the hard case (blacksky's black mark on dark).
+	we keep them transparent and trace each mark with a thin theme-aware keyline so it
+	clears the WCAG 1.4.11 non-text contrast bar (3:1) against the surface — light on
+	dark, dark on light. a crisp hard-edge outline (no blur) rather than a soft glow:
+	it contours the mark without bleeding into its negative space, so fine marks like
+	blacksky's starburst stay legible without looking distorted.
 -->
 <img
 	class="client-logo"
@@ -23,14 +25,18 @@
 <style>
 	.client-logo {
 		object-fit: contain;
-		/* dark theme (default): light halo */
-		filter: drop-shadow(0 0 0.5px rgba(255, 255, 255, 0.9))
-			drop-shadow(0 0 1.5px rgba(255, 255, 255, 0.55));
+		/* dark theme (default): thin light keyline */
+		filter: drop-shadow(0.5px 0 0 rgba(255, 255, 255, 0.5))
+			drop-shadow(-0.5px 0 0 rgba(255, 255, 255, 0.5))
+			drop-shadow(0 0.5px 0 rgba(255, 255, 255, 0.5))
+			drop-shadow(0 -0.5px 0 rgba(255, 255, 255, 0.5));
 	}
 
 	:global(:root.theme-light) .client-logo {
-		/* light theme: dark halo */
-		filter: drop-shadow(0 0 0.5px rgba(0, 0, 0, 0.75))
-			drop-shadow(0 0 1.5px rgba(0, 0, 0, 0.4));
+		/* light theme: thin dark keyline */
+		filter: drop-shadow(0.5px 0 0 rgba(0, 0, 0, 0.4))
+			drop-shadow(-0.5px 0 0 rgba(0, 0, 0, 0.4))
+			drop-shadow(0 0.5px 0 rgba(0, 0, 0, 0.4))
+			drop-shadow(0 -0.5px 0 rgba(0, 0, 0, 0.4));
 	}
 </style>


### PR DESCRIPTION
Fast-follow on #1608. The soft blurred halo glowed and bled into the negative space of fine marks (blacksky's starburst), distorting them — it read like we were defacing the other clients' branding.

Swap the soft glow for a crisp **hard-edge keyline**: four `0.5px` zero-blur drop-shadows at half opacity that *contour* the mark instead of glowing around it. Still clears WCAG 1.4.11 (3:1) non-text contrast against the surface (light keyline on dark, dark on light), but leaves the logo shape — and especially the already-contrasting colored marks — visibly untouched.

Validated all marks against the live icon URLs; blacksky on dark reads cleanly without the gaps filling in. `svelte-check` / `eslint` / `loq` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)