### PR TITLE
feat(subsonic): album/artist browsing, scrobble, and a catch-all error envelope

### DIFF
--- a/backend/src/backend/api/subsonic/__init__.py
+++ b/backend/src/backend/api/subsonic/__init__.py
@@ -1,6 +1,10 @@
 """subsonic-compatible API surface (/rest/*)."""
 
 from backend.api.subsonic import endpoints as endpoints
+from backend.api.subsonic import browsing as browsing
+from backend.api.subsonic import (
+    fallback as fallback,
+)  # must import last: catch-all route
 from backend.api.subsonic.router import router
 
 __all__ = ["router"]

--- a/backend/src/backend/api/subsonic/browsing.py
+++ b/backend/src/backend/api/subsonic/browsing.py
@@ -1,0 +1,221 @@
+"""subsonic library-browsing endpoints: albums, artists, genres, capability stubs.
+
+clients build their library views from these. albums and artists map onto the
+existing models; albums with no visible tracks are hidden (matching the main
+albums API, where empty albums are unfinalized drafts).
+"""
+
+from typing import Any
+
+from fastapi import Request, Response
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from backend._internal import Session
+from backend._internal.track_visibility import track_visible_filter
+from backend.api.subsonic.endpoints import Params, _require, _rest, _run, _song
+from backend.api.subsonic.responses import ERROR_NOT_FOUND, SubsonicError
+from backend.models import Album, Artist, Track
+from backend.utilities.database import db_session
+
+_MAX_LIST_SIZE = 500
+
+
+def _int_param(params: Params, name: str, default: int) -> int:
+    try:
+        return max(0, int(params.get(name, default)))
+    except ValueError:
+        return default
+
+
+def _album_entry(
+    album: Album, artist: Artist, song_count: int, duration: int
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "id": album.id,
+        "name": album.title,
+        "title": album.title,
+        "album": album.title,
+        "isDir": True,
+        "artist": artist.display_name or artist.handle,
+        "artistId": artist.did,
+        "songCount": song_count,
+        "duration": duration,
+        "created": album.created_at.isoformat(),
+    }
+    if album.image_url or album.thumbnail_url:
+        entry["coverArt"] = f"al-{album.id}"
+    return entry
+
+
+async def _album_rows(
+    db: AsyncSession,
+    session_did: str | None,
+    order_by: Any,
+    size: int,
+    offset: int,
+) -> list[tuple[Album, Artist, int]]:
+    """albums (with owning artist + visible-track count), hiding empty albums."""
+    result = await db.execute(
+        select(Album, Artist, func.count(Track.id))
+        .join(Artist, Album.artist_did == Artist.did)
+        .join(Track, Track.album_id == Album.id)
+        .where(track_visible_filter(session_did))
+        .group_by(Album.id, Artist.did)
+        .order_by(order_by)
+        .limit(size)
+        .offset(offset)
+    )
+    return [(album, artist, count) for album, artist, count in result.all()]
+
+
+async def _album_list_payload(session: Session, params: Params) -> list[dict[str, Any]]:
+    list_type = params.get("type", "alphabeticalByName")
+    size = min(_int_param(params, "size", 10), _MAX_LIST_SIZE)
+    offset = _int_param(params, "offset", 0)
+    if list_type in ("newest", "recent"):
+        order_by = Album.created_at.desc()
+    elif list_type == "random":
+        order_by = func.random()
+    else:
+        order_by = func.lower(Album.title)
+    async with db_session() as db:
+        rows = await _album_rows(db, session.did, order_by, size, offset)
+    return [_album_entry(album, artist, count, 0) for album, artist, count in rows]
+
+
+@_rest("getAlbumList")
+async def get_album_list(request: Request) -> Response:
+    async def impl(session: Session, params: Params) -> dict[str, Any]:
+        return {"albumList": {"album": await _album_list_payload(session, params)}}
+
+    return await _run(request, impl)
+
+
+@_rest("getAlbumList2")
+async def get_album_list2(request: Request) -> Response:
+    async def impl(session: Session, params: Params) -> dict[str, Any]:
+        return {"albumList2": {"album": await _album_list_payload(session, params)}}
+
+    return await _run(request, impl)
+
+
+@_rest("getAlbum")
+async def get_album(request: Request) -> Response:
+    async def impl(session: Session, params: Params) -> dict[str, Any]:
+        album_id = _require(params, "id")
+        async with db_session() as db:
+            result = await db.execute(
+                select(Album, Artist)
+                .join(Artist, Album.artist_did == Artist.did)
+                .where(Album.id == album_id)
+            )
+            row = result.first()
+            if not row:
+                raise SubsonicError(ERROR_NOT_FOUND, "album not found")
+            album, artist = row
+            track_result = await db.execute(
+                select(Track)
+                .options(selectinload(Track.artist))
+                .where(Track.album_id == album.id)
+                .where(track_visible_filter(session.did))
+                .order_by(Track.created_at)
+            )
+            tracks = list(track_result.scalars().all())
+        songs = [_song(track) for track in tracks]
+        return {
+            "album": {
+                **_album_entry(
+                    album,
+                    artist,
+                    len(songs),
+                    sum(track.duration or 0 for track in tracks),
+                ),
+                "song": songs,
+            }
+        }
+
+    return await _run(request, impl)
+
+
+@_rest("getArtists")
+async def get_artists(request: Request) -> Response:
+    async def impl(session: Session, _: Params) -> dict[str, Any]:
+        async with db_session() as db:
+            result = await db.execute(
+                select(
+                    Artist, func.count(func.distinct(Track.album_id)).label("albums")
+                )
+                .join(Track, Track.artist_did == Artist.did)
+                .where(track_visible_filter(session.did))
+                .group_by(Artist.did)
+                .order_by(func.lower(Artist.display_name))
+            )
+            rows = result.all()
+        indexes: dict[str, list[dict[str, Any]]] = {}
+        for artist, album_count in rows:
+            name = artist.display_name or artist.handle
+            letter = name[0].upper() if name and name[0].isalpha() else "#"
+            indexes.setdefault(letter, []).append(
+                {"id": artist.did, "name": name, "albumCount": album_count}
+            )
+        return {
+            "artists": {
+                "ignoredArticles": "",
+                "index": [
+                    {"name": letter, "artist": artists}
+                    for letter, artists in indexes.items()
+                ],
+            }
+        }
+
+    return await _run(request, impl)
+
+
+@_rest("getArtist")
+async def get_artist(request: Request) -> Response:
+    async def impl(session: Session, params: Params) -> dict[str, Any]:
+        artist_did = _require(params, "id")
+        async with db_session() as db:
+            artist = await db.scalar(select(Artist).where(Artist.did == artist_did))
+            if not artist:
+                raise SubsonicError(ERROR_NOT_FOUND, "artist not found")
+            rows = await _album_rows(
+                db,
+                session.did,
+                func.lower(Album.title),
+                _MAX_LIST_SIZE,
+                0,
+            )
+        albums = [
+            _album_entry(album, album_artist, count, 0)
+            for album, album_artist, count in rows
+            if album.artist_did == artist_did
+        ]
+        return {
+            "artist": {
+                "id": artist.did,
+                "name": artist.display_name or artist.handle,
+                "albumCount": len(albums),
+                "album": albums,
+            }
+        }
+
+    return await _run(request, impl)
+
+
+@_rest("getGenres")
+async def get_genres(request: Request) -> Response:
+    async def impl(_: Session, __: Params) -> dict[str, Any]:
+        return {"genres": {"genre": []}}
+
+    return await _run(request, impl)
+
+
+@_rest("getOpenSubsonicExtensions")
+async def get_open_subsonic_extensions(request: Request) -> Response:
+    async def impl(_: Session, __: Params) -> dict[str, Any]:
+        return {"openSubsonicExtensions": []}
+
+    return await _run(request, impl)

