### PR TITLE
fix(subsonic): include albumId/artistId/parent linkage on song entries

### DIFF
--- a/backend/src/backend/api/subsonic/endpoints.py
+++ b/backend/src/backend/api/subsonic/endpoints.py
@@ -103,8 +103,14 @@ def _require(params: Params, name: str) -> str:
 
 
 def _song(track: Track) -> dict[str, Any]:
+    # offline-first clients (Amperfy) store songs locally and resolve album
+    # views by albumId — songs without the linkage fields sync but never
+    # appear under their album
     entry: dict[str, Any] = {
         "id": str(track.id),
+        "parent": track.album_id,
+        "albumId": track.album_id,
+        "artistId": track.artist_did,
         "isDir": False,
         "type": "music",
         "title": track.title,

--- a/backend/tests/api/test_subsonic.py
+++ b/backend/tests/api/test_subsonic.py
@@ -276,6 +276,10 @@ async def test_get_album_list2_and_get_album(
     detail = await asyncio.to_thread(conn.getAlbum, albums[0]["id"])
     songs = detail["album"]["song"]
     assert [s["title"] for s in songs] == ["first upload"]
+    # offline-first clients resolve album views by these linkage fields
+    assert songs[0]["albumId"] == albums[0]["id"]
+    assert songs[0]["parent"] == albums[0]["id"]
+    assert songs[0]["artistId"] == DID
 
 
 async def test_scrobble_increments_play_count(


### PR DESCRIPTION
real-client failure mode from Amperfy on prod: opening an album showed the header ("1 Song · 3m") but an **empty song list**. the server response was verified correct — Amperfy is offline-first, stores synced songs in its local DB, and resolves album detail views by the song's `albumId`. our `_song` entries omitted the standard linkage fields (`albumId`, `artistId`, `parent`), so songs synced but never attached to their album.

adds the three linkage fields to every song entry (album fields omitted automatically for albumless tracks via the existing None-pruning). extends the libsonic round-trip test to assert them.

follow-up to #1644/#1646.

🤖 Generated with [Claude Code](https://claude.com/claude-code)