### PR TITLE
fix(queue): repeat toggle lives with the queue actions, not the label row

### DIFF
--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -371,6 +371,22 @@
 							<line x1="4" y1="4" x2="9" y2="9"></line>
 						</svg>
 					</button>
+					<button
+						class="repeat-btn"
+						class:active={queue.repeatMode === 'one'}
+						onclick={() => queue.toggleRepeatMode()}
+						title={queue.repeatMode === 'one' ? 'stop repeating' : 'repeat this track'}
+					>
+						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<path d="m17 2 4 4-4 4"></path>
+							<path d="M3 11v-1a4 4 0 0 1 4-4h14"></path>
+							<path d="m7 22-4-4 4-4"></path>
+							<path d="M21 13v1a4 4 0 0 1-4 4H3"></path>
+							{#if queue.repeatMode === 'one'}
+								<path d="M11 10h1v4"></path>
+							{/if}
+						</svg>
+					</button>
 					{#if upcoming.length > 0}
 						<button
 							class="clear-btn"
@@ -424,30 +440,13 @@
 				<section class="now-playing">
 					<div class="section-label">
 						<span>now playing</span>
-						<span class="label-chips">
-							{#if queue.repeatMode === 'one' && !player.radio && !jam.active}
-								<button
-									class="repeat-chip"
-									onclick={() => queue.toggleRepeatMode()}
-									title="repeating this track — click to stop"
-								>
-									<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-										<path d="m17 2 4 4-4 4"></path>
-										<path d="M3 11v-1a4 4 0 0 1 4-4h14"></path>
-										<path d="m7 22-4-4 4-4"></path>
-										<path d="M21 13v1a4 4 0 0 1-4 4H3"></path>
-										<path d="M11 10h1v4"></path>
-									</svg>
-								</button>
-							{/if}
-							{#if player.radio}
-								<a class="source-chip radio-source" href="/radio">{currentSourceLabel}</a>
-							{:else if jam.active && jam.code}
-								<a class="source-chip" href={`/jam/${jam.code}`}>{currentSourceLabel}</a>
-							{:else}
-								<span class="source-chip">{currentSourceLabel}</span>
-							{/if}
-						</span>
+						{#if player.radio}
+							<a class="source-chip radio-source" href="/radio">{currentSourceLabel}</a>
+						{:else if jam.active && jam.code}
+							<a class="source-chip" href={`/jam/${jam.code}`}>{currentSourceLabel}</a>
+						{:else}
+							<span class="source-chip">{currentSourceLabel}</span>
+						{/if}
 					</div>
 					<div class="now-playing-card">
 						{@render media(currentTrack)}
@@ -720,7 +719,8 @@
 		gap: 0.5rem;
 	}
 
-	.shuffle-btn {
+	.shuffle-btn,
+	.repeat-btn {
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -735,13 +735,15 @@
 		transition: all 0.15s ease;
 	}
 
-	.shuffle-btn:hover {
+	.shuffle-btn:hover,
+	.repeat-btn:hover {
 		color: var(--text-secondary);
 		border-color: var(--border-default);
 		background: var(--bg-secondary);
 	}
 
-	.shuffle-btn.active {
+	.shuffle-btn.active,
+	.repeat-btn.active {
 		color: var(--accent);
 		border-color: var(--accent);
 	}
@@ -807,35 +809,10 @@
 		margin-bottom: 0.5rem;
 	}
 
-	.label-chips {
-		display: flex;
-		align-items: center;
-		gap: 0.3rem;
-		min-width: 0;
-		max-width: 55%;
-	}
-
-	.repeat-chip {
-		display: inline-flex;
-		align-items: center;
-		padding: 0.16rem 0.45rem;
-		border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border-subtle));
-		border-radius: var(--radius-full);
-		background: transparent;
-		color: var(--accent);
-		cursor: pointer;
-		flex-shrink: 0;
-	}
-
-	.repeat-chip:hover {
-		border-color: var(--accent);
-		background: color-mix(in srgb, var(--accent) 10%, transparent);
-	}
-
 	.source-chip {
 		display: inline-flex;
 		align-items: center;
-		max-width: 100%;
+		max-width: 45%;
 		padding: 0.1rem 0.45rem;
 		border: 1px solid var(--border-subtle);
 		border-radius: var(--radius-full);


### PR DESCRIPTION
follow-up to #1655, which put the repeat-one indicator in the wrong place: a clickable accent pill next to the inert `queue` source chip — two visually identical pills with different affordances, in a different row from the queue's actual controls (jam / shuffle / clear).

repeat is the same species as shuffle — a playback mode toggle — so it now follows shuffle's pattern exactly:

- a 32px icon button in the queue-actions row, right after shuffle
- active state (accent color + border, "1" appears in the glyph) IS the state indicator, same as shuffle's active treatment
- the now-playing label row goes back to label + source chip only; the `.label-chips` / `.repeat-chip` CSS from #1655 is removed

rendered against the app palette and visually verified (idle + active states) before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
