### PR TITLE
fix(copyright): clear flags only on explicit negation, not absent labels (#1602)

### DIFF
--- a/backend/src/backend/_internal/clients/moderation.py
+++ b/backend/src/backend/_internal/clients/moderation.py
@@ -399,6 +399,51 @@ class ModerationClient:
             )
             return set(uris)
 
+    async def get_negated_labels(self, uris: list[str]) -> set[str]:
+        """check which URIs have an explicit negation (dismissal) label.
+
+        a negation is the only thing that resolves a copyright flag: it means a
+        moderator reviewed the flag and dismissed it. absence of an *active*
+        label is NOT a resolution — post-#703 a scan never auto-emits a label,
+        so flagged-but-never-reviewed tracks have no label at all and must stay
+        flagged (#1602).
+
+        fails closed by returning an EMPTY set (resolve nothing) if the labeler
+        is unreachable — the opposite direction from `get_active_labels`, so an
+        outage can never silently clear a flag.
+
+        args:
+            uris: list of AT URIs to check
+
+        returns:
+            set of URIs that have been explicitly negated
+        """
+        if not uris:
+            return set()
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.post(
+                    f"{self.labeler_url}/admin/negated-labels",
+                    json={"uris": uris},
+                    headers=self._headers(),
+                )
+                response.raise_for_status()
+                data = response.json()
+                negated_uris = set(data.get("negated_uris", []))
+
+                logfire.info(
+                    "checked negated copyright labels",
+                    total_uris=len(uris),
+                    negated_count=len(negated_uris),
+                )
+                return negated_uris
+
+        except Exception as e:
+            # fail closed: if we can't confirm a negation, resolve nothing
+            logger.warning("failed to check negated labels, resolving nothing: %s", e)
+            return set()
+
     async def _cache_label_status(self, uris: list[str], active_uris: set[str]) -> None:
         """cache label status in redis."""
         try:

--- a/backend/src/backend/_internal/tasks/copyright.py
+++ b/backend/src/backend/_internal/tasks/copyright.py
@@ -38,10 +38,12 @@ async def sync_copyright_resolutions(
 ) -> None:
     """sync resolution status from labeler to backend database.
 
-    finds tracks that are flagged but have no resolution, checks the labeler
-    to see if the labels were negated (dismissed), and marks them as resolved.
+    finds flagged tracks, asks the labeler which of their URIs were explicitly
+    negated (a moderator dismissed the flag), and clears `is_flagged` for only
+    those. a flag that was never labelled is left alone — post-#703 the scan no
+    longer auto-emits a label, so "no active label" is the normal state of a
+    real flag, not a resolution (#1602).
 
-    this replaces the lazy reconciliation that was happening on read paths.
     runs automatically every 5 minutes via docket's Perpetual.
     """
     from backend._internal.clients.moderation import get_moderation_client
