### PR TITLE
feat(auth): global post-login intent preservation (revives #1448) + listener/creator landing default

### DIFF
--- a/frontend/src/lib/components/AlbumUploadForm.svelte
+++ b/frontend/src/lib/components/AlbumUploadForm.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import type { AlbumSummary, Artist } from '$lib/types';
 	import type { TrackEntry } from '$lib/components/TrackEntryCard.svelte';
 	import TrackEntryCard from '$lib/components/TrackEntryCard.svelte';
 	import PdsTooltip from '$lib/components/PdsTooltip.svelte';
 	import { uploader, type UploadResult } from '$lib/uploader.svelte';
 	import { toast } from '$lib/toast.svelte';
-	import { setReturnUrl } from '$lib/utils/return-url';
+	import { redirectToLogin } from '$lib/utils/auth-redirect';
 	import { preflightAuth } from '$lib/upload-form-stash';
 	import { getServerConfig, API_URL } from '$lib/config';
 	import { profileLink } from '$lib/atclients';
@@ -245,9 +244,8 @@
 		// form is lost on redirect, but at least the error is honest.)
 		const authStatus = await preflightAuth();
 		if (authStatus === 'expired') {
-			setReturnUrl('/upload?mode=album');
 			toast.error('your session expired — sign in to continue your upload');
-			goto('/login');
+			redirectToLogin('/upload?mode=album');
 			return;
 		}
 		if (authStatus === 'unverified') {

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -7,6 +7,7 @@
 	import { search } from '$lib/search.svelte';
 	import { feedback } from '$lib/feedback.svelte';
 	import { APP_NAME, APP_TAGLINE, APP_STAGE } from '$lib/branding';
+	import { redirectToLogin } from '$lib/utils/auth-redirect';
 
 	interface Props {
 		user: User | null;
@@ -15,6 +16,12 @@
 	}
 
 	let { user, isAuthenticated, onLogout }: Props = $props();
+
+	function signIn(e: MouseEvent) {
+		// preserve where the user was so login brings them back here
+		e.preventDefault();
+		redirectToLogin();
+	}
 </script>
 
 <header>
@@ -75,7 +82,7 @@
 
 			<UserMenu {user} {onLogout} />
 		{:else}
-			<a href="/login" class="btn-primary">sign in</a>
+			<a href="/login" class="btn-primary" onclick={signIn}>sign in</a>
 		{/if}
 	</div>
 
@@ -110,7 +117,7 @@
 		{#if isAuthenticated}
 			<ProfileMenu {user} {onLogout} />
 		{:else}
-			<a href="/login" class="btn-primary">sign in</a>
+			<a href="/login" class="btn-primary" onclick={signIn}>sign in</a>
 		{/if}
 	</div>
 </header>

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -16,6 +16,7 @@
 	} from '$lib/audio-source';
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
+	import { loginHref } from '$lib/utils/auth-redirect';
 	import TrackInfo from './TrackInfo.svelte';
 	import PlaybackControls from './PlaybackControls.svelte';
 	import type { Track } from '$lib/types';
@@ -391,7 +392,10 @@
 
 	function handleGatedDenial(err: GatedError): void {
 		if (err.requiresAuth) {
-			toast.info('sign in to play supporter-only tracks');
+			toast.info('sign in to play supporter-only tracks', 5000, {
+				label: 'sign in',
+				href: loginHref()
+			});
 		} else {
 			const supportUrl = err.artistDid
 				? `${ATPROTOFANS_URL}/${err.artistDid}`

--- a/frontend/src/lib/playback.svelte.ts
+++ b/frontend/src/lib/playback.svelte.ts
@@ -9,6 +9,7 @@ import { browser } from '$app/environment';
 import { queue } from './queue.svelte';
 import { toast } from './toast.svelte';
 import { API_URL, getAtprotofansSupportUrl } from './config';
+import { loginHref } from './utils/auth-redirect';
 import type { Track } from './types';
 
 interface GatedCheckResult {
@@ -71,7 +72,10 @@ async function checkAccess(track: Track): Promise<GatedCheckResult> {
  */
 function showDeniedToast(result: GatedCheckResult): void {
 	if (result.requiresAuth) {
-		toast.info('sign in to play supporter-only tracks');
+		toast.info('sign in to play supporter-only tracks', 5000, {
+			label: 'sign in',
+			href: loginHref()
+		});
 	} else if (result.artistDid) {
 		toast.info('this track is for supporters only', 5000, {
 			label: 'become a supporter',
@@ -87,7 +91,10 @@ function showDeniedToast(result: GatedCheckResult): void {
  */
 function showGatedToast(track: Track, isAuthenticated: boolean): void {
 	if (!isAuthenticated) {
-		toast.info('sign in to play supporter-only tracks');
+		toast.info('sign in to play supporter-only tracks', 5000, {
+			label: 'sign in',
+			href: loginHref()
+		});
 	} else if (track.artist_did) {
 		toast.info('this track is for supporters only', 5000, {
 			label: 'become a supporter',

--- a/frontend/src/lib/utils/auth-redirect.test.ts
+++ b/frontend/src/lib/utils/auth-redirect.test.ts
@@ -1,0 +1,60 @@
+// post-login intent preservation: a logged-out user who follows any deep link
+// (shared jam, gated track, settings section) must land back on it after
+// signing in, riding the plyr_return_to cookie across the OAuth round-trip.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { goto } from '$app/navigation';
+
+const gotoSpy = vi.mocked(goto);
+
+import { loginHref, redirectToLogin, resolvePostLogin } from './auth-redirect';
+import { getReturnUrl, setReturnUrl, clearReturnUrl } from './return-url';
+
+beforeEach(() => {
+	gotoSpy.mockClear();
+	clearReturnUrl();
+});
+
+describe('loginHref', () => {
+	it('carries a relative destination', () => {
+		expect(loginHref('/jam/abc123')).toBe(`/login?return_to=${encodeURIComponent('/jam/abc123')}`);
+	});
+
+	it('drops absolute and protocol-relative destinations (open-redirect guard)', () => {
+		expect(loginHref('https://evil.example')).toBe('/login');
+		expect(loginHref('//evil.example')).toBe('/login');
+	});
+});
+
+describe('redirectToLogin', () => {
+	it('stashes the intent in the cookie and navigates to login', () => {
+		redirectToLogin('/track/7?t=42#comments');
+		expect(getReturnUrl()).toBe('/track/7?t=42#comments');
+		expect(gotoSpy).toHaveBeenCalledWith(
+			`/login?return_to=${encodeURIComponent('/track/7?t=42#comments')}`
+		);
+	});
+
+	it('never stashes an unsafe destination', () => {
+		redirectToLogin('https://evil.example');
+		expect(getReturnUrl()).toBeNull();
+		expect(gotoSpy).toHaveBeenCalledWith('/login');
+	});
+});
+
+describe('resolvePostLogin', () => {
+	it('returns false with nothing stashed', () => {
+		expect(resolvePostLogin()).toBe(false);
+	});
+
+	it('consumes the stash exactly once', () => {
+		setReturnUrl('/jam/abc123');
+		// jsdom forbids real navigation; observe the href assignment instead
+		const target: { href?: string } = {};
+		vi.spyOn(window, 'location', 'get').mockReturnValue(target as Location);
+		expect(resolvePostLogin()).toBe(true);
+		expect(target.href).toBe('/jam/abc123');
+		vi.restoreAllMocks();
+		expect(getReturnUrl()).toBeNull();
+		expect(resolvePostLogin()).toBe(false);
+	});
+});

--- a/frontend/src/lib/utils/auth-redirect.ts
+++ b/frontend/src/lib/utils/auth-redirect.ts
@@ -1,0 +1,38 @@
+import { goto } from '$app/navigation';
+import { setReturnUrl, getReturnUrl, clearReturnUrl, isValidReturnPath } from './return-url';
+
+/**
+ * global post-login intent preservation.
+ *
+ * one mechanism for "send a logged-out user to sign in, then bring them back
+ * to where they were". the destination rides in the `plyr_return_to` cookie
+ * (see return-url.ts) so it survives the external OAuth round-trip; the
+ * `?return_to=` param makes the same destination work for shareable links
+ * (the login page arms the cookie from it).
+ */
+
+/** the spot a logged-out action should return to: path + query + hash */
+export function currentIntent(): string {
+	if (typeof window === 'undefined') return '/';
+	return window.location.pathname + window.location.search + window.location.hash;
+}
+
+/** a /login href carrying the return destination — for declarative links + toast actions */
+export function loginHref(intent: string = currentIntent()): string {
+	return isValidReturnPath(intent) ? `/login?return_to=${encodeURIComponent(intent)}` : '/login';
+}
+
+/** stash where the user is and send them to sign in (defaults to the current page) */
+export function redirectToLogin(intent: string = currentIntent()): void {
+	setReturnUrl(intent);
+	goto(loginHref(intent));
+}
+
+/** consume a stashed destination after auth; returns true if it navigated away */
+export function resolvePostLogin(): boolean {
+	const target = getReturnUrl();
+	if (!target) return false;
+	clearReturnUrl();
+	window.location.href = target;
+	return true;
+}

--- a/frontend/src/routes/liked/+page.svelte
+++ b/frontend/src/routes/liked/+page.svelte
@@ -5,6 +5,7 @@
 	import { queue } from '$lib/queue.svelte';
 	import { toast } from '$lib/toast.svelte';
 	import { auth } from '$lib/auth.svelte';
+	import { redirectToLogin } from '$lib/utils/auth-redirect';
 	import { API_URL } from '$lib/config';
 	import type { Track } from '$lib/types';
 	import type { PageData } from './$types';
@@ -195,6 +196,7 @@
 			{#if !auth.isAuthenticated}
 				<h2>sign in to like tracks</h2>
 				<p>you need to be signed in to like tracks</p>
+				<a class="empty-cta" href="/login" onclick={(e) => { e.preventDefault(); redirectToLogin(); }}>sign in</a>
 			{:else}
 				<h2>no liked tracks yet</h2>
 				<p>tracks you like will appear here</p>
@@ -423,6 +425,21 @@
 	.empty-state p {
 		font-size: var(--text-base);
 		margin: 0;
+	}
+
+	.empty-cta {
+		display: inline-block;
+		margin-top: 1.25rem;
+		padding: 0.5rem 1.25rem;
+		border-radius: var(--radius-md);
+		background: var(--accent);
+		color: white;
+		font-size: var(--text-sm);
+		text-decoration: none;
+	}
+
+	.empty-cta:hover {
+		background: var(--accent-hover);
 	}
 
 	.tracks-list {

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -3,7 +3,7 @@
 	import { APP_NAME } from '$lib/branding';
 	import { API_URL } from '$lib/config';
 	import HandleAutocomplete from '$lib/components/HandleAutocomplete.svelte';
-	import { isValidReturnPath } from '$lib/utils/return-url';
+	import { isValidReturnPath, setReturnUrl } from '$lib/utils/return-url';
 
 	const returnTo = (() => {
 		const raw = new URLSearchParams(typeof window !== 'undefined' ? window.location.search : '').get('return_to');
@@ -32,6 +32,10 @@
 	let selectedPds = $state('');
 
 	onMount(async () => {
+		// arm the return destination so it survives the OAuth round-trip — this is
+		// what makes a shared /login?return_to=… link land back on the right page
+		if (returnTo) setReturnUrl(returnTo);
+
 		try {
 			const res = await fetch(`${API_URL}/auth/pds-options`);
 			if (res.ok) {

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { invalidateAll, replaceState } from '$app/navigation';
+	import { goto, invalidateAll, replaceState } from '$app/navigation';
 	import Header from '$lib/components/Header.svelte';
 	import WaveLoading from '$lib/components/WaveLoading.svelte';
 	import MigrationBanner from '$lib/components/MigrationBanner.svelte';
@@ -71,6 +71,20 @@
 						toast.success('copyright paradigm configured');
 					} else if (resolvePostLogin()) {
 						return;
+					} else {
+						// no captured intent: creators (with published tracks) land on
+						// their dashboard; everyone else lands on the app itself. only
+						// applies to this just-signed-in arrival — deliberate /portal
+						// navigation is never redirected.
+						try {
+							const r = await fetch(`${API_URL}/tracks/me?limit=1`, { credentials: 'include' });
+							if (r.ok && (await r.json()).total === 0) {
+								await goto('/', { replaceState: true });
+								return;
+							}
+						} catch {
+							// can't tell — stay on the portal
+						}
 					}
 				}
 			} catch (_e) {

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -23,7 +23,7 @@
 	import { auth } from '$lib/auth.svelte';
 	import { uploader } from '$lib/uploader.svelte';
 	import { player } from '$lib/player.svelte';
-	import { preferences } from '$lib/preferences.svelte'; import { getReturnUrl, clearReturnUrl } from '$lib/utils/return-url';
+	import { preferences } from '$lib/preferences.svelte'; import { redirectToLogin, resolvePostLogin } from '$lib/utils/auth-redirect';
 
 	// supported audio formats — matches backend AudioFormat enum + AlbumUploadForm
 	const AUDIO_FILE_INPUT_ACCEPT = '.mp3,.wav,.m4a,.aiff,.aif,.flac,audio/mpeg,audio/wav,audio/mp4,audio/aiff,audio/x-aiff,audio/flac';
@@ -170,13 +170,8 @@
 					await preferences.fetch();
 					if (isScopeUpgrade) {
 						toast.success('copyright paradigm configured');
-					} else {
-						const r = getReturnUrl();
-						if (r) {
-							clearReturnUrl();
-							window.location.href = r;
-							return;
-						}
+					} else if (resolvePostLogin()) {
+						return;
 					}
 				}
 			} catch (_e) {
@@ -192,7 +187,7 @@
 		}
 
 		if (!auth.isAuthenticated) {
-			window.location.href = '/login';
+			redirectToLogin();
 			return;
 		}
 

--- a/frontend/src/routes/profile/setup/+page.svelte
+++ b/frontend/src/routes/profile/setup/+page.svelte
@@ -4,7 +4,7 @@
 	import { invalidateAll, replaceState } from '$app/navigation';
 	import { API_URL } from '$lib/config';
 	import { auth } from '$lib/auth.svelte';
-	import { getReturnUrl, clearReturnUrl } from '$lib/utils/return-url';
+	import { redirectToLogin, resolvePostLogin } from '$lib/utils/auth-redirect';
 
 	let loading = true;
 	let saving = false;
@@ -45,7 +45,7 @@
 		}
 
 		if (!auth.isAuthenticated) {
-			window.location.href = '/login';
+			redirectToLogin();
 			return;
 		}
 
@@ -57,7 +57,7 @@
 			await fetchAvatar();
 		} catch {
 			auth.clearSession();
-			window.location.href = '/login';
+			redirectToLogin();
 		} finally {
 			loading = false;
 		}
@@ -108,12 +108,7 @@
 			});
 
 			if (response.ok) {
-				const returnTo = getReturnUrl();
-				if (returnTo) {
-					clearReturnUrl();
-					window.location.href = returnTo;
-					return;
-				}
+				if (resolvePostLogin()) return;
 				window.location.href = '/portal';
 			} else {
 				const errorData = await response.json();

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -11,6 +11,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 	import { AT_CLIENTS, DEFAULT_AT_CLIENT } from '$lib/atclients';
 	import { ambient } from '$lib/ambient.svelte';
 	import { queue } from '$lib/queue.svelte';
+	import { redirectToLogin } from '$lib/utils/auth-redirect';
 
 	let loading = $state(true);
 
@@ -112,7 +113,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		}
 
 		if (!auth.isAuthenticated) {
-			window.location.href = '/login';
+			redirectToLogin();
 			return;
 		}
 

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -22,6 +22,7 @@
 	import { auth } from '$lib/auth.svelte';
 	import { toast } from '$lib/toast.svelte';
 	import { trackCoverUrl } from '$lib/track-cover';
+	import { redirectToLogin } from '$lib/utils/auth-redirect';
 	import type { Track } from '$lib/types';
 
 	interface Comment {
@@ -719,7 +720,7 @@ $effect(() => {
 					</form>
 				{:else if !loadingComments}
 					<p class="login-prompt">
-						<a href="/login">sign in</a> to leave a comment
+						<a href="/login" onclick={(e) => { e.preventDefault(); redirectToLogin(); }}>sign in</a> to leave a comment
 					</p>
 				{/if}
 

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { onMount } from "svelte";
-	import { goto } from "$app/navigation";
 	import Header from "$lib/components/Header.svelte";
 	import HandleSearch from "$lib/components/HandleSearch.svelte";
 	import AlbumSelect from "$lib/components/AlbumSelect.svelte";
@@ -17,7 +16,7 @@
 	import { uploader } from "$lib/uploader.svelte";
 	import { toast } from "$lib/toast.svelte";
 	import { auth } from "$lib/auth.svelte";
-	import { setReturnUrl } from "$lib/utils/return-url";
+	import { redirectToLogin } from "$lib/utils/auth-redirect";
 	import {
 		stashTrackForm,
 		restoreTrackForm,
@@ -91,7 +90,7 @@
 		}
 
 		if (!auth.isAuthenticated) {
-			goto("/login");
+			redirectToLogin();
 			return;
 		}
 
@@ -172,11 +171,10 @@
 				autoTag,
 				trackUnlisted,
 			});
-			setReturnUrl("/upload");
 			toast.error(
 				"your session expired — sign in to continue your upload",
 			);
-			goto("/login");
+			redirectToLogin("/upload");
 			return;
 		}
 		if (authStatus === "unverified") {

--- a/frontend/src/tests/stubs/app-navigation.ts
+++ b/frontend/src/tests/stubs/app-navigation.ts
@@ -1,0 +1,6 @@
+// test stand-in for the `$app/navigation` virtual module
+import { vi } from 'vitest';
+
+export const goto = vi.fn(() => Promise.resolve());
+export const invalidateAll = vi.fn(() => Promise.resolve());
+export const replaceState = vi.fn();

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 		alias: {
 			$lib: path.resolve(import.meta.dirname, 'src/lib'),
 			'$app/environment': path.resolve(import.meta.dirname, 'src/tests/stubs/app-environment.ts'),
+			'$app/navigation': path.resolve(import.meta.dirname, 'src/tests/stubs/app-navigation.ts'),
 			'$app/stores': path.resolve(import.meta.dirname, 'src/tests/stubs/app-stores.ts'),
 			'$env/static/public': path.resolve(import.meta.dirname, 'src/tests/stubs/env-static-public.ts')
 		},

--- a/loq.toml
+++ b/loq.toml
@@ -148,7 +148,7 @@ max_lines = 730
 
 [[rules]]
 path = "frontend/src/routes/liked/+page.svelte"
-max_lines = 540
+max_lines = 552
 
 [[rules]]
 path = "frontend/src/routes/playlist/\\[id\\]/+page.svelte"
@@ -208,7 +208,7 @@ max_lines = 628
 
 [[rules]]
 path = "frontend/src/routes/login/+page.svelte"
-max_lines = 535
+max_lines = 537
 
 [[rules]]
 path = "backend/src/backend/_internal/tasks/ingest.py"


### PR DESCRIPTION
## punchline

signing in now returns you to wherever you were — a shared jam link, a gated track, a settings deep-link, or just the page you were browsing — instead of always dumping you on `/portal`. Revives the stale #1448 on current main and adds one new behavior: when there's *no* captured intent, creators (with published tracks) land on the portal and everyone else lands on the app itself.

## background

the jam share flow first exposed this: following a shared jam link while logged out meant sign in → portal → manually re-find the link. The `plyr_return_to` cookie mechanism (10-min TTL, relative-path-validated) was built then, but capture only ever existed on the jam page — the login page parsed `?return_to=` and used it *only* for the back-arrow, never arming the cookie, and the backend callback hardcodes `/portal`. #1448 (May 26) generalized capture but went stale; this PR is that work rebased across five weeks of churn (portal tabs, upload-form stash refactor, header height plumbing) plus the additions below.

## what changed

- **`lib/utils/auth-redirect.ts`** (from #1448): `redirectToLogin(intent?)` stashes path+query+hash and navigates to sign-in; `resolvePostLogin()` consumes the stash after the OAuth exchange; `loginHref(intent?)` for declarative links. All validated by the existing `isValidReturnPath` (relative-only — open-redirect-safe).
- **capture at every sign-in touchpoint**: the login page arms the cookie from `?return_to=` (shared links now work on their own); header sign-in buttons capture the current page; auth-guarded pages (`/settings`, `/portal`, `/profile/setup`), upload session-expiry paths, the track-page comment prompt, gated-track toasts, and the liked empty-state CTA.
- **new: listener/creator no-intent default** — after a login with no captured intent, the portal checks `GET /tracks/me?limit=1`; `total === 0` → `goto('/')`. Scoped strictly to the just-signed-in arrival (exchange token present): deliberate `/portal` navigation is never redirected, and the check failing open keeps today's portal-landing behavior.
- **tests** (didn't exist when #1448 was written — vitest does now): `auth-redirect.test.ts` covers intent stash/consume round-trip, one-shot consumption, and the open-redirect guard on both `loginHref` and `redirectToLogin`. Added a `$app/navigation` stub to the established vitest stub pattern.

## intentional non-behaviors

- **cookie, not localStorage**: the 10-min TTL means a stale intent can't teleport you somewhere surprising days later, and there's no multi-tab bleed on expiry semantics. The cookie already survives the external OAuth round-trip (it's a frontend-domain cookie read client-side after return).
- **scope-upgrade flow untouched** — it threads `redirect_to` through backend session state (`pending_scope_upgrade`) for a server-known destination and already works.
- **logout handlers untouched** — signing out intentionally goes to `/login` with no return intent.
- the backend callback still redirects to `/portal?exchange_token=…`; the portal remains the exchange consumer and forwards from there. Moving the exchange consumer out of the portal is a bigger refactor than this needs.

supersedes #1448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)