### PR TITLE
feat(api): minimal subsonic-compatible surface at /rest

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "ruff>=0.12.0",
     "httpx>=0.28.0",
     "ty>=0.0.1a25",
+    "py-sonic>=1.1.2",
 ]
 
 [build-system]
@@ -127,6 +128,10 @@ extend-select = [
     "B008",
 ] # Allow Depends() and File() in FastAPI route defaults
 "src/backend/main.py" = ["E402"] # Need warnings filter before imports
+# the local alembic/ migrations dir makes ruff versions disagree on whether
+# `alembic` is first- or third-party, so import sorting here can never satisfy
+# both the pre-commit hook and the locked ruff
+"scripts/init_db.py" = ["I001"]
 
 [tool.coverage.run]
 source = ["src"]

--- a/backend/scripts/init_db.py
+++ b/backend/scripts/init_db.py
@@ -9,9 +9,9 @@ import asyncio
 import sys
 
 import sqlalchemy as sa
+from alembic.config import Config
 
 from alembic import command
-from alembic.config import Config
 from backend.models import Base
 from backend.utilities.database import get_engine
 

--- a/backend/src/backend/api/subsonic/__init__.py
+++ b/backend/src/backend/api/subsonic/__init__.py
@@ -1,0 +1,6 @@
+"""subsonic-compatible API surface (/rest/*)."""
+
+from backend.api.subsonic import endpoints as endpoints
+from backend.api.subsonic.router import router
+
+__all__ = ["router"]

--- a/backend/src/backend/api/subsonic/auth.py
+++ b/backend/src/backend/api/subsonic/auth.py
@@ -1,0 +1,71 @@
+"""authenticate subsonic requests against plyr.fm developer tokens.
+
+the subsonic "password" is a plyr.fm developer token. clients can send it
+directly via `p` (plain or `enc:`-hex, subsonic legacy auth), or prove
+possession via the token scheme: `t` = md5(token + salt `s`) with `u` set to
+the account handle or DID. the token scheme requires scanning the user's
+developer tokens because the md5 digest can't be reversed to a session id.
+"""
+
+import hashlib
+from collections.abc import Mapping
+
+from sqlalchemy import or_, select
+
+from backend._internal import Session
+from backend._internal.auth.session import get_session
+from backend.api.subsonic.responses import (
+    ERROR_MISSING_PARAMETER,
+    ERROR_WRONG_CREDENTIALS,
+    SubsonicError,
+)
+from backend.models import UserSession
+from backend.utilities.database import db_session
+
+
+async def authenticate(params: Mapping[str, str]) -> Session:
+    """resolve subsonic credential params to a plyr.fm session or raise SubsonicError."""
+
+    if password := params.get("p"):
+        if session := await get_session(_decode_password(password)):
+            return session
+        raise SubsonicError(ERROR_WRONG_CREDENTIALS, "wrong username or password")
+
+    username = params.get("u")
+    salt = params.get("s")
+    digest = params.get("t")
+    if username and salt and digest:
+        for candidate in await _developer_token_ids(username):
+            hashed = hashlib.md5(
+                (candidate + salt).encode(), usedforsecurity=False
+            ).hexdigest()
+            if hashed == digest and (session := await get_session(candidate)):
+                return session
+        raise SubsonicError(ERROR_WRONG_CREDENTIALS, "wrong username or password")
+
+    raise SubsonicError(
+        ERROR_MISSING_PARAMETER, "required parameter is missing: p or u+t+s"
+    )
+
+
+def _decode_password(password: str) -> str:
+    if password.startswith("enc:"):
+        try:
+            return bytes.fromhex(password[4:]).decode()
+        except (ValueError, UnicodeDecodeError):
+            raise SubsonicError(
+                ERROR_WRONG_CREDENTIALS, "wrong username or password"
+            ) from None
+    return password
+
+
+async def _developer_token_ids(username: str) -> list[str]:
+    """developer token session ids for a handle or DID (token-scheme candidates)."""
+    async with db_session() as db:
+        result = await db.execute(
+            select(UserSession.session_id).where(
+                or_(UserSession.handle == username, UserSession.did == username),
+                UserSession.is_developer_token == True,  # noqa: E712
+            )
+        )
+        return list(result.scalars().all())

