### PR TITLE
fix(queue): give the empty up-next region a drop target

### DIFF
--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -21,6 +21,10 @@
 	let touchDragElement = $state<HTMLElement | null>(null);
 	let queueTracksElement = $state<HTMLElement | null>(null);
 
+	// drop target for promoting a tail track when the explicit up-next is empty
+	let dropZoneElement = $state<HTMLElement | null>(null);
+	let dropZoneActive = $state(false);
+
 	// per-track artwork load failures (file_id), so a broken thumbnail falls
 	// back to the placeholder rather than showing a busted image
 	let imgErrored = $state(new Set<string>());
@@ -149,6 +153,16 @@
 		const offset = touchCurrentY - touchStartY;
 		touchDragElement.style.transform = `translateY(${offset}px)`;
 
+		// hovering the empty up-next drop zone promotes instead of reordering
+		if (dropZoneElement) {
+			const rect = dropZoneElement.getBoundingClientRect();
+			dropZoneActive = touch.clientY >= rect.top && touch.clientY <= rect.bottom;
+			if (dropZoneActive) {
+				dragOverIndex = null;
+				return;
+			}
+		}
+
 		// find which track we're hovering over
 		const tracks = queueTracksElement.querySelectorAll('.queue-track');
 		for (let i = 0; i < tracks.length; i++) {
@@ -173,9 +187,12 @@
 	}
 
 	function handleTouchEnd() {
-		if (touchDragIndex !== null && dragOverIndex !== null && touchDragIndex !== dragOverIndex) {
+		if (touchDragIndex !== null && dropZoneActive) {
+			queue.promoteToUpNext(touchDragIndex);
+		} else if (touchDragIndex !== null && dragOverIndex !== null && touchDragIndex !== dragOverIndex) {
 			queue.moveTrack(touchDragIndex, dragOverIndex);
 		}
+		dropZoneActive = false;
 
 		// cleanup
 		if (touchDragElement) {
@@ -470,6 +487,31 @@
 						{#each explicitUpcoming as { track, index } (`${track.file_id}:${index}`)}
 							{@render queueRow(track, index)}
 						{/each}
+
+						{#if explicitUpcoming.length === 0 && continuationUpcoming.length > 0}
+							<!-- with no explicit picks the up-next region has zero height, so a
+							     dragged tail track would have nowhere to land — give it a target -->
+							<div
+								class="up-next-drop-zone"
+								class:drag-over={dropZoneActive}
+								role="listitem"
+								bind:this={dropZoneElement}
+								ondragover={(e) => {
+									e.preventDefault();
+									dropZoneActive = true;
+									dragOverIndex = null;
+								}}
+								ondragleave={() => (dropZoneActive = false)}
+								ondrop={(e) => {
+									e.preventDefault();
+									if (draggedIndex !== null) queue.promoteToUpNext(draggedIndex);
+									dropZoneActive = false;
+									draggedIndex = null;
+								}}
+							>
+								<span>drag here to play next</span>
+							</div>
+						{/if}
 
 						{#if continuationUpcoming.length > 0}
 							<div class="section-header continuation-header">
@@ -1084,6 +1126,22 @@
 		.remove-btn {
 			opacity: 1;
 		}
+	}
+
+	.up-next-drop-zone {
+		border: 1px dashed var(--border-subtle);
+		border-radius: var(--radius-base);
+		padding: 0.85rem;
+		text-align: center;
+		color: var(--text-muted);
+		font-size: var(--text-sm);
+		transition: all 0.15s ease;
+	}
+
+	.up-next-drop-zone.drag-over {
+		border-color: var(--accent);
+		color: var(--text-secondary);
+		background: color-mix(in srgb, var(--accent) 12%, transparent);
 	}
 
 	.empty-up-next {

--- a/frontend/src/lib/queue-context.test.ts
+++ b/frontend/src/lib/queue-context.test.ts
@@ -162,6 +162,41 @@ describe('queue.clearUpNext', () => {
 	});
 });
 
+// dragging a tail track onto the (possibly empty) up-next zone promotes it
+// into the explicit picks — the tail is auto-generated, a drag is a conscious
+// choice.
+describe('queue.promoteToUpNext', () => {
+	it('moves a tail track to the end of the explicit picks', () => {
+		queue.setQueue(album([1, 2]), 0); // current 1, explicit 2
+		queue.appendContinuation(album([50, 51, 52]));
+
+		queue.promoteToUpNext(3); // 51
+
+		expect(queue.tracks.map((t) => t.id)).toEqual([1, 2, 51, 50, 52]);
+		expect(queue.continuationFromIndex).toBe(3);
+		expect(queue.isContinuationIndex(2)).toBe(false); // 51 now explicit
+		expect(queue.isContinuationIndex(3)).toBe(true); // 50 still tail
+	});
+
+	it('works when the explicit up-next is empty (the zero-height drop zone case)', () => {
+		queue.setQueue(album([1]), 0);
+		queue.appendContinuation(album([50, 51]));
+		expect(queue.continuationFromIndex).toBe(1); // no explicit picks
+
+		queue.promoteToUpNext(2); // 51
+
+		expect(queue.tracks.map((t) => t.id)).toEqual([1, 51, 50]);
+		expect(queue.continuationFromIndex).toBe(2);
+		expect(queue.isContinuationIndex(1)).toBe(false);
+	});
+
+	it('ignores non-tail indexes', () => {
+		queue.setQueue(album([1, 2, 3]), 0);
+		queue.promoteToUpNext(1); // explicit, not tail
+		expect(queue.tracks.map((t) => t.id)).toEqual([1, 2, 3]);
+	});
+});
+
 // the For You feed changes slowly, so fillContinuation shuffles candidates
 // before appending — otherwise the same top-of-feed track leads the tail after
 // every refill (drove a "same song after everything I play" report).

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -764,6 +764,24 @@ class Queue {
 		this.syncState();
 	}
 
+	/**
+	 * Promote a continuation-tail track into the explicit up-next region
+	 * (dropped on the up-next zone). It lands at the end of the explicit
+	 * picks, just before the tail.
+	 */
+	promoteToUpNext(fromIndex: number) {
+		if (!this.isContinuationIndex(fromIndex)) return;
+
+		this.lastUpdateWasLocal = true;
+		const updated = [...this.tracks];
+		const [moved] = updated.splice(fromIndex, 1);
+		const insertAt = Math.max(this.currentIndex + 1, Math.min(this.continuationFromIndex, updated.length));
+		updated.splice(insertAt, 0, moved);
+		this.tracks = updated;
+		this.continuationFromIndex = Math.min(this.continuationFromIndex + 1, updated.length);
+		this.syncState();
+	}
+
 	moveTrack(fromIndex: number, toIndex: number) {
 		if (fromIndex === toIndex) return;
 		if (fromIndex < 0 || fromIndex >= this.tracks.length) return;

--- a/loq.toml
+++ b/loq.toml
@@ -104,7 +104,7 @@ max_lines = 1193
 
 [[rules]]
 path = "frontend/src/lib/components/Queue.svelte"
-max_lines = 1185
+max_lines = 1238
 
 [[rules]]
 path = "frontend/src/lib/components/SearchModal.svelte"


### PR DESCRIPTION
follow-up to #1668, reported from live use: with zero explicit picks, the up-next region has zero height — dragging a "next from" tail track into it is physically impossible because there's nowhere for it to land.

## what changed

- **`queue.promoteToUpNext(fromIndex)`**: a dedicated promote operation — pulls a continuation-tail track and inserts it at the end of the explicit picks, bumping the tail boundary. `moveTrack`'s promotion path (`toIndex < boundary`) can't express a drop into an *empty* explicit region (there is no valid `toIndex` strictly below the boundary that isn't before the current track), hence the new method rather than a special case in `moveTrack`.
- **a visible drop zone** ("drag here to play next", dashed, accent highlight on hover) renders between the up-next header and the "next from" header — only when the explicit region is empty and a tail exists, so it never shows as dead chrome otherwise.
- wired for both drag flavors: native HTML5 drag (dragover/drop) and the touch press-and-hold path (`handleTouchMove` hit-tests the zone's rect; `handleTouchEnd` promotes instead of reordering).

## regression tests

`queue.promoteToUpNext` suite: promote from a populated explicit region (lands at the end of picks, boundary advances), promote into an *empty* explicit region (the reported case), and non-tail indexes are ignored.

## intentionally not done

- no drop zone when the whole queue is empty (nothing to drag from) — the empty-state CTA from #1667 still covers that.
- reordering semantics for populated regions are untouched; drops on real rows still go through `moveTrack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)