### PR TITLE
fix(queue): clear means clear your picks — never veto keep-playing

### DIFF
--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -360,7 +360,8 @@
 					<button
 						class="shuffle-btn"
 						onclick={() => queue.toggleShuffle()}
-						title="shuffle up next"
+						disabled={explicitUpcoming.length < 2}
+						title={explicitUpcoming.length < 2 ? 'nothing to shuffle' : 'shuffle up next'}
 					>
 						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 							<polyline points="16 3 21 3 21 8"></polyline>
@@ -386,11 +387,11 @@
 							{/if}
 						</svg>
 					</button>
-					{#if upcoming.length > 0}
+					{#if explicitUpcoming.length > 0}
 						<button
 							class="clear-btn"
 							onclick={() => queue.clearUpNext()}
-							title="clear upcoming tracks"
+							title="clear your queued tracks"
 						>
 							clear
 						</button>
@@ -733,11 +734,16 @@
 		transition: all 0.15s ease;
 	}
 
-	.shuffle-btn:hover,
+	.shuffle-btn:hover:not(:disabled),
 	.repeat-btn:hover {
 		color: var(--text-secondary);
 		border-color: var(--border-default);
 		background: var(--bg-secondary);
+	}
+
+	.shuffle-btn:disabled {
+		opacity: 0.4;
+		cursor: default;
 	}
 
 	.repeat-btn.active {

--- a/frontend/src/lib/queue-context.test.ts
+++ b/frontend/src/lib/queue-context.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { queue, shuffleInPlace } from '$lib/queue.svelte';
 import { player } from '$lib/player.svelte';
+import { forYouCache } from '$lib/for-you.svelte';
 import type { Track } from '$lib/types';
 
 function track(id: number): Track {
@@ -106,6 +107,58 @@ describe('queue.playContext', () => {
 		// track 2 stays in the explicit region and is not re-added to the tail
 		expect(queue.tracks.map((t) => t.id)).toEqual([5, 2, 6]);
 		expect(queue.continuationFromIndex).toBe(2);
+	});
+});
+
+// "clear" clears the conscious picks — the tracks the user explicitly queued.
+// it must never touch the continuation tail or veto keep-playing backfill
+// (a persisted suppression flag used to silently kill keep-playing until the
+// next explicit add).
+describe('queue.clearUpNext', () => {
+	it('removes explicit up-next but keeps the continuation tail', () => {
+		queue.setQueue(album([1, 2, 3]), 0); // current 1, explicit up-next 2, 3
+		queue.appendContinuation(album([50, 51])); // For You tail
+
+		queue.clearUpNext();
+
+		expect(queue.tracks.map((t) => t.id)).toEqual([1, 50, 51]);
+		expect(queue.currentIndex).toBe(0);
+		expect(queue.continuationFromIndex).toBe(1);
+	});
+
+	it('keeps a labeled collection tail too', () => {
+		queue.setQueue(album([1, 2]), 0); // explicit up-next: 2
+		queue.playContext(album([10, 11, 12]), 0, 'road mix'); // tapped 10, explicit 2, tail 11, 12
+
+		queue.clearUpNext();
+
+		expect(queue.tracks.map((t) => t.id)).toEqual([10, 11, 12]);
+		expect(queue.continuationLabel).toBe('road mix');
+	});
+
+	it('does not block keep-playing backfill afterwards', async () => {
+		queue.setQueue(album([1, 2]), 0);
+		queue.clearUpNext();
+		expect(queue.tracks.map((t) => t.id)).toEqual([1]);
+
+		// keep-playing tops the tail back up — a past clear must not veto it
+		forYouCache.tracks = album([60, 61]);
+		forYouCache.hasMore = false;
+		await queue.fillContinuation();
+
+		// the tail is shuffled on append, so assert membership not order
+		expect(queue.tracks.map((t) => t.id).sort()).toEqual([1, 60, 61]);
+		expect(queue.currentTrack?.id).toBe(1);
+		expect(queue.isContinuationIndex(1)).toBe(true);
+	});
+
+	it('no-ops when there are no explicit picks (tail-only queue)', () => {
+		queue.setQueue(album([1]), 0);
+		queue.appendContinuation(album([50, 51]));
+
+		queue.clearUpNext();
+
+		expect(queue.tracks.map((t) => t.id)).toEqual([1, 50, 51]);
 	});
 });
 

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -55,14 +55,6 @@ class Queue {
 	continuationFromIndex = $state(0);
 
 	/**
-	 * "the user explicitly cleared the queue" intent. Suppresses backfill until
-	 * the next explicit play context so "clear upcoming" actually clears.
-	 * Persisted (`continuation_suppressed`) so the clear is authoritative across
-	 * tabs and reloads, not just in the tab that clicked it.
-	 */
-	suppressContinuation = false;
-
-	/**
 	 * Label for the continuation tail, rendered as "next from: <label>".
 	 * `null` means the tail is the For You feed (the default fallback source).
 	 * A collection name (album/playlist) is set by `playContext` when a track is
@@ -350,10 +342,6 @@ class Queue {
 				? Math.max(0, Math.min(restored, this.tracks.length))
 				: this.tracks.length;
 
-		// restore the "user cleared it" intent so clear stays authoritative
-		// across tabs/reload (a refilling tab can't undo another's clear)
-		this.suppressContinuation = state.continuation_suppressed ?? false;
-
 		// a tail with no items has no meaningful label
 		this.continuationLabel =
 			this.continuationFromIndex < this.tracks.length ? (state.continuation_label ?? null) : null;
@@ -434,7 +422,6 @@ class Queue {
 				original_order_ids: this.originalOrder.map((t) => t.file_id),
 				progress_ms: this.progressMs,
 				continuation_from_index: this.continuationFromIndex,
-				continuation_suppressed: this.suppressContinuation,
 				continuation_label: this.continuationLabel
 			};
 
@@ -543,7 +530,6 @@ class Queue {
 		if (tracks.length === 0) return;
 
 		this.lastUpdateWasLocal = true;
-		this.suppressContinuation = false;
 
 		// explicit adds slot ahead of the continuation tail (so the user's own picks
 		// play before recommendations) but never before the current track —
@@ -634,7 +620,6 @@ class Queue {
 		}
 
 		this.lastUpdateWasLocal = true;
-		this.suppressContinuation = false;
 		this.tracks = [...tracks];
 		this.originalOrder = [...tracks];
 		this.currentIndex = this.clampIndex(startIndex);
@@ -645,7 +630,6 @@ class Queue {
 	playNow(track: Track, autoPlay = true) {
 		player.radio = null; // playing a track leaves radio mode
 		this.lastUpdateWasLocal = autoPlay;
-		this.suppressContinuation = false;
 		// keep explicitly-queued up-next, but drop the stale "next from" tail —
 		// the new track is a new context, so let backfill regenerate it
 		const upNext = this.tracks.slice(this.currentIndex + 1, this.continuationFromIndex);
@@ -670,7 +654,6 @@ class Queue {
 		if (tracks.length === 0) return;
 		player.radio = null; // playing a track leaves radio mode
 		this.lastUpdateWasLocal = true;
-		this.suppressContinuation = false;
 
 		const start = Math.max(0, Math.min(startIndex, tracks.length - 1));
 		const tapped = tracks[start];
@@ -691,7 +674,6 @@ class Queue {
 
 	clear() {
 		this.lastUpdateWasLocal = true;
-		this.suppressContinuation = false;
 		this.tracks = [];
 		this.originalOrder = [];
 		this.currentIndex = 0;
@@ -862,21 +844,21 @@ class Queue {
 		this.syncState();
 	}
 
+	/**
+	 * Clear the explicit up-next picks — the tracks the user consciously queued.
+	 * The continuation tail (a collection remainder or the For You backfill) is
+	 * not a conscious pick, so it stays; "keep playing" keeps playing.
+	 */
 	clearUpNext() {
-		if (this.tracks.length === 0) return;
+		const start = this.currentIndex + 1;
+		const end = Math.max(start, Math.min(this.continuationFromIndex, this.tracks.length));
+		if (end <= start) return;
 
 		this.lastUpdateWasLocal = true;
-
-		// keep only the current track
-		const currentTrack = this.tracks[this.currentIndex];
-		if (!currentTrack) return;
-
-		// explicit "clear" intent — don't let backfill immediately refill it
-		this.suppressContinuation = true;
-		this.tracks = [currentTrack];
-		this.originalOrder = [currentTrack];
-		this.currentIndex = 0;
-		this.resetContinuation();
+		const removedIds = new Set(this.tracks.slice(start, end).map((t) => t.file_id));
+		this.tracks = [...this.tracks.slice(0, start), ...this.tracks.slice(end)];
+		this.originalOrder = this.originalOrder.filter((t) => !removedIds.has(t.file_id));
+		this.continuationFromIndex = start;
 
 		this.syncState();
 	}
@@ -890,7 +872,6 @@ class Queue {
 	async fillContinuation(): Promise<void> {
 		if (!browser) return;
 		if (this.jamBridge) return;
-		if (this.suppressContinuation) return;
 		if (this.backfilling) return;
 
 		this.backfilling = true;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -106,8 +106,6 @@ export interface QueueState {
 	progress_ms?: number;
 	/** index where the auto-generated continuation tail begins (== length when none) */
 	continuation_from_index?: number;
-	/** user explicitly cleared the queue — suppress backfill until next play context */
-	continuation_suppressed?: boolean;
 	/** label for the continuation tail ("next from: <label>"); null/absent => the For You feed */
 	continuation_label?: string | null;
 	repeat_mode?: RepeatMode;


### PR DESCRIPTION
"keep playing" was silently dead for anyone who had ever pressed "clear": `clearUpNext()` set a **persisted** `suppressContinuation` flag that blocked For You backfill until the next explicit queue action. the symptom (reported from live use): queue panel says "nothing else in the queue" despite keep-playing being enabled in settings — then adding any track "mysteriously" makes the "next from: for you" tail appear (because `addTracks` reset the flag).

the design call: **clear means clear the conscious choices you've made to queue up songs.** it is not an override of the ambient-continuation setting. so the suppression mechanism isn't mistuned — it's wrong, and it's removed entirely.

## what changed

- **`suppressContinuation` is gone**: the field, its persistence (`continuation_suppressed` in queue state), the guard in `fillContinuation`, and the five scattered resets. older persisted states carrying the key are simply ignored.
- **`clearUpNext()` now removes only the explicit up-next region** (between the current track and `continuationFromIndex`). the continuation tail — For You backfill or a labeled collection remainder — survives, and keep-playing keeps refilling as designed. it also no longer discards played history.
- **the clear button shows only when there are explicit picks to clear** (`explicitUpcoming` instead of all `upcoming`), and its tooltip says what it does: "clear your queued tracks".
- **shuffle is disabled when there's nothing it can shuffle**: `toggleShuffle` only reorders the explicit up-next (the auto tail is already shuffled at generation), and it silently no-ops below 2 explicit picks — the button now reflects that (disabled + "nothing to shuffle") instead of pretending to work.

## regression tests

new `queue.clearUpNext` suite in `queue-context.test.ts`: clear keeps the For You tail; clear keeps a labeled collection tail; clear does not block a subsequent `fillContinuation` (seeded via `forYouCache` — this one fails against the old suppression guard); tail-only queues no-op.

## intentionally not done

- the empty-state "find something to play" → /for-you link (shipped in #1667) stays: with suppression gone it now only shows in states where the queue genuinely has nothing coming.
- jam-mode clear path untouched (jams have no continuation).
- the vestigial `queue.shuffle` boolean still exists in state sync; pruning it is separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)