### PR TITLE
fix(album): return 409 on album rename slug collision instead of 500

### DIFF
--- a/backend/src/backend/api/albums/mutations.py
+++ b/backend/src/backend/api/albums/mutations.py
@@ -386,10 +386,29 @@ async def update_album(
     title_changed = title is not None and title.strip() != old_title
 
     if title is not None:
-        album.title = title.strip()
         # sync slug when title changes so get_or_create_album lookups work
         if title_changed:
-            album.slug = slugify(title.strip())
+            new_slug = slugify(title.strip())
+            # another of this artist's albums may already own the new slug.
+            # without this guard the (artist_did, slug) unique constraint
+            # surfaces as an unhandled 500 at commit, and only after the
+            # ATProto record sync below has run. reject the collision here,
+            # before mutating the album, like create_album's matching guard.
+            if new_slug != old_slug:
+                slug_owner = await db.execute(
+                    select(Album).where(
+                        Album.artist_did == album.artist_did,
+                        Album.slug == new_slug,
+                        Album.id != album_id,
+                    )
+                )
+                if slug_owner.scalar_one_or_none() is not None:
+                    raise HTTPException(
+                        status_code=409,
+                        detail="another of your albums already uses that name",
+                    )
+            album.slug = new_slug
+        album.title = title.strip()
     if description is not None:
         album.description = description.strip() if description.strip() else None
 
@@ -440,7 +459,17 @@ async def update_album(
             )
             album.atproto_record_cid = new_list_cid
 
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError:
+        # a concurrent rename can take the same (artist_did, slug) while the
+        # ATProto sync above is in flight. surface the same 409 the pre-check
+        # returns instead of an unhandled 500.
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="another of your albums already uses that name",
+        ) from None
 
     # invalidate cache for old slug (new slug will be a cache miss)
     await invalidate_album_cache(auth_session.handle, old_slug)

--- a/backend/tests/api/test_albums.py
+++ b/backend/tests/api/test_albums.py
@@ -722,6 +722,95 @@ async def test_update_album_title(test_app: FastAPI, db_session: AsyncSession):
         assert updated_album.atproto_record_cid == "new_list_cid"
 
 
+async def test_update_album_title_slug_collision_returns_409(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    """renaming an album onto another album's slug returns a 409, not a 500.
+
+    regression for the (artist_did, slug) unique constraint surfacing as an
+    unhandled UniqueViolation. the artist already has an album at slug
+    "test-albumz", so renaming a second album to a title that slugifies to the
+    same value is rejected with a detail the client can toast instead of 500ing
+    at commit. the ATProto record sync must not run before the rejection.
+    """
+    artist = Artist(
+        did="did:test:user123",
+        handle="test.artist",
+        display_name="Test Artist",
+    )
+    db_session.add(artist)
+    await db_session.flush()
+
+    # existing album already owns the target slug
+    occupying = Album(
+        artist_did=artist.did,
+        slug="test-albumz",
+        title="Test Albumz",
+    )
+    # the album being renamed onto that slug
+    renamed = Album(
+        artist_did=artist.did,
+        slug="demo",
+        title="Demo",
+    )
+    db_session.add_all([occupying, renamed])
+    await db_session.flush()
+
+    # give the renamed album a track with an ATProto record. without the
+    # collision pre-check, update_record would be called before the failing
+    # commit, so asserting it is not called proves the short-circuit.
+    track = Track(
+        title="Demo Track",
+        file_id="test-file-collision",
+        file_type="mp3",
+        artist_did=artist.did,
+        album_id=renamed.id,
+        extra={"album": "Demo"},
+        r2_url="https://r2.example.com/audio/test-file-collision.mp3",
+        atproto_record_uri="at://did:test:user123/fm.plyr.track/collision",
+        atproto_record_cid="collision_cid",
+    )
+    db_session.add(track)
+    await db_session.commit()
+
+    renamed_id = renamed.id
+
+    with (
+        patch(
+            "backend.api.albums.mutations.update_record",
+            new_callable=AsyncMock,
+        ) as mock_track_update,
+        patch(
+            "backend.api.albums.mutations.update_list_record",
+            new_callable=AsyncMock,
+        ) as mock_list_update,
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.patch(f"/albums/{renamed_id}?title=Test%20Albumz")
+
+    assert response.status_code == 409
+    assert (
+        response.json()["detail"] == "another of your albums already uses that name"
+    )
+    # the collision is rejected before any ATProto work happens
+    mock_track_update.assert_not_called()
+    mock_list_update.assert_not_called()
+
+    # the rename was rejected cleanly, so title and slug are unchanged
+    from backend.utilities.database import get_engine
+
+    engine = get_engine()
+    async with AsyncSession(engine, expire_on_commit=False) as fresh_session:
+        result = await fresh_session.execute(
+            select(Album).where(Album.id == renamed_id)
+        )
+        unchanged = result.scalar_one()
+        assert unchanged.title == "Demo"
+        assert unchanged.slug == "demo"
+
+
 async def test_update_album_forbidden_for_non_owner(
     test_app: FastAPI, db_session: AsyncSession
 ):


### PR DESCRIPTION
fixes #1580.

renaming an album via `PATCH /albums/{id}?title=...` re-derives the slug from the new title with no collision check. when the new slug matches another of the artist's albums, the `uq_albums_artist_slug` constraint raises a `UniqueViolation` at `db.commit()`, which surfaces as an unhandled 500. the browser sees it as `net::ERR_FAILED` because the error response has no CORS headers. the commit also fails after the ATProto record sync has run, so the remote records are rewritten to the new title before the request fails.

## fix

`update_album` now checks for a slug collision before mutating the album or doing any ATProto work, and returns a 409 with a `detail` the client can toast ("another of your albums already uses that name"). this reuses the same `(artist_did, slug)` guard `create_album` has, except update rejects the conflict instead of returning the existing row, since returning a different album from a rename would be surprising. an `IntegrityError` handler around the commit covers the concurrent-rename race, whose window spans the ATProto network calls.

behavior is unchanged when the new title slugifies to the same slug, to a free slug, or when only the description changes.

## test

`test_update_album_title_slug_collision_returns_409` sets up two albums and renames one onto the other's slug. it asserts a 409 with the detail, that the ATProto sync does not run (the renamed album has a track with an atproto record, so `update_record` would be called without the fix, and the test asserts it is not), and that the album's title and slug are left unchanged. the existing `test_update_album_title` still covers the happy path.

## out of scope

the issue's related observation, that a rename re-slugs the album and breaks its existing `/u/{handle}/album/{old-slug}` URL, is a product decision (de-dup vs. reject vs. keep the old slug), so it is not addressed here. i can follow up once you decide the direction.

disclosure: this change was AI-assisted, written with claude opus 4.8 in claude code (ultracode) and reviewed by codex.
