### PR TITLE
feat(playlists): remove-cover action so composites can take over

### DIFF
--- a/backend/src/backend/api/lists/__init__.py
+++ b/backend/src/backend/api/lists/__init__.py
@@ -7,5 +7,6 @@ from .router import router
 from . import reorder as _reorder  # /liked/reorder, /{rkey}/reorder
 from . import resolver as _resolver  # /by-uri
 from . import playlists as _playlists  # /playlists, /playlists/{id}, ...
+from . import covers as _covers  # /playlists/{id}/cover
 
 __all__ = ["router"]

--- a/backend/src/backend/api/lists/covers.py
+++ b/backend/src/backend/api/lists/covers.py
@@ -1,0 +1,122 @@
+"""playlist cover art endpoints — upload and remove.
+
+an explicit cover always wins on clients; removing it lets the composite
+cover (cached member-track artwork, see `previews.py`) take over.
+"""
+
+import contextlib
+import logging
+
+from fastapi import Depends, File, HTTPException, UploadFile
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import Session as AuthSession
+from backend._internal import require_auth
+from backend._internal.image_uploads import COVER_EXTENSIONS, process_image_upload
+from backend.models import Artist, Playlist, get_db
+from backend.storage import storage
+
+from .playlists import _assert_can_mutate, _build_playlist_response
+from .router import router
+from .schemas import PlaylistResponse
+
+logger = logging.getLogger(__name__)
+
+
+async def _get_owned_playlist(
+    db: AsyncSession, playlist_id: str, session: AuthSession
+) -> tuple[Playlist, Artist]:
+    result = await db.execute(
+        select(Playlist, Artist)
+        .join(Artist, Playlist.owner_did == Artist.did)
+        .where(Playlist.id == playlist_id)
+    )
+    row = result.first()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="playlist not found")
+
+    playlist, artist = row
+    _assert_can_mutate(session, playlist)
+    return playlist, artist
+
+
+async def _delete_cover_object_best_effort(playlist: Playlist) -> None:
+    if not playlist.image_id:
+        return
+    with contextlib.suppress(Exception):
+        if playlist.image_url:
+            await storage.delete_image(playlist.image_id, playlist.image_url)
+        else:
+            await storage.delete(playlist.image_id)
+
+
+@router.post("/playlists/{playlist_id}/cover")
+async def upload_playlist_cover(
+    playlist_id: str,
+    session: AuthSession = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+    image: UploadFile = File(...),
+) -> dict[str, str | None]:
+    """upload cover art for a playlist (requires authentication).
+
+    accepts jpg, jpeg, png, webp images up to 20MB.
+    """
+    playlist, _artist = await _get_owned_playlist(db, playlist_id, session)
+
+    try:
+        uploaded = await process_image_upload(
+            image, "playlist", allowed_extensions=COVER_EXTENSIONS
+        )
+
+        # delete old image if exists (prevent R2 object leaks)
+        if playlist.image_id != uploaded.image_id:
+            await _delete_cover_object_best_effort(playlist)
+
+        playlist.image_id = uploaded.image_id
+        playlist.image_url = uploaded.image_url
+        playlist.thumbnail_url = uploaded.thumbnail_url
+        await db.commit()
+
+        return {
+            "image_url": uploaded.image_url,
+            "image_id": uploaded.image_id,
+            "thumbnail_url": uploaded.thumbnail_url,
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"failed to upload playlist cover: {e}")
+        raise HTTPException(
+            status_code=500, detail="failed to upload cover image"
+        ) from e
+
+
+@router.delete("/playlists/{playlist_id}/cover", response_model=PlaylistResponse)
+async def remove_playlist_cover(
+    playlist_id: str,
+    session: AuthSession = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+) -> PlaylistResponse:
+    """remove a playlist's explicit cover art.
+
+    the composite cover (member-track artwork) takes over on clients once
+    `image_url` is null. deleting the R2 object is best-effort — the
+    user-facing state is already correct once the row is cleared.
+    """
+    playlist, artist = await _get_owned_playlist(db, playlist_id, session)
+
+    if not playlist.image_id and not playlist.image_url:
+        raise HTTPException(status_code=400, detail="playlist has no cover")
+
+    await _delete_cover_object_best_effort(playlist)
+
+    playlist.image_id = None
+    playlist.image_url = None
+    playlist.thumbnail_url = None
+    await db.commit()
+    await db.refresh(playlist)
+
+    return _build_playlist_response(playlist, artist.handle)

