### PR TITLE
fix(playlists): composite covers render at display resolution

### DIFF
--- a/backend/src/backend/api/lists/covers.py
+++ b/backend/src/backend/api/lists/covers.py
@@ -92,10 +92,11 @@ async def _fetch_image(client: httpx.AsyncClient, url: str) -> bytes | None:
 
 
 async def _full_size_previews(db: AsyncSession, previews: list[str]) -> list[str]:
-    """swap cached thumbnail URLs (96px) for the tracks' full-size artwork.
+    """swap legacy cached thumbnail URLs (96px) for the tracks' full-size artwork.
 
-    entries that don't resolve (e.g. the cache stored `image_url` because the
-    track had no thumbnail) pass through unchanged.
+    the preview cache now stores full-size URLs, but rows written before that
+    change hold thumbnails until a detail read heals them. entries that don't
+    resolve pass through unchanged.
     """
     result = await db.execute(
         select(Track.thumbnail_url, Track.image_url).where(

--- a/backend/src/backend/api/lists/previews.py
+++ b/backend/src/backend/api/lists/previews.py
@@ -4,6 +4,11 @@
 URLs in playlist order. clients render a composite cover from them when
 the playlist has no explicit image. refreshed on item mutations and
 self-healed on detail reads.
+
+the cache stores each track's *full-size* artwork URL — clients request
+display-sized renditions at the CDN edge, so a big hero mosaic and a tiny
+menu tile both come from the same cached URL. (older rows cached the 96px
+thumbnail; the detail-read heal rewrites them.)
 """
 
 from sqlalchemy import select
@@ -31,7 +36,7 @@ async def compute_preview_thumbnails(
             Track.atproto_record_uri.in_(item_uris)
         )
     )
-    art_by_uri = {uri: thumbnail or image for uri, thumbnail, image in result.all()}
+    art_by_uri = {uri: image or thumbnail for uri, thumbnail, image in result.all()}
     previews: list[str] = []
     for uri in item_uris:
         if (art := art_by_uri.get(uri)) and art not in previews:
@@ -45,7 +50,7 @@ def previews_from_tracks(tracks: list[TrackResponse]) -> list[str]:
     """same projection as `compute_preview_thumbnails`, from hydrated tracks."""
     previews: list[str] = []
     for track in tracks:
-        if (art := track.thumbnail_url or track.image_url) and art not in previews:
+        if (art := track.image_url or track.thumbnail_url) and art not in previews:
             previews.append(art)
             if len(previews) == PREVIEW_THUMBNAIL_LIMIT:
                 break

