### PR TITLE
feat(auth): JIT dev-token minting for CI — mint, use, throw away

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,9 +38,9 @@ jobs:
       - name: check token configuration
         id: check-tokens
         run: |
-          if [ -z "${{ secrets.PLYR_TEST_TOKEN_1 }}" ]; then
+          if [ -z "${{ secrets.APP_PASSWORD_MINT_SECRET }}" ]; then
             echo "has_tokens=false" >> $GITHUB_OUTPUT
-            echo "::warning::PLYR_TEST_TOKEN_1 not configured - integration tests will be skipped"
+            echo "::warning::APP_PASSWORD_MINT_SECRET not configured - integration tests will be skipped"
           else
             echo "has_tokens=true" >> $GITHUB_OUTPUT
           fi
@@ -66,16 +66,53 @@ jobs:
         if: steps.check-tokens.outputs.has_tokens == 'true'
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
+      # mint short-lived dev tokens just-in-time from stored app-passwords, so no
+      # long-lived token is ever stored (nothing to rotate, nothing to expire).
+      # the tokens are revoked in teardown; they also self-GC (1-day TTL).
+      - name: mint JIT dev tokens
+        if: steps.check-tokens.outputs.has_tokens == 'true'
+        env:
+          API: https://api-stg.plyr.fm
+          MINT_SECRET: ${{ secrets.APP_PASSWORD_MINT_SECRET }}
+          AP1: ${{ secrets.PLYR_TEST_APP_PASSWORD_1 }}
+          AP2: ${{ secrets.PLYR_TEST_APP_PASSWORD_2 }}
+          AP3: ${{ secrets.PLYR_TEST_APP_PASSWORD_3 }}
+        run: |
+          set -euo pipefail
+          mint() {
+            local handle="$1" apppw="$2" var="$3" resp token
+            resp=$(curl -sf -X POST "$API/auth/dev-token/app-password" \
+              -H "content-type: application/json" \
+              -H "x-admin-token: $MINT_SECRET" \
+              -d "{\"identifier\":\"$handle\",\"app_password\":\"$apppw\"}")
+            token=$(printf '%s' "$resp" | python3 -c "import sys,json;print(json.load(sys.stdin)['token'])")
+            echo "::add-mask::$token"
+            echo "$var=$token" >> "$GITHUB_ENV"
+          }
+          mint "zzstoatzz.io" "$AP1" PLYR_TEST_TOKEN_1
+          mint "plyr.fm" "$AP2" PLYR_TEST_TOKEN_2
+          mint "zzstoatzzdevlog.bsky.social" "$AP3" PLYR_TEST_TOKEN_3
+
       - name: run integration tests
         if: steps.check-tokens.outputs.has_tokens == 'true'
         env:
           PLYR_API_URL: https://api-stg.plyr.fm
-          PLYR_TEST_TOKEN_1: ${{ secrets.PLYR_TEST_TOKEN_1 }}
-          PLYR_TEST_TOKEN_2: ${{ secrets.PLYR_TEST_TOKEN_2 }}
-          PLYR_TEST_TOKEN_3: ${{ secrets.PLYR_TEST_TOKEN_3 }}
         run: |
           cd backend
           uv run pytest tests/integration -m integration -v --tb=short
+
+      # throw the JIT tokens away — revoke even if the tests failed.
+      - name: revoke JIT dev tokens
+        if: always() && steps.check-tokens.outputs.has_tokens == 'true'
+        env:
+          API: https://api-stg.plyr.fm
+        run: |
+          for var in PLYR_TEST_TOKEN_1 PLYR_TEST_TOKEN_2 PLYR_TEST_TOKEN_3; do
+            token="${!var:-}"
+            [ -z "$token" ] && continue
+            curl -s -X DELETE "$API/auth/developer-tokens/${token:0:8}" \
+              -H "Authorization: Bearer $token" >/dev/null || true
+          done
 
       - name: prune uv cache
         if: always()

--- a/backend/src/backend/_internal/auth/app_password.py
+++ b/backend/src/backend/_internal/auth/app_password.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import httpx
+from atproto_oauth.security import is_safe_url
 
 from backend._internal.auth.session import create_session
 from backend.config import settings
@@ -27,12 +28,41 @@ class AppPasswordAuthError(Exception):
     """raised when app-password minting is disabled or the PDS login fails."""
 
 
