### PR TITLE
fix(embed): keep the radio embed playing across track boundaries

### DIFF
--- a/frontend/src/lib/components/embed/RadioEmbed.svelte
+++ b/frontend/src/lib/components/embed/RadioEmbed.svelte
@@ -13,6 +13,11 @@
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 	let playing = $state(false);
+	/** listener intent: true while the user wants to stay tuned in. `playing`
+	 * tracks the raw element state, which flips false at every track boundary
+	 * (the browser fires pause before ended) — resume decisions key off this
+	 * flag so auto-advance survives the boundary. */
+	let tunedIn = $state(false);
 	let stations = $state<RadioStation[]>([]);
 	/** selected station slug; null defers to the server default. seeded from
 	 * the iframe url's ?station= so embedders can pin a station. */
@@ -41,7 +46,7 @@
 		const seek = () => {
 			if (!el || !fetched.current) return;
 			if (Number.isFinite(target)) el.currentTime = Math.min(target, fetched.current.duration);
-			if (playing) el.play().catch(() => (playing = false));
+			if (tunedIn) el.play().catch(() => (playing = tunedIn = false));
 		};
 		if (el.readyState >= 1 && !changed) {
 			if (Math.abs(el.currentTime - target) > 5) seek();
@@ -99,11 +104,23 @@
 		const el = audioElement;
 		if (!el || !current) return;
 		if (playing) {
+			tunedIn = false;
 			el.pause();
 		} else {
 			// user gesture — safe to start audio
+			tunedIn = true;
 			syncAudio(radioState!);
-			el.play().then(() => (playing = true)).catch(() => (playing = false));
+			el.play().then(() => (playing = true)).catch(() => (playing = tunedIn = false));
+		}
+	}
+
+	/** at a track boundary the server rotation may not have flipped yet — retry
+	 * briefly so the embed doesn't sit silent until the next 30s poll. */
+	async function advance(endedSrc: string): Promise<void> {
+		for (let attempt = 0; attempt < 5; attempt++) {
+			await loadState(true);
+			if (!tunedIn || (current && current.stream_url !== endedSrc)) return;
+			await new Promise((resolve) => setTimeout(resolve, 2000));
 		}
 	}
 
@@ -118,7 +135,7 @@
 		loadState(false).then(() => {
 			if (autoplay && !playing) toggle();
 		});
-		pollTimer = window.setInterval(() => loadState(playing), 30000);
+		pollTimer = window.setInterval(() => loadState(tunedIn), 30000);
 		return () => {
 			if (pollTimer) window.clearInterval(pollTimer);
 		};
@@ -128,9 +145,14 @@
 <audio
 	bind:this={audioElement}
 	preload="metadata"
-	onended={() => loadState(true)}
+	onended={(e) => advance(e.currentTarget.src)}
 	onplay={() => (playing = true)}
-	onpause={() => (playing = false)}
+	onpause={(e) => {
+		playing = false;
+		// pause fired by reaching the end of a track keeps the listener tuned
+		// in; only an explicit pause (media keys, OS controls) drops intent
+		if (!e.currentTarget.ended) tunedIn = false;
+	}}
 ></audio>
 
 <div class="radio-embed">

--- a/frontend/src/lib/components/embed/RadioEmbed.test.ts
+++ b/frontend/src/lib/components/embed/RadioEmbed.test.ts
@@ -26,6 +26,7 @@ const SENSITIVE_ART = 'https://images.test/images/sens123.webp';
 const SAFE_ART = 'https://images.test/images/safe456.webp';
 
 let artworkUrl = SENSITIVE_ART;
