### PR TITLE
fix(tests): repair staging integration suite now that it actually runs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -106,7 +106,10 @@ jobs:
           PLYR_API_URL: https://api-stg.plyr.fm
         run: |
           cd backend
-          uv run pytest tests/integration -m integration -v --tb=short
+          # test_private_media.py needs local postgres/redis fixtures and runs
+          # in test-backend.yml; this workflow only has the staging API
+          uv run pytest tests/integration -m integration -v --tb=short \
+            --ignore=tests/integration/test_private_media.py
 
       # throw the JIT tokens away — revoke even if the tests failed.
       - name: revoke JIT dev tokens

--- a/backend/tests/integration/test_audio_revisions.py
+++ b/backend/tests/integration/test_audio_revisions.py
@@ -91,14 +91,14 @@ async def test_replace_audio_creates_revision(
     assert integration_settings.token_1
     token = integration_settings.token_1
 
-    upload = await client.upload(
+    upload = await client.tracks.upload(
         drone_a4,
         "integration: replace creates revision",
         tags={"integration-test", "audio-revisions"},
     )
     track_id = upload.track_id
     try:
-        original = await client.get_track(track_id)
+        original = await client.tracks.get(track_id)
         original_file_id = original.file_id
 
         # before any replace: history is empty
@@ -133,7 +133,7 @@ async def test_replace_audio_creates_revision(
             assert "file_id" not in rev
             assert "audio_url" not in rev
     finally:
-        await client.delete(track_id)
+        await client.tracks.delete(track_id)
 
 
 async def test_restore_swaps_audio_and_rotates_revision(
@@ -150,14 +150,14 @@ async def test_restore_swaps_audio_and_rotates_revision(
     assert integration_settings.token_1
     token = integration_settings.token_1
 
-    upload = await client.upload(
+    upload = await client.tracks.upload(
         drone_a4,
         "integration: restore rotates revision",
         tags={"integration-test", "audio-revisions"},
     )
     track_id = upload.track_id
     try:
-        original = await client.get_track(track_id)
+        original = await client.tracks.get(track_id)
         original_file_id = original.file_id
 
         async with httpx.AsyncClient(timeout=60.0) as http:
@@ -206,7 +206,7 @@ async def test_restore_swaps_audio_and_rotates_revision(
             assert revisions_after[0]["id"] == snapshot_payload["id"]
             del replaced_file_id  # asserted indirectly via the snapshot id mapping
     finally:
-        await client.delete(track_id)
+        await client.tracks.delete(track_id)
 
 
 async def test_non_owner_cannot_list_or_restore(
@@ -225,7 +225,7 @@ async def test_non_owner_cannot_list_or_restore(
     token2 = integration_settings.token_2
     del user2_client  # only used to surface the multi-user skip via the fixture
 
-    upload = await user1_client.upload(
+    upload = await user1_client.tracks.upload(
         drone_a4,
         "integration: ownership check on revisions",
         tags={"integration-test", "audio-revisions"},
@@ -268,4 +268,4 @@ async def test_non_owner_cannot_list_or_restore(
             )
             assert restore_resp.status_code == 403
     finally:
-        await user1_client.delete(track_id)
+        await user1_client.tracks.delete(track_id)

--- a/backend/tests/integration/test_interactions.py
+++ b/backend/tests/integration/test_interactions.py
@@ -28,7 +28,7 @@ async def test_cross_user_like(
     client2 = user2_client
 
     # user1 uploads a track
-    result = await client1.upload(
+    result = await client1.tracks.upload(
         drone_a4,
         "Test Drone - Cross User Like",
         tags={"integration-test"},
@@ -37,35 +37,35 @@ async def test_cross_user_like(
 
     try:
         # get initial like count
-        track = await client1.get_track(track_id)
+        track = await client1.tracks.get(track_id)
         initial_likes = track.like_count
 
         # user2 likes the track
-        await client2.like(track_id)
+        await client2.tracks.like(track_id)
 
         # verify like count increased
-        track = await client1.get_track(track_id)
+        track = await client1.tracks.get(track_id)
         assert track.like_count == initial_likes + 1
 
         # verify track appears in user2's liked tracks
-        liked = await client2.liked_tracks(limit=100)
+        liked = await client2.tracks.liked(limit=100)
         liked_ids = [t.id for t in liked]
         assert track_id in liked_ids
 
         # user2 unlikes the track
-        await client2.unlike(track_id)
+        await client2.tracks.unlike(track_id)
 
         # verify like count decreased
-        track = await client1.get_track(track_id)
+        track = await client1.tracks.get(track_id)
         assert track.like_count == initial_likes
 
         # verify track no longer in user2's liked tracks
-        liked = await client2.liked_tracks(limit=100)
+        liked = await client2.tracks.liked(limit=100)
         liked_ids = [t.id for t in liked]
         assert track_id not in liked_ids
 
     finally:
-        await client1.delete(track_id)
+        await client1.tracks.delete(track_id)
 
 
 async def test_cannot_delete_others_track(
@@ -78,7 +78,7 @@ async def test_cannot_delete_others_track(
     client2 = user2_client
 
     # user1 uploads a track
-    result = await client1.upload(
+    result = await client1.tracks.upload(
         drone_e4,
         "Test Drone - Cannot Delete",
         tags={"integration-test"},
@@ -88,7 +88,7 @@ async def test_cannot_delete_others_track(
     try:
         # user2 tries to delete - should fail
         with pytest.raises(Exception) as exc_info:
-            await client2.delete(track_id)
+            await client2.tracks.delete(track_id)
 
         # verify it's a permission error (403 or similar)
         assert (
@@ -96,12 +96,12 @@ async def test_cannot_delete_others_track(
         )
 
         # verify track still exists
-        track = await client1.get_track(track_id)
+        track = await client1.tracks.get(track_id)
         assert track.id == track_id
 
     finally:
         # user1 cleans up
-        await client1.delete(track_id)
+        await client1.tracks.delete(track_id)
 
 
 async def test_cannot_edit_others_track(
@@ -116,7 +116,7 @@ async def test_cannot_edit_others_track(
     client2 = user2_client
 
     # user1 uploads a track
-    result = await client1.upload(
+    result = await client1.tracks.upload(
         drone_c4,
         "Test Drone - Cannot Edit",
         tags={"integration-test"},
@@ -126,7 +126,7 @@ async def test_cannot_edit_others_track(
     try:
         # user2 tries to edit - should fail
         with pytest.raises(Exception) as exc_info:
-            await client2.update_track(
+            await client2.tracks.update(
                 track_id,
                 TrackPatch(title="Malicious Edit"),
             )
@@ -137,11 +137,11 @@ async def test_cannot_edit_others_track(
         )
 
         # verify title unchanged
-        track = await client1.get_track(track_id)
+        track = await client1.tracks.get(track_id)
         assert track.title == "Test Drone - Cannot Edit"
 
     finally:
-        await client1.delete(track_id)
+        await client1.tracks.delete(track_id)
 
 
 async def test_public_track_visibility(
@@ -154,7 +154,7 @@ async def test_public_track_visibility(
     client2 = user2_client
 
     # user1 uploads a track
-    result = await client1.upload(
+    result = await client1.tracks.upload(
         drone_a4,
         "Test Drone - Public Visibility",
         tags={"integration-test"},
@@ -163,9 +163,9 @@ async def test_public_track_visibility(
 
     try:
         # user2 can see the track
-        track = await client2.get_track(track_id)
+        track = await client2.tracks.get(track_id)
         assert track.id == track_id
         assert track.title == "Test Drone - Public Visibility"
 
     finally:
-        await client1.delete(track_id)
+        await client1.tracks.delete(track_id)

--- a/backend/tests/integration/test_longform_upload.py
+++ b/backend/tests/integration/test_longform_upload.py
@@ -115,8 +115,8 @@ async def test_longform_upload_completes(
                     )
         assert track_id is not None, "upload stream ended without a terminal event"
 
-        track = await client.get_track(track_id)
+        track = await client.tracks.get(track_id)
         assert track.title == "longform streaming regression"
     finally:
         if track_id is not None:
-            await client.delete(track_id)
+            await client.tracks.delete(track_id)

--- a/backend/tests/integration/test_lossless_uploads.py
+++ b/backend/tests/integration/test_lossless_uploads.py
@@ -66,7 +66,7 @@ async def _upload_support_gated_track(
     audio_path: Path,
     title: str,
 ) -> int:
-    """upload a supporter-gated track via raw HTTP; the SDK lacks support_gate."""
+    """upload a supporter-gated track via raw HTTP; the SDK lacks visibility."""
     with audio_path.open("rb") as audio_file:
         response = await http.post(
             f"{api_url}/tracks/",
@@ -74,7 +74,9 @@ async def _upload_support_gated_track(
             data={
                 "title": title,
                 "tags": json.dumps(["integration-test", "lossless", "gated"]),
-                "support_gate": json.dumps({"type": "any"}),
+                # visibility is the single visibility/access input (#1557);
+                # the server derives support_gate {"type": "any"} from it
+                "visibility": "supporters",
             },
             files={
                 "file": (

--- a/backend/tests/integration/test_lossless_uploads.py
+++ b/backend/tests/integration/test_lossless_uploads.py
@@ -95,7 +95,7 @@ async def test_upload_flac(user1_client: AsyncPlyrClient, drone_flac: Path):
     """upload FLAC file - stored directly as FLAC (web-playable, no transcoding)."""
     client = user1_client
 
-    result = await client.upload(
+    result = await client.tracks.upload(
         drone_flac,
         "Test FLAC Upload",
         tags={"integration-test", "lossless", "flac"},
@@ -104,20 +104,20 @@ async def test_upload_flac(user1_client: AsyncPlyrClient, drone_flac: Path):
     assert track_id is not None
 
     try:
-        track = await client.get_track(track_id)
+        track = await client.tracks.get(track_id)
         assert track.title == "Test FLAC Upload"
         # FLAC is web-playable — stored directly, no transcoding
         assert track.file_type == "flac", f"expected flac, got {track.file_type}"
 
     finally:
-        await client.delete(track_id)
+        await client.tracks.delete(track_id)
 
 
 async def test_upload_aiff(user1_client: AsyncPlyrClient, drone_aiff: Path):
     """upload AIFF file - should eventually optimize to MP3."""
     client = user1_client
 
-    result = await client.upload(
+    result = await client.tracks.upload(
         drone_aiff,
         "Test AIFF Upload",
         tags={"integration-test", "lossless", "aiff"},
@@ -131,14 +131,14 @@ async def test_upload_aiff(user1_client: AsyncPlyrClient, drone_aiff: Path):
         assert track.file_type == "mp3", f"expected mp3, got {track.file_type}"
 
     finally:
-        await client.delete(track_id)
+        await client.tracks.delete(track_id)
 
 
 async def test_upload_aif(user1_client: AsyncPlyrClient, drone_aif: Path):
     """upload AIF file (AIFF alias) - should eventually optimize to MP3."""
     client = user1_client
 
-    result = await client.upload(
+    result = await client.tracks.upload(
         drone_aif,
         "Test AIF Upload",
         tags={"integration-test", "lossless", "aif"},
@@ -152,7 +152,7 @@ async def test_upload_aif(user1_client: AsyncPlyrClient, drone_aif: Path):
         assert track.file_type == "mp3", f"expected mp3, got {track.file_type}"
 
     finally:
-        await client.delete(track_id)
+        await client.tracks.delete(track_id)
 
 
 async def test_upload_support_gated_aiff_optimizes_to_private_mp3(
@@ -200,13 +200,9 @@ async def test_upload_support_gated_aiff_optimizes_to_private_mp3(
 
             assert track.title == "Test Support-Gated AIFF Upload"
             assert track.file_type == "mp3"
-            # the SDK Track model doesn't carry support_gate; assert via the API
-            gated_response = await http.get(
-                f"{api_url}/tracks/{track_id}", headers=_auth_headers(token)
-            )
-            gated_response.raise_for_status()
-            assert gated_response.json()["support_gate"] == {"type": "any"}
-            assert track.r2_url is None
+            assert track.visibility == "supporters"
+            assert track.support_gate == {"type": "any"}
+            assert track.audio_url is None  # gated: no public r2 url
             assert track.audio_storage == "r2"
             assert track.pds_blob_cid is None
             assert track.original_file_id is not None
@@ -214,7 +210,7 @@ async def test_upload_support_gated_aiff_optimizes_to_private_mp3(
 
         finally:
             if track_id is not None:
-                await client.delete(track_id)
+                await client.tracks.delete(track_id)
 
             restore_response = await http.post(
                 f"{api_url}/preferences/",

--- a/backend/tests/integration/test_lossless_uploads.py
+++ b/backend/tests/integration/test_lossless_uploads.py
@@ -10,46 +10,24 @@ requires:
 
 from __future__ import annotations
 
-import asyncio
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import httpx
 import pytest
 
 from .conftest import IntegrationSettings
+from .utils.tracks import poll_until_file_type
 
 if TYPE_CHECKING:
     from plyrfm import AsyncPlyrClient
 
 pytestmark = [pytest.mark.integration, pytest.mark.timeout(180)]
 
-POLL_INTERVAL_SEC = 1.0
-POLL_MAX_ATTEMPTS = 90
-
 
 def _auth_headers(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
-
-
-async def _poll_until_file_type(
-    client: AsyncPlyrClient,
-    track_id: int,
-    expected_file_type: str,
-) -> Any:
-    """wait for background optimization to swap the track to the target type."""
-    for _ in range(POLL_MAX_ATTEMPTS):
-        track = await client.get_track(track_id)
-        if track.file_type == expected_file_type:
-            return track
-        await asyncio.sleep(POLL_INTERVAL_SEC)
-
-    track = await client.get_track(track_id)
-    raise AssertionError(
-        f"track {track_id} did not become {expected_file_type} within "
-        f"{POLL_MAX_ATTEMPTS * POLL_INTERVAL_SEC}s; still {track.file_type}"
-    )
 
 
 async def _wait_for_upload(
@@ -146,7 +124,7 @@ async def test_upload_aiff(user1_client: AsyncPlyrClient, drone_aiff: Path):
     assert track_id is not None
 
     try:
-        track = await _poll_until_file_type(client, track_id, "mp3")
+        track = await poll_until_file_type(client, track_id, "mp3")
         assert track.title == "Test AIFF Upload"
         assert track.file_type == "mp3", f"expected mp3, got {track.file_type}"
 
@@ -167,7 +145,7 @@ async def test_upload_aif(user1_client: AsyncPlyrClient, drone_aif: Path):
     assert track_id is not None
 
     try:
-        track = await _poll_until_file_type(client, track_id, "mp3")
+        track = await poll_until_file_type(client, track_id, "mp3")
         assert track.title == "Test AIF Upload"
         assert track.file_type == "mp3", f"expected mp3, got {track.file_type}"
 
@@ -216,11 +194,16 @@ async def test_upload_support_gated_aiff_optimizes_to_private_mp3(
                 drone_aiff,
                 "Test Support-Gated AIFF Upload",
             )
-            track = await _poll_until_file_type(client, track_id, "mp3")
+            track = await poll_until_file_type(client, track_id, "mp3")
 
             assert track.title == "Test Support-Gated AIFF Upload"
             assert track.file_type == "mp3"
-            assert track.support_gate == {"type": "any"}
+            # the SDK Track model doesn't carry support_gate; assert via the API
+            gated_response = await http.get(
+                f"{api_url}/tracks/{track_id}", headers=_auth_headers(token)
+            )
+            gated_response.raise_for_status()
+            assert gated_response.json()["support_gate"] == {"type": "any"}
             assert track.r2_url is None
             assert track.audio_storage == "r2"
             assert track.pds_blob_cid is None

--- a/backend/tests/integration/test_record_formats.py
+++ b/backend/tests/integration/test_record_formats.py
@@ -31,7 +31,7 @@ async def test_upload_webm(user1_client: AsyncPlyrClient, drone_webm: Path):
     """upload opus-in-webm (Chromium MediaRecorder) — should transcode to MP3."""
     client = user1_client
 
-    result = await client.upload(
+    result = await client.tracks.upload(
         drone_webm,
         "Test WEBM Upload",
         tags={"integration-test", "record", "webm"},
@@ -40,21 +40,21 @@ async def test_upload_webm(user1_client: AsyncPlyrClient, drone_webm: Path):
     assert track_id is not None
 
     try:
-        track = await client.get_track(track_id)
+        track = await client.tracks.get(track_id)
         assert track.title == "Test WEBM Upload"
         # transcode is a deferred optimize task, not part of the upload path —
         # wait for the mp3 rendition to be swapped in
         track = await poll_until_file_type(client, track_id, "mp3")
         assert track.file_type == "mp3"
     finally:
-        await client.delete(track_id)
+        await client.tracks.delete(track_id)
 
 
 async def test_upload_ogg(user1_client: AsyncPlyrClient, drone_ogg: Path):
     """upload opus-in-ogg (Firefox MediaRecorder) — should transcode to MP3."""
     client = user1_client
 
-    result = await client.upload(
+    result = await client.tracks.upload(
         drone_ogg,
         "Test OGG Upload",
         tags={"integration-test", "record", "ogg"},
@@ -63,11 +63,11 @@ async def test_upload_ogg(user1_client: AsyncPlyrClient, drone_ogg: Path):
     assert track_id is not None
 
     try:
-        track = await client.get_track(track_id)
+        track = await client.tracks.get(track_id)
         assert track.title == "Test OGG Upload"
         # transcode is a deferred optimize task, not part of the upload path —
         # wait for the mp3 rendition to be swapped in
         track = await poll_until_file_type(client, track_id, "mp3")
         assert track.file_type == "mp3"
     finally:
-        await client.delete(track_id)
+        await client.tracks.delete(track_id)

--- a/backend/tests/integration/test_record_formats.py
+++ b/backend/tests/integration/test_record_formats.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from .utils.tracks import poll_until_file_type
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -40,7 +42,10 @@ async def test_upload_webm(user1_client: AsyncPlyrClient, drone_webm: Path):
     try:
         track = await client.get_track(track_id)
         assert track.title == "Test WEBM Upload"
-        assert track.file_type == "mp3", f"expected mp3, got {track.file_type}"
+        # transcode is a deferred optimize task, not part of the upload path —
+        # wait for the mp3 rendition to be swapped in
+        track = await poll_until_file_type(client, track_id, "mp3")
+        assert track.file_type == "mp3"
     finally:
         await client.delete(track_id)
 
@@ -60,6 +65,9 @@ async def test_upload_ogg(user1_client: AsyncPlyrClient, drone_ogg: Path):
     try:
         track = await client.get_track(track_id)
         assert track.title == "Test OGG Upload"
-        assert track.file_type == "mp3", f"expected mp3, got {track.file_type}"
+        # transcode is a deferred optimize task, not part of the upload path —
+        # wait for the mp3 rendition to be swapped in
+        track = await poll_until_file_type(client, track_id, "mp3")
+        assert track.file_type == "mp3"
     finally:
         await client.delete(track_id)

--- a/backend/tests/integration/test_track_lifecycle.py
+++ b/backend/tests/integration/test_track_lifecycle.py
@@ -22,7 +22,7 @@ async def test_upload_verify_delete(user1_client: AsyncPlyrClient, drone_a4: Pat
     client = user1_client
 
     # upload
-    result = await client.upload(
+    result = await client.tracks.upload(
         drone_a4,
         "Test Drone A4",
         tags={"integration-test", "drone"},
@@ -32,7 +32,7 @@ async def test_upload_verify_delete(user1_client: AsyncPlyrClient, drone_a4: Pat
 
     try:
         # verify upload succeeded
-        track = await client.get_track(track_id)
+        track = await client.tracks.get(track_id)
         assert track.title == "Test Drone A4"
         assert "integration-test" in track.tags
         assert "drone" in track.tags
@@ -40,11 +40,11 @@ async def test_upload_verify_delete(user1_client: AsyncPlyrClient, drone_a4: Pat
 
     finally:
         # always cleanup
-        await client.delete(track_id)
+        await client.tracks.delete(track_id)
 
         # verify deletion
         with pytest.raises(Exception):  # noqa: B017
-            await client.get_track(track_id)
+            await client.tracks.get(track_id)
 
 
 async def test_upload_edit_title(user1_client: AsyncPlyrClient, drone_e4: Path):
@@ -54,7 +54,7 @@ async def test_upload_edit_title(user1_client: AsyncPlyrClient, drone_e4: Path):
     client = user1_client
 
     # upload
-    result = await client.upload(
+    result = await client.tracks.upload(
         drone_e4,
         "Test Drone E4 - Original",
         tags={"integration-test"},
@@ -63,22 +63,22 @@ async def test_upload_edit_title(user1_client: AsyncPlyrClient, drone_e4: Path):
 
     try:
         # verify original title
-        track = await client.get_track(track_id)
+        track = await client.tracks.get(track_id)
         assert track.title == "Test Drone E4 - Original"
 
         # edit title
-        updated = await client.update_track(
+        updated = await client.tracks.update(
             track_id,
             TrackPatch(title="Test Drone E4 - Edited"),
         )
         assert updated.title == "Test Drone E4 - Edited"
 
         # verify edit persisted
-        track = await client.get_track(track_id)
+        track = await client.tracks.get(track_id)
         assert track.title == "Test Drone E4 - Edited"
 
     finally:
-        await client.delete(track_id)
+        await client.tracks.delete(track_id)
 
 
 async def test_upload_edit_tags(user1_client: AsyncPlyrClient, drone_c4: Path):
@@ -88,7 +88,7 @@ async def test_upload_edit_tags(user1_client: AsyncPlyrClient, drone_c4: Path):
     client = user1_client
 
     # upload with initial tags
-    result = await client.upload(
+    result = await client.tracks.upload(
         drone_c4,
         "Test Drone C4",
         tags={"integration-test", "original-tag"},
@@ -97,12 +97,12 @@ async def test_upload_edit_tags(user1_client: AsyncPlyrClient, drone_c4: Path):
 
     try:
         # verify initial tags
-        track = await client.get_track(track_id)
+        track = await client.tracks.get(track_id)
         assert "integration-test" in track.tags
         assert "original-tag" in track.tags
 
         # edit tags
-        updated = await client.update_track(
+        updated = await client.tracks.update(
             track_id,
             TrackPatch(tags=["integration-test", "new-tag", "another-tag"]),
         )
@@ -110,7 +110,7 @@ async def test_upload_edit_tags(user1_client: AsyncPlyrClient, drone_c4: Path):
         assert "another-tag" in updated.tags
 
     finally:
-        await client.delete(track_id)
+        await client.tracks.delete(track_id)
 
 
 async def test_upload_appears_in_my_tracks(
@@ -120,7 +120,7 @@ async def test_upload_appears_in_my_tracks(
     """uploaded track appears in user's track list."""
     client = user1_client
 
-    result = await client.upload(
+    result = await client.tracks.upload(
         drone_a4,
         "Test Drone - My Tracks",
         tags={"integration-test"},
@@ -129,12 +129,12 @@ async def test_upload_appears_in_my_tracks(
 
     try:
         # verify track appears in my_tracks
-        my_tracks = await client.my_tracks(limit=100)
+        my_tracks = await client.tracks.my(limit=100)
         track_ids = [t.id for t in my_tracks]
         assert track_id in track_ids
 
     finally:
-        await client.delete(track_id)
+        await client.tracks.delete(track_id)
 
 
 async def test_upload_searchable(user1_client: AsyncPlyrClient, drone_a4: Path):
@@ -146,7 +146,7 @@ async def test_upload_searchable(user1_client: AsyncPlyrClient, drone_a4: Path):
     # use unique title for search
     unique_title = "TestDroneSearchable12345"
 
-    result = await client.upload(
+    result = await client.tracks.upload(
         drone_a4,
         unique_title,
         tags={"integration-test"},
@@ -157,7 +157,7 @@ async def test_upload_searchable(user1_client: AsyncPlyrClient, drone_a4: Path):
         # search may take a moment to index - retry a few times
         found = False
         for _ in range(5):
-            search_result = await client.search(unique_title, type="tracks")
+            search_result = await client.discover.search(unique_title, type="tracks")
             # search results are in search_result.results, filter for tracks
             for item in search_result.results:
                 if item.type == "track" and getattr(item, "id", None) == track_id:
@@ -170,4 +170,4 @@ async def test_upload_searchable(user1_client: AsyncPlyrClient, drone_a4: Path):
         assert found, f"track {track_id} not found in search results"
 
     finally:
-        await client.delete(track_id)
+        await client.tracks.delete(track_id)

--- a/backend/tests/integration/utils/tracks.py
+++ b/backend/tests/integration/utils/tracks.py
@@ -19,12 +19,12 @@ async def poll_until_file_type(
 ) -> Any:
     """wait for the deferred optimize task to swap the track to the target type."""
     for _ in range(POLL_MAX_ATTEMPTS):
-        track = await client.get_track(track_id)
+        track = await client.tracks.get(track_id)
         if track.file_type == expected_file_type:
             return track
         await asyncio.sleep(POLL_INTERVAL_SEC)
 
-    track = await client.get_track(track_id)
+    track = await client.tracks.get(track_id)
     raise AssertionError(
         f"track {track_id} did not become {expected_file_type} within "
         f"{POLL_MAX_ATTEMPTS * POLL_INTERVAL_SEC}s; still {track.file_type}"

--- a/backend/tests/integration/utils/tracks.py
+++ b/backend/tests/integration/utils/tracks.py
@@ -1,0 +1,31 @@
+"""shared track helpers for staging integration tests."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from plyrfm import AsyncPlyrClient
+
+POLL_INTERVAL_SEC = 1.0
+POLL_MAX_ATTEMPTS = 90
+
+
+async def poll_until_file_type(
+    client: AsyncPlyrClient,
+    track_id: int,
+    expected_file_type: str,
+) -> Any:
+    """wait for the deferred optimize task to swap the track to the target type."""
+    for _ in range(POLL_MAX_ATTEMPTS):
+        track = await client.get_track(track_id)
+        if track.file_type == expected_file_type:
+            return track
+        await asyncio.sleep(POLL_INTERVAL_SEC)
+
+    track = await client.get_track(track_id)
+    raise AssertionError(
+        f"track {track_id} did not become {expected_file_type} within "
+        f"{POLL_MAX_ATTEMPTS * POLL_INTERVAL_SEC}s; still {track.file_type}"
+    )

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -860,6 +860,21 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/53/977540be379b0c82550df872912446def343ab0dfa138b8726120427f83d/cyclopts-4.21.0.tar.gz", hash = "sha256:477c18c791c924cca4836f79fce000a7bae45f551e340d9e1654e102c6d9ab9d", size = 190914, upload-time = "2026-07-09T19:07:07.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/f6/1c671874560a70d902dd57028a75411c176910de2df3d6a6a533de424131/cyclopts-4.21.0-py3-none-any.whl", hash = "sha256:ded3ddb15b0c815f44d245011fc4cdd5a4809a3bb8202869e9e02195a87c0e18", size = 230066, upload-time = "2026-07-09T19:07:05.326Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -905,6 +920,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -2103,9 +2127,10 @@ wheels = [
 
 [[package]]
 name = "plyrfm"
-version = "0.0.1a16.dev1+c291037"
-source = { git = "https://github.com/zzstoatzz/plyr-python-client?subdirectory=packages%2Fplyrfm#c2910373083b2e1c6238b40c7f9be22abbf7252d" }
+version = "0.0.1a22.dev1+40c0706"
+source = { git = "https://github.com/zzstoatzz/plyr-python-client?subdirectory=packages%2Fplyrfm#40c07063465d19fc1a2b2b53987e372a653ca119" }
 dependencies = [
+    { name = "cyclopts" },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -2969,6 +2994,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/84/4831f881aa6ff3c976f6d6809b58cdfa350593ffc0dc3c58f5f6586780fb/rich-14.3.1.tar.gz", hash = "sha256:b8c5f568a3a749f9290ec6bddedf835cec33696bfc1e48bcfecb276c7386e4b8", size = 230125, upload-time = "2026-01-24T21:40:44.847Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/2a/a1810c8627b9ec8c57ec5ec325d306701ae7be50235e8fd81266e002a3cc/rich-14.3.1-py3-none-any.whl", hash = "sha256:da750b1aebbff0b372557426fb3f35ba56de8ef954b3190315eb64076d6fb54e", size = 309952, upload-time = "2026-01-24T21:40:42.969Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/d6/d0b9fafc73b65767200da027acab1db1bdb1048f4fea5ebf659df01c700e/rich_rst-2.1.0.tar.gz", hash = "sha256:f4d117b49697f338769759fa5cacf5197da4888b347b9fda2e50aef5cd8d93bd", size = 302732, upload-time = "2026-07-05T02:59:44.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/68/1fc93dd759605b5d00fc98b50200739e41ed32bd22d6ba35ca6c3932371b/rich_rst-2.1.0-py3-none-any.whl", hash = "sha256:7ecd1343ee12c879d0e7ae74c3eb6d263b023d2929c6d114212eb1fd91057255", size = 272987, upload-time = "2026-07-05T02:59:42.792Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
follow-up to #1660: with the JIT pipeline wired and the silent-skip removed, the suite ran for the first time in a month and surfaced accumulated rot. verified green on this branch: [run 29116976516](https://github.com/zzstoatzz/plyr.fm/actions/runs/29116976516) — 22 passed, 4 deselected.

- webm/ogg record-format tests now poll for the deferred optimize-task transcode (shared helper in `tests/integration/utils/tracks.py`) instead of asserting mp3 immediately
- the supporter-gated upload speaks the post-#1557 contract (`visibility=supporters`; the server derives `support_gate`)
- gating/storage assertions go through the SDK, which now surfaces `visibility`/`support_gate`/`audio_storage`/`pds_blob_cid`/`original_file_*` (plyr-python-client#37); lock bumped a16 → a22
- the lock bump crossed the SDK namespace redesign, so all call sites migrated to `client.tracks.*` / `client.discover.search`
- `test_private_media.py` is excluded from this staging-facing workflow — it needs the local postgres/redis fixtures it gets in test-backend.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)