+async def resolve_pds(handle: str) -> str:
+    """resolve a handle to its PDS service endpoint via its DID document.
+
+    lets callers pass just a handle (createSession needs the account's PDS). the
+    resolved endpoint is is_safe_url-checked before use so a hostile handle
+    cannot point the login at a private address.
+    """
+    async with httpx.AsyncClient(timeout=15) as http:
+        r = await http.get(
+            "https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle",
+            params={"handle": handle},
+        )
+        r.raise_for_status()
+        did = r.json()["did"]
+        if did.startswith("did:web:"):
+            domain = did.removeprefix("did:web:").replace(":", "/")
+            doc = (await http.get(f"https://{domain}/.well-known/did.json")).json()
+        else:
+            doc = (await http.get(f"https://plc.directory/{did}")).json()
+    for svc in doc.get("service", []):
+        if svc.get("id", "").endswith("atproto_pds"):
+            endpoint = svc["serviceEndpoint"]
+            if not is_safe_url(endpoint):
+                raise AppPasswordAuthError(f"unsafe PDS endpoint for {handle}")
+            return endpoint
+    raise AppPasswordAuthError(f"no PDS service endpoint in DID document for {handle}")
+
+
 async def create_app_password_session(
     identifier: str,
     app_password: str,
     pds_url: str,
     *,
     token_name: str | None = None,
+    expires_in_days: int = APP_PASSWORD_REFRESH_DAYS,
 ) -> dict[str, str]:
     """mint a developer-token session from an atproto app-password.
 
@@ -51,6 +81,8 @@ async def create_app_password_session(
         )
 
     base = pds_url.rstrip("/")
+    if not is_safe_url(base):
+        raise AppPasswordAuthError(f"unsafe PDS url: {base}")
     async with httpx.AsyncClient(timeout=30) as http:
         resp = await http.post(
             f"{base}/xrpc/com.atproto.server.createSession",
@@ -84,7 +116,7 @@ async def create_app_password_session(
         did=did,
         handle=handle,
         oauth_session=oauth_session,
-        expires_in_days=APP_PASSWORD_REFRESH_DAYS,
+        expires_in_days=expires_in_days,
         is_developer_token=True,
         token_name=token_name,
     )

--- a/backend/src/backend/api/auth.py
+++ b/backend/src/backend/api/auth.py
@@ -1,9 +1,10 @@
 """authentication api endpoints."""
 
 import logging
+import secrets as secrets_lib
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 from pydantic import BaseModel, field_validator
 from sqlalchemy import select
@@ -41,6 +42,11 @@ from backend._internal import (
 )
 from backend._internal.atproto.spaces import detect_permissioned_capability
 from backend._internal.auth import get_refresh_token_lifetime_days
+from backend._internal.auth.app_password import (
+    AppPasswordAuthError,
+    create_app_password_session,
+    resolve_pds,
+)
 from backend._internal.copyright import complete_indiemusi_setup
 from backend._internal.tasks import schedule_atproto_sync
 from backend.config import settings
@@ -559,6 +565,61 @@ async def delete_developer_token(
         raise HTTPException(status_code=404, detail="token not found")
 
     return JSONResponse(content={"message": "token revoked successfully"})
+
+
+class AppPasswordTokenRequest(BaseModel):
+    """mint a JIT developer token from an atproto app-password."""
+
+    identifier: str
+    app_password: str
+    pds_url: str | None = None
+    name: str | None = None
+
+
+class AppPasswordTokenResponse(BaseModel):
+    """the minted developer token and the account it belongs to."""
+
+    token: str
+    did: str
+    handle: str
+
+
+@router.post("/dev-token/app-password")
+@limiter.limit(settings.rate_limit.auth_limit)
+async def mint_app_password_dev_token(
+    request: Request,
+    body: AppPasswordTokenRequest,
+    x_admin_token: Annotated[str | None, Header()] = None,
+) -> AppPasswordTokenResponse:
+    """mint a short-lived developer token from an atproto app-password.
+
+    browserless just-in-time provisioning for CI test accounts: the caller
+    presents an app-password (the account authorization) and gets back a token
+    it uses for one job, then throws away. requires BOTH
+    ``AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS=true`` and a matching
+    ``AUTH_APP_PASSWORD_MINT_SECRET`` — dev/staging only, never production. the
+    admin secret keeps the endpoint from being a public credential oracle.
+    """
+    secret = settings.auth.app_password_mint_secret
+    if not settings.auth.allow_app_password_dev_tokens or not secret:
+        # feature off — do not reveal the endpoint exists
+        raise HTTPException(status_code=404, detail="not found")
+    if not x_admin_token or not secrets_lib.compare_digest(x_admin_token, secret):
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    try:
+        pds = body.pds_url or await resolve_pds(body.identifier)
+        result = await create_app_password_session(
+            identifier=body.identifier,
+            app_password=body.app_password,
+            pds_url=pds,
+            token_name=body.name or "ci-jit",
+            expires_in_days=1,
+        )
+    except AppPasswordAuthError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    return AppPasswordTokenResponse(**result)
 
 
 class DevTokenStartRequest(BaseModel):

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -1039,6 +1039,14 @@ class AuthSettings(AppSettingsSection):
             "enable only in dev/staging for test-account provisioning, never prod."
         ),
     )
+    app_password_mint_secret: str = Field(
+        default="",
+        description=(
+            "Shared admin secret required by the POST /auth/dev-token/app-password "
+            "endpoint. Empty (default) disables the endpoint even when "
+            "allow_app_password_dev_tokens is on — both must be set for JIT minting."
+        ),
+    )
 
 
 class AccountCreationSettings(AppSettingsSection):

--- a/backend/tests/api/test_app_password_endpoint.py
+++ b/backend/tests/api/test_app_password_endpoint.py
@@ -1,0 +1,97 @@
+"""POST /auth/dev-token/app-password — gated JIT dev-token minting for CI.
+
+the endpoint is doubly gated (AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS + a shared
+admin secret) and unauthenticated by session — the app-password in the body is
+the account authorization, the admin secret keeps it from being a public oracle.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from backend.config import settings
+from backend.main import app
+
+URL = "/auth/dev-token/app-password"
+BODY = {"identifier": "tester.example", "app_password": "pw-xxxx"}
+
+
+async def _post(headers: dict | None = None) -> tuple[int, dict]:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.post(URL, json=BODY, headers=headers or {})
+    return r.status_code, (r.json() if r.content else {})
+
+
+async def test_disabled_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings.auth, "allow_app_password_dev_tokens", False)
+    monkeypatch.setattr(settings.auth, "app_password_mint_secret", "shh")
+    status, _ = await _post({"x-admin-token": "shh"})
+    assert status == 404
+
+
+async def test_disabled_when_secret_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings.auth, "allow_app_password_dev_tokens", True)
+    monkeypatch.setattr(settings.auth, "app_password_mint_secret", "")
+    status, _ = await _post({"x-admin-token": "anything"})
+    assert status == 404
+
+
+async def test_missing_admin_token_forbidden(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings.auth, "allow_app_password_dev_tokens", True)
+    monkeypatch.setattr(settings.auth, "app_password_mint_secret", "shh")
+    status, _ = await _post()
+    assert status == 403
+
+
+async def test_wrong_admin_token_forbidden(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings.auth, "allow_app_password_dev_tokens", True)
+    monkeypatch.setattr(settings.auth, "app_password_mint_secret", "shh")
+    status, _ = await _post({"x-admin-token": "wrong"})
+    assert status == 403
+
+
+async def test_success_mints_short_lived_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings.auth, "allow_app_password_dev_tokens", True)
+    monkeypatch.setattr(settings.auth, "app_password_mint_secret", "shh")
+    mint = AsyncMock(
+        return_value={"token": "tok-1", "did": "did:plc:x", "handle": "tester.example"}
+    )
+    with (
+        patch(
+            "backend.api.auth.resolve_pds",
+            AsyncMock(return_value="https://pds.example"),
+        ),
+        patch("backend.api.auth.create_app_password_session", mint),
+    ):
+        status, body = await _post({"x-admin-token": "shh"})
+
+    assert status == 200
+    assert body == {"token": "tok-1", "did": "did:plc:x", "handle": "tester.example"}
+    # JIT tokens are short-lived so an un-revoked one still GCs quickly
+    assert mint.await_args.kwargs["expires_in_days"] == 1
+
+
+async def test_bad_app_password_returns_400(monkeypatch: pytest.MonkeyPatch) -> None:
+    from backend._internal.auth.app_password import AppPasswordAuthError
+
+    monkeypatch.setattr(settings.auth, "allow_app_password_dev_tokens", True)
+    monkeypatch.setattr(settings.auth, "app_password_mint_secret", "shh")
+    with (
+        patch(
+            "backend.api.auth.resolve_pds",
+            AsyncMock(return_value="https://pds.example"),
+        ),
+        patch(
+            "backend.api.auth.create_app_password_session",
+            AsyncMock(side_effect=AppPasswordAuthError("createSession failed: 401")),
+        ),
+    ):
+        status, body = await _post({"x-admin-token": "shh"})
+
+    assert status == 400
+    assert "createSession failed" in body["detail"]

