### PR TITLE
fix(queue): drop the redundant queue chip, honest shuffle tooltip, empty-state CTA

### DIFF
--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -359,9 +359,8 @@
 					</button>
 					<button
 						class="shuffle-btn"
-						class:active={queue.shuffle}
 						onclick={() => queue.toggleShuffle()}
-						title={queue.shuffle ? 'disable shuffle' : 'enable shuffle'}
+						title="shuffle up next"
 					>
 						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 							<polyline points="16 3 21 3 21 8"></polyline>
@@ -444,8 +443,6 @@
 							<a class="source-chip radio-source" href="/radio">{currentSourceLabel}</a>
 						{:else if jam.active && jam.code}
 							<a class="source-chip" href={`/jam/${jam.code}`}>{currentSourceLabel}</a>
-						{:else}
-							<span class="source-chip">{currentSourceLabel}</span>
 						{/if}
 					</div>
 					<div class="now-playing-card">
@@ -497,6 +494,7 @@
 				{:else}
 					<div class="empty-up-next">
 						<span>nothing else in the queue</span>
+						<a href="/for-you" class="empty-cta">find something to play</a>
 					</div>
 				{/if}
 			</section>
@@ -742,7 +740,6 @@
 		background: var(--bg-secondary);
 	}
 
-	.shuffle-btn.active,
 	.repeat-btn.active {
 		color: var(--accent);
 		border-color: var(--accent);
@@ -1084,11 +1081,26 @@
 	}
 
 	.empty-up-next {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
 		border: 1px dashed var(--border-subtle);
 		border-radius: var(--radius-base);
 		padding: 1.25rem;
 		text-align: center;
 		color: var(--text-tertiary);
+	}
+
+	.empty-cta {
+		font-size: var(--text-sm);
+		color: var(--accent);
+		text-decoration: none;
+		transition: color 0.15s ease;
+	}
+
+	.empty-cta:hover {
+		text-decoration: underline;
 	}
 
 	.queue.empty {


### PR DESCRIPTION
three pieces of queue-panel noise reported from live use, all in `Queue.svelte`.

## what changed

**1. the redundant "queue" chip on the now-playing row is gone.** the panel is already titled QUEUE; a chip restating "queue" two rows down was pure visual noise. the chip remains only when it carries information: `radio` (links to /radio) and `jam` (links to the jam) — i.e. when what's playing is *not* from the queue.

**2. the shuffle tooltip no longer claims to be a mode.** `toggleShuffle()` is documented and implemented as "an action, not a mode" (`queue.svelte.ts`) — it reshuffles the explicit up-next once per press and never sets the `queue.shuffle` flag. the old `enable shuffle` / `disable shuffle` toggle wording (and the `class:active={queue.shuffle}` styling keyed on a flag the button never sets) described a mode that doesn't exist. now a static `shuffle up next`, with the dead `.shuffle-btn.active` selector removed (svelte-check flags unused selectors).

**3. the empty up-next state has a call to action.** "nothing else in the queue" now carries a `find something to play` accent link to `/for-you`, styled like the existing continuation-header source links (accent color, lowercase, underline on hover).

## intentionally not done

- the `queue.shuffle` state field itself is untouched — it round-trips through the cross-tab queue-state payload and `originalOrder` maintenance; pruning it is a separate cleanup.
- jam-mode header and radio/jam chips are behaviorally unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)