### PR TITLE
fix(player): count plays + dispatch teal scrobbles for radio listening

### DIFF
--- a/frontend/src/lib/player-radio.test.ts
+++ b/frontend/src/lib/player-radio.test.ts
@@ -72,3 +72,52 @@ describe('playRadio under autoplay policy', () => {
 		expect(player.radio?.track.id).toBe(1);
 	});
 });
+
+// radio bypasses the queue track loader, which is the only place play counting
+// used to get armed — so radio listening never called /play and therefore never
+// counted plays or dispatched teal scrobbles for signed-in listeners.
+describe('play counting in radio mode', () => {
+	const fetchSpy = vi.fn((..._args: Parameters<typeof fetch>) =>
+		Promise.resolve(new Response())
+	);
+
+	beforeEach(() => {
+		fetchSpy.mockClear();
+		vi.stubGlobal('fetch', fetchSpy);
+		playSpy.mockResolvedValue(undefined);
+	});
+
+	function listen(seconds: number): void {
+		// simulate natural timeupdate progression (sub-threshold forward steps)
+		for (let t = 0; t <= seconds; t += 1) {
+			player.currentTime = t;
+			player.incrementPlayCount();
+		}
+	}
+
+	it('reports a play for the on-air track after sustained listening', () => {
+		player.playRadio(nowPlaying(42));
+		player.duration = 180;
+		listen(31);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(String(fetchSpy.mock.calls[0]?.[0])).toContain('/tracks/42/play');
+	});
+
+	it('does not report before the listened-time threshold', () => {
+		player.playRadio(nowPlaying(42));
+		player.duration = 180;
+		listen(10);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it('re-arms for the next on-air track at a boundary', () => {
+		player.playRadio(nowPlaying(1));
+		player.duration = 180;
+		listen(31);
+		player.playRadio(nowPlaying(2));
+		player.duration = 200;
+		listen(31);
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+		expect(String(fetchSpy.mock.calls[1]?.[0])).toContain('/tracks/2/play');
+	});
+});

--- a/frontend/src/lib/player.svelte.ts
+++ b/frontend/src/lib/player.svelte.ts
@@ -88,6 +88,12 @@ class PlayerState {
 		const assigned = this.radio;
 		this.currentTrack = null; // exit track mode; the track loader bails on null
 		this.paused = !autoplay;
+		// arm play counting for the on-air track. reset BEFORE the src swap so a
+		// stale near-end currentTime from the previous source can't fire, then
+		// unlock immediately — radio bypasses the queue loader whose `loadeddata`
+		// listener normally unlocks, which is why radio never counted or scrobbled.
+		this.resetPlayCount();
+		this.unlockPlayCount();
 		const el = this.audioElement;
 		if (!el) return;
 		el.src = np.stream_url;
@@ -129,7 +135,10 @@ class PlayerState {
 
 	incrementPlayCount() {
 		if (this._playCountLocked) return;
-		if (!this.currentTrack || this.playCountedForTrack === this.currentTrack.id || !this.duration) {
+		// radio plays through the same element — count the on-air track so radio
+		// listening feeds play counts and teal scrobbles like queue playback does
+		const track = this.radio?.track ?? this.currentTrack;
+		if (!track || this.playCountedForTrack === track.id || !this.duration) {
 			return;
 		}
 
@@ -146,7 +155,7 @@ class PlayerState {
 		this._lastProgressTime = now;
 
 		// synchronous check to prevent race condition from batched reactive updates
-		if (this._playCountPending === this.currentTrack.id) {
+		if (this._playCountPending === track.id) {
 			return;
 		}
 
@@ -155,13 +164,13 @@ class PlayerState {
 
 		if (this._playedSeconds >= threshold) {
 			// set synchronous guard immediately (before async fetch)
-			this._playCountPending = this.currentTrack.id;
-			this.playCountedForTrack = this.currentTrack.id;
+			this._playCountPending = track.id;
+			this.playCountedForTrack = track.id;
 
 			// include ref if it's for this track (for share link tracking)
-			const refForTrack = this._refTrackId === this.currentTrack.id ? this.ref : null;
+			const refForTrack = this._refTrackId === track.id ? this.ref : null;
 
-			fetch(`${API_URL}/tracks/${this.currentTrack.id}/play`, {
+			fetch(`${API_URL}/tracks/${track.id}/play`, {
 				method: 'POST',
 				credentials: 'include',
 				headers: refForTrack ? { 'Content-Type': 'application/json' } : undefined,


### PR DESCRIPTION
## punchline

signed-in radio listening never produced teal scrobbles (or play counts) — reported live by a listener whose teal pref, OAuth scopes, and backend dispatch were all correctly configured. the frontend simply never called `POST /tracks/{id}/play` from radio mode, and that endpoint is the sole dispatch point for scrobbles.

## root cause

scrobbling has one mechanism: the player accumulates *listened* time and calls `/tracks/{id}/play` at a threshold (min(30s, 50% of duration)); the backend increments `play_count` and, if the user has the pref + teal scopes, schedules the scrobble. radio was retrofitted as a second **source** on the same `<audio>` element and (for iOS autoplay reasons) swaps `audio.src` directly — bypassing the queue-track loader whose `loadeddata` listener is the only thing that unlocks play counting. on top of that, `incrementPlayCount` targeted `player.currentTrack`, which radio mode nulls out. so radio playback never armed the counter and had no track to count. this was a known deferred item from the radio-as-player-mode work (May 30/31); telemetry confirms the reporter (an active radio listener) has zero `/play` calls in 14 days while the endpoint works normally for queue listeners.

## what changed

- `incrementPlayCount` targets `radio?.track ?? currentTrack` — one mechanism for both sources, same threshold, same endpoint, same server-side dedup (per listener per track for ~one track length, so loop repeats don't inflate).
- `playRadio` arms the counter for the on-air track: `resetPlayCount()` before the src swap (so a stale near-end `currentTime` from the previous source can't fire spuriously — same ordering the queue loader uses) then `unlockPlayCount()`.

side effect worth naming: radio listening now also increments `play_count` for the first time. that feeds the `loved`/`deep-cuts` lens inputs, so the radio self-reinforcement consideration noted in #1620 now actually applies; acceptable, and the exploration floor bounds it.

## intentional non-behaviors

- anonymous radio listeners: `/play` fires (play counts) but no session → no scrobble, same as anonymous queue playback.
- joining mid-track still requires the threshold of *listened* time from the join point — no credit for the station position.
- no backfill of missed scrobbles.

## tests

new `play counting in radio mode` suite in `player-radio.test.ts` (threshold fires for the on-air track, sub-threshold doesn't, re-arms across track boundaries). verified the suite fails 2/3 against the pre-fix player. svelte-check, eslint, vitest (54), loq all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)