--- a/docs/internal/authentication.md
+++ b/docs/internal/authentication.md
@@ -492,6 +492,8 @@ AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS=true just mint-dev-token --verify
 - `--set-gh-secret PLYR_TEST_TOKEN_1` rotates a CI secret in the same command.
 - `--verify` proves the write path by uploading a throwaway blob through the backend (the exact path that was 500ing).
 
+For **CI, prefer minting just-in-time** over storing a token: `POST /auth/dev-token/app-password` takes an app-password and returns a short-lived (1-day) token with no DB access on the caller. It's doubly gated — needs `AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS=true` **and** a shared `AUTH_APP_PASSWORD_MINT_SECRET` (sent as the `x-admin-token` header); either unset → 404. The integration workflow mints per-run and revokes in teardown, so no long-lived token is ever stored (see [testing/integration-tests.md](testing/integration-tests.md#test-accounts)).
+
 ## OAuth client types: public vs confidential
 
 ATProto OAuth distinguishes between two types of clients based on their ability to authenticate themselves to the authorization server.

--- a/docs/internal/testing/integration-tests.md
+++ b/docs/internal/testing/integration-tests.md
@@ -19,16 +19,35 @@ uv run pytest tests/integration -m integration -v
 
 ## test accounts
 
-| secret | handle | purpose |
-|--------|--------|---------|
-| `PLYR_TEST_TOKEN_1` | zzstoatzz.io | primary test user - all single-user tests |
-| `PLYR_TEST_TOKEN_2` | plyr.fm | secondary user - cross-user interaction tests |
-| `PLYR_TEST_TOKEN_3` | zzstoatzzdevlog.bsky.social | tertiary user - reserved for future tests |
+CI **mints its tokens just-in-time** and throws them away — no long-lived token is stored, so nothing expires (`SessionExpiredError`) or needs rotating. The `mint JIT dev tokens` step calls `POST /auth/dev-token/app-password` on staging with a stored app-password per account, uses the 1-day token for the run, and revokes it in teardown.
 
