### PR TITLE
fix(accessibility): stop nesting interactive controls in the track row

### DIFF
--- a/frontend/src/lib/components/TrackItem.stories.svelte
+++ b/frontend/src/lib/components/TrackItem.stories.svelte
@@ -21,16 +21,10 @@
 		tags: ['house', 'disco']
 	};
 
-	// a11y 'todo' (structural, not contrast — contrast is fixed): the whole track
-	// row is a <button> (click-to-play) that contains other interactive controls
-	// (likes, comments, the actions menu), which axe flags as nested-interactive —
-	// invalid HTML and a keyboard/screen-reader problem. fixing it means reworking
-	// how a track row's click-to-play is wired (a real interaction-model change),
-	// so it's tracked for a focused refactor rather than rushed here. still warns.
 	const { Story } = defineMeta({
 		title: 'track/TrackItem',
 		component: TrackItem,
-		parameters: { layout: 'padded', a11y: { test: 'todo' } },
+		parameters: { layout: 'padded' },
 		args: { track, onPlay: fn(), isAuthenticated: true }
 	});
 </script>

--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -184,9 +184,6 @@
 	}
 
 	function handleCommentsKeydown(event: KeyboardEvent) {
-		if (event.key === 'Enter' || event.key === ' ') {
-			// don't prevent default - let the link navigate
-		}
 		if (event.key === 'Escape') {
 			showCommentersTooltip = false;
 		}
@@ -210,21 +207,22 @@
 	{#if showIndex}
 		<span class="track-index">{index + 1}</span>
 	{/if}
-	<button
-		class="track"
-		onclick={async (e) => {
-			// only play if clicking the track itself, not a link inside
-			if (e.target instanceof HTMLAnchorElement || (e.target as HTMLElement).closest('a')) {
-				return;
-			}
-			// use playTrack for gated content checks, fall back to onPlay for non-gated
-			if (track.gated) {
-				await playTrack(track);
-			} else {
-				onPlay(track);
-			}
-		}}
-	>
+	<div class="track">
+		<!-- the primary action (play) is a real button stretched across the row as
+		     its background; the links/controls sit above it (z-index), so clicking
+		     the background plays and clicking a link navigates — same behavior as
+		     before, without nesting interactive controls inside a button. -->
+		<button
+			class="track-play"
+			aria-label="play {track.title}"
+			onclick={async () => {
+				if (track.gated) {
+					await playTrack(track);
+				} else {
+					onPlay(track);
+				}
+			}}
+		></button>
 		<div class="track-image-wrapper" class:gated={track.gated}>
 			{#if (coverFullUrl || coverThumbUrl) && !trackImageError}
 				<SensitiveImage src={coverThumbUrl ?? coverFullUrl}>
@@ -362,22 +360,18 @@
 				{/if}
 				{#if commentCount > 0}
 					<span class="meta-separator">•</span>
-					<span
-						class="comments-wrapper"
-						role="button"
-						tabindex="0"
-						aria-label="{commentCount} {commentCount === 1 ? 'comment' : 'comments'} (focus to view participants)"
-						aria-expanded={showCommentersTooltip}
-						onmouseenter={handleCommentsMouseEnter}
-						onmouseleave={handleCommentsMouseLeave}
-						onfocus={handleCommentsMouseEnter}
-						onblur={handleCommentsMouseLeave}
-						onkeydown={handleCommentsKeydown}
-					>
+					<span class="comments-wrapper">
 						<a
 							href="/track/{track.id}"
 							class="comments"
 							title="view comments"
+							aria-label="{commentCount} {commentCount === 1 ? 'comment' : 'comments'} (view comments)"
+							aria-expanded={showCommentersTooltip}
+							onmouseenter={handleCommentsMouseEnter}
+							onmouseleave={handleCommentsMouseLeave}
+							onfocus={handleCommentsMouseEnter}
+							onblur={handleCommentsMouseLeave}
+							onkeydown={handleCommentsKeydown}
 						>
 							<svg class="comment-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 								<path d="M2 3h12v8H5l-3 3V3z" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/>
@@ -400,7 +394,7 @@
 			{/if}
 			</div>
 		</div>
-	</button>
+	</div>
 	<div class="track-actions" role="presentation" onclick={(e) => e.stopPropagation()}>
 		<!-- desktop: show individual buttons -->
 		<div class="desktop-actions">
@@ -524,17 +518,41 @@
 	}
 
 	.track {
-		background: transparent;
-		border: none;
-		cursor: pointer;
+		position: relative;
 		text-align: left;
-		padding: 0;
 		flex: 1;
 		min-width: 0;
 		display: flex;
 		align-items: center;
 		gap: 0.75rem;
 		font-family: inherit;
+	}
+
+	/* stretched primary action: clicking the row background plays the track */
+	.track-play {
+		position: absolute;
+		inset: 0;
+		z-index: 0;
+		margin: 0;
+		padding: 0;
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		font: inherit;
+	}
+
+	.track-play:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: -2px;
+		border-radius: var(--radius-base);
+	}
+
+	/* real links/controls sit above the play overlay so they stay clickable and
+	   keyboard-focusable — this is what removes the nested-interactive violation */
+	.track a,
+	.track [role='button'] {
+		position: relative;
+		z-index: 1;
 	}
 
 	.track-image-wrapper {


### PR DESCRIPTION
The track row was one big `<button>` (click-to-play) that **wrapped other links and buttons** — the title, artist, album, and tag links, plus the likes and comments controls. Nesting interactive controls inside a button is invalid HTML and breaks keyboard + screen-reader navigation. This is the structural item I flagged (and deliberately did *not* rush) in the contrast PR. **Behavior is unchanged** — it's the same click-to-play row, just built correctly.

## how to review this (in Storybook 👀)
This is exactly the kind of interaction change Storybook is good for. Run `just frontend storybook`, open **track → TrackItem**, and try each state (Default, Playing, CopyrightFlagged, LoggedOut):
- **Mouse:** click the row background → plays. Click the title / artist / album / tags / comments → navigates. (same as today)
- **Keyboard:** press Tab — you now land on a real "play {title}" control with a visible focus ring, then tab through the links. Previously the whole row was one giant button that swallowed everything.

## the pattern (plain version)
The standard "clickable card with a primary action":
- The row is now a plain container.
- One real `<button class="track-play">` is **stretched invisibly across the whole row** as the background — that's the play target, with a proper label and focus ring.
- The real links/controls sit **above** that background (via `z-index`), so they keep working normally.

Result: click the background → play; click a link → navigate. Identical to before, but valid and fully keyboard-navigable.

<details>
<summary>second, smaller fix in the same file</summary>

The comments control was *also* a nested case on its own: a `role="button"` span wrapping an `<a>`. The link is the real interactive element, so the wrapper is now just a container and the link itself carries the hover/focus/keyboard tooltip behavior.
</details>

## why it matters
With both fixed, **every** story now passes the accessibility gate at the enforcing level — no `todo` exceptions left anywhere in the suite. That's the "totally in compliance, not hypocritical" bar you asked for, now actually met.

## verification
Accessibility gate green (30/30 with TrackItem enforcing), 90 unit tests, svelte-check 0/0, eslint + loq clean.

**Not merging** — this touches how clicking a track behaves, so it's yours to eyeball in Storybook first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)