### PR TITLE
feat(radio): widen rotation breadth — per-station decay, 4h reseeding, exploration floor

### DIFF
--- a/backend/src/backend/api/radio/sampler.py
+++ b/backend/src/backend/api/radio/sampler.py
@@ -1,11 +1,12 @@
 """Deterministic, per-artist-budgeted rotation sampler.
 
-Turns a scored corpus into a daily rotation that doesn't let one artist stack it:
+Turns a scored corpus into a rotation that doesn't let one artist stack it:
 
-* **Deterministic per (station, day):** seeded by the station slug + calendar day,
-  so every client computes the same rotation for the same day — required by the
-  stateless wall-clock loop that existing consumers depend on. It reshuffles once
-  a day.
+* **Deterministic per (station, period):** seeded by the station slug + a rotation
+  period, so every client computes the same rotation for the same period —
+  required by the stateless wall-clock loop that existing consumers depend on.
+  The caller picks the period granularity (currently a few hours, so a listener
+  with a fixed daily listening window doesn't land on the same slice every day).
 
 * **Per-artist airtime budget:** once an artist has contributed
   ``ARTIST_AIRTIME_CAP_SECONDS`` of clock time they stop being drawn, so a creator
@@ -19,6 +20,12 @@ Turns a scored corpus into a daily rotation that doesn't let one artist stack it
 * **Weighted draw without replacement:** tracks are sampled in proportion to their
   lens weight, so the rotation isn't a fixed top-N chart and the long tail turns
   over.
+
+* **Exploration floor:** a fraction of draws ignore the lens weights and pick
+  uniformly from whatever hasn't been drawn yet. Rank-decay weights alone leave
+  everything past the head effectively unreachable (with a static ranking, ~90%
+  of the corpus never airs); the floor guarantees the dormant tail cycles through
+  while the lens still shapes most of the rotation.
 """
 
 import hashlib
@@ -30,6 +37,7 @@ from backend.models import Track
 DEFAULT_TRACK_SECONDS = 180
 ARTIST_AIRTIME_CAP_SECONDS = 20 * 60  # an artist is done once past ~20 min of airtime
 TARGET_ROTATION_SECONDS = 4 * 60 * 60  # aim for ~4 hours of programming per rotation
+EXPLORATION_FRACTION = 0.25  # share of draws that ignore lens weights entirely
 
 
 def rank_decay_weights(ranked_ids: list[int], scale: float) -> dict[int, float]:
@@ -42,8 +50,10 @@ def rank_decay_weights(ranked_ids: list[int], scale: float) -> dict[int, float]:
     return {item: math.exp(-rank / scale) for rank, item in enumerate(ranked_ids)}
 
 
-def _seed(station_slug: str, day: str) -> int:
-    digest = hashlib.blake2s(f"{station_slug}:{day}".encode(), digest_size=8).digest()
+def _seed(station_slug: str, period: str) -> int:
+    digest = hashlib.blake2s(
+        f"{station_slug}:{period}".encode(), digest_size=8
+    ).digest()
     return int.from_bytes(digest, "big")
 
 
@@ -58,27 +68,30 @@ def build_rotation(
     weights: dict[int, float],
     *,
     station_slug: str,
-    day: str,
+    period: str,
     max_tracks: int,
     target_seconds: int = TARGET_ROTATION_SECONDS,
     artist_airtime_cap_seconds: int = ARTIST_AIRTIME_CAP_SECONDS,
+    exploration: float = EXPLORATION_FRACTION,
 ) -> list[Track]:
     """Draw a deterministic, airtime-fair rotation from scored candidates.
 
     Args:
         candidates: the eligible corpus (already filtered for this station).
         weights: track id -> non-negative lens weight.
-        station_slug: identifies the station for the daily seed.
-        day: ISO calendar day (UTC); rotation is stable within it.
+        station_slug: identifies the station for the rotation seed.
+        period: opaque rotation-period key; rotation is stable within it.
         max_tracks: hard ceiling on rotation length (the API ``limit``).
         target_seconds: stop once the rotation reaches roughly this much airtime.
         artist_airtime_cap_seconds: per-artist airtime budget before they drop out.
+        exploration: probability that a draw is uniform over the remaining pool
+            instead of lens-weighted, so the tail is reachable.
     """
     pool = [t for t in candidates if weights.get(t.id, 0.0) > 0.0]
     if not pool:
         return []
 