--- a/backend/tests/api/test_playlist_preview_thumbnails.py
+++ b/backend/tests/api/test_playlist_preview_thumbnails.py
@@ -127,12 +127,12 @@ async def test_previews_follow_adds_in_order(
         assert playlist["preview_thumbnails"] == []
 
         body = await _add_track(client, playlist["id"], tracks[1])
-        assert body["preview_thumbnails"] == ["https://img.test/thumb1.webp"]
+        assert body["preview_thumbnails"] == ["https://img.test/full1.jpg"]
 
         body = await _add_track(client, playlist["id"], tracks[0])
         assert body["preview_thumbnails"] == [
-            "https://img.test/thumb1.webp",
-            "https://img.test/thumb0.webp",
+            "https://img.test/full1.jpg",
+            "https://img.test/full0.jpg",
         ]
 
 
@@ -147,10 +147,10 @@ async def test_previews_skip_artless_dedupe_and_cap_at_four(
             body = await _add_track(client, playlist["id"], track)
 
         assert body["preview_thumbnails"] == [
-            "https://img.test/thumb0.webp",
-            "https://img.test/thumb1.webp",
-            "https://img.test/thumb2.webp",
-            "https://img.test/thumb3.webp",
+            "https://img.test/full0.jpg",
+            "https://img.test/full1.jpg",
+            "https://img.test/full2.jpg",
+            "https://img.test/full3.jpg",
         ]
 
 
@@ -167,7 +167,7 @@ async def test_previews_refresh_on_remove(
             f"/lists/playlists/{playlist['id']}/tracks/{tracks[0].atproto_record_uri}",
         )
         assert resp.status_code == 200
-        assert resp.json()["preview_thumbnails"] == ["https://img.test/thumb1.webp"]
+        assert resp.json()["preview_thumbnails"] == ["https://img.test/full1.jpg"]
 
 
 async def test_remove_cover_falls_back_to_composite(
@@ -194,7 +194,7 @@ async def test_remove_cover_falls_back_to_composite(
         assert resp.status_code == 200
         body = resp.json()
         assert body["image_url"] is None
-        assert body["preview_thumbnails"] == ["https://img.test/thumb0.webp"]
+        assert body["preview_thumbnails"] == ["https://img.test/full0.jpg"]
 
         resp = await client.delete(f"/lists/playlists/{playlist['id']}/cover")
         assert resp.status_code == 400
@@ -224,14 +224,37 @@ async def test_og_cover_redirects_to_explicit_cover(
 async def test_og_cover_below_four_redirects_to_full_size_first_artwork(
     app_as_owner: FastAPI, tracks: list[Track]
 ) -> None:
-    """the cache stores 96px thumbnails; the og redirect upgrades to the
-    track's full-size artwork."""
     async with _client(app_as_owner) as client:
         playlist = await _create_private_playlist(client)
         await _add_track(client, playlist["id"], tracks[0])
         await _add_track(client, playlist["id"], tracks[1])
 
         resp = await client.get(f"/lists/playlists/{playlist['id']}/og-cover")
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "https://img.test/full0.jpg"
+
+
+async def test_og_cover_upgrades_legacy_cached_thumbnails(
+    app_as_owner: FastAPI,
+    db_session: AsyncSession,
+    owner: Artist,
+    tracks: list[Track],
+) -> None:
+    """rows cached before previews stored full-size URLs hold 96px thumbnails;
+    the og redirect still upgrades them to the track's full-size artwork."""
+    playlist = Playlist(
+        owner_did=owner.did,
+        name="legacy thumbs",
+        is_private=True,
+        items_json=[{"uri": tracks[0].atproto_record_uri, "cid": "c"}],
+        track_count=1,
+        preview_thumbnails=["https://img.test/thumb0.webp"],
+    )
+    db_session.add(playlist)
+    await db_session.commit()
+
+    async with _client(app_as_owner) as client:
+        resp = await client.get(f"/lists/playlists/{playlist.id}/og-cover")
     assert resp.status_code == 307
     assert resp.headers["location"] == "https://img.test/full0.jpg"
 
@@ -303,6 +326,6 @@ async def test_legacy_private_playlist_heals_on_list(
     assert resp.status_code == 200
     listed = {p["id"]: p for p in resp.json()}
     assert listed[playlist.id]["preview_thumbnails"] == [
-        "https://img.test/thumb2.webp",
-        "https://img.test/thumb0.webp",
+        "https://img.test/full2.jpg",
+        "https://img.test/full0.jpg",
     ]

--- a/frontend/src/lib/components/PlaylistCover.svelte
+++ b/frontend/src/lib/components/PlaylistCover.svelte
@@ -1,24 +1,31 @@
 <script lang="ts">
+	import { IMAGE_WIDTHS, resizedImageUrl } from '$lib/utils/display-image';
+
 	interface Props {
 		/** explicit playlist cover — always wins when set */
 		imageUrl?: string | null;
 		/** distinct member-track artwork URLs, in playlist order */
 		previews?: string[];
 		alt?: string;
+		/** rendered width of the whole cover slot, in device pixels */
+		width?: number;
 	}
 
-	let { imageUrl = null, previews = [], alt = '' }: Props = $props();
+	let { imageUrl = null, previews = [], alt = '', width = IMAGE_WIDTHS.thumb }: Props = $props();
 
 	// spotify's rule: a 2x2 mosaic only at 4+ distinct artworks; below that,
 	// the first track's artwork stands in for the whole cover
 	const mosaic = $derived(!imageUrl && previews.length >= 4);
-	const src = $derived(imageUrl ?? (previews.length > 0 ? previews[0] : null));
+	const src = $derived(
+		resizedImageUrl(imageUrl ?? (previews.length > 0 ? previews[0] : null), width)
+	);
+	const tileWidth = $derived(Math.ceil(width / 2));
 </script>
 
 {#if mosaic}
 	<div class="cover mosaic" role="img" aria-label={alt}>
 		{#each previews.slice(0, 4) as url (url)}
-			<img src={url} alt="" loading="lazy" />
+			<img src={resizedImageUrl(url, tileWidth)} alt="" loading="lazy" />
 		{/each}
 	</div>
 {:else if src}

--- a/frontend/src/lib/components/PlaylistCover.test.ts
+++ b/frontend/src/lib/components/PlaylistCover.test.ts
@@ -1,0 +1,54 @@
+// composite covers must request display-sized renditions: the preview cache
+// stores full-size artwork URLs, and stretching a 96px thumbnail across a
+// hero-sized mosaic quadrant (the pre-fix behavior) looks terrible.
+import { describe, it, expect, afterEach } from 'vitest';
+import { mount, unmount } from 'svelte';
+import PlaylistCover from '$lib/components/PlaylistCover.svelte';
+import { IMAGE_WIDTHS } from '$lib/utils/display-image';
+
+const PREVIEWS = [1, 2, 3, 4].map((i) => `https://images.plyr.fm/images/art${i}.jpg`);
+
+let component: Record<string, unknown> | null = null;
+
+function mountCover(props: Record<string, unknown>): void {
+	component = mount(PlaylistCover, { target: document.body, props });
+}
+
+afterEach(() => {
+	if (component) unmount(component);
+	component = null;
+	document.body.innerHTML = '';
+});
+
+describe('PlaylistCover', () => {
+	it('resizes mosaic quadrants to half the slot width', () => {
+		mountCover({ previews: PREVIEWS, width: IMAGE_WIDTHS.hero });
+		const srcs = [...document.querySelectorAll('.mosaic img')].map((img) =>
+			img.getAttribute('src')
+		);
+		expect(srcs).toHaveLength(4);
+		for (const [i, src] of srcs.entries()) {
+			expect(src).toBe(
+				`https://images.plyr.fm/cdn-cgi/image/width=${IMAGE_WIDTHS.hero / 2},quality=82,format=auto/images/art${i + 1}.jpg`
+			);
+		}
+	});
+
+	it('resizes a single-preview cover to the slot width', () => {
+		mountCover({ previews: PREVIEWS.slice(0, 1), width: IMAGE_WIDTHS.hero });
+		expect(document.querySelector('img.cover')?.getAttribute('src')).toBe(
+			`https://images.plyr.fm/cdn-cgi/image/width=${IMAGE_WIDTHS.hero},quality=82,format=auto/images/art1.jpg`
+		);
+	});
+
+	it('resizes an explicit cover and passes external hosts through', () => {
+		mountCover({
+			imageUrl: 'https://cdn.example.com/cover.jpg',
+			previews: PREVIEWS,
+			width: IMAGE_WIDTHS.thumb
+		});
+		expect(document.querySelector('img.cover')?.getAttribute('src')).toBe(
+			'https://cdn.example.com/cover.jpg'
+		);
+	});
+});

--- a/frontend/src/routes/playlist/[id]/+page.svelte
+++ b/frontend/src/routes/playlist/[id]/+page.svelte
@@ -5,6 +5,7 @@
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
 	import PlaylistCover from '$lib/components/PlaylistCover.svelte';
 	import { hasPlaylistArt } from '$lib/playlist-cover';
+	import { IMAGE_WIDTHS, resizedImageUrl } from '$lib/utils/display-image';
 	import AddTracksModal from '$lib/components/playlist/AddTracksModal.svelte';
 	import OwnerActionButtons from '$lib/components/playlist/OwnerActionButtons.svelte';
 	import PlaylistTrackList from '$lib/components/playlist/PlaylistTrackList.svelte';
@@ -486,6 +487,7 @@
 								imageUrl={playlist.image_url}
 								previews={playlist.preview_thumbnails}
 								alt="{playlist.name} artwork"
+								width={IMAGE_WIDTHS.hero}
 							/>
 						</div>
 					{:else}
@@ -556,13 +558,18 @@
 				<div class="playlist-art-wrapper">
 					{#if playlist.image_url}
 						<SensitiveImage src={playlist.image_url} tooltipPosition="center">
-							<img src={playlist.image_url} alt="{playlist.name} artwork" class="playlist-art" />
+							<img
+								src={resizedImageUrl(playlist.image_url, IMAGE_WIDTHS.hero)}
+								alt="{playlist.name} artwork"
+								class="playlist-art"
+							/>
 						</SensitiveImage>
 					{:else if playlist.preview_thumbnails?.length}
 						<div class="playlist-art">
 							<PlaylistCover
 								previews={playlist.preview_thumbnails}
 								alt="{playlist.name} artwork"
+								width={IMAGE_WIDTHS.hero}
 							/>
 						</div>
 					{:else}


### PR DESCRIPTION
the playlist hero's composite mosaic looked super low-res: the `preview_thumbnails` cache stored the **96px WebP thumbnails** and the hero stretched four of them across a 200px (400 device px) slot. this flips the architecture to match #1672 — cache the full-size artwork URL, size at the CDN edge per surface.

<details>
<summary>details</summary>

**backend**
- `previews.py` now caches `image_url or thumbnail_url` (full-size first) in both `compute_preview_thumbnails` and `previews_from_tracks`
- rows cached before this change hold thumbnails until the existing detail-read heal rewrites them; the og-cover `_full_size_previews` swap stays as the legacy upgrade path (new regression test covers it)

**frontend**
- `PlaylistCover` takes a `width` prop (device px of the slot) and requests edge renditions via `resizedImageUrl` — the whole cover at `width`, mosaic quadrants at `width/2`
- playlist hero passes `IMAGE_WIDTHS.hero` (640w for the 200px slot); the explicit-cover `<img>` on the hero is edge-resized too (the `SensitiveImage` moderation check keeps the canonical URL, per #1672's contract)
- library / profile / add-to-menu call sites are 48px slots and keep the 96w default — same visual quality as before, but now served as renditions of the original rather than the pregenerated thumb

**intentional non-behaviors**
- no backfill of existing cached rows — the detail-read heal covers them organically
- external hosts (legacy r2.dev, bsky) still pass through `resizedImageUrl` untouched, so a legacy-host original can now reach a small tile at full size; same trade #1672 already accepted

**tests**
- backend expectations updated to full-size URLs + new og-cover legacy-thumbnail upgrade test
- new `PlaylistCover.test.ts` asserts mosaic quadrants and single covers get edge-resized and external hosts pass through
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)