### PR TITLE
fix(accessibility): bring existing stories into WCAG contrast compliance

### DIFF
--- a/frontend/.storybook/plyr-tokens.css
+++ b/frontend/.storybook/plyr-tokens.css
@@ -14,6 +14,7 @@
 	--accent-hover: #8ab3ff;
 	--accent-muted: #4a7ddd;
 	--accent-rgb: 106, 159, 255;
+	--accent-contrast: #0a0a0a;
 
 	/* backgrounds */
 	--bg-primary: #0a0a0a;

--- a/frontend/src/lib/components/ColorSettings.svelte
+++ b/frontend/src/lib/components/ColorSettings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { preferences } from '$lib/preferences.svelte';
+	import { preferences, getContrastColor } from '$lib/preferences.svelte';
 
 	let showSettings = $state(false);
 
@@ -40,6 +40,7 @@
 		const b = parseInt(color.slice(5, 7), 16);
 		const hover = `rgb(${Math.min(255, r + 30)}, ${Math.min(255, g + 30)}, ${Math.min(255, b + 30)})`;
 		document.documentElement.style.setProperty('--accent-hover', hover);
+		document.documentElement.style.setProperty('--accent-contrast', getContrastColor(color));
 	}
 
 	async function applyColor(color: string) {

--- a/frontend/src/lib/components/ConfirmDialog.stories.svelte
+++ b/frontend/src/lib/components/ConfirmDialog.stories.svelte
@@ -5,15 +5,10 @@
 
 	// the dialog uses <dialog>.showModal(), so it renders in the top layer over
 	// the whole viewport — fullscreen layout keeps it centered without a frame.
-	// a11y 'todo': the confirm/cancel buttons use white text on the accent/error
-	// fills, which fail WCAG AA contrast (2.6:1 / 3.8:1). that's the app's global
-	// button styling against the user-configurable accent — a design decision, not
-	// a per-component fix. tracked for a dedicated contrast pass; still surfaced as
-	// a warning here.
 	const { Story } = defineMeta({
 		title: 'overlays/ConfirmDialog',
 		component: ConfirmDialog,
-		parameters: { layout: 'fullscreen', a11y: { test: 'todo' } },
+		parameters: { layout: 'fullscreen' },
 		args: { open: true, onConfirm: fn(), onCancel: fn() }
 	});
 </script>

--- a/frontend/src/lib/components/ConfirmDialog.svelte
+++ b/frontend/src/lib/components/ConfirmDialog.svelte
@@ -174,12 +174,15 @@
 	.confirm-btn {
 		background: var(--accent);
 		border: 1px solid var(--accent);
-		color: white;
+		/* accent is user-chosen, so derive readable text instead of assuming white */
+		color: var(--accent-contrast, white);
 	}
 
 	.confirm-btn.danger {
-		background: #ef4444;
-		border-color: #ef4444;
+		/* darkened error red so white text meets WCAG AA contrast */
+		background: color-mix(in srgb, var(--error) 80%, black);
+		border-color: color-mix(in srgb, var(--error) 80%, black);
+		color: white;
 	}
 
 	.confirm-btn:hover:not(:disabled) {

--- a/frontend/src/lib/components/ProfileMenu.svelte
+++ b/frontend/src/lib/components/ProfileMenu.svelte
@@ -2,7 +2,7 @@
 	import { portal } from 'svelte-portal';
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
-	import { preferences, FONT_OPTIONS, type Theme, type FontFamily } from '$lib/preferences.svelte';
+	import { preferences, getContrastColor, FONT_OPTIONS, type Theme, type FontFamily } from '$lib/preferences.svelte';
 	import { ambient } from '$lib/ambient.svelte';
 	import { API_URL } from '$lib/config';
 	import type { User, LinkedAccount } from '$lib/types';
@@ -101,6 +101,7 @@
 		const b = parseInt(color.slice(5, 7), 16);
 		const hover = `rgb(${Math.min(255, r + 30)}, ${Math.min(255, g + 30)}, ${Math.min(255, b + 30)})`;
 		document.documentElement.style.setProperty('--accent-hover', hover);
+		document.documentElement.style.setProperty('--accent-contrast', getContrastColor(color));
 	}
 
 	async function applyColor(color: string) {

--- a/frontend/src/lib/components/RichText.stories.svelte
+++ b/frontend/src/lib/components/RichText.stories.svelte
@@ -2,14 +2,10 @@
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import RichText from './RichText.svelte';
 
-	// a11y 'todo': auto-linked text renders in --accent, which fails WCAG AA
-	// contrast on some backgrounds. accent is the app's user-configurable link
-	// color — a token-level design decision, not a per-story fix. tracked for a
-	// dedicated contrast pass; still surfaced here as a warning.
 	const { Story } = defineMeta({
 		title: 'content/RichText',
 		component: RichText,
-		parameters: { layout: 'padded', a11y: { test: 'todo' } },
+		parameters: { layout: 'padded' },
 		argTypes: { text: { control: 'text' } }
 	});
 </script>

--- a/frontend/src/lib/components/RichText.svelte
+++ b/frontend/src/lib/components/RichText.svelte
@@ -92,11 +92,9 @@
 <style>
 	.rich-text-link {
 		color: var(--accent);
-		text-decoration: none;
-		word-break: break-all;
-	}
-
-	.rich-text-link:hover {
+		/* underline so links are distinguishable from body text by more than color
+		   (WCAG link-in-text-block) */
 		text-decoration: underline;
+		word-break: break-all;
 	}
 </style>

--- a/frontend/src/lib/components/TrackItem.stories.svelte
+++ b/frontend/src/lib/components/TrackItem.stories.svelte
@@ -21,10 +21,12 @@
 		tags: ['house', 'disco']
 	};
 
-	// a11y 'todo': the meta line (play count / tags) uses --text-tertiary on the
-	// track background, which falls just under WCAG AA contrast (3.8:1). bumping it
-	// changes the app-wide visual hierarchy of track lists — a design decision, not
-	// a per-story fix. tracked for a dedicated contrast pass; still surfaced here.
+	// a11y 'todo' (structural, not contrast — contrast is fixed): the whole track
+	// row is a <button> (click-to-play) that contains other interactive controls
+	// (likes, comments, the actions menu), which axe flags as nested-interactive —
+	// invalid HTML and a keyboard/screen-reader problem. fixing it means reworking
+	// how a track row's click-to-play is wired (a real interaction-model change),
+	// so it's tracked for a focused refactor rather than rushed here. still warns.
 	const { Story } = defineMeta({
 		title: 'track/TrackItem',
 		component: TrackItem,

--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -828,14 +828,14 @@
 
 	.track-meta {
 		font-size: var(--text-sm);
-		color: var(--text-tertiary);
+		color: var(--text-secondary);
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
 	}
 
 	.plays {
-		color: var(--text-tertiary);
+		color: var(--text-secondary);
 		font-family: inherit;
 	}
 
@@ -845,7 +845,7 @@
 	}
 
 	.likes {
-		color: var(--text-tertiary);
+		color: var(--text-secondary);
 		font-family: inherit;
 		position: relative;
 		cursor: help;
@@ -871,7 +871,7 @@
 	}
 
 	.comments {
-		color: var(--text-tertiary);
+		color: var(--text-secondary);
 		font-family: inherit;
 		display: inline-flex;
 		align-items: center;

--- a/frontend/src/lib/contrast.test.ts
+++ b/frontend/src/lib/contrast.test.ts
@@ -1,0 +1,29 @@
+// getContrastColor picks readable text for a solid fill of a user-chosen accent.
+// locks the WCAG crossover so a future refactor can't silently return unreadable
+// text (the reason ConfirmDialog's buttons failed the a11y gate).
+import { describe, it, expect } from 'vitest';
+import { getContrastColor } from '$lib/preferences.svelte';
+
+const DARK = '#0a0a0a';
+const WHITE = '#ffffff';
+
+describe('getContrastColor', () => {
+	it('uses dark text on the default (light-ish) accent', () => {
+		expect(getContrastColor('#6a9fff')).toBe(DARK);
+	});
+
+	it('uses white text on dark accents', () => {
+		expect(getContrastColor('#0a3d91')).toBe(WHITE); // deep blue
+		expect(getContrastColor('#4a148c')).toBe(WHITE); // deep purple
+	});
+
+	it('uses dark text on light/bright accents', () => {
+		expect(getContrastColor('#ffd54f')).toBe(DARK); // amber
+		expect(getContrastColor('#4ade80')).toBe(DARK); // green
+	});
+
+	it('handles the extremes', () => {
+		expect(getContrastColor('#ffffff')).toBe(DARK);
+		expect(getContrastColor('#000000')).toBe(WHITE);
+	});
+});

--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -19,6 +19,22 @@ export const FONT_OPTIONS: { value: FontFamily; label: string; stack: string }[]
 
 export const DEFAULT_FONT: FontFamily = 'georgia';
 
+// pick readable text (near-black or white) for a solid fill of the given hex —
+// the accent is user-chosen, so a fixed text color can't guarantee WCAG contrast.
+// returns whichever of dark/white has the higher contrast against the color.
+export function getContrastColor(hex: string): string {
+	const toLinear = (channel: number) => {
+		const c = channel / 255;
+		return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+	};
+	const luminance =
+		0.2126 * toLinear(parseInt(hex.slice(1, 3), 16)) +
+		0.7152 * toLinear(parseInt(hex.slice(3, 5), 16)) +
+		0.0722 * toLinear(parseInt(hex.slice(5, 7), 16));
+	// crossover (~0.179) where dark text starts to out-contrast white text
+	return luminance >= 0.179 ? '#0a0a0a' : '#ffffff';
+}
+
 export interface UiSettings {
 	background_image_url?: string;
 	background_tile?: boolean;
@@ -195,6 +211,7 @@ class PreferencesManager {
 		const b = parseInt(color.slice(5, 7), 16);
 		const hover = `rgb(${Math.min(255, r + 30)}, ${Math.min(255, g + 30)}, ${Math.min(255, b + 30)})`;
 		root.style.setProperty('--accent-hover', hover);
+		root.style.setProperty('--accent-contrast', getContrastColor(color));
 	}
 
 	applyTheme(theme: Theme): void {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -17,7 +17,7 @@
 	import { page } from '$app/stores';
 	import { afterNavigate, goto } from '$app/navigation';
 	import { auth } from '$lib/auth.svelte';
-	import { preferences } from '$lib/preferences.svelte';
+	import { preferences, getContrastColor } from '$lib/preferences.svelte';
 	import { ambient } from '$lib/ambient.svelte';
 	import { moderation } from '$lib/moderation.svelte';
 	import { player } from '$lib/player.svelte';
@@ -377,6 +377,7 @@
 		if (savedAccent) {
 			document.documentElement.style.setProperty('--accent', savedAccent);
 			document.documentElement.style.setProperty('--accent-hover', getHoverColor(savedAccent));
+			document.documentElement.style.setProperty('--accent-contrast', getContrastColor(savedAccent));
 		}
 
 		// apply saved theme from localStorage
@@ -575,6 +576,8 @@
 		--accent-hover: #8ab3ff;
 		--accent-muted: #4a7ddd;
 		--accent-rgb: 106, 159, 255;
+		/* readable text on a solid --accent fill; recomputed in JS per chosen accent */
+		--accent-contrast: #0a0a0a;
 
 		/* backgrounds */
 		--bg-primary: #0a0a0a;

--- a/loq.toml
+++ b/loq.toml
@@ -100,7 +100,7 @@ max_lines = 801
 
 [[rules]]
 path = "frontend/src/lib/components/ProfileMenu.svelte"
-max_lines = 1192
+max_lines = 1193
 
 [[rules]]
 path = "frontend/src/lib/components/Queue.svelte"
@@ -132,7 +132,7 @@ max_lines = 950
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"
-max_lines = 843
+max_lines = 846
 
 [[rules]]
 path = "frontend/src/routes/costs/+page.svelte"


### PR DESCRIPTION
The accessibility gate (just merged) flagged **real color-contrast problems in shipped UI**. This fixes them at the source so every existing story passes at the enforcing level — so we hold our own components to the same bar we now ask of new ones (your "not being hypocritical" point).

## what was actually wrong, and the fix

| what | problem | fix |
|---|---|---|
| **primary buttons** (`ConfirmDialog`, app-wide pattern) | white text on the user-chosen accent — 2.6:1, fails AA | accent is a *free color picker*, so no fixed text color is safe. Added `getContrastColor()` + an `--accent-contrast` token (dark or light text chosen from the accent's brightness), set everywhere `--accent` is applied. Buttons now use `color: var(--accent-contrast)`. |
| **danger button** | white on error-red — 3.8:1 | darkened the red fill so white text clears AA |
| **`RichText` links** | link color only 2.1:1 vs surrounding body text | underline links by default (distinguishable by more than color) |
| **`TrackItem` meta** (plays/likes/comments) | `--text-tertiary` too faint on the track bg — 3.8:1 | bumped to `--text-secondary` |

`getContrastColor` has a unit test locking the WCAG luminance crossover. 90 unit tests + the full story gate pass.

## visible changes worth a look (this touches the theme system)
- primary buttons: text flips to **dark on light accents** (was always white). Robust for *any* accent a user picks — verify with a couple accent colors in Settings.
- rich-text links are now **always underlined** (were underline-on-hover).
- track meta text is **slightly brighter**.
- danger buttons are a **slightly deeper red**.

## one honest exception (still `todo`, documented)
`TrackItem` also trips **nested-interactive**: the whole track row is a `<button>` (click-to-play) that *contains* the likes/comments/menu controls. That's invalid and a real keyboard/screen-reader issue — but fixing it is an **interaction-model change** (how click-to-play is wired), not a contrast tweak. I did **not** rush that in here; it's marked `todo` with a comment and wants its own focused refactor + your input on the UX. That's the last thing between us and zero exceptions.

## verification
Gate green, unit tests green, check/lint/loq green. The static default renders correctly in the gate; I'd suggest a quick manual check of the dynamic path (change your accent in Settings, confirm button text stays readable) before/after merge since it touches accent application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)