### PR TITLE
fix(queue): truncate collection label + marquee long track titles

### DIFF
--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -5,6 +5,7 @@
 	import { jam } from '$lib/jam.svelte';
 	import { toast } from '$lib/toast.svelte';
 	import SensitiveImage from './SensitiveImage.svelte';
+	import ScrollingText from './ScrollingText.svelte';
 	import { trackCoverUrl, trackThumbnailUrl } from '$lib/track-cover';
 	import type { Track, JamParticipant } from '$lib/types';
 
@@ -216,9 +217,14 @@
 {#snippet media(track: Track)}
 	{@render artwork(track)}
 	<div class="track-info">
-		<div class="track-title">{track.title}</div>
+		<div class="track-title"><ScrollingText text={track.title} /></div>
 		<div class="track-artist">
-			<a href="/u/{track.artist_handle}" draggable="false" onclick={(e) => e.stopPropagation()}>
+			<a
+				href="/u/{track.artist_handle}"
+				draggable="false"
+				title={track.artist}
+				onclick={(e) => e.stopPropagation()}
+			>
 				{track.artist}
 			</a>
 		</div>
@@ -454,9 +460,17 @@
 						{#if continuationUpcoming.length > 0}
 							<div class="section-header continuation-header">
 								{#if queue.continuationLabel}
-									<h3>next from: <span class="source-link">{queue.continuationLabel}</span></h3>
+									<h3>
+										<span class="continuation-prefix">next from:</span>
+										<span class="source-link" title={queue.continuationLabel}
+											>{queue.continuationLabel}</span
+										>
+									</h3>
 								{:else}
-									<h3>next from: <a href="/for-you" class="source-link">for you</a></h3>
+									<h3>
+										<span class="continuation-prefix">next from:</span>
+										<a href="/for-you" class="source-link">for you</a>
+									</h3>
 								{/if}
 							</div>
 							{#each continuationUpcoming as { track, index } (`${track.file_id}:${index}`)}
@@ -879,10 +893,25 @@
 		border-top: 1px solid var(--border-subtle);
 	}
 
+	.continuation-header h3 {
+		display: flex;
+		align-items: baseline;
+		gap: 0.4ch;
+		min-width: 0;
+	}
+
+	.continuation-header .continuation-prefix {
+		flex-shrink: 0;
+	}
+
 	.continuation-header .source-link {
 		color: var(--accent);
 		text-decoration: none;
 		transition: color 0.15s ease;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.continuation-header .source-link:hover {
@@ -982,9 +1011,7 @@
 	.track-title {
 		font-weight: 500;
 		color: var(--text-primary);
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
+		min-width: 0;
 		margin-bottom: 0.25rem;
 	}
 

--- a/frontend/src/lib/components/ScrollingText.svelte
+++ b/frontend/src/lib/components/ScrollingText.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	// one-line text that truncates with an ellipsis, reveals the full value as a
+	// native tooltip, and marquee-scrolls on hover when it overflows — the same
+	// scroll technique the footer player uses (TrackInfo.svelte), factored out so
+	// list rows (the queue) can reuse it without every row animating at once.
+	interface Props {
+		text: string;
+		/** 'hover' scrolls only while hovered (calm lists); 'always' scrolls whenever it overflows. */
+		trigger?: 'hover' | 'always';
+	}
+
+	let { text, trigger = 'hover' }: Props = $props();
+
+	let el = $state<HTMLElement | null>(null);
+	let overflows = $state(false);
+	let hovered = $state(false);
+
+	function measure() {
+		if (typeof window === 'undefined' || !el) return;
+		window.requestAnimationFrame(() => {
+			if (el) overflows = el.scrollWidth > el.clientWidth;
+		});
+	}
+
+	// re-measure whenever the text changes (row reused for a new track)
+	$effect(() => {
+		void text;
+		measure();
+	});
+
+	let scrolling = $derived(overflows && (trigger === 'always' || hovered));
+</script>
+
+<div
+	class="scroller"
+	class:scrolling
+	bind:this={el}
+	title={text}
+	onpointerenter={() => (hovered = true)}
+	onpointerleave={() => (hovered = false)}
+>
+	<span>{text}</span>
+</div>
+
+<style>
+	.scroller {
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		max-width: 100%;
+		/* inherit font + color from the caller so this is purely a text-fit concern */
+		color: inherit;
+		font: inherit;
+	}
+
+	.scroller > span {
+		color: inherit;
+	}
+
+	.scroller.scrolling {
+		text-overflow: clip;
+		mask-image: linear-gradient(to right, black 0%, black calc(100% - 16px), transparent 100%);
+		-webkit-mask-image: linear-gradient(to right, black 0%, black calc(100% - 16px), transparent 100%);
+	}
+
+	.scroller.scrolling > span {
+		display: inline-block;
+		padding-right: 2rem;
+		animation: scroll-text 8s linear infinite;
+	}
+
+	@keyframes scroll-text {
+		0%,
+		15% {
+			transform: translateX(0);
+		}
+		100% {
+			transform: translateX(-100%);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.scroller.scrolling > span {
+			animation: none;
+		}
+	}
+</style>

--- a/loq.toml
+++ b/loq.toml
@@ -104,7 +104,7 @@ max_lines = 1192
 
 [[rules]]
 path = "frontend/src/lib/components/Queue.svelte"
-max_lines = 1116
+max_lines = 1143
 
 [[rules]]
 path = "frontend/src/lib/components/SearchModal.svelte"


### PR DESCRIPTION
Aesthetic polish on the collection-continuity queue (spotted post-ship).

- **"next from: &lt;collection&gt;" header** wrapped to two awkward lines on a long name (e.g. "sounds for/from airports"). Now: `next from:` stays put and the label truncates to one line with an ellipsis + full-name tooltip (flex row, label is the shrinking part).
- **Long queue track titles** had no way to see the full name and no motion. New `ScrollingText` component: ellipsis + native `title` tooltip, plus a **hover-triggered marquee** reusing the footer player's scroll technique (`TrackInfo.svelte`). Hover-gated so a queue full of long titles doesn't all animate at once — only the row you're pointing at scrolls. Artist links get a tooltip too.

`prefers-reduced-motion` disables the scroll. Static-validated (svelte-check, eslint, prod build); I'll eyeball it on plyr.fm once the frontend release lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)