### PR TITLE
fix(auth): app-password sessions bypass the OAuth scope gate

### DIFF
--- a/backend/src/backend/_internal/auth/dependencies.py
+++ b/backend/src/backend/_internal/auth/dependencies.py
@@ -54,6 +54,13 @@ async def require_auth(
             detail="invalid or expired session",
         )
 
+    # app-password sessions hold full repo access rather than an OAuth grant, so
+    # the scope-coverage gate below — which reasons about granted OAuth scopes —
+    # does not apply. without this they'd 403 with scope_upgrade_required.
+    if session.oauth_session.get("auth_type") == "app_password":
+        _tag_span_with_user(session)
+        return session
+
     # check if session has all required scopes
     granted_scope = session.oauth_session.get("scope", "")
     required_scope = settings.atproto.resolved_scope

--- a/backend/tests/_internal/test_require_auth_app_password.py
+++ b/backend/tests/_internal/test_require_auth_app_password.py
@@ -1,0 +1,55 @@
+"""require_auth must not apply the OAuth scope-coverage gate to app-password
+sessions — they hold full repo access, not an OAuth grant, so scope_upgrade
+does not apply. regression for JIT dev tokens 403ing on scope-gated endpoints.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from backend._internal import Session as AuthSession
+from backend._internal.auth.dependencies import require_auth
+
+
+def _session(oauth: dict) -> AuthSession:
+    return AuthSession(
+        session_id="s", did="did:plc:x", handle="tester.example", oauth_session=oauth
+    )
+
+
+async def test_app_password_session_bypasses_scope_gate() -> None:
+    sess = _session(
+        {"auth_type": "app_password", "access_token": "a", "pds_url": "https://p"}
+    )
+    with (
+        patch(
+            "backend._internal.auth.dependencies.get_session",
+            AsyncMock(return_value=sess),
+        ),
+        # even if the scope check would fail, the app-password session bypasses it
+        patch(
+            "backend._internal.auth.dependencies.check_scope_coverage",
+            return_value=False,
+        ),
+    ):
+        result = await require_auth(authorization="Bearer tok")
+    assert result is sess
+
+
+async def test_oauth_session_still_scope_gated() -> None:
+    sess = _session({"access_token": "a", "scope": "atproto"})  # no auth_type
+    with (
+        patch(
+            "backend._internal.auth.dependencies.get_session",
+            AsyncMock(return_value=sess),
+        ),
+        patch(
+            "backend._internal.auth.dependencies.check_scope_coverage",
+            return_value=False,
+        ),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await require_auth(authorization="Bearer tok")
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "scope_upgrade_required"


### PR DESCRIPTION
Follow-up to #1630, caught while proving JIT minting end-to-end against a local backend.

`require_auth` 403'd app-password dev tokens with `scope_upgrade_required`: app-password sessions hold **full repo access** and carry no OAuth `scope` string, so `check_scope_coverage("", required)` failed. They aren't OAuth-scoped, so the gate simply doesn't apply — `require_auth` now returns early for `auth_type == "app_password"` sessions.

## proven live
Against a local backend running the merged code (both gates on):
```
1. no admin token        -> 403  ✓
2. wrong admin token     -> 403  ✓
3. correct admin token   -> 200  (token returned)  ✓
4. token authenticates on a scope-gated GET -> 200  ✓   ← this was 403 before the fix
5. revoke JIT token      -> 200  ✓
```

Regression test patches `check_scope_coverage` to fail and asserts an app-password session bypasses it while a normal OAuth session still 403s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)