### PR TITLE
feat(playlists): composite covers from member-track artwork

### DIFF
--- a/backend/alembic/versions/2026_07_12_000000_a1c4f2b7d3e9_add_playlist_preview_thumbnails.py
+++ b/backend/alembic/versions/2026_07_12_000000_a1c4f2b7d3e9_add_playlist_preview_thumbnails.py
@@ -1,0 +1,38 @@
+"""add playlist preview thumbnails
+
+Revision ID: a1c4f2b7d3e9
+Revises: 816ec59cc00a
+Create Date: 2026-07-12 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1c4f2b7d3e9"
+down_revision: str | Sequence[str] | None = "816ec59cc00a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add cached member-track artwork previews to playlists.
+
+    up to 4 distinct artwork URLs in playlist order, used to render a
+    composite cover when the playlist has no explicit image. refreshed on
+    item mutations and self-healed on detail reads.
+    """
+    op.add_column(
+        "playlists",
+        sa.Column("preview_thumbnails", JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove cached artwork previews from playlists."""
+    op.drop_column("playlists", "preview_thumbnails")

--- a/backend/src/backend/api/lists/playlists.py
+++ b/backend/src/backend/api/lists/playlists.py
@@ -49,6 +49,7 @@ from backend.storage import storage
 from backend.utilities.redis import get_async_redis_client
 
 from .hydration import hydrate_tracks_from_uris
+from .previews import compute_preview_thumbnails, heal_preview_thumbnails
 from .router import router
 from .schemas import (
     AddTrackRequest,
@@ -82,6 +83,7 @@ def _build_playlist_response(playlist: Playlist, owner_handle: str) -> PlaylistR
         atproto_record_uri=playlist.atproto_record_uri,
         is_private=playlist.is_private,
         created_at=playlist.created_at.isoformat(),
+        preview_thumbnails=playlist.preview_thumbnails or [],
     )
 
 
@@ -296,6 +298,24 @@ async def list_playlists(
         .order_by(Playlist.created_at.desc())
     )
     rows = result.all()
+
+    # legacy private playlists predate the preview cache; their items are
+    # local, so backfill inline. public ones heal on their next detail read.
+    healed = False
+    for playlist, _ in rows:
+        if playlist.preview_thumbnails is None and playlist.is_private:
+            playlist.preview_thumbnails = await compute_preview_thumbnails(
+                db,
+                [
+                    item["uri"]
+                    for item in (playlist.items_json or [])
+                    if item.get("uri")
+                ],
+            )
+            healed = True
+    if healed:
+        await db.commit()
+
     return [
         _build_playlist_response(playlist, artist.handle) for playlist, artist in rows
     ]
@@ -362,6 +382,8 @@ async def get_playlist_by_uri(
         [ref["uri"] for ref in item_refs],
         session_did=session.did if session else None,
     )
+
+    await heal_preview_thumbnails(db, playlist, tracks)
 
     return _build_playlist_with_tracks(playlist, artist.handle, tracks)
 
@@ -435,6 +457,8 @@ async def get_playlist(
         [ref["uri"] for ref in item_refs],
         session_did=session.did if session else None,
     )
+
+    await heal_preview_thumbnails(db, playlist, tracks)
 
     return _build_playlist_with_tracks(playlist, artist.handle, tracks)
 
@@ -523,6 +547,10 @@ async def add_track_to_playlist(
 
         playlist.atproto_record_cid = cid
         playlist.track_count = len(new_items)
+
+    playlist.preview_thumbnails = await compute_preview_thumbnails(
+        db, [item["uri"] for item in new_items if item.get("uri")]
+    )
 
     if not playlist.is_private:
         # private additions don't go in the platform-wide activity feed
@@ -625,6 +653,10 @@ async def remove_track_from_playlist(
         playlist.atproto_record_cid = cid
         playlist.track_count = len(new_items)
 
+    playlist.preview_thumbnails = await compute_preview_thumbnails(
+        db, [item["uri"] for item in new_items if item.get("uri")]
+    )
+
     await db.commit()
     await db.refresh(playlist)
 
@@ -683,6 +715,10 @@ async def reorder_playlist(
             raise HTTPException(
                 status_code=500, detail=f"failed to reorder playlist: {e}"
             ) from e
+
+    playlist.preview_thumbnails = await compute_preview_thumbnails(
+        db, [item["uri"] for item in body.items if item.get("uri")]
+    )
 
     await db.commit()
     await db.refresh(playlist)

--- a/backend/src/backend/api/lists/previews.py
+++ b/backend/src/backend/api/lists/previews.py
@@ -1,0 +1,67 @@
+"""cached member-track artwork previews for composite playlist covers.
+
+`Playlist.preview_thumbnails` holds up to 4 distinct member-track artwork
+URLs in playlist order. clients render a composite cover from them when
+the playlist has no explicit image. refreshed on item mutations and
+self-healed on detail reads.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.models import Playlist, Track
+from backend.schemas import TrackResponse
+
+PREVIEW_THUMBNAIL_LIMIT = 4
+"""max member-track artwork URLs cached per playlist."""
+
+
+async def compute_preview_thumbnails(
+    db: AsyncSession, item_uris: list[str]
+) -> list[str]:
+    """first N distinct member-track artwork URLs, in playlist order.
+
+    tracks without artwork are skipped; duplicates (e.g. an album's tracks
+    sharing one cover) collapse so the composite shows distinct art.
+    """
+    if not item_uris:
+        return []
+    result = await db.execute(
+        select(Track.atproto_record_uri, Track.thumbnail_url, Track.image_url).where(
+            Track.atproto_record_uri.in_(item_uris)
+        )
+    )
+    art_by_uri = {uri: thumbnail or image for uri, thumbnail, image in result.all()}
+    previews: list[str] = []
+    for uri in item_uris:
+        if (art := art_by_uri.get(uri)) and art not in previews:
+            previews.append(art)
+            if len(previews) == PREVIEW_THUMBNAIL_LIMIT:
+                break
+    return previews
+
+
+def previews_from_tracks(tracks: list[TrackResponse]) -> list[str]:
+    """same projection as `compute_preview_thumbnails`, from hydrated tracks."""
+    previews: list[str] = []
+    for track in tracks:
+        if (art := track.thumbnail_url or track.image_url) and art not in previews:
+            previews.append(art)
+            if len(previews) == PREVIEW_THUMBNAIL_LIMIT:
+                break
+    return previews
+
+
+async def heal_preview_thumbnails(
+    db: AsyncSession, playlist: Playlist, tracks: list[TrackResponse]
+) -> None:
+    """refresh the cached previews when they've drifted from actual items.
+
+    detail reads already hydrate the full track list, so this catches edits
+    made by other atproto clients directly against the PDS list record.
+    """
+    if (previews := previews_from_tracks(tracks)) != (
+        playlist.preview_thumbnails or []
+    ):
+        playlist.preview_thumbnails = previews
+        await db.commit()

--- a/backend/src/backend/api/lists/schemas.py
+++ b/backend/src/backend/api/lists/schemas.py
@@ -32,6 +32,9 @@ class PlaylistResponse(BaseModel):
     """null for private playlists (no public ATProto record)."""
     is_private: bool
     created_at: str
+    preview_thumbnails: list[str] = []
+    """up to 4 distinct member-track artwork URLs, in playlist order.
+    clients render a composite cover from these when `image_url` is null."""
 
 
 class PlaylistWithTracksResponse(PlaylistResponse):

--- a/backend/src/backend/models/playlist.py
+++ b/backend/src/backend/models/playlist.py
@@ -62,6 +62,10 @@ class Playlist(Base):
     )
     """only populated for private playlists. shape: `[{"uri", "cid"}, ...]`."""
     track_count: Mapped[int] = mapped_column(default=0)
+    preview_thumbnails: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
+    """up to 4 distinct member-track artwork URLs, in playlist order. cached
+    for composite covers when no explicit image is set; refreshed on item
+    mutations and self-healed on detail reads."""
     show_on_profile: Mapped[bool] = mapped_column(
         Boolean, default=False, nullable=False
     )

--- a/backend/tests/api/test_playlist_preview_thumbnails.py
+++ b/backend/tests/api/test_playlist_preview_thumbnails.py
@@ -1,0 +1,200 @@
+"""tests for playlist preview thumbnails (composite covers).
+
+`preview_thumbnails` caches up to 4 distinct member-track artwork URLs in
+playlist order so clients can render a composite cover when the playlist
+has no explicit image. private playlists are used throughout — their items
+live locally, so the full add/remove/list flow runs without a PDS.
+"""
+
+from collections.abc import Generator
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import Session, get_optional_session, require_auth
+from backend.main import app
+from backend.models import Artist, Playlist, Track
+
+
+class MockSession(Session):
+    """mock session for auth bypass in tests."""
+
+    def __init__(self, did: str = "did:plc:owner"):
+        self.did = did
+        self.handle = "owner.test"
+        self.session_id = "test_session_id"
+        self.access_token = "test_token"
+        self.refresh_token = "test_refresh"
+        self.oauth_session = {
+            "did": did,
+            "handle": "owner.test",
+            "pds_url": "https://test.pds",
+            "authserver_iss": "https://auth.test",
+            "scope": "atproto transition:generic",
+            "access_token": "test_token",
+            "refresh_token": "test_refresh",
+            "dpop_private_key_pem": "fake_key",
+            "dpop_authserver_nonce": "",
+            "dpop_pds_nonce": "",
+        }
+
+
+@pytest.fixture
+async def owner(db_session: AsyncSession) -> Artist:
+    artist = Artist(did="did:plc:owner", handle="owner.test", display_name="Owner")
+    db_session.add(artist)
+    await db_session.commit()
+    return artist
+
+
+@pytest.fixture
+def app_as_owner() -> Generator[FastAPI, None, None]:
+    async def _auth() -> Session:
+        return MockSession(did="did:plc:owner")
+
+    app.dependency_overrides[require_auth] = _auth
+    app.dependency_overrides[get_optional_session] = _auth
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def tracks(db_session: AsyncSession, owner: Artist) -> list[Track]:
+    """six tracks: 0-3 have distinct art, 4 has no art, 5 duplicates 0's art."""
+    rows: list[Track] = []
+    for i in range(6):
+        if i == 4:
+            thumbnail = None
+            image = None
+        elif i == 5:
+            thumbnail = "https://img.test/thumb0.webp"
+            image = "https://img.test/full0.jpg"
+        else:
+            thumbnail = f"https://img.test/thumb{i}.webp"
+            image = f"https://img.test/full{i}.jpg"
+        track = Track(
+            title=f"Track {i}",
+            file_id=f"previewtrack{i}",
+            file_type="audio/mpeg",
+            artist_did=owner.did,
+            atproto_record_uri=f"at://did:plc:owner/fm.plyr.track/preview{i}",
+            atproto_record_cid=f"bafypreview{i}",
+            thumbnail_url=thumbnail,
+            image_url=image,
+        )
+        db_session.add(track)
+        rows.append(track)
+    await db_session.commit()
+    for track in rows:
+        await db_session.refresh(track)
+    return rows
+
+
+def _client(test_app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test")
+
+
+async def _create_private_playlist(client: AsyncClient) -> dict:
+    resp = await client.post(
+        "/lists/playlists", json={"name": "mix", "is_private": True}
+    )
+    assert resp.status_code == 200
+    return resp.json()
+
+
+async def _add_track(client: AsyncClient, playlist_id: str, track: Track) -> dict:
+    resp = await client.post(
+        f"/lists/playlists/{playlist_id}/tracks",
+        json={
+            "track_uri": track.atproto_record_uri,
+            "track_cid": track.atproto_record_cid,
+        },
+    )
+    assert resp.status_code == 200
+    return resp.json()
+
+
+async def test_previews_follow_adds_in_order(
+    app_as_owner: FastAPI, tracks: list[Track]
+) -> None:
+    async with _client(app_as_owner) as client:
+        playlist = await _create_private_playlist(client)
+        assert playlist["preview_thumbnails"] == []
+
+        body = await _add_track(client, playlist["id"], tracks[1])
+        assert body["preview_thumbnails"] == ["https://img.test/thumb1.webp"]
+
+        body = await _add_track(client, playlist["id"], tracks[0])
+        assert body["preview_thumbnails"] == [
+            "https://img.test/thumb1.webp",
+            "https://img.test/thumb0.webp",
+        ]
+
+
+async def test_previews_skip_artless_dedupe_and_cap_at_four(
+    app_as_owner: FastAPI, tracks: list[Track]
+) -> None:
+    async with _client(app_as_owner) as client:
+        playlist = await _create_private_playlist(client)
+        # artless first, then a duplicate of track 0's art, then all four
+        # distinct arts — expect the four distinct thumbnails in item order
+        for track in [tracks[4], tracks[5], tracks[0], tracks[1], tracks[2], tracks[3]]:
+            body = await _add_track(client, playlist["id"], track)
+
+        assert body["preview_thumbnails"] == [
+            "https://img.test/thumb0.webp",
+            "https://img.test/thumb1.webp",
+            "https://img.test/thumb2.webp",
+            "https://img.test/thumb3.webp",
+        ]
+
+
+async def test_previews_refresh_on_remove(
+    app_as_owner: FastAPI, tracks: list[Track]
+) -> None:
+    async with _client(app_as_owner) as client:
+        playlist = await _create_private_playlist(client)
+        await _add_track(client, playlist["id"], tracks[0])
+        await _add_track(client, playlist["id"], tracks[1])
+
+        resp = await client.request(
+            "DELETE",
+            f"/lists/playlists/{playlist['id']}/tracks/{tracks[0].atproto_record_uri}",
+        )
+        assert resp.status_code == 200
+        assert resp.json()["preview_thumbnails"] == ["https://img.test/thumb1.webp"]
+
+
+async def test_legacy_private_playlist_heals_on_list(
+    app_as_owner: FastAPI,
+    db_session: AsyncSession,
+    owner: Artist,
+    tracks: list[Track],
+) -> None:
+    """playlists created before the preview cache have `None`; the list
+    endpoint backfills private ones from their local items."""
+    playlist = Playlist(
+        owner_did=owner.did,
+        name="legacy",
+        is_private=True,
+        items_json=[
+            {"uri": tracks[2].atproto_record_uri, "cid": "c"},
+            {"uri": tracks[0].atproto_record_uri, "cid": "c"},
+        ],
+        track_count=2,
+        preview_thumbnails=None,
+    )
+    db_session.add(playlist)
+    await db_session.commit()
+
+    async with _client(app_as_owner) as client:
+        resp = await client.get("/lists/playlists")
+
+    assert resp.status_code == 200
+    listed = {p["id"]: p for p in resp.json()}
+    assert listed[playlist.id]["preview_thumbnails"] == [
+        "https://img.test/thumb2.webp",
+        "https://img.test/thumb0.webp",
+    ]

--- a/frontend/src/lib/components/AddToMenu.svelte
+++ b/frontend/src/lib/components/AddToMenu.svelte
@@ -3,6 +3,8 @@
 	import { toast } from '$lib/toast.svelte';
 	import { API_URL } from '$lib/config';
 	import type { Playlist } from '$lib/types';
+	import PlaylistCover from '$lib/components/PlaylistCover.svelte';
+	import { hasPlaylistArt } from '$lib/playlist-cover';
 
 	interface Props {
 		trackId: number;
@@ -397,8 +399,10 @@
 										onclick={(e) => addToPlaylist(playlist, e)}
 										disabled={addingToPlaylist === playlist.id}
 									>
-										{#if playlist.image_url}
-											<img src={playlist.image_url} alt="" class="playlist-thumb" />
+										{#if hasPlaylistArt(playlist)}
+											<div class="playlist-thumb">
+												<PlaylistCover imageUrl={playlist.image_url} previews={playlist.preview_thumbnails} />
+											</div>
 										{:else}
 											<div class="playlist-thumb-placeholder">
 												<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -612,7 +616,7 @@
 	}
 
 	.playlist-thumb {
-		object-fit: cover;
+		overflow: hidden;
 	}
 
 	.playlist-thumb-placeholder {

--- a/frontend/src/lib/components/PlaylistCover.stories.svelte
+++ b/frontend/src/lib/components/PlaylistCover.stories.svelte
@@ -1,0 +1,44 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import PlaylistCover from './PlaylistCover.svelte';
+
+	// inline SVG artwork so the stories pull no network images
+	function art(a: string, b: string): string {
+		return `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='240'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop offset='0' stop-color='%23${a}'/%3E%3Cstop offset='1' stop-color='%23${b}'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='240' height='240' fill='url(%23g)'/%3E%3C/svg%3E`;
+	}
+
+	const ARTS = [
+		art('6a9fff', 'c04bff'),
+		art('ff9f6a', 'ff4b6e'),
+		art('6affc4', '4b8bff'),
+		art('ffe86a', 'ff8b4b')
+	];
+
+	const { Story } = defineMeta({
+		title: 'media/PlaylistCover',
+		component: PlaylistCover,
+		parameters: { layout: 'centered' }
+	});
+</script>
+
+<!-- an explicit playlist image always wins, even with member artwork present -->
+<Story name="Explicit image">
+	<div style="width:200px;height:200px;border-radius:8px;overflow:hidden">
+		<PlaylistCover imageUrl={ARTS[0]} previews={ARTS} alt="playlist cover" />
+	</div>
+</Story>
+
+<!-- fewer than 4 distinct member artworks: the first stands in for the cover
+     (spotify's rule — no 2- or 3-pane splits) -->
+<Story name="Fallback to first artwork">
+	<div style="width:200px;height:200px;border-radius:8px;overflow:hidden">
+		<PlaylistCover previews={ARTS.slice(0, 2)} alt="playlist cover" />
+	</div>
+</Story>
+
+<!-- 4+ distinct member artworks: 2x2 mosaic in playlist order -->
+<Story name="Mosaic">
+	<div style="width:200px;height:200px;border-radius:8px;overflow:hidden">
+		<PlaylistCover previews={ARTS} alt="playlist cover" />
+	</div>
+</Story>

--- a/frontend/src/lib/components/PlaylistCover.svelte
+++ b/frontend/src/lib/components/PlaylistCover.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	interface Props {
+		/** explicit playlist cover — always wins when set */
+		imageUrl?: string | null;
+		/** distinct member-track artwork URLs, in playlist order */
+		previews?: string[];
+		alt?: string;
+	}
+
+	let { imageUrl = null, previews = [], alt = '' }: Props = $props();
+
+	// spotify's rule: a 2x2 mosaic only at 4+ distinct artworks; below that,
+	// the first track's artwork stands in for the whole cover
+	const mosaic = $derived(!imageUrl && previews.length >= 4);
+	const src = $derived(imageUrl ?? (previews.length > 0 ? previews[0] : null));
+</script>
+
+{#if mosaic}
+	<div class="cover mosaic" role="img" aria-label={alt}>
+		{#each previews.slice(0, 4) as url (url)}
+			<img src={url} alt="" loading="lazy" />
+		{/each}
+	</div>
+{:else if src}
+	<img {src} {alt} class="cover" loading="lazy" />
+{/if}
+
+<style>
+	.cover {
+		width: 100%;
+		height: 100%;
+		display: block;
+		object-fit: cover;
+	}
+
+	.mosaic {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		grid-template-rows: 1fr 1fr;
+	}
+
+	.mosaic img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+		min-height: 0;
+		min-width: 0;
+	}
+</style>

--- a/frontend/src/lib/playlist-cover.ts
+++ b/frontend/src/lib/playlist-cover.ts
@@ -1,0 +1,9 @@
+import type { Playlist } from '$lib/types';
+
+/** whether a playlist has anything for PlaylistCover to render
+ * (explicit image or member-track artwork) vs. needing a placeholder */
+export function hasPlaylistArt(
+	playlist: Pick<Playlist, 'image_url' | 'preview_thumbnails'>
+): boolean {
+	return !!playlist.image_url || (playlist.preview_thumbnails?.length ?? 0) > 0;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -156,6 +156,9 @@ export interface Playlist {
 	atproto_record_uri: string | null;
 	is_private: boolean;
 	created_at: string;
+	/** up to 4 distinct member-track artwork URLs, in playlist order —
+	 * used for the composite cover when no explicit image is set */
+	preview_thumbnails?: string[];
 }
 
 export interface PlaylistWithTracks extends Playlist {

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -8,6 +8,8 @@
 	import type { PageData } from './$types';
 	import type { Playlist } from '$lib/types';
 	import { toast } from '$lib/toast.svelte';
+	import PlaylistCover from '$lib/components/PlaylistCover.svelte';
+	import { hasPlaylistArt } from '$lib/playlist-cover';
 
 	let { data }: { data: PageData } = $props();
 	let playlists = $state<Playlist[]>(data.playlists);
@@ -183,8 +185,10 @@
 			<div class="playlists-list">
 				{#each playlists as playlist}
 					<a href="/playlist/{playlist.id}" class="collection-card">
-						{#if playlist.image_url}
-							<img src={playlist.image_url} alt="" class="playlist-artwork" />
+						{#if hasPlaylistArt(playlist)}
+							<div class="playlist-artwork">
+								<PlaylistCover imageUrl={playlist.image_url} previews={playlist.preview_thumbnails} />
+							</div>
 						{:else}
 							<div class="collection-icon playlist">
 								<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -361,7 +365,7 @@
 		width: 48px;
 		height: 48px;
 		border-radius: var(--radius-md);
-		object-fit: cover;
+		overflow: hidden;
 		flex-shrink: 0;
 	}
 

--- a/frontend/src/routes/playlist/[id]/+page.svelte
+++ b/frontend/src/routes/playlist/[id]/+page.svelte
@@ -3,6 +3,8 @@
 	import Header from '$lib/components/Header.svelte';
 	import ShareButton from '$lib/components/ShareButton.svelte';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
+	import PlaylistCover from '$lib/components/PlaylistCover.svelte';
+	import { hasPlaylistArt } from '$lib/playlist-cover';
 	import AddTracksModal from '$lib/components/playlist/AddTracksModal.svelte';
 	import OwnerActionButtons from '$lib/components/playlist/OwnerActionButtons.svelte';
 	import PlaylistTrackList from '$lib/components/playlist/PlaylistTrackList.svelte';
@@ -458,8 +460,14 @@
 					aria-label="change cover image"
 					disabled={uploadingCover}
 				>
-					{#if playlist.image_url}
-						<img src={playlist.image_url} alt="{playlist.name} artwork" class="playlist-art" />
+					{#if hasPlaylistArt(playlist)}
+						<div class="playlist-art">
+							<PlaylistCover
+								imageUrl={playlist.image_url}
+								previews={playlist.preview_thumbnails}
+								alt="{playlist.name} artwork"
+							/>
+						</div>
 					{:else}
 						<div class="playlist-art-placeholder">
 							<svg
@@ -519,6 +527,13 @@
 						<SensitiveImage src={playlist.image_url} tooltipPosition="center">
 							<img src={playlist.image_url} alt="{playlist.name} artwork" class="playlist-art" />
 						</SensitiveImage>
+					{:else if playlist.preview_thumbnails?.length}
+						<div class="playlist-art">
+							<PlaylistCover
+								previews={playlist.preview_thumbnails}
+								alt="{playlist.name} artwork"
+							/>
+						</div>
 					{:else}
 						<div class="playlist-art-placeholder">
 							<svg
@@ -720,6 +735,7 @@
 		height: 200px;
 		border-radius: var(--radius-md);
 		object-fit: cover;
+		overflow: hidden;
 		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 	}
 

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -10,6 +10,8 @@
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
 	import SupporterBadge from '$lib/components/SupporterBadge.svelte';
 	import RichText from '$lib/components/RichText.svelte';
+	import PlaylistCover from '$lib/components/PlaylistCover.svelte';
+	import { hasPlaylistArt } from '$lib/playlist-cover';
 	import { moderation } from '$lib/moderation.svelte';
 	import { player } from '$lib/player.svelte';
 	import { queue } from '$lib/queue.svelte';
@@ -667,8 +669,12 @@ $effect(() => {
 					{#each publicPlaylists as playlist}
 						<a href="/playlist/{playlist.id}" class="collection-link">
 							<div class="collection-icon playlist">
-								{#if playlist.image_url}
-									<img src={playlist.image_url} alt="{playlist.name} cover" />
+								{#if hasPlaylistArt(playlist)}
+									<PlaylistCover
+										imageUrl={playlist.image_url}
+										previews={playlist.preview_thumbnails}
+										alt="{playlist.name} cover"
+									/>
 								{:else}
 									<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 										<path d="M9 18V5l12-2v13"/>
@@ -1389,12 +1395,6 @@ $effect(() => {
 	.collection-icon.playlist {
 		background: var(--bg-tertiary);
 		color: var(--text-secondary);
-	}
-
-	.collection-icon.playlist img {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
 	}
 
 	.collection-info {

--- a/loq.toml
+++ b/loq.toml
@@ -96,7 +96,7 @@ max_lines = 523
 
 [[rules]]
 path = "frontend/src/lib/components/AddToMenu.svelte"
-max_lines = 801
+max_lines = 805
 
 [[rules]]
 path = "frontend/src/lib/components/ProfileMenu.svelte"
@@ -252,7 +252,7 @@ max_lines = 594
 
 [[rules]]
 path = "backend/src/backend/api/lists/playlists.py"
-max_lines = 1050
+max_lines = 1086
 
 [[rules]]
 path = "backend/src/backend/api/tracks/audio_replace.py"


### PR DESCRIPTION
playlists without an explicit cover now adopt their member tracks' artwork, spotify-style: a 2×2 mosaic when the playlist has 4+ distinct track artworks, the first track's artwork below that, and the existing list-icon placeholder only when no member has art. an explicitly uploaded cover always wins.

## motivation

placeholder icons made the library and profile playlist rows feel empty even when the playlists were full of art. rather than inventing 2- and 3-pane square splits, this copies the established paradigm exactly (spotify renders a mosaic only at 4+ distinct covers; below that the first cover stands in for the whole) so there's nothing novel to tune.

## design

**backend — a cached `preview_thumbnails` column.** public playlists keep their items on the PDS (the list record is source of truth), so the `GET /playlists` list endpoint has no member tracks to derive art from. instead, `playlists.preview_thumbnails` (JSONB) caches up to 4 **distinct** member-track artwork URLs in playlist order:

- refreshed on every item mutation (add / remove / reorder) — the endpoints already hold the full item list at that point
- self-healed on detail reads (`GET /playlists/{id}`, `/by-uri`), which already hydrate full tracks — this catches edits made by other atproto clients directly against the PDS record
- legacy **private** playlists (rows predating the column) backfill inline in the list endpoint since their items are local; legacy **public** ones heal on their next detail view
- distinctness is by URL, so an album's tracks sharing one cover collapse to a single tile; `thumbnail_url` preferred over `image_url`; artless tracks skipped
- helpers live in a new `backend/api/lists/previews.py`

`PlaylistResponse` grows `preview_thumbnails: list[str]` (default `[]`); `PlaylistWithTracksResponse` inherits it.

**frontend — one shared `PlaylistCover` component** (with a `hasPlaylistArt` helper), replacing four inlined `<img>`/placeholder pairs: library cards, playlist detail hero (both the owner-edit button and read-only variants), profile page playlist rows, and the add-to-playlist menu. the component fills its container; callers keep their existing sizing/placeholder markup, so visuals are unchanged wherever an explicit cover exists. storybook stories cover the three states (explicit image wins / <4 falls back to first artwork / 4+ mosaic).

## intentional non-behaviors

- **no 2- or 3-pane layouts** — below 4 distinct artworks the first artwork is the cover, exactly like spotify. the mosaic threshold is a client concern, so a future layout change needs no backend/API change (the API just serves up to 4 URLs).
- **composite is not written anywhere durable** — not to the PDS list record, not to OG/twitter meta tags (those still use the explicit `image_url` only), not rendered server-side. it's a pure client-side presentation of cached URLs.
- **sensitive-image gating unchanged**: an explicit playlist cover still routes through `SensitiveImage` on the detail page. mosaic tiles are the same track thumbnails already shown ungated in track rows/queue, so they render plain.
- **privacy transitions don't touch previews** — the item set is unchanged by public↔private flips.
- search results and embeds are untouched (they don't currently surface playlist covers beyond `image_url`; follow-up if wanted).

## migration

one additive nullable JSONB column (`a1c4f2b7d3e9`); no backfill step — the heal paths above populate rows organically.

## tests

- `backend/tests/api/test_playlist_preview_thumbnails.py`: previews follow adds in order; artless tracks skipped, duplicates collapsed, cap at 4; refresh on remove; legacy private playlists heal on list.
- storybook stories for `PlaylistCover` (runs under the CI axe a11y gate; the mosaic exposes `role="img"` + `aria-label` rather than four decorative imgs).
- loq: preview helpers extracted to `previews.py`; `playlists.py` and `AddToMenu.svelte` limits relaxed via `just loq-relax` for the residual overage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)