### PR TITLE
fix(release): count scripts/costs/ as release-worthy changes

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -67,7 +67,19 @@ def main() -> int:
 
         # check for backend changes since last release
         result = subprocess.run(
-            ["git", "log", f"{last_release}..HEAD", "--oneline", "--", "backend/src/backend/", "backend/alembic/"],
+            # scripts/costs rides releases too: the hourly export-costs workflow
+            # checks out the latest release tag (#1166), so a costs-script fix
+            # only takes effect once a release includes it.
+            [
+                "git",
+                "log",
+                f"{last_release}..HEAD",
+                "--oneline",
+                "--",
+                "backend/src/backend/",
+                "backend/alembic/",
+                "scripts/costs/",
+            ],
             capture_output=True,
             text=True,
             check=True,


### PR DESCRIPTION
`just release` refused to cut the release that #1673 (costs-export user-agent fix) needs to take effect: the export-costs workflow deliberately runs from the **latest release tag** (#1166, so the JSON shape matches the released frontend), but the release script's backend-change detector only counted `backend/src/backend/` and `backend/alembic/` — so a `scripts/costs/`-only fix could never reach the tag it's pinned to.

this adds `scripts/costs/` to the detector's paths. release-pinned code should be able to trigger the release that ships it.

## intentionally not done
- not un-pinning the workflow from release tags — #1166's rationale (schema shape must match the released frontend) still holds
- no other `scripts/` paths added — only `scripts/costs/` is release-pinned

## verified
- `git log 2026.0715.061424..HEAD --oneline -- backend/src/backend/ backend/alembic/ scripts/costs/` now returns #1673's commit, so `just release` proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)