--- a/backend/src/backend/api/subsonic/endpoints.py
+++ b/backend/src/backend/api/subsonic/endpoints.py
@@ -1,0 +1,290 @@
+"""minimal subsonic endpoint surface: ping, license, playlists, stream, cover art.
+
+every endpoint is registered at both `/<name>` and `/<name>.view` for GET and
+POST (the spec allows either; libsonic POSTs a form body by default). streaming
+and cover art 307-redirect into the existing `/audio/{file_id}` and image CDN
+surfaces rather than re-serving bytes.
+"""
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from fastapi import Request, Response
+from fastapi.responses import RedirectResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from backend._internal import Session
+from backend._internal.track_visibility import track_visible_filter
+from backend.api.lists.playlists import _can_view, _read_playlist_items
+from backend.api.subsonic.auth import authenticate
+from backend.api.subsonic.responses import (
+    ERROR_GENERIC,
+    ERROR_MISSING_PARAMETER,
+    ERROR_NOT_AUTHORIZED,
+    ERROR_NOT_FOUND,
+    SubsonicError,
+    error_response,
+    subsonic_response,
+)
+from backend.api.subsonic.router import router
+from backend.models import Artist, Playlist, Track
+from backend.utilities.database import db_session
+
+_AUDIO_CONTENT_TYPES = {
+    "mp3": "audio/mpeg",
+    "m4a": "audio/mp4",
+    "aac": "audio/aac",
+    "flac": "audio/flac",
+    "wav": "audio/wav",
+    "ogg": "audio/ogg",
+    "opus": "audio/opus",
+    "aiff": "audio/aiff",
+}
+
+Handler = Callable[[Request], Awaitable[Response]]
+Params = Mapping[str, str]
+
+
+def _rest(path: str) -> Callable[[Handler], Handler]:
+    """register a handler at /rest/<path> and /rest/<path>.view for GET+POST."""
+
+    def wrap(handler: Handler) -> Handler:
+        for route_path in (f"/{path}.view", f"/{path}"):
+            router.api_route(route_path, methods=["GET", "POST"])(handler)
+        return handler
+
+    return wrap
+
+
+async def _request_params(request: Request) -> Params:
+    """merge query params with a POSTed form body (spec allows either)."""
+    merged: dict[str, str] = dict(request.query_params)
+    if request.method == "POST":
+        form = await request.form()
+        merged.update({k: v for k, v in form.items() if isinstance(v, str)})
+    return merged
+
+
+async def _run(
+    request: Request,
+    impl: Callable[[Session, Params], Awaitable[dict[str, Any] | Response]],
+) -> Response:
+    params = await _request_params(request)
+    try:
+        session = await authenticate(params)
+        result = await impl(session, params)
+    except SubsonicError as error:
+        return error_response(params, error)
+    if isinstance(result, Response):
+        return result
+    return subsonic_response(params, result)
+
+
+def _require(params: Params, name: str) -> str:
+    if value := params.get(name):
+        return value
+    raise SubsonicError(
+        ERROR_MISSING_PARAMETER, f"required parameter is missing: {name}"
+    )
+
+
+def _song(track: Track) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "id": str(track.id),
+        "isDir": False,
+        "type": "music",
+        "title": track.title,
+        "artist": track.artist.display_name or track.artist.handle,
+        "album": track.album,
+        "duration": track.duration,
+        "playCount": track.play_count,
+        "suffix": track.file_type,
+        "contentType": _AUDIO_CONTENT_TYPES.get(track.file_type),
+        "created": track.created_at.isoformat(),
+    }
+    if track.image_url or track.thumbnail_url:
+        entry["coverArt"] = str(track.id)
+    return entry
+
+
+def _playlist(playlist: Playlist, owner_handle: str) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "id": playlist.id,
+        "name": playlist.name,
+        "owner": owner_handle,
+        "public": not playlist.is_private,
+        "songCount": playlist.track_count,
+        "duration": 0,
+        "created": playlist.created_at.isoformat(),
+    }
+    if playlist.image_url or playlist.thumbnail_url:
+        entry["coverArt"] = f"pl-{playlist.id}"
+    return entry
+
+
+async def _tracks_by_uris(
+    db: AsyncSession, uris: list[str], session_did: str | None
+) -> list[Track]:
+    """load visible tracks by AT-URI, preserving list order."""
+    if not uris:
+        return []
+    result = await db.execute(
+        select(Track)
+        .options(selectinload(Track.artist))
+        .where(Track.atproto_record_uri.in_(uris))
+        .where(track_visible_filter(session_did))
+    )
+    by_uri = {t.atproto_record_uri: t for t in result.scalars().all()}
+    return [by_uri[uri] for uri in uris if uri in by_uri]
+
+
+async def _track_by_id(params: Params, session_did: str | None) -> Track:
+    raw_id = _require(params, "id")
+    try:
+        track_id = int(raw_id)
+    except ValueError:
+        raise SubsonicError(ERROR_NOT_FOUND, "song not found") from None
+    async with db_session() as db:
+        result = await db.execute(
+            select(Track)
+            .options(selectinload(Track.artist))
+            .where(Track.id == track_id)
+            .where(track_visible_filter(session_did))
+        )
+        if track := result.scalar_one_or_none():
+            return track
+    raise SubsonicError(ERROR_NOT_FOUND, "song not found")
+
+
+@_rest("ping")
+async def ping(request: Request) -> Response:
+    async def impl(_: Session, __: Params) -> dict[str, Any]:
+        return {}
+
+    return await _run(request, impl)
+
+
+@_rest("getLicense")
+async def get_license(request: Request) -> Response:
+    async def impl(_: Session, __: Params) -> dict[str, Any]:
+        return {"license": {"valid": True}}
+
+    return await _run(request, impl)
+
+
+@_rest("getMusicFolders")
+async def get_music_folders(request: Request) -> Response:
+    async def impl(_: Session, __: Params) -> dict[str, Any]:
+        return {"musicFolders": {"musicFolder": [{"id": "1", "name": "plyr.fm"}]}}
+
+    return await _run(request, impl)
+
+
+@_rest("getPlaylists")
+async def get_playlists(request: Request) -> Response:
+    async def impl(session: Session, _: Params) -> dict[str, Any]:
+        async with db_session() as db:
+            result = await db.execute(
+                select(Playlist, Artist)
+                .join(Artist, Playlist.owner_did == Artist.did)
+                .where(Playlist.owner_did == session.did)
+                .order_by(Playlist.created_at.desc())
+            )
+            rows = result.all()
+        return {
+            "playlists": {
+                "playlist": [
+                    _playlist(playlist, artist.handle) for playlist, artist in rows
+                ]
+            }
+        }
+
+    return await _run(request, impl)
+
+
+@_rest("getPlaylist")
+async def get_playlist(request: Request) -> Response:
+    async def impl(session: Session, params: Params) -> dict[str, Any]:
+        playlist_id = _require(params, "id")
+        async with db_session() as db:
+            result = await db.execute(
+                select(Playlist, Artist)
+                .join(Artist, Playlist.owner_did == Artist.did)
+                .where(Playlist.id == playlist_id)
+            )
+            row = result.first()
+            if not row or not _can_view(session.did, row[0]):
+                raise SubsonicError(ERROR_NOT_FOUND, "playlist not found")
+            playlist, artist = row
+            try:
+                item_refs = await _read_playlist_items(playlist, artist)
+            except Exception as exc:
+                raise SubsonicError(
+                    ERROR_GENERIC, f"failed to read playlist items: {exc}"
+                ) from exc
+            tracks = await _tracks_by_uris(
+                db, [ref["uri"] for ref in item_refs], session.did
+            )
+        songs = [_song(track) for track in tracks]
+        return {
+            "playlist": {
+                **_playlist(playlist, artist.handle),
+                "songCount": len(songs),
+                "duration": sum(track.duration or 0 for track in tracks),
+                "entry": songs,
+            }
+        }
+
+    return await _run(request, impl)
+
+
+@_rest("getSong")
+async def get_song(request: Request) -> Response:
+    async def impl(session: Session, params: Params) -> dict[str, Any]:
+        track = await _track_by_id(params, session.did)
+        return {"song": _song(track)}
+
+    return await _run(request, impl)
+
+
+@_rest("download")
+@_rest("stream")
+async def stream(request: Request) -> Response:
+    async def impl(session: Session, params: Params) -> Response:
+        track = await _track_by_id(params, session.did)
+        # gated and private tracks resolve their audio through cookie-bound
+        # session checks that a redirected subsonic client can't satisfy
+        if track.is_private or track.support_gate is not None:
+            raise SubsonicError(
+                ERROR_NOT_AUTHORIZED, "not authorized to stream this track"
+            )
+        # 302 (not the default 307): clients may POST, and a method-preserving
+        # redirect of a POST is refused by urllib-family HTTP stacks
+        return RedirectResponse(url=f"/audio/{track.file_id}", status_code=302)
+
+    return await _run(request, impl)
+
+
+@_rest("getCoverArt")
+async def get_cover_art(request: Request) -> Response:
+    async def impl(session: Session, params: Params) -> Response:
+        art_id = _require(params, "id")
+        if art_id.startswith("pl-"):
+            async with db_session() as db:
+                result = await db.execute(
+                    select(Playlist).where(Playlist.id == art_id.removeprefix("pl-"))
+                )
+                playlist = result.scalar_one_or_none()
+            if not playlist or not _can_view(session.did, playlist):
+                raise SubsonicError(ERROR_NOT_FOUND, "cover art not found")
+            url = playlist.image_url or playlist.thumbnail_url
+        else:
+            track = await _track_by_id(params, session.did)
+            url = track.image_url or track.thumbnail_url
+        if not url:
+            raise SubsonicError(ERROR_NOT_FOUND, "cover art not found")
+        return RedirectResponse(url=url, status_code=302)
+
+    return await _run(request, impl)