+let trackNum = 1;
 
 function jsonResponse(body: unknown): Response {
 	return new Response(JSON.stringify(body), {
@@ -40,12 +41,12 @@ function radioState() {
 		generated_at: new Date().toISOString(),
 		progress_seconds: 10,
 		current: {
-			id: 1,
-			title: 'a track',
+			id: trackNum,
+			title: `track ${trackNum}`,
 			artist_handle: 'artist.test',
 			artwork_url: artworkUrl,
 			duration: 100,
-			stream_url: 'https://audio.test/1.mp3'
+			stream_url: `https://audio.test/${trackNum}.mp3`
 		},
 		rotation: []
 	};
@@ -93,6 +94,7 @@ afterEach(() => {
 	}
 	document.body.innerHTML = '';
 	pageUrl.value = 'http://localhost/';
+	trackNum = 1;
 	playSpy.mockClear();
 });
 
@@ -121,6 +123,42 @@ describe('RadioEmbed autoplay', () => {
 	it('stays paused without the param', async () => {
 		artworkUrl = SAFE_ART;
 		await mountRadioEmbed();
+		expect(playSpy).not.toHaveBeenCalled();
+	});
+});
+
+// regression for the boundary bug: the browser fires pause before ended, which
+// used to clear the playing flag and leave the next track loaded but silent
+describe('RadioEmbed auto-advance', () => {
+	async function tuneIn(): Promise<HTMLAudioElement> {
+		artworkUrl = SAFE_ART;
+		pageUrl.value = 'http://localhost/?autoplay=1';
+		await mountRadioEmbed();
+		await vi.waitFor(() => expect(playSpy).toHaveBeenCalled());
+		playSpy.mockClear();
+		return document.querySelector('audio')!;
+	}
+
+	it('keeps playing the next track when the current one ends', async () => {
+		const audio = await tuneIn();
+		trackNum = 2;
+		// jsdom pins .ended to false; a real end-of-track pause sees ended=true
+		const endedSpy = vi.spyOn(HTMLMediaElement.prototype, 'ended', 'get').mockReturnValue(true);
+		audio.dispatchEvent(new Event('pause')); // browsers fire pause first…
+		audio.dispatchEvent(new Event('ended')); // …then ended
+		endedSpy.mockRestore();
+		await vi.waitFor(() => expect(audio.src).toBe('https://audio.test/2.mp3'));
+		audio.dispatchEvent(new Event('loadedmetadata'));
+		await vi.waitFor(() => expect(playSpy).toHaveBeenCalled());
+	});
+
+	it('does not resume after an explicit pause', async () => {
+		const audio = await tuneIn();
+		audio.dispatchEvent(new Event('pause')); // user pause: element not ended
+		trackNum = 2;
+		audio.dispatchEvent(new Event('ended'));
+		await vi.waitFor(() => expect(audio.src).toBe('https://audio.test/2.mp3'));
+		audio.dispatchEvent(new Event('loadedmetadata'));
 		expect(playSpy).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
fixes the radio embed going silent after the first track — reported by @graham.systems using `https://plyr.fm/embed/radio?autoplay=1` as an OBS browser source.

## why it broke

browsers fire `pause` before `ended` at the end of a track. the embed's `onpause` handler set `playing = false`, and both `syncAudio`'s resume (`if (playing) el.play()`) and the 30s poll (`loadState(playing)`) keyed off that flag — so at every track boundary the next track loaded but never played, and the poll stopped syncing entirely. `?autoplay=1` (#1593) made this visible: unattended embeds play exactly one track.

## design

- new `tunedIn` flag tracks **listener intent**, separate from the raw element `playing` state. only `toggle()` (and a rejected `play()`) changes intent; an end-of-track `pause` (element `.ended === true`) keeps it. explicit pauses (OS media controls) still drop intent, so an embed a viewer paused stays paused.
- `syncAudio` resume and the 30s poll now key off `tunedIn`.
- `onended` calls a small `advance()` retry loop (5 × 2s): the server rotation may not have flipped past the finished track at the instant it ends locally, and previously that gap left the embed silent until the next 30s poll (which, per the above, no longer synced).

## regression tests

added to the existing `RadioEmbed.test.ts` harness:
- pause-then-ended (real boundary sequence, with jsdom's read-only `.ended` mocked true) → next track's src loads **and** playback resumes
- explicit pause then ended → next track loads but does **not** resume

the boundary test fails on the unfixed component (verified via stash) and passes with the fix.

## intentional non-behaviors

- the main app's radio player (`player-radio`) is untouched — it has its own advance path and isn't affected by this bug.
- no change to the autoplay-policy handling from #1593: a blocked initial `play()` still degrades to the normal paused widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)