@@ -72,13 +74,12 @@ async def sync_copyright_resolutions(
             return
 
         client = get_moderation_client()
-        active_uris = await client.get_active_labels(list(scan_by_uri.keys()))
+        negated_uris = await client.get_negated_labels(list(scan_by_uri.keys()))
 
-        # find scans that are no longer active (label was negated)
+        # clear flags only for URIs a moderator explicitly negated
         resolved_count = 0
         for uri, scan in scan_by_uri.items():
-            if uri not in active_uris:
-                # label was negated - track is no longer flagged
+            if uri in negated_uris:
                 scan.is_flagged = False
                 resolved_count += 1
 

--- a/backend/tests/test_moderation.py
+++ b/backend/tests/test_moderation.py
@@ -365,7 +365,13 @@ async def test_get_active_copyright_labels_service_error() -> None:
 
 
 async def test_sync_copyright_resolutions(db_session: AsyncSession) -> None:
-    """test that sync_copyright_resolutions updates flagged scans."""
+    """sync clears a flag only when the labeler reports an explicit negation.
+
+    a flag whose URI was never labelled (the common case post-#703, where the
+    scan no longer auto-emits a label) must survive — absence of an active
+    label is NOT a resolution. only a negation label (a moderator dismissal)
+    clears the flag.
+    """
     from backend._internal.tasks import sync_copyright_resolutions
 
     # create test artist and tracks
@@ -377,7 +383,7 @@ async def test_sync_copyright_resolutions(db_session: AsyncSession) -> None:
     db_session.add(artist)
     await db_session.commit()
 
-    # track 1: flagged, will be resolved
+    # track 1: flagged, moderator dismissed it (negation label emitted)
     track1 = Track(
         title="Flagged Track 1",
         file_id="flagged_1",
@@ -388,7 +394,7 @@ async def test_sync_copyright_resolutions(db_session: AsyncSession) -> None:
     )
     db_session.add(track1)
 
-    # track 2: flagged, will stay flagged
+    # track 2: flagged, never labelled — must stay flagged (the #1602 bug)
     track2 = Track(
         title="Flagged Track 2",
         file_id="flagged_2",
@@ -422,9 +428,9 @@ async def test_sync_copyright_resolutions(db_session: AsyncSession) -> None:
         "backend._internal.clients.moderation.get_moderation_client"
     ) as mock_get_client:
         mock_client = AsyncMock()
-        # only track2's URI is still active
-        mock_client.get_active_labels.return_value = {
-            "at://did:plc:synctest/fm.plyr.track/2"
+        # only track1's URI was explicitly negated by a moderator
+        mock_client.get_negated_labels.return_value = {
+            "at://did:plc:synctest/fm.plyr.track/1"
         }
         mock_get_client.return_value = mock_client
 
@@ -437,8 +443,65 @@ async def test_sync_copyright_resolutions(db_session: AsyncSession) -> None:
     # scan1 should no longer be flagged (label was negated)
     assert scan1.is_flagged is False
 
-    # scan2 should still be flagged
+    # scan2 should still be flagged (never labelled — must not be wiped)
     assert scan2.is_flagged is True
+
+
+async def test_sync_copyright_resolutions_keeps_unlabelled_flags(
+    db_session: AsyncSession,
+) -> None:
+    """regression for #1602: with no negations, every flag survives sync.
+
+    the old logic cleared `is_flagged` for any URI absent from the labeler's
+    active-label set. post-#703 a flag never emits a label, so that absence is
+    universal and the 5-minute sync silently wiped every flag.
+    """
+    from backend._internal.tasks import sync_copyright_resolutions
+
+    artist = Artist(
+        did="did:plc:nolabel",
+        handle="nolabel.bsky.social",
+        display_name="No Label User",
+    )
+    db_session.add(artist)
+    await db_session.commit()
+
+    scans: list[CopyrightScan] = []
+    for i in range(3):
+        track = Track(
+            title=f"Unlabelled Flagged Track {i}",
+            file_id=f"unlabelled_{i}",
+            file_type="mp3",
+            artist_did=artist.did,
+            r2_url=f"https://example.com/unlabelled{i}.mp3",
+            atproto_record_uri=f"at://did:plc:nolabel/fm.plyr.track/{i}",
+        )
+        db_session.add(track)
+        await db_session.commit()
+        scan = CopyrightScan(
+            track_id=track.id,
+            is_flagged=True,
+            highest_score=90,
+            matches=[{"artist": "Test", "title": f"Song {i}"}],
+            raw_response={},
+        )
+        db_session.add(scan)
+        scans.append(scan)
+    await db_session.commit()
+
+    with patch(
+        "backend._internal.clients.moderation.get_moderation_client"
+    ) as mock_get_client:
+        mock_client = AsyncMock()
+        # nothing was negated — no moderator has dismissed any flag
+        mock_client.get_negated_labels.return_value = set()
+        mock_get_client.return_value = mock_client
+
+        await sync_copyright_resolutions()
+
+    for scan in scans:
+        await db_session.refresh(scan)
+        assert scan.is_flagged is True
 
 
 # tests for sensitive images

--- a/loq.toml
+++ b/loq.toml
@@ -76,7 +76,7 @@ max_lines = 569
 
 [[rules]]
 path = "backend/tests/test_moderation.py"
-max_lines = 718
+max_lines = 781
 
 [[rules]]
 path = "docs/internal/authentication.md"
@@ -180,11 +180,11 @@ max_lines = 949
 
 [[rules]]
 path = "services/moderation/src/admin.rs"
-max_lines = 688
+max_lines = 716
 
 [[rules]]
 path = "services/moderation/src/db.rs"
-max_lines = 1285
+max_lines = 1297
 
 [[rules]]
 path = "frontend/src/lib/components/FeedbackModal.svelte"

--- a/services/moderation/src/admin.rs
+++ b/services/moderation/src/admin.rs
@@ -104,6 +104,12 @@ pub struct ActiveLabelsResponse {
     pub active_uris: Vec<String>,
 }
 
+/// Response with URIs that have an explicit negation (dismissal) label.
+#[derive(Debug, Serialize)]
+pub struct NegatedLabelsResponse {
+    pub negated_uris: Vec<String>,
+}
+
 /// Request to add a sensitive image.
 #[derive(Debug, Deserialize)]
 pub struct AddSensitiveImageRequest {
@@ -316,6 +322,28 @@ pub async fn get_active_labels(
     );
 
     Ok(Json(ActiveLabelsResponse { active_uris }))
+}
+
+/// Get which URIs have an explicit negation (dismissal) copyright label.
+///
+/// Used by the backend to clear flags only when a moderator dismissed them —
+/// absence of an active label is not a resolution (see backend #1602).
+pub async fn get_negated_labels(
+    State(state): State<AppState>,
+    Json(request): Json<ActiveLabelsRequest>,
+) -> Result<Json<NegatedLabelsResponse>, AppError> {
+    let db = state.db.as_ref().ok_or(AppError::LabelerNotConfigured)?;
+
+    tracing::debug!(uri_count = request.uris.len(), "checking negated labels");
+
+    let negated_uris = db.get_negated_labels(&request.uris).await?;
+
+    tracing::debug!(
+        negated_count = negated_uris.len(),
+        "returning negated labels"
+    );
+
+    Ok(Json(NegatedLabelsResponse { negated_uris }))
 }
 
 /// Store context for a label (for backfill without re-emitting labels).

--- a/services/moderation/src/db.rs
+++ b/services/moderation/src/db.rs
@@ -717,6 +717,28 @@ impl LabelDb {
         Ok(active_uris)
     }
 
+    /// Get URIs that have an explicit negation (dismissal) copyright label.
+    ///
+    /// A negation means a moderator reviewed the flag and dismissed it. This is
+    /// the only signal the backend uses to clear a flag — absence of an active
+    /// label is not a resolution, since flags no longer auto-emit a label.
+    pub async fn get_negated_labels(&self, uris: &[String]) -> Result<Vec<String>, sqlx::Error> {
+        if uris.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        sqlx::query_scalar::<_, String>(
+            r#"
+            SELECT DISTINCT uri
+            FROM labels
+            WHERE val = 'copyright-violation' AND neg = true AND uri = ANY($1)
+            "#,
+        )
+        .bind(uris)
+        .fetch_all(&self.pool)
+        .await
+    }
+
     /// Get all copyright-violation labels with their resolution status and context.
     ///
     /// A label is resolved if there's a negation label for the same uri+val.

--- a/services/moderation/src/main.rs
+++ b/services/moderation/src/main.rs
@@ -106,6 +106,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/admin/resolve-htmx", post(admin::resolve_flag_htmx))
         .route("/admin/context", post(admin::store_context))
         .route("/admin/active-labels", post(admin::get_active_labels))
+        .route("/admin/negated-labels", post(admin::get_negated_labels))
         .route("/admin/sensitive-images", post(admin::add_sensitive_image))
         .route(
             "/admin/sensitive-images/remove",


### PR DESCRIPTION
Copyright flags have been silently wiped within ~5 minutes of being raised — `sync_copyright_resolutions` treated *absence of an active label* as a resolution, but since #703 a flag never emits a label at all, so that absence is the normal state of every real flag. This makes the sync clear a flag only when the labeler reports an **explicit negation** (a moderator dismissal).

Closes #1602.

## the bug

`sync_copyright_resolutions` (runs every 5 min) did:

```python
active_uris = await client.get_active_labels(...)
for uri, scan in scan_by_uri.items():
    if uri not in active_uris:   # <-- "not active" assumed to mean "negated"
        scan.is_flagged = False
```

The assumption held only while flags auto-emitted a label. **#703 disabled auto-labeling** (per legal advice — scanning flags + notifies, humans decide takedowns). After that, a flagged track has *no label at all*, so it's never in `active_uris`, so the very next sync clears `is_flagged`. Copyright flagging has been effectively non-functional in prod since.

**Verified against prod:** `copyright_scans` has 10 flagged rows, all from Nov–Dec 2025 (`highest_score=0`, legacy) — **zero new persisted flags in ~6 months**, consistent with new flags being wiped before anyone sees them.

## the fix

The labeler already records negations (`neg=true` copyright labels via `/admin/resolve`) but only exposed the *active* set, which conflates "never labelled" with "dismissed". This:

- **moderation service (Rust):** adds `POST /admin/negated-labels` → returns the subset of URIs with an explicit `neg=true` copyright label (`db.get_negated_labels`).
- **backend:** adds `ModerationClient.get_negated_labels(...)` and flips the sync to clear a flag **only when its URI is negated**. Absence of a label is no longer a resolution.

<details>
<summary>fail-closed direction is inverted (intentional)</summary>

`get_active_labels` fails closed by returning *all* URIs as active (so an outage never wrongly resolves). The negation query fails closed by returning an **empty set** — an outage resolves *nothing* and leaves flags intact. Same safety property (an outage can never clear a flag), opposite default because the question is inverted.
</details>

## rollout / coupling

The backend can ship ahead of the moderation service safely: until `/admin/negated-labels` is deployed the client 404s → fails closed to an empty set → flags simply **stop being wiped** (strictly safer than today). Resolution-clearing begins working once the moderation service deploys. The moderation service deploys separately (`deploy-moderation.yml`).

## tests (TDD)

- Rewrote `test_sync_copyright_resolutions` to encode correct semantics: a negated URI clears, a **never-labelled** URI stays flagged.
- Added `test_sync_copyright_resolutions_keeps_unlabelled_flags` — the direct #1602 regression: with zero negations, all flags survive.
- **Confirmed red→green**: both fail against the pre-fix sync (`assert False is True` — flag wiped) and pass after. Full copyright suite (74 tests) green; `cargo check` green.

## intentional non-scope

- No backfill of the 10 stale prod flags — they're pre-existing legacy rows, untouched.
- `get_active_labels` is left in place (still the right call for "is this currently enforced?" read paths); only the *sync/resolution* path changes.