### PR TITLE
fix(api): answer 200 at the API root for client reachability probes

### DIFF
--- a/backend/src/backend/api/meta.py
+++ b/backend/src/backend/api/meta.py
@@ -15,6 +15,14 @@ from backend.models import Album, Artist, Track, get_db
 router = APIRouter(tags=["meta"])
 
 
+@router.get("/")
+async def root() -> dict[str, str]:
+    """API root. some clients (e.g. subsonic apps like Amperfy) probe the bare
+    server URL for reachability before touching real endpoints — a 404 here
+    reads as "server doesn't exist" to them."""
+    return {"service": "plyr.fm api", "docs": "https://docs.plyr.fm"}
+
+
 @router.get("/health")
 async def health() -> dict[str, str]:
     """health check endpoint."""

--- a/backend/tests/api/test_root.py
+++ b/backend/tests/api/test_root.py
@@ -1,0 +1,15 @@
+"""the bare server URL must answer 200: subsonic clients (Amperfy) probe it
+for reachability before attempting /rest endpoints."""
+
+from httpx import ASGITransport, AsyncClient
+
+from backend.main import app
+
+
+async def test_root_returns_200() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/")
+    assert response.status_code == 200
+    assert response.json()["service"] == "plyr.fm api"


### PR DESCRIPTION
subsonic clients — Amperfy first among them — probe the bare server URL for reachability before attempting any \`/rest\` endpoint. the backend had no \`/\` route, so the probe got a 404 and Amperfy reported "404" at sign-in without ever calling \`/rest/ping\` (confirmed in staging telemetry: three \`GET /\` → 404, zero \`/rest/*\` attempts).

adds a tiny \`GET /\` on the meta router returning \`{"service": "plyr.fm api", "docs": "https://docs.plyr.fm"}\`, plus a regression test. no other behavior changes.

follow-up to #1644.

🤖 Generated with [Claude Code](https://claude.com/claude-code)