### PR TITLE
fix(playlists): carry preview_thumbnails through the SSR meta path

### DIFF
--- a/frontend/src/routes/playlist/[id]/+page.ts
+++ b/frontend/src/routes/playlist/[id]/+page.ts
@@ -28,6 +28,7 @@ export async function load({ params, data }: LoadEvent): Promise<PageData> {
 				atproto_record_uri: serverData?.playlistMeta?.atproto_record_uri ?? null,
 				is_private: serverData?.playlistMeta?.is_private ?? false,
 				created_at: serverData?.playlistMeta?.created_at ?? '',
+				preview_thumbnails: serverData?.playlistMeta?.preview_thumbnails ?? [],
 				tracks: [],
 			},
 			playlistMeta: serverData?.playlistMeta ?? null,

--- a/frontend/src/routes/playlist/[id]/og-meta.test.ts
+++ b/frontend/src/routes/playlist/[id]/og-meta.test.ts
@@ -1,0 +1,44 @@
+// regression: the SSR branch of the playlist load rebuilds the playlist
+// object field-by-field from /meta; dropping a field there silently strips
+// it from the OG head render (preview_thumbnails went missing → imageless
+// link previews for composite covers).
+import { describe, expect, it, vi } from 'vitest';
+import type { LoadEvent } from '@sveltejs/kit';
+import type { Playlist } from '$lib/types';
+
+vi.mock('$app/environment', () => ({ browser: false }));
+
+import { load } from './+page';
+
+const meta: Playlist = {
+	id: 'p1',
+	name: 'ambient',
+	owner_did: 'did:plc:owner',
+	owner_handle: 'owner.test',
+	track_count: 4,
+	show_on_profile: false,
+	atproto_record_uri: null,
+	is_private: false,
+	created_at: '2026-01-01T00:00:00Z',
+	preview_thumbnails: ['a.webp', 'b.webp', 'c.webp', 'd.webp']
+};
+
+describe('playlist SSR load', () => {
+	it('carries preview_thumbnails through to the head data', async () => {
+		const result = await load({
+			params: { id: 'p1' },
+			data: { playlistMeta: meta }
+		} as unknown as LoadEvent);
+
+		expect(result.playlist.preview_thumbnails).toEqual(['a.webp', 'b.webp', 'c.webp', 'd.webp']);
+	});
+
+	it('defaults to no previews when meta is unavailable', async () => {
+		const result = await load({
+			params: { id: 'p1' },
+			data: { playlistMeta: null }
+		} as unknown as LoadEvent);
+
+		expect(result.playlist.preview_thumbnails).toEqual([]);
+	});
+});


### PR DESCRIPTION
#1665 shipped the og-cover endpoint and pointed the playlist page's `og:image` at it — but pasting a composite-cover playlist link still produced an imageless card. root cause: the SSR branch of `+page.ts` rebuilds the playlist object **field by field** from the server-loaded `/meta` response and never copied `preview_thumbnails`, so the head's `{:else if playlist.preview_thumbnails?.length}` was always false during SSR — exactly the render scrapers see. (the field is optional in the `Playlist` type, so typechecking couldn't catch the omission.)

one-line fix: pass `preview_thumbnails` through with an `[]` default.

regression test (`og-meta.test.ts`) drives the real SSR load path (`$app/environment` mocked to `browser: false`) and asserts the previews survive into the head data — verified failing against the pre-fix load and passing with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)