### PR TITLE
fix(subsonic): OpenSubsonic envelope fields (serverVersion, openSubsonic)

### DIFF
--- a/backend/src/backend/api/subsonic/responses.py
+++ b/backend/src/backend/api/subsonic/responses.py
@@ -8,6 +8,7 @@ inside a `status="failed"` envelope with HTTP 200, not as HTTP error codes.
 
 import xml.etree.ElementTree as ET
 from collections.abc import Mapping
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
 import orjson
@@ -15,6 +16,11 @@ from fastapi import Response
 
 SUBSONIC_API_VERSION = "1.16.1"
 _XMLNS = "http://subsonic.org/restapi"
+
+try:
+    _SERVER_VERSION = version("backend")
+except PackageNotFoundError:
+    _SERVER_VERSION = "0"
 
 # subsonic protocol error codes
 ERROR_GENERIC = 0
@@ -63,11 +69,15 @@ def subsonic_response(
     params: Mapping[str, str], payload: dict[str, Any], *, status: str = "ok"
 ) -> Response:
     """wrap a payload in the subsonic-response envelope, honoring `f`."""
+    # serverVersion + openSubsonic: OpenSubsonic-era clients (Shelv, Feishin)
+    # decode these as required envelope fields and fail without them
     body = _prune(
         {
             "status": status,
             "version": SUBSONIC_API_VERSION,
             "type": "plyr.fm",
+            "serverVersion": _SERVER_VERSION,
+            "openSubsonic": True,
             **payload,
         }
     )

--- a/backend/tests/api/test_subsonic.py
+++ b/backend/tests/api/test_subsonic.py
@@ -318,3 +318,17 @@ async def test_subsonic_routes_stay_out_of_openapi_schema() -> None:
     """the /rest surface is experimental — it must not appear in the API reference."""
     paths = app.openapi()["paths"]
     assert not [p for p in paths if p.startswith("/rest")]
+
+
+async def test_envelope_carries_opensubsonic_fields(
+    live_server: str, dev_token: str
+) -> None:
+    """opensubsonic-era clients decode serverVersion/openSubsonic as required."""
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{live_server}/rest/ping",
+            params={"u": HANDLE, "p": dev_token, "f": "json"},
+        )
+    body = response.json()["subsonic-response"]
+    assert body["openSubsonic"] is True
+    assert isinstance(body["serverVersion"], str) and body["serverVersion"]


### PR DESCRIPTION
second real-client failure mode, this time from Shelv (iOS): "The data couldn't be read because it is missing" at connect. prod telemetry showed Shelv's `ping` succeeding (200, token auth fine) then retrying forever — the failure is client-side JSON decoding. Shelv is an OpenSubsonic-era client whose `Codable` envelope model requires `serverVersion` (and reads `openSubsonic`); modern servers (Navidrome etc.) include both in every response and we sent neither.

adds `serverVersion` (the backend package version) and `openSubsonic: true` to the envelope. claiming `openSubsonic` is honest: we already serve `getOpenSubsonicExtensions` with an (empty) extensions list, which is exactly the negotiation surface the flag points clients at.

regression test asserts both fields on the json envelope.

follow-up to #1644/#1646/#1648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)