### PR TITLE
feat(auth): browserless dev-token minting via atproto app-password

### DIFF
--- a/backend/src/backend/_internal/atproto/client.py
+++ b/backend/src/backend/_internal/atproto/client.py
@@ -342,6 +342,182 @@ async def _refresh_session_tokens(
             raise ValueError(f"failed to refresh access token: {e}") from e
 
 
+async def _refresh_app_password_session(
+    auth_session: AuthSession, stale_access_token: str
+) -> str:
+    """refresh a bearer app-password session via com.atproto.server.refreshSession.
+
+    mirrors _refresh_session_tokens for the app-password path: serialize per
+    session, skip the network call if another coroutine already rotated, and
+    surface a dead refresh token as SessionExpiredError so handlers return 401.
+    """
+    from backend._internal.auth.app_password import APP_PASSWORD_REFRESH_DAYS
+
+    session_id = auth_session.session_id
+    async with _session_refresh_lock(session_id):
+        updated = await get_session(session_id)
+        if not updated:
+            raise ValueError(f"session {session_id} no longer exists")
+        data = updated.oauth_session
+        if data.get("access_token") != stale_access_token:
+            # another coroutine refreshed while we waited on the lock
+            return data["access_token"]
+
+        pds = data["pds_url"].rstrip("/")
+        async with httpx.AsyncClient(timeout=30) as http:
+            resp = await http.post(
+                f"{pds}/xrpc/com.atproto.server.refreshSession",
+                headers={"Authorization": f"Bearer {data['refresh_token']}"},
+            )
+        if resp.status_code != 200:
+            # a dead/expired refresh token is terminal — a fresh app-password
+            # login is required. surface it like the OAuth path so handlers 401.
+            raise SessionExpiredError(
+                "atproto session expired — re-authentication required"
+            )
+
+        body = resp.json()
+        new_data = {
+            **data,
+            "access_token": body["accessJwt"],
+            "refresh_token": body["refreshJwt"],
+            "refresh_token_expires_at": (
+                datetime.now(UTC) + timedelta(days=APP_PASSWORD_REFRESH_DAYS)
+            ).isoformat(),
+        }
+        await update_session_tokens(session_id, new_data)
+        logger.info("refreshed app-password session for %s", auth_session.did)
+        return body["accessJwt"]
+
+
+async def _app_password_request(
+    auth_session: AuthSession,
+    method: str,
+    endpoint: str,
+    payload: dict[str, Any] | None,
+    params: dict[str, Any] | None,
+    success_codes: tuple[int, ...],
+) -> dict[str, Any]:
+    """make_pds_request for bearer app-password sessions (no DPoP/OAuth client)."""
+    data = auth_session.oauth_session
+    access_token = data["access_token"]
+    url = f"{data['pds_url'].rstrip('/')}/xrpc/{endpoint}"
+    has_refreshed = False
+    response = None
+
+    for attempt in range(_PDS_MAX_ATTEMPTS):
+        kwargs: dict[str, Any] = {}
+        if payload:
+            kwargs["json"] = payload
+        if params:
+            kwargs["params"] = params
+        try:
+            async with httpx.AsyncClient(timeout=30) as http:
+                response = await http.request(
+                    method,
+                    url,
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    **kwargs,
+                )
+        except _TRANSIENT_HTTP_ERRORS as e:
+            if attempt < _PDS_MAX_ATTEMPTS - 1:
+                await asyncio.sleep(_backoff_for_attempt(attempt))
+                continue
+            raise Exception(
+                f"PDS request failed after {_PDS_MAX_ATTEMPTS} attempts: {_describe_exc(e)}"
+            ) from e
+
+        if response.status_code in success_codes:
+            return {} if response.status_code == 204 else response.json()
+
+        if response.status_code == 401 and not has_refreshed:
+            has_refreshed = True
+            access_token = await _refresh_app_password_session(
+                auth_session, access_token
+            )
+            continue
+
+        if 500 <= response.status_code < 600 and attempt < _PDS_MAX_ATTEMPTS - 1:
+            await asyncio.sleep(_backoff_for_attempt(attempt))
+            continue
+        break
+
+    if response is None:
+        raise Exception("PDS request failed: no response received")
+    raise Exception(
+        f"PDS request failed: {response.status_code} {response.text or '<empty body>'}"
+    )
+
+
+async def _app_password_upload_blob(
+    auth_session: AuthSession,
+    *,
+    data: bytes | BinaryIO | None,
+    body_factory: StreamBodyFactory | None,
+    content_length: int | None,
+    content_type: str,
+    heartbeat: ProgressHeartbeat | None,
+) -> BlobRef:
+    """upload_blob for bearer app-password sessions (plain bearer, no DPoP nonce)."""
+    sess = auth_session.oauth_session
+    access_token = sess["access_token"]
+    url = f"{sess['pds_url'].rstrip('/')}/xrpc/com.atproto.repo.uploadBlob"
+
+    blob_data: bytes | None = None
+    if body_factory is None:
+        assert data is not None
+        blob_data = data if isinstance(data, bytes) else data.read()
+
+    response: httpx.Response | None = None
+    for attempt in range(_PDS_MAX_ATTEMPTS):
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": content_type,
+        }
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(None)) as http:
+                if body_factory is not None:
+                    assert content_length is not None
+                    headers["Content-Length"] = str(content_length)
+                    content = (
+                        _heartbeating_body(body_factory, heartbeat)
+                        if heartbeat is not None
+                        else body_factory()
+                    )
+                    response = await http.post(url, headers=headers, content=content)
+                else:
+                    response = await http.post(url, headers=headers, content=blob_data)
+        except _TRANSIENT_HTTP_ERRORS as e:
+            if attempt < _PDS_MAX_ATTEMPTS - 1:
+                await asyncio.sleep(_backoff_for_attempt(attempt))
+                continue
+            raise Exception(
+                f"blob upload failed after {_PDS_MAX_ATTEMPTS} attempts: {_describe_exc(e)}"
+            ) from e
+
+        if response.status_code == 200:
+            return response.json()["blob"]
+        if response.status_code == 413:
+            raise PayloadTooLargeError(
+                f"blob too large for PDS (limit exceeded): {response.text or '<empty body>'}"
+            )
+        if response.status_code == 401 and attempt < _PDS_MAX_ATTEMPTS - 1:
+            access_token = await _refresh_app_password_session(
+                auth_session, access_token
+            )
+            continue
+        if 500 <= response.status_code < 600 and attempt < _PDS_MAX_ATTEMPTS - 1:
+            await asyncio.sleep(_backoff_for_attempt(attempt))
+            continue
+        break
+
+    if response is None:
+        raise Exception("blob upload failed: no response received")
+    raise Exception(
+        f"blob upload failed: {response.status_code} {response.text or '<empty body>'}"
+    )
+
+
 async def make_pds_request(
     auth_session: AuthSession,
     method: str,
@@ -371,6 +547,11 @@ async def make_pds_request(
     if not oauth_data or "access_token" not in oauth_data:
         raise ValueError(
             f"OAuth session data missing or invalid for {auth_session.did}"
+        )
+
+    if oauth_data.get("auth_type") == "app_password":
+        return await _app_password_request(
+            auth_session, method, endpoint, payload, params, success_codes
         )
 
     oauth_session = reconstruct_oauth_session(oauth_data)
@@ -571,6 +752,16 @@ async def upload_blob(
     if not oauth_data or "access_token" not in oauth_data:
         raise ValueError(
             f"OAuth session data missing or invalid for {auth_session.did}"
+        )
+
+    if oauth_data.get("auth_type") == "app_password":
+        return await _app_password_upload_blob(
+            auth_session,
+            data=data,
+            body_factory=body_factory,
+            content_length=content_length,
+            content_type=content_type,
+            heartbeat=heartbeat,
         )
 
     oauth_session = reconstruct_oauth_session(oauth_data)

--- a/backend/src/backend/_internal/auth/app_password.py
+++ b/backend/src/backend/_internal/auth/app_password.py
@@ -1,0 +1,92 @@
+"""Browserless developer-token minting via an atproto app-password.
+
+The normal developer-token path (`/auth/developer-token/start` → browser OAuth
+consent → `/auth/callback`) hard-requires a browser redirect. For CI / test
+accounts we instead log in with `com.atproto.server.createSession` (identifier +
+app-password) and wrap the returned bearer JWTs into a developer-token session
+the PDS write path can use. Gated OFF by default; enable only in dev/staging.
+"""
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+
+from backend._internal.auth.session import create_session
+from backend.config import settings
+
+logger = logging.getLogger(__name__)
+
+# app-password refresh tokens on reference PDSes last ~90 days and rotate on
+# use; cap the session to match so it never outlives its refresh token.
+APP_PASSWORD_REFRESH_DAYS = 90
+
+
+class AppPasswordAuthError(Exception):
+    """raised when app-password minting is disabled or the PDS login fails."""
+
+
+async def create_app_password_session(
+    identifier: str,
+    app_password: str,
+    pds_url: str,
+    *,
+    token_name: str | None = None,
+) -> dict[str, str]:
+    """mint a developer-token session from an atproto app-password.
+
+    logs in to `pds_url` via `com.atproto.server.createSession` and persists the
+    bearer session as an `is_developer_token` row the write path recognizes by
+    its `auth_type: "app_password"` discriminator.
+
+    returns `{"token": session_id, "did": did, "handle": handle}`.
+
+    raises AppPasswordAuthError when disabled by config or the PDS rejects login.
+    """
+    if not settings.auth.allow_app_password_dev_tokens:
+        raise AppPasswordAuthError(
+            "app-password developer tokens are disabled "
+            "(set AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS=true in dev/staging only)"
+        )
+
+    base = pds_url.rstrip("/")
+    async with httpx.AsyncClient(timeout=30) as http:
+        resp = await http.post(
+            f"{base}/xrpc/com.atproto.server.createSession",
+            json={"identifier": identifier, "password": app_password},
+        )
+    if resp.status_code != 200:
+        raise AppPasswordAuthError(
+            f"createSession failed for {identifier}: "
+            f"{resp.status_code} {resp.text or '<empty body>'}"
+        )
+
+    body = resp.json()
+    did = body["did"]
+    handle = body.get("handle", identifier)
+    now = datetime.now(UTC)
+
+    oauth_session: dict[str, Any] = {
+        "auth_type": "app_password",
+        "did": did,
+        "handle": handle,
+        "pds_url": base,
+        "access_token": body["accessJwt"],
+        "refresh_token": body["refreshJwt"],
+        # explicit so create_session's OAuth-lifetime defaults don't apply
+        "refresh_token_expires_at": (
+            now + timedelta(days=APP_PASSWORD_REFRESH_DAYS)
+        ).isoformat(),
+    }
+
+    session_id = await create_session(
+        did=did,
+        handle=handle,
+        oauth_session=oauth_session,
+        expires_in_days=APP_PASSWORD_REFRESH_DAYS,
+        is_developer_token=True,
+        token_name=token_name,
+    )
+    logger.info("minted app-password developer token for %s (%s)", handle, did)
+    return {"token": session_id, "did": did, "handle": handle}

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -1031,6 +1031,14 @@ class AuthSettings(AppSettingsSection):
         default=365,
         description="Maximum allowed expiration in days for developer tokens",
     )
+    allow_app_password_dev_tokens: bool = Field(
+        default=False,
+        description=(
+            "Allow minting developer-token sessions from an atproto app-password "
+            "(browserless, via com.atproto.server.createSession). Fail-safe OFF; "
+            "enable only in dev/staging for test-account provisioning, never prod."
+        ),
+    )
 
 
 class AccountCreationSettings(AppSettingsSection):

--- a/backend/tests/_internal/test_app_password.py
+++ b/backend/tests/_internal/test_app_password.py
@@ -1,0 +1,219 @@
+"""app-password developer-token minting + the bearer PDS write path.
+
+covers the browserless mint (`create_app_password_session`) and the app-password
+branch of the atproto client (`make_pds_request` / `upload_blob` dispatch, bearer
+requests, and `com.atproto.server.refreshSession` rotation) that stands in for
+the OAuth/DPoP path when a session carries `auth_type: "app_password"`.
+"""
+
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend._internal import Session as AuthSession
+from backend._internal.atproto.client import (
+    SessionExpiredError,
+    _refresh_app_password_session,
+    make_pds_request,
+    upload_blob,
+)
+from backend._internal.auth.app_password import (
+    AppPasswordAuthError,
+    create_app_password_session,
+)
+from backend.config import settings
+
+
+def _response(status_code: int = 200, json_data: dict | None = None) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.text = "ok"
+    return resp
+
+
+def _fake_async_client(responses: list) -> tuple[MagicMock, MagicMock]:
+    """build a patch target for httpx.AsyncClient.
+
+    every `async with httpx.AsyncClient() as http` yields the same http mock;
+    its request/post return `responses` in order (an httpx error in the list is
+    raised). returns (client_factory, http) so tests can assert call counts.
+    """
+    http = MagicMock()
+    http.request = AsyncMock(side_effect=list(responses))
+    http.post = AsyncMock(side_effect=list(responses))
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=http)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=cm), http
+
+
+def _app_pw_session(
+    access: str = "access-1", refresh: str = "refresh-1"
+) -> AuthSession:
+    return AuthSession(
+        session_id="sess-1",
+        did="did:plc:test",
+        handle="tester.example",
+        oauth_session={
+            "auth_type": "app_password",
+            "did": "did:plc:test",
+            "handle": "tester.example",
+            "pds_url": "https://pds.example",
+            "access_token": access,
+            "refresh_token": refresh,
+        },
+    )
+
+
+@contextlib.asynccontextmanager
+async def _noop_lock(session_id: str):
+    yield
+
+
+# --- minting -------------------------------------------------------------
+
+
+async def test_mint_disabled_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings.auth, "allow_app_password_dev_tokens", False)
+    with pytest.raises(AppPasswordAuthError, match="disabled"):
+        await create_app_password_session("h.example", "pw", "https://pds.example")
+
+
+async def test_mint_builds_app_password_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings.auth, "allow_app_password_dev_tokens", True)
+    factory, _ = _fake_async_client(
+        [
+            _response(
+                200,
+                {
+                    "did": "did:plc:test",
+                    "handle": "tester.example",
+                    "accessJwt": "acc",
+                    "refreshJwt": "ref",
+                },
+            )
+        ]
+    )
+    create_mock = AsyncMock(return_value="sess-xyz")
+    with (
+        patch("backend._internal.auth.app_password.httpx.AsyncClient", factory),
+        patch("backend._internal.auth.app_password.create_session", create_mock),
+    ):
+        result = await create_app_password_session(
+            "tester.example", "pw", "https://pds.example/", token_name="ci"
+        )
+
+    assert result == {
+        "token": "sess-xyz",
+        "did": "did:plc:test",
+        "handle": "tester.example",
+    }
+    kwargs = create_mock.await_args.kwargs
+    assert kwargs["is_developer_token"] is True
+    assert kwargs["token_name"] == "ci"
+    session = kwargs["oauth_session"]
+    assert session["auth_type"] == "app_password"
+    assert session["access_token"] == "acc"
+    assert session["refresh_token"] == "ref"
+    assert session["pds_url"] == "https://pds.example"  # trailing slash stripped
+    assert "refresh_token_expires_at" in session
+
+
+async def test_mint_bad_credentials_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings.auth, "allow_app_password_dev_tokens", True)
+    factory, _ = _fake_async_client([_response(401, {})])
+    with (
+        patch("backend._internal.auth.app_password.httpx.AsyncClient", factory),
+        pytest.raises(AppPasswordAuthError, match="createSession failed"),
+    ):
+        await create_app_password_session("h.example", "bad", "https://pds.example")
+
+
+# --- bearer request path -------------------------------------------------
+
+
+async def test_make_pds_request_dispatches_to_bearer_path() -> None:
+    """an app_password session must never touch the OAuth/DPoP reconstruction."""
+    factory, http = _fake_async_client([_response(200, {"uri": "at://x"})])
+    with patch("backend._internal.atproto.client.httpx.AsyncClient", factory):
+        result = await make_pds_request(
+            _app_pw_session(), "POST", "com.atproto.repo.createRecord", payload={"a": 1}
+        )
+    assert result == {"uri": "at://x"}
+    # bearer auth, not DPoP
+    assert (
+        http.request.await_args.kwargs["headers"]["Authorization"] == "Bearer access-1"
+    )
+
+
+async def test_bearer_request_refreshes_on_401_then_succeeds() -> None:
+    factory, _ = _fake_async_client([_response(401, {}), _response(200, {"ok": 1})])
+    refresh = AsyncMock(return_value="access-2")
+    with (
+        patch("backend._internal.atproto.client.httpx.AsyncClient", factory),
+        patch(
+            "backend._internal.atproto.client._refresh_app_password_session", refresh
+        ),
+    ):
+        result = await make_pds_request(
+            _app_pw_session(), "POST", "com.atproto.repo.createRecord", payload={}
+        )
+    assert result == {"ok": 1}
+    refresh.assert_awaited_once()
+
+
+async def test_upload_blob_dispatches_to_bearer_path() -> None:
+    factory, http = _fake_async_client(
+        [_response(200, {"blob": {"ref": {"$link": "bafyblob"}}})]
+    )
+    with patch("backend._internal.atproto.client.httpx.AsyncClient", factory):
+        blob = await upload_blob(
+            _app_pw_session(), data=b"RIFFwav", content_type="audio/wav"
+        )
+    assert blob == {"ref": {"$link": "bafyblob"}}
+    assert http.post.await_args.kwargs["headers"]["Authorization"] == "Bearer access-1"
+
+
+# --- refresh -------------------------------------------------------------
+
+
+async def test_refresh_rotates_and_persists() -> None:
+    factory, _ = _fake_async_client(
+        [_response(200, {"accessJwt": "acc-new", "refreshJwt": "ref-new"})]
+    )
+    update = AsyncMock()
+    reloaded = _app_pw_session()  # same access token → forces a real refresh
+    with (
+        patch("backend._internal.atproto.client._session_refresh_lock", _noop_lock),
+        patch(
+            "backend._internal.atproto.client.get_session",
+            AsyncMock(return_value=reloaded),
+        ),
+        patch("backend._internal.atproto.client.update_session_tokens", update),
+        patch("backend._internal.atproto.client.httpx.AsyncClient", factory),
+    ):
+        new_access = await _refresh_app_password_session(_app_pw_session(), "access-1")
+
+    assert new_access == "acc-new"
+    persisted = update.await_args.args[1]
+    assert persisted["access_token"] == "acc-new"
+    assert persisted["refresh_token"] == "ref-new"
+    assert persisted["auth_type"] == "app_password"
+
+
+async def test_refresh_dead_token_raises_session_expired() -> None:
+    factory, _ = _fake_async_client([_response(400, {"error": "ExpiredToken"})])
+    with (
+        patch("backend._internal.atproto.client._session_refresh_lock", _noop_lock),
+        patch(
+            "backend._internal.atproto.client.get_session",
+            AsyncMock(return_value=_app_pw_session()),
+        ),
+        patch("backend._internal.atproto.client.httpx.AsyncClient", factory),
+        pytest.raises(SessionExpiredError),
+    ):
+        await _refresh_app_password_session(_app_pw_session(), "access-1")

