### PR TITLE
fix(radio): cache the per-station rotation instead of rebuilding it every poll

### DIFF
--- a/backend/src/backend/api/radio/cache.py
+++ b/backend/src/backend/api/radio/cache.py
@@ -6,10 +6,18 @@ under real listener load that recomputation saturated the database (2026-07-14).
 The cache stores the *anonymous* serialized rotation; per-user liked state and
 the wall-clock playhead are applied per request on top of it.
 
+The miss path is single-flight: concurrent polls that all observe an expired
+key would otherwise stampede the database in a burst every TTL, which is the
+same saturation the cache exists to prevent. One request takes a short-lived
+build lock and rebuilds; the rest poll for the populated value and only build
+themselves if the lock holder dies or stalls.
+
 Fails open: with Redis unavailable, every request just rebuilds the rotation.
 """
 
+import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 
 from pydantic import TypeAdapter
 
@@ -21,6 +29,11 @@ from .schemas import RadioTrack
 logger = logging.getLogger(__name__)
 
 ROTATION_CACHE_PREFIX = "plyr:radio:rotation:"
+# generous next to a normal sub-second rebuild, so the lock only expires under
+# a genuinely dead or stalled holder rather than a slow database.
+BUILD_LOCK_TTL_SECONDS = 10
+BUILD_WAIT_POLL_SECONDS = 0.1
+BUILD_WAIT_MAX_POLLS = 20
 
 _rotation_adapter = TypeAdapter(list[RadioTrack])
 
@@ -29,33 +42,66 @@ def rotation_cache_key(station_slug: str, limit: int, period: str) -> str:
     return f"{ROTATION_CACHE_PREFIX}{station_slug}:{limit}:{period}"
 
 
-async def get_cached_rotation(
-    station_slug: str, limit: int, period: str
-) -> list[RadioTrack] | None:
-    """Return the cached anonymous rotation, or None on miss/disabled/error."""
+async def get_rotation(
+    station_slug: str,
+    limit: int,
+    period: str,
+    build: Callable[[], Awaitable[list[RadioTrack]]],
+) -> list[RadioTrack]:
+    """Return the anonymous rotation, building it at most once per TTL.
+
+    ``build`` runs on a cache miss, guarded by a single-flight lock so
+    concurrent misses don't each hit the database. Any Redis failure falls
+    back to building directly.
+    """
     if settings.radio.rotation_cache_ttl_seconds <= 0:
-        return None
+        return await build()
+
+    key = rotation_cache_key(station_slug, limit, period)
     try:
         redis = get_async_redis_client()
-        if cached := await redis.get(rotation_cache_key(station_slug, limit, period)):
+        if cached := await redis.get(key):
             return _rotation_adapter.validate_json(cached)
-    except Exception:
-        logger.debug("failed to read rotation cache for %s", station_slug)
-    return None
-
-
-async def set_cached_rotation(
-    station_slug: str, limit: int, period: str, rotation: list[RadioTrack]
-) -> None:
-    """Cache the anonymous rotation. Fails silently."""
-    if settings.radio.rotation_cache_ttl_seconds <= 0:
-        return
-    try:
-        redis = get_async_redis_client()
-        await redis.set(
-            rotation_cache_key(station_slug, limit, period),
-            _rotation_adapter.dump_json(rotation),
-            ex=settings.radio.rotation_cache_ttl_seconds,
+        acquired = await redis.set(
+            f"{key}:build", "1", nx=True, ex=BUILD_LOCK_TTL_SECONDS
         )
     except Exception:
-        logger.debug("failed to write rotation cache for %s", station_slug)
+        logger.debug("rotation cache unavailable for %s; building", station_slug)
+        return await build()
+
+    if not acquired:
+        if awaited := await _wait_for_rotation(key):
+            return awaited
+        logger.debug("rotation build lock holder stalled for %s", station_slug)
+        return await build()
+
+    try:
+        rotation = await build()
+        if rotation:
+            try:
+                await redis.set(
+                    key,
+                    _rotation_adapter.dump_json(rotation),
+                    ex=settings.radio.rotation_cache_ttl_seconds,
+                )
+            except Exception:
+                logger.debug("failed to write rotation cache for %s", station_slug)
+        return rotation
+    finally:
+        try:
+            await redis.delete(f"{key}:build")
+        except Exception:
+            logger.debug("failed to release rotation build lock for %s", station_slug)
+
+
+async def _wait_for_rotation(key: str) -> list[RadioTrack] | None:
+    """Poll for the value another request is building; None if it never lands."""
+    for _ in range(BUILD_WAIT_MAX_POLLS):
+        await asyncio.sleep(BUILD_WAIT_POLL_SECONDS)
+        try:
+            redis = get_async_redis_client()
+            if cached := await redis.get(key):
+                return _rotation_adapter.validate_json(cached)
+        except Exception:
+            return None
+    return None

--- a/backend/src/backend/api/radio/cache.py
+++ b/backend/src/backend/api/radio/cache.py
@@ -1,0 +1,61 @@
+"""Redis cache for the per-station radio rotation.
+
+The rotation is deterministic per (station, limit, period), so every poll of
+``/radio/state`` recomputing it from the full eligible catalog is pure waste —
+under real listener load that recomputation saturated the database (2026-07-14).
+The cache stores the *anonymous* serialized rotation; per-user liked state and
+the wall-clock playhead are applied per request on top of it.
+
+Fails open: with Redis unavailable, every request just rebuilds the rotation.
+"""
+
+import logging
+
+from pydantic import TypeAdapter
+
+from backend.config import settings
+from backend.utilities.redis import get_async_redis_client
+
+from .schemas import RadioTrack
+
+logger = logging.getLogger(__name__)
+
+ROTATION_CACHE_PREFIX = "plyr:radio:rotation:"
+
+_rotation_adapter = TypeAdapter(list[RadioTrack])
+
+
+def rotation_cache_key(station_slug: str, limit: int, period: str) -> str:
+    return f"{ROTATION_CACHE_PREFIX}{station_slug}:{limit}:{period}"
+
+
+async def get_cached_rotation(
+    station_slug: str, limit: int, period: str
+) -> list[RadioTrack] | None:
+    """Return the cached anonymous rotation, or None on miss/disabled/error."""
+    if settings.radio.rotation_cache_ttl_seconds <= 0:
+        return None
+    try:
+        redis = get_async_redis_client()
+        if cached := await redis.get(rotation_cache_key(station_slug, limit, period)):
+            return _rotation_adapter.validate_json(cached)
+    except Exception:
+        logger.debug("failed to read rotation cache for %s", station_slug)
+    return None
+
+
+async def set_cached_rotation(
+    station_slug: str, limit: int, period: str, rotation: list[RadioTrack]
+) -> None:
+    """Cache the anonymous rotation. Fails silently."""
+    if settings.radio.rotation_cache_ttl_seconds <= 0:
+        return
+    try:
+        redis = get_async_redis_client()
+        await redis.set(
+            rotation_cache_key(station_slug, limit, period),
+            _rotation_adapter.dump_json(rotation),
+            ex=settings.radio.rotation_cache_ttl_seconds,
+        )
+    except Exception:
+        logger.debug("failed to write rotation cache for %s", station_slug)

--- a/backend/src/backend/api/radio/state.py
+++ b/backend/src/backend/api/radio/state.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session
 from backend.api.radio import stations
+from backend.api.radio.cache import get_cached_rotation, set_cached_rotation
 from backend.api.radio.corpus import load_corpus
 from backend.api.radio.lenses import LensContext
 from backend.api.radio.router import router
@@ -109,9 +110,8 @@ async def _to_radio_tracks(
     db: AsyncSession,
     tracks: list[Track],
     like_counts: dict[int, int],
-    liked_ids: set[int],
 ) -> list[RadioTrack]:
-    """Serialize tracks for public radio consumers."""
+    """Serialize tracks for public radio consumers (anonymous: liked=False)."""
     track_ids = [track.id for track in tracks]
     tag_map = await get_track_tags(db, track_ids)
     return [
@@ -132,9 +132,50 @@ async def _to_radio_tracks(
             tags=sorted(tag_map.get(track.id, set())),
             like_count=like_counts.get(track.id, 0),
             play_count=track.play_count,
-            liked=track.id in liked_ids,
         )
         for track in tracks
+    ]
+
+
+async def _load_rotation(
+    db: AsyncSession,
+    station: stations.Station,
+    limit: int,
+    now: datetime,
+) -> list[RadioTrack]:
+    """Return the station's anonymous rotation, cached per (station, limit, period).
+
+    The rotation is deterministic within a period, so recomputing it on every
+    poll only reloads the same full catalog from the database; under real
+    listener volume that recomputation was enough to saturate the database and
+    slow every other endpoint down (2026-07-14).
+    """
+    period = str(int(now.timestamp()) // ROTATION_PERIOD_SECONDS)
+    if cached := await get_cached_rotation(station.slug, limit, period):
+        return cached
+
+    tracks, like_counts = await _select_rotation(db, station, limit, now)
+    rotation = await _to_radio_tracks(db, tracks, like_counts)
+    if rotation:
+        await set_cached_rotation(station.slug, limit, period, rotation)
+    return rotation
+
+
+async def _with_liked_state(
+    db: AsyncSession,
+    rotation: list[RadioTrack],
+    session: AuthSession | None,
+) -> list[RadioTrack]:
+    """Overlay the requesting user's likes on an anonymous rotation."""
+    if session is None or not rotation:
+        return rotation
+    liked_ids = await get_user_liked_track_ids(
+        db, session.did, [track.id for track in rotation]
+    )
+    if not liked_ids:
+        return rotation
+    return [
+        track.model_copy(update={"liked": track.id in liked_ids}) for track in rotation
     ]
 
 
