### PR TITLE
fix(player): skip on load failure so auto-advance never dead-airs

### DIFF
--- a/frontend/src/lib/audio-source.test.ts
+++ b/frontend/src/lib/audio-source.test.ts
@@ -1,0 +1,57 @@
+// findNextPlayableIndex is the shared forward-scan behind every "current track
+// can't play, skip ahead" path (gated denial, still-processing, load/media
+// failure). the load-failure path is what stops auto-advance from dead-airing
+// on a 404 / dead R2 url / corrupt media — regression cover for that.
+import { describe, it, expect, vi } from 'vitest';
+
+// control the "still on an undecodable interim rendition" predicate directly.
+const isOptimizingMock = vi.hoisted(() => vi.fn((_t: Track) => false));
+const canPlayFormatMock = vi.hoisted(() => vi.fn((_f?: string) => true));
+vi.mock('$lib/utils/track-audio', () => ({ isOptimizing: isOptimizingMock }));
+vi.mock('$lib/audio-support', () => ({
+	canPlayFormat: canPlayFormatMock,
+	hasPlayableLossless: () => true
+}));
+
+import { findNextPlayableIndex } from './audio-source';
+import type { Track } from './types';
+
+function track(id: number, extra: Partial<Track> = {}): Track {
+	return { id, file_id: `f${id}`, file_type: 'mp3', gated: false, ...extra } as Track;
+}
+
+describe('findNextPlayableIndex', () => {
+	it('returns the next non-gated track after the current one', () => {
+		const tracks = [track(1), track(2), track(3)];
+		expect(findNextPlayableIndex(tracks, 0)).toBe(1);
+	});
+
+	it('skips consecutive gated tracks to the first playable one', () => {
+		const tracks = [track(1), track(2, { gated: true }), track(3, { gated: true }), track(4)];
+		expect(findNextPlayableIndex(tracks, 0)).toBe(3);
+	});
+
+	it('returns -1 when only gated tracks remain (so the player pauses)', () => {
+		const tracks = [track(1), track(2, { gated: true }), track(3, { gated: true })];
+		expect(findNextPlayableIndex(tracks, 0)).toBe(-1);
+	});
+
+	it('returns -1 at the end of the queue', () => {
+		expect(findNextPlayableIndex([track(1), track(2)], 1)).toBe(-1);
+	});
+
+	it('skips tracks still awaiting a playable rendition by default', () => {
+		// track 2 is optimizing and this browser cannot play its interim format.
+		isOptimizingMock.mockImplementation((t: Track) => t.id === 2);
+		canPlayFormatMock.mockReturnValue(false);
+		const tracks = [track(1), track(2), track(3)];
+		expect(findNextPlayableIndex(tracks, 0)).toBe(2);
+	});
+
+	it('does not skip awaiting tracks when skipAwaiting is off (gated-denial scan)', () => {
+		isOptimizingMock.mockImplementation((t: Track) => t.id === 2);
+		canPlayFormatMock.mockReturnValue(false);
+		const tracks = [track(1), track(2), track(3)];
+		expect(findNextPlayableIndex(tracks, 0, { skipAwaiting: false })).toBe(1);
+	});
+});

