### PR TITLE
fix(ingest): verify R2 object exists before trusting a record's audioUrl

### DIFF
--- a/backend/src/backend/_internal/tasks/ingest.py
+++ b/backend/src/backend/_internal/tasks/ingest.py
@@ -9,6 +9,8 @@ unique constraint checks or existence queries.
 
 import logging
 from datetime import UTC, datetime, timedelta
+from pathlib import PurePosixPath
+from urllib.parse import urlparse
 
 import logfire
 from docket import ConcurrencyLimit, ExponentialRetry
@@ -25,6 +27,8 @@ from backend._internal.tasks.pds import is_like_uri_cancelled
 from backend.config import settings
 from backend.models import Artist, Playlist, Track, TrackComment, TrackLike
 from backend.models.session import UserSession
+from backend.storage import storage
+from backend.storage.keys import InvalidMediaExtension
 from backend.utilities.database import db_session
 from backend.utilities.lexicon import validate_record
 from backend.utilities.redis import get_async_redis_client
@@ -34,6 +38,27 @@ logger = logging.getLogger(__name__)
 
 class SubjectNotFoundError(Exception):
     """referenced subject (track) not yet indexed — triggers retry."""
+
+
+async def _audio_object_exists(audio_url: str) -> bool:
+    """HEAD the R2 object a plyr-CDN audioUrl points at.
+
+    origin trust says the URL *names* our CDN; it does not say the bytes are
+    there. a foreign client can mint a well-formed `audio/<hash>.<ext>` URL on
+    our CDN (or a half-failed write can leave the row pointing at one) with no
+    object behind it, which 404s forever on playback. we only call this for a
+    URL that already passed the origin check, so the object — if it exists — is
+    in our own bucket and resolvable via `storage.get_url`.
+    """
+    path = PurePosixPath(urlparse(audio_url).path)
+    if not (stem := path.stem) or not (ext := path.suffix.lstrip(".")):
+        return False
+    try:
+        return (
+            await storage.get_url(stem, file_type="audio", extension=ext)
+        ) is not None
+    except InvalidMediaExtension:
+        return False
 
 
 def _features_to_did_list(features: list | None) -> list[dict[str, str]]:
@@ -218,6 +243,27 @@ async def ingest_track_create(
             else:
                 logfire.warn(
                     "ingest: rejecting track with untrusted audioUrl and no blob",
+                    uri=uri,
+                    audio_url=audio_url,
+                )
+                return
+
+        # origin trust is not existence: a record can claim a plyr-CDN audioUrl
+        # for an object we never stored (a foreign client computing our
+        # content-addressed URL, or an interrupted write). drop the dead URL and
+        # lean on the PDS blob — the real substrate — rather than persisting an
+        # r2_url that 404s forever on playback (issue: natespilman 1153/1154).
+        if audio_url and not await _audio_object_exists(audio_url):
+            if audio_blob:
+                logfire.warn(
+                    "ingest: audioUrl has no backing R2 object, using blob only",
+                    uri=uri,
+                    audio_url=audio_url,
+                )
+                audio_url = None
+            else:
+                logfire.warn(
+                    "ingest: audioUrl has no backing R2 object and no blob, skipping",
                     uri=uri,
                     audio_url=audio_url,
                 )

--- a/backend/tests/test_jetstream.py
+++ b/backend/tests/test_jetstream.py
@@ -66,6 +66,19 @@ def _mock_trusted_origins():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _mock_audio_object_exists():
+    """default: a trusted audioUrl is backed by a real R2 object.
+
+    the unbacked case (the natespilman 1153/1154 bug) is exercised explicitly
+    by the regression tests below, which override this to False.
+    """
+    with patch(
+        "backend._internal.tasks.ingest._audio_object_exists", return_value=True
+    ) as m:
+        yield m
+
+
 @pytest.fixture
 async def artist(db_session: AsyncSession) -> Artist:
     """create a test artist with a unique DID (xdist-safe)."""
@@ -435,6 +448,73 @@ class TestIngestTrackCreate:
         assert track.audio_storage == "both"
         assert track.pds_blob_cid == "bafyaudioblob"
         assert track.r2_url == "https://r2.example.com/both_001.mp3"
+
+    async def test_unbacked_audio_url_falls_back_to_blob(
+        self,
+        db_session: AsyncSession,
+        artist: Artist,
+        _mock_audio_object_exists: MagicMock,
+    ) -> None:
+        """audioUrl with no backing R2 object is dropped; the track serves from
+        its PDS blob instead of persisting an r2_url that 404s forever.
+
+        regression for natespilman 1153/1154: a firehose record claimed a
+        plyr-CDN audioUrl for an object plyr never stored. without the existence
+        check this lands as audio_storage='both' with a dead r2_url.
+        """
+        _mock_audio_object_exists.return_value = False
+        record = {
+            "title": "Unbacked Both Track",
+            "artist": "Test Artist",
+            "fileId": "unbacked_001",
+            "fileType": "mp3",
+            "audioBlob": {"ref": {"$link": "bafyrealblob"}, "mimeType": "audio/mpeg"},
+            "audioUrl": "https://r2.example.com/unbacked_001.mp3",
+            "createdAt": _recent_ts(),
+        }
+        uri = "at://did:plc:jetstream_test/fm.plyr.track/unbacked1"
+
+        await ingest_track_create(
+            did=artist.did, rkey="unbacked1", record=record, uri=uri, cid="bafynew"
+        )
+
+        track = (
+            await db_session.execute(
+                select(Track).where(Track.atproto_record_uri == uri)
+            )
+        ).scalar_one()
+        assert track.audio_storage == "pds"
+        assert track.r2_url is None
+        assert track.pds_blob_cid == "bafyrealblob"
+
+    async def test_unbacked_audio_url_no_blob_skipped(
+        self,
+        db_session: AsyncSession,
+        artist: Artist,
+        _mock_audio_object_exists: MagicMock,
+    ) -> None:
+        """audioUrl with no backing R2 object and no blob is rejected — there is
+        nothing playable to ingest."""
+        _mock_audio_object_exists.return_value = False
+        record = {
+            "title": "Unbacked No Blob",
+            "artist": "Test Artist",
+            "fileId": "unbacked_002",
+            "fileType": "mp3",
+            "audioUrl": "https://r2.example.com/unbacked_002.mp3",
+            "createdAt": _recent_ts(),
+        }
+        uri = "at://did:plc:jetstream_test/fm.plyr.track/unbacked2"
+
+        await ingest_track_create(
+            did=artist.did, rkey="unbacked2", record=record, uri=uri, cid="bafynew"
+        )
+
+        assert (
+            await db_session.execute(
+                select(Track).where(Track.atproto_record_uri == uri)
+            )
+        ).scalar_one_or_none() is None
 
     async def test_pds_only_audio_storage(
         self, db_session: AsyncSession, artist: Artist

--- a/loq.toml
+++ b/loq.toml
@@ -212,11 +212,11 @@ max_lines = 540
 
 [[rules]]
 path = "backend/src/backend/_internal/tasks/ingest.py"
-max_lines = 867
+max_lines = 907
 
 [[rules]]
 path = "backend/tests/test_jetstream.py"
-max_lines = 1890
+max_lines = 1959
 
 [[rules]]
 path = "frontend/src/lib/components/embed/CollectionEmbed.svelte"


### PR DESCRIPTION
**A firehose-ingested track can claim an `audioUrl` on plyr's own CDN for an object plyr never stored — origin trust verified the URL *names* our CDN, not that the bytes are there.** The row then persisted as `audio_storage='both'` with an `r2_url` that 404s forever on playback, even though a perfectly usable `audioBlob` sat in the same record. This fix HEAD-checks the object during ingest and, when it's missing, falls back to the PDS blob (the real substrate) instead of trusting the dead URL.

Found via [@iame.li's report](https://plyr.fm/track/1153) that Nate Spilman's "Right Back To It" (tracks 1153 & 1154) 404'd while "looking okay on the PDS." Both already recovered in prod (objects restored from the PDS blob, cache purged); this PR stops it recurring.

<details>
<summary>Root cause</summary>

`ingest_track_create`'s *create-from-scratch* branch (a `fm.plyr.track` record that arrives on the firehose with no pending row plyr created) trusted a record's `audioUrl` by **origin** alone (`is_trusted_audio_origin` → `audio.plyr.fm` is ours). But a foreign client can mint a well-formed, content-addressed `audio.plyr.fm/audio/<sha256[:16]>.<ext>` URL (or an upload can half-fail) with **no object behind it**. Ingest set `audio_storage='both'` + `r2_url=<that url>` without ever checking R2 had the bytes, and never stamped `pds_blob_size`.

Confirmed via Logfire: these two tracks were `jetstream dispatched track.create` → `ingest: track created`, and genre classification 404'd on `audio.plyr.fm/audio/7b9a5381d4341813.mp3` **at ingest time** — the object was never there. `file_id` was the rkey (not a content hash), the tell that they bypassed plyr's own `R2.save()` upload path.
</details>

<details>
<summary>The fix</summary>

In the create-from-scratch branch, after the origin check, HEAD the object the `audioUrl` points at (`_audio_object_exists` → `storage.get_url`). If it's absent:
- **blob present** → drop the URL, `audio_storage='pds'` (serve from the PDS blob);
- **no blob** → skip the record (nothing playable to ingest).

The check only runs for genuinely *foreign* records — plyr's own uploads hit the "finalize pending row" branch and never reach this code, so there is **no added cost on the normal upload/playback path**. The HEAD is one-time, at ingest.

**Why not a playback-time R2→blob fallback?** That would add an R2 HEAD to every `/audio/{id}` request (the endpoint is a cheap 307 redirect today). Better to pay the cost once at ingest and keep the row correct.
</details>

<details>
<summary>Scope / blast radius</summary>

Isolated. Across all of prod, the create-from-scratch path (rkey-style `file_id` + an `r2_url`) has produced **exactly these 2 tracks** — one external publish to one artist's PDS. Every other `r2_url` track has a content-hash `file_id` from plyr's own upload path (which actually writes the object). Not a fleet-wide pattern.
</details>

<details>
<summary>Tests</summary>

`tests/test_jetstream.py`:
- `test_unbacked_audio_url_falls_back_to_blob` — unbacked `audioUrl` + blob → `audio_storage='pds'`, `r2_url is None` (fails as `'both'` with a dead URL under the old code).
- `test_unbacked_audio_url_no_blob_skipped` — unbacked `audioUrl`, no blob → no track created.
- New autouse fixture `_mock_audio_object_exists` (default `True`) keeps the existing `both`/hook tests asserting backed behavior; the regression tests override to `False`.

`loq.toml` limits relaxed for the two touched files (per project convention; no code golf).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)