### PR TITLE
fix(costs): identify ourselves to the infra-costs feed

### DIFF
--- a/scripts/costs/export_costs.py
+++ b/scripts/costs/export_costs.py
@@ -55,7 +55,12 @@ def fetch_infra_costs() -> dict[str, Any]:
     note carrying the service count. raises if the feed is unreachable or has no
     plyr.fm line items, so we never silently publish stale/empty data.
     """
-    with urllib.request.urlopen(INFRA_COSTS_URL, timeout=15) as resp:
+    # cloudflare's bot protection on the aggregator zone 403s the default
+    # Python-urllib user agent; identify ourselves instead.
+    request = urllib.request.Request(
+        INFRA_COSTS_URL, headers={"User-Agent": "plyr-costs-export/1.0"}
+    )
+    with urllib.request.urlopen(request, timeout=15) as resp:
         feed = json.loads(resp.read())
 
     lines = [li for li in feed.get("lineItems", []) if li.get("project") == PROJECT_KEY]


### PR DESCRIPTION
the hourly `export costs` job has failed **200 consecutive runs** (since ~july 7), so `plyr.fm/costs` has served stale numbers for a week. two stacked causes, one already fixed in infrastructure:

1. **hub.waow.tech went behind Cloudflare Access** (~july 7) — the previously-public `/api/costs.json` feed started 302ing to the Access login, which the script surfaced as `HTTP Error 403: Forbidden`. fixed outside this repo: a path-scoped Access application (`hub.waow.tech/api/costs.json`) with a bypass-everyone policy makes the feed public again while the rest of hub stays gated. verified: the feed returns JSON anonymously; `hub.waow.tech/` still redirects to Access login.
2. **the zone's bot protection 403s `Python-urllib/3.12`** specifically (verified: same request with any other user agent returns 200, with urllib's default UA returns 403). this PR sends an identifying `plyr-costs-export/1.0` user agent — good hygiene regardless.

## verified

- `fetch_infra_costs()` run locally against the live feed with this change returns real per-service numbers (relay-api $24.56, staging $17.96, transcoder, moderation, redis ×2)
- with the old default UA, the same request 403s

## intentionally not done

- no WAF exception for python UAs on the waow.tech zone — identifying the client in the script is more robust and self-documenting
- no retry/backoff added — the job is hourly and fail-loud is the intended design (it must never silently publish stale data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)