--- a/frontend/src/lib/audio-source.ts
+++ b/frontend/src/lib/audio-source.ts
@@ -72,6 +72,28 @@ export function isAwaitingPlayableRendition(track: Track): boolean {
 }
 
 /**
+ * Index of the next track after `fromIndex` that can actually play now, or -1
+ * if none remain. Shared by every "the current track can't play, skip ahead"
+ * path (gated denial, still-processing, load/media failure) so auto-advance
+ * never dead-airs on a broken track. `skipAwaiting` also skips tracks still on
+ * an undecodable interim rendition; gated-denial leaves it off to preserve its
+ * original narrower scan.
+ */
+export function findNextPlayableIndex(
+	tracks: Track[],
+	fromIndex: number,
+	{ skipAwaiting = true }: { skipAwaiting?: boolean } = {}
+): number {
+	for (let i = fromIndex + 1; i < tracks.length; i++) {
+		const t = tracks[i];
+		if (t.gated) continue;
+		if (skipAwaiting && isAwaitingPlayableRendition(t)) continue;
+		return i;
+	}
+	return -1;
+}
+
+/**
  * Resolve a track's audio source URL.
  *
  * Returns a structured result so callers don't have to differentiate

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -9,8 +9,8 @@
 	import { preferences } from '$lib/preferences.svelte';
 	import { toast } from '$lib/toast.svelte';
 	import {
+		findNextPlayableIndex,
 		gatedErrorFromResolution,
-		isAwaitingPlayableRendition,
 		pickFileIdForTrack,
 		resolveAudioSource,
 		type GatedError,
@@ -415,13 +415,9 @@
 		// auto-play the skipped-to track: whether the user clicked a gated
 		// track or natural auto-advance landed on one, the user wants the
 		// next playable track to start. matches pre-fast-path behavior.
-		let nextPlayable = -1;
-		for (let i = queue.currentIndex + 1; i < queue.tracks.length; i++) {
-			if (!queue.tracks[i].gated) {
-				nextPlayable = i;
-				break;
-			}
-		}
+		const nextPlayable = findNextPlayableIndex(queue.tracks, queue.currentIndex, {
+			skipAwaiting: false
+		});
 		if (nextPlayable >= 0) {
 			shouldAutoPlay = true;
 			queue.goTo(nextPlayable);
@@ -436,14 +432,25 @@
 		// skip to the next track that's actually playable now (not gated, not
 		// still awaiting its transcoded rendition in this browser). mirrors
 		// handleGatedDenial so auto-advance never dead-airs on a processing track.
-		let nextPlayable = -1;
-		for (let i = queue.currentIndex + 1; i < queue.tracks.length; i++) {
-			const t = queue.tracks[i];
-			if (!t.gated && !isAwaitingPlayableRendition(t)) {
-				nextPlayable = i;
-				break;
-			}
+		const nextPlayable = findNextPlayableIndex(queue.tracks, queue.currentIndex);
+		if (nextPlayable >= 0) {
+			shouldAutoPlay = true;
+			queue.goTo(nextPlayable);
+		} else {
+			player.paused = true;
 		}
+	}
+
+	// a track's audio failed to load or play (404, dead R2 url, network
+	// error, or a runtime media error). mirror handleGatedDenial/handleProcessing
+	// so auto-advance never dead-airs: skip past the broken track to the next
+	// playable one, or pause at the end of the queue. no toast — a broken track
+	// in a collection tail should skip quietly, and the next track starting is
+	// its own feedback.
+	function handleLoadFailure(reason: unknown): void {
+		console.error('failed to load audio:', reason);
+
+		const nextPlayable = findNextPlayableIndex(queue.tracks, queue.currentIndex);
 		if (nextPlayable >= 0) {
 			shouldAutoPlay = true;
 			queue.goTo(nextPlayable);
@@ -532,7 +539,7 @@
 				handleProcessing();
 				return;
 			}
-			console.error('failed to load audio:', resolved.error);
+			handleLoadFailure(resolved.error);
 		});
 	});
 
@@ -801,6 +808,14 @@
 	onplay={() => { if (!jam.active) player.paused = false; }}
 	onpause={() => { if (!jam.active) player.paused = true; }}
 	onended={() => (player.radio ? radio.onEnded() : handleTrackEnded())}
+	onerror={() => {
+		// a src that resolved `ready` but failed at decode/playback time (dead url
+		// that passed the HEAD pre-check, corrupt body). radio owns its own stream,
+		// and a fresh load hasn't attached a track yet — skip only for the queue.
+		if (player.radio || !player.currentTrack || !player.audioElement?.src) return;
+		if (attachedTrackId !== player.currentTrack.id) return;
+		handleLoadFailure(`media error on ${player.currentTrack.id}`);
+	}}
 ></audio>
 
 {#if nowPlayingTrack}


### PR DESCRIPTION
Auto-advance into a track whose audio can't play left the footer parked on it forever. Gated (401/402) and still-processing tracks already skipped forward; genuine **load failures did not** — there was no handler for the `failed` resolution and no `onerror` on the `<audio>` element. This finishes the pattern so the player always skips to the next playable track (or pauses cleanly at the end of the queue).

Surfaced while reviewing collection continuity (#1626): tapping a track now runs the rest of the album/playlist through the player, so a broken track mid-collection could dead-air. But the hole is the player's — it already affected the "play album" button and the keep-playing tail — so it's fixed here on its own.

<details>
<summary>what could dead-air before</summary>

| resolution | before | now |
|---|---|---|
| `gated-denied` (401/402) | skip forward ✅ | unchanged |
| `processing` | skip forward ✅ | unchanged |
| **`failed`** (404, dead R2 url, network) | `console.error` only → **stall** | skip forward |
| **runtime media error** (src resolved `ready` but decode/playback fails) | no `<audio onerror>` → **stall** | skip forward |

</details>

<details>
<summary>design</summary>

- New `handleLoadFailure(reason)` mirrors `handleGatedDenial`/`handleProcessing`: skip to the next playable track, else `player.paused = true` at the end of the queue. No toast — a broken track in a collection tail should skip quietly, and the next track starting is its own feedback.
- New `<audio onerror>` funnels into the same handler. Guarded to ignore radio (owns its own stream), the no-current-track/no-src teardown window, and errors whose src is no longer the attached track — so intentional src swaps can't trigger a spurious skip or loop. Termination is bounded by the forward-scan, so an all-broken tail pauses at the end rather than looping.
- Extracted the forward-scan the three paths duplicated into `findNextPlayableIndex(tracks, from, { skipAwaiting })` in `audio-source.ts`. `skipAwaiting` also skips tracks still on an undecodable interim rendition; gated-denial keeps it off to preserve its original narrower scan.

</details>

<details>
<summary>tests</summary>

`src/lib/audio-source.test.ts` covers `findNextPlayableIndex`: next non-gated, skipping consecutive gated, `-1` when only gated remain (→ pause), `-1` at end of queue, and both `skipAwaiting` modes against the real `isOptimizing`/`canPlayFormat` predicates. Full frontend suite green (77 tests), svelte-check + eslint + loq clean.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)