--- a/backend/src/backend/api/subsonic/responses.py
+++ b/backend/src/backend/api/subsonic/responses.py
@@ -1,0 +1,96 @@
+"""subsonic-response envelope serialization.
+
+subsonic clients negotiate the wire format via the `f` query param: xml is
+the protocol default, `f=json` wraps the same shape in `{"subsonic-response":
+{...}}`, and `f=jsonp` adds a `callback(...)` wrapper. protocol errors travel
+inside a `status="failed"` envelope with HTTP 200, not as HTTP error codes.
+"""
+
+import xml.etree.ElementTree as ET
+from collections.abc import Mapping
+from typing import Any
+
+import orjson
+from fastapi import Response
+
+SUBSONIC_API_VERSION = "1.16.1"
+_XMLNS = "http://subsonic.org/restapi"
+
+# subsonic protocol error codes
+ERROR_GENERIC = 0
+ERROR_MISSING_PARAMETER = 10
+ERROR_WRONG_CREDENTIALS = 40
+ERROR_NOT_AUTHORIZED = 50
+ERROR_NOT_FOUND = 70
+
+
+class SubsonicError(Exception):
+    """carries a subsonic protocol error code to the error envelope."""
+
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _prune(value: Any) -> Any:
+    """drop None values recursively so they never hit the wire."""
+    if isinstance(value, dict):
+        return {k: _prune(v) for k, v in value.items() if v is not None}
+    if isinstance(value, list):
+        return [_prune(item) for item in value]
+    return value
+
+
+def _element(name: str, data: dict[str, Any]) -> ET.Element:
+    """map a payload dict onto subsonic xml: scalars become attributes,
+    dicts become child elements, lists become repeated child elements."""
+    element = ET.Element(name)
+    for key, value in data.items():
+        if isinstance(value, dict):
+            element.append(_element(key, value))
+        elif isinstance(value, list):
+            for item in value:
+                element.append(_element(key, item))
+        elif isinstance(value, bool):
+            element.set(key, "true" if value else "false")
+        else:
+            element.set(key, str(value))
+    return element
+
+
+def subsonic_response(
+    params: Mapping[str, str], payload: dict[str, Any], *, status: str = "ok"
+) -> Response:
+    """wrap a payload in the subsonic-response envelope, honoring `f`."""
+    body = _prune(
+        {
+            "status": status,
+            "version": SUBSONIC_API_VERSION,
+            "type": "plyr.fm",
+            **payload,
+        }
+    )
+    response_format = params.get("f", "xml")
+    if response_format in ("json", "jsonp"):
+        document = orjson.dumps({"subsonic-response": body}).decode()
+        if response_format == "jsonp" and (callback := params.get("callback")):
+            return Response(
+                f"{callback}({document});", media_type="application/javascript"
+            )
+        return Response(document, media_type="application/json")
+    root = _element("subsonic-response", {"xmlns": _XMLNS, **body})
+    document = ET.tostring(root, encoding="unicode")
+    return Response(
+        f'<?xml version="1.0" encoding="UTF-8"?>\n{document}',
+        media_type="text/xml",
+    )
+
+
+def error_response(params: Mapping[str, str], error: SubsonicError) -> Response:
+    """render a SubsonicError as a failed envelope (HTTP 200, per protocol)."""
+    return subsonic_response(
+        params,
+        {"error": {"code": error.code, "message": error.message}},
+        status="failed",
+    )

