### PR TITLE
fix(ci): provide PUBLIC_API_URL to the storybook build

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -24,6 +24,10 @@ jobs:
 
       - name: build
         run: cd frontend && bun install && bun run build-storybook
+        env:
+          # $env/static/public requires this to exist at build time; storybook
+          # only renders components, so the value is never actually called.
+          PUBLIC_API_URL: https://api.plyr.fm
 
       - name: deploy to cloudflare pages
         uses: cloudflare/wrangler-action@v3

--- a/frontend/justfile
+++ b/frontend/justfile
@@ -22,4 +22,4 @@ storybook:
 
 # build the static storybook (used to sanity-check stories in CI)
 build-storybook:
-    bun run build-storybook
+    PUBLIC_API_URL="${PUBLIC_API_URL:-https://api.plyr.fm}" bun run build-storybook


### PR DESCRIPTION
The storybook deploy started failing once the `TrackItem`/`TagInput` stories landed (#1637): they transitively import `$lib/config`, whose `import { PUBLIC_API_URL } from '$env/static/public'` requires the var to exist at build time. CI has no `.env` (gitignored), so SvelteKit's virtual env module doesn't export it and the strict rollup build errors. It built locally only because a local `.env` supplies it.

- set `PUBLIC_API_URL` in the deploy step (storybook only renders components, so the value is never actually called)
- default it in the `build-storybook` recipe so a clean local build is deterministic too

Reproduced by hiding `.env`: fails without the var, builds with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)