### PR TITLE
feat(storybook): automated accessibility gate (axe on every story)

### DIFF
--- a/.github/workflows/test-storybook.yml
+++ b/.github/workflows/test-storybook.yml
@@ -1,0 +1,38 @@
+name: storybook a11y
+
+# accessibility gate: renders every story in real chromium and fails on axe
+# violations (a11y.test='error' in .storybook/preview.ts). kept as its own job so
+# the fast unit-test path (pre-commit) stays browser- and Playwright-free.
+
+on:
+  pull_request:
+    paths:
+      - "frontend/**"
+      - ".github/workflows/test-storybook.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-a11y-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  a11y:
+    name: story accessibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: install deps
+        run: cd frontend && bun install
+
+      - name: install chromium
+        run: cd frontend && bunx playwright install --with-deps chromium
+
+      - name: run storybook a11y gate
+        run: cd frontend && bun run test-storybook
+        env:
+          # stories import $lib/config, which needs this at build time; it's never
+          # actually called (components only render).
+          PUBLIC_API_URL: https://api.plyr.fm

--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -8,7 +8,8 @@ const config: StorybookConfig = {
   "addons": [
     "@storybook/addon-svelte-csf",
     "@storybook/addon-a11y",
-    "@storybook/addon-docs"
+    "@storybook/addon-docs",
+    "@storybook/addon-vitest"
   ],
   "framework": "@storybook/sveltekit"
 };