--- a/backend/src/backend/api/lists/playlists.py
+++ b/backend/src/backend/api/lists/playlists.py
@@ -14,12 +14,11 @@ permissioned-data spec describes reader-side enforcement, even though
 we're not on that substrate yet.
 """
 
-import contextlib
 import json
 import logging
 from typing import Annotated
 
-from fastapi import Depends, File, Form, HTTPException, Query, UploadFile
+from fastapi import Depends, Form, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -34,7 +33,6 @@ from backend._internal.atproto.records import (
     fetch_list_item_uris,
     update_list_record,
 )
-from backend._internal.image_uploads import COVER_EXTENSIONS, process_image_upload
 from backend._internal.recommendations import get_playlist_recommendations
 from backend.config import settings
 from backend.models import (
@@ -45,7 +43,6 @@ from backend.models import (
     get_db,
 )
 from backend.schemas import DeletedResponse
-from backend.storage import storage
 from backend.utilities.redis import get_async_redis_client
 
 from .hydration import hydrate_tracks_from_uris
@@ -756,66 +753,6 @@ async def delete_playlist(
     await db.commit()
 
     return DeletedResponse()
-
-
-@router.post("/playlists/{playlist_id}/cover")
-async def upload_playlist_cover(
-    playlist_id: str,
-    session: AuthSession = Depends(require_auth),
-    db: AsyncSession = Depends(get_db),
-    image: UploadFile = File(...),
-) -> dict[str, str | None]:
-    """upload cover art for a playlist (requires authentication).
-
-    accepts jpg, jpeg, png, webp images up to 20MB.
-    """
-    # verify playlist exists and belongs to the authenticated user
-    result = await db.execute(
-        select(Playlist, Artist)
-        .join(Artist, Playlist.owner_did == Artist.did)
-        .where(Playlist.id == playlist_id)
-    )
-    row = result.first()
-
-    if not row:
-        raise HTTPException(status_code=404, detail="playlist not found")
-
-    playlist, _artist = row
-
-    _assert_can_mutate(session, playlist)
-
-    try:
-        uploaded = await process_image_upload(
-            image, "playlist", allowed_extensions=COVER_EXTENSIONS
-        )
-
-        # delete old image if exists (prevent R2 object leaks)
-        if playlist.image_id and playlist.image_id != uploaded.image_id:
-            with contextlib.suppress(Exception):
-                if playlist.image_url:
-                    await storage.delete_image(playlist.image_id, playlist.image_url)
-                else:
-                    await storage.delete(playlist.image_id)
-
-        # update playlist with new image
-        playlist.image_id = uploaded.image_id
-        playlist.image_url = uploaded.image_url
-        playlist.thumbnail_url = uploaded.thumbnail_url
-        await db.commit()
-
-        return {
-            "image_url": uploaded.image_url,
-            "image_id": uploaded.image_id,
-            "thumbnail_url": uploaded.thumbnail_url,
-        }
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.exception(f"failed to upload playlist cover: {e}")
-        raise HTTPException(
-            status_code=500, detail="failed to upload cover image"
-        ) from e
 
 
 @router.patch("/playlists/{playlist_id}")

--- a/backend/tests/api/test_playlist_preview_thumbnails.py
+++ b/backend/tests/api/test_playlist_preview_thumbnails.py
@@ -167,6 +167,36 @@ async def test_previews_refresh_on_remove(
         assert resp.json()["preview_thumbnails"] == ["https://img.test/thumb1.webp"]
 
 
+async def test_remove_cover_falls_back_to_composite(
+    app_as_owner: FastAPI,
+    db_session: AsyncSession,
+    owner: Artist,
+    tracks: list[Track],
+) -> None:
+    """DELETE /cover clears the explicit image so clients composite from
+    `preview_thumbnails`; a second call is a 400 (nothing to remove)."""
+    async with _client(app_as_owner) as client:
+        playlist = await _create_private_playlist(client)
+        await _add_track(client, playlist["id"], tracks[0])
+
+    row = await db_session.get(Playlist, playlist["id"])
+    assert row is not None
+    row.image_id = "coverimageid"
+    row.image_url = "https://img.test/cover.jpg"
+    row.thumbnail_url = "https://img.test/cover_thumb.webp"
+    await db_session.commit()
+
+    async with _client(app_as_owner) as client:
+        resp = await client.delete(f"/lists/playlists/{playlist['id']}/cover")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["image_url"] is None
+        assert body["preview_thumbnails"] == ["https://img.test/thumb0.webp"]
+
+        resp = await client.delete(f"/lists/playlists/{playlist['id']}/cover")
+        assert resp.status_code == 400
+
+
 async def test_legacy_private_playlist_heals_on_list(
     app_as_owner: FastAPI,
     db_session: AsyncSession,

--- a/frontend/src/lib/playlist-actions.ts
+++ b/frontend/src/lib/playlist-actions.ts
@@ -150,6 +150,20 @@ export async function uploadCover(playlistId: string, file: File): Promise<{ ima
 	return response.json();
 }
 
+/** remove the explicit cover — the composite (member-track artwork) takes over. */
+export async function removeCover(playlistId: string): Promise<Playlist> {
+	const response = await fetch(`${API_URL}/lists/playlists/${playlistId}/cover`, {
+		method: 'DELETE',
+		credentials: 'include'
+	});
+
+	if (!response.ok) {
+		throw new Error(await detailFrom(response, 'failed to remove cover'));
+	}
+
+	return response.json();
+}
+
 /**
  * persist the current track order. returns false when no track has an ATProto
  * record to reference (nothing to persist), true after a successful save.

--- a/frontend/src/routes/playlist/[id]/+page.svelte
+++ b/frontend/src/routes/playlist/[id]/+page.svelte
@@ -128,6 +128,7 @@
 	let editShowOnProfile = $state(false);
 	let coverInputElement = $state<HTMLInputElement | null>(null);
 	let uploadingCover = $state(false);
+	let removingCover = $state(false);
 
 	// recommendations state
 	let recommendations = $state<PlaylistTrackCandidate[]>([]);
@@ -318,6 +319,20 @@
 		uploadCover(file);
 	}
 
+	async function removeCover() {
+		removingCover = true;
+		try {
+			const updated = await playlistActions.removeCover(playlist.id);
+			playlist.image_url = undefined;
+			playlist.preview_thumbnails = updated.preview_thumbnails;
+			toast.success('cover removed');
+		} catch (e) {
+			toast.error(e instanceof Error ? e.message : 'failed to remove cover');
+		} finally {
+			removingCover = false;
+		}
+	}
+
 	async function uploadCover(file: File) {
 		uploadingCover = true;
 		try {
@@ -453,6 +468,7 @@
 				hidden
 			/>
 			{#if isEditMode && isOwner}
+				<div class="playlist-art-col">
 				<button
 					class="playlist-art-wrapper clickable"
 					onclick={() => coverInputElement?.click()}
@@ -521,6 +537,17 @@
 						{/if}
 					</div>
 				</button>
+				{#if playlist.image_url}
+					<button
+						class="remove-cover-btn"
+						type="button"
+						onclick={removeCover}
+						disabled={removingCover}
+					>
+						{removingCover ? 'removing…' : 'remove cover'}
+					</button>
+				{/if}
+				</div>
 			{:else}
 				<div class="playlist-art-wrapper">
 					{#if playlist.image_url}
@@ -756,6 +783,33 @@
 		width: 200px;
 		height: 200px;
 		flex-shrink: 0;
+	}
+
+	.playlist-art-col {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
+		flex-shrink: 0;
+	}
+
+	.remove-cover-btn {
+		background: none;
+		border: none;
+		padding: 0.25rem 0.5rem;
+		font-family: inherit;
+		font-size: var(--text-sm);
+		color: var(--text-muted);
+		cursor: pointer;
+	}
+
+	.remove-cover-btn:hover:not(:disabled) {
+		color: var(--error);
+	}
+
+	.remove-cover-btn:disabled {
+		cursor: default;
+		opacity: 0.6;
 	}
 
 	button.playlist-art-wrapper {


### PR DESCRIPTION
follow-up to #1663: playlists with an explicit cover could never show the new composite artwork because there was no way to *unset* a cover — the edit flow only uploads/replaces. this adds the minimal affordance: in edit mode, a small "remove cover" action appears under the artwork (only when an explicit cover exists). removing it deletes the R2 object, nulls the image fields, and the composite — or the placeholder, if there isn't enough member art — applies immediately.

## design

- **backend**: `DELETE /lists/playlists/{id}/cover` — owner-only (same 404-for-private-non-owners gate as everything else), 400 when there's no cover to remove, best-effort R2 object deletion (row state is what matters), returns the full `PlaylistResponse` so the client gets `preview_thumbnails` for the immediate composite swap.
- **frontend**: `playlistActions.removeCover()` + a text button beneath the art in playlist edit mode. it's a sibling of the change-cover button, not nested inside it (keeping the no-nested-interactive-controls rule from #1642). hover tints `var(--error)` to read as destructive.
- **refactor**: both cover endpoints (upload + the new remove) moved from `playlists.py` into `backend/api/lists/covers.py` with shared owned-playlist lookup and best-effort-delete helpers — `playlists.py` was over its loq limit and covers are a natural module.

## intentional non-behaviors

- no confirmation dialog — removal is low-stakes (re-upload restores any image) and the button is edit-mode-only.
- no checkbox/preference for "use composite" — absence of an explicit cover *is* the signal, matching #1663's precedence rule.
- album covers untouched; this is playlist-only.

## tests

`test_remove_cover_falls_back_to_composite`: DELETE returns 200 with `image_url: null` and populated `preview_thumbnails`; second DELETE is 400. existing playlist suites pass; svelte-check/eslint/loq clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)