### PR TITLE
fix permissioned-spaces client drift

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -65,6 +65,23 @@ jobs:
           DOCKET_URL: redis://localhost:6379
         run: cd backend && uv run pytest tests/ -n auto
 
+      # Repository secrets are unavailable to fork PRs. Keep them scoped to the
+      # one live-boundary test rather than exposing them to the whole suite.
+      - name: run live private-media integration
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          DATABASE_URL: postgresql+asyncpg://relay_test:relay_test@localhost:5432/relay_test
+          DOCKET_URL: redis://localhost:6379
+          ZAT_TEST_PDS: ${{ secrets.ZAT_TEST_PDS }}
+          ZAT_TEST_HANDLE: ${{ secrets.ZAT_TEST_HANDLE }}
+          ZAT_TEST_PASSWORD: ${{ secrets.ZAT_TEST_PASSWORD }}
+        run: |
+          test -n "$ZAT_TEST_PDS"
+          test -n "$ZAT_TEST_HANDLE"
+          test -n "$ZAT_TEST_PASSWORD"
+          cd backend
+          uv run pytest tests/integration/test_private_media.py -v --tb=short
+
       - name: prune uv cache
         if: always()
         run: uv cache prune --ci

--- a/backend/src/backend/_internal/atproto/client.py
+++ b/backend/src/backend/_internal/atproto/client.py
@@ -397,6 +397,7 @@ async def _app_password_request(
     payload: dict[str, Any] | None,
     params: dict[str, Any] | None,
     success_codes: tuple[int, ...],
+    parse_response: bool,
 ) -> dict[str, Any]:
     """make_pds_request for bearer app-password sessions (no DPoP/OAuth client)."""
     data = auth_session.oauth_session
@@ -428,7 +429,11 @@ async def _app_password_request(
             ) from e
 
         if response.status_code in success_codes:
-            return {} if response.status_code == 204 else response.json()
+            return (
+                response.json()
+                if parse_response and response.status_code != 204
+                else {}
+            )
 
         if response.status_code == 401 and not has_refreshed:
             has_refreshed = True
@@ -525,6 +530,7 @@ async def make_pds_request(
     payload: dict[str, Any] | None = None,
     params: dict[str, Any] | None = None,
     success_codes: tuple[int, ...] = (200, 201),
+    parse_response: bool = True,
 ) -> dict[str, Any]:
     """make an authenticated request to the PDS with automatic token refresh.
 
@@ -535,6 +541,8 @@ async def make_pds_request(
         payload: request JSON payload (for POST)
         params: query parameters (for GET)
         success_codes: HTTP status codes considered successful
+        parse_response: decode successful response JSON; disable when the body
+            is not needed
 
     returns:
         response JSON dict (empty dict for 204 responses)
@@ -551,7 +559,13 @@ async def make_pds_request(
 
     if oauth_data.get("auth_type") == "app_password":
         return await _app_password_request(
-            auth_session, method, endpoint, payload, params, success_codes
+            auth_session,
+            method,
+            endpoint,
+            payload,
+            params,
+            success_codes,
+            parse_response,
         )
 
     oauth_session = reconstruct_oauth_session(oauth_data)
@@ -588,7 +602,7 @@ async def make_pds_request(
             ) from e
 
         if response.status_code in success_codes:
-            if response.status_code == 204:
+            if response.status_code == 204 or not parse_response:
                 return {}
             return response.json()
 

--- a/backend/src/backend/_internal/atproto/spaces/__init__.py
+++ b/backend/src/backend/_internal/atproto/spaces/__init__.py
@@ -11,6 +11,7 @@ from backend._internal.atproto.spaces.capability import (
 from backend._internal.atproto.spaces.uris import (
     build_record_uri,
     build_space_uri,
+    parse_space_record_uri,
     parse_space_uri,
 )
 
@@ -18,5 +19,6 @@ __all__ = [
     "build_record_uri",
     "build_space_uri",
     "detect_permissioned_capability",
+    "parse_space_record_uri",
     "parse_space_uri",
 ]

--- a/backend/src/backend/_internal/atproto/spaces/client.py
+++ b/backend/src/backend/_internal/atproto/spaces/client.py
@@ -1,15 +1,16 @@
-"""client for the permissioned-data space surface (com.atproto.space.*).
+"""client for the permissioned-data space surfaces.
 
 owner/author writes go through the DPoP-protected OAuth path
 ([make_pds_request][backend._internal.atproto.client.make_pds_request]); the
-credential exchange and credential-gated reads use plain Bearer tokens (member
-grants and space credentials are JWTs, not DPoP-bound), so those go through a
-small raw-bearer helper.
+credential exchange and credential-gated reads use plain Bearer tokens
+(delegation tokens and space credentials are JWTs, not DPoP-bound), so those go
+through a small raw-bearer helper.
 
 read path (per permissioned-data diary 6):
 
-    user OAuth -> getMemberGrant (member PDS, DPoP) -> getSpaceCredential
-    (space owner, plain Bearer grant) -> getRecord / getBlob (plain Bearer credential)
+    user OAuth -> getDelegationToken (requester PDS, DPoP) -> getSpaceCredential
+    (space authority, plain Bearer token) -> getRecord / getBlob
+    (plain Bearer credential)
 """
 
 import logging
@@ -53,7 +54,7 @@ async def _raw_bearer_request(
     json: dict[str, Any] | None = None,
     params: dict[str, Any] | None = None,
 ) -> httpx.Response:
-    """call an XRPC method with a plain Bearer token (member grant / space credential)."""
+    """call XRPC with a plain Bearer token (delegation token / space credential)."""
     url = f"{pds_url}/xrpc/{endpoint}"
     if not is_safe_url(url):
         raise ValueError(f"unsafe PDS URL: {url}")
@@ -82,8 +83,8 @@ async def ensure_personal_space(
     has a reader member list (#1573), and private-space credentials are owner-only
     by default, so for this MVP the owner is the sole reader. any broader access
     (label/supporter rosters) is plyr.fm app-layer state, not a PDS member list.
-    `appAccessMode:"allow"` + empty exceptions is the app-access policy that leaves
-    plyr.fm's OAuth client default-allowed for the credential exchange.
+    `appAccess:{"type":"open"}` leaves plyr.fm's OAuth client allowed for the
+    credential exchange.
     """
     space_type = space_type or settings.atproto.private_media_space_type
     space_uri = build_space_uri(auth_session.did, space_type, skey)
@@ -91,15 +92,13 @@ async def ensure_personal_space(
         await make_pds_request(
             auth_session,
             "POST",
-            "com.atproto.space.createSpace",
+            "com.atproto.simplespace.createSpace",
             payload={
-                "did": auth_session.did,
                 "type": space_type,
                 "skey": skey,
                 "managingApp": settings.atproto.client_id,
-                "isPublic": False,
-                "appAccessMode": "allow",
-                "appExceptions": [],
+                "policy": "member-list",
+                "appAccess": {"type": "open"},
             },
         )
     except Exception as exc:
@@ -145,26 +144,36 @@ _credential_cache: dict[str, tuple[str, float]] = {}
 
 async def _mint_credential(auth_session: AuthSession, space: str) -> str:
     pds_url = _pds_url(auth_session)
-    grant_resp = await make_pds_request(
+    delegation_resp = await make_pds_request(
         auth_session,
         "GET",
-        "com.atproto.space.getMemberGrant",
+        "com.atproto.space.getDelegationToken",
         params={"space": space},
     )
-    grant = grant_resp["grant"]
+    delegation_token = delegation_resp["token"]
 
-    # exchange the grant (plain Bearer) for an owner-signed space credential
+    # exchange the delegation token (plain Bearer) for an authority-signed
+    # space credential. plyr.fm has no notification receiver to register.
     cred_resp = await _raw_bearer_request(
         pds_url,
         "POST",
         "com.atproto.space.getSpaceCredential",
-        grant,
+        delegation_token,
         json={"space": space},
     )
     if cred_resp.status_code != 200:
         body = cred_resp.text
-        if any(e in body for e in ("AppNotPermitted", "NotAMember", "SpaceDeleted")):
-            raise SpaceAccessError(f"space owner refused credential: {body}")
+        refused_errors = (
+            "AppNotPermitted",
+            "AppNotAuthorized",
+            "NotAMember",
+            "NotAuthorized",
+            "NotPermitted",
+            "SpaceDeleted",
+            "UserNotAuthorized",
+        )
+        if any(error in body for error in refused_errors):
+            raise SpaceAccessError(f"space authority refused credential: {body}")
         raise Exception(f"getSpaceCredential failed: {cred_resp.status_code} {body}")
     return cred_resp.json()["credential"]
 

--- a/backend/src/backend/_internal/atproto/spaces/client.py
+++ b/backend/src/backend/_internal/atproto/spaces/client.py
@@ -24,7 +24,10 @@ from atproto_oauth.security import is_safe_url
 
 from backend._internal import Session as AuthSession
 from backend._internal.atproto.client import make_pds_request
-from backend._internal.atproto.spaces.uris import build_space_uri
+from backend._internal.atproto.spaces.uris import (
+    build_space_uri,
+    parse_space_record_uri,
+)
 from backend.config import settings
 
 logger = logging.getLogger(__name__)
@@ -100,6 +103,10 @@ async def ensure_personal_space(
                 "policy": "member-list",
                 "appAccess": {"type": "open"},
             },
+            # The returned config is not needed. Current ZDS appends one extra
+            # closing brace to this otherwise-successful response, so decoding
+            # it would turn a created space into a failed upload.
+            parse_response=False,
         )
     except Exception as exc:
         if "SpaceAlreadyExists" not in str(exc):
@@ -133,6 +140,23 @@ async def create_space_record(
         endpoint = "com.atproto.space.createRecord"
     result = await make_pds_request(auth_session, "POST", endpoint, payload=payload)
     return result["uri"], result["cid"]
+
+
+async def delete_space_record(auth_session: AuthSession, record_uri: str) -> None:
+    """delete a record from its permissioned space."""
+    record = parse_space_record_uri(record_uri)
+    await make_pds_request(
+        auth_session,
+        "POST",
+        "com.atproto.space.deleteRecord",
+        payload={
+            "space": record.space,
+            "repo": record.author_did,
+            "collection": record.collection,
+            "rkey": record.rkey,
+        },
+        success_codes=(200, 201, 204),
+    )
 
 
 # --- credential exchange (diary-6 read path) ----------------------------------

--- a/backend/src/backend/_internal/atproto/spaces/uris.py
+++ b/backend/src/backend/_internal/atproto/spaces/uris.py
@@ -18,6 +18,13 @@ class SpaceUri(NamedTuple):
     skey: str
 
 
+class SpaceRecordUri(NamedTuple):
+    space: str
+    author_did: str
+    collection: str
+    rkey: str
+
+
 def build_space_uri(owner_did: str, space_type: str, skey: str) -> str:
     return f"{ATS_SCHEME}{owner_did}/{space_type}/{skey}"
 
@@ -39,3 +46,18 @@ def parse_space_uri(uri: str) -> SpaceUri:
     if len(segments) < 3 or not all(segments[:3]):
         raise ValueError(f"space URI needs 3 non-empty segments: {uri!r}")
     return SpaceUri(owner_did=segments[0], space_type=segments[1], skey=segments[2])
+
+
+def parse_space_record_uri(uri: str) -> SpaceRecordUri:
+    """parse a full 6-segment permissioned-space record URI."""
+    if not uri.startswith(ATS_SCHEME):
+        raise ValueError(f"not an ats:// URI: {uri!r}")
+    segments = uri[len(ATS_SCHEME) :].split("/")
+    if len(segments) != 6 or not all(segments):
+        raise ValueError(f"space record URI needs 6 non-empty segments: {uri!r}")
+    return SpaceRecordUri(
+        space=build_space_uri(segments[0], segments[1], segments[2]),
+        author_did=segments[3],
+        collection=segments[4],
+        rkey=segments[5],
+    )

--- a/backend/src/backend/api/tracks/mutations.py
+++ b/backend/src/backend/api/tracks/mutations.py
@@ -30,6 +30,7 @@ from backend._internal.atproto.records import (
     rebuild_track_pds_record,
     update_record,
 )
+from backend._internal.atproto.spaces.client import delete_space_record
 from backend._internal.atproto.tid import datetime_to_tid
 from backend._internal.audio import AudioFormat
 from backend._internal.image_uploads import process_image_upload
@@ -76,7 +77,10 @@ async def delete_track(
     # delete ATProto record if it exists
     if track.atproto_record_uri:
         try:
-            await delete_record_by_uri(auth_session, track.atproto_record_uri)
+            if track.atproto_record_uri.startswith("ats://"):
+                await delete_space_record(auth_session, track.atproto_record_uri)
+            else:
+                await delete_record_by_uri(auth_session, track.atproto_record_uri)
             logfire.info(
                 "deleted ATProto record",
                 track_id=track_id,
@@ -103,11 +107,12 @@ async def delete_track(
                 ) from e
 
     # delete audio file from storage
-    try:
-        await storage.delete(track.file_id, track.file_type)
-    except Exception as e:
-        # log but don't fail - maybe file was already deleted
-        logger.warning(f"failed to delete file {track.file_id}: {e}", exc_info=True)
+    if not track.is_private:
+        try:
+            await storage.delete(track.file_id, track.file_type)
+        except Exception as e:
+            # log but don't fail - maybe file was already deleted
+            logger.warning(f"failed to delete file {track.file_id}: {e}", exc_info=True)
 
     # delete image file from storage (if album doesn't share it)
     if track.image_id:

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -1590,9 +1590,11 @@ async def upload_track(
         # passes without it). the granted token carries the expanded
         # `space:<nsid>?...` scopes, so match on the NSID. absent → tell the
         # frontend to run the opt-in scope upgrade (which requests include:<nsid>).
-        if settings.atproto.private_media_space_type not in (
-            auth_session.oauth_session or {}
-        ).get("scope", ""):
+        auth_data = auth_session.oauth_session or {}
+        has_space_access = auth_data.get("auth_type") == "app_password" or (
+            settings.atproto.private_media_space_type in auth_data.get("scope", "")
+        )
+        if not has_space_access:
             raise HTTPException(status_code=403, detail="permissioned_scope_required")
         if not audio_format.is_web_playable:
             raise HTTPException(

--- a/backend/tests/_internal/test_permissioned_spaces.py
+++ b/backend/tests/_internal/test_permissioned_spaces.py
@@ -5,6 +5,9 @@ helpers, the OAuth scope composition, and space-credential caching/renewal. the
 full data path is exercised against a live ZDS by scripts/permissioned_smoke.py.
 """
 
+from unittest.mock import AsyncMock
+
+import httpx
 import pytest
 
 from backend._internal import Session
@@ -162,6 +165,103 @@ def test_permissioned_scope_opt_in_only():
 
 
 # --- space credential caching + renewal ---------------------------------------
+
+
+async def test_ensure_personal_space_uses_simplespace_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = AsyncMock(return_value={"uri": "unused"})
+    monkeypatch.setattr(space_client, "make_pds_request", request)
+    session = Session(
+        session_id="s",
+        did="did:plc:x",
+        handle="x.test",
+        oauth_session={"pds_url": "https://x"},
+    )
+
+    space = await space_client.ensure_personal_space(
+        session, space_type="fm.plyr.privateMedia", skey="self"
+    )
+
+    assert space == "ats://did:plc:x/fm.plyr.privateMedia/self"
+    request.assert_awaited_once_with(
+        session,
+        "POST",
+        "com.atproto.simplespace.createSpace",
+        payload={
+            "type": "fm.plyr.privateMedia",
+            "skey": "self",
+            "managingApp": settings.atproto.client_id,
+            "policy": "member-list",
+            "appAccess": {"type": "open"},
+        },
+    )
+
+
+async def test_mint_credential_uses_delegation_token_flow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pds_request = AsyncMock(return_value={"token": "delegation-token"})
+    bearer_request = AsyncMock(
+        return_value=httpx.Response(200, json={"credential": "space-credential"})
+    )
+    monkeypatch.setattr(space_client, "make_pds_request", pds_request)
+    monkeypatch.setattr(space_client, "_raw_bearer_request", bearer_request)
+    session = Session(
+        session_id="s",
+        did="did:plc:x",
+        handle="x.test",
+        oauth_session={"pds_url": "https://pds.test"},
+    )
+    space = "ats://did:plc:x/fm.plyr.privateMedia/self"
+
+    credential = await space_client._mint_credential(session, space)
+
+    assert credential == "space-credential"
+    pds_request.assert_awaited_once_with(
+        session,
+        "GET",
+        "com.atproto.space.getDelegationToken",
+        params={"space": space},
+    )
+    bearer_request.assert_awaited_once_with(
+        "https://pds.test",
+        "POST",
+        "com.atproto.space.getSpaceCredential",
+        "delegation-token",
+        json={"space": space},
+    )
+
+
+async def test_mint_credential_maps_zds_access_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        space_client,
+        "make_pds_request",
+        AsyncMock(return_value={"token": "delegation-token"}),
+    )
+    monkeypatch.setattr(
+        space_client,
+        "_raw_bearer_request",
+        AsyncMock(
+            return_value=httpx.Response(
+                403,
+                json={"error": "NotPermitted", "message": "requester denied"},
+            )
+        ),
+    )
+    session = Session(
+        session_id="s",
+        did="did:plc:x",
+        handle="x.test",
+        oauth_session={"pds_url": "https://pds.test"},
+    )
+
+    with pytest.raises(space_client.SpaceAccessError, match="authority refused"):
+        await space_client._mint_credential(
+            session, "ats://did:plc:x/fm.plyr.privateMedia/self"
+        )
 
 
 async def test_space_credential_cache_and_force_refresh(monkeypatch):

--- a/backend/tests/_internal/test_permissioned_spaces.py
+++ b/backend/tests/_internal/test_permissioned_spaces.py
@@ -16,6 +16,7 @@ from backend._internal.atproto.spaces import client as space_client
 from backend._internal.atproto.spaces.uris import (
     build_record_uri,
     build_space_uri,
+    parse_space_record_uri,
     parse_space_uri,
 )
 from backend.config import settings
@@ -39,6 +40,12 @@ def test_space_and_record_uri_roundtrip():
         assert parsed.space_type == "fm.plyr.privateMedia"
         assert parsed.skey == "self"
 
+    parsed_record = parse_space_record_uri(record)
+    assert parsed_record.space == space
+    assert parsed_record.author_did == "did:plc:abc"
+    assert parsed_record.collection == "fm.plyr.track"
+    assert parsed_record.rkey == "rkey1"
+
 
 @pytest.mark.parametrize(
     "bad", ["at://did:plc:abc/x/y", "ats://did:plc:abc", "ats://did:plc:abc//self", ""]
@@ -46,6 +53,20 @@ def test_space_and_record_uri_roundtrip():
 def test_parse_space_uri_rejects_malformed(bad):
     with pytest.raises(ValueError):
         parse_space_uri(bad)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "at://did:plc:abc/x/y",
+        "ats://did:plc:abc/x/self",
+        "ats://did:plc:abc/x/self/did:plc:abc/y",
+        "ats://did:plc:abc/x/self/did:plc:abc/y/rkey/extra",
+    ],
+)
+def test_parse_space_record_uri_rejects_malformed(bad: str) -> None:
+    with pytest.raises(ValueError):
+        parse_space_record_uri(bad)
 
 
 # --- capability probe interpretation -----------------------------------------
