### PR TITLE
fix(ci): integration workflow fails loudly when unwired, and prune stops crying wolf

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,8 +39,15 @@ jobs:
         id: check-tokens
         run: |
           if [ -z "${{ secrets.APP_PASSWORD_MINT_SECRET }}" ]; then
-            echo "has_tokens=false" >> $GITHUB_OUTPUT
-            echo "::warning::APP_PASSWORD_MINT_SECRET not configured - integration tests will be skipped"
+            # a missing secret on our own main is a broken pipeline, not a skip;
+            # only a manual dispatch that explicitly opts in may skip
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.skip_if_no_tokens }}" = "true" ]; then
+              echo "has_tokens=false" >> $GITHUB_OUTPUT
+              echo "::warning::APP_PASSWORD_MINT_SECRET not configured - integration tests skipped by request"
+            else
+              echo "::error::APP_PASSWORD_MINT_SECRET is not configured - integration tests cannot run"
+              exit 1
+            fi
           else
             echo "has_tokens=true" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -115,5 +115,5 @@ jobs:
           done
 
       - name: prune uv cache
-        if: always()
+        if: always() && steps.check-tokens.outputs.has_tokens == 'true'
         run: uv cache prune --ci


### PR DESCRIPTION
two behaviors fixed in the `integration tests` workflow, plus the missing wiring set up out-of-band:

1. **prune step no longer fails skipped runs** — it was `always()` while every other step was gated on `has_tokens`, so a skipped run died at `uv cache prune` with exit 127 (`uv` never installed). red on main since july 6 with zero tests failing.
2. **a missing mint secret is now a failure, not a skip** — on `workflow_run` (main) the workflow errors immediately; only a manual dispatch with `skip_if_no_tokens=true` may skip. the silent skip hid the fact that the JIT token pipeline was never wired.

### wiring done alongside this PR (out-of-band, not in the diff)

- generated `AUTH_APP_PASSWORD_MINT_SECRET`, set on `relay-api-staging` together with `AUTH_ALLOW_APP_PASSWORD_DEV_TOKENS=true`
- set the matching `APP_PASSWORD_MINT_SECRET` repo secret
- set `PLYR_TEST_APP_PASSWORD_1` (zzstoatzz.io)
- verified live: minted a JIT token against api-stg.plyr.fm and revoked it (`200`)

### still needed to go green

`PLYR_TEST_APP_PASSWORD_2` (plyr.fm) and `PLYR_TEST_APP_PASSWORD_3` (zzstoatzzdevlog.bsky.social) — app passwords only the account owner can create. until they're set, the mint step fails loudly, which is now the intended behavior for a broken pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)