### PR TITLE
docs: audio dispatch tree, jetstream ingest, dead-audioUrl retrospective

### DIFF
--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -17,6 +17,7 @@ organized knowledge base for plyr.fm development.
 - **[database/](./backend/database/)** - connection pooling, neon-specific patterns
 - **[feature-flags.md](./backend/feature-flags.md)** - per-user feature rollout system
 - **[streaming-uploads.md](./backend/streaming-uploads.md)** - SSE progress tracking
+- **[audio-streaming.md](./backend/audio-streaming.md)** - the `GET /audio` dispatch tree (public / gated / private), driven by visibility + support_gate
 - **[album-uploads.md](./backend/album-uploads.md)** - multi-track album upload flow (create → finalize) and why the ATProto list record is authoritative for track order
 - **[transcoder.md](./backend/transcoder.md)** - rust audio conversion service (lossless support)
 - **[mood-search.md](./backend/mood-search.md)** - semantic search with CLAP embeddings (Modal + turbopuffer)
@@ -24,6 +25,11 @@ organized knowledge base for plyr.fm development.
 - **[playlist-recommendations.md](./backend/playlist-recommendations.md)** - inline track suggestions via CLAP embeddings
 - **[liked-tracks.md](./backend/liked-tracks.md)** - like system and liked tracks endpoint
 - **[atproto-identity.md](./backend/atproto-identity.md)** - ATProto identity resolution and handle management
+
+### architecture
+- **[jetstream-ingest.md](./architecture/jetstream-ingest.md)** - firehose → database; the two ways a track row is born and the origin-trust/existence model
+- **[jams.md](./architecture/jams.md)** - real-time shared listening rooms
+- **[permissioned-private-media.md](./architecture/permissioned-private-media.md)** - private audio in ATProto permissioned spaces (experimental)
 
 ### frontend
 - **[state-management.md](./frontend/state-management.md)** - svelte 5 runes patterns