--- a/docs/internal/authentication.md
+++ b/docs/internal/authentication.md
@@ -477,6 +477,21 @@ the PDS enforces these scopes at the protocol level — not just plyr.fm's API. 
 
 **security notes**: tokens grant full access to plyr.fm features, but are namespace-scoped at the protocol level. each token is independent — revoke individually via [settings](https://plyr.fm/settings#developer) or API.
 
+### browserless minting (dev/staging test tokens)
+
+the OAuth flow above needs a browser consent redirect, which is painful for CI test accounts whose sessions periodically expire (`SessionExpiredError`). for **dev/staging only**, a token can be minted without a browser from an atproto **app-password**:
+
+```bash
+# needs ZAT_TEST_HANDLE / ZAT_TEST_PASSWORD / ZAT_TEST_PDS in .env
+AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS=true just mint-dev-token --verify
+```
+
+`create_app_password_session` (`_internal/auth/app_password.py`) logs in via `com.atproto.server.createSession`, wraps the returned bearer JWTs into a developer-token session tagged `auth_type: "app_password"`, and returns the token. The atproto client (`_internal/atproto/client.py`) dispatches these sessions to a bearer write path (refresh via `com.atproto.server.refreshSession`) — the OAuth/DPoP path is untouched.
+
+- **gated OFF by default** (`AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS`); never enable in production. app-password sessions carry full repo access, unlike the namespace-scoped OAuth grants above — acceptable only for throwaway test accounts.
+- `--set-gh-secret PLYR_TEST_TOKEN_1` rotates a CI secret in the same command.
+- `--verify` proves the write path by uploading a throwaway blob through the backend (the exact path that was 500ing).
+
 ## OAuth client types: public vs confidential
 
 ATProto OAuth distinguishes between two types of clients based on their ability to authenticate themselves to the authorization server.

--- a/docs/internal/testing/integration-tests.md
+++ b/docs/internal/testing/integration-tests.md
@@ -25,7 +25,10 @@ uv run pytest tests/integration -m integration -v
 | `PLYR_TEST_TOKEN_2` | plyr.fm | secondary user - cross-user interaction tests |
 | `PLYR_TEST_TOKEN_3` | zzstoatzzdevlog.bsky.social | tertiary user - reserved for future tests |
 
-tokens are developer tokens created at [plyr.fm/settings#developer](https://plyr.fm/settings#developer) → "developer tokens".
+tokens are developer tokens. two ways to mint them:
+
+- **browser:** [plyr.fm/settings#developer](https://plyr.fm/settings#developer) → "developer tokens" (full OAuth consent flow).
+- **browserless** (for refreshing these when they expire — `SessionExpiredError` in CI): `just mint-dev-token --handle <h> --bootstrap --set-gh-secret PLYR_TEST_TOKEN_N`, which mints a scoped app-password from an account password (`$MAIN_BSKY_PASSWORD`) and rotates the CI secret. Requires `AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS=true` (dev/staging only). See [authentication.md](../authentication.md#browserless-minting-devstaging-test-tokens).
 
 ## github actions
 

--- a/justfile
+++ b/justfile
@@ -45,3 +45,7 @@ loq-relax *FILES:
 # expose backend via ngrok tunnel
 tunnel:
     ngrok http 8001 --domain tunnel.zzstoatzz.io
+
+# mint a browserless dev token from an app-password (see scripts/mint_dev_token.py)
+mint-dev-token *ARGS:
+    uv run --project backend scripts/mint_dev_token.py {{ ARGS }}

--- a/loq.toml
+++ b/loq.toml
@@ -44,7 +44,7 @@ max_lines = 1841
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 1142
+max_lines = 1150
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
@@ -80,7 +80,7 @@ max_lines = 781
 
 [[rules]]
 path = "docs/internal/authentication.md"
-max_lines = 631
+max_lines = 643
 
 [[rules]]
 path = "docs/internal/backend/liked-tracks.md"
@@ -284,7 +284,7 @@ max_lines = 2589
 
 [[rules]]
 path = "backend/src/backend/_internal/atproto/client.py"
-max_lines = 683
+max_lines = 874
 
 [[rules]]
 path = "backend/src/backend/_internal/auth/oauth.py"

--- a/scripts/mint_dev_token.py
+++ b/scripts/mint_dev_token.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env -S uv run --script --quiet
+"""mint a plyr developer token from an atproto app-password — no browser.
+
+The normal dev-token path requires a browser OAuth consent redirect. This mints
+the same kind of `is_developer_token` session by logging in with
+`com.atproto.server.createSession` (identifier + app-password) and wrapping the
+bearer JWTs into a session the PDS write path recognizes. Gated by
+`AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS` — enable in dev/staging only, never prod.
+
+## Usage
+
+```bash
+# mint against the ZAT_TEST_* account in the root .env, print the token
+uv run scripts/mint_dev_token.py
+
+# also prove the backend write path works (uploads a throwaway blob to the PDS —
+# the exact path that was 500ing with SessionExpiredError)
+uv run scripts/mint_dev_token.py --verify
+
+# mint and rotate a CI secret in one shot
+uv run scripts/mint_dev_token.py --set-gh-secret PLYR_TEST_TOKEN_1
+```
+
+Needs `ZAT_TEST_HANDLE` / `ZAT_TEST_PASSWORD` / `ZAT_TEST_PDS` in the root `.env`
+(or pass `--handle` / `--password` / `--pds`), and the backend's `.env` for the
+DB + encryption key the session is written with.
+"""
+
+import argparse
+import asyncio
+import os
+import subprocess
+import sys
+
+from dotenv import load_dotenv
+
+from backend._internal.auth.app_password import (
+    AppPasswordAuthError,
+    create_app_password_session,
+)
+
+load_dotenv()
+
+
+async def _mint(
+    handle: str, password: str, pds: str, name: str | None
+) -> dict[str, str]:
+    return await create_app_password_session(
+        identifier=handle, app_password=password, pds_url=pds, token_name=name
+    )
+
+
+async def _verify(token: str) -> str:
+    """prove the minted session drives a real PDS write (uploadBlob).
+
+    this is the exact bearer path that replaces the expired-OAuth 500. returns
+    the stored blob CID.
+    """
+    from backend._internal import get_session
+    from backend._internal.atproto.client import upload_blob
+
+    session = await get_session(token)
+    if session is None:
+        raise SystemExit("verify failed: minted session not found in DB")
+    blob = await upload_blob(
+        session,
+        data=b"RIFF\x24\x00\x00\x00WAVEfmt mint-dev-token verify",
+        content_type="audio/wav",
+    )
+    return blob["ref"]["$link"]
+
+
+def _set_gh_secret(name: str, value: str) -> None:
+    subprocess.run(
+        ["gh", "secret", "set", name],
+        input=value.encode(),
+        check=True,
+    )
+    print(f"✓ set GitHub secret {name}", file=sys.stderr)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--handle", default=os.getenv("ZAT_TEST_HANDLE"))
+    parser.add_argument("--password", default=os.getenv("ZAT_TEST_PASSWORD"))
+    parser.add_argument("--pds", default=os.getenv("ZAT_TEST_PDS"))
+    parser.add_argument("--name", default="mint_dev_token.py", help="token label")
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="upload a throwaway blob through the backend to prove the write path",
+    )
+    parser.add_argument(
+        "--set-gh-secret",
+        metavar="NAME",
+        help="rotate this GitHub Actions secret to the minted token",
+    )
+    args = parser.parse_args()
+
+    if not (args.handle and args.password and args.pds):
+        parser.error(
+            "need --handle/--password/--pds or ZAT_TEST_HANDLE/PASSWORD/PDS in .env"
+        )
+
+    try:
+        result = asyncio.run(_mint(args.handle, args.password, args.pds, args.name))
+    except AppPasswordAuthError as e:
+        print(f"✗ {e}", file=sys.stderr)
+        return 1
+
+    token = result["token"]
+    print(
+        f"✓ minted dev token for {result['handle']} ({result['did']})", file=sys.stderr
+    )
+
+    if args.verify:
+        cid = asyncio.run(_verify(token))
+        print(f"✓ write path verified — uploaded blob {cid}", file=sys.stderr)
+
+    if args.set_gh_secret:
+        _set_gh_secret(args.set_gh_secret, token)
+
+    # the token itself goes to stdout so it can be captured/piped
+    print(token)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mint_dev_token.py
+++ b/scripts/mint_dev_token.py
@@ -10,20 +10,20 @@ bearer JWTs into a session the PDS write path recognizes. Gated by
 ## Usage
 
 ```bash
-# mint against the ZAT_TEST_* account in the root .env, print the token
-uv run scripts/mint_dev_token.py
+# bootstrap: use an ACCOUNT password to mint a scoped, revocable app-password
+# (com.atproto.server.createAppPassword) and then a dev token from it. reads the
+# account password from $MAIN_BSKY_PASSWORD. --verify proves the write path by
+# uploading a throwaway blob through the backend (the path that was 500ing).
+uv run scripts/mint_dev_token.py --handle zzstoatzz.io --bootstrap --verify
 
-# also prove the backend write path works (uploads a throwaway blob to the PDS —
-# the exact path that was 500ing with SessionExpiredError)
-uv run scripts/mint_dev_token.py --verify
+# direct: you already have an app-password
+uv run scripts/mint_dev_token.py --handle h.example --app-password xxxx-xxxx-xxxx-xxxx
 
 # mint and rotate a CI secret in one shot
-uv run scripts/mint_dev_token.py --set-gh-secret PLYR_TEST_TOKEN_1
+uv run scripts/mint_dev_token.py --handle zzstoatzz.io --bootstrap --set-gh-secret PLYR_TEST_TOKEN_1
 ```
 
-Needs `ZAT_TEST_HANDLE` / `ZAT_TEST_PASSWORD` / `ZAT_TEST_PDS` in the root `.env`
-(or pass `--handle` / `--password` / `--pds`), and the backend's `.env` for the
-DB + encryption key the session is written with.
+The PDS is auto-resolved from the handle; pass `--pds` to override.
 """
 
 import argparse
@@ -32,6 +32,7 @@ import os
 import subprocess
 import sys
 
+import httpx
 from dotenv import load_dotenv
 
 from backend._internal.auth.app_password import (
@@ -42,19 +43,61 @@ from backend._internal.auth.app_password import (
 load_dotenv()
 
 
-async def _mint(
-    handle: str, password: str, pds: str, name: str | None
-) -> dict[str, str]:
-    return await create_app_password_session(
-        identifier=handle, app_password=password, pds_url=pds, token_name=name
-    )
+async def _resolve_pds(handle: str) -> str:
+    """resolve a handle to its PDS service endpoint via DID document."""
+    async with httpx.AsyncClient(timeout=15) as http:
+        r = await http.get(
+            "https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle",
+            params={"handle": handle},
+        )
+        r.raise_for_status()
+        did = r.json()["did"]
+        if did.startswith("did:web:"):
+            domain = did.removeprefix("did:web:").replace(":", "/")
+            doc = (await http.get(f"https://{domain}/.well-known/did.json")).json()
+        else:
+            doc = (await http.get(f"https://plc.directory/{did}")).json()
+    for svc in doc.get("service", []):
+        if svc.get("id", "").endswith("atproto_pds"):
+            return svc["serviceEndpoint"]
+    raise SystemExit(f"no PDS service endpoint in DID document for {handle}")
+
+
+async def _bootstrap_app_password(
+    handle: str, account_password: str, pds: str, name: str
+) -> str:
+    """use an account password to mint a scoped, revocable app-password.
+
+    this is the "token that can mint tokens" step: a full-password session is
+    only used to call createAppPassword, then discarded. the returned
+    app-password is what the dev-token session is actually built from.
+    """
+    async with httpx.AsyncClient(timeout=30) as http:
+        s = await http.post(
+            f"{pds}/xrpc/com.atproto.server.createSession",
+            json={"identifier": handle, "password": account_password},
+        )
+        if s.status_code != 200:
+            raise SystemExit(
+                f"createSession failed for {handle}: {s.status_code} {s.text}"
+            )
+        access = s.json()["accessJwt"]
+        r = await http.post(
+            f"{pds}/xrpc/com.atproto.server.createAppPassword",
+            headers={"Authorization": f"Bearer {access}"},
+            json={"name": name},
+        )
+        if r.status_code != 200:
+            raise SystemExit(f"createAppPassword failed: {r.status_code} {r.text}")
+    return r.json()["password"]
 
 
 async def _verify(token: str) -> str:
     """prove the minted session drives a real PDS write (uploadBlob).
 
-    this is the exact bearer path that replaces the expired-OAuth 500. returns
-    the stored blob CID.
+    this is the exact bearer path that replaces the expired-OAuth 500. the blob
+    is unreferenced (no record points at it) so the PDS garbage-collects it.
+    returns the stored blob CID.
     """
     from backend._internal import get_session
     from backend._internal.atproto.client import upload_blob
@@ -71,19 +114,64 @@ async def _verify(token: str) -> str:
 
 
 def _set_gh_secret(name: str, value: str) -> None:
-    subprocess.run(
-        ["gh", "secret", "set", name],
-        input=value.encode(),
-        check=True,
-    )
+    subprocess.run(["gh", "secret", "set", name], input=value.encode(), check=True)
     print(f"✓ set GitHub secret {name}", file=sys.stderr)
+
+
+async def _run(args: argparse.Namespace) -> str:
+    pds = args.pds or await _resolve_pds(args.handle)
+    print(f"  pds: {pds}", file=sys.stderr)
+
+    if args.bootstrap:
+        account_password = os.getenv(args.account_password_env)
+        if not account_password:
+            raise SystemExit(f"--bootstrap needs ${args.account_password_env} set")
+        app_password = await _bootstrap_app_password(
+            args.handle, account_password, pds, args.name
+        )
+        print("✓ minted scoped app-password via createAppPassword", file=sys.stderr)
+    else:
+        app_password = args.app_password
+        if not app_password:
+            raise SystemExit("need --app-password (or --bootstrap)")
+
+    result = await create_app_password_session(
+        identifier=args.handle,
+        app_password=app_password,
+        pds_url=pds,
+        token_name=args.name,
+    )
+    print(
+        f"✓ minted dev token for {result['handle']} ({result['did']})", file=sys.stderr
+    )
+    token = result["token"]
+
+    if args.verify:
+        cid = await _verify(token)
+        print(f"✓ write path verified — uploaded blob {cid}", file=sys.stderr)
+
+    return token
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--handle", default=os.getenv("ZAT_TEST_HANDLE"))
-    parser.add_argument("--password", default=os.getenv("ZAT_TEST_PASSWORD"))
-    parser.add_argument("--pds", default=os.getenv("ZAT_TEST_PDS"))
+    parser.add_argument("--pds", help="override PDS (default: resolved from handle)")
+    parser.add_argument(
+        "--app-password",
+        default=os.getenv("ZAT_TEST_PASSWORD"),
+        help="an existing app-password (direct mode)",
+    )
+    parser.add_argument(
+        "--bootstrap",
+        action="store_true",
+        help="mint a scoped app-password from an account password first",
+    )
+    parser.add_argument(
+        "--account-password-env",
+        default="MAIN_BSKY_PASSWORD",
+        help="env var holding the account password for --bootstrap",
+    )
     parser.add_argument("--name", default="mint_dev_token.py", help="token label")
     parser.add_argument(
         "--verify",
@@ -97,25 +185,14 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    if not (args.handle and args.password and args.pds):
-        parser.error(
-            "need --handle/--password/--pds or ZAT_TEST_HANDLE/PASSWORD/PDS in .env"
-        )
+    if not args.handle:
+        parser.error("need --handle (or ZAT_TEST_HANDLE in .env)")
 
     try:
-        result = asyncio.run(_mint(args.handle, args.password, args.pds, args.name))
+        token = asyncio.run(_run(args))
     except AppPasswordAuthError as e:
         print(f"✗ {e}", file=sys.stderr)
         return 1
-
-    token = result["token"]
-    print(
-        f"✓ minted dev token for {result['handle']} ({result['did']})", file=sys.stderr
-    )
-
-    if args.verify:
-        cid = asyncio.run(_verify(token))
-        print(f"✓ write path verified — uploaded blob {cid}", file=sys.stderr)
 
     if args.set_gh_secret:
         _set_gh_secret(args.set_gh_secret, token)


### PR DESCRIPTION
Mint a plyr developer token from an atproto **app-password** — no browser. This kills the recurring pain where CI's `PLYR_TEST_TOKEN_*` rot into `SessionExpiredError` (their inline OAuth grant expires) with no programmatic way to re-provision. `just mint-dev-token` is the Cloudflare-style CLI we wanted.

## how our tokens work today (the problem)
A plyr API token *is* a `user_sessions` row; welded to it is an inline, encrypted **OAuth grant**. The only mint path is `/auth/developer-token/start` → **browser consent at your PDS** → `/auth/callback`. When the inline refresh token expires (`invalid_grant`), OAuth can only recover via *another browser redirect*. That's what broke CI's integration tests.

## the fix
`com.atproto.server.createSession` (identifier + app-password, no browser) → wrap the bearer JWTs into an `is_developer_token` session tagged `auth_type: "app_password"`. The atproto client dispatches these to a small **bearer** write path (refresh via `com.atproto.server.refreshSession`).

```bash
# account password → scoped app-password (createAppPassword) → dev token, then
# prove the write path by uploading a throwaway blob through the backend
AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS=true just mint-dev-token --handle zzstoatzz.io --bootstrap --verify
```

## ✅ live, end-to-end against the local stack
```
  pds: https://pds.zzstoatzz.io                         # auto-resolved from handle
✓ minted scoped app-password via createAppPassword       # main pw never persisted
✓ minted dev token for zzstoatzz.io (did:plc:xbtmt2zjwlrfegqvch7fboei)
✓ write path verified — uploaded blob bafkreict3moadc7jnlwj4rxsuexaqtko3rqrgxmtarzlyrlm46zkdeq53y
```
The verified blob upload is the exact path that was 500ing with `SessionExpiredError`. (Token value redacted; the run created an app-password + dev token on the real account for the demo — both revocable.)

<details>
<summary>design — why this is low-risk</summary>

- **OAuth/DPoP path untouched.** Dispatch is a single `if oauth_data.get("auth_type") == "app_password"` at the top of `make_pds_request` / `upload_blob`. Existing OAuth sessions never carry `auth_type`, so they never branch. The hard-won cluster-wide refresh lock is byte-for-byte unchanged.
- **Bearer path mirrors the OAuth one's shape** — same retry/backoff constants, same per-session refresh serialization, and a dead refresh token raises the same `SessionExpiredError` so handlers still 401.
- **Gated OFF by default** (`AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS=false`). App-password sessions carry full repo access (unlike the namespace-scoped OAuth grants), so this is acceptable **only** for throwaway dev/staging test accounts — enforced by the flag + minting being a script, not a public endpoint (no password-accepting API surface added).
- **`--bootstrap`** uses the account password only to call `createAppPassword`, then discards it — the persisted session is built from a scoped, **revocable** app-password. PDS is auto-resolved from the handle (`resolveHandle` → DID doc), so it generalizes across accounts/PDSes.

</details>

<details>
<summary>tests</summary>

`tests/_internal/test_app_password.py` (8, all green) — mint builds the right session dict, gate-off raises, bad creds raise, `make_pds_request`/`upload_blob` dispatch to the bearer path (asserting `Bearer` not DPoP), 401→refresh→retry, refresh rotates+persists, dead refresh → `SessionExpiredError`. Existing PDS/OAuth client tests still green (21 passed together).

</details>

<details>
<summary>follow-ups (not in this PR)</summary>

- CI self-provisioning: the 3 CI tokens are 3 distinct users (cross-user tests). A `mint-tokens` step would `--bootstrap` three accounts and `--set-gh-secret PLYR_TEST_TOKEN_{1,2,3}`, with staging set to `AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS=true`.
- A gated endpoint (vs the script) if we want CI to mint without DB access — deliberately deferred to avoid a password-accepting API surface now.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)