@@ -212,13 +253,9 @@ async def radio_state(
         raise HTTPException(status_code=404, detail=f"unknown station: {station}")
 
     now = datetime.now(UTC)
-    tracks, like_counts = await _select_rotation(db, resolved, limit, now)
-    liked_ids = (
-        await get_user_liked_track_ids(db, session.did, [t.id for t in tracks])
-        if session
-        else set()
+    rotation = await _with_liked_state(
+        db, await _load_rotation(db, resolved, limit, now), session
     )
-    rotation = await _to_radio_tracks(db, tracks, like_counts, liked_ids)
     current_index, progress, started_at, ends_at = _live_window(now, rotation)
     current = rotation[current_index] if current_index is not None else None
 

--- a/backend/src/backend/api/radio/state.py
+++ b/backend/src/backend/api/radio/state.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session
 from backend.api.radio import stations
-from backend.api.radio.cache import get_cached_rotation, set_cached_rotation
+from backend.api.radio.cache import get_rotation
 from backend.api.radio.corpus import load_corpus
 from backend.api.radio.lenses import LensContext
 from backend.api.radio.router import router
@@ -150,15 +150,13 @@ async def _load_rotation(
     listener volume that recomputation was enough to saturate the database and
     slow every other endpoint down (2026-07-14).
     """
-    period = str(int(now.timestamp()) // ROTATION_PERIOD_SECONDS)
-    if cached := await get_cached_rotation(station.slug, limit, period):
-        return cached
 
-    tracks, like_counts = await _select_rotation(db, station, limit, now)
-    rotation = await _to_radio_tracks(db, tracks, like_counts)
-    if rotation:
-        await set_cached_rotation(station.slug, limit, period, rotation)
-    return rotation
+    async def build() -> list[RadioTrack]:
+        tracks, like_counts = await _select_rotation(db, station, limit, now)
+        return await _to_radio_tracks(db, tracks, like_counts)
+
+    period = str(int(now.timestamp()) // ROTATION_PERIOD_SECONDS)
+    return await get_rotation(station.slug, limit, period, build)
 
 
 async def _with_liked_state(

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -899,6 +899,26 @@ class TurbopufferSettings(AppSettingsSection):
     )
 
 
+class RadioSettings(AppSettingsSection):
+    """Public radio settings."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="RADIO_",
+        env_file=".env",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    rotation_cache_ttl_seconds: int = Field(
+        default=60,
+        description=(
+            "TTL for the cached per-station rotation. Every /radio/state poll "
+            "rebuilds the rotation from the full eligible catalog, so this "
+            "bounds that work to once per station per TTL. 0 disables caching."
+        ),
+    )
+
+
 class JetstreamSettings(AppSettingsSection):
     """ATProto Jetstream consumer settings for real-time record ingestion."""
 
@@ -1144,6 +1164,10 @@ class Settings(AppSettingsSection):
     modal: ModalSettings = Field(
         default_factory=ModalSettings,
         description="Modal CLAP embedding service settings",
+    )
+    radio: RadioSettings = Field(
+        default_factory=RadioSettings,
+        description="Public radio settings",
     )
     turbopuffer: TurbopufferSettings = Field(
         default_factory=TurbopufferSettings,

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -1,5 +1,6 @@
 """tests for public radio state and the station lineup."""
 
+import asyncio
 from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
 
@@ -15,6 +16,7 @@ from backend.api.radio import lenses
 from backend.api.radio import state as radio_state
 from backend.api.radio.lenses import LensContext
 from backend.api.radio.sampler import build_rotation, rank_decay_weights
+from backend.api.radio.schemas import RadioTrack
 from backend.config import settings
 from backend.main import app
 from backend.models import Artist, Tag, Track, TrackLike, TrackTag, get_db
@@ -43,13 +45,25 @@ class _FakeRedis:
     """minimal in-memory stand-in for the async redis client."""
 
     def __init__(self) -> None:
-        self.store: dict[str, bytes] = {}
+        self.store: dict[str, bytes | str] = {}
 
-    async def get(self, key: str) -> bytes | None:
+    async def get(self, key: str) -> bytes | str | None:
         return self.store.get(key)
 
-    async def set(self, key: str, value: bytes, ex: int | None = None) -> None:
+    async def set(
+        self,
+        key: str,
+        value: bytes | str,
+        ex: int | None = None,
+        nx: bool = False,
+    ) -> bool | None:
+        if nx and key in self.store:
+            return None
         self.store[key] = value
+        return True
+
+    async def delete(self, key: str) -> None:
+        self.store.pop(key, None)
 
 
 # --- lens semantics (pure functions, no sampler randomness) -----------------
@@ -740,3 +754,44 @@ async def test_cached_rotation_is_anonymous_with_per_request_likes(
     finally:
         del radio_app.dependency_overrides[get_optional_session]
     assert {t["id"]: t["liked"] for t in hit.json()["rotation"]}[liked.id] is True
+
+
+async def test_concurrent_cache_misses_build_once(
+    rotation_cache: _FakeRedis,
+) -> None:
+    """expiry doesn't stampede: concurrent misses coalesce onto one build."""
+    builds = 0
+
+    async def build() -> list[RadioTrack]:
+        nonlocal builds
+        builds += 1
+        # hold the build lock long enough for the other misses to arrive
+        await asyncio.sleep(0.3)
+        return [
+            RadioTrack(
+                id=1,
+                title="t",
+                artist="a",
+                artist_handle="a.plyr.fm",
+                artist_did="did:plc:a",
+                stream_url="https://api.plyr.fm/audio/t",
+                file_type="mp3",
+                duration=180,
+                artwork_url=None,
+                thumbnail_url=None,
+                atproto_record_uri=None,
+                atproto_record_cid=None,
+                created_at="2026-07-14T00:00:00+00:00",
+                tags=[],
+                like_count=0,
+                play_count=0,
+            )
+        ]
+
+    results = await asyncio.gather(
+        *(radio_cache.get_rotation("loved", 40, "period", build) for _ in range(10))
+    )
+
+    assert builds == 1
+    assert all(rotation == results[0] for rotation in results)
+    assert all(rotation[0].id == 1 for rotation in results)

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -10,7 +10,9 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, get_optional_session
+from backend.api.radio import cache as radio_cache
 from backend.api.radio import lenses
+from backend.api.radio import state as radio_state
 from backend.api.radio.lenses import LensContext
 from backend.api.radio.sampler import build_rotation, rank_decay_weights
 from backend.config import settings
@@ -29,6 +31,25 @@ class _MockSession(Session):
 
 # clear_database only removes timestamped rows created after test start.
 TEST_TIME_OFFSET = timedelta(minutes=10)
+
+
+@pytest.fixture(autouse=True)
+def _rotation_cache_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """keep tests hermetic: each request rebuilds its rotation from this test's data."""
+    monkeypatch.setattr(settings.radio, "rotation_cache_ttl_seconds", 0)
+
+
+class _FakeRedis:
+    """minimal in-memory stand-in for the async redis client."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+
+    async def get(self, key: str) -> bytes | None:
+        return self.store.get(key)
+
+    async def set(self, key: str, value: bytes, ex: int | None = None) -> None:
+        self.store[key] = value
 
 
 # --- lens semantics (pure functions, no sampler randomness) -----------------
@@ -606,3 +627,116 @@ async def test_radio_marks_liked_tracks_for_authenticated_user(
     rotation = {track["id"]: track["liked"] for track in response.json()["rotation"]}
     assert rotation[liked.id] is True
     assert rotation[plain.id] is False
+
+
+# --- rotation cache (#1671) --------------------------------------------------
+# regression: every /radio/state poll rebuilt the rotation from the full
+# eligible catalog; under real listener volume that saturated the database
+# (2026-07-14) and slowed every endpoint. The rotation is deterministic per
+# (station, limit, period), so it's cached anonymously and the requesting
+# user's likes are overlaid per request.
+
+
+@pytest.fixture
+def rotation_cache(monkeypatch: pytest.MonkeyPatch) -> _FakeRedis:
+    """enable the rotation cache against an in-memory redis."""
+    fake = _FakeRedis()
+    monkeypatch.setattr(settings.radio, "rotation_cache_ttl_seconds", 60)
+    monkeypatch.setattr(radio_cache, "get_async_redis_client", lambda: fake)
+    return fake
+
+
+async def test_cached_rotation_skips_corpus_reload(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+    rotation_cache: _FakeRedis,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """the second poll within the TTL serves the cached rotation."""
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
+    await _create_track(
+        db_session, radio_artist, title="Cached", file_id="cached", created_at=now
+    )
+    await db_session.commit()
+
+    corpus_calls = 0
+    real_load_corpus = radio_state.load_corpus
+
+    async def counting_load_corpus(db: AsyncSession) -> list[Track]:
+        nonlocal corpus_calls
+        corpus_calls += 1
+        return await real_load_corpus(db)
+
+    monkeypatch.setattr(radio_state, "load_corpus", counting_load_corpus)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=radio_app),
+        base_url="https://radio.plyr.fm",
+    ) as client:
+        first = await client.get("/radio/state.json")
+        second = await client.get("/radio/state.json")
+
+    assert first.status_code == second.status_code == 200
+    assert corpus_calls == 1
+    assert rotation_cache.store  # the rotation actually landed in the cache
+    assert [t["id"] for t in first.json()["rotation"]] == [
+        t["id"] for t in second.json()["rotation"]
+    ]
+
+
+async def test_cached_rotation_is_anonymous_with_per_request_likes(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+    rotation_cache: _FakeRedis,
+) -> None:
+    """a signed-in warmup can't leak liked=True to others; hits still get likes."""
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
+    liked = await _create_track(
+        db_session, radio_artist, title="Liked", file_id="liked", created_at=now
+    )
+    db_session.add(
+        TrackLike(
+            track_id=liked.id,
+            user_did="did:test:user123",
+            atproto_like_uri="at://did:test:user123/fm.plyr.like/liked",
+        )
+    )
+    await db_session.commit()
+
+    async def mock_session() -> Session:
+        return _MockSession("did:test:user123")
+
+    # signed-in request warms the cache
+    radio_app.dependency_overrides[get_optional_session] = mock_session
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=radio_app),
+            base_url="https://radio.plyr.fm",
+        ) as client:
+            warm = await client.get("/radio/state.json")
+    finally:
+        del radio_app.dependency_overrides[get_optional_session]
+
+    assert {t["id"]: t["liked"] for t in warm.json()["rotation"]}[liked.id] is True
+
+    # anonymous cache hit: no liked state leaks
+    async with AsyncClient(
+        transport=ASGITransport(app=radio_app),
+        base_url="https://radio.plyr.fm",
+    ) as client:
+        anon = await client.get("/radio/state.json")
+    assert all(not track["liked"] for track in anon.json()["rotation"])
+
+    # signed-in cache hit: likes overlaid on the cached rotation
+    radio_app.dependency_overrides[get_optional_session] = mock_session
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=radio_app),
+            base_url="https://radio.plyr.fm",
+        ) as client:
+            hit = await client.get("/radio/state.json")
+    finally:
+        del radio_app.dependency_overrides[get_optional_session]
+    assert {t["id"]: t["liked"] for t in hit.json()["rotation"]}[liked.id] is True

--- a/loq.toml
+++ b/loq.toml
@@ -332,7 +332,7 @@ max_lines = 954
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"
-max_lines = 742
+max_lines = 797
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"

--- a/loq.toml
+++ b/loq.toml
@@ -44,7 +44,7 @@ max_lines = 1843
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 1158
+max_lines = 1182
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
@@ -332,7 +332,7 @@ max_lines = 954
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"
-max_lines = 608
+max_lines = 742
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"


### PR DESCRIPTION
every `/radio/state` poll rebuilt the station rotation from the **full eligible catalog**, and at July 14's listener volume that saturated the prod Neon compute — dragging every endpoint's latency up. the rotation is deterministic per (station, limit, period) by design, so it's now cached in redis and rebuilt at most once per TTL, with a single-flight lock so cache expiry can't stampede.

## the incident (July 14, UTC)

- radio-state poll volume tripled around 11:00 (more listeners/embeds tuned in)
- from ~14:00, real degradation: radio-state p95 hit 7–13s, unrelated routes' p95 climbed to ~1.9s, db `connect` spans went from ~6ms to ~106ms avg, and a traced `/radio/state.json` request spent **20.7s inside one SELECT**
- `pg_stat_statements`: the eligible-tracks query (`SELECT tracks.* FROM tracks JOIN artists ... ORDER BY created_at DESC`, no LIMIT) had run **61,615 times returning 55.7M rows total** (~the whole ~900-track catalog per call, ~53ms mean, 3,265s total exec time)
- prod compute autoscales only to 2 CU; the constant per-poll recomputation pushed it past the ceiling and everything else queued. no lock pileup — pure compute pressure.

## design

- **what's cached**: the *anonymous* serialized rotation (`list[RadioTrack]`, `liked=False`), keyed `plyr:radio:rotation:{station}:{limit}:{period}`. the requesting user's likes are overlaid per request via `model_copy`, so per-user state never enters the cache and a signed-in warmup can't leak `liked=True` to anonymous listeners.
- **TTL 60s** (`RADIO_ROTATION_CACHE_TTL_SECONDS`, `0` disables), not the full 4h period: like counts, tags, and new uploads (the `fresh` station's identity) stay at most a minute stale, while per-poll db work drops from every-request to once-per-station-per-minute. the period is still in the key, so the cache naturally rolls at rotation reseed boundaries.
- **single-flight miss path**: concurrent polls observing an expired key would otherwise all rebuild — a burst every TTL at exactly the volume the cache exists to absorb. one request takes a `SET NX EX` build lock (10s, generous vs a normal sub-second rebuild so it only expires under a genuinely dead holder); the rest poll briefly (100ms × 20) for the populated value and fail open to a self-build if the holder stalls.
- **fail-open**: redis errors fall back to rebuilding, matching the existing album-cache pattern (`api/albums/cache.py`). determinism is unaffected — cached copies are the same rotation every client would compute.
- **wall-clock playhead** (`_live_window`, `up_next`) is computed per request as before; only the rotation itself is cached.

## intentionally not done

- no change to `load_corpus` itself (the no-LIMIT full-catalog load is deliberate per #1620's breadth work; the cache makes its frequency the fix, not its shape)
- no in-process cache: the two fly VMs each hit redis, which keeps them serving identical rotations and needs no invalidation machinery
- the `/radio/state` ~450ms latency floor observed even at quiet hours predates this incident; the cache should collapse it for cache hits, but profiling any remaining floor is deferred until this lands

## testing

- regression test proves the second poll within the TTL does **not** reload the corpus (fails pre-fix: 2 corpus loads)
- stampede regression test: 10 concurrent cache misses coalesce onto exactly one build, all callers get the same rotation
- anonymity test: signed-in warmup → anonymous hit shows no liked state; signed-in hit gets likes overlaid on the cached rotation
- existing radio tests run with the cache disabled via an autouse fixture (they rely on per-request rebuilds from per-test data); cache tests use an in-memory fake redis
- loq limits relaxed via `loq relax` for `config.py` and `test_radio.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)