### PR TITLE
feat(moderation): enforce adult audio labels

### DIFF
--- a/backend/alembic/versions/2026_07_15_000000_b7e2c4d8a1f6_add_sensitive_audio_preference.py
+++ b/backend/alembic/versions/2026_07_15_000000_b7e2c4d8a1f6_add_sensitive_audio_preference.py
@@ -1,0 +1,37 @@
+"""add sensitive audio preference
+
+Revision ID: b7e2c4d8a1f6
+Revises: a1c4f2b7d3e9
+Create Date: 2026-07-15 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b7e2c4d8a1f6"
+down_revision: str | Sequence[str] | None = "a1c4f2b7d3e9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the opt-in controlling adult-labeled audio."""
+    op.add_column(
+        "user_preferences",
+        sa.Column(
+            "show_sensitive_audio",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove the sensitive-audio preference."""
+    op.drop_column("user_preferences", "show_sensitive_audio")

--- a/backend/src/backend/_internal/clients/moderation.py
+++ b/backend/src/backend/_internal/clients/moderation.py
@@ -4,6 +4,7 @@ centralized client for all moderation service interactions.
 replaces scattered httpx calls with a single, testable interface.
 """
 
+import json
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -171,11 +172,11 @@ class ModerationClient:
                 # invalidate cache since label status changed
                 await self.invalidate_cache(uri)
 
-                logfire.info("copyright label emitted", uri=uri, cid=cid)
+                logfire.info("moderation label emitted", uri=uri, cid=cid, val=val)
                 return EmitLabelResult(success=True)
 
         except Exception as e:
-            logger.warning("failed to emit copyright label for %s: %s", uri, e)
+            logger.warning("failed to emit moderation label for %s: %s", uri, e)
             return EmitLabelResult(success=False, error=str(e))
 
     async def get_sensitive_images(self) -> SensitiveImagesResult:
@@ -399,6 +400,65 @@ class ModerationClient:
             )
             return set(uris)
 
+    async def get_active_label_values(
+        self, uris: list[str], *, strict: bool = False
+    ) -> dict[str, set[str]]:
+        """Return current active label values grouped by subject URI.
+
+        Values are cached per URI because the labeler is the source of truth but
+        track serialization and audio authorization are hot paths. An empty set
+        is cached too, preventing unlabeled catalog traffic from repeatedly
+        hitting the moderation service.
+
+        Discovery callers fail open on a labeler outage. Authorization callers
+        pass ``strict=True`` so an outage cannot silently turn into access to
+        content that may be adult-labeled.
+        """
+        if not uris:
+            return {}
+        if not self.auth_token:
+            return {uri: set() for uri in uris}
+
+        labels_by_uri: dict[str, set[str]] = {}
+        uris_to_fetch: list[str] = []
+
+        try:
+            redis = get_async_redis_client()
+            cache_keys = [self._label_values_cache_key(uri) for uri in uris]
+            cached_values = await redis.mget(cache_keys)
+            for uri, cached_value in zip(uris, cached_values, strict=True):
+                if cached_value is None:
+                    uris_to_fetch.append(uri)
+                    continue
+                labels_by_uri[uri] = set(json.loads(cached_value))
+        except Exception as e:
+            logger.warning("label values cache unavailable: %s", e)
+            uris_to_fetch = list(uris)
+
+        if not uris_to_fetch:
+            return labels_by_uri
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.post(
+                    f"{self.labeler_url}/admin/labels",
+                    json={"uris": uris_to_fetch},
+                    headers=self._headers(),
+                )
+                response.raise_for_status()
+                raw_labels = response.json().get("labels", {})
+                fetched = {uri: set(raw_labels.get(uri, [])) for uri in uris_to_fetch}
+                labels_by_uri.update(fetched)
+                await self._cache_label_values(fetched)
+                return labels_by_uri
+        except Exception as e:
+            logger.warning("failed to query active label values: %s", e)
+            if strict:
+                raise
+            for uri in uris_to_fetch:
+                labels_by_uri.setdefault(uri, set())
+            return labels_by_uri
+
     async def get_negated_labels(self, uris: list[str]) -> set[str]:
         """check which URIs have an explicit negation (dismissal) label.
 
@@ -457,11 +517,33 @@ class ModerationClient:
         except Exception as e:
             logger.warning("failed to update redis cache: %s", e)
 
+    def _label_values_cache_key(self, uri: str) -> str:
+        """Return the cache key for a URI's complete active label set."""
+        return f"{self.label_cache_prefix}values:{uri}"
+
+    async def _cache_label_values(self, labels_by_uri: dict[str, set[str]]) -> None:
+        """Cache complete active label sets, including empty sets."""
+        try:
+            redis = get_async_redis_client()
+            async with redis.pipeline() as pipe:
+                for uri, values in labels_by_uri.items():
+                    await pipe.set(
+                        self._label_values_cache_key(uri),
+                        json.dumps(sorted(values)),
+                        ex=self.label_cache_ttl_seconds,
+                    )
+                await pipe.execute()
+        except Exception as e:
+            logger.warning("failed to cache label values: %s", e)
+
     async def invalidate_cache(self, uri: str) -> None:
         """invalidate cache entry for a URI when its label status changes."""
         try:
             redis = get_async_redis_client()
-            await redis.delete(f"{self.label_cache_prefix}{uri}")
+            await redis.delete(
+                f"{self.label_cache_prefix}{uri}",
+                self._label_values_cache_key(uri),
+            )
         except Exception as e:
             logger.warning("failed to invalidate label cache for %s: %s", uri, e)
 

--- a/backend/src/backend/_internal/content_labels.py
+++ b/backend/src/backend/_internal/content_labels.py
@@ -1,0 +1,123 @@
+"""Content-label interpretation and viewer policy.
+
+The moderation service owns label state. This module is the deliberately small
+policy boundary that translates interoperable ATProto values into plyr.fm
+behavior; classifier evidence and moderation workflow state do not belong here.
+"""
+
+from collections.abc import Iterable
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal.auth.session import Session
+from backend._internal.clients.moderation import get_moderation_client
+from backend.models import Track, UserPreferences
+
+ADULT_AUDIO_LABELS = frozenset({"sexual", "porn"})
+
+
+def has_adult_audio_label(labels: Iterable[str]) -> bool:
+    """Return whether labels require the adult-audio preference."""
+    return bool(ADULT_AUDIO_LABELS.intersection(labels))
+
+
+async def get_track_label_values(tracks: Iterable[Track]) -> dict[int, set[str]]:
+    """Fetch active labels for tracks in one labeler request."""
+    tracks_with_uris = [track for track in tracks if track.atproto_record_uri]
+    if not tracks_with_uris:
+        return {}
+
+    uris = [
+        track.atproto_record_uri
+        for track in tracks_with_uris
+        if track.atproto_record_uri is not None
+    ]
+    by_uri = await get_moderation_client().get_active_label_values(uris)
+    return {
+        track.id: by_uri.get(track.atproto_record_uri, set())
+        for track in tracks_with_uris
+    }
+
+
+async def viewer_shows_sensitive_audio(
+    db: AsyncSession, session: Session | None
+) -> bool:
+    """Return the listener's saved adult-audio preference.
+
+    Anonymous viewers and authenticated viewers without a preference row use
+    the safe default. Track owners are handled per track by the caller.
+    """
+    if session is None:
+        return False
+    value = await db.scalar(
+        select(UserPreferences.show_sensitive_audio).where(
+            UserPreferences.did == session.did
+        )
+    )
+    return bool(value)
+
+
+async def viewer_did_shows_sensitive_audio(
+    db: AsyncSession, viewer_did: str | None
+) -> bool:
+    """Return the saved audio preference when only a viewer DID is available."""
+    if viewer_did is None:
+        return False
+    value = await db.scalar(
+        select(UserPreferences.show_sensitive_audio).where(
+            UserPreferences.did == viewer_did
+        )
+    )
+    return bool(value)
+
+
+async def filter_sensitive_audio_tracks(
+    db: AsyncSession,
+    tracks: Iterable[Track],
+    session: Session | None,
+) -> tuple[list[Track], dict[int, set[str]]]:
+    """Hide adult-labeled tracks unless the viewer opted in or owns them."""
+    track_list = list(tracks)
+    return await filter_sensitive_audio_tracks_for_viewer(
+        db,
+        track_list,
+        session.did if session else None,
+    )
+
+
+async def filter_sensitive_audio_tracks_for_viewer(
+    db: AsyncSession,
+    tracks: Iterable[Track],
+    viewer_did: str | None,
+) -> tuple[list[Track], dict[int, set[str]]]:
+    """Hide adult-labeled tracks for a viewer identified only by DID."""
+    track_list = list(tracks)
+    labels_by_id = await get_track_label_values(track_list)
+    if await viewer_did_shows_sensitive_audio(db, viewer_did):
+        return track_list, labels_by_id
+
+    visible = [
+        track
+        for track in track_list
+        if track.artist_did == viewer_did
+        or not has_adult_audio_label(labels_by_id.get(track.id, set()))
+    ]
+    return visible, labels_by_id
+
+
+async def may_stream_sensitive_audio(
+    db: AsyncSession,
+    *,
+    labels: Iterable[str],
+    artist_did: str,
+    session: Session | None,
+) -> bool:
+    """Authorize a labeled audio stream for its owner or an opted-in adult."""
+    if not has_adult_audio_label(labels):
+        return True
+    if session is None:
+        return False
+    if session.did == artist_did:
+        return True
+    return await viewer_shows_sensitive_audio(db, session)

--- a/backend/src/backend/_internal/jams.py
+++ b/backend/src/backend/_internal/jams.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 from sqlalchemy import select, update
 from sqlalchemy.orm import selectinload
 
+from backend._internal.content_labels import filter_sensitive_audio_tracks_for_viewer
 from backend.models import Track
 from backend.models.jam import Jam, JamParticipant
 from backend.schemas import TrackResponse
@@ -857,13 +858,20 @@ class JamService:
         )
         result = await db.execute(stmt)
         tracks = result.scalars().all()
