### PR TITLE
ci: publish storybook to cloudflare pages (storybook.plyr.fm)

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,33 @@
+name: deploy storybook
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/deploy-storybook.yml"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: deploy storybook
+    runs-on: ubuntu-latest
+    concurrency: deploy-storybook
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: build
+        run: cd frontend && bun install && bun run build-storybook
+
+      - name: deploy to cloudflare pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy frontend/storybook-static --project-name plyr-storybook --branch main


### PR DESCRIPTION
Publishes the component Storybook as a public site at **storybook.plyr.fm** — living, browsable documentation of the UI components (the copyright popover from #1633/#1635 is the first entry).

- new `deploy-storybook.yml`: builds `build-storybook` and `wrangler pages deploy`s to a `plyr-storybook` CF Pages project on every push to `main` that touches `frontend/**`
- **reuses the existing `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets** (same as `deploy-docs.yml`) — no new secrets
- the `plyr-storybook` Pages project + `storybook.plyr.fm` custom domain + DNS were provisioned out-of-band via the CF API

First publish fires when this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)