### PR TITLE
docs: fix stale internal doc references

### DIFF
--- a/backend/src/backend/_internal/CLAUDE.md
+++ b/backend/src/backend/_internal/CLAUDE.md
@@ -18,7 +18,7 @@ internal services and business logic.
 
 gotchas:
 - ATProto records organized under `_internal/atproto/records/` by lexicon namespace
-- file_id is sha256 hash truncated to 16 chars
+- file_id is sha256 hash truncated to 16 chars on the upload path; firehose-ingested tracks fall back to the record's rkey (`ingest_track_create`), so a `file_id` that isn't a 16-char hex hash means the track came from the firehose, not a plyr upload
 - queue cache is TTL-based (5min), hydration includes duplicate track_ids
 - background tasks use docket (Redis-backed) with asyncio fallback for local dev
 - **OAuth scope coupling**: when adding a new lexicon integration (new `repo:` token),

--- a/docs/internal/CLAUDE.md
+++ b/docs/internal/CLAUDE.md
@@ -11,7 +11,6 @@ structure:
 - **tools/** - logfire queries, neon mcp, pdsx cli, plyr.fm mcp
 - **local-development/** - setup guide for new contributors
 - **moderation/** - copyright detection, sensitive content, ATProto labeler
-- **lexicons/** - ATProto record schemas (track, like, comment, list, profile)
 - **runbooks/** - operational procedures for production incidents
 - **testing/** - pytest patterns, parallel execution, template databases
 

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -9,6 +9,7 @@ organized knowledge base for plyr.fm development.
 ### operations
 - **[runbooks/](./runbooks/)** - production incident procedures
   - [connection-pool-exhaustion](./runbooks/connection-pool-exhaustion.md) - 500s, stuck connections
+  - [worker-silence-alert](./runbooks/worker-silence-alert.md) - docket worker stopped or crash-looping
 
 ### backend
 - **[background-tasks.md](./backend/background-tasks.md)** - docket-based task system (copyright scan, export, scrobble, genre classification)
@@ -41,9 +42,10 @@ organized knowledge base for plyr.fm development.
 - **[plyrfm.md](./tools/plyrfm.md)** - Python SDK and MCP server
 - **[tap.md](./tools/tap.md)** - ATProto sync utility for backfilling custom lexicons
 - **[status-maintenance.md](./tools/status-maintenance.md)** - automated status podcasts
+- **[skills.md](./tools/skills.md)** - Claude Code skills for this repo
 
 ### atproto
-- **[lexicons/](./lexicons/)** - record schemas (track, like, comment, list, profile)
+- **[lexicons overview](../public/lexicons/overview.md)** - record schemas (track, like, comment, list, profile)
 - **[authentication.md](./authentication.md)** - OAuth 2.1 flow
 
 ### moderation

--- a/docs/internal/tools/logfire.md
+++ b/docs/internal/tools/logfire.md
@@ -159,7 +159,7 @@ ORDER BY start_timestamp DESC
 - The `/audio/{file_id}` endpoint redirects to Cloudflare R2 CDN URLs when using R2 storage
 - 307 preserves the GET method during redirect (unlike 302)
 - This offloads bandwidth to R2's CDN instead of proxying through the app
-- See `src/backend/api/audio.py` for implementation
+- See `backend/src/backend/api/audio.py` for implementation
 
 ## Database Query Spans
 
@@ -299,39 +299,6 @@ WHERE otel_status_code = 'ERROR'
 GROUP BY endpoint
 ORDER BY error_count DESC
 ```
-
-## Known Issues
-
-### `/tracks/` 500 Error on First Load
-
-**Trace ID:** `019a46fe0b20c24432f5a7536d8561a6`
-**Timestamp:** 2025-11-02T23:54:05.472754Z
-**Status:** 500
-
-**Symptoms:**
-- First request to `GET /tracks/` fails with 500 error
-- Subsequent requests succeed with 200 status
-- Database connection and SELECT query both execute successfully in the trace
-
-**Root Cause:**
-SSL connection pooling issue with Neon database. The error appears in `otel_status_message`:
-```
-consuming input failed: SSL connection has been closed unexpectedly
-```
-
-**Analysis:**
-- This is a Neon PostgreSQL connection pool issue where SSL connections are being dropped
-- First request attempts to use a stale/closed SSL connection from the pool
-- Subsequent requests work because the pool recovers and establishes a fresh connection
-- The error is captured in `otel_status_code: "ERROR"` and `otel_status_message` fields
-
-**Potential Fixes:**
-1. Configure SQLAlchemy connection pool settings for Neon:
-   - Set `pool_pre_ping=True` to verify connections before use
-   - Adjust `pool_recycle` to match Neon's connection timeout
-2. Review Neon-specific SSL connection settings
-3. Add retry logic for initial database connections
-4. Consider connection pool size tuning
 
 ## Pre-built Dashboards
 


### PR DESCRIPTION
**Five high-confidence stale-reference fixes surfaced while reviewing the doc surfaces** (after the #1616 audio incident). No new docs — just corrections to things that had drifted from the code.

<details>
<summary>What changed</summary>

- **`_internal/CLAUDE.md`** — "file_id is sha256 hash truncated to 16 chars" was only true for the upload path. Firehose-ingested tracks fall back to the record's rkey (`ingest_track_create`), so a non-hash `file_id` signals a firehose-originated track. (This exact divergence is what made #1616 confusing.)
- **`tools/logfire.md`** — removed the "Known Issues" `/tracks/` 500 entry: it's resolved (its own "Potential Fixes" — `pool_pre_ping`/`pool_recycle` — already shipped in `config.py` + `utilities/database.py`). Fixed the `audio.py` path prefix (`src/backend/...` → `backend/src/backend/...`).
- **`README.md`** — fixed the dead `lexicons/` directory link (lexicon docs actually live at `docs/public/lexicons/overview.md`); indexed the two missing entries `tools/skills.md` and `runbooks/worker-silence-alert.md`.
- **`docs/internal/CLAUDE.md`** — dropped the nonexistent `lexicons/` subdir from the structure list.
</details>

<details>
<summary>Deliberately NOT in this PR</summary>

The doc survey also flagged larger items being handled separately/deferred: a jetstream-ingest doc and an audio-streaming dispatch doc (pending a correct cross-cutting model of public / supporter-gated / private-space audio), and public-docs polish (troubleshooting, glossary feature-flag framing, accepted-formats reconciliation). No Cloudflare credential/token documentation will be written — that would codify sensitive/under-scoped-token mechanics.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)