--- a/docs/internal/architecture/jetstream-ingest.md
+++ b/docs/internal/architecture/jetstream-ingest.md
@@ -1,0 +1,98 @@
+---
+title: "jetstream ingest — firehose → database"
+---
+
+how records authored on a PDS (by plyr.fm itself or by any other ATProto client)
+become rows in plyr's index. the consumer is `backend/src/backend/_internal/
+jetstream.py`; the per-record tasks live in `backend/src/backend/_internal/tasks/
+ingest.py`.
+
+## the path
+
+1. `JetstreamConsumer` holds a websocket to the jetstream firehose, filtered to
+   the `fm.plyr.*` collections and the set of known artist DIDs.
+2. for each commit/identity/account event it dispatches a docket task —
+   `ingest_track_create` / `_update` / `_delete`, the like/comment/list
+   equivalents, and `ingest_identity_update` / `ingest_account_status_change`.
+3. each task resolves the event into the DB. all tasks are **idempotent**
+   (dedupe by AT-URI or unique constraint) so a cursor rewind replaying events
+   is safe.
+
+the consumer runs in its **own fly process group** (not the docket worker loop) —
+it was starving as a worker task. see `runbooks/worker-silence-alert.md` and the
+`#identity` notes in `tasks/ingest.py`.
+
+## two ways a track row is born
+
+`ingest_track_create` has two distinct branches, and they behave very
+differently:
+
+### A. finalize a pending row (plyr's own uploads)
+
+When a user uploads through plyr, the upload path **reserves** a DB row
+(`publish_state="pending"`) and then writes the `fm.plyr.track` record to the
+PDS. The firehose echoes that record back; ingest finds the existing row by URI
+and just **finalizes** it — sets the record CID, flips `publish_state` to
+`"published"`, and fires the post-create hooks. The audio bytes were already
+written to R2 by the upload path, and `file_id` is the **content hash**
+(`sha256[:16]`).
+
+### B. create from scratch (foreign clients)
+
+When **no** pending row exists, the record came from some other ATProto client
+writing `fm.plyr.track` directly to a PDS. Ingest builds the row from the record
+alone. Two consequences worth knowing:
+
+- `file_id = record.get("fileId", rkey)` — foreign records rarely carry a
+  `fileId`, so the `file_id` is the **record rkey** (a TID), *not* a content
+  hash. A non-hash `file_id` is the tell that a track came in this way.
+- plyr never wrote any audio to R2 for this track. The bytes are wherever the
+  record says — a PDS `audioBlob`, an `audioUrl`, or both.
+
+### storage-mode derivation (branch B)
+
+From the record's `audioBlob` / `audioUrl`, ingest derives `audio_storage`:
+
+| record has | `audio_storage` | `r2_url` | `pds_blob_cid` |
+|------------|-----------------|----------|----------------|
+| blob + url | `both` | the url | blob ref |
+| blob only | `pds` | `None` | blob ref |
+| url only | `r2` | the url | `None` |
+| neither | (rejected — nothing playable) | | |
+
+`pds_blob_size` is **not** set on this path (only the upload path records it).
+
+## trust: origin is not existence
+
+A record's `audioUrl` is attacker/foreign-controlled, so it passes two gates
+before it's persisted:
+
+1. **origin trust** (`tasks/origin_trust.py`) — the URL must be on a trusted
+   origin (currently only plyr's own R2 CDN; the BYOS hook for per-artist
+   registered origins is stubbed). An untrusted URL is stripped (fall back to
+   the blob) or, with no blob, the record is rejected.
+2. **existence** (`_audio_object_exists`, added #1616) — origin trust only says
+   the URL *names* our CDN, not that the bytes are there. A foreign client can
+   mint a well-formed, content-addressed `audio.plyr.fm/audio/<sha256[:16]>.<ext>`
+   URL with **no object behind it** (or an interrupted write can leave one). So
+   we `HEAD` the object; if it's absent we drop the URL and fall back to the PDS
+   blob (the real substrate), or skip the record when there's no blob. This runs
+   only in branch B — plyr's own uploads (branch A) never reach it, so there's
+   no added cost on the normal path.
+
+This is the fix for the 2026-06-30 dead-audioUrl incident; without it a foreign
+record landed as `audio_storage="both"` with an `r2_url` that `404`d forever on
+playback. See the retrospective and `backend/audio-streaming.md`.
+
+> `ingest_track_update` strips an untrusted `audioUrl` but (unlike create) never
+> rejects the whole update, and does not currently run the existence check — an
+> update can only mutate an already-ingested track.
+
+## other guards
+
+- **future-timestamp**: a record whose `createdAt` is beyond `_MAX_CLOCK_SKEW`
+  (5 min) is skipped.
+- **tombstones**: a deleted URI is tombstoned in Redis for 5 min so a cursor
+  rewind can't resurrect a just-deleted record as a ghost. plyr always mints
+  fresh TID rkeys, so a legitimate same-URI re-create never happens.
+- **unknown artist**: events for a DID with no `Artist` row are skipped.

--- a/docs/internal/backend/audio-streaming.md
+++ b/docs/internal/backend/audio-streaming.md
@@ -1,0 +1,96 @@
+---
+title: "audio streaming — the /audio dispatch tree"
+---
+
+how `GET /audio/{file_id}` decides what bytes to serve, and from where. the
+endpoint lives in `backend/src/backend/api/audio.py`.
+
+the load-bearing thing to internalize: **dispatch is driven by `Track.visibility`
+and `Track.support_gate`, not by `audio_storage`.** `audio_storage` (`r2` / `pds`
+/ `both`) only answers the secondary question "where do the bytes physically
+live" *within* a branch. getting this backwards is what made the 2026-06-30 dead-
+audioUrl incident confusing (see the retrospective).
+
+## the four track types
+
+`Track.visibility` is the single source of truth (one mutually-exclusive value;
+see the column comment in `backend/src/backend/models/track.py`). copyright gating
+is orthogonal — it rides on `public`/`unlisted` via `support_gate`.
+
+| type | `visibility` | `support_gate` | who can play | where audio lives |
+|------|-------------|----------------|--------------|-------------------|
+| public | `public` | `None` | anyone | R2 / CDN (or PDS blob if pds-only) |
+| unlisted | `unlisted` | `None` | anyone with the link | R2 / CDN |
+| copyright-gated | `public`/`unlisted` | `{"type":"copyright"}` | any **authenticated** listener | R2 (copyright tracks never get a PDS blob) |
+| supporter-gated | `supporters` | `{"type":"any"}` | artist or validated atprotofans supporter | R2 **private** bucket (presigned) — or PDS blob if pds-stored |
+| private | `private` | `None` | owner only (app-layer policy) | artist's **permissioned space on their PDS**, never R2 |
+
+## dispatch order in `stream_audio`
+
+```
+is_private (visibility == "private") ?  → _handle_private_audio
+support_gate is not None ?              → _handle_gated_audio
+otherwise (public/unlisted, ungated)   → public path
+```
+
+### private → `_handle_private_audio`
+
+audio + record live in the artist's ATProto permissioned space on their PDS,
+never R2. the browser has no space credential, so we cannot redirect — we
+**proxy** the bytes through the owner's credential (`open_space_blob` →
+`getMemberGrant` → `getSpaceCredential` → ranged `getBlob`). access is
+**owner-only by plyr's app-layer policy** (the protocol no longer enumerates
+readers — ZDS dropped member lists, #1573); a non-owner or anonymous request
+gets a `404`, identical to a missing file, so private tracks don't leak their
+existence. `Range` is passed through so seek/`206` survives the proxy.
+
+> experimental: the `com.atproto.space.*` surface is implemented only by ZDS
+> (`pds.zat.dev`); inert on prod PDSes. see
+> `architecture/permissioned-private-media.md`.
+
+### gated → `_handle_gated_audio`
+
+both copyright- and supporter-gated tracks flow through here, but
+`_check_gate_access` applies **different** checks by `support_gate["type"]`:
+
+- `"copyright"` (indiemusi paradigm) — any authenticated listener is allowed;
+  anonymous → `401`.
+- `"any"` (supporters) — the artist always passes; otherwise the listener must
+  be a validated atprotofans supporter, else `402` with `X-Support-Required`.
+
+after the access check, the bytes come from the PDS blob (`audio_storage=="pds"`)
+or a presigned URL into the R2 **private** bucket. `HEAD` requests return
+`200`/`401`/`402` **without** redirecting (used as a pre-flight auth check —
+avoids CORS issues with cross-origin redirects).
+
+### public/unlisted ungated → the common path
+
+1. if serving the **original lossless** file (the request `file_id` matches
+   `original_file_id`), resolve and redirect to it.
+2. else if `r2_url` is set (`audio_storage` `r2` or `both`) → `307` redirect to
+   it (the CDN). **this is where R2 "wins" over the PDS blob for `both` tracks —
+   there is no automatic fallback to the blob if the R2 object is missing.**
+3. else if pds-only (`audio_storage=="pds"`, `pds_blob_cid`, no `r2_url`) →
+   redirect to the PDS `getBlob` URL.
+4. else resolve via `storage.get_url`; `404` if nothing resolves.
+
+The `307` (not `302`) preserves the GET method through the redirect and offloads
+bandwidth to R2's CDN instead of proxying through the app.
+
+## why R2 can "win" but be empty
+
+For a `both` track, step 2 trusts `r2_url` unconditionally — it does not verify
+the object exists. If the row carries an `r2_url` for an object that was never
+written (the dead-audioUrl ingest bug, #1616), playback `307`s to a CDN `404`
+and the track "serves nothing" even though a usable PDS blob is present. The fix
+keeps the row honest **at ingest** (verify the object exists before trusting the
+URL) rather than adding an R2 `HEAD` to every playback request — see
+`architecture/jetstream-ingest.md` and the 2026-06-30 retrospective.
+
+## related
+
+- `GET /audio/{file_id}/url` mirrors this dispatch but returns the URL as JSON
+  (used by offline mode); private tracks return this backend's own stream URL,
+  since the bytes need the space credential the client doesn't hold.
+- the R2 key scheme and `file_id` semantics: `backend/streaming-uploads.md`.
+- `Track.visibility` model: column comment in `models/track.py`.

--- a/docs/internal/retrospectives/2026-06-30-dead-audiourl-ingest.md
+++ b/docs/internal/retrospectives/2026-06-30-dead-audiourl-ingest.md
@@ -1,0 +1,93 @@
+# retrospective: firehose-ingested tracks with a dead audioUrl served no audio (2026-06-23 → 2026-06-30)
+
+## summary
+
+two tracks by `@natespilman.com` — "Right Back To It" (1153) and "Sympathy is a
+Knife" (1154) — loaded their track pages fine but played **nothing**: `0 plays`,
+scrubber stuck at `0:00`. The records had been authored by a non-plyr ATProto
+client and **ingested from the firehose** on **2026-06-23 20:58 UTC**. Each record
+carried a well-formed, content-addressed `audio.plyr.fm/audio/<sha256[:16]>.<ext>`
+URL **and** a PDS `audioBlob` — but plyr had never written the R2 object, because
+plyr never did the upload. Ingest trusted the `audioUrl` by **origin** (it names
+our CDN) without checking the bytes existed, so the rows landed as
+`audio_storage="both"` with an `r2_url` that `404`d forever, while the playback
+path redirects to `r2_url` for `both` tracks with no fallback to the (perfectly
+good) PDS blob.
+
+The R2 object was missing from the very first minute — genre classification
+`404`d on both URLs at ingest time (**2026-06-23 22:26 UTC**) — but nothing was
+watching that signal. The breakage surfaced **6 days later** when `@iame.li`
+reported it on bsky ("404ing… looks okay on the PDS tho") on **2026-06-30**. Both
+tracks were recovered the same day (R2 objects restored from the intact PDS
+blobs, hash-verified) and the root cause fixed and released to production
+(`2026.0630.055544`, PR #1616).
+
+**Blast radius: isolated.** A fleet scan for the create-from-scratch signature
+(non-hash `file_id` + an `r2_url`) found **exactly these two tracks** — one
+external publish to one artist's PDS. Every other `r2_url` track has a content-
+hash `file_id` from plyr's own upload path, which actually writes the object.
+
+## timeline (UTC)
+
+| time | event |
+|------|-------|
+| 2026-06-23 20:58:28 / 20:58:38 | tracks 1153 / 1154 created from the firehose (`jetstream dispatched track.create` → `ingest: track created`). records carry an `audio.plyr.fm` content-addressed audioUrl + an audioBlob; `file_id` = the record rkey (not a content hash). no R2 write ever happens. |
+| 2026-06-23 22:26:46 | deferred genre classification fails: `404 … audio.plyr.fm/audio/7b9a5381d4341813.mp3` and `…/98665f6728c87c86.wav`. **first hard evidence the R2 objects never existed.** unwatched. |
+| 2026-06-29 ~22:35 CDT | `@iame.li` reports on bsky that `plyr.fm/track/1153` 404s "but looks okay on the PDS." |
+| 2026-06-30 | investigation: backend `/audio/{file_id}` returns `307` → the dead R2 URL (origin `404`, cache MISS — never written). artist's real PDS (`oyster…bsky.network`, resolved from the DB, **not** assumed) serves the blob `200`; `sha256(blob)[:16]` matches the key in `r2_url` for both tracks — byte-identical to what should have been in R2. |
+| 2026-06-30 | recovery: restored both R2 objects from the PDS blobs, purged the cached `404` at the edge, stamped the `pds_blob_size` the ingest path had left `NULL`. both tracks serve `206`. |
+| 2026-06-30 | fix (PR #1616) merged and released to production (`2026.0630.055544`). |
+
+## root causes
+
+### 1. origin trust is not existence (the bug)
+
+`ingest_track_create`'s create-from-scratch branch
+(`backend/src/backend/_internal/tasks/ingest.py`) accepted the record's
+`audioUrl` after only an **origin** check (`tasks/origin_trust.py` →
+`audio.plyr.fm` is ours). But a foreign client can mint a well-formed,
+content-addressed URL on our CDN with **no object behind it** (the rkey-style
+`file_id` and `pds_blob_size IS NULL` are the tells that these bypassed plyr's
+own `R2.save()` path). Ingest set `audio_storage="both"` + `r2_url=<dead url>`
+without verifying the bytes existed — even though a usable `audioBlob` was in the
+same record.
+
+### 2. no playback fallback (why it was a hard failure, not a degraded one)
+
+`GET /audio/{file_id}` (`backend/src/backend/api/audio.py`) redirects `both`
+tracks to `r2_url` unconditionally, with no fallback to the PDS blob when R2 is
+missing. So a dead `r2_url` is a hard `404` on playback instead of self-healing
+to the blob that was sitting right there. See `backend/audio-streaming.md`.
+
+### 3. silent detection gap
+
+The R2 objects `404`d at ingest time (genre classification, 2026-06-23 22:26),
+but that failure isn't alerted on, so the only signal that ever escalated was a
+user report 6 days later.
+
+## resolution
+
+PR #1616 added an existence check to the create-from-scratch branch: after the
+origin check, `HEAD` the R2 object the `audioUrl` points at
+(`_audio_object_exists`). If it's absent, drop the URL and fall back to the PDS
+blob (`audio_storage="pds"`), or skip the record when there's no blob. The check
+runs **only** for foreign records — plyr's own uploads finalize a pending row and
+never reach it — so there's no added cost on the normal path. Regression tests in
+`backend/tests/test_jetstream.py`.
+
+The two affected tracks were recovered out-of-band (the source audio was safe in
+the artist's PDS the whole time; only plyr's R2 cache copy was missing).
+
+## prevention / follow-ups
+
+- **shipped**: the ingest existence check (#1616); this retrospective;
+  `architecture/jetstream-ingest.md` and `backend/audio-streaming.md`, which
+  document the create-from-scratch path and the "R2 wins, no fallback" playback
+  precedence that made this confusing.
+- **fixed the diagnosis trap**: `_internal/CLAUDE.md` no longer claims `file_id`
+  is always `sha256[:16]` — a non-hash `file_id` now correctly signals a
+  firehose-originated track.
+- **open**: nothing alerts on a track whose `r2_url` object is missing (root
+  cause #3). A periodic audit of `both` rows with `pds_blob_size IS NULL`, or an
+  alert on post-ingest `404`s from genre classification, would have caught this
+  in minutes instead of days. Not yet built.


### PR DESCRIPTION
**Three internal docs the #1616 incident exposed as missing** — how audio is actually served, how firehose records become rows, and a postmortem of the dead-`audioUrl` bug. (Replaces #1618, which auto-closed when its stacked base branch was deleted on merge of #1617; rebased onto main.)

<details>
<summary>What's here</summary>

- **`backend/audio-streaming.md`** — the `GET /audio` dispatch tree across the four track types (public, copyright-gated, supporter-gated, private). Dispatch is driven by **`visibility` + `support_gate`**, not `audio_storage`, and R2 "wins" over the PDS blob for `both` tracks with **no fallback** — the precedence that made "looks fine on the PDS but serves nothing" confusing.
- **`architecture/jetstream-ingest.md`** — firehose → DB: the **finalize-pending-row** vs **create-from-scratch** branches, the `audioBlob`/`audioUrl` → `audio_storage` derivation, and the **origin-trust-is-not-existence** model (the #1616 fix).
- **`retrospectives/2026-06-30-dead-audiourl-ingest.md`** — postmortem: timeline, root causes, isolated blast radius (2 tracks, one external publish), resolution, and the one **open** follow-up — nothing alerts on a track whose `r2_url` object is missing.
- **`README.md`** — indexes the new docs and adds the previously-unindexed `architecture/` section.
</details>

No Cloudflare token/credential documentation (would codify sensitive mechanics); the retrospective describes recovery operationally without credential details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)