### PR TITLE
feat(subsonic): navidrome-native /auth/login compat for navidrome-first clients

### DIFF
--- a/backend/src/backend/api/subsonic/__init__.py
+++ b/backend/src/backend/api/subsonic/__init__.py
@@ -1,10 +1,11 @@
-"""subsonic-compatible API surface (/rest/*)."""
+"""subsonic-compatible API surface (/rest/* plus navidrome-native compat)."""
 
 from backend.api.subsonic import endpoints as endpoints
 from backend.api.subsonic import browsing as browsing
 from backend.api.subsonic import (
     fallback as fallback,
 )  # must import last: catch-all route
+from backend.api.subsonic.compat import router as compat_router
 from backend.api.subsonic.router import router
 
-__all__ = ["router"]
+__all__ = ["compat_router", "router"]

--- a/backend/src/backend/api/subsonic/compat.py
+++ b/backend/src/backend/api/subsonic/compat.py
@@ -1,0 +1,41 @@
+"""navidrome-native compatibility (outside /rest).
+
+navidrome-first clients (Shelv) save a server by calling navidrome's native
+`POST /auth/login` and decoding the returned user `id` — subsonic ping alone
+isn't enough for them. this validates the developer token and answers with
+the account DID as the stable user id. no session or cookie is issued; every
+subsequent request re-authenticates through the subsonic params like any
+other subsonic client.
+"""
+
+from fastapi import APIRouter
+from fastapi.responses import ORJSONResponse
+from pydantic import BaseModel
+
+from backend.api.subsonic.auth import authenticate
+from backend.api.subsonic.responses import SubsonicError
+
+router = APIRouter(tags=["subsonic"])
+
+
+class NavidromeLoginRequest(BaseModel):
+    """navidrome native login body."""
+
+    username: str
+    password: str
+
+
+@router.post("/auth/login", include_in_schema=False)
+async def navidrome_login(body: NavidromeLoginRequest) -> ORJSONResponse:
+    try:
+        session = await authenticate({"u": body.username, "p": body.password})
+    except SubsonicError:
+        return ORJSONResponse({"error": "invalid credentials"}, status_code=401)
+    return ORJSONResponse(
+        {
+            "id": session.did,
+            "username": session.handle,
+            "name": session.handle,
+            "isAdmin": False,
+        }
+    )

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -45,6 +45,7 @@ from backend.api import (
 from backend.api.albums import router as albums_router
 from backend.api.lists import router as lists_router
 from backend.api.migration import router as migration_router
+from backend.api.subsonic import compat_router as subsonic_compat_router
 from backend.api.subsonic import router as subsonic_router
 from backend.config import settings
 from backend.utilities.database import get_engine
@@ -203,4 +204,5 @@ app.include_router(users_router)
 app.include_router(meta_router)
 app.include_router(xrpc_router)
 app.include_router(subsonic_router)
+app.include_router(subsonic_compat_router)
 app.include_router(copyright_router)

--- a/backend/tests/api/test_subsonic.py
+++ b/backend/tests/api/test_subsonic.py
@@ -332,3 +332,19 @@ async def test_envelope_carries_opensubsonic_fields(
     body = response.json()["subsonic-response"]
     assert body["openSubsonic"] is True
     assert isinstance(body["serverVersion"], str) and body["serverVersion"]
+
+
+async def test_navidrome_native_login(live_server: str, dev_token: str) -> None:
+    """shelv (navidrome-first) saves a server via POST /auth/login and needs `id`."""
+    async with httpx.AsyncClient() as client:
+        ok = await client.post(
+            f"{live_server}/auth/login",
+            json={"username": HANDLE, "password": dev_token},
+        )
+        bad = await client.post(
+            f"{live_server}/auth/login",
+            json={"username": HANDLE, "password": "not-a-token"},
+        )
+    assert ok.status_code == 200
+    assert ok.json()["id"] == DID
+    assert bad.status_code == 401


### PR DESCRIPTION
third real-client failure mode, reproduced first-hand with Shelv (iOS): "Test Connection"/save kept failing with an iOS decode error even after #1649 fixed the OpenSubsonic envelope. reading Shelv's source settled it: its **Test Connection** uses subsonic `ping` (fine — its exact `Codable` structs decode our live envelope, verified with a swift script), but **Save** calls navidrome's *native* `POST /auth/login` and requires the returned user `id`. we had no such route, FastAPI's 404 JSON has no `id`, so saving a server was impossible. the request never touches `/rest`, which is why the subsonic telemetry looked clean.

adds a minimal navidrome-compat `POST /auth/login` in the subsonic package (own router, since it lives outside the `/rest` prefix): validates the developer token through the existing subsonic `authenticate` helper and returns `{id: <did>, username, name, isAdmin: false}`. 401 on bad credentials. **no session or cookie is issued** — this is a credential check + identity echo only; every subsequent request re-authenticates via subsonic params like any other client. Shelv only uses the `id` as a stable local identifier for the saved server (its sole navidrome-native call — verified across its codebase).

`include_in_schema=False`, consistent with the rest of the experimental surface. regression test covers the ok + 401 paths against the live-server harness.

follow-up to #1644/#1646/#1648/#1649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)