@@ -195,6 +216,7 @@ async def test_ensure_personal_space_uses_simplespace_shape(
             "policy": "member-list",
             "appAccess": {"type": "open"},
         },
+        parse_response=False,
     )
 
 
@@ -262,6 +284,37 @@ async def test_mint_credential_maps_zds_access_refusal(
         await space_client._mint_credential(
             session, "ats://did:plc:x/fm.plyr.privateMedia/self"
         )
+
+
+async def test_delete_space_record_uses_record_uri_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = AsyncMock(return_value={})
+    monkeypatch.setattr(space_client, "make_pds_request", request)
+    session = Session(
+        session_id="s",
+        did="did:plc:x",
+        handle="x.test",
+        oauth_session={"pds_url": "https://x"},
+    )
+
+    await space_client.delete_space_record(
+        session,
+        "ats://did:plc:x/fm.plyr.privateMedia/self/did:plc:x/fm.plyr.track/rk",
+    )
+
+    request.assert_awaited_once_with(
+        session,
+        "POST",
+        "com.atproto.space.deleteRecord",
+        payload={
+            "space": "ats://did:plc:x/fm.plyr.privateMedia/self",
+            "repo": "did:plc:x",
+            "collection": "fm.plyr.track",
+            "rkey": "rk",
+        },
+        success_codes=(200, 201, 204),
+    )
 
 
 async def test_space_credential_cache_and_force_refresh(monkeypatch):

--- a/backend/tests/api/test_private_media_upload.py
+++ b/backend/tests/api/test_private_media_upload.py
@@ -26,7 +26,9 @@ PERM_SCOPE = f"space:{_TYPE}?action=create&did=*&skey=self&collection={_TYPE}"
 
 
 class _MockSession(Session):
-    def __init__(self, *, with_space_scope: bool = False) -> None:
+    def __init__(
+        self, *, with_space_scope: bool = False, app_password: bool = False
+    ) -> None:
         self.did = "did:test:artist"
         self.handle = "artist.test"
         self.session_id = "test_session_private_media"
@@ -44,6 +46,8 @@ class _MockSession(Session):
             "dpop_authserver_nonce": "",
             "dpop_pds_nonce": "",
         }
