### PR TITLE
fix(subsonic): keep the experimental /rest surface out of the OpenAPI schema

### DIFF
--- a/backend/src/backend/api/subsonic/endpoints.py
+++ b/backend/src/backend/api/subsonic/endpoints.py
@@ -61,7 +61,10 @@ def _rest(path: str) -> Callable[[Handler], Handler]:
 
     def wrap(handler: Handler) -> Handler:
         for route_path in (f"/{path}.view", f"/{path}"):
-            router.api_route(route_path, methods=["GET", "POST"])(handler)
+            # experimental surface: kept out of the published OpenAPI schema
+            router.api_route(
+                route_path, methods=["GET", "POST"], include_in_schema=False
+            )(handler)
         return handler
 
     return wrap

--- a/backend/src/backend/api/subsonic/fallback.py
+++ b/backend/src/backend/api/subsonic/fallback.py
@@ -13,7 +13,7 @@ from backend.api.subsonic.responses import ERROR_GENERIC, SubsonicError, error_r
 from backend.api.subsonic.router import router
 
 
-@router.api_route("/{method}", methods=["GET", "POST"])
+@router.api_route("/{method}", methods=["GET", "POST"], include_in_schema=False)
 async def unimplemented(method: str, request: Request) -> Response:
     params = await _request_params(request)
     name = method.removesuffix(".view")

--- a/backend/tests/api/test_subsonic.py
+++ b/backend/tests/api/test_subsonic.py
@@ -308,3 +308,9 @@ async def test_unknown_method_returns_error_envelope_not_404(
     body = response.json()["subsonic-response"]
     assert body["status"] == "failed"
     assert "not implemented" in body["error"]["message"]
+
+
+async def test_subsonic_routes_stay_out_of_openapi_schema() -> None:
+    """the /rest surface is experimental — it must not appear in the API reference."""
+    paths = app.openapi()["paths"]
+    assert not [p for p in paths if p.startswith("/rest")]


### PR DESCRIPTION
the subsonic shim (#1644/#1646) is experimental — it shouldn't advertise itself in the published API reference yet. sets `include_in_schema=False` at both route-registration points (the `_rest` helper and the catch-all), with a regression test asserting no `/rest` path ever appears in `app.openapi()`.

no behavior change for subsonic clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)