### PR TITLE
fix(portal): tap/hover copyright popover + explain what a flag means

### DIFF
--- a/docs/public/artists.md
+++ b/docs/public/artists.md
@@ -161,6 +161,29 @@ this is the one exception to the "your audio, your data" promise: because atprot
 
 we'd also like to support more expressive gating — tiers, time-limited early access, per-track pricing — as the ecosystem matures.
 
+## copyright detection
+
+every upload is automatically scanned for copyrighted audio. if the scan finds a likely match, your track gets a **yellow ⚠ marker** in the [portal](https://plyr.fm/portal) — tap or hover it to see what was matched.
+
+### what a match means
+
+a match is a **flag for review, not a takedown**. your track stays up and playable. the marker is there so you (and plyr.fm) know the audio resembles a known recording — it's a heads-up, not an accusation.
+
+matches can be wrong. common false positives:
+
+- **samples and loops** reused across many songs
+- **covers, remixes, and mashups** — legal gray areas, not necessarily infringement
+- **similar chord progressions or drum patterns**
+- coincidental audio artifacts
+
+that's why a match is flagged rather than auto-enforced — a human decides whether anything actually needs to happen.
+
+### how the scan works
+
+after your upload finishes, plyr.fm scans the audio against [AudD](https://audd.io/)'s recognition database in short segments. the more of your track that consistently matches the *same* recording, the stronger the signal. a match that carries an [ISRC code](https://en.wikipedia.org/wiki/International_Standard_Recording_Code) (a unique recording identifier) is strong evidence of a specific recording, not just similar-sounding audio.
+
+if you believe a match is a false positive, or you hold the rights to the matched work, [get in touch](https://plyr.fm) — nothing about the flag is automatic or final.
+
 ## your data
 
 ![the artist portal — manage your profile, tracks, and albums](/screenshots/portal-dashboard.png)

--- a/frontend/src/lib/components/portal/CopyrightFlag.svelte
+++ b/frontend/src/lib/components/portal/CopyrightFlag.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+	interface Props {
+		match?: string | null;
+		recordUrl?: string | null;
+		docsUrl?: string;
+	}
+
+	let {
+		match = null,
+		recordUrl = null,
+		docsUrl = 'https://docs.plyr.fm/artists/#copyright-detection'
+	}: Props = $props();
+
+	let open = $state(false);
+	let hideTimeout: ReturnType<typeof setTimeout> | null = null;
+	let wrapper = $state<HTMLElement | null>(null);
+
+	function clearHide() {
+		if (hideTimeout) {
+			clearTimeout(hideTimeout);
+			hideTimeout = null;
+		}
+	}
+
+	function show() {
+		clearHide();
+		open = true;
+	}
+
+	// desktop hover-out: brief grace period so the pointer can travel from the
+	// trigger into the popover without it closing underneath them.
+	function scheduleHide() {
+		clearHide();
+		hideTimeout = setTimeout(() => {
+			open = false;
+			hideTimeout = null;
+		}, 150);
+	}
+
+	function toggle() {
+		open = !open;
+	}
+
+	function onWindowPointerDown(event: PointerEvent) {
+		const target = event.target;
+		if (wrapper && target instanceof Node && !wrapper.contains(target)) open = false;
+	}
+
+	function onKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') open = false;
+	}
+
+	$effect(() => {
+		if (!open) return;
+		window.addEventListener('pointerdown', onWindowPointerDown);
+		window.addEventListener('keydown', onKeydown);
+		return () => {
+			window.removeEventListener('pointerdown', onWindowPointerDown);
+			window.removeEventListener('keydown', onKeydown);
+		};
+	});
+</script>
+
+<span class="copyright-flag-wrapper" bind:this={wrapper}>
+	<button
+		type="button"
+		class="copyright-flag-trigger"
+		aria-label="possible copyright match — details"
+		aria-expanded={open}
+		onclick={toggle}
+		onmouseenter={show}
+		onmouseleave={scheduleHide}
+		onfocus={show}
+		onblur={scheduleHide}
+	>
+		<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+			<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+			<line x1="12" y1="9" x2="12" y2="13"></line>
+			<line x1="12" y1="17" x2="12.01" y2="17"></line>
+		</svg>
+	</button>
+
+	{#if open}
+		<span class="copyright-flag-popover" role="tooltip" onmouseenter={show} onmouseleave={scheduleHide}>
+			<strong class="copyright-flag-heading">possible copyright match</strong>
+			{#if match}
+				<span class="copyright-flag-match">matched: {match}</span>
+			{/if}
+			<span class="copyright-flag-body">
+				a match doesn't mean your track is removed — it's flagged for review, and
+				false positives happen with samples, covers, and similar progressions.
+			</span>
+			<span class="copyright-flag-links">
+				{#if recordUrl}
+					<a href={recordUrl} target="_blank" rel="noopener noreferrer">view record</a>
+				{/if}
+				<a href={docsUrl} target="_blank" rel="noopener noreferrer">how this works →</a>
+			</span>
+		</span>
+	{/if}
+</span>
+
+<style>
+	.copyright-flag-wrapper {
+		position: relative;
+		display: inline-flex;
+		flex-shrink: 0;
+	}
+
+	.copyright-flag-trigger {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		/* comfortable tap target around the 16px glyph without disturbing row layout */
+		width: 1.75rem;
+		height: 1.75rem;
+		margin: -0.375rem 0;
+		padding: 0;
+		background: none;
+		border: none;
+		color: var(--warning);
+		cursor: pointer;
+	}
+
+	.copyright-flag-trigger:hover,
+	.copyright-flag-trigger[aria-expanded='true'] {
+		color: color-mix(in srgb, var(--warning) 80%, white);
+	}
+
+	.copyright-flag-popover {
+		position: absolute;
+		left: 0;
+		top: calc(100% + 0.35rem);
+		z-index: 20;
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+		width: max-content;
+		max-width: min(20rem, calc(100vw - 2rem));
+		padding: 0.6rem 0.75rem;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-sm);
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+		white-space: normal;
+		text-align: left;
+		cursor: default;
+	}
+
+	.copyright-flag-heading {
+		font-size: var(--text-sm);
+		font-weight: 600;
+		color: var(--warning);
+	}
+
+	.copyright-flag-match {
+		font-size: var(--text-sm);
+		color: var(--text-primary);
+		word-break: break-word;
+	}
+
+	.copyright-flag-body {
+		font-size: var(--text-xs);
+		line-height: 1.4;
+		color: var(--text-secondary);
+	}
+
+	.copyright-flag-links {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+		margin-top: 0.15rem;
+	}
+
+	.copyright-flag-links a {
+		font-size: var(--text-xs);
+		color: var(--accent);
+		text-decoration: none;
+	}
+
+	.copyright-flag-links a:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/frontend/src/lib/components/portal/CopyrightFlag.test.ts
+++ b/frontend/src/lib/components/portal/CopyrightFlag.test.ts
@@ -1,0 +1,76 @@
+// CopyrightFlag popover contract: the copyright match info must be reachable by
+// tap/click (mobile has no hover) and dismissable, and it must surface both the
+// matched-song text and a link to the docs — the old native `title` attribute
+// gave none of this on touch (see Woody report).
+import { describe, it, expect, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import CopyrightFlag from '$lib/components/portal/CopyrightFlag.svelte';
+
+let component: Record<string, unknown> | null = null;
+
+function mountFlag(props: Record<string, unknown>): HTMLButtonElement {
+	component = mount(CopyrightFlag, { target: document.body, props });
+	const trigger = document.querySelector<HTMLButtonElement>('.copyright-flag-trigger');
+	expect(trigger).toBeTruthy();
+	return trigger!;
+}
+
+function popover(): HTMLElement | null {
+	return document.querySelector<HTMLElement>('.copyright-flag-popover');
+}
+
+afterEach(() => {
+	if (component) {
+		unmount(component);
+		component = null;
+	}
+	document.body.innerHTML = '';
+});
+
+describe('CopyrightFlag', () => {
+	it('is closed until the trigger is clicked (works without hover)', () => {
+		const trigger = mountFlag({ match: 'Love Story by Taylor Swift' });
+		expect(popover()).toBeNull();
+
+		flushSync(() => trigger.click());
+		const open = popover();
+		expect(open).toBeTruthy();
+		expect(open!.textContent).toContain('Love Story by Taylor Swift');
+	});
+
+	it('toggles closed on a second click', () => {
+		const trigger = mountFlag({ match: 'Some Song' });
+		flushSync(() => trigger.click());
+		expect(popover()).toBeTruthy();
+		flushSync(() => trigger.click());
+		expect(popover()).toBeNull();
+	});
+
+	it('dismisses on an outside pointerdown', () => {
+		const trigger = mountFlag({ match: 'Some Song' });
+		flushSync(() => trigger.click());
+		expect(popover()).toBeTruthy();
+
+		const outside = document.createElement('div');
+		document.body.appendChild(outside);
+		flushSync(() => outside.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true })));
+		expect(popover()).toBeNull();
+	});
+
+	it('always links to the docs and to the record when present', () => {
+		const trigger = mountFlag({ match: 'X', recordUrl: 'https://pds.example/record/1' });
+		flushSync(() => trigger.click());
+		const hrefs = Array.from(popover()!.querySelectorAll('a')).map((a) => a.getAttribute('href'));
+		expect(hrefs).toContain('https://pds.example/record/1');
+		expect(hrefs.some((h) => h?.includes('docs.plyr.fm'))).toBe(true);
+	});
+
+	it('renders without a match string (scan flagged but no primary match)', () => {
+		const trigger = mountFlag({ match: null });
+		flushSync(() => trigger.click());
+		const open = popover();
+		expect(open).toBeTruthy();
+		expect(open!.querySelector('.copyright-flag-match')).toBeNull();
+		expect(open!.textContent).toContain('possible copyright match');
+	});
+});

--- a/frontend/src/lib/components/portal/TracksSection.svelte
+++ b/frontend/src/lib/components/portal/TracksSection.svelte
@@ -7,6 +7,7 @@
 	import type { TrackRights } from '$lib/components/CopyrightRightsPanel.svelte';
 	import type { Track, FeaturedArtist, AlbumSummary } from '$lib/types';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
+	import CopyrightFlag from '$lib/components/portal/CopyrightFlag.svelte';
 	import AudioRevisionsSheet from '$lib/components/AudioRevisionsSheet.svelte';
 	import { API_URL, getServerConfig } from '$lib/config';
 	import { toast } from '$lib/toast.svelte';
@@ -779,30 +780,10 @@
 									</span>
 								{/if}
 								{#if track.copyright_flagged}
-									{@const matchText = track.copyright_match ? `potential copyright violation: ${track.copyright_match}` : 'potential copyright violation'}
-									{#if track.atproto_record_url}
-										<a
-											href={track.atproto_record_url}
-											target="_blank"
-											rel="noopener noreferrer"
-											class="copyright-flag"
-											title="{matchText}"
-										>
-											<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-												<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
-												<line x1="12" y1="9" x2="12" y2="13"></line>
-												<line x1="12" y1="17" x2="12.01" y2="17"></line>
-											</svg>
-										</a>
-									{:else}
-										<span class="copyright-flag" title={matchText}>
-											<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-												<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
-												<line x1="12" y1="9" x2="12" y2="13"></line>
-												<line x1="12" y1="17" x2="12.01" y2="17"></line>
-											</svg>
-										</span>
-									{/if}
+									<CopyrightFlag
+										match={track.copyright_match}
+										recordUrl={track.atproto_record_url}
+									/>
 								{/if}
 							</div>
 							<div class="track-meta">
@@ -1233,25 +1214,6 @@
 		flex-shrink: 0;
 	}
 
-	.copyright-flag {
-		display: inline-flex;
-		align-items: center;
-		color: var(--warning);
-		flex-shrink: 0;
-		text-decoration: none;
-	}
-
-	.copyright-flag:hover {
-		color: color-mix(in srgb, var(--warning) 80%, white);
-	}
-
-	a.copyright-flag {
-		cursor: pointer;
-	}
-
-	a.copyright-flag:hover {
-		transform: scale(1.1);
-	}
 
 	.track-meta {
 		font-size: var(--text-base);


### PR DESCRIPTION
The portal copyright indicator was a 14px warning triangle carrying only a native `title=` attribute — so on mobile it showed **nothing** (native `title` never fires on touch), and on desktop it was a tiny hit area behind the browser's long, inconsistent tooltip delay. A creator reported both symptoms: "can't make the copyright popover happen consistently," and — separately — mistook the yellow warning for something being wrong with his upload because there was no explanation of what a flag *means*.

This replaces the badge with a real popover and adds public docs.

## what changed

- **new `CopyrightFlag.svelte`** (portal): toggles on **tap/click** (mobile works now) plus hover/focus on desktop with a 150ms travel grace period; dismisses on outside `pointerdown` or `Escape`. Larger tap target around the glyph (no row-layout shift). Viewport-safe sizing (`max-width: min(20rem, calc(100vw - 2rem))`, wraps) so it never overflows on small screens.
- **content that answers the actual confusion**: a match is *review, not takedown*; names the matched song; links to the atproto record (when present) and to the docs. False-positive causes spelled out.
- **docs**: new `## copyright detection` section in the creator guide (`artists.md`) — what a flag means, why false positives happen (samples/covers/similar progressions), how the segment-based AudD scan works, ISRC as strong signal. The popover's "how this works →" links to `https://docs.plyr.fm/artists/#copyright-detection`.
- **removed** the dead `.copyright-flag` CSS and the inline badge markup from `TracksSection.svelte`.

<details>
<summary>intentional behaviors / non-behaviors</summary>

- The "learn more" target is a section anchor in the existing creator guide, not a new top-level docs page (keeps the sidebar tidy; sits next to supporter-gating).
- On desktop, a click while hovering will toggle the popover closed — acceptable; re-hover re-opens.
- `onWindowPointerDown` guards `event.target instanceof Node` (defensive; real pointer events always carry a Node target).
- No `stopPropagation` on the trigger: the portal `.track-item` row has no play/click handler, only explicit edit/delete buttons.
</details>

## tests

`CopyrightFlag.test.ts` drives the real component mount: tap-to-open surfaces the match text, second tap toggles closed, outside `pointerdown` dismisses, docs + record links both present, and the no-match case (flagged scan with no primary match) still renders. Verified failing against the old `title`-only badge (no popover element to assert on).

`just frontend check`, `bun run lint`, and `uvx loq` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)