### PR TITLE
feat(playlists): og-cover endpoint so link previews match the composite

### DIFF
--- a/backend/src/backend/api/lists/covers.py
+++ b/backend/src/backend/api/lists/covers.py
@@ -4,20 +4,26 @@ an explicit cover always wins on clients; removing it lets the composite
 cover (cached member-track artwork, see `previews.py`) take over.
 """
 
+import asyncio
 import contextlib
 import logging
+from io import BytesIO
 
-from fastapi import Depends, File, HTTPException, UploadFile
+import anyio.to_thread
+import httpx
+from fastapi import Depends, File, HTTPException, Response, UploadFile
+from fastapi.responses import RedirectResponse
+from PIL import Image, ImageOps
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session as AuthSession
-from backend._internal import require_auth
+from backend._internal import get_optional_session, require_auth
 from backend._internal.image_uploads import COVER_EXTENSIONS, process_image_upload
-from backend.models import Artist, Playlist, get_db
+from backend.models import Artist, Playlist, Track, get_db
 from backend.storage import storage
 
-from .playlists import _assert_can_mutate, _build_playlist_response
+from .playlists import _assert_can_mutate, _build_playlist_response, _can_view
 from .router import router
 from .schemas import PlaylistResponse
 
@@ -50,6 +56,98 @@ async def _delete_cover_object_best_effort(playlist: Playlist) -> None:
             await storage.delete_image(playlist.image_id, playlist.image_url)
         else:
             await storage.delete(playlist.image_id)
+
+
+OG_COVER_TILE = 300
+"""side length of each mosaic tile; the composed image is 600x600."""
+
+OG_COVER_CACHE_SECONDS = 3600
+
+
+def _compose_og_mosaic(tiles: list[bytes]) -> bytes:
+    """2x2 grid of the first four artworks, PNG-encoded."""
+    canvas = Image.new("RGB", (OG_COVER_TILE * 2, OG_COVER_TILE * 2))
+    for i, data in enumerate(tiles[:4]):
+        img = Image.open(BytesIO(data))
+        img = ImageOps.exif_transpose(img) or img
+        if img.mode not in ("RGB", "L"):
+            img = img.convert("RGB")
+        img = ImageOps.fit(
+            img, (OG_COVER_TILE, OG_COVER_TILE), Image.Resampling.LANCZOS
+        )
+        canvas.paste(img, ((i % 2) * OG_COVER_TILE, (i // 2) * OG_COVER_TILE))
+    buf = BytesIO()
+    canvas.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+async def _fetch_image(client: httpx.AsyncClient, url: str) -> bytes | None:
+    try:
+        response = await client.get(url, follow_redirects=True, timeout=10.0)
+        response.raise_for_status()
+        return response.content
+    except Exception as e:
+        logger.warning("failed to fetch artwork %s for og cover: %s", url, e)
+        return None
+
+
+async def _full_size_previews(db: AsyncSession, previews: list[str]) -> list[str]:
+    """swap cached thumbnail URLs (96px) for the tracks' full-size artwork.
+
+    entries that don't resolve (e.g. the cache stored `image_url` because the
+    track had no thumbnail) pass through unchanged.
+    """
+    result = await db.execute(
+        select(Track.thumbnail_url, Track.image_url).where(
+            Track.thumbnail_url.in_(previews)
+        )
+    )
+    full_by_thumb = {thumb: image for thumb, image in result.all() if image}
+    return [full_by_thumb.get(url, url) for url in previews]
+
+
+@router.get("/playlists/{playlist_id}/og-cover")
+async def playlist_og_cover(
+    playlist_id: str,
+    db: AsyncSession = Depends(get_db),
+    session: AuthSession | None = Depends(get_optional_session),
+) -> Response:
+    """the playlist's cover as one fetchable image, for link previews.
+
+    scrapers can't run the client-side composite, so this serves whatever
+    the site shows: 307 to the explicit cover when set, a composed 2x2 PNG
+    at 4+ distinct member artworks, 307 to the first artwork below that,
+    404 when there's nothing to show.
+    """
+    result = await db.execute(select(Playlist).where(Playlist.id == playlist_id))
+    playlist = result.scalar_one_or_none()
+
+    if not playlist or not _can_view(session.did if session else None, playlist):
+        raise HTTPException(status_code=404, detail="playlist not found")
+
+    if playlist.image_url:
+        return RedirectResponse(playlist.image_url, status_code=307)
+
+    previews = playlist.preview_thumbnails or []
+    if not previews:
+        raise HTTPException(status_code=404, detail="playlist has no artwork")
+
+    urls = await _full_size_previews(db, previews)
+    if len(urls) < 4:
+        return RedirectResponse(urls[0], status_code=307)
+
+    async with httpx.AsyncClient() as client:
+        fetched = await asyncio.gather(*(_fetch_image(client, url) for url in urls))
+    tiles = [data for data in fetched if data]
+    if len(tiles) < 4:
+        return RedirectResponse(urls[0], status_code=307)
+
+    png = await anyio.to_thread.run_sync(_compose_og_mosaic, tiles)
+    return Response(
+        content=png,
+        media_type="image/png",
+        headers={"Cache-Control": f"public, max-age={OG_COVER_CACHE_SECONDS}"},
+    )
 
 
 @router.post("/playlists/{playlist_id}/cover")

--- a/backend/tests/api/test_playlist_preview_thumbnails.py
+++ b/backend/tests/api/test_playlist_preview_thumbnails.py
@@ -7,13 +7,16 @@ live locally, so the full add/remove/list flow runs without a PDS.
 """
 
 from collections.abc import Generator