--- a/backend/src/backend/api/subsonic/endpoints.py
+++ b/backend/src/backend/api/subsonic/endpoints.py
@@ -9,6 +9,7 @@ surfaces rather than re-serving bytes.
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
+from atproto_oauth.scopes import ScopesSet
 from fastapi import Request, Response
 from fastapi.responses import RedirectResponse
 from sqlalchemy import select
@@ -16,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from backend._internal import Session
+from backend._internal.tasks import schedule_teal_scrobble
 from backend._internal.track_visibility import track_visible_filter
 from backend.api.lists.playlists import _can_view, _read_playlist_items
 from backend.api.subsonic.auth import authenticate
@@ -29,7 +31,14 @@ from backend.api.subsonic.responses import (
     subsonic_response,
 )
 from backend.api.subsonic.router import router
-from backend.models import Artist, Playlist, Track
+from backend.api.tracks.playback import (
+    _PLAY_DEDUP_DEFAULT_TTL_S,
+    _PLAY_DEDUP_MAX_TTL_S,
+    _PLAY_DEDUP_MIN_TTL_S,
+    _claim_play,
+)
+from backend.config import settings
+from backend.models import Album, Artist, Playlist, Track, UserPreferences
 from backend.utilities.database import db_session
 
 _AUDIO_CONTENT_TYPES = {
@@ -267,6 +276,55 @@ async def stream(request: Request) -> Response:
     return await _run(request, impl)
 
 
+@_rest("scrobble")
+async def scrobble(request: Request) -> Response:
+    async def impl(session: Session, params: Params) -> dict[str, Any]:
+        raw_id = _require(params, "id")
+        # submission=false is a "now playing" notification — acknowledged, not counted
+        if params.get("submission", "true").lower() == "false":
+            return {}
+        try:
+            track_id = int(raw_id)
+        except ValueError:
+            raise SubsonicError(ERROR_NOT_FOUND, "song not found") from None
+        async with db_session() as db:
+            result = await db.execute(
+                select(Track)
+                .options(selectinload(Track.artist), selectinload(Track.album_rel))
+                .where(Track.id == track_id)
+                .where(track_visible_filter(session.did))
+            )
+            if not (track := result.scalar_one_or_none()):
+                raise SubsonicError(ERROR_NOT_FOUND, "song not found")
+            ttl = max(
+                _PLAY_DEDUP_MIN_TTL_S,
+                min(track.duration or _PLAY_DEDUP_DEFAULT_TTL_S, _PLAY_DEDUP_MAX_TTL_S),
+            )
+            if not await _claim_play(f"did:{session.did}", track.id, ttl):
+                return {}
+            track.play_count += 1
+            await db.commit()
+            prefs = await db.scalar(
+                select(UserPreferences).where(UserPreferences.did == session.did)
+            )
+        if prefs and prefs.enable_teal_scrobbling:
+            scopes = ScopesSet.from_string(session.oauth_session.get("scope", ""))
+            if scopes.matches(
+                "repo", collection=settings.teal.play_collection, action="create"
+            ):
+                await schedule_teal_scrobble(
+                    session_id=session.session_id,
+                    track_id=track.id,
+                    track_title=track.title,
+                    artist_name=track.artist.display_name or track.artist.handle,
+                    duration=track.duration,
+                    album_name=track.album_rel.title if track.album_rel else None,
+                )
+        return {}
+
+    return await _run(request, impl)
+
+
 @_rest("getCoverArt")
 async def get_cover_art(request: Request) -> Response:
     async def impl(session: Session, params: Params) -> Response:
@@ -280,6 +338,14 @@ async def get_cover_art(request: Request) -> Response:
             if not playlist or not _can_view(session.did, playlist):
                 raise SubsonicError(ERROR_NOT_FOUND, "cover art not found")
             url = playlist.image_url or playlist.thumbnail_url
+        elif art_id.startswith("al-"):
+            async with db_session() as db:
+                album = await db.scalar(
+                    select(Album).where(Album.id == art_id.removeprefix("al-"))
+                )
+            if not album:
+                raise SubsonicError(ERROR_NOT_FOUND, "cover art not found")
+            url = album.image_url or album.thumbnail_url
         else:
             track = await _track_by_id(params, session.did)
             url = track.image_url or track.thumbnail_url

--- a/backend/src/backend/api/subsonic/fallback.py
+++ b/backend/src/backend/api/subsonic/fallback.py
@@ -1,0 +1,22 @@
+"""catch-all for unimplemented subsonic methods.
+
+per protocol, unknown methods should come back as a failed envelope with
+HTTP 200 — a raw 404 reads as "server broken" to clients and surfaces scary
+error banners for optional features. registered last so every real endpoint
+wins route matching.
+"""
+
+from fastapi import Request, Response
+
+from backend.api.subsonic.endpoints import _request_params
+from backend.api.subsonic.responses import ERROR_GENERIC, SubsonicError, error_response
+from backend.api.subsonic.router import router
+
+
+@router.api_route("/{method}", methods=["GET", "POST"])
+async def unimplemented(method: str, request: Request) -> Response:
+    params = await _request_params(request)
+    name = method.removesuffix(".view")
+    return error_response(
+        params, SubsonicError(ERROR_GENERIC, f"{name} is not implemented")
+    )

--- a/backend/tests/api/test_subsonic.py
+++ b/backend/tests/api/test_subsonic.py
@@ -249,3 +249,62 @@ async def test_xml_is_the_default_format(live_server: str, dev_token: str) -> No
     assert response.text.startswith('<?xml version="1.0"')
     assert 'status="ok"' in response.text
     assert 'xmlns="http://subsonic.org/restapi"' in response.text
+
+
+async def test_get_album_list2_and_get_album(
+    live_server: str,
+    dev_token: str,
+    library: dict[str, object],
+    db_session: AsyncSession,
+) -> None:
+    """album browsing: the home-screen sync amperfy does on every launch."""
+    from backend.models import Album
+
+    album = Album(artist_did=DID, slug="demo", title="demo album")
+    db_session.add(album)
+    await db_session.flush()
+    track = library["tracks"][0]  # type: ignore[index]
+    track.album_id = album.id
+    await db_session.commit()
+
+    conn = _connection(live_server, dev_token)
+    result = await asyncio.to_thread(lambda: conn.getAlbumList2(ltype="newest"))
+    albums = result["albumList2"]["album"]
+    assert [a["name"] for a in albums] == ["demo album"]
+    assert albums[0]["songCount"] == 1
+
+    detail = await asyncio.to_thread(conn.getAlbum, albums[0]["id"])
+    songs = detail["album"]["song"]
+    assert [s["title"] for s in songs] == ["first upload"]
+
+
+async def test_scrobble_increments_play_count(
+    live_server: str,
+    dev_token: str,
+    library: dict[str, object],
+    db_session: AsyncSession,
+) -> None:
+    track = library["tracks"][0]  # type: ignore[index]
+    assert track.play_count == 0
+    conn = _connection(live_server, dev_token)
+    await asyncio.to_thread(lambda: conn.scrobble(sid=str(track.id), submission=True))
+    await db_session.refresh(track)
+    assert track.play_count == 1
+    # now-playing notifications (submission=false) are acknowledged, not counted
+    await asyncio.to_thread(lambda: conn.scrobble(sid=str(track.id), submission=False))
+    await db_session.refresh(track)
+    assert track.play_count == 1
+
+
+async def test_unknown_method_returns_error_envelope_not_404(
+    live_server: str, dev_token: str
+) -> None:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{live_server}/rest/getStarred2.view",
+            params={"u": HANDLE, "p": dev_token, "f": "json"},
+        )
+    assert response.status_code == 200
+    body = response.json()["subsonic-response"]
+    assert body["status"] == "failed"
+    assert "not implemented" in body["error"]["message"]