-    rng = random.Random(_seed(station_slug, day))
+    rng = random.Random(_seed(station_slug, period))
     remaining = pool[:]
     remaining_weights = [weights[t.id] for t in remaining]
 
@@ -87,7 +100,10 @@ def build_rotation(
     total_seconds = 0
 
     while remaining and len(rotation) < max_tracks and total_seconds < target_seconds:
-        chosen_idx = _weighted_pick(rng, remaining_weights)
+        if rng.random() < exploration:
+            chosen_idx = rng.randrange(len(remaining))
+        else:
+            chosen_idx = _weighted_pick(rng, remaining_weights)
         track = remaining.pop(chosen_idx)
         remaining_weights.pop(chosen_idx)
 

--- a/backend/src/backend/api/radio/state.py
+++ b/backend/src/backend/api/radio/state.py
@@ -37,11 +37,11 @@ from backend.utilities.aggregations import (
 DEFAULT_TRACK_SECONDS = 180
 DEFAULT_ROTATION_SIZE = 40
 MAX_ROTATION_SIZE = 75
-# decay over a station's own ranking: the top ~RANK_DECAY*3 tracks by the lens
-# carry the station, the long tail falls off fast. Weighting by rank (not raw lens
-# score) keeps one station's signal from swamping another and bounds the tail mass
-# regardless of catalog size, so e.g. a 200-day-old track can't leak into `fresh`.
-RANK_DECAY = 12.0
+# a rotation lasts one period, then reseeds. Reseeding a few times a day (rather
+# than daily) keeps a listener with a fixed daily listening window from landing
+# on the same slice of the same rotation every day, while every client still
+# computes the identical rotation within a period.
+ROTATION_PERIOD_SECONDS = 4 * 60 * 60
 
 
 def _stream_url(track: Track) -> str:
@@ -88,15 +88,19 @@ async def _select_rotation(
     # rank within this station's pool.
     recency_rank = {track.id: rank for rank, track in enumerate(eligible)}
     ctx = LensContext(like_counts=like_counts, now=now, recency_rank=recency_rank)
-    # rank by the station's lens, then weight by rank-decay (not the raw score)
+    # rank by the station's lens, then weight by rank-decay (not the raw score):
+    # weighting by rank keeps one station's signal from swamping another and
+    # bounds the tail mass regardless of catalog size, so e.g. a 200-day-old
+    # track can't leak into `fresh`. The decay scale is per-station.
     ranked = sorted(eligible, key=lambda t: station.lens(t, ctx), reverse=True)
-    weights = rank_decay_weights([t.id for t in ranked], RANK_DECAY)
+    weights = rank_decay_weights([t.id for t in ranked], station.rank_decay)
     rotation = build_rotation(
         eligible,
         weights,
         station_slug=station.slug,
-        day=now.date().isoformat(),
+        period=str(int(now.timestamp()) // ROTATION_PERIOD_SECONDS),
         max_tracks=limit,
+        exploration=station.exploration,
     )
     return rotation, like_counts
 

--- a/backend/src/backend/api/radio/stations.py
+++ b/backend/src/backend/api/radio/stations.py
@@ -37,6 +37,14 @@ def _only_slop(track: Track, tags: set[str]) -> bool:
     return _has_hidden_tag(tags) and track.artist.handle != PLYR_FM_ACCOUNT_HANDLE
 
 
+# how far down a station's lens ranking the sampler meaningfully reaches: weights
+# decay as exp(-rank/scale), so roughly the top ~3*scale ranks carry the station.
+DEFAULT_RANK_DECAY = 12.0
+# share of draws that ignore the lens and pick uniformly from the un-drawn pool,
+# so the dormant tail cycles through instead of never airing.
+DEFAULT_EXPLORATION = 0.25
+
+
 @dataclass(frozen=True)
 class Station:
     slug: str
@@ -45,6 +53,8 @@ class Station:
     lens: Lens
     # default: keep the same ai/suno tracks out that the homepage hides
     corpus_filter: CorpusFilter = field(default=_exclude_slop)
+    rank_decay: float = DEFAULT_RANK_DECAY
+    exploration: float = DEFAULT_EXPLORATION
 
 
 STATIONS: tuple[Station, ...] = (
@@ -59,12 +69,20 @@ STATIONS: tuple[Station, ...] = (
         name="fresh",
         description="the newest uploads on plyr.fm",
         lens=lenses.fresh,
+        # fresh IS its head — a uniform draw would leak arbitrarily old tracks
+        # into "the newest uploads". its turnover comes from uploads, not from
+        # exploring the back catalog.
+        exploration=0.0,
     ),
     Station(
         slug="deep-cuts",
         name="deep cuts",
         description="underplayed tracks from the back catalog",
         lens=lenses.deep_cuts,
+        # the whole point is the long tail — its lens scores are near-ties across
+        # hundreds of underplayed tracks, so a tight head would freeze one slice
+        # of them into rotation. reach much deeper than the popularity stations.
+        rank_decay=48.0,
     ),
     Station(
         slug="slop",

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend._internal import Session, get_optional_session
 from backend.api.radio import lenses
 from backend.api.radio.lenses import LensContext
-from backend.api.radio.sampler import rank_decay_weights
+from backend.api.radio.sampler import build_rotation, rank_decay_weights
 from backend.config import settings
 from backend.main import app
 from backend.models import Artist, Tag, Track, TrackLike, TrackTag, get_db
@@ -215,12 +215,85 @@ def test_rank_decay_weights_zero_the_long_tail() -> None:
     assert sum(weights.values()) < 20
 
 
-async def test_rotation_is_deterministic_per_day(
+def _sampler_track(track_id: int, *, artist_did: str) -> Track:
+    return Track(
+        id=track_id,
+        artist_did=artist_did,
+        play_count=0,
+        created_at=datetime.now(UTC),
+        extra={"duration": 180},
+    )
+
+
+def test_rotation_reseeds_across_periods() -> None:
+    """different periods produce different rotations from the same corpus.
+
+    Regression: rotations used to reseed once per calendar day, so a listener
+    with a fixed daily listening window heard the same slice every day.
+    """
+    corpus = [_sampler_track(i, artist_did=f"did:plc:a{i}") for i in range(200)]
+    weights = rank_decay_weights([t.id for t in corpus], 12.0)
+    rotations = [
+        [
+            t.id
+            for t in build_rotation(
+                corpus,
+                weights,
+                station_slug="loved",
+                period=str(period),
+                max_tracks=40,
+            )
+        ]
+        for period in range(3)
+    ]
+    assert rotations[0] == [
+        t.id
+        for t in build_rotation(
+            corpus, weights, station_slug="loved", period="0", max_tracks=40
+        )
+    ]  # deterministic within a period
+    assert rotations[0] != rotations[1] != rotations[2]
+
+
+def test_exploration_floor_reaches_the_dormant_tail() -> None:
+    """uniform exploration draws make the deep tail reachable.
+
+    Regression: with a static ranking and rank-decay weights alone, nothing past
+    ~rank 85 ever aired — 14 simulated days touched only ~8% of a 918-track
+    corpus. The exploration floor guarantees deep ranks get airtime.
+    """
+    corpus = [_sampler_track(i, artist_did=f"did:plc:a{i}") for i in range(900)]
+    weights = rank_decay_weights([t.id for t in corpus], 12.0)
+
+    def reach(exploration: float) -> set[int]:
+        drawn: set[int] = set()
+        for period in range(20):
+            drawn.update(
+                t.id
+                for t in build_rotation(
+                    corpus,
+                    weights,
+                    station_slug="loved",
+                    period=str(period),
+                    max_tracks=40,
+                    exploration=exploration,
+                )
+            )
+        return drawn
+
+    weighted_only = reach(0.0)
+    with_floor = reach(0.25)
+    assert max(weighted_only) < 150  # the tail is unreachable without the floor
+    assert max(with_floor) > 500
+    assert len(with_floor) > len(weighted_only)
+
+
+async def test_rotation_is_deterministic_within_a_period(
     radio_app: FastAPI,
     db_session: AsyncSession,
     radio_artist: Artist,
 ) -> None:
-    """same (station, day) yields the same rotation for every client."""
+    """same (station, period) yields the same rotation for every client."""
     now = datetime.now(UTC) + TEST_TIME_OFFSET
     for index in range(8):
         await _create_track(

--- a/loq.toml
+++ b/loq.toml
@@ -332,7 +332,7 @@ max_lines = 948
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"
-max_lines = 535
+max_lines = 608
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"


### PR DESCRIPTION
## punchline

users report radio feels repetitive. the corpus isn't the problem (918 eligible tracks, ~117h of audio) — the sampler's reach was: simulating the exact sampler against prod data, consecutive-day rotations overlapped **81%**, and over 14 days only **8% of the corpus ever aired** (nothing deeper than lens-rank ~85). this PR widens reach with three small, composable changes confined to the radio module, all still stateless + deterministic.

## what changed

1. **per-station rank decay** (`stations.py`): `RANK_DECAY` moves from a global constant in `state.py` onto `Station`. `loved`/`fresh`/`slop` keep 12 (tight head is their identity); `deep-cuts` gets 48 — its lens scores are near-ties across hundreds of underplayed tracks, so a tight head froze one arbitrary slice of them into rotation, defeating the station's stated purpose.

2. **4-hour reseeding** (`state.py`, `sampler.py`): rotations were seeded per `(station, calendar day)`, so a listener with a fixed daily listening window (commute, work session) landed on the same slice of the same 4h loop every day. the seed key is now `epoch // 4h`. the sampler's `day` param is renamed to an opaque `period` accordingly. every client still computes the identical rotation within a period.

3. **exploration floor** (`sampler.py`): each draw has a per-station probability (default 0.25) of picking uniformly from the un-drawn pool instead of lens-weighted. rank-decay weights alone leave everything past the head effectively unreachable regardless of seed; the floor guarantees the dormant tail (376 mature tracks with ≤2 plays) actually cycles through. **`fresh` gets 0.0** — its identity is the leading edge, and a uniform draw would leak arbitrarily old tracks into "the newest uploads" (the exact regression the rank-decay weighting was built to prevent).

## measured effect (real prod corpus, 14 simulated days, exact production code paths)

| station | distinct tracks aired (before → after) | consecutive overlap | artists |
|---|---|---|---|
| loved | 72 (8%) → 483 (55%) | 70% → 51% | 32 → 62 |
| fresh | 83 (9%) → 100 (11%) | 66% → 68% | 17 → 20 |
| deep-cuts | 66 (8%) → 489 (56%) | 82% → 11% | 19 → 66 |
| slop | 20/20 already | 93% (20-track corpus; saturated) | 5 |

`fresh` barely moves by design — its turnover is bounded by the upload rate (~10–20/week), not the sampler. `loved` keeps a real head (decay 12 still concentrates weighted draws on the top ~36) while the floor + reseeding stop it starving everything else.

## intentional non-behaviors / deferred

- **no anti-repeat memory across periods** (down-weighting recently-aired tracks): would help further but needs replaying prior seeds; deferred to keep this change small and observable first.
- **no play-source attribution**: `loved` still self-reinforces (radio plays feed `play_count`, its own lens input). structural fix needs tracking where a play came from — separate issue-worthy work.
- **rotation still changes abruptly at a period boundary** mid-listen — same behavior as the existing daily boundary, just more frequent.
- **slop untouched in practice**: 20-track corpus, everything already airs.

## tests

- `test_rotation_reseeds_across_periods` — regression for the daily-seed fixed-window problem.
- `test_exploration_floor_reaches_the_dormant_tail` — proves the tail (rank >500 of 900) is reachable with the floor and unreachable (rank <150) without it, using the real sampler.
- existing determinism test renamed to `test_rotation_is_deterministic_within_a_period`.
- full backend suite: 1208 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)