--- a/backend/src/backend/api/subsonic/router.py
+++ b/backend/src/backend/api/subsonic/router.py
@@ -1,0 +1,5 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/rest", tags=["subsonic"])
+
+__all__ = ["router"]

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -45,6 +45,7 @@ from backend.api import (
 from backend.api.albums import router as albums_router
 from backend.api.lists import router as lists_router
 from backend.api.migration import router as migration_router
+from backend.api.subsonic import router as subsonic_router
 from backend.config import settings
 from backend.utilities.database import get_engine
 from backend.utilities.middleware import SecurityHeadersMiddleware
@@ -201,4 +202,5 @@ app.include_router(stats_router)
 app.include_router(users_router)
 app.include_router(meta_router)
 app.include_router(xrpc_router)
+app.include_router(subsonic_router)
 app.include_router(copyright_router)

--- a/backend/tests/api/test_subsonic.py
+++ b/backend/tests/api/test_subsonic.py
@@ -1,0 +1,251 @@
+"""subsonic compatibility tests.
+
+these run the real app on a live uvicorn server and drive it with py-sonic
+(`libsonic`), an unmodified off-the-shelf subsonic client library — the same
+protocol stack a real subsonic app (Symfonium, play:Sub, Sonixd, ...) uses.
+that exercises the wire format for real: `.view` paths, `f=json`, both auth
+schemes, and the full stream redirect chain out to the (stubbed) CDN origin.
+"""
+
+import asyncio
+import socket
+import threading
+from collections.abc import AsyncGenerator, Generator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import httpx
+import libsonic
+import pytest
+import uvicorn
+from libsonic.errors import CredentialError, SonicError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import create_session
+from backend.main import app
+from backend.models import Artist, Playlist, Track
+
+AUDIO_BYTES = b"ID3\x03\x00fake-mp3-payload-for-subsonic-stream-test"
+DID = "did:plc:subsonicuser"
+HANDLE = "subsonic.test"
+
+OAUTH_SESSION = {
+    "did": DID,
+    "handle": HANDLE,
+    "pds_url": "https://test.pds",
+    "authserver_iss": "https://auth.test",
+    "scope": "atproto transition:generic",
+    "access_token": "test_token",
+    "refresh_token": "test_refresh",
+    "dpop_private_key_pem": "fake_key",
+    "dpop_authserver_nonce": "",
+    "dpop_pds_nonce": "",
+}
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class _OriginHandler(BaseHTTPRequestHandler):
+    """stands in for the R2/CDN origin that /audio redirects point at."""
+
+    def do_GET(self) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "audio/mpeg")
+        self.send_header("Content-Length", str(len(AUDIO_BYTES)))
+        self.end_headers()
+        self.wfile.write(AUDIO_BYTES)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+@pytest.fixture
+def audio_origin() -> Generator[str, None, None]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _OriginHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_address[1]}"
+    server.shutdown()
+    thread.join()
+
+
+@pytest.fixture
+async def live_server() -> AsyncGenerator[str, None]:
+    """run the real app on a live port in the test's event loop."""
+    port = _free_port()
+    config = uvicorn.Config(
+        app, host="127.0.0.1", port=port, log_level="warning", lifespan="off"
+    )
+    server = uvicorn.Server(config)
+    task = asyncio.create_task(server.serve())
+    while not server.started:
+        await asyncio.sleep(0.01)
+    yield f"http://127.0.0.1:{port}"
+    server.should_exit = True
+    await task
+
+
+@pytest.fixture
+async def dev_token(db_session: AsyncSession) -> str:
+    return await create_session(
+        DID,
+        HANDLE,
+        dict(OAUTH_SESSION),
+        is_developer_token=True,
+        token_name="subsonic-test",
+    )
+
+
+@pytest.fixture
+async def library(db_session: AsyncSession, audio_origin: str) -> dict[str, object]:
+    """an artist with two tracks and a private playlist ordering them [2, 1]."""
+    artist = Artist(did=DID, handle=HANDLE, display_name="Subsonic Tester")
+    db_session.add(artist)
+    track_one = Track(
+        title="first upload",
+        file_id="subsonic_file_1",
+        file_type="mp3",
+        artist_did=DID,
+        atproto_record_uri=f"at://{DID}/fm.plyr.track/one",
+        r2_url=f"{audio_origin}/subsonic_file_1.mp3",
+        image_url=f"{audio_origin}/cover1.webp",
+        extra={"duration": 111},
+    )
+    track_two = Track(
+        title="second upload",
+        file_id="subsonic_file_2",
+        file_type="mp3",
+        artist_did=DID,
+        atproto_record_uri=f"at://{DID}/fm.plyr.track/two",
+        r2_url=f"{audio_origin}/subsonic_file_2.mp3",
+        extra={"duration": 222},
+    )
+    db_session.add_all([track_one, track_two])
+    playlist = Playlist(
+        owner_did=DID,
+        name="late night",
+        is_private=True,
+        items_json=[
+            {"uri": track_two.atproto_record_uri, "cid": ""},
+            {"uri": track_one.atproto_record_uri, "cid": ""},
+        ],
+        track_count=2,
+    )
+    db_session.add(playlist)
+    await db_session.commit()
+    await db_session.refresh(track_one)
+    await db_session.refresh(track_two)
+    return {"tracks": [track_one, track_two], "playlist": playlist}
+
+
+def _connection(base_url: str, token: str, **kwargs: object) -> libsonic.Connection:
+    host, _, port = base_url.rpartition(":")
+    return libsonic.Connection(
+        host,
+        username=HANDLE,
+        password=token,
+        port=int(port),
+        appName="plyr-test",
+        **kwargs,
+    )
+
+
+async def test_ping_with_subsonic_token_auth(live_server: str, dev_token: str) -> None:
+    """the default libsonic auth scheme: t=md5(password+salt), s=salt."""
+    conn = _connection(live_server, dev_token)
+    assert await asyncio.to_thread(conn.ping) is True
+
+
+async def test_ping_with_legacy_password_auth(live_server: str, dev_token: str) -> None:
+    """legacy auth: the token travels as p=enc:<hex>."""
+    conn = _connection(live_server, dev_token, legacyAuth=True)
+    assert await asyncio.to_thread(conn.ping) is True
+
+
+async def test_ping_rejects_bad_token(live_server: str, dev_token: str) -> None:
+    conn = _connection(live_server, "not-a-real-token")
+    with pytest.raises(CredentialError):
+        await asyncio.to_thread(conn.ping)
+
+
+async def test_get_playlists(
+    live_server: str, dev_token: str, library: dict[str, object]
+) -> None:
+    conn = _connection(live_server, dev_token)
+    result = await asyncio.to_thread(conn.getPlaylists)
+    playlists = result["playlists"]["playlist"]
+    assert [p["name"] for p in playlists] == ["late night"]
+    assert playlists[0]["songCount"] == 2
+
+
+async def test_get_playlist_entries_in_order(
+    live_server: str, dev_token: str, library: dict[str, object]
+) -> None:
+    conn = _connection(live_server, dev_token)
+    playlists = await asyncio.to_thread(conn.getPlaylists)
+    playlist_id = playlists["playlists"]["playlist"][0]["id"]
+    result = await asyncio.to_thread(conn.getPlaylist, playlist_id)
+    entries = result["playlist"]["entry"]
+    assert [e["title"] for e in entries] == ["second upload", "first upload"]
+    assert [e["duration"] for e in entries] == [222, 111]
+    assert result["playlist"]["duration"] == 333
+    assert all(e["artist"] == "Subsonic Tester" for e in entries)
+
+
+async def test_stream_returns_audio_bytes(
+    live_server: str, dev_token: str, library: dict[str, object]
+) -> None:
+    """stream follows the redirect chain /rest/stream → /audio/{file_id} → origin."""
+    conn = _connection(live_server, dev_token)
+    track = library["tracks"][0]  # type: ignore[index]
+    response = await asyncio.to_thread(conn.stream, str(track.id))
+    assert response.read() == AUDIO_BYTES
+
+
+async def test_get_cover_art_returns_bytes(
+    live_server: str, dev_token: str, library: dict[str, object]
+) -> None:
+    conn = _connection(live_server, dev_token)
+    track = library["tracks"][0]  # type: ignore[index]
+    response = await asyncio.to_thread(conn.getCoverArt, str(track.id))
+    assert (
+        response.read() == AUDIO_BYTES
+    )  # origin stub serves one payload for all paths
+
+
+async def test_stream_refuses_gated_track(
+    live_server: str, dev_token: str, db_session: AsyncSession, audio_origin: str
+) -> None:
+    artist = Artist(did=DID, handle=HANDLE, display_name="Subsonic Tester")
+    db_session.add(artist)
+    track = Track(
+        title="supporters only",
+        file_id="subsonic_gated",
+        file_type="mp3",
+        artist_did=DID,
+        r2_url=f"{audio_origin}/gated.mp3",
+        support_gate={"type": "any"},
+    )
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+
+    conn = _connection(live_server, dev_token)
+    with pytest.raises(SonicError):
+        await asyncio.to_thread(conn.stream, str(track.id))
+
+
+async def test_xml_is_the_default_format(live_server: str, dev_token: str) -> None:
+    """clients that don't send f=json get the xml envelope."""
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{live_server}/rest/ping.view", params={"u": HANDLE, "p": dev_token}
+        )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/xml")
+    assert response.text.startswith('<?xml version="1.0"')
+    assert 'status="ok"' in response.text
+    assert 'xmlns="http://subsonic.org/restapi"' in response.text

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -366,6 +366,7 @@ dev = [
     { name = "pdbpp" },
     { name = "plyrfm" },
     { name = "prek" },
+    { name = "py-sonic" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -416,6 +417,7 @@ dev = [
     { name = "pdbpp", specifier = ">=0.10.3" },
     { name = "plyrfm", git = "https://github.com/zzstoatzz/plyr-python-client?subdirectory=packages%2Fplyrfm" },
     { name = "prek", specifier = ">=0.2.13" },
+    { name = "py-sonic", specifier = ">=1.1.2" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
@@ -2389,6 +2391,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/7b/e4/1971dfc4620a3a15b
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/e4/b8b0a03ece72f47dce2307d36e1c34725b7223d209fc679315ffe6a4e2c3/py_key_value_shared-0.3.0-py3-none-any.whl", hash = "sha256:5b0efba7ebca08bb158b1e93afc2f07d30b8f40c2fc12ce24a4c0d84f42f9298", size = 19560, upload-time = "2025-11-17T16:50:05.954Z" },
 ]
+
+[[package]]
+name = "py-sonic"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/a1/c458ca52c6e18eb0fc139fb0b5641f06ddce1050f97da8935d7d2ebfbaa3/py_sonic-1.1.2.tar.gz", hash = "sha256:5b3ca04cf61caaa89f1762b6d437ccc386e300b5609464b730e8a3617c1bd1d9", size = 35939, upload-time = "2026-04-18T21:46:12.8Z" }
 
 [[package]]
 name = "pyasn1"


### PR DESCRIPTION
a minimal, isolated [Subsonic API](https://opensubsonic.netlify.app/) shim so any off-the-shelf subsonic client (Symfonium, play:Sub, Sonixd, Tempo, ...) can sign in with a plyr.fm developer token and play your playlists. prompted by @tynanpurdy asking whether plyr.fm exposes a subsonic-compatible API.

## what's in it

a new `backend/src/backend/api/subsonic/` package mounted at `/rest` — one `include_router` line in `main.py` is the only touch to existing code paths.

- **endpoints**: `ping`, `getLicense`, `getMusicFolders`, `getPlaylists`, `getPlaylist`, `getSong`, `stream`, `download`, `getCoverArt` — each at both `/<name>` and `/<name>.view`, GET and POST (the spec allows either; libsonic POSTs by default)
- **auth**: the subsonic "password" is a plyr.fm developer token (already an independent OAuth grant — the natural app-password analogue). both schemes work:
  - legacy: `p=<token>` or `p=enc:<hex>` → `get_session(token)` directly
  - token scheme: `t=md5(token+salt)`, `s=salt`, `u=<handle or DID>` — resolved by scanning the user's developer-token sessions and md5-matching, since the digest can't be reversed to a session id
- **wire format**: xml envelope by default, `f=json` / `f=jsonp` supported; protocol errors travel as `status="failed"` envelopes with HTTP 200, per spec
- **streaming**: `stream` 302-redirects into the existing `/audio/{file_id}` surface (which 307s to the CDN) — no bytes re-served, no second streaming path. 302 not 307 because urllib-family clients refuse method-preserving redirects of a POST
- **cover art**: 302 to the stored `image_url`/`thumbnail_url`
- **visibility**: track lookups go through the existing `track_visible_filter`; playlist access through `_can_view`. gated (`support_gate`) and private tracks refuse to stream with subsonic error 50 — their audio resolution depends on session checks a redirected subsonic client can't satisfy (deliberate non-behavior for this MVP, including for the owner)

## empirical testing

`tests/api/test_subsonic.py` runs the real app on a live uvicorn server and drives it with **py-sonic (`libsonic`), an unmodified third-party subsonic client library** (dev-dependency only) — the same protocol stack real clients use. plus a tiny stub HTTP origin standing in for the R2 CDN. covered end-to-end:

- ping with both auth schemes; bad token → `CredentialError` (subsonic code 40)
- `getPlaylists` / `getPlaylist` with correct entry ordering, durations, artist names
- `stream` pulls actual audio bytes through the full redirect chain (`/rest/stream` → `/audio/{file_id}` → origin)
- `getCoverArt` bytes; gated track refused; xml is the default format for non-libsonic clients

these found two real protocol bugs while writing them (GET-only routes broke POSTing clients; 307 broke urllib redirect-following) — exactly what the off-the-shelf-client approach was for.

## deliberately out of scope (follow-ups if this direction sticks)

- `scrobble` → `POST /tracks/{id}/play` (play counts + teal), `search3`, `getArtists`/`getAlbum*` browsing (needed by some clients' library views), `getRandomSongs`
- transcoding params (`maxBitRate`, `format`) are accepted and ignored
- playlist `duration` in `getPlaylists` is 0 (computing it needs per-playlist hydration); `getPlaylist` reports the real sum
- OpenSubsonic extensions

## also in this diff

- `scripts/init_db.py` import sorting had `just backend lint` red on main: the local `alembic/` migrations dir makes ruff 0.14 (locked) and ruff 0.12.1 (pre-commit hook) disagree on whether `alembic` is first- or third-party, so no ordering satisfies both. scoped a `per-file-ignores` I001 to that one file (reclassifying `alembic` via `known-third-party` would churn all 60+ migration files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)