### PR DESCRIPTION
follow-up to #1644, driven by watching a real client (Amperfy on iOS) against staging. Amperfy connected and played from a playlist fine, but its home screen threw a red "Newest Albums Sync — 404" banner and its now-playing/scrobble pings were dropped. staging telemetry showed exactly which endpoints it wanted: `getAlbumList2`, `getGenres`, `getOpenSubsonicExtensions`, and `scrobble` — all raw HTTP 404s, because those routes didn't exist.

## what's in it

- **album browsing** (`browsing.py`): `getAlbumList`/`getAlbumList2` (`newest`/`recent` → `created_at desc`, `random`, everything else alphabetical; `size` capped at 500), `getAlbum` (songs ordered by `created_at`, matching the main albums API fallback), `getArtists` (letter-indexed) + `getArtist`. albums with zero visible tracks are hidden, matching the main albums API's unfinalized-drafts rule; track visibility goes through `track_visible_filter` throughout.
- **`scrobble`**: `submission=true` increments `play_count` through the same redis dedup (`_claim_play`, same TTL clamp) as `POST /tracks/{id}/play`, and dispatches a teal scrobble when the user's prefs + scopes allow — one counting mechanism, not a second one. `submission=false` (now-playing notification) is acknowledged and deliberately not counted.
- **capability stubs**: `getGenres` (empty), `getOpenSubsonicExtensions` (empty) — clients probe these at login.
- **catch-all** (`fallback.py`, registered last): any unimplemented `/rest/{method}` now returns a proper subsonic failed envelope with HTTP 200 instead of a raw 404, so optional client features degrade politely instead of surfacing error banners.
- `getCoverArt` learns `al-<id>` album art ids.

## testing

extends the live-server + unmodified `libsonic` client harness from #1644: album list/detail round-trip, scrobble increments `play_count` exactly once (dedup + `submission=false` non-counting asserted against the DB), unknown method (`getStarred2`) returns a failed envelope not 404.

## deliberately out of scope

- `search3`, starred/favorites, `getRandomSongs`, real genre data (tags exist and could back `getGenres` later)
- playlist/album `duration` aggregates remain 0 in list views (real sums in detail views)
- transcoding params still accepted-and-ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)