--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -36,8 +36,10 @@ const preview: Preview = {
 		controls: {
 			matchers: { color: /(background|color)$/i, date: /Date$/i }
 		},
-		// surface accessibility findings in the a11y panel for every story
-		a11y: { test: 'todo' },
+		// accessibility is enforced: axe violations fail `bun run test-storybook`
+		// (and the CI gate). flip a specific story to 'todo' only with a documented
+		// reason if it has an accepted, intentional violation.
+		a11y: { test: 'error' },
 		options: {
 			storySort: {
 				order: [

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -14,6 +14,7 @@
         "@storybook/addon-a11y": "^10.4.6",
         "@storybook/addon-docs": "^10.4.6",
         "@storybook/addon-svelte-csf": "^5.1.2",
+        "@storybook/addon-vitest": "^10.4.6",
         "@storybook/sveltekit": "^10.4.6",
         "@sveltejs/adapter-auto": "^7.0.0",
         "@sveltejs/adapter-cloudflare": "^7.2.4",
@@ -23,10 +24,12 @@
         "@typescript-eslint/eslint-plugin": "^8.46.4",
         "@typescript-eslint/parser": "^8.46.4",
         "@vite-pwa/sveltekit": "^1.0.1",
+        "@vitest/browser-playwright": "4.1.8",
         "eslint": "^9.39.1",
         "eslint-plugin-storybook": "^10.4.6",
         "eslint-plugin-svelte": "^3.13.0",
         "jsdom": "^29.1.1",
+        "playwright": "^1.61.1",
         "prettier": "^3.7.4",
         "prettier-plugin-svelte": "^3.4.1",
         "storybook": "^10.4.6",
@@ -639,6 +642,8 @@
 
     "@storybook/addon-svelte-csf": ["@storybook/addon-svelte-csf@5.1.2", "", { "dependencies": { "@storybook/csf": "^0.1.13", "dedent": "^1.5.3", "es-toolkit": "^1.26.1", "esrap": "^1.2.2", "magic-string": "^0.30.12", "svelte-ast-print": "^0.4.0", "zimmerframe": "^1.1.2" }, "peerDependencies": { "@storybook/svelte": "^0.0.0-0 || ^8.2.0 || ^9.0.0 || ^9.1.0-0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0", "@sveltejs/vite-plugin-svelte": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0", "storybook": "^0.0.0-0 || ^8.2.0 || ^9.0.0 || ^9.1.0-0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0", "svelte": "^5.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-NpImknEb48J7yr/ArTYpvhDSvGUrgm5Nuybu9PCicjSKTACsXX7cln2R19572ORtns399RTE+t20BBOKxSPm2g=="],
 
+    "@storybook/addon-vitest": ["@storybook/addon-vitest@10.4.6", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.2" }, "peerDependencies": { "@vitest/browser": "^3.0.0 || ^4.0.0", "@vitest/browser-playwright": "^4.0.0", "@vitest/runner": "^3.0.0 || ^4.0.0", "storybook": "^10.4.6", "vitest": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@vitest/browser", "@vitest/browser-playwright", "@vitest/runner", "vitest"] }, "sha512-VvskHge0GZy86LG6kcY5Ww34z8rDV8JBxqSdUpcJVsWfIvyX6MfAbqI76LlereSyBIJGZJZsqaLwRXsQoVY+0Q=="],
+
     "@storybook/builder-vite": ["@storybook/builder-vite@10.4.6", "", { "dependencies": { "@storybook/csf-plugin": "10.4.6", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.4.6", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-BHBtD81HiXUiDQz/CaFynLtWmm7AFUQn8VnXuHipZ8KlnUANopa4yqdVuy/Gwz8ub254uFI5NMZsW/KlgWNgNg=="],
 
     "@storybook/csf": ["@storybook/csf@0.1.13", "", { "dependencies": { "type-fest": "^2.19.0" } }, "sha512-7xOOwCLGB3ebM87eemep89MYRFTko+D8qE7EdAAq74lgdqRR5cOUtYWJLjO2dLtP94nqoOdHJo6MdLLKzg412Q=="],
@@ -1007,7 +1012,7 @@
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1825,9 +1830,9 @@
 
     "miniflare/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
 
-    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
-
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "svelte/esrap": ["esrap@2.1.1", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-ebTT9B6lOtZGMgJ3o5r12wBacHctG7oEWazIda8UlPfA3HD/Wrv8FdXoVo73vzdpwCxNyXjPauyN2bbJzMkB9A=="],
 
@@ -1836,6 +1841,8 @@
     "svelte-ast-print/zimmerframe": ["zimmerframe@1.1.2", "", {}, "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w=="],
 
     "tempy/type-fest": ["type-fest@0.16.0", "", {}, "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "vitest/@vitest/expect": ["@vitest/expect@4.1.8", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ=="],
 
@@ -1850,6 +1857,8 @@
     "workbox-build/source-map": ["source-map@0.8.0-beta.0", "", { "dependencies": { "whatwg-url": "^7.0.0" } }, "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA=="],
 
     "wrangler/esbuild": ["esbuild@0.25.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.4", "@esbuild/android-arm": "0.25.4", "@esbuild/android-arm64": "0.25.4", "@esbuild/android-x64": "0.25.4", "@esbuild/darwin-arm64": "0.25.4", "@esbuild/darwin-x64": "0.25.4", "@esbuild/freebsd-arm64": "0.25.4", "@esbuild/freebsd-x64": "0.25.4", "@esbuild/linux-arm": "0.25.4", "@esbuild/linux-arm64": "0.25.4", "@esbuild/linux-ia32": "0.25.4", "@esbuild/linux-loong64": "0.25.4", "@esbuild/linux-mips64el": "0.25.4", "@esbuild/linux-ppc64": "0.25.4", "@esbuild/linux-riscv64": "0.25.4", "@esbuild/linux-s390x": "0.25.4", "@esbuild/linux-x64": "0.25.4", "@esbuild/netbsd-arm64": "0.25.4", "@esbuild/netbsd-x64": "0.25.4", "@esbuild/openbsd-arm64": "0.25.4", "@esbuild/openbsd-x64": "0.25.4", "@esbuild/sunos-x64": "0.25.4", "@esbuild/win32-arm64": "0.25.4", "@esbuild/win32-ia32": "0.25.4", "@esbuild/win32-x64": "0.25.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q=="],
+
+    "wrangler/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "youch/cookie": ["cookie@1.0.2", "", {}, "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="],
 
@@ -1885,7 +1894,13 @@
 
     "@pydantic/logfire-browser/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
+    "@rollup/plugin-babel/rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "@rollup/plugin-node-resolve/@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@rollup/plugin-replace/rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@rollup/pluginutils/rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -1906,6 +1921,8 @@
     "vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "workbox-build/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "workbox-build/rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "workbox-build/source-map/whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="],
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -16,7 +16,7 @@ export default [
 			'storybook-static/**',
 			'.storybook/**',
 			'**/*.config.js',
-			'vitest.config.ts'
+			'vitest*.config.ts'
 		]
 	},
 	js.configs.recommended,

--- a/frontend/justfile
+++ b/frontend/justfile
@@ -12,9 +12,14 @@ run:
 check:
     bun run check
 
-# run component tests
+# run component tests (jsdom, fast — no browser)
 test:
     bun run test
+
+# accessibility gate: render every story in chromium, fail on axe violations
+# (needs `bunx playwright install chromium` once)
+test-storybook:
+    PUBLIC_API_URL="${PUBLIC_API_URL:-https://api.plyr.fm}" bun run test-storybook
 
 # preview components in isolation (storybook, http://localhost:6006)
 storybook:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"test": "vitest run",
+		"test-storybook": "vitest run --config vitest.storybook.config.ts",
 		"lint": "eslint .",
 		"format": "prettier --write .",
 		"format:check": "prettier --check .",
@@ -41,7 +42,10 @@
 		"@storybook/addon-svelte-csf": "^5.1.2",
 		"@storybook/addon-a11y": "^10.4.6",
 		"@storybook/addon-docs": "^10.4.6",
-		"eslint-plugin-storybook": "^10.4.6"
+		"@storybook/addon-vitest": "^10.4.6",
+		"eslint-plugin-storybook": "^10.4.6",
+		"@vitest/browser-playwright": "4.1.8",
+		"playwright": "^1.61.1"
 	},
 	"dependencies": {
 		"@atproto/api": "^0.18.7",

--- a/frontend/src/lib/components/ConfirmDialog.stories.svelte
+++ b/frontend/src/lib/components/ConfirmDialog.stories.svelte
@@ -5,10 +5,15 @@
 
 	// the dialog uses <dialog>.showModal(), so it renders in the top layer over
 	// the whole viewport — fullscreen layout keeps it centered without a frame.
+	// a11y 'todo': the confirm/cancel buttons use white text on the accent/error
+	// fills, which fail WCAG AA contrast (2.6:1 / 3.8:1). that's the app's global
+	// button styling against the user-configurable accent — a design decision, not
+	// a per-component fix. tracked for a dedicated contrast pass; still surfaced as
+	// a warning here.
 	const { Story } = defineMeta({
 		title: 'overlays/ConfirmDialog',
 		component: ConfirmDialog,
-		parameters: { layout: 'fullscreen' },
+		parameters: { layout: 'fullscreen', a11y: { test: 'todo' } },
 		args: { open: true, onConfirm: fn(), onCancel: fn() }
 	});
 </script>

--- a/frontend/src/lib/components/RichText.stories.svelte
+++ b/frontend/src/lib/components/RichText.stories.svelte
@@ -2,10 +2,14 @@
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import RichText from './RichText.svelte';
 
+	// a11y 'todo': auto-linked text renders in --accent, which fails WCAG AA
+	// contrast on some backgrounds. accent is the app's user-configurable link
+	// color — a token-level design decision, not a per-story fix. tracked for a
+	// dedicated contrast pass; still surfaced here as a warning.
 	const { Story } = defineMeta({
 		title: 'content/RichText',
 		component: RichText,
-		parameters: { layout: 'padded' },
+		parameters: { layout: 'padded', a11y: { test: 'todo' } },
 		argTypes: { text: { control: 'text' } }
 	});
 </script>

--- a/frontend/src/lib/components/TrackItem.stories.svelte
+++ b/frontend/src/lib/components/TrackItem.stories.svelte
@@ -21,10 +21,14 @@
 		tags: ['house', 'disco']
 	};
 
+	// a11y 'todo': the meta line (play count / tags) uses --text-tertiary on the
+	// track background, which falls just under WCAG AA contrast (3.8:1). bumping it
+	// changes the app-wide visual hierarchy of track lists — a design decision, not
+	// a per-story fix. tracked for a dedicated contrast pass; still surfaced here.
 	const { Story } = defineMeta({
 		title: 'track/TrackItem',
 		component: TrackItem,
-		parameters: { layout: 'padded' },
+		parameters: { layout: 'padded', a11y: { test: 'todo' } },
 		args: { track, onPlay: fn(), isAuthenticated: true }
 	});
 </script>

--- a/frontend/src/stories/Typography.stories.svelte
+++ b/frontend/src/stories/Typography.stories.svelte
@@ -27,7 +27,7 @@
 			<div style="display:flex; align-items:baseline; gap:1rem; padding:0.5rem 0; border-bottom:1px solid var(--border-subtle)">
 				<span style="font-size:var({size.token})">the quick brown fox jumps</span>
 				<code style="margin-left:auto; font-size:var(--text-xs); color:var(--text-tertiary); white-space:nowrap">{size.token}</code>
-				<span style="font-size:var(--text-xs); color:var(--text-muted); white-space:nowrap; min-width:8rem; text-align:right">{size.use}</span>
+				<span style="font-size:var(--text-xs); color:var(--text-secondary); white-space:nowrap; min-width:8rem; text-align:right">{size.use}</span>
 			</div>
 		{/each}
 	</div>

--- a/frontend/vitest.storybook.config.ts
+++ b/frontend/vitest.storybook.config.ts
@@ -1,0 +1,39 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vitest/config';
+import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+import { playwright } from '@vitest/browser-playwright';
+import path from 'node:path';
+
+// dedicated config for the storybook accessibility gate — kept separate from
+// vitest.config.ts so the everyday `bun run test` (jsdom unit tests) never pulls
+// in a browser or Playwright. this runs each story in real chromium and, with
+// a11y.test='error' in .storybook/preview.ts, fails on axe violations.
+//
+// the svelte plugin + these $lib/$app/$env aliases mirror vitest.config.ts so
+// stories (and storybook's own internal .svelte components) compile and resolve
+// the same way the unit tests do; keep them in sync.
+export default defineConfig({
+	plugins: [
+		svelte(),
+		storybookTest({ configDir: path.join(import.meta.dirname, '.storybook') })
+	],
+	resolve: {
+		alias: {
+			$lib: path.resolve(import.meta.dirname, 'src/lib'),
+			'$app/environment': path.resolve(import.meta.dirname, 'src/tests/stubs/app-environment.ts'),
+			'$app/navigation': path.resolve(import.meta.dirname, 'src/tests/stubs/app-navigation.ts'),
+			'$app/stores': path.resolve(import.meta.dirname, 'src/tests/stubs/app-stores.ts'),
+			'$env/static/public': path.resolve(import.meta.dirname, 'src/tests/stubs/env-static-public.ts')
+		},
+		conditions: ['browser']
+	},
+	test: {
+		name: 'storybook',
+		browser: {
+			enabled: true,
+			headless: true,
+			provider: playwright(),
+			instances: [{ browser: 'chromium' }]
+		}
+	}
+});


### PR DESCRIPTION
Makes accessibility **enforced**, not just an interactive panel someone might click: every story renders in real Chromium and the build fails on axe violations. This is the "automated a11y gate" we discussed.

Built the current (2026) way — `@storybook/addon-vitest` + `@storybook/addon-a11y` with `a11y.test: 'error'` — but structured for the long haul rather than copied from the initializer.

## design decisions (long-term maintainer lens)

- **Quarantined the weight.** The gate has its **own vitest config** (`vitest.storybook.config.ts`) and its **own CI job** (`test-storybook.yml`). The everyday `bun run test` (jsdom unit tests, in `pre_commit`) is completely untouched — no browser, no Playwright, still ~3s. Playwright/Chromium only load in the dedicated gate.
- **It actually bites — verified.** I proved it by adding a story with a missing `alt` and confirming the run fails, then removed it. (Also caught that a stale `setProjectAnnotations` setup file was *silently suppressing* a11y — removed it; the gate now genuinely runs.)
- **Went in green, honestly.** The gate immediately surfaced real **color-contrast debt**. I fixed the one thing I own (a faint Typography helper label) and marked the genuine app-wide debt as documented `a11y.test: 'todo'` — those stories still run and **warn**, they just don't fail the gate on pre-existing issues. I did **not** silently redesign core UI in an infra PR.

## ⚠️ real accessibility finding for you

The gate flagged genuine WCAG AA contrast failures in shipped UI:

| where | issue | ratio (need 4.5:1) |
|---|---|---|
| `ConfirmDialog` / all primary buttons | white text on the **accent** fill | **2.6:1** |
| `ConfirmDialog` danger buttons | white text on **error red** | 3.8:1 |
| `TrackItem` meta line | `--text-tertiary` on track bg | 3.8:1 |
| `RichText` links | render in `--accent` | fails on some bg |

These are **token/design decisions** — especially since `--accent` is *user-configurable*, so button contrast varies per listener's chosen color. They deserve a dedicated contrast pass with your input, not a rushed change here. Marked `todo` and commented in each story so they're tracked, not buried.

## how it runs

- CI: new `storybook a11y` job on PRs touching `frontend/**`.
- Local: `just frontend test-storybook` (needs `bunx playwright install chromium` once).
- New stories default to `error` — accessibility is the default expectation going forward.

## not merging yet
Holding for your say-so since this reintroduces Playwright and the contrast finding is worth a look. Two questions: (1) merge the gate as-is, and (2) want me to do the **contrast pass** as a follow-up (flip those `todo`s back to `error` once fixed)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)