### PR TITLE
feat(subsonic): getRandomSongs + real play-count ordering for type=frequent

### DIFF
--- a/backend/src/backend/api/subsonic/browsing.py
+++ b/backend/src/backend/api/subsonic/browsing.py
@@ -78,6 +78,8 @@ async def _album_list_payload(session: Session, params: Params) -> list[dict[str
         order_by = Album.created_at.desc()
     elif list_type == "random":
         order_by = func.random()
+    elif list_type in ("frequent", "highest"):
+        order_by = func.sum(Track.play_count).desc()
     else:
         order_by = func.lower(Album.title)
     async with db_session() as db:
@@ -201,6 +203,24 @@ async def get_artist(request: Request) -> Response:
                 "album": albums,
             }
         }
+
+    return await _run(request, impl)
+
+
+@_rest("getRandomSongs")
+async def get_random_songs(request: Request) -> Response:
+    async def impl(session: Session, params: Params) -> dict[str, Any]:
+        size = min(_int_param(params, "size", 10), _MAX_LIST_SIZE)
+        async with db_session() as db:
+            result = await db.execute(
+                select(Track)
+                .options(selectinload(Track.artist))
+                .where(track_visible_filter(session.did))
+                .order_by(func.random())
+                .limit(size)
+            )
+            tracks = list(result.scalars().all())
+        return {"randomSongs": {"song": [_song(track) for track in tracks]}}
 
     return await _run(request, impl)
 

--- a/backend/tests/api/test_subsonic.py
+++ b/backend/tests/api/test_subsonic.py
@@ -348,3 +348,39 @@ async def test_navidrome_native_login(live_server: str, dev_token: str) -> None:
     assert ok.status_code == 200
     assert ok.json()["id"] == DID
     assert bad.status_code == 401
+
+
+async def test_get_random_songs(
+    live_server: str, dev_token: str, library: dict[str, object]
+) -> None:
+    """shelv's shuffle button."""
+    conn = _connection(live_server, dev_token)
+    result = await asyncio.to_thread(lambda: conn.getRandomSongs(size=10))
+    titles = {s["title"] for s in result["randomSongs"]["song"]}
+    assert titles == {"first upload", "second upload"}
+
+
+async def test_album_list_frequent_orders_by_play_count(
+    live_server: str,
+    dev_token: str,
+    library: dict[str, object],
+    db_session: AsyncSession,
+) -> None:
+    """'most played' asks for type=frequent — real play counts, not alphabetical."""
+    from backend.models import Album
+
+    quiet = Album(artist_did=DID, slug="quiet", title="a quiet album")
+    loud = Album(artist_did=DID, slug="loud", title="z loud album")
+    db_session.add_all([quiet, loud])
+    await db_session.flush()
+    track_one, track_two = library["tracks"]  # type: ignore[misc]
+    track_one.album_id = quiet.id
+    track_one.play_count = 1
+    track_two.album_id = loud.id
+    track_two.play_count = 50
+    await db_session.commit()
+
+    conn = _connection(live_server, dev_token)
+    result = await asyncio.to_thread(lambda: conn.getAlbumList2(ltype="frequent"))
+    names = [a["name"] for a in result["albumList2"]["album"]]
+    assert names == ["z loud album", "a quiet album"]


### PR DESCRIPTION
two gaps surfaced by using Shelv against prod:

- **shuffle** calls `getRandomSongs`, which hit the not-implemented catch-all. now returns `size` (default 10, capped 500) random visible tracks with the full song shape (linkage fields included).
- **"most played"** calls `getAlbumList2?type=frequent`, which silently fell back to alphabetical — the client rendered a "most played" list that was actually A→Z. `frequent` (and `highest`) now order by summed track `play_count` descending, which is real signal: subsonic listening feeds `play_count` via `scrobble` since #1646.

`recent` intentionally stays on `created_at` (subsonic semantics want recently *played*, but we don't track per-album last-played; noted as a future refinement, not faked).

tests: libsonic round-trips for both (`getRandomSongs` returns the library; `frequent` orders a 50-play album above a 1-play album against alphabetical order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)