+from io import BytesIO
 
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from PIL import Image as PILImage
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, get_optional_session, require_auth
+from backend.api.lists import covers
 from backend.main import app
 from backend.models import Artist, Playlist, Track
 
@@ -195,6 +198,81 @@ async def test_remove_cover_falls_back_to_composite(
 
         resp = await client.delete(f"/lists/playlists/{playlist['id']}/cover")
         assert resp.status_code == 400
+
+
+async def test_og_cover_redirects_to_explicit_cover(
+    app_as_owner: FastAPI,
+    db_session: AsyncSession,
+    owner: Artist,
+    tracks: list[Track],
+) -> None:
+    async with _client(app_as_owner) as client:
+        playlist = await _create_private_playlist(client)
+        await _add_track(client, playlist["id"], tracks[0])
+
+    row = await db_session.get(Playlist, playlist["id"])
+    assert row is not None
+    row.image_url = "https://img.test/cover.jpg"
+    await db_session.commit()
+
+    async with _client(app_as_owner) as client:
+        resp = await client.get(f"/lists/playlists/{playlist['id']}/og-cover")
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "https://img.test/cover.jpg"
+
+
+async def test_og_cover_below_four_redirects_to_full_size_first_artwork(
+    app_as_owner: FastAPI, tracks: list[Track]
+) -> None:
+    """the cache stores 96px thumbnails; the og redirect upgrades to the
+    track's full-size artwork."""
+    async with _client(app_as_owner) as client:
+        playlist = await _create_private_playlist(client)
+        await _add_track(client, playlist["id"], tracks[0])
+        await _add_track(client, playlist["id"], tracks[1])
+
+        resp = await client.get(f"/lists/playlists/{playlist['id']}/og-cover")
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "https://img.test/full0.jpg"
+
+
+async def test_og_cover_404_without_artwork(
+    app_as_owner: FastAPI, tracks: list[Track]
+) -> None:
+    async with _client(app_as_owner) as client:
+        playlist = await _create_private_playlist(client)
+        await _add_track(client, playlist["id"], tracks[4])
+
+        resp = await client.get(f"/lists/playlists/{playlist['id']}/og-cover")
+    assert resp.status_code == 404
+
+
+async def test_og_cover_composes_mosaic_at_four(
+    app_as_owner: FastAPI,
+    tracks: list[Track],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tile_buf = BytesIO()
+    PILImage.new("RGB", (64, 64), color=(200, 40, 40)).save(tile_buf, format="PNG")
+    tile = tile_buf.getvalue()
+
+    async def fake_fetch(client: object, url: str) -> bytes:
+        return tile
+
+    monkeypatch.setattr(covers, "_fetch_image", fake_fetch)
+
+    async with _client(app_as_owner) as client:
+        playlist = await _create_private_playlist(client)
+        for track in tracks[:4]:
+            await _add_track(client, playlist["id"], track)
+
+        resp = await client.get(f"/lists/playlists/{playlist['id']}/og-cover")
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "image/png"
+    assert "max-age" in resp.headers["cache-control"]
+    composed = PILImage.open(BytesIO(resp.content))
+    assert composed.size == (600, 600)
 
 
 async def test_legacy_private_playlist_heals_on_list(

--- a/frontend/src/routes/playlist/[id]/+page.svelte
+++ b/frontend/src/routes/playlist/[id]/+page.svelte
@@ -431,10 +431,12 @@
 	<meta property="og:site_name" content={APP_NAME} />
 	{#if playlist.image_url}
 		<meta property="og:image" content={playlist.image_url} />
+	{:else if playlist.preview_thumbnails?.length}
+		<meta property="og:image" content="{API_URL}/lists/playlists/{playlist.id}/og-cover" />
 	{/if}
 
 	<!-- Twitter -->
-	<meta name="twitter:card" content={playlist.image_url ? 'summary_large_image' : 'summary'} />
+	<meta name="twitter:card" content={hasPlaylistArt(playlist) ? 'summary_large_image' : 'summary'} />
 	<meta name="twitter:title" content={playlist.name} />
 	<meta
 		name="twitter:description"
@@ -445,6 +447,8 @@
 	/>
 	{#if playlist.image_url}
 		<meta name="twitter:image" content={playlist.image_url} />
+	{:else if playlist.preview_thumbnails?.length}
+		<meta name="twitter:image" content="{API_URL}/lists/playlists/{playlist.id}/og-cover" />
 	{/if}
 	<link
 		rel="alternate"


### PR DESCRIPTION
follow-up to #1663/#1664: sharing a playlist that relies on the composite cover produced a link preview with **no image** — the mosaic exists only as client-side CSS, and the page emitted `og:image`/`twitter:image` only when an explicit cover was set. removing a cover (#1664) therefore *downgraded* that playlist's link previews. reported live: removing the cover on a real playlist and pasting the link produced an imageless card (telemetry shows the cover DELETE followed by the scraper's `/meta` fetches).

## design

**`GET /lists/playlists/{id}/og-cover`** (in `covers.py`) serves the playlist's cover as a single fetchable image, mirroring the site's precedence exactly:

- explicit cover set → **307** to `image_url`
- 4+ distinct member artworks → composed **600×600 PNG** of the same 2×2 the site renders, `Cache-Control: public, max-age=3600`
- 1–3 artworks → **307** to the first artwork
- no artwork → **404**; private playlists stay 404 for non-owners (same `_can_view` gate)

detail worth noting: the cached `preview_thumbnails` are 96px thumbnails — fine for 48px library cards, blurry for a link card. the endpoint resolves each thumbnail back to its track's **full-size** `image_url` before redirecting/composing (entries that stored a full-size URL because the track had no thumbnail pass through unchanged). fetches are concurrent with per-image failure tolerance (if fewer than 4 tiles survive, degrade to the first-artwork redirect rather than a gappy mosaic); PIL composition runs off the event loop via `anyio.to_thread`.

**frontend**: `og:image`/`twitter:image` fall back to the endpoint when there's no explicit cover but previews exist; `twitter:card` upgrades to `summary_large_image` whenever any art exists (was: only for explicit covers).

## intentional non-behaviors

- no R2 persistence of the composed PNG — it's cheap to compose (four CDN-cached fetches + one paste), scraper traffic is sparse, and an hour of HTTP caching covers repeat scrapes. persisting would add invalidation coupling to every playlist mutation.
- no `og:image:width`/`height` tags — scrapers read dimensions from the image itself.
- track/album link previews untouched — they always have a single real image already.

## tests

four new cases in `test_playlist_preview_thumbnails.py`: explicit-cover 307, <4 redirect upgrades thumb→full-size, artless 404, and the 4+ mosaic (fetch mocked; asserts png content-type, cache-control, and 600×600 composition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)