### PR TITLE
feat(#1445): repeat-one control on the player

### DIFF
--- a/frontend/src/lib/components/player/PlaybackControls.svelte
+++ b/frontend/src/lib/components/player/PlaybackControls.svelte
@@ -158,6 +158,23 @@
 			</svg>
 		</button>
 
+		<button
+			class="control-btn"
+			class:active={queue.repeatMode === 'one'}
+			onclick={() => queue.toggleRepeatMode()}
+			title={queue.repeatMode === 'one' ? 'stop repeating' : 'repeat this track'}
+		>
+			<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+				<polyline points="17 1 21 5 17 9"></polyline>
+				<path d="M3 11V9a4 4 0 0 1 4-4h14"></path>
+				<polyline points="7 23 3 19 7 15"></polyline>
+				<path d="M21 13v2a4 4 0 0 1-4 4H3"></path>
+				{#if queue.repeatMode === 'one'}
+					<text x="12" y="17" text-anchor="middle" font-size="9" font-weight="700" fill="currentColor" stroke="none">1</text>
+				{/if}
+			</svg>
+		</button>
+
 		<div class="time-control">
 			<span class="time">{formattedCurrentTime}</span>
 			<input
@@ -259,6 +276,10 @@
 	.control-btn:hover {
 		color: var(--accent);
 		background: color-mix(in srgb, var(--accent) 10%, transparent);
+	}
+
+	.control-btn.active {
+		color: var(--accent);
 	}
 
 	.control-btn.play-pause:active {
@@ -442,6 +463,10 @@
 			grid-column: 6;
 		}
 
+		.control-btn:nth-of-type(4) {
+			grid-column: 7;
+		}
+
 		.control-btn svg {
 			width: 28px;
 			height: 28px;
@@ -454,13 +479,13 @@
 
 		.time-control {
 			grid-row: 2;
-			grid-column: 1 / 7;
+			grid-column: 1 / 8;
 		}
 
 		/* radio: "live" takes the scrubber's row instead of the control row */
 		.live-pill {
 			grid-row: 2;
-			grid-column: 1 / 7;
+			grid-column: 1 / 8;
 			text-align: center;
 		}
 

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -694,6 +694,15 @@
 	});
 
 	function handleTrackEnded() {
+		if (queue.repeatMode === 'one') {
+			const audio = player.audioElement;
+			if (audio) {
+				audio.currentTime = 0;
+				audio.play().catch(() => {});
+			}
+			return;
+		}
+
 		const next = queue.autoAdvanceTrack;
 		if (!next) {
 			player.reset();
@@ -935,7 +944,7 @@
 		}
 
 		.player-content {
-			grid-template-columns: 48px 1fr auto auto auto auto;
+			grid-template-columns: 48px 1fr auto auto auto auto auto;
 			grid-template-rows: auto auto;
 			gap: 0.5rem 0.75rem;
 		}

--- a/frontend/src/lib/player-repeat.test.ts
+++ b/frontend/src/lib/player-repeat.test.ts
@@ -1,0 +1,78 @@
+// repeat-one (#1445): a natural track end must restart the current track
+// instead of advancing the queue — and advancing must resume when repeat
+// is toggled back off.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import { player } from '$lib/player.svelte';
+import { queue } from '$lib/queue.svelte';
+import type { Track } from '$lib/types';
+
+vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
+vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+const playSpy = vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+
+vi.stubGlobal(
+	'fetch',
+	vi.fn(() => Promise.resolve(new Response(JSON.stringify({}))))
+);
+
+function track(id: number): Track {
+	return {
+		id,
+		title: `track ${id}`,
+		artist: 'artist',
+		artist_handle: 'artist.test',
+		file_id: `file-${id}`,
+		file_type: 'mp3',
+		play_count: 0
+	};
+}
+
+let component: Record<string, unknown>;
+
+async function mountPlayer(): Promise<HTMLAudioElement> {
+	const Player = (await import('$lib/components/player/Player.svelte')).default;
+	component = mount(Player, { target: document.body });
+	flushSync();
+	const audio = player.audioElement;
+	if (!audio) throw new Error('player audio element did not mount');
+	return audio;
+}
+
+beforeEach(() => {
+	playSpy.mockClear();
+	queue.tracks = [track(1), track(2)];
+	queue.currentIndex = 0;
+	queue.repeatMode = 'none';
+	player.currentTrack = track(1);
+	player.radio = null;
+	player.paused = false;
+});
+
+afterEach(() => {
+	unmount(component);
+	document.body.innerHTML = '';
+});
+
+describe('handleTrackEnded with repeat-one', () => {
+	it('restarts the current track and does not advance', async () => {
+		const audio = await mountPlayer();
+		queue.repeatMode = 'one';
+		playSpy.mockClear();
+
+		audio.dispatchEvent(new Event('ended'));
+
+		expect(playSpy).toHaveBeenCalled();
+		expect(queue.currentIndex).toBe(0);
+		expect(player.currentTrack?.id).toBe(1);
+	});
+
+	it('advances to the next track when repeat is off (control)', async () => {
+		const audio = await mountPlayer();
+
+		audio.dispatchEvent(new Event('ended'));
+		flushSync();
+
+		expect(queue.currentIndex).toBe(1);
+	});
+});

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -1,5 +1,5 @@
 import { browser } from '$app/environment';
-import type { QueueResponse, QueueState, Track } from './types';
+import type { QueueResponse, QueueState, RepeatMode, Track } from './types';
 import { API_URL } from './config';
 import { APP_BROADCAST_PREFIX } from './branding';
 import { auth } from './auth.svelte';
@@ -41,6 +41,7 @@ class Queue {
 	tracks = $state<Track[]>([]);
 	currentIndex = $state(0);
 	shuffle = $state(false);
+	repeatMode = $state<RepeatMode>('none');
 	originalOrder = $state<Track[]>([]);
 	progressMs = $state(0);
 
@@ -329,6 +330,7 @@ class Queue {
 		}
 
 		this.shuffle = state.shuffle;
+		this.repeatMode = state.repeat_mode ?? 'none';
 
 		if (state.progress_ms !== undefined) {
 			this.progressMs = state.progress_ms;
@@ -428,6 +430,7 @@ class Queue {
 				current_index: this.currentIndex,
 				current_track_id: this.currentTrack?.file_id ?? null,
 				shuffle: this.shuffle,
+				repeat_mode: this.repeatMode,
 				original_order_ids: this.originalOrder.map((t) => t.file_id),
 				progress_ms: this.progressMs,
 				continuation_from_index: this.continuationFromIndex,
@@ -771,6 +774,12 @@ class Queue {
 		this.tracks = [...before, ...shuffled, ...continuationTail];
 
 		this.schedulePush();
+	}
+
+	toggleRepeatMode() {
+		if (this.jamBridge) return;
+		this.repeatMode = this.repeatMode === 'one' ? 'none' : 'one';
+		this.syncState();
 	}
 
 	moveTrack(fromIndex: number, toIndex: number) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -94,6 +94,8 @@ export interface Artist {
 	support_url?: string;
 }
 
+export type RepeatMode = 'none' | 'one';
+
 export interface QueueState {
 	track_ids: string[];
 	current_index: number;
@@ -108,6 +110,7 @@ export interface QueueState {
 	continuation_suppressed?: boolean;
 	/** label for the continuation tail ("next from: <label>"); null/absent => the For You feed */
 	continuation_label?: string | null;
+	repeat_mode?: RepeatMode;
 }
 
 export interface QueueResponse {

--- a/loq.toml
+++ b/loq.toml
@@ -128,7 +128,7 @@ max_lines = 987
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"
-max_lines = 950
+max_lines = 955
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"
@@ -345,3 +345,7 @@ max_lines = 1722
 [[rules]]
 path = "frontend/src/lib/components/playlist/PlaylistTrackList.svelte"
 max_lines = 668
+
+[[rules]]
+path = "frontend/src/lib/components/player/PlaybackControls.svelte"
+max_lines = 501


### PR DESCRIPTION
adds a repeat-this-track toggle to the player controls: when armed, a natural track end restarts the current track instead of advancing the queue. revives @AilaScott's #1518 (her commit authorship is preserved), cut down to the piece we want to ship now.

## motivation

#1445 asks for loop + shuffle. shuffle already exists as a queue action; the missing piece people actually reach for is "repeat this song". #1518 implemented a spotify-style none/all/one cycle plus a shuffle button, but it went stale (five weeks behind the player rework: radio play counts #1622, keep-playing continuation) and its branch was entangled with an unrelated #1408 backend fix.

## design

- **repeat is off/one only** — no repeat-all. repeat-all is collection-level behavior that interacts with the "next from" continuation machinery (when the queue drains: loop, or fall through to For You?). that design call is deliberately deferred rather than half-answered here; the `RepeatMode` type leaves room to add `'all'` later.
- `queue.repeatMode` syncs in the queue state payload and is restored in `applyState`, so it round-trips across tabs like `shuffle` does. blocked during jams (same guard as other queue mutations).
- `handleTrackEnded` short-circuits before the autoplay fast path: reseek to 0 + same-tick `play()`, preserving the ended-event playback grace.
- mobile keeps the `display: contents` grid placement (the parent player grid gains one `auto` column) rather than #1518's grid rework.

## intentional non-behaviors

- **no shuffle button** on the controls — shuffle stays where it is today.
- **no repeat-all** (see above).
- a repeated listen does not re-fire `POST /tracks/{id}/play` — the play counter re-arms on track load, and the server dedups plays anyway.
- repeat state is per-queue-state, not a persisted user preference.

## testing

`player-repeat.test.ts` mounts the real Player component and dispatches `ended` on the audio element: repeat-one restarts without advancing; the control case proves the same harness detects a normal advance (i.e. the test fails against the pre-fix player).

toward #1445. supersedes #1518 — thank you @AilaScott!

🤖 Generated with [Claude Code](https://claude.com/claude-code)