### PR TITLE
perf(images): serve display-sized artwork renditions from the CDN edge

### DIFF
--- a/frontend/src/lib/components/embed/CollectionEmbed.svelte
+++ b/frontend/src/lib/components/embed/CollectionEmbed.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/stores';
 	import { onMount, tick } from 'svelte';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
+	import { IMAGE_WIDTHS, resizedImageUrl } from '$lib/utils/display-image';
 	import {
 		clearMediaSessionMetadata,
 		setMediaSessionActionHandlers,
@@ -234,7 +235,7 @@
 			<div class="now-playing">
 				{#if currentTrack?.image_url}
 					<SensitiveImage src={currentTrack.image_url} compact respectPreference={false}>
-						<img class="np-art" src={currentTrack.image_url} alt="" />
+						<img class="np-art" src={resizedImageUrl(currentTrack.image_url, IMAGE_WIDTHS.thumb)} alt="" />
 					</SensitiveImage>
 				{:else}
 					<div class="np-art-placeholder">&#9835;</div>

--- a/frontend/src/lib/components/embed/RadioEmbed.svelte
+++ b/frontend/src/lib/components/embed/RadioEmbed.svelte
@@ -4,6 +4,7 @@
 	import { API_URL } from '$lib/config';
 	import TunerDial from '$lib/components/radio/TunerDial.svelte';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
+	import { IMAGE_WIDTHS, resizedImageUrl } from '$lib/utils/display-image';
 	import type { RadioState, RadioStation, RadioTrack } from '$lib/radio.svelte';
 
 	// standalone embed player: this is its own iframe context (not the main app),
@@ -176,7 +177,7 @@
 		<div class="now" class:tuning={switching}>
 			{#if current.artwork_url}
 				<SensitiveImage src={current.artwork_url} compact respectPreference={false}>
-					<img class="art" src={current.artwork_url} alt="" />
+					<img class="art" src={resizedImageUrl(current.artwork_url, IMAGE_WIDTHS.tile)} alt="" />
 				</SensitiveImage>
 			{:else}
 				<div class="art fallback"></div>

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -8,6 +8,7 @@
 	import { moderation } from '$lib/moderation.svelte';
 	import { preferences } from '$lib/preferences.svelte';
 	import { toast } from '$lib/toast.svelte';
+	import { resizedImageUrl } from '$lib/utils/display-image';
 	import {
 		findNextPlayableIndex,
 		gatedErrorFromResolution,
@@ -40,10 +41,10 @@
 		// build artwork array, respecting sensitive content settings
 		const artwork: MediaImage[] = [];
 		if (shouldShowArtwork(track.image_url)) {
-			artwork.push({ src: track.image_url!, sizes: '512x512', type: 'image/jpeg' });
+			artwork.push({ src: resizedImageUrl(track.image_url, 512)!, sizes: '512x512' });
 		} else if (shouldShowArtwork(track.album?.image_url)) {
 			// fall back to album artwork if no track artwork (or track artwork is sensitive)
-			artwork.push({ src: track.album!.image_url!, sizes: '512x512', type: 'image/jpeg' });
+			artwork.push({ src: resizedImageUrl(track.album!.image_url, 512)!, sizes: '512x512' });
 		} else if (shouldShowArtwork(track.artist_avatar_url)) {
 			// fall back to artist avatar if no album artwork (or album artwork is sensitive)
 			artwork.push({ src: track.artist_avatar_url!, sizes: '256x256', type: 'image/jpeg' });

--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -2,6 +2,7 @@
 	import type { Track } from '$lib/types';
 	import { onMount } from 'svelte';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
+	import { IMAGE_WIDTHS, resizedImageUrl } from '$lib/utils/display-image';
 
 	interface Props {
 		track: Track;
@@ -60,7 +61,7 @@
 		<a href="/track/{track.id}" class="player-artwork" aria-label={`view ${track.title}`}>
 			{#if (track.image_url || track.album?.image_url) && !imageError}
 				<img
-					src={track.image_url || track.album?.image_url}
+					src={resizedImageUrl(track.image_url || track.album?.image_url, IMAGE_WIDTHS.thumb)}
 					alt="{track.title} artwork"
 					onerror={() => imageError = true}
 				/>

--- a/frontend/src/lib/utils/display-image.test.ts
+++ b/frontend/src/lib/utils/display-image.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { IMAGE_WIDTHS, resizedImageUrl } from './display-image';
+
+describe('resizedImageUrl', () => {
+	it('rewrites plyr image hosts to a transformation URL', () => {
+		expect(
+			resizedImageUrl('https://images.plyr.fm/images/abc123.jpeg', 640)
+		).toBe(
+			'https://images.plyr.fm/cdn-cgi/image/width=640,quality=82,format=auto/images/abc123.jpeg'
+		);
+		expect(resizedImageUrl('https://images-stg.plyr.fm/xyz.png', 96)).toBe(
+			'https://images-stg.plyr.fm/cdn-cgi/image/width=96,quality=82,format=auto/xyz.png'
+		);
+	});
+
+	it('passes external hosts through unchanged', () => {
+		const bsky =
+			'https://cdn.bsky.app/img/avatar/plain/did:plc:x/bafkrei@jpeg';
+		expect(resizedImageUrl(bsky, 640)).toBe(bsky);
+		const r2 = 'https://pub-308b.r2.dev/abc.jpg';
+		expect(resizedImageUrl(r2, 640)).toBe(r2);
+	});
+
+	it('does not double-transform an already-transformed URL', () => {
+		const once = resizedImageUrl(
+			'https://images.plyr.fm/images/abc123.jpeg',
+			IMAGE_WIDTHS.hero
+		);
+		expect(resizedImageUrl(once, IMAGE_WIDTHS.thumb)).toBe(once);
+	});
+
+	it('tolerates null, undefined, and unparseable input', () => {
+		expect(resizedImageUrl(null, 640)).toBeNull();
+		expect(resizedImageUrl(undefined, 640)).toBeNull();
+		expect(resizedImageUrl('not a url', 640)).toBe('not a url');
+	});
+});

--- a/frontend/src/lib/utils/display-image.ts
+++ b/frontend/src/lib/utils/display-image.ts
@@ -1,0 +1,46 @@
+/**
+ * resize images at the CDN edge for display.
+ *
+ * artists upload full-resolution artwork (multi-MB originals) and the app used
+ * to serve those bytes for every render — a 5MB jpeg for a 56px footer tile.
+ * our image hosts sit behind a CDN that can transform on the fly via a URL
+ * prefix, so this helper rewrites an image URL to request a display-sized,
+ * modern-format rendition instead of the original.
+ *
+ * the CDN specifics live entirely in this module: callers just say how wide
+ * the image renders. URLs on hosts we don't control (external avatars, legacy
+ * r2.dev links) pass through unchanged, as does anything already transformed.
+ * pass the *original* URL to moderation checks (`SensitiveImage src`) — only
+ * the `<img src>` should be resized.
+ */
+
+/** hosts served from a zone with edge image transformations enabled. */
+const RESIZABLE_HOSTS = new Set(['images.plyr.fm', 'images-stg.plyr.fm']);
+
+const TRANSFORM_PREFIX = '/cdn-cgi/image/';
+
+/** widths for common artwork slots (device-pixel headroom included). */
+export const IMAGE_WIDTHS = {
+	thumb: 96,
+	tile: 320,
+	hero: 640
+} as const;
+
+export function resizedImageUrl(
+	url: string | null | undefined,
+	width: number
+): string | null {
+	if (!url) return null;
+	try {
+		const parsed = new URL(url);
+		if (
+			!RESIZABLE_HOSTS.has(parsed.hostname) ||
+			parsed.pathname.startsWith(TRANSFORM_PREFIX)
+		) {
+			return url;
+		}
+		return `${parsed.origin}${TRANSFORM_PREFIX}width=${width},quality=82,format=auto${parsed.pathname}`;
+	} catch {
+		return url;
+	}
+}

--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -11,6 +11,7 @@
 	import TunerDial from '$lib/components/radio/TunerDial.svelte';
 	import WaveLoading from '$lib/components/WaveLoading.svelte';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
+	import { IMAGE_WIDTHS, resizedImageUrl } from '$lib/utils/display-image';
 	import AddToMenu from '$lib/components/AddToMenu.svelte';
 	import type { PageData } from './$types';
 
@@ -167,12 +168,12 @@
 				<div class="now-block" class:tuning={radio.switching}>
 				<div class="art-stage">
 					{#if radio.current.artwork_url}
-						<img class="art-bg" src={radio.current.artwork_url} alt="" aria-hidden="true" />
+						<img class="art-bg" src={resizedImageUrl(radio.current.artwork_url, IMAGE_WIDTHS.tile)} alt="" aria-hidden="true" />
 					{/if}
 					<SensitiveImage src={radio.current.artwork_url} tooltipPosition="center">
 						<a class="art-link" href={`/track/${radio.current.id}`} aria-label={`view ${radio.current.title}`}>
 							{#if radio.current.artwork_url}
-								<img src={radio.current.artwork_url} alt="" class="art" />
+								<img src={resizedImageUrl(radio.current.artwork_url, IMAGE_WIDTHS.hero)} alt="" class="art" />
 							{:else}
 								<div class="art fallback"></div>
 							{/if}
@@ -238,7 +239,7 @@
 						>
 							<SensitiveImage src={track.thumbnail_url ?? track.artwork_url} compact>
 								{#if track.thumbnail_url || track.artwork_url}
-									<img src={track.thumbnail_url ?? track.artwork_url ?? ''} alt="" />
+									<img src={track.thumbnail_url ?? resizedImageUrl(track.artwork_url, IMAGE_WIDTHS.thumb) ?? ''} alt="" />
 								{:else}
 									<div class="rotation-fallback"></div>
 								{/if}

--- a/loq.toml
+++ b/loq.toml
@@ -220,7 +220,7 @@ max_lines = 1959
 
 [[rules]]
 path = "frontend/src/lib/components/embed/CollectionEmbed.svelte"
-max_lines = 645
+max_lines = 646
 
 [[rules]]
 path = "backend/tests/api/test_track_deletion.py"
@@ -328,7 +328,7 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/[[][[]station[]][]]/+page.svelte"
-max_lines = 954
+max_lines = 955
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"


### PR DESCRIPTION
the radio page (and every other artwork surface) served artists' full-resolution originals — the current rotation includes **5.3MB and 4.1MB JPEGs** rendered into a ~400px hero and 40px thumbnails, tens of MB per page on a modest connection. edge image transformations are now enabled on the zone, and the app requests display-sized renditions through a provider-abstracted helper.

## measured multiples (heaviest artwork in today's live rotation)

| image | original | 640w rendition | 96w rendition |
|---|---|---|---|
| `3edefad5....jpeg` | 5,266,565 B / 28.3s* | 156,450 B / 0.32s (**34× smaller**) | 2,512 B (**2096× smaller**) |
| `93543296....jpg` | 4,117,690 B / 6.0s | 141,200 B / 0.94s (**29× smaller**) | 3,234 B (**1273× smaller**) |
| `73ef6c7d....jpeg` | 2,450,552 B / 6.0s | 84,528 B / 1.46s (**29× smaller**) | 2,092 B (**1171× smaller**) |

*load times from a ~6.5Mbps connection (measured against Cloudflare's own speed-test endpoint as control) — exactly the class of connection where users reported the radio page loading painfully. all transformed responses verified live with `cf-resized: internal=ok`, `content-type: image/webp`.

## infrastructure (already applied)

zone-level **image transformations** enabled on the `plyr.fm` zone via `PATCH /zones/{id}/settings/transformations` → `"on"` (same-origin sources only — `/cdn-cgi/image/` requests can only reference originals on the same zone, so this is not an open resizing proxy). covers both `images.plyr.fm` and `images-stg.plyr.fm`, so staging exercises the same path. applied with a 1-day-scoped token; no other zone settings touched.

## design

- `lib/utils/display-image.ts` exposes `resizedImageUrl(url, width)` + `IMAGE_WIDTHS` presets (`thumb` 96 / `tile` 320 / `hero` 640). the CDN URL scheme lives only in this module — swapping providers later means changing one function.
- only URLs on plyr image hosts are rewritten; external hosts (bsky avatar fallbacks, legacy `r2.dev`) and already-transformed URLs pass through unchanged, and unparseable input falls back to the original string.
- `SensitiveImage src` (moderation matching) keeps receiving the **canonical** URL — only the rendered `<img src>` is resized.
- applied at: radio hero + blurred backdrop + rotation thumbnails (the reported page), radio/collection embeds, the player footer artwork, and media-session artwork (512px, `type` hint dropped since renditions are format-negotiated).

## intentionally not done

- no `srcset`/`sizes` responsive sets — single per-slot widths capture the multiples above; finer-grained responsive loading can layer on later
- no backend URL changes — the API keeps returning canonical originals; display sizing is a presentation concern
- the 96×96 WebP upload-time thumbnail pipeline is untouched; `thumbnail_url` is still preferred where it exists (edge resize now covers the fallback case)
- track/album/portal pages that already render `thumbnail_url` lists are unchanged; any remaining full-res surfaces can adopt the helper incrementally

## testing

- vitest coverage for the helper: host allowlist, pass-through of external/unparseable/null input, and no double-transform
- verified live against production images before opening this PR (table above)
- `bun run test` (107 passed), `svelte-check`, eslint, loq all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)