-tokens are developer tokens. two ways to mint them:
+| account | tests |
+|--------|---------|
+| zzstoatzz.io | primary - all single-user tests |
+| plyr.fm | secondary - cross-user interaction tests |
+| zzstoatzzdevlog.bsky.social | tertiary - reserved |
 
-- **browser:** [plyr.fm/settings#developer](https://plyr.fm/settings#developer) → "developer tokens" (full OAuth consent flow).
-- **browserless** (for refreshing these when they expire — `SessionExpiredError` in CI): `just mint-dev-token --handle <h> --bootstrap --set-gh-secret PLYR_TEST_TOKEN_N`, which mints a scoped app-password from an account password (`$MAIN_BSKY_PASSWORD`) and rotates the CI secret. Requires `AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS=true` (dev/staging only). See [authentication.md](../authentication.md#browserless-minting-devstaging-test-tokens).
+### secrets (GitHub Actions)
+
+| secret | what |
+|--------|------|
+| `APP_PASSWORD_MINT_SECRET` | admin secret for the mint endpoint (also set on staging as `AUTH_APP_PASSWORD_MINT_SECRET`) |
+| `PLYR_TEST_APP_PASSWORD_{1,2,3}` | an atproto app-password per account above |
+
+### staging setup (one-time)
+
+The mint endpoint is doubly gated and OFF everywhere by default. Enable it **on staging only**:
+
+```
+AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS=true
+AUTH_APP_PASSWORD_MINT_SECRET=<same value as the APP_PASSWORD_MINT_SECRET GH secret>
+```
+
+Generate each account's app-password once (bsky settings → app passwords, or your PDS) and store as the `PLYR_TEST_APP_PASSWORD_*` secrets. To rotate, replace the app-password — the tokens themselves are ephemeral.
+
+### running locally
+
+`just mint-dev-token --handle <h> --bootstrap` mints a token from an account password (`$MAIN_BSKY_PASSWORD`); pass `--verify` to prove the write path. Or export `PLYR_TEST_TOKEN_{1,2,3}` yourself and run `uv run pytest tests/integration -m integration -v`. See [authentication.md](../authentication.md#browserless-minting-devstaging-test-tokens).
 
 ## github actions
 

--- a/loq.toml
+++ b/loq.toml
@@ -28,7 +28,7 @@ max_lines = 896
 
 [[rules]]
 path = "backend/src/backend/api/auth.py"
-max_lines = 862
+max_lines = 923
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
@@ -44,7 +44,7 @@ max_lines = 1841
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 1150
+max_lines = 1158
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
@@ -80,7 +80,7 @@ max_lines = 781
 
 [[rules]]
 path = "docs/internal/authentication.md"
-max_lines = 643
+max_lines = 645
 
 [[rules]]
 path = "docs/internal/backend/liked-tracks.md"

--- a/scripts/mint_dev_token.py
+++ b/scripts/mint_dev_token.py
@@ -38,29 +38,10 @@ from dotenv import load_dotenv
 from backend._internal.auth.app_password import (
     AppPasswordAuthError,
     create_app_password_session,
+    resolve_pds,
 )
 
 load_dotenv()
-
-
-async def _resolve_pds(handle: str) -> str:
-    """resolve a handle to its PDS service endpoint via DID document."""
-    async with httpx.AsyncClient(timeout=15) as http:
-        r = await http.get(
-            "https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle",
-            params={"handle": handle},
-        )
-        r.raise_for_status()
-        did = r.json()["did"]
-        if did.startswith("did:web:"):
-            domain = did.removeprefix("did:web:").replace(":", "/")
-            doc = (await http.get(f"https://{domain}/.well-known/did.json")).json()
-        else:
-            doc = (await http.get(f"https://plc.directory/{did}")).json()
-    for svc in doc.get("service", []):
-        if svc.get("id", "").endswith("atproto_pds"):
-            return svc["serviceEndpoint"]
-    raise SystemExit(f"no PDS service endpoint in DID document for {handle}")
 
 
 async def _bootstrap_app_password(
@@ -119,7 +100,7 @@ def _set_gh_secret(name: str, value: str) -> None:
 
 
 async def _run(args: argparse.Namespace) -> str:
-    pds = args.pds or await _resolve_pds(args.handle)
+    pds = args.pds or await resolve_pds(args.handle)
     print(f"  pds: {pds}", file=sys.stderr)
 
     if args.bootstrap:


### PR DESCRIPTION
Tier 1 of the token-management plan: **CI mints a short-lived token per run and throws it away** — no long-lived `PLYR_TEST_TOKEN_*` stored, so nothing rots into `SessionExpiredError` and there's nothing to rotate. Builds on the app-password mint mechanism from #1629.

The right split (per the DevOps discussion): the *only* durable secret is an app-password per test account (rarely changes); the token is derived, disposable, and minted just-in-time.

## what's here
- **`POST /auth/dev-token/app-password`** — takes an app-password, returns a **1-day** dev token. So a CI runner holds only an app-password, never DB creds.
  - **Doubly gated:** `AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS=true` **and** a shared `AUTH_APP_PASSWORD_MINT_SECRET` (`x-admin-token` header, constant-time compare). Either unset → **404** (endpoint doesn't reveal itself). The app-password is the account authorization; the admin secret stops it being a public credential oracle.
- **`integration-tests.yml`** — mints 3 JIT tokens from stored app-passwords, runs, and **revokes them in teardown** (`if: always()`); they also self-GC via the 1-day TTL. Gates on `APP_PASSWORD_MINT_SECRET`.
- **`resolve_pds`** (handle → DID doc → PDS, `is_safe_url`-checked) moved into the module and shared with the script; `create_app_password_session` gains `expires_in_days` + an `is_safe_url` guard on the PDS.

## ⚠️ staging setup required before this helps CI (one-time)
Endpoint is OFF everywhere by default. On **staging only**:
- env: `AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS=true`, `AUTH_APP_PASSWORD_MINT_SECRET=<value>`
- GH secrets: `APP_PASSWORD_MINT_SECRET` (same value), `PLYR_TEST_APP_PASSWORD_{1,2,3}` (an app-password per account)

Until those exist, the integration job skips (as it does today). I did **not** touch staging env or secrets — that's yours to apply (happy to walk through it or mint the app-passwords for accounts you have creds for).

<details>
<summary>security model</summary>

- Unauthenticated by session (CI has no session) — auth is the app-password + admin secret. Constant-time secret compare. Rate-limited via the existing `auth_limit`.
- Never enabled in prod (both gates default off/empty). Returns 404 when disabled so prod doesn't advertise it.
- `is_safe_url` on both the resolved and passed PDS prevents a hostile handle pointing login at a private address (SSRF).
- Tokens are 1-day + revoked in teardown, so a leaked/un-revoked one is short-lived.

</details>

<details>
<summary>tests</summary>

`tests/api/test_app_password_endpoint.py` (6): 404 when flag off, 404 when secret unset, 403 missing/wrong admin token, 200 mints with `expires_in_days=1`, 400 on bad app-password. Plus the 8 from #1629's module still green. `oauth scope universe` metadata check passes (new endpoint carries no scopes).

</details>

<details>
<summary>follow-up</summary>

Tier 2 (a standing external token refreshed by a `schedule:` cron) reuses this exact endpoint + `gh secret set`; not needed for CI, which is fixed by JIT alone.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)