+        if app_password:
+            self.oauth_session["auth_type"] = "app_password"
 
 
 def _auth_app(*, with_space_scope: bool) -> Generator[FastAPI, None, None]:
@@ -101,6 +105,34 @@ def test_private_capable_but_scope_missing_requests_upgrade(app_no_scope: FastAP
         resp = _post(client, data={"visibility": "private"})
     assert resp.status_code == 403
     assert resp.json()["detail"] == "permissioned_scope_required"
+
+
+def test_private_app_password_session_bypasses_oauth_scope_gate(
+    app_no_scope: FastAPI,
+) -> None:
+    async def _profile() -> Session:
+        return _MockSession(app_password=True)
+
+    app_no_scope.dependency_overrides[require_artist_profile] = _profile
+    fake_blob = {
+        "$type": "blob",
+        "ref": {"$link": "bafkreiappassword"},
+        "mimeType": "audio/wav",
+        "size": len(_WAV),
+    }
+
+    with (
+        patch(
+            "backend.api.tracks.uploads.detect_permissioned_capability",
+            return_value=True,
+        ),
+        patch("backend.api.tracks.uploads.upload_blob", return_value=fake_blob),
+        patch("backend.api.tracks.uploads.schedule_track_upload"),
+        TestClient(app_no_scope) as client,
+    ):
+        resp = _post(client, data={"visibility": "private"})
+
+    assert resp.status_code == 200, resp.text
 
 
 def test_private_rejects_non_web_playable(app_with_scope: FastAPI):

--- a/backend/tests/api/test_track_deletion.py
+++ b/backend/tests/api/test_track_deletion.py
@@ -227,6 +227,59 @@ async def test_atproto_cleanup_on_track_delete(
     assert result.scalar_one_or_none() is None
 
 
+async def test_private_track_delete_uses_space_api_and_never_r2(
+    test_app: FastAPI, db_session: AsyncSession, test_artist: Artist
+) -> None:
+    """permissioned records delete through space.deleteRecord; their synthetic
+    content-hash file IDs must never be interpreted as R2 object keys."""
+    record_uri = (
+        "ats://did:plc:artist123/fm.plyr.privateMedia/self/"
+        "did:plc:artist123/fm.plyr.track/private1"
+    )
+    track = Track(
+        title="private track",
+        artist_did=test_artist.did,
+        file_id="contenthashcollision",
+        file_type="wav",
+        extra={},
+        visibility="private",
+        audio_storage="pds",
+        space_uri="ats://did:plc:artist123/fm.plyr.privateMedia/self",
+        pds_blob_cid="bafkreiprivate",
+        atproto_record_uri=record_uri,
+        atproto_record_cid="bafyprivate",
+    )
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+
+    with (
+        patch(
+            "backend.api.tracks.mutations.delete_space_record",
+            new_callable=AsyncMock,
+        ) as delete_space,
+        patch(
+            "backend.api.tracks.mutations.delete_record_by_uri",
+            new_callable=AsyncMock,
+        ) as delete_public,
+        patch(
+            "backend.api.tracks.mutations.storage.delete",
+            new_callable=AsyncMock,
+        ) as delete_storage,
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.delete(f"/tracks/{track.id}")
+
+    assert response.status_code == 200
+    assert delete_space.await_count == 1
+    assert delete_space.await_args is not None
+    assert delete_space.await_args.args[1] == record_uri
+    delete_public.assert_not_awaited()
+    delete_storage.assert_not_awaited()
+
+
 async def test_atproto_cleanup_handles_404(
     test_app: FastAPI, db_session: AsyncSession, test_artist: Artist
 ):

--- a/backend/tests/integration/test_private_media.py
+++ b/backend/tests/integration/test_private_media.py
@@ -1,0 +1,186 @@
+"""live-ZDS integration coverage for permissioned private tracks.
+
+The API and database run locally against the normal isolated test services; only
+the ATProto boundary is live. The upload worker is executed inline so the test
+does not need a second process, while all upload phases themselves remain real.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import get_session
+from backend._internal.atproto.client import make_pds_request
+from backend._internal.atproto.spaces.client import delete_space_record
+from backend._internal.atproto.spaces.uris import parse_space_record_uri
+from backend._internal.auth.app_password import create_app_password_session
+from backend.api.tracks import uploads
+from backend.config import settings
+from backend.models import Artist, Track
+
+pytestmark = [pytest.mark.integration, pytest.mark.timeout(120)]
+
+
+def _live_zds_credentials() -> tuple[str, str, str]:
+    pds = os.getenv("ZAT_TEST_PDS")
+    handle = os.getenv("ZAT_TEST_HANDLE")
+    password = os.getenv("ZAT_TEST_PASSWORD")
+    if not all((pds, handle, password)):
+        pytest.skip("live ZDS credentials are not configured")
+    assert pds is not None and handle is not None and password is not None
+    return pds.rstrip("/"), handle, password
+
+
+def _completed_upload(response_text: str) -> dict[str, Any]:
+    events = [
+        json.loads(line.removeprefix("data: "))
+        for line in response_text.splitlines()
+        if line.startswith("data: ")
+    ]
+    assert events, "upload progress returned no events"
+    final = events[-1]
+    assert final["status"] == "completed", final
+    return final
+
+
+async def test_private_track_upload_playback_and_delete_live_zds(
+    fastapi_app: FastAPI,
+    db_session: AsyncSession,
+    drone_a4: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """upload, publish, read, range-stream, deny, and delete a private track."""
+    pds, handle, password = _live_zds_credentials()
+    monkeypatch.setattr(settings.auth, "allow_app_password_dev_tokens", True)
+
+    auth = await create_app_password_session(
+        identifier=handle,
+        app_password=password,
+        pds_url=pds,
+        token_name="private-media-ci",
+        expires_in_days=1,
+    )
+    token = auth["token"]
+    session = await get_session(token)
+    assert session is not None
+
+    db_session.add(
+        Artist(
+            did=session.did,
+            handle=session.handle,
+            display_name="private media integration",
+            pds_url=pds,
+        )
+    )
+    await db_session.commit()
+
+    async def run_upload_inline(ctx: uploads.UploadContext) -> None:
+        await uploads._process_upload_background(ctx)
+
+    monkeypatch.setattr(uploads, "schedule_track_upload", run_upload_inline)
+
+    headers = {"Authorization": f"Bearer {token}"}
+    track_id: int | None = None
+    record_uri: str | None = None
+    title = f"private media ci {uuid4().hex}"
+
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=fastapi_app), base_url="http://test"
+        ) as http:
+            with drone_a4.open("rb") as audio:
+                uploaded = await http.post(
+                    "/tracks/",
+                    headers=headers,
+                    data={
+                        "title": title,
+                        "visibility": "private",
+                        "tags": json.dumps(["integration-test", "private-media"]),
+                    },
+                    files={"file": (drone_a4.name, audio, "audio/wav")},
+                )
+            uploaded.raise_for_status()
+
+            progress = await http.get(
+                f"/tracks/uploads/{uploaded.json()['upload_id']}/progress",
+                headers=headers,
+            )
+            progress.raise_for_status()
+            completed = _completed_upload(progress.text)
+            track_id = int(completed["track_id"])
+
+            track_response = await http.get(f"/tracks/{track_id}", headers=headers)
+            track_response.raise_for_status()
+            track = track_response.json()
+            assert track["title"] == title
+            assert track["visibility"] == "private"
+            assert track["audio_storage"] == "pds"
+            assert track["r2_url"] is None
+            assert track["pds_blob_cid"]
+            assert track["atproto_record_uri"].startswith("ats://")
+            record_uri = track["atproto_record_uri"]
+
+            parsed = parse_space_record_uri(record_uri)
+            stored = await make_pds_request(
+                session,
+                "GET",
+                "com.atproto.space.getRecord",
+                params={
+                    "space": parsed.space,
+                    "repo": parsed.author_did,
+                    "collection": parsed.collection,
+                    "rkey": parsed.rkey,
+                },
+            )
+            assert stored["value"]["title"] == title
+
+            ranged = await http.get(
+                f"/audio/{track['file_id']}",
+                headers={**headers, "Range": "bytes=0-3"},
+            )
+            assert ranged.status_code == 206, ranged.text
+            assert ranged.content == b"RIFF"
+            assert ranged.headers["content-range"].startswith("bytes 0-3/")
+
+            denied = await http.get(
+                f"/audio/{track['file_id']}", headers={"Range": "bytes=0-3"}
+            )
+            assert denied.status_code == 404
+
+            deleted = await http.delete(f"/tracks/{track_id}", headers=headers)
+            deleted.raise_for_status()
+
+            missing = await http.get(f"/tracks/{track_id}", headers=headers)
+            assert missing.status_code == 404
+
+            with pytest.raises(Exception, match=r"404|RecordNotFound"):
+                await make_pds_request(
+                    session,
+                    "GET",
+                    "com.atproto.space.getRecord",
+                    params={
+                        "space": parsed.space,
+                        "repo": parsed.author_did,
+                        "collection": parsed.collection,
+                        "rkey": parsed.rkey,
+                    },
+                )
+    finally:
+        if record_uri is not None:
+            with contextlib.suppress(Exception):
+                await delete_space_record(session, record_uri)
+        if track_id is not None:
+            await db_session.rollback()
+            if leftover := await db_session.get(Track, track_id):
+                await db_session.delete(leftover)
+                await db_session.commit()

--- a/docs/internal/architecture/permissioned-private-media.md
+++ b/docs/internal/architecture/permissioned-private-media.md
@@ -6,11 +6,13 @@ whose PDS implements it. ports cleanly from today's public track flow: the recor
 is the same `fm.plyr.track` lexicon — only the write target (a permissioned space repo)
 and the read auth (a space credential) differ.
 
-> **update (#1573): the protocol no longer has a reader member list.** ZDS removed the
-> member-list routes (`addMember`/`removeMember`/`getMembers`/`getMemberState`/
+> **update (#1573): the generic space protocol no longer has a reader member list.** ZDS
+> removed its old member-list routes (`addMember`/`removeMember`/`getMembers`/`getMemberState`/
 > `getMemberOplog`/`notifyMembership`) and `getSpace`/`listSpaces` no longer expose
-> `members`/`isMember`. the **space credential is the substrate**; reader/group semantics
-> live **above** it, in the app. private-space credentials are owner-only by default.
+> `members`/`isMember`. the newer `com.atproto.simplespace.*` baseline does have a
+> `member-list` access policy, but it is space management rather than a generic sync
+> surface. the **space credential is the substrate**; richer reader/group semantics live
+> **above** it, in the app. simplespace adds the authority as a member by default.
 > plyr.fm does not depend on any of the removed surface (audited: we never read
 > `members`/`isMember` and never called a member-list route). access for this MVP is
 > **owner-only by plyr's app-layer policy** — see the owner-model section. broader access
@@ -55,32 +57,33 @@ isolation point.
 
 - **Owner DID = artist DID.** Personal namespaces use the user's own DID (diary 5); no
   dedicated space DID is needed until ownership must transfer (shared/gated spaces).
-- **Access: owner-only.** Post-#1573 the protocol has no reader member list — private-space
-  credentials are owner-only by default, and any wider read ACL is plyr's app-layer concern.
-  for this MVP the owner is the sole reader; write legitimacy is also app policy (below).
+- **Access: owner-only.** The personal simplespace uses the baseline `member-list` policy;
+  its authority is added automatically and plyr.fm adds nobody else. any wider read ACL
+  remains plyr's app-layer concern. write legitimacy is also app policy (below).
 - **plyr.fm's OAuth client ID is default-allowed.** The space is created with
-  `appAccessMode: "allow"` and empty `appExceptions`, so any OAuth client (including
-  plyr.fm) may obtain a credential. A future shared-space pass can flip to an allow-list.
+  `appAccess: {"type": "open"}`, so any OAuth client (including plyr.fm) may obtain a
+  credential for an authorized user. A future shared-space pass can flip to an allow-list.
   ZDS binds the issued credential to the requesting client ID and enforces
   `spaceAllowsClient` at `getSpaceCredential` time.
 
-## the read path: OAuth → member grant → space credential (with renewal/errors)
+## the read path: OAuth → delegation token → space credential (with renewal/errors)
 
-1. `getMemberGrant?space=<uri>` — authenticated with the user's **OAuth (DPoP)** token via
-   `make_pds_request`. Returns a short-lived, one-use grant signed by the member's PDS,
+1. `getDelegationToken?space=<uri>` — authenticated with the user's **OAuth (DPoP)** token
+   via `make_pds_request`. Returns a short-lived token signed by the requester's PDS and
    bound to plyr.fm's client ID.
-2. `getSpaceCredential` (POST) — authenticated with the grant as a **plain Bearer** token
-   (grants/credentials are JWTs, *not* DPoP-bound, so they bypass `make_pds_request`'s DPoP
-   path via a raw-bearer helper). Returns an owner-signed space credential (~hours TTL,
-   client-ID-bound), verifiable offline by any member PDS.
+2. `getSpaceCredential` (POST) — authenticated with the delegation token as a **plain
+   Bearer** token (delegation tokens/credentials are JWTs, *not* DPoP-bound, so they bypass
+   `make_pds_request`'s DPoP path via a raw-bearer helper). Returns an authority-signed
+   space credential (~hours TTL, client-ID-bound).
 3. reads (`getRecord`/`listRecords`/`getBlob`) accept the credential as a plain Bearer
    token.
 
 **Renewal:** credentials are cached per `(space, client_id)` for ~50 min; a read that gets
-`401`/`InvalidToken` triggers one re-mint (grant → credential) and retry.
-**Errors:** `AppNotPermitted` / `NotAMember` / `SpaceDeleted` surface as a typed
-`SpaceAccessError`; `getSpaceCredential` requires the member DID to be PLC-resolvable (the
-owner's PDS verifies the grant signature). Code: `backend/_internal/atproto/spaces/client.py`.
+`401`/`InvalidToken` triggers one re-mint (delegation token → credential) and retry.
+**Errors:** authorization refusals and `SpaceDeleted` surface as a typed
+`SpaceAccessError`; `getSpaceCredential` requires the requester DID to be resolvable (the
+authority's PDS verifies the delegation token signature). Code:
+`backend/_internal/atproto/spaces/client.py`.
 
 ## the record, and how it references the blob
 
@@ -108,9 +111,9 @@ richer write/role policy.
 
 ## ZDS endpoints plyr.fm depends on (MVP)
 
-`createSpace`, `getSpace`/`listSpaces` (capability probe + idempotent ensure),
+`simplespace.createSpace`, `space.getSpace`/`listSpaces` (capability probe + idempotent ensure),
 `com.atproto.repo.uploadBlob`, `space.createRecord`/`putRecord`, `space.getRecord`,
-`space.listRecords`, `space.getMemberGrant`, `space.getSpaceCredential`, `space.getBlob`
+`space.listRecords`, `space.getDelegationToken`, `space.getSpaceCredential`, `space.getBlob`
 (with Range). All exist in the current ZDS source; the data path
 (`createSpace`→`uploadBlob`→`createRecord`→`getRecord`/`listRecords`→`getBlob` ranged) is
 verified against a local `ZDS_PERMISSIONED_DATA=true` build by `scripts/permissioned_smoke.py`.

--- a/docs/internal/backend/audio-streaming.md
+++ b/docs/internal/backend/audio-streaming.md
@@ -38,7 +38,7 @@ otherwise (public/unlisted, ungated)   → public path
 audio + record live in the artist's ATProto permissioned space on their PDS,
 never R2. the browser has no space credential, so we cannot redirect — we
 **proxy** the bytes through the owner's credential (`open_space_blob` →
-`getMemberGrant` → `getSpaceCredential` → ranged `getBlob`). access is
+`getDelegationToken` → `getSpaceCredential` → ranged `getBlob`). access is
 **owner-only by plyr's app-layer policy** (the protocol no longer enumerates
 readers — ZDS dropped member lists, #1573); a non-owner or anonymous request
 gets a `404`, identical to a missing file, so private tracks don't leak their

--- a/loq.toml
+++ b/loq.toml
@@ -40,7 +40,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1841
+max_lines = 1843
 
 [[rules]]
 path = "backend/src/backend/config.py"
@@ -224,7 +224,7 @@ max_lines = 645
 
 [[rules]]
 path = "backend/tests/api/test_track_deletion.py"
-max_lines = 521
+max_lines = 574
 
 [[rules]]
 path = "backend/tests/api/test_top_tracks.py"
@@ -284,7 +284,7 @@ max_lines = 2589
 
 [[rules]]
 path = "backend/src/backend/_internal/atproto/client.py"
-max_lines = 874
+max_lines = 888
 
 [[rules]]
 path = "backend/src/backend/_internal/auth/oauth.py"

--- a/scripts/permissioned_smoke.py
+++ b/scripts/permissioned_smoke.py
@@ -87,16 +87,14 @@ def main() -> int:
     created = xrpc(
         c,
         "POST",
-        "com.atproto.space.createSpace",
+        "com.atproto.simplespace.createSpace",
         token=token,
         json={
-            "did": did,
             "type": SPACE_TYPE,
             "skey": SKEY,
             "managingApp": CLIENT_ID,
-            "isPublic": False,
-            "appAccessMode": "allow",
-            "appExceptions": [],
+            "policy": "member-list",
+            "appAccess": {"type": "open"},
         },
     )
     if created.status_code == 400 and "SpaceAlreadyExists" in created.text:
@@ -159,21 +157,21 @@ def main() -> int:
     listed.raise_for_status()
     print(f"✓ listRecords  {listed.text[:120]}")
 
-    # credential flow: OAuth-ish bearer -> member grant -> space credential
-    grant_resp = xrpc(
+    # credential flow: OAuth-ish bearer -> delegation token -> space credential
+    delegation_resp = xrpc(
         c,
         "GET",
-        "com.atproto.space.getMemberGrant",
+        "com.atproto.space.getDelegationToken",
         token=token,
         params={"space": space_uri},
     )
-    grant_resp.raise_for_status()
-    grant = grant_resp.json()["grant"]
-    print("✓ getMemberGrant")
+    delegation_resp.raise_for_status()
+    delegation_token = delegation_resp.json()["token"]
+    print("✓ getDelegationToken")
 
     cred_resp = c.post(
         f"{PDS}/xrpc/com.atproto.space.getSpaceCredential",
-        headers={"authorization": f"Bearer {grant}"},
+        headers={"authorization": f"Bearer {delegation_token}"},
         json={"space": space_uri},
     )
     cred_resp.raise_for_status()

--- a/scripts/permissioned_smoke.py
+++ b/scripts/permissioned_smoke.py
@@ -101,7 +101,9 @@ def main() -> int:
         print("✓ createSpace → already exists (idempotent)")
     else:
         created.raise_for_status()
-        assert created.json()["uri"] == space_uri, created.text
+        # Current ZDS appends an extra closing brace to the successful create
+        # response. The client intentionally ignores this unneeded body.
+        assert f'"uri":"{space_uri}"' in created.text, created.text
         print(f"✓ createSpace  uri={space_uri}")
 
     # write the private track record (reuses the fm.plyr track lexicon body)


### PR DESCRIPTION
## what changed

- create personal private-media spaces through `com.atproto.simplespace.createSpace` using ZDS's current `policy` and `appAccess` shape
- replace the removed member-grant request with `getDelegationToken` and exchange its `token` for a space credential
- ignore the unneeded `createSpace` response body because current ZDS returns successful but malformed JSON (one extra closing brace)
- let full-access app-password sessions drive permissioned uploads in CI
- delete `ats://` records through `com.atproto.space.deleteRecord` and never treat private content hashes as R2 keys
- add a secret-backed live-ZDS integration test to backend CI

## end-to-end coverage

The new test runs the real FastAPI upload pipeline and isolated PostgreSQL/Redis state locally, with only the ATProto boundary pointed at `pds.zat.dev`. It verifies:

1. app-password authentication and permissioned capability detection
2. private WAV upload to the live PDS blobstore
3. personal space creation and `fm.plyr.track` record publication
4. persisted local metadata (`private`, PDS-only, no R2 URL)
5. credential exchange and ranged playback through `/audio` (`206`, `RIFF`)
6. anonymous playback denial (`404`)
7. API deletion of both the local row and live space record

The queue handoff itself is executed inline so CI does not need a second worker process; every upload worker phase remains real.

## why

Current ZDS no longer routes `com.atproto.space.createSpace` or `getMemberGrant`. Capability detection still succeeds, so private media advertised support and then failed during space creation or credential minting. Exercising the complete path also found the app-password scope mismatch, malformed ZDS create response, and missing private-record deletion path.

Fixes #1656.

## validation

- live ZDS integration — passed locally in 2.34s
- focused private-media/protocol/deletion suite — 47 passed
- `just backend lint` — ruff clean; ty completed with 9 pre-existing unrelated warnings
- commit hooks passed, including loq, ruff, formatting, and type checking
- repository secrets `ZAT_TEST_PDS`, `ZAT_TEST_HANDLE`, and `ZAT_TEST_PASSWORD` configured for CI