-        track_by_file_id = {track.file_id: track for track in tracks}
+        visible_tracks, labels_by_id = await filter_sensitive_audio_tracks_for_viewer(
+            db, tracks, None
+        )
+        track_by_file_id = {track.file_id: track for track in visible_tracks}
 
         serialized: list[dict[str, Any]] = []
         for file_id in track_ids:
             if track := track_by_file_id.get(file_id):
                 track_response = await TrackResponse.from_track(
-                    track, pds_url=None, liked_track_ids=None, like_counts=None
+                    track,
+                    pds_url=None,
+                    liked_track_ids=None,
+                    like_counts=None,
+                    content_labels=labels_by_id,
                 )
                 serialized.append(track_response.model_dump(mode="json"))
 

--- a/backend/src/backend/_internal/queue.py
+++ b/backend/src/backend/_internal/queue.py
@@ -13,6 +13,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
+from backend._internal.content_labels import filter_sensitive_audio_tracks_for_viewer
 from backend.config import settings
 from backend.models import QueueState, Track, UserPreferences
 from backend.schemas import TrackResponse
@@ -182,6 +183,7 @@ class QueueService:
                 tracks = await self._hydrate_tracks(
                     db,
                     queue_state.state.get("track_ids", []),
+                    did,
                 )
                 # include auto_advance in state
                 state = {**queue_state.state, "auto_advance": auto_advance}
@@ -253,6 +255,7 @@ class QueueService:
                 tracks = await self._hydrate_tracks(
                     db,
                     existing.state.get("track_ids", []),
+                    did,
                 )
 
                 # notify other instances
@@ -325,6 +328,7 @@ class QueueService:
         self,
         db,
         track_ids: list[str],
+        viewer_did: str,
     ) -> list[dict[str, Any]]:
         """fetch track metadata for queue display, preserving order."""
         if not track_ids:
@@ -345,6 +349,10 @@ class QueueService:
             track = track_by_file_id.get(file_id)
             if track:
                 tracks_in_order.append(track)
+
+        tracks_in_order, labels_by_id = await filter_sensitive_audio_tracks_for_viewer(
+            db, tracks_in_order, viewer_did
+        )
 
         # batch backfill image URLs for legacy records
         tracks_needing_backfill = [
@@ -372,6 +380,7 @@ class QueueService:
                 pds_url=None,
                 liked_track_ids=None,
                 like_counts=None,
+                content_labels=labels_by_id,
             )
             serialized.append(track_response.model_dump(mode="json"))
 

--- a/backend/src/backend/_internal/tasks/hooks.py
+++ b/backend/src/backend/_internal/tasks/hooks.py
@@ -24,7 +24,7 @@ from backend.utilities.redis import get_async_redis_client
 
 logger = logging.getLogger(__name__)
 
-_DISCOVERY_CACHE_KEY = "plyr:tracks:discovery"
+_DISCOVERY_CACHE_KEY = "plyr:tracks:discovery:v2"
 
 
 async def invalidate_tracks_discovery_cache() -> None:

--- a/backend/src/backend/api/albums/cache.py
+++ b/backend/src/backend/api/albums/cache.py
@@ -12,7 +12,7 @@ from .schemas import AlbumListItem, AlbumMetadata, ArtistAlbumListItem
 
 logger = logging.getLogger(__name__)
 
-ALBUM_CACHE_PREFIX = "plyr:album:"
+ALBUM_CACHE_PREFIX = "plyr:album:v2:"
 ALBUM_CACHE_TTL_SECONDS = 300  # 5 minutes
 
 

--- a/backend/src/backend/api/albums/listing.py
+++ b/backend/src/backend/api/albums/listing.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import selectinload
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session
 from backend._internal.atproto.records import fetch_list_item_uris
+from backend._internal.content_labels import filter_sensitive_audio_tracks
 from backend._internal.track_visibility import track_visible_filter, viewer_did
 from backend.models import Album, Artist, Track, TrackLike, get_db
 from backend.schemas import TrackResponse
