### PR TITLE
fix(portal): polish the copyright popover

### DIFF
--- a/frontend/.storybook/preview-head.html
+++ b/frontend/.storybook/preview-head.html
@@ -1,0 +1,40 @@
+<!-- mirror the app's design tokens (from src/routes/+layout.svelte) so components
+     preview the way they render in production — dark bg, Georgia serif, accents. -->
+<style>
+	:root {
+		--accent: #6a9fff;
+		--accent-hover: #8ab3ff;
+
+		--bg-primary: #0a0a0a;
+		--bg-secondary: #141414;
+		--bg-tertiary: #1a1a1a;
+
+		--border-subtle: #282828;
+		--border-default: #333333;
+		--border-emphasis: #444444;
+
+		--text-primary: #e8e8e8;
+		--text-secondary: #b0b0b0;
+		--text-tertiary: #808080;
+		--text-muted: #666666;
+
+		--text-xs: 0.75rem;
+		--text-sm: 0.85rem;
+		--text-base: 0.9rem;
+
+		--radius-sm: 4px;
+		--radius-base: 6px;
+		--radius-md: 8px;
+
+		--success: #4ade80;
+		--warning: #fbbf24;
+		--error: #ef4444;
+	}
+
+	body {
+		font-family: 'Georgia', 'Times New Roman', serif;
+		background-color: var(--bg-primary);
+		color: var(--text-primary);
+		-webkit-font-smoothing: antialiased;
+	}
+</style>

--- a/frontend/src/lib/components/portal/CopyrightFlag.svelte
+++ b/frontend/src/lib/components/portal/CopyrightFlag.svelte
@@ -82,19 +82,34 @@
 
 	{#if open}
 		<span class="copyright-flag-popover" role="tooltip" onmouseenter={show} onmouseleave={scheduleHide}>
-			<strong class="copyright-flag-heading">possible copyright match</strong>
+			<span class="copyright-flag-caret" aria-hidden="true"></span>
+			<span class="copyright-flag-header">
+				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+					<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+					<line x1="12" y1="9" x2="12" y2="13"></line>
+					<line x1="12" y1="17" x2="12.01" y2="17"></line>
+				</svg>
+				<strong class="copyright-flag-heading">possible copyright match</strong>
+			</span>
 			{#if match}
-				<span class="copyright-flag-match">matched: {match}</span>
+				<span class="copyright-flag-match">
+					<span class="copyright-flag-match-label">matched</span>
+					<span class="copyright-flag-match-song">{match}</span>
+				</span>
 			{/if}
 			<span class="copyright-flag-body">
 				a match doesn't mean your track is removed — it's flagged for review, and
 				false positives happen with samples, covers, and similar progressions.
 			</span>
 			<span class="copyright-flag-links">
+				<a class="copyright-flag-link primary" href={docsUrl} target="_blank" rel="noopener noreferrer">
+					how this works →
+				</a>
 				{#if recordUrl}
-					<a href={recordUrl} target="_blank" rel="noopener noreferrer">view record</a>
+					<a class="copyright-flag-link" href={recordUrl} target="_blank" rel="noopener noreferrer">
+						view record
+					</a>
 				{/if}
-				<a href={docsUrl} target="_blank" rel="noopener noreferrer">how this works →</a>
 			</span>
 		</span>
 	{/if}
@@ -129,56 +144,103 @@
 
 	.copyright-flag-popover {
 		position: absolute;
-		left: 0;
-		top: calc(100% + 0.35rem);
+		left: -0.5rem;
+		top: calc(100% + 0.5rem);
 		z-index: 20;
 		display: flex;
 		flex-direction: column;
-		gap: 0.35rem;
+		gap: 0.5rem;
 		width: max-content;
-		max-width: min(20rem, calc(100vw - 2rem));
-		padding: 0.6rem 0.75rem;
-		background: var(--bg-primary);
+		max-width: min(19rem, calc(100vw - 2rem));
+		padding: 0.75rem 0.875rem;
+		background: var(--bg-secondary);
 		border: 1px solid var(--border-default);
-		border-radius: var(--radius-sm);
-		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+		border-top: 2px solid var(--warning);
+		border-radius: var(--radius-md);
+		box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
 		white-space: normal;
 		text-align: left;
 		cursor: default;
 	}
 
-	.copyright-flag-heading {
-		font-size: var(--text-sm);
-		font-weight: 600;
+	/* little arrow linking the popover back to the ⚠ trigger */
+	.copyright-flag-caret {
+		position: absolute;
+		top: -5px;
+		left: 0.9rem;
+		width: 8px;
+		height: 8px;
+		background: var(--bg-secondary);
+		border-top: 2px solid var(--warning);
+		border-left: 1px solid var(--border-default);
+		transform: rotate(45deg);
+	}
+
+	.copyright-flag-header {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
 		color: var(--warning);
 	}
 
-	.copyright-flag-match {
+	.copyright-flag-heading {
 		font-size: var(--text-sm);
-		color: var(--text-primary);
+		font-weight: 600;
+		letter-spacing: 0.01em;
+	}
+
+	.copyright-flag-match {
+		display: flex;
+		align-items: baseline;
+		gap: 0.4rem;
+		padding: 0.3rem 0.45rem;
+		background: color-mix(in srgb, var(--warning) 9%, transparent);
+		border-radius: var(--radius-sm);
+		font-size: var(--text-sm);
 		word-break: break-word;
+	}
+
+	.copyright-flag-match-label {
+		flex-shrink: 0;
+		font-size: var(--text-xs);
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--text-tertiary);
+	}
+
+	.copyright-flag-match-song {
+		color: var(--text-primary);
+		font-weight: 500;
 	}
 
 	.copyright-flag-body {
 		font-size: var(--text-xs);
-		line-height: 1.4;
+		line-height: 1.5;
 		color: var(--text-secondary);
 	}
 
 	.copyright-flag-links {
 		display: flex;
 		flex-wrap: wrap;
-		gap: 0.75rem;
-		margin-top: 0.15rem;
+		align-items: center;
+		gap: 0.4rem 1rem;
+		margin-top: 0.1rem;
+		padding-top: 0.55rem;
+		border-top: 1px solid var(--border-subtle);
 	}
 
-	.copyright-flag-links a {
+	.copyright-flag-link {
 		font-size: var(--text-xs);
-		color: var(--accent);
+		color: var(--text-tertiary);
 		text-decoration: none;
 	}
 
-	.copyright-flag-links a:hover {
+	.copyright-flag-link.primary {
+		color: var(--accent);
+		font-weight: 600;
+	}
+
+	.copyright-flag-link:hover {
 		text-decoration: underline;
 	}
 </style>


### PR DESCRIPTION
Visual pass on the copyright popover from #1633 — same behavior, better hierarchy.

- warning triangle sits inline with the heading; warning-colored top border + a caret linking the popover back to the ⚠ trigger
- matched song moves into its own warning-tinted row with an uppercase label (was running inline with the heading)
- **how this works** is now the primary accent action, **view record** secondary, separated from the body by a hairline divider
- softer radius, deeper shadow, roomier spacing, renders on `--bg-secondary`

Also mirrors the app's design tokens into Storybook via `.storybook/preview-head.html`, so components preview on the real dark bg + Georgia serif (the default white/sans was misleading — that's what made the popover look unstyled in isolation).

Behavior unchanged; the #1633 regression tests still pass (the `.copyright-flag-match` row only renders when a match exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)