### PR TITLE
fix(album): finish #1612 — green CI + surface the rename 409 to users

### DIFF
--- a/backend/tests/api/test_albums.py
+++ b/backend/tests/api/test_albums.py
@@ -791,9 +791,7 @@ async def test_update_album_title_slug_collision_returns_409(
             response = await client.patch(f"/albums/{renamed_id}?title=Test%20Albumz")
 
     assert response.status_code == 409
-    assert (
-        response.json()["detail"] == "another of your albums already uses that name"
-    )
+    assert response.json()["detail"] == "another of your albums already uses that name"
     # the collision is rejected before any ATProto work happens
     mock_track_update.assert_not_called()
     mock_list_update.assert_not_called()

--- a/frontend/src/lib/album-actions.test.ts
+++ b/frontend/src/lib/album-actions.test.ts
@@ -54,10 +54,20 @@ describe('updateTitle', () => {
 		expect(init.credentials).toBe('include');
 	});
 
-	it('throws on failure', async () => {
+	it('throws the generic fallback when the response has no detail', async () => {
 		fetchMock.mockResolvedValueOnce(jsonResponse({}, 500));
 
 		await expect(updateTitle(ALBUM_ID, 'x')).rejects.toThrow('failed to update title');
+	});
+
+	it('surfaces the server detail so a slug-collision 409 reaches the toast', async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse({ detail: 'another of your albums already uses that name' }, 409)
+		);
+
+		await expect(updateTitle(ALBUM_ID, 'x')).rejects.toThrow(
+			'another of your albums already uses that name'
+		);
 	});
 });
 

--- a/frontend/src/lib/album-actions.ts
+++ b/frontend/src/lib/album-actions.ts
@@ -17,7 +17,9 @@ export async function updateTitle(albumId: string, title: string): Promise<void>
 	});
 
 	if (!response.ok) {
-		throw new Error('failed to update title');
+		// surface the server detail (e.g. the 409 on a slug collision) so the
+		// caller can toast it, matching removeTrack/reorderTracks below.
+		throw new Error(await detailFrom(response, 'failed to update title'));
 	}
 }
 

--- a/loq.toml
+++ b/loq.toml
@@ -56,7 +56,7 @@ max_lines = 710
 
 [[rules]]
 path = "backend/tests/api/test_albums.py"
-max_lines = 1503
+max_lines = 1579
 
 [[rules]]
 path = "backend/tests/api/test_list_record_sync.py"
@@ -248,7 +248,7 @@ max_lines = 701
 
 [[rules]]
 path = "backend/src/backend/api/albums/mutations.py"
-max_lines = 574
+max_lines = 594
 
 [[rules]]
 path = "backend/src/backend/api/lists/playlists.py"


### PR DESCRIPTION
Fast-follow completing #1612 (fork PR whose own CI never ran, so it merged red and shipped a 409 the user never sees).

## 1. un-red `main`
#1612's push was the first failing `pre-commit checks` since #1625/#1626 (both green) — regression from that merge, not pre-existing debt.
- **loq** — the collision guard + regression test crossed limits: `mutations.py` 594 > 574, `test_albums.py` 1579 > 1503. Raised via `uvx loq relax` (line-count only; the code is the right shape).
- **ruff-format** (pinned v0.12.1) — collapsed a one-line assertion the merged test had wrapped.

## 2. surface the 409 detail (finishes the contribution's intent)
`updateTitle` in `album-actions.ts` was the one mutation throwing a generic error instead of the server `detail`, so #1612's *"another of your albums already uses that name"* never reached the toast — even though the album page already toasts the thrown message and the file already has a `detailFrom` helper (used by `removeTrack`/`reorderTracks`). Routed it through `detailFrom` so the message actually shows, with a test asserting the 409 detail propagates.

<details>
<summary>not included</summary>

- The `scripts/init_db.py` import-sort I flagged earlier was a **phantom** — my local ruff is newer/stricter than CI's pinned v0.12.1, which considers the original fine (the hook reverted my "fix"). No CI issue; left alone. (Worth reconciling the local-vs-CI ruff version drift separately.)
- The old-slug URL breakage on rename (`/u/{handle}/album/{old-slug}` 404s) remains a product decision, per sronix's out-of-scope note.

</details>

Full pre-commit green (whole-repo loq included); album-actions + album tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)