@@ -130,7 +131,7 @@ async def get_album(
     cache_key = _album_cache_key(handle, slug)
     try:
         redis = get_async_redis_client()
-        if cached := await redis.get(cache_key):
+        if session is None and (cached := await redis.get(cache_key)):
             return AlbumResponse.model_validate_json(cached)
     except Exception:
         logger.debug("album cache read failed for %s/%s", handle, slug)
@@ -192,7 +193,9 @@ async def get_album(
         # no ATProto record - order by created_at
         ordered_tracks = sorted(all_tracks, key=lambda t: t.created_at)
 
-    tracks = ordered_tracks
+    tracks, labels_by_id = await filter_sensitive_audio_tracks(
+        db, ordered_tracks, session
+    )
     track_ids = [track.id for track in tracks]
 
     # batch fetch aggregations
@@ -227,6 +230,7 @@ async def get_album(
                 like_counts,
                 comment_counts,
                 track_tags=track_tags,
+                content_labels=labels_by_id,
             )
             for track in tracks
         ]
@@ -245,9 +249,10 @@ async def get_album(
         redis = get_async_redis_client()
         cache_tracks = [{**t, "is_liked": False} for t in response.tracks]
         cacheable = AlbumResponse(metadata=response.metadata, tracks=cache_tracks)
-        await redis.set(
-            cache_key, cacheable.model_dump_json(), ex=ALBUM_CACHE_TTL_SECONDS
-        )
+        if session is None:
+            await redis.set(
+                cache_key, cacheable.model_dump_json(), ex=ALBUM_CACHE_TTL_SECONDS
+            )
     except Exception:
         logger.debug("album cache write failed for %s/%s", handle, slug)
 

--- a/backend/src/backend/api/audio.py
+++ b/backend/src/backend/api/audio.py
@@ -5,10 +5,13 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, get_optional_session, validate_supporter
 from backend._internal.atproto.client import pds_blob_url
 from backend._internal.atproto.spaces.client import SpaceAccessError, open_space_blob
+from backend._internal.clients.moderation import get_moderation_client
+from backend._internal.content_labels import may_stream_sensitive_audio
 from backend.config import settings
 from backend.models import Artist, Track
 from backend.storage import storage
@@ -35,6 +38,39 @@ class AudioUrlResponse(BaseModel):
     url: str
     file_id: str
     file_type: str | None
+
+
+async def _enforce_content_label_access(
+    db: AsyncSession,
+    *,
+    uri: str | None,
+    artist_did: str,
+    session: Session | None,
+) -> None:
+    """Require an authenticated opt-in before serving adult-labeled audio."""
+    if not uri:
+        return
+    try:
+        labels = (
+            await get_moderation_client().get_active_label_values([uri], strict=True)
+        ).get(uri, set())
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="content safety service temporarily unavailable",
+        ) from exc
+    if await may_stream_sensitive_audio(
+        db,
+        labels=labels,
+        artist_did=artist_did,
+        session=session,
+    ):
+        return
+    raise HTTPException(
+        status_code=401 if session is None else 403,
+        detail="sensitive audio is hidden; enable it in settings to listen",
+        headers={"X-Content-Labels": ",".join(sorted(labels))},
+    )
 
 
 @router.head("/{file_id}")
@@ -71,6 +107,7 @@ async def stream_audio(
                 Track.pds_blob_cid,
                 Track.is_private,
                 Track.space_uri,
+                Track.atproto_record_uri,
             )
             .where(or_(Track.file_id == file_id, Track.original_file_id == file_id))
             .order_by(Track.r2_url.is_not(None).desc(), Track.created_at.desc())
@@ -93,7 +130,15 @@ async def stream_audio(
             pds_blob_cid,
             is_private,
             space_uri,
+            atproto_record_uri,
         ) = track_data
+
+        await _enforce_content_label_access(
+            db,
+            uri=atproto_record_uri,
+            artist_did=artist_did,
+            session=session,
+        )
 
     # private media lives in a permissioned space — proxy the bytes through the
     # owner's space credential (can't redirect: the browser has no credential).
@@ -253,6 +298,7 @@ async def get_audio_url(
                 Track.pds_blob_cid,
                 Track.is_private,
                 Track.space_uri,
+                Track.atproto_record_uri,
             )
             .where(or_(Track.file_id == file_id, Track.original_file_id == file_id))
             .order_by(Track.r2_url.is_not(None).desc(), Track.created_at.desc())
@@ -275,7 +321,15 @@ async def get_audio_url(
             pds_blob_cid,
             is_private,
             _space_uri,
+            atproto_record_uri,
         ) = track_data
+
+        await _enforce_content_label_access(
+            db,
+            uri=atproto_record_uri,
+            artist_did=artist_did,
+            session=session,
+        )
 
     # private media is proxied through the permissioned-space credential path,
     # so the cacheable "url" is this backend's own stream endpoint (which holds

--- a/backend/src/backend/api/for_you.py
+++ b/backend/src/backend/api/for_you.py
@@ -31,6 +31,7 @@ from sqlalchemy.orm import selectinload
 
 from backend._internal import Session as AuthSession
 from backend._internal import get_supported_artists, require_auth
+from backend._internal.content_labels import filter_sensitive_audio_tracks
 from backend.models import (
     Artist,
     Tag,
@@ -388,6 +389,9 @@ async def get_for_you_feed(
     )
     tracks_by_id = {t.id: t for t in track_result.scalars().all()}
     tracks = [tracks_by_id[tid] for tid in page_ids if tid in tracks_by_id]
+    tracks, content_labels = await filter_sensitive_audio_tracks(
+        db, tracks, auth_session
+    )
 
     # step 6: batch aggregations + liked set + supporter status (mirrors /tracks/)
     liked_result = await db.execute(
@@ -431,6 +435,7 @@ async def get_for_you_feed(
                 track_tags=track_tags,
                 viewer_did=actor_did,
                 supported_artist_dids=supported_artist_dids,
+                content_labels=content_labels,
             )
             for t in tracks
         ]

--- a/backend/src/backend/api/lists/hydration.py
+++ b/backend/src/backend/api/lists/hydration.py
@@ -4,6 +4,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from backend._internal.content_labels import filter_sensitive_audio_tracks_for_viewer
 from backend._internal.track_visibility import track_visible_filter
 from backend.models import Track, TrackLike
 from backend.schemas import TrackResponse
@@ -30,7 +31,9 @@ async def hydrate_tracks_from_uris(
         # a private track referenced by a list hydrates only for its owner
         .where(track_visible_filter(session_did))
     )
-    all_tracks = track_result.scalars().all()
+    all_tracks, labels_by_id = await filter_sensitive_audio_tracks_for_viewer(
+        db, track_result.scalars().all(), session_did
+    )
     track_by_uri = {t.atproto_record_uri: t for t in all_tracks}
 
     track_ids = [t.id for t in all_tracks]
@@ -56,6 +59,7 @@ async def hydrate_tracks_from_uris(
                 liked_track_ids=liked_track_ids,
                 like_counts=like_counts,
                 comment_counts=comment_counts,
+                content_labels=labels_by_id,
             )
             tracks.append(track_response)
 

--- a/backend/src/backend/api/preferences.py
+++ b/backend/src/backend/api/preferences.py
@@ -32,6 +32,7 @@ class PreferencesResponse(BaseModel):
     # indicates if user needs to re-login to activate teal scrobbling
     teal_needs_reauth: bool = False
     show_sensitive_artwork: bool = False
+    show_sensitive_audio: bool = False
     show_liked_on_profile: bool = False
     support_url: str | None = None
     # extensible UI settings (background_image_url, glass_effects, custom_colors, etc.)
@@ -49,6 +50,7 @@ class PreferencesUpdate(BaseModel):
     hidden_tags: list[str] | None = None
     enable_teal_scrobbling: bool | None = None
     show_sensitive_artwork: bool | None = None
+    show_sensitive_audio: bool | None = None
     show_liked_on_profile: bool | None = None
     support_url: str | None = None
     ui_settings: dict[str, Any] | None = None
@@ -113,6 +115,7 @@ async def get_preferences(
         enable_teal_scrobbling=prefs.enable_teal_scrobbling,
         teal_needs_reauth=teal_needs_reauth,
         show_sensitive_artwork=prefs.show_sensitive_artwork,
+        show_sensitive_audio=prefs.show_sensitive_audio,
         show_liked_on_profile=prefs.show_liked_on_profile,
         support_url=prefs.support_url,
         ui_settings=prefs.ui_settings or {},
@@ -153,6 +156,9 @@ async def update_preferences(
             show_sensitive_artwork=update.show_sensitive_artwork
             if update.show_sensitive_artwork is not None
             else False,
+            show_sensitive_audio=update.show_sensitive_audio
+            if update.show_sensitive_audio is not None
+            else False,
             show_liked_on_profile=update.show_liked_on_profile
             if update.show_liked_on_profile is not None
             else False,
@@ -176,6 +182,8 @@ async def update_preferences(
             prefs.enable_teal_scrobbling = update.enable_teal_scrobbling
         if update.show_sensitive_artwork is not None:
             prefs.show_sensitive_artwork = update.show_sensitive_artwork
+        if update.show_sensitive_audio is not None:
+            prefs.show_sensitive_audio = update.show_sensitive_audio
         if update.show_liked_on_profile is not None:
             prefs.show_liked_on_profile = update.show_liked_on_profile
         if update.support_url is not None:
@@ -201,6 +209,7 @@ async def update_preferences(
         enable_teal_scrobbling=prefs.enable_teal_scrobbling,
         teal_needs_reauth=teal_needs_reauth,
         show_sensitive_artwork=prefs.show_sensitive_artwork,
+        show_sensitive_audio=prefs.show_sensitive_audio,
         show_liked_on_profile=prefs.show_liked_on_profile,
         support_url=prefs.support_url,
         ui_settings=prefs.ui_settings or {},

--- a/backend/src/backend/api/radio/cache.py
+++ b/backend/src/backend/api/radio/cache.py
@@ -28,7 +28,7 @@ from .schemas import RadioTrack
 
 logger = logging.getLogger(__name__)
 
-ROTATION_CACHE_PREFIX = "plyr:radio:rotation:"
+ROTATION_CACHE_PREFIX = "plyr:radio:rotation:v2:"
 # generous next to a normal sub-second rebuild, so the lock only expires under
 # a genuinely dead or stalled holder rather than a slow database.
 BUILD_LOCK_TTL_SECONDS = 10

--- a/backend/src/backend/api/radio/corpus.py
+++ b/backend/src/backend/api/radio/corpus.py
@@ -10,6 +10,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from backend._internal.content_labels import (
+    get_track_label_values,
+    has_adult_audio_label,
+)
 from backend.models import Artist, Track
 
 
@@ -27,4 +31,12 @@ async def load_corpus(db: AsyncSession) -> list[Track]:
         .order_by(Track.created_at.desc(), Track.id.desc())
     )
     result = await db.execute(stmt)
-    return list(result.scalars().all())
+    tracks = list(result.scalars().all())
+    labels_by_id = await get_track_label_values(tracks)
+    # Radio is a shared wall-clock rotation, including anonymous embeds. It
+    # cannot vary by listener preference, so adult audio never enters it.
+    return [
+        track
+        for track in tracks
+        if not has_adult_audio_label(labels_by_id.get(track.id, set()))
+    ]

--- a/backend/src/backend/api/search.py
+++ b/backend/src/backend/api/search.py
@@ -8,8 +8,10 @@ from pydantic import BaseModel
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from backend._internal import Session, get_optional_session
 from backend._internal.clients.clap import get_clap_client
 from backend._internal.clients.tpuf import query as tpuf_query
+from backend._internal.content_labels import filter_sensitive_audio_tracks
 from backend.config import settings
 from backend.models import Album, Artist, Playlist, Tag, Track, TrackTag, get_db
 
@@ -103,6 +105,7 @@ async def unified_search(
         description="filter by type: tracks, artists, albums, tags (comma-separated for multiple)",
     ),
     limit: int = Query(20, ge=1, le=50, description="max results per type"),
+    session: Session | None = Depends(get_optional_session),
 ) -> SearchResponse:
     """unified search across tracks, artists, albums, and tags.
 
@@ -126,7 +129,7 @@ async def unified_search(
 
     # search tracks
     if "tracks" in types:
-        track_results = await _search_tracks(db, q, limit)
+        track_results = await _search_tracks(db, q, limit, session)
         results.extend(track_results)
         counts["tracks"] = len(track_results)
 
@@ -161,7 +164,7 @@ async def unified_search(
 
 
 async def _search_tracks(
-    db: AsyncSession, query: str, limit: int
+    db: AsyncSession, query: str, limit: int, session: Session | None = None
 ) -> list[TrackSearchResult]:
     """search tracks by title using trigram similarity + substring matching."""
     # use pg_trgm similarity function for fuzzy matching
@@ -181,6 +184,10 @@ async def _search_tracks(
 
     result = await db.execute(stmt)
     rows = result.all()
+    visible_tracks, _ = await filter_sensitive_audio_tracks(
+        db, [track for track, _artist, _relevance in rows], session
+    )
+    visible_ids = {track.id for track in visible_tracks}
 
     return [
         TrackSearchResult(
@@ -192,6 +199,7 @@ async def _search_tracks(
             relevance=round(relevance, 3),
         )
         for track, artist, relevance in rows
+        if track.id in visible_ids
     ]
 
 
@@ -373,6 +381,7 @@ async def semantic_search(
         description="text description of desired audio",
     ),
     limit: int = Query(10, ge=1, le=50, description="max results"),
+    session: Session | None = Depends(get_optional_session),
 ) -> SemanticSearchResponse:
     """semantic audio search — describe a mood and get matching tracks.
 
@@ -410,11 +419,16 @@ async def semantic_search(
     )
     result = await db.execute(stmt)
     rows = result.all()
+    visible_tracks, _ = await filter_sensitive_audio_tracks(
+        db, [track for track, _artist in rows], session
+    )
+    visible_ids = {track.id for track in visible_tracks}
 
     # build lookup and preserve vector similarity ordering
     track_lookup: dict[int, tuple[Track, Artist]] = {}
     for track, artist in rows:
-        track_lookup[track.id] = (track, artist)
+        if track.id in visible_ids:
+            track_lookup[track.id] = (track, artist)
 
     results: list[SemanticTrackResult] = []
     for track_id in track_ids:

--- a/backend/src/backend/api/subsonic/browsing.py
+++ b/backend/src/backend/api/subsonic/browsing.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from backend._internal import Session
+from backend._internal.content_labels import filter_sensitive_audio_tracks_for_viewer
 from backend._internal.track_visibility import track_visible_filter
 from backend.api.subsonic.endpoints import Params, _require, _rest, _run, _song
 from backend.api.subsonic.responses import ERROR_NOT_FOUND, SubsonicError
@@ -124,7 +125,9 @@ async def get_album(request: Request) -> Response:
                 .where(track_visible_filter(session.did))
                 .order_by(Track.created_at)
             )
-            tracks = list(track_result.scalars().all())
+            tracks, _ = await filter_sensitive_audio_tracks_for_viewer(
+                db, track_result.scalars().all(), None
+            )
         songs = [_song(track) for track in tracks]
         return {
             "album": {
@@ -219,7 +222,9 @@ async def get_random_songs(request: Request) -> Response:
                 .order_by(func.random())
                 .limit(size)
             )
-            tracks = list(result.scalars().all())
+            tracks, _ = await filter_sensitive_audio_tracks_for_viewer(
+                db, result.scalars().all(), None
+            )
         return {"randomSongs": {"song": [_song(track) for track in tracks]}}
 
     return await _run(request, impl)

--- a/backend/src/backend/api/subsonic/endpoints.py
+++ b/backend/src/backend/api/subsonic/endpoints.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from backend._internal import Session
+from backend._internal.content_labels import filter_sensitive_audio_tracks_for_viewer
 from backend._internal.tasks import schedule_teal_scrobble
 from backend._internal.track_visibility import track_visible_filter
 from backend.api.lists.playlists import _can_view, _read_playlist_items
@@ -154,7 +155,14 @@ async def _tracks_by_uris(
         .where(Track.atproto_record_uri.in_(uris))
         .where(track_visible_filter(session_did))
     )
-    by_uri = {t.atproto_record_uri: t for t in result.scalars().all()}
+    visible, _ = await filter_sensitive_audio_tracks_for_viewer(
+        # Subsonic's redirect cannot carry the plyr.fm cookie required by the
+        # audio endpoint, so adult audio stays hidden on this surface.
+        db,
+        result.scalars().all(),
+        None,
+    )
+    by_uri = {t.atproto_record_uri: t for t in visible}
     return [by_uri[uri] for uri in uris if uri in by_uri]
 
 
@@ -172,7 +180,11 @@ async def _track_by_id(params: Params, session_did: str | None) -> Track:
             .where(track_visible_filter(session_did))
         )
         if track := result.scalar_one_or_none():
-            return track
+            visible, _ = await filter_sensitive_audio_tracks_for_viewer(
+                db, [track], None
+            )
+            if visible:
+                return track
     raise SubsonicError(ERROR_NOT_FOUND, "song not found")
 
 

--- a/backend/src/backend/api/tracks/constants.py
+++ b/backend/src/backend/api/tracks/constants.py
@@ -1,4 +1,4 @@
 """constants for track endpoints."""
 
-DISCOVERY_CACHE_KEY = "plyr:tracks:discovery"
+DISCOVERY_CACHE_KEY = "plyr:tracks:discovery:v2"
 DISCOVERY_CACHE_TTL_SECONDS = 60

--- a/backend/src/backend/api/tracks/likes.py
+++ b/backend/src/backend/api/tracks/likes.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import selectinload
 
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session, require_auth
+from backend._internal.content_labels import filter_sensitive_audio_tracks
 from backend._internal.tasks import (
     schedule_pds_create_like,
     schedule_pds_delete_like,
@@ -72,7 +73,9 @@ async def list_liked_tracks(
     )
 
     result = await db.execute(stmt)
-    tracks = result.scalars().all()
+    tracks, labels_by_id = await filter_sensitive_audio_tracks(
+        db, result.scalars().all(), auth_session
+    )
 
     liked_track_ids = {track.id for track in tracks}
     track_ids = [track.id for track in tracks]
@@ -88,6 +91,7 @@ async def list_liked_tracks(
                 liked_track_ids=liked_track_ids,
                 like_counts=like_counts,
                 comment_counts=comment_counts,
+                content_labels=labels_by_id,
             )
             for track in tracks
         ]

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import selectinload
 
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session, get_supported_artists, require_auth
+from backend._internal.content_labels import filter_sensitive_audio_tracks
 from backend.config import settings
 from backend.models import (
     Artist,
@@ -184,6 +185,11 @@ async def list_tracks(
     with logfire.span("materialize track objects"):
         tracks = list(result.scalars().all())
 
+    # The labeler is the content-classification source of truth. Apply adult
+    # audio policy before pagination metadata or serialization so hidden tracks
+    # do not leak through the default/anonymous discovery response.
+    tracks, content_labels = await filter_sensitive_audio_tracks(db, tracks, session)
+
     # check if there are more results and trim to requested limit
     if has_more := len(tracks) > limit:
         tracks = tracks[:limit]
@@ -317,6 +323,7 @@ async def list_tracks(
                     track_tags=track_tags,
                     viewer_did=viewer_did,
                     supported_artist_dids=supported_artist_dids,
+                    content_labels=content_labels,
                 )
                 for track in tracks
             ]
@@ -384,6 +391,7 @@ async def list_top_tracks(
 
     # preserve order from top_track_ids (unlisted tracks silently dropped)
     tracks = [tracks_by_id[tid] for tid in top_track_ids if tid in tracks_by_id]
+    tracks, content_labels = await filter_sensitive_audio_tracks(db, tracks, session)
 
     # get authenticated user's liked tracks (scoped to current track IDs only)
     liked_track_ids: set[int] | None = None
@@ -436,6 +444,7 @@ async def list_top_tracks(
                 track_tags=track_tags,
                 viewer_did=viewer_did,
                 supported_artist_dids=supported_artist_dids,
+                content_labels=content_labels,
             )
             for track in tracks
         ]

--- a/backend/src/backend/api/tracks/playback.py
+++ b/backend/src/backend/api/tracks/playback.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from backend._internal import Session, get_optional_session
+from backend._internal.content_labels import get_track_label_values
 from backend._internal.tasks import schedule_teal_scrobble
 from backend._internal.track_visibility import ensure_track_visible, viewer_did
 from backend.config import settings
@@ -108,9 +109,10 @@ async def _resolve_track(
     ):
         liked_track_ids = {track.id}
 
-    like_counts, track_tags = await asyncio.gather(
+    like_counts, track_tags, content_labels = await asyncio.gather(
         get_like_counts(db, [track.id]),
         get_track_tags(db, [track.id]),
+        get_track_label_values([track]),
     )
 
     return await TrackResponse.from_track(
@@ -118,6 +120,7 @@ async def _resolve_track(
         liked_track_ids=liked_track_ids,
         like_counts=like_counts,
         track_tags=track_tags,
+        content_labels=content_labels,
     )
 
 

--- a/backend/src/backend/api/users.py
+++ b/backend/src/backend/api/users.py
@@ -5,11 +5,12 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from backend._internal import Session, get_optional_session
+from backend._internal.content_labels import filter_sensitive_audio_tracks
 from backend._internal.track_visibility import track_visible_filter, viewer_did
 from backend.models import Artist, Track, TrackLike, get_db
 from backend.schemas import TrackResponse
@@ -66,7 +67,9 @@ async def get_user_liked_tracks(
     )
 
     track_result = await db.execute(stmt)
-    tracks = track_result.scalars().all()
+    tracks, labels_by_id = await filter_sensitive_audio_tracks(
+        db, track_result.scalars().all(), session
+    )
 
     # get current user's liked track IDs if authenticated
     liked_track_ids: set[int] = set()
@@ -88,20 +91,13 @@ async def get_user_liked_tracks(
                 liked_track_ids=liked_track_ids,
                 like_counts=like_counts,
                 comment_counts=comment_counts,
+                content_labels=labels_by_id,
             )
             for track in tracks
         ]
     )
 
-    # total like count — match the visible list (exclude others' private tracks)
-    count_stmt = (
-        select(func.count())
-        .select_from(TrackLike)
-        .join(Track, Track.id == TrackLike.track_id)
-        .where(TrackLike.user_did == artist.did)
-        .where(track_visible_filter(viewer_did(session)))
-    )
-    total_count = await db.scalar(count_stmt)
+    total_count = len(tracks)
 
     return UserLikedTracksResponse(
         user=UserInfo(

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -754,11 +754,11 @@ class ModerationSettings(AppSettingsSection):
     )
     label_cache_prefix: str = Field(
         default="plyr:copyright-label:",
-        description="Redis key prefix for caching copyright label status",
+        description="Redis key prefix for caching label status",
     )
     label_cache_ttl_seconds: int = Field(
         default=300,
-        description="TTL in seconds for cached copyright label status (default 5 min)",
+        description="TTL in seconds for cached label status (default 5 min)",
     )
     image_moderation_enabled: bool = Field(
         default=True,

--- a/backend/src/backend/models/preferences.py
+++ b/backend/src/backend/models/preferences.py
@@ -54,6 +54,11 @@ class UserPreferences(Base):
     show_sensitive_artwork: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=text("false")
     )
+    # when enabled, tracks carrying the global `sexual` or `porn` label may be
+    # discovered and streamed. Anonymous listeners always use the safe default.
+    show_sensitive_audio: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
 
     # profile preferences
     # when enabled, liked tracks are displayed on the user's artist page

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from backend._internal.atproto.client import parse_at_uri
+from backend.config import settings
 from backend.models import Album, Track
 from backend.utilities.aggregations import CopyrightInfo
 
@@ -155,6 +156,7 @@ class TrackResponse(BaseModel):
     pds_blob_cid: str | None = None  # CID if stored on user's PDS
     visibility: str = "public"  # public | unlisted | supporters | private
     unlisted: bool = False  # derived: excluded from discovery feeds
+    labels: set[str] = Field(default_factory=set)
 
     @classmethod
     async def from_track(
@@ -168,6 +170,7 @@ class TrackResponse(BaseModel):
         track_tags: dict[int, set[str]] | None = None,
         viewer_did: str | None = None,
         supported_artist_dids: set[str] | None = None,
+        content_labels: dict[int, set[str]] | None = None,
     ) -> "TrackResponse":
         """build track response from Track model.
 
@@ -213,8 +216,6 @@ class TrackResponse(BaseModel):
             and pds_url
             and track.atproto_record_uri.startswith("at://")
         ):
-            from backend.config import settings
-
             _, _, rkey = parse_at_uri(track.atproto_record_uri)
             atproto_record_url = (
                 f"{pds_url}/xrpc/com.atproto.repo.getRecord"
@@ -249,6 +250,16 @@ class TrackResponse(BaseModel):
                 )
                 gated = not (is_owner or is_supporter)
 
+        # Never expose the backing CDN/PDS URL in API responses. The backend
+        # audio endpoint is the stable public URL and enforces content labels,
+        # supporter gates, and private-media policy before redirecting/proxying.
+        audio_available = bool(track.r2_url or track.pds_blob_cid)
+        stream_url = (
+            f"{settings.atproto.base_url.rstrip('/')}/audio/{track.file_id}"
+            if audio_available
+            else None
+        )
+
         return cls(
             id=track.id,
             title=track.title,
@@ -259,7 +270,7 @@ class TrackResponse(BaseModel):
             file_id=track.file_id,
             file_type=track.file_type,
             features=await _hydrate_features(track.features),
-            r2_url=track.r2_url,
+            r2_url=stream_url,
             atproto_record_uri=track.atproto_record_uri,
             atproto_record_cid=track.atproto_record_cid,
             atproto_record_url=atproto_record_url,
@@ -285,4 +296,5 @@ class TrackResponse(BaseModel):
             unlisted=not track.in_discovery,
             copyright_song_uri=track.copyright_song_uri,
             copyright_recording_uri=track.copyright_recording_uri,
+            labels=content_labels.get(track.id, set()) if content_labels else set(),
         )

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -250,15 +250,19 @@ class TrackResponse(BaseModel):
                 )
                 gated = not (is_owner or is_supporter)
 
-        # Never expose the backing CDN/PDS URL in API responses. The backend
-        # audio endpoint is the stable public URL and enforces content labels,
-        # supporter gates, and private-media policy before redirecting/proxying.
-        audio_available = bool(track.r2_url or track.pds_blob_cid)
-        stream_url = (
-            f"{settings.atproto.base_url.rstrip('/')}/audio/{track.file_id}"
-            if audio_available
-            else None
-        )
+        labels = content_labels.get(track.id, set()) if content_labels else set()
+
+        # Preserve the existing API contract for ordinary and private tracks.
+        # Adult-labeled audio is the narrow exception: never expose its backing
+        # CDN URL, because playback must pass through the preference-enforcing
+        # backend endpoint even if a client cached older track metadata.
+        stream_url = track.r2_url
+        if labels.intersection({"sexual", "porn"}) and (
+            track.r2_url or track.pds_blob_cid
+        ):
+            stream_url = (
+                f"{settings.atproto.base_url.rstrip('/')}/audio/{track.file_id}"
+            )
 
         return cls(
             id=track.id,
@@ -296,5 +300,5 @@ class TrackResponse(BaseModel):
             unlisted=not track.in_discovery,
             copyright_song_uri=track.copyright_song_uri,
             copyright_recording_uri=track.copyright_recording_uri,
-            labels=content_labels.get(track.id, set()) if content_labels else set(),
+            labels=labels,
         )

--- a/backend/tests/api/test_audio.py
+++ b/backend/tests/api/test_audio.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, get_optional_session, require_auth
 from backend.main import app
-from backend.models import Artist, Track
+from backend.models import Artist, Track, UserPreferences
 
 
 @pytest.fixture
@@ -164,6 +164,69 @@ async def test_stream_audio_file_not_in_storage(
 
     assert response.status_code == 404
     assert response.json()["detail"] == "audio file not found"
+
+
+async def test_adult_labeled_audio_is_hidden_from_anonymous_viewers(
+    test_app: FastAPI,
+    test_track_with_r2_url: Track,
+    db_session: AsyncSession,
+):
+    """A global sexual label must gate the bytes, not only discovery UI."""
+    test_track_with_r2_url.atproto_record_uri = (
+        "at://did:plc:artist123/fm.plyr.feed.track/adult-track"
+    )
+    await db_session.commit()
+    mock_moderation = MagicMock()
+    mock_moderation.get_active_label_values = AsyncMock(
+        return_value={test_track_with_r2_url.atproto_record_uri: {"sexual"}}
+    )
+
+    with patch("backend.api.audio.get_moderation_client", return_value=mock_moderation):
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.get(
+                f"/audio/{test_track_with_r2_url.file_id}", follow_redirects=False
+            )
+
+    assert response.status_code == 401
+    assert response.headers["x-content-labels"] == "sexual"
+
+
+async def test_adult_labeled_audio_is_available_after_opt_in(
+    test_app: FastAPI,
+    test_track_with_r2_url: Track,
+    mock_session: Session,
+    db_session: AsyncSession,
+):
+    """Authenticated listeners may opt into adult-labeled audio independently."""
+    test_track_with_r2_url.atproto_record_uri = (
+        "at://did:plc:artist123/fm.plyr.feed.track/adult-track"
+    )
+    db_session.add(UserPreferences(did=mock_session.did, show_sensitive_audio=True))
+    await db_session.commit()
+    mock_moderation = MagicMock()
+    mock_moderation.get_active_label_values = AsyncMock(
+        return_value={test_track_with_r2_url.atproto_record_uri: {"sexual"}}
+    )
+    test_app.dependency_overrides[get_optional_session] = lambda: mock_session
+
+    try:
+        with patch(
+            "backend.api.audio.get_moderation_client", return_value=mock_moderation
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=test_app), base_url="http://test"
+            ) as client:
+                response = await client.get(
+                    f"/audio/{test_track_with_r2_url.file_id}",
+                    follow_redirects=False,
+                )
+    finally:
+        test_app.dependency_overrides.pop(get_optional_session, None)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == test_track_with_r2_url.r2_url
 
 
 # tests for /audio/{file_id}/url endpoint (offline caching, requires auth)

--- a/backend/tests/api/test_preferences.py
+++ b/backend/tests/api/test_preferences.py
@@ -96,8 +96,25 @@ async def test_get_preferences_includes_teal_fields(
     data = response.json()
     assert "enable_teal_scrobbling" in data
     assert "teal_needs_reauth" in data
+    assert data["show_sensitive_artwork"] is False
+    assert data["show_sensitive_audio"] is False
     # default should be disabled
     assert data["enable_teal_scrobbling"] is False
+
+
+async def test_sensitive_content_preferences_are_independent(
+    client_no_teal: AsyncClient,
+):
+    """Artwork and audio can share a UI master toggle without coupling storage."""
+    response = await client_no_teal.post(
+        "/preferences/",
+        json={"show_sensitive_artwork": True, "show_sensitive_audio": False},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["show_sensitive_artwork"] is True
+    assert data["show_sensitive_audio"] is False
 
 
 async def test_update_teal_scrobbling_preference(

--- a/backend/tests/api/test_private_media_visibility.py
+++ b/backend/tests/api/test_private_media_visibility.py
@@ -101,6 +101,30 @@ async def test_private_track_serializes_without_at_uri_crash(
     # passing a pds_url used to push the ats:// URI through parse_at_uri and raise
     resp = await TrackResponse.from_track(track, pds_url="https://test.pds")
     assert resp.atproto_record_url is None
+    assert resp.r2_url is None
+
+
+async def test_adult_track_serializes_through_policy_endpoint(
+    db_session: AsyncSession, artist: Artist
+):
+    track = await _make_track(
+        db_session, title="adult", fid="adult_public", private=False
+    )
+    track.r2_url = "https://cdn.example.com/audio/adult.mp3"
+    await db_session.commit()
+    track = (
+        await db_session.execute(
+            select(Track)
+            .options(selectinload(Track.artist), selectinload(Track.album_rel))
+            .where(Track.file_id == "adult_public")
+        )
+    ).scalar_one()
+
+    resp = await TrackResponse.from_track(track, content_labels={track.id: {"sexual"}})
+
+    assert resp.r2_url is not None
+    assert resp.r2_url.endswith("/audio/adult_public")
+    assert "cdn.example.com" not in resp.r2_url
 
 
 # --- centralized helper (the chokepoint every endpoint routes through) --------

--- a/backend/tests/test_post_create_hooks.py
+++ b/backend/tests/test_post_create_hooks.py
@@ -471,7 +471,7 @@ class TestRunPostTrackCreateHooks:
                 track.id, audio_url="https://r2.example.com/test.mp3"
             )
 
-        mock_redis.delete.assert_called_once_with("plyr:tracks:discovery")
+        mock_redis.delete.assert_called_once_with("plyr:tracks:discovery:v2")
 
     async def test_no_audio_url_skips_audio_tasks(
         self, db_session: AsyncSession

--- a/docs/internal/moderation/atproto-labeler.md
+++ b/docs/internal/moderation/atproto-labeler.md
@@ -20,6 +20,8 @@ this enables **stackable moderation**: multiple labelers can label the same cont
 
 for plyr.fm, this means:
 - we produce `copyright-violation` labels when admin confirms a match (or Osprey auto-emits)
+- we use global ATProto content labels such as `sexual` and `porn` for audio as
+  well as images; the media type does not change the label vocabulary
 - other ATProto apps can query our labels and apply their own policies
 - users/apps can choose to subscribe to our labeler or ignore it
 - we can revoke labels by emitting negations (`neg: true`)
@@ -90,9 +92,28 @@ curl "https://moderation.plyr.fm/xrpc/com.atproto.label.queryLabels?sources=did:
 
 WebSocket endpoint for real-time label streaming. apps can subscribe to receive new labels as they're created (monotonic sequence cursor).
 
-### POST /admin/active-labels
+### POST /admin/labels
 
-backend uses this to check which track URIs have active (non-negated) `copyright-violation` labels. powers the label cache in `backend/_internal/clients/moderation.py`.
+the backend uses this generic endpoint to fetch the current active values for
+each subject URI. This is the primary consumer API for discovery and playback
+policy.
+
+```json
+{
+  "uris": ["at://did:plc:abc123/fm.plyr.track/xyz789"]
+}
+```
+
+```json
+{
+  "labels": {
+    "at://did:plc:abc123/fm.plyr.track/xyz789": ["sexual"]
+  }
+}
+```
+
+`POST /admin/active-labels` remains as a compatibility projection for the
+copyright synchronization task and returns only `copyright-violation` subjects.
 
 ```bash
 curl -X POST https://moderation.plyr.fm/admin/active-labels \
@@ -129,6 +150,13 @@ the original overview discussed three options. we went with **option B** — the
 |-----|---------|------------|
 | `copyright-violation` | confirmed copyright match | admin dashboard (now), Osprey high-confidence rule (future) |
 | `copyright-review` | needs manual review | Osprey moderate-confidence rule (future) |
+| `sexual` | sexually suggestive or explicit content; global ATProto value | creator self-label or operator |
+| `porn` | pornographic content; global ATProto value | creator self-label or operator |
+
+`sexual` and `porn` are deliberately not plyr.fm-specific inventions. They are
+global ATProto label values, and ATProto's media labels apply to audio as well as
+images and video. A label is an assertion; plyr.fm's separate policy layer maps
+both values to the adult-audio preference and keeps anonymous access disabled.
 
 ### negation labels
 

--- a/docs/internal/moderation/sensitive-content.md
+++ b/docs/internal/moderation/sensitive-content.md
@@ -4,7 +4,10 @@ title: "sensitive content moderation"
 
 ## overview
 
-plyr.fm allows creators to upload cover art and use their Bluesky avatars. some of this content may be inappropriate for general audiences (nudity, graphic imagery, etc.). rather than blocking uploads, we blur sensitive images by default and let users opt-in to view them.
+plyr.fm allows creators to upload audio and cover art and use their Bluesky
+avatars. some of this content may be inappropriate for general audiences.
+sensitive images are blurred by default, and adult-labeled audio is omitted and
+cannot be streamed until an authenticated listener opts in.
 
 this follows our core moderation philosophy: **information, not enforcement**. we flag content and let users decide what they want to see.
 
@@ -25,6 +28,7 @@ CREATE TABLE sensitive_images (
 
 -- user preference
 ALTER TABLE user_preferences ADD COLUMN show_sensitive_artwork BOOLEAN DEFAULT false;
+ALTER TABLE user_preferences ADD COLUMN show_sensitive_audio BOOLEAN DEFAULT false;
 ```
 
 images can be flagged by either:
@@ -112,15 +116,19 @@ returns arrays for SSR compatibility (Sets don't serialize to JSON).
 ### default behavior
 
 - all images matching `sensitive_images` table are blurred
+- tracks with an active global `sexual` or `porn` label are absent from
+  discovery, search, lists, queues, and shared radio
+- the audio endpoint rejects anonymous access to those tracks; authenticated
+  listeners must explicitly enable sensitive audio
 - tooltip on hover explains how to enable
 - link previews (og:image) exclude sensitive images entirely
 
 ### opt-in flow
 
-1. user navigates to portal → "your data"
-2. toggles "sensitive artwork" to enabled
-3. `show_sensitive_artwork` preference saved to database
-4. all sensitive images immediately unblur
+1. user navigates to settings → "privacy & display"
+2. uses the sensitive-content master toggle, or changes artwork/audio separately
+3. the independent preferences are saved to the database
+4. sensitive images unblur and/or adult-labeled audio becomes discoverable and playable
 
 ## current limitations
 
@@ -135,18 +143,21 @@ the `sensitive_images` table is currently populated manually by admins. this is 
 3. **user reporting** - let users flag inappropriate content
 4. **artist self-labeling** - let artists mark their own content as sensitive
 
-### no ATProto labels yet
+### audio labels
 
-unlike copyright moderation, sensitive content flags don't emit ATProto labels. this is intentional for now - we're still figuring out the right taxonomy for content labels vs. copyright labels.
+audio uses the existing signed ATProto labeler rather than a parallel NSFW
+table. The canonical global values are:
 
-future work might include:
-- `content-warning` label type
-- integration with Bluesky's existing content label system
-- respecting labels from other ATProto services
+- `sexual`: sexually suggestive or explicit audio
+- `porn`: pornographic audio
+
+both map to the same default-hide policy today. Keeping the assertion and policy
+separate means the taxonomy remains interoperable while the product can later
+offer finer preferences without relabeling content.
 
 ## moderation workflow
 
-### current process
+### current image process
 
 1. admin discovers inappropriate image (user report, browsing, etc.)
 2. admin identifies the image source:
@@ -154,6 +165,15 @@ future work might include:
    - external: copy full URL
 3. admin inserts row into `sensitive_images` via SQL or Neon console
 4. image is immediately blurred for all users
+
+### current audio process
+
+1. creator self-labels a track or an operator reviews reported audio
+2. the moderation service emits a signed `sexual` or `porn` label against the
+   track AT URI and CID
+3. the backend consumes the active label and applies the listener preference
+4. revocation uses the labeler's normal `neg: true` event rather than deleting
+   history
 
 ### example: flagging an R2 image
 

--- a/frontend/src/lib/audio-source.ts
+++ b/frontend/src/lib/audio-source.ts
@@ -105,6 +105,7 @@ export async function resolveAudioSource(
 	track: Track,
 	fileIdUsed: string
 ): Promise<ResolvedSource> {
+	const hasAdultLabel = track.labels?.some((label) => label === 'sexual' || label === 'porn') ?? false;
 	// the interim raw source isn't playable in this browser yet — surface a
 	// "processing" outcome rather than handing `<audio>` a file it can't decode.
 	// checked before the cache lookup: a cached interim blob is just as
@@ -113,19 +114,24 @@ export async function resolveAudioSource(
 		return { kind: 'processing', trackId: track.id };
 	}
 
-	try {
-		const cachedUrl = await getCachedAudioUrl(fileIdUsed);
-		if (cachedUrl) {
-			return {
-				kind: 'ready',
-				trackId: track.id,
-				fileIdUsed,
-				src: cachedUrl,
-				ownsBlob: cachedUrl.startsWith('blob:')
-			};
+	// Adult-labeled audio must always pass through the backend's current
+	// preference check. A blob cached before the label was applied must not
+	// become a permanent authorization bypass.
+	if (!hasAdultLabel) {
+		try {
+			const cachedUrl = await getCachedAudioUrl(fileIdUsed);
+			if (cachedUrl) {
+				return {
+					kind: 'ready',
+					trackId: track.id,
+					fileIdUsed,
+					src: cachedUrl,
+					ownsBlob: cachedUrl.startsWith('blob:')
+				};
+			}
+		} catch (err) {
+			console.error('failed to check audio cache:', err);
 		}
-	} catch (err) {
-		console.error('failed to check audio cache:', err);
 	}
 
 	if (track.gated) {

--- a/frontend/src/lib/components/embed/CollectionEmbed.svelte
+++ b/frontend/src/lib/components/embed/CollectionEmbed.svelte
@@ -22,7 +22,11 @@
 	let currentIndex = $state(0);
 
 	let currentTrack = $derived(collection.tracks[currentIndex]);
-	let isPlayable = $derived(currentTrack?.r2_url && !currentTrack?.gated);
+	const hasAdultLabel = (track: (typeof collection.tracks)[number]) =>
+		track.labels?.some((label) => label === 'sexual' || label === 'porn') ?? false;
+	let isPlayable = $derived(
+		currentTrack?.r2_url && !currentTrack?.gated && !hasAdultLabel(currentTrack)
+	);
 	let showCopied = $state(false);
 
 	async function copyShareLink() {
@@ -44,7 +48,7 @@
 
 	async function playTrack(index: number) {
 		const track = collection.tracks[index];
-		if (!track?.r2_url || track.gated) return;
+		if (!track?.r2_url || track.gated || hasAdultLabel(track)) return;
 		if (index === currentIndex && !paused) {
 			audio.pause();
 		} else {
@@ -61,7 +65,7 @@
 		}
 		for (let i = currentIndex - 1; i >= 0; i--) {
 			const t = collection.tracks[i];
-			if (t.r2_url && !t.gated) {
+			if (t.r2_url && !t.gated && !hasAdultLabel(t)) {
 				currentIndex = i;
 				await tick();
 				audio.play().catch(() => {});
@@ -73,7 +77,7 @@
 	async function skipNext() {
 		for (let i = currentIndex + 1; i < collection.tracks.length; i++) {
 			const t = collection.tracks[i];
-			if (t.r2_url && !t.gated) {
+			if (t.r2_url && !t.gated && !hasAdultLabel(t)) {
 				currentIndex = i;
 				await tick();
 				audio.play().catch(() => {});
@@ -210,12 +214,12 @@
 		<div class="track-list">
 			{#each collection.tracks as track, i (track.id)}
 				<button
-					class="track-row" class:active={i === currentIndex} class:gated={!track.r2_url || track.gated}
+					class="track-row" class:active={i === currentIndex} class:gated={!track.r2_url || track.gated || hasAdultLabel(track)}
 					onclick={(e) => {
 						if ((e.target as HTMLElement).closest?.('a')) return;
 						playTrack(i);
 					}}
-					disabled={!track.r2_url || track.gated}
+					disabled={!track.r2_url || track.gated || hasAdultLabel(track)}
 				>
 					<span class="track-num">
 						{#if i === currentIndex && !paused}
@@ -281,7 +285,7 @@
 		</div>
 	</div>
 
-	{#if currentTrack?.r2_url && !currentTrack.gated}
+	{#if currentTrack?.r2_url && !currentTrack.gated && !hasAdultLabel(currentTrack)}
 		<audio
 			bind:this={audio} src={currentTrack.r2_url}
 			bind:paused bind:currentTime bind:duration

--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -55,6 +55,7 @@ export interface Preferences {
 	enable_teal_scrobbling: boolean;
 	teal_needs_reauth: boolean;
 	show_sensitive_artwork: boolean;
+	show_sensitive_audio: boolean;
 	show_liked_on_profile: boolean;
 	support_url: string | null;
 	ui_settings: UiSettings;
@@ -71,6 +72,7 @@ const DEFAULT_PREFERENCES: Preferences = {
 	enable_teal_scrobbling: false,
 	teal_needs_reauth: false,
 	show_sensitive_artwork: false,
+	show_sensitive_audio: false,
 	show_liked_on_profile: false,
 	support_url: null,
 	ui_settings: {},
@@ -125,6 +127,14 @@ class PreferencesManager {
 
 	get showSensitiveArtwork(): boolean {
 		return this.data?.show_sensitive_artwork ?? DEFAULT_PREFERENCES.show_sensitive_artwork;
+	}
+
+	get showSensitiveAudio(): boolean {
+		return this.data?.show_sensitive_audio ?? DEFAULT_PREFERENCES.show_sensitive_audio;
+	}
+
+	get showSensitiveContent(): boolean {
+		return this.showSensitiveArtwork && this.showSensitiveAudio;
 	}
 
 	get showLikedOnProfile(): boolean {
@@ -266,6 +276,7 @@ class PreferencesManager {
 					enable_teal_scrobbling: data.enable_teal_scrobbling ?? DEFAULT_PREFERENCES.enable_teal_scrobbling,
 					teal_needs_reauth: data.teal_needs_reauth ?? DEFAULT_PREFERENCES.teal_needs_reauth,
 					show_sensitive_artwork: data.show_sensitive_artwork ?? DEFAULT_PREFERENCES.show_sensitive_artwork,
+					show_sensitive_audio: data.show_sensitive_audio ?? DEFAULT_PREFERENCES.show_sensitive_audio,
 					show_liked_on_profile: data.show_liked_on_profile ?? DEFAULT_PREFERENCES.show_liked_on_profile,
 					support_url: data.support_url ?? DEFAULT_PREFERENCES.support_url,
 					ui_settings: data.ui_settings ?? DEFAULT_PREFERENCES.ui_settings,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -57,6 +57,7 @@ export interface Track {
 	is_liked?: boolean;
 	copyright_flagged?: boolean | null; // null = not scanned, false = clear, true = flagged
 	copyright_match?: string | null; // "Title by Artist" of primary match
+	labels?: string[]; // active ATProto moderation labels on the track record
 	support_gate?: SupportGate | null; // if set, track requires supporter access
 	gated?: boolean; // true if track is gated AND viewer lacks access
 	original_file_id?: string | null; // original file hash if transcoded
@@ -244,4 +245,3 @@ export interface CollectionData {
 	imageUrl: string | null;
 	tracks: Track[];
 }
-

--- a/frontend/src/routes/embed/track/[id]/+page.svelte
+++ b/frontend/src/routes/embed/track/[id]/+page.svelte
@@ -15,8 +15,11 @@
 	let { data }: { data: PageData } = $props();
 	let track = $derived(data.track);
 	let coverUrl = $derived(trackCoverUrl(track));
+	let isAdultLabeled = $derived(
+		track.labels?.some((label) => label === 'sexual' || label === 'porn') ?? false
+	);
 
-	let audio: HTMLAudioElement;
+	let audio: HTMLAudioElement = $state() as HTMLAudioElement;
 	let paused = $state(true);
 	let currentTime = $state(0);
 	let duration = $state(0);
@@ -31,6 +34,7 @@
 	}
 
 	function togglePlay() {
+		if (isAdultLabeled) return;
 		if (audio.paused) {
 			audio.play();
 		} else {
@@ -54,7 +58,7 @@
 
 	onMount(() => {
 		const autoplay = $page.url.searchParams.get('autoplay') === '1';
-		if (autoplay) {
+		if (autoplay && !isAdultLabeled) {
 			audio.play().catch(() => {
 				// Autoplay policy might block this
 				paused = true;
@@ -154,7 +158,7 @@
 			{/if}
 		</div>
 		<div class="header">
-			<button class="play-btn" onclick={togglePlay} aria-label={paused ? 'Play' : 'Pause'}>
+			<button class="play-btn" onclick={togglePlay} disabled={isAdultLabeled} aria-label={isAdultLabeled ? 'Adult content hidden' : paused ? 'Play' : 'Pause'}>
 				{#if paused}
 					<svg viewBox="0 0 24 24" fill="currentColor" class="icon">
 						<path d="M8 5v14l11-7z" />
@@ -197,6 +201,7 @@
 		</div>
 	</div>
 
+	{#if !isAdultLabeled}
 	<audio
 		bind:this={audio}
 		src={track.r2_url}
@@ -205,6 +210,7 @@
 		bind:duration
 		onended={() => (paused = true)}
 	></audio>
+	{/if}
 </div>
 
 <style>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -21,6 +21,8 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 	let enableTealScrobbling = $derived(preferences.enableTealScrobbling);
 	let tealNeedsReauth = $derived(preferences.tealNeedsReauth);
 	let showSensitiveArtwork = $derived(preferences.showSensitiveArtwork);
+	let showSensitiveAudio = $derived(preferences.showSensitiveAudio);
+	let showSensitiveContent = $derived(preferences.showSensitiveContent);
 	let showLikedOnProfile = $derived(preferences.showLikedOnProfile);
 	let currentTheme = $derived(preferences.theme);
 	let currentColor = $derived(preferences.accentColor ?? '#6a9fff');
@@ -334,6 +336,29 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		try {
 			await preferences.update({ show_sensitive_artwork: enabled });
 			toast.success(enabled ? 'sensitive artwork shown' : 'sensitive artwork hidden');
+		} catch (_e) {
+			console.error('failed to save preference:', _e);
+			toast.error('failed to update preference');
+		}
+	}
+
+	async function saveShowSensitiveAudio(enabled: boolean) {
+		try {
+			await preferences.update({ show_sensitive_audio: enabled });
+			toast.success(enabled ? 'sensitive audio shown' : 'sensitive audio hidden');
+		} catch (_e) {
+			console.error('failed to save preference:', _e);
+			toast.error('failed to update preference');
+		}
+	}
+
+	async function saveShowSensitiveContent(enabled: boolean) {
+		try {
+			await preferences.update({
+				show_sensitive_artwork: enabled,
+				show_sensitive_audio: enabled
+			});
+			toast.success(enabled ? 'sensitive content shown' : 'sensitive content hidden');
 		} catch (_e) {
 			console.error('failed to save preference:', _e);
 			toast.error('failed to update preference');
@@ -666,6 +691,21 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 			<div class="settings-card">
 				<div class="setting-row">
 					<div class="setting-info">
+						<h3>sensitive content</h3>
+						<p>show all sensitive artwork and adult-labeled audio</p>
+					</div>
+					<label class="toggle-switch">
+						<input
+							type="checkbox"
+							checked={showSensitiveContent}
+							onchange={(e) => saveShowSensitiveContent((e.target as HTMLInputElement).checked)}
+						/>
+						<span class="toggle-slider"></span>
+					</label>
+				</div>
+
+				<div class="setting-row">
+					<div class="setting-info">
 						<h3>sensitive artwork</h3>
 						<p>show artwork that has been flagged as sensitive (nudity, etc.)</p>
 					</div>
@@ -674,6 +714,21 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 							type="checkbox"
 							checked={showSensitiveArtwork}
 							onchange={(e) => saveShowSensitiveArtwork((e.target as HTMLInputElement).checked)}
+						/>
+						<span class="toggle-slider"></span>
+					</label>
+				</div>
+
+				<div class="setting-row">
+					<div class="setting-info">
+						<h3>sensitive audio</h3>
+						<p>show and play tracks labeled sexual or pornographic</p>
+					</div>
+					<label class="toggle-switch">
+						<input
+							type="checkbox"
+							checked={showSensitiveAudio}
+							onchange={(e) => saveShowSensitiveAudio((e.target as HTMLInputElement).checked)}
 						/>
 						<span class="toggle-slider"></span>
 					</label>

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -20,6 +20,7 @@
 	import { queue } from '$lib/queue.svelte';
 	import { playTrack, guardGatedTrack } from '$lib/playback.svelte';
 	import { auth } from '$lib/auth.svelte';
+	import { preferences } from '$lib/preferences.svelte';
 	import { toast } from '$lib/toast.svelte';
 	import { trackCoverUrl } from '$lib/track-cover';
 	import { redirectToLogin } from '$lib/utils/auth-redirect';
@@ -44,6 +45,14 @@
 	// refetch below fills it in for the owner, or flips `notFound`.
 	let track = $state<Track | null>(data.track);
 	let notFound = $state(false);
+	let isAdultLabeled = $derived(
+		track?.labels?.some((label) => label === 'sexual' || label === 'porn') ?? false
+	);
+	let mayPlayAdultAudio = $derived(
+		!isAdultLabeled ||
+		preferences.showSensitiveAudio ||
+		(auth.user?.did != null && auth.user.did === track?.artist_did)
+	);
 
 	// the visible cover and the og:image cascade share the same root rule
 	// (track art → album art); the og:image then fans out to the artist
@@ -160,6 +169,14 @@
 
 	async function handlePlay() {
 		if (!track) return;
+		if (!mayPlayAdultAudio) {
+			if (!auth.isAuthenticated) {
+				redirectToLogin();
+			} else {
+				toast.error('enable sensitive audio in settings to listen');
+			}
+			return;
+		}
 		if (player.currentTrack?.id === track.id) {
 			// this track is already loaded - just toggle play/pause
 			queue.togglePlayPause();
@@ -176,6 +193,10 @@
 
 	function addToQueue() {
 		if (!track) return;
+		if (!mayPlayAdultAudio) {
+			toast.error('enable sensitive audio in settings to queue this track');
+			return;
+		}
 		if (!guardGatedTrack(track, auth.isAuthenticated)) return;
 		queue.addTracks([track]);
 		toast.success(`queued ${track.title}`, 1800);
@@ -538,7 +559,7 @@ $effect(() => {
 		<meta property="og:image:height" content="1200" />
 	{/if}
 	<meta property="og:image:alt" content="{track.title} by {track.artist}" />
-	{#if track.r2_url}
+	{#if track.r2_url && !isAdultLabeled}
 		<meta property="og:audio" content="{track.r2_url}" />
 		<meta property="og:audio:type" content="audio/{track.file_type}" />
 	{/if}
@@ -567,6 +588,17 @@ $effect(() => {
 		<Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={handleLogout} />
 		<main>
 			<div class="track-detail">
+			{#if isAdultLabeled && !mayPlayAdultAudio}
+				<div class="adult-content-warning" role="note">
+					<strong>adult content</strong>
+					<span>this audio has been labeled as sexually explicit and is hidden by default.</span>
+					{#if auth.isAuthenticated}
+						<a href="/settings">enable sensitive audio in settings</a>
+					{:else}
+						<button type="button" onclick={() => redirectToLogin()}>sign in to change this setting</button>
+					{/if}
+				</div>
+			{/if}
 				{#if notFound}
 					<p class="track-missing">track not found</p>
 				{:else}
@@ -1698,6 +1730,35 @@ $effect(() => {
 		.skeleton-bar {
 			animation: none;
 		}
+	}
+
+	.adult-content-warning {
+		grid-column: 1 / -1;
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5rem 0.75rem;
+		padding: 0.8rem 1rem;
+		border: 1px solid var(--border-emphasis);
+		border-radius: var(--radius-md);
+		background: var(--bg-secondary);
+		color: var(--text-secondary);
+	}
+
+	.adult-content-warning strong {
+		color: var(--text-primary);
+		text-transform: lowercase;
+	}
+
+	.adult-content-warning a,
+	.adult-content-warning button {
+		margin-left: auto;
+		border: 0;
+		background: none;
+		color: var(--accent);
+		font: inherit;
+		cursor: pointer;
+		text-decoration: underline;
 	}
 
 	@media (max-width: 768px) {

--- a/lexicons/track.json
+++ b/lexicons/track.json
@@ -72,6 +72,11 @@
             "description": "Track description (liner notes, show notes, etc.).",
             "maxLength": 5000
           },
+          "labels": {
+            "type": "union",
+            "description": "Creator-applied content warnings using global ATProto label values.",
+            "refs": ["com.atproto.label.defs#selfLabels"]
+          },
           "audioBlob": {
             "type": "blob",
             "description": "Audio file stored on the user's PDS. When present, this is the canonical source; audioUrl is the CDN fallback.",

--- a/loq.toml
+++ b/loq.toml
@@ -24,7 +24,7 @@ max_lines = 612
 
 [[rules]]
 path = "backend/src/backend/_internal/jams.py"
-max_lines = 896
+max_lines = 904
 
 [[rules]]
 path = "backend/src/backend/api/auth.py"
@@ -32,7 +32,7 @@ max_lines = 923
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
-max_lines = 601
+max_lines = 609
 
 [[rules]]
 path = "backend/src/backend/api/tracks/mutations.py"
@@ -52,7 +52,7 @@ max_lines = 905
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"
-max_lines = 710
+max_lines = 769
 
 [[rules]]
 path = "backend/tests/api/test_albums.py"
@@ -160,7 +160,7 @@ max_lines = 3961
 
 [[rules]]
 path = "frontend/src/routes/settings/+page.svelte"
-max_lines = 1657
+max_lines = 1709
 
 [[rules]]
 path = "frontend/src/routes/track/\\[id\\]/+page.svelte"
@@ -180,11 +180,11 @@ max_lines = 949
 
 [[rules]]
 path = "services/moderation/src/admin.rs"
-max_lines = 716
+max_lines = 743
 
 [[rules]]
 path = "services/moderation/src/db.rs"
-max_lines = 1297
+max_lines = 1303
 
 [[rules]]
 path = "frontend/src/lib/components/FeedbackModal.svelte"
@@ -220,7 +220,7 @@ max_lines = 1959
 
 [[rules]]
 path = "frontend/src/lib/components/embed/CollectionEmbed.svelte"
-max_lines = 646
+max_lines = 650
 
 [[rules]]
 path = "backend/tests/api/test_track_deletion.py"
@@ -272,7 +272,7 @@ max_lines = 672
 
 [[rules]]
 path = "frontend/src/routes/embed/track/[[]id[]]/+page.svelte"
-max_lines = 623
+max_lines = 629
 
 [[rules]]
 path = "backend/tests/api/test_private_playlists.py"
@@ -340,7 +340,7 @@ max_lines = 502
 
 [[rules]]
 path = "frontend/src/routes/track/[[]id[]]/+page.svelte"
-max_lines = 1722
+max_lines = 1783
 
 [[rules]]
 path = "frontend/src/lib/components/playlist/PlaylistTrackList.svelte"
@@ -349,3 +349,7 @@ max_lines = 668
 [[rules]]
 path = "frontend/src/lib/components/player/PlaybackControls.svelte"
 max_lines = 512
+
+[[rules]]
+path = "backend/src/backend/_internal/clients/moderation.py"
+max_lines = 579

--- a/services/moderation/src/admin.rs
+++ b/services/moderation/src/admin.rs
@@ -9,6 +9,7 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 use crate::db::LabelContext;
 use crate::state::{AppError, AppState};
@@ -102,6 +103,12 @@ pub struct ActiveLabelsRequest {
 #[derive(Debug, Serialize)]
 pub struct ActiveLabelsResponse {
     pub active_uris: Vec<String>,
+}
+
+/// Current active label values grouped by subject URI.
+#[derive(Debug, Serialize)]
+pub struct LabelValuesResponse {
+    pub labels: HashMap<String, Vec<String>>,
 }
 
 /// Response with URIs that have an explicit negation (dismissal) label.
@@ -322,6 +329,26 @@ pub async fn get_active_labels(
     );
 
     Ok(Json(ActiveLabelsResponse { active_uris }))
+}
+
+/// Get all current active label values for the requested URIs.
+///
+/// This is the generic label-consumption API. The older `/active-labels`
+/// endpoint remains as a copyright-only compatibility projection.
+pub async fn get_label_values(
+    State(state): State<AppState>,
+    Json(request): Json<ActiveLabelsRequest>,
+) -> Result<Json<LabelValuesResponse>, AppError> {
+    let db = state.db.as_ref().ok_or(AppError::LabelerNotConfigured)?;
+
+    tracing::debug!(uri_count = request.uris.len(), "querying active label values");
+
+    let mut labels: HashMap<String, Vec<String>> = HashMap::new();
+    for (uri, val) in db.get_active_label_values(&request.uris).await? {
+        labels.entry(uri).or_default().push(val);
+    }
+
+    Ok(Json(LabelValuesResponse { labels }))
 }
 
 /// Get which URIs have an explicit negation (dismissal) copyright label.

--- a/services/moderation/src/db.rs
+++ b/services/moderation/src/db.rs
@@ -676,45 +676,51 @@ impl LabelDb {
             .map(|s| s.unwrap_or(0))
     }
 
-    /// Get URIs that have active (non-negated) copyright-violation labels.
+    /// Get the current active label values for a set of URIs.
     ///
-    /// For each URI, checks if there's a negation label. Returns only those
-    /// that are still actively flagged.
-    pub async fn get_active_labels(&self, uris: &[String]) -> Result<Vec<String>, sqlx::Error> {
+    /// Label state is event-sourced: the newest event for each
+    /// (source, URI, value) tuple wins. This deliberately permits a value to be
+    /// re-applied after a negation, unlike the old "any historical negation"
+    /// query which made revocation permanent.
+    pub async fn get_active_label_values(
+        &self,
+        uris: &[String],
+    ) -> Result<Vec<(String, String)>, sqlx::Error> {
         if uris.is_empty() {
             return Ok(Vec::new());
         }
 
-        // Get all negated URIs from our input set
-        let negated_uris: std::collections::HashSet<String> = sqlx::query_scalar::<_, String>(
+        sqlx::query_as::<_, (String, String)>(
             r#"
-            SELECT DISTINCT uri
-            FROM labels
-            WHERE val = 'copyright-violation' AND neg = true AND uri = ANY($1)
+            SELECT uri, val
+            FROM (
+                SELECT DISTINCT ON (src, uri, val)
+                       src, uri, val, neg, exp, seq
+                FROM labels
+                WHERE uri = ANY($1)
+                ORDER BY src, uri, val, seq DESC
+            ) current_labels
+            WHERE neg = false
+              AND (exp IS NULL OR exp > NOW())
+            ORDER BY uri, val
             "#,
         )
         .bind(uris)
         .fetch_all(&self.pool)
-        .await?
-        .into_iter()
-        .collect();
+        .await
+    }
 
-        // Get URIs that have a positive label and are not negated
-        let active_uris: Vec<String> = sqlx::query_scalar::<_, String>(
-            r#"
-            SELECT DISTINCT uri
-            FROM labels
-            WHERE val = 'copyright-violation' AND neg = false AND uri = ANY($1)
-            "#,
-        )
-        .bind(uris)
-        .fetch_all(&self.pool)
-        .await?
-        .into_iter()
-        .filter(|uri| !negated_uris.contains(uri))
-        .collect();
-
-        Ok(active_uris)
+    /// Get URIs that have an active copyright-violation label.
+    ///
+    /// Kept as a compatibility projection for the copyright reconciliation
+    /// task. New consumers should use `get_active_label_values`.
+    pub async fn get_active_labels(&self, uris: &[String]) -> Result<Vec<String>, sqlx::Error> {
+        Ok(self
+            .get_active_label_values(uris)
+            .await?
+            .into_iter()
+            .filter_map(|(uri, val)| (val == "copyright-violation").then_some(uri))
+            .collect())
     }
 
     /// Get URIs that have an explicit negation (dismissal) copyright label.

--- a/services/moderation/src/main.rs
+++ b/services/moderation/src/main.rs
@@ -106,6 +106,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/admin/resolve-htmx", post(admin::resolve_flag_htmx))
         .route("/admin/context", post(admin::store_context))
         .route("/admin/active-labels", post(admin::get_active_labels))
+        .route("/admin/labels", post(admin::get_label_values))
         .route("/admin/negated-labels", post(admin::get_negated_labels))
         .route("/admin/sensitive-images", post(admin::add_sensitive_image))
         .route(


### PR DESCRIPTION
## What changed

- generalizes the moderation service's active-label query from the copyright-only projection to current values per AT URI
- treats the global ATProto `sexual` and `porn` values as adult audio assertions
- hides adult-labeled tracks from discovery, search, albums/lists, queues, recommendations, radio, embeds, and Subsonic's cookie-less surface by default
- routes public track audio through the backend and enforces authenticated opt-in at the byte endpoint (including offline-cache protection)
- adds independent `show_sensitive_audio` and `show_sensitive_artwork` preferences plus a shared sensitive-content master toggle
- adds creator self-label support to the track lexicon
- documents the taxonomy and the separation between label assertions and plyr.fm policy
- fixes label state resolution so a newer positive event can correctly re-apply a value after an older negation

## Why

Two newly uploaded podcast episodes contain explicit sexual audio. The existing signed ATProto labeler was already the right assertion mechanism, but backend consumers were hard-coded around `copyright-violation` and sensitive-content preferences only covered artwork.

Using global ATProto values keeps the taxonomy interoperable instead of inventing a plyr.fm-only “NSFW” value. Policy remains local: anonymous listeners and authenticated listeners without opt-in cannot discover or stream adult-labeled audio.

## Production moderation action

The two confirmed records were labeled through the production signed labeler:

- track 1178 → `sexual`, sequence 717
- track 1179 → `sexual`, sequence 718

Both labels were re-queried successfully from `com.atproto.label.queryLabels`.

## Rollout note

Deploy the moderation service's new `POST /admin/labels` endpoint before (or atomically with) the backend consumer. The audio authorization path deliberately fails closed if label state cannot be checked.

The live labeler DID and service record are valid. Its `app.bsky.labeler.service/self` policy roster was updated and publicly verified with `copyright-violation`, `sexual`, and `porn`.

## Validation

- backend lint: pass (only the repository's 9 existing ty diagnostics)
- backend full suite: 1,267 passed / 25 skipped, with one cache-key expectation updated afterward
- affected backend slice after update: 129 passed
- Subsonic + cache hook follow-up: 36 passed
- frontend Svelte check: 0 errors, 0 warnings
- frontend tests: 107 passed
- moderation Rust tests: 8 passed
- commit hooks: all passed (loq, Ruff, type check, Svelte, ESLint, frontend tests, Cargo)
