### PR TITLE
feat(moderation): support creator self-labels

### DIFF
--- a/backend/alembic/versions/2026_07_16_000000_c8f3a6d9e2b1_add_track_self_labels.py
+++ b/backend/alembic/versions/2026_07_16_000000_c8f3a6d9e2b1_add_track_self_labels.py
@@ -1,0 +1,38 @@
+"""add track self labels
+
+Revision ID: c8f3a6d9e2b1
+Revises: b7e2c4d8a1f6
+Create Date: 2026-07-16 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c8f3a6d9e2b1"
+down_revision: str | Sequence[str] | None = "b7e2c4d8a1f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Store creator-published ATProto label values separately from operators."""
+    op.add_column(
+        "tracks",
+        sa.Column(
+            "self_labels",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove indexed creator self-label values."""
+    op.drop_column("tracks", "self_labels")

--- a/backend/scripts/backfill_track_self_labels.py
+++ b/backend/scripts/backfill_track_self_labels.py
@@ -1,0 +1,129 @@
+"""Reconcile indexed creator self-labels from canonical public PDS records."""
+
+import argparse
+import asyncio
+from dataclasses import dataclass
+
+from sqlalchemy import select
+
+from backend._internal.atproto.records.fm_plyr.track import (
+    get_record_public_resilient,
+)
+from backend._internal.atproto.self_labels import self_label_values_from_record
+from backend.models import Artist, Track
+from backend.utilities.database import db_session
+
+
+@dataclass(frozen=True)
+class TrackSubject:
+    """Minimal immutable input for one public record fetch."""
+
+    track_id: int
+    uri: str
+    pds_url: str | None
+    current_labels: list[str]
+
+
+@dataclass(frozen=True)
+class Reconciliation:
+    """One fetched creator-label result."""
+
+    subject: TrackSubject
+    labels: list[str] | None
+    error: str | None = None
+
+
+async def fetch_labels(
+    subject: TrackSubject, semaphore: asyncio.Semaphore
+) -> Reconciliation:
+    """Fetch and parse one canonical track record with bounded concurrency."""
+    try:
+        async with semaphore:
+            record, _ = await get_record_public_resilient(subject.uri, subject.pds_url)
+        value = record.get("value", {})
+        labels = self_label_values_from_record(
+            value.get("labels") if isinstance(value, dict) else None
+        )
+        return Reconciliation(subject=subject, labels=labels)
+    except Exception as exc:
+        return Reconciliation(subject=subject, labels=None, error=str(exc))
+
+
+async def run(*, apply: bool, track_id: int | None, limit: int | None) -> None:
+    """Fetch public records, report differences, and optionally persist them."""
+    async with db_session() as db:
+        query = (
+            select(Track, Artist.pds_url)
+            .join(Artist, Artist.did == Track.artist_did)
+            .where(Track.atproto_record_uri.like("at://%"))
+            .order_by(Track.id)
+        )
+        if track_id is not None:
+            query = query.where(Track.id == track_id)
+        if limit is not None:
+            query = query.limit(limit)
+        rows = (await db.execute(query)).all()
+        subjects = [
+            TrackSubject(
+                track_id=track.id,
+                uri=track.atproto_record_uri,
+                pds_url=pds_url,
+                current_labels=list(track.self_labels or []),
+            )
+            for track, pds_url in rows
+            if track.atproto_record_uri is not None
+        ]
+
+    semaphore = asyncio.Semaphore(10)
+    results = await asyncio.gather(
+        *(fetch_labels(subject, semaphore) for subject in subjects)
+    )
+    changes = [
+        result
+        for result in results
+        if result.labels is not None and result.labels != result.subject.current_labels
+    ]
+    failures = [result for result in results if result.error is not None]
+
+    for result in changes:
+        print(
+            f"track {result.subject.track_id}: "
+            f"{result.subject.current_labels} -> {result.labels}"
+        )
+    for result in failures:
+        print(f"track {result.subject.track_id}: fetch failed: {result.error}")
+
+    if apply and changes:
+        by_id = {
+            result.subject.track_id: result.labels
+            for result in changes
+            if result.labels is not None
+        }
+        async with db_session() as db:
+            tracks = (
+                await db.execute(select(Track).where(Track.id.in_(by_id)))
+            ).scalars()
+            for track in tracks:
+                track.self_labels = by_id[track.id]
+            await db.commit()
+
+    mode = "applied" if apply else "dry-run"
+    print(
+        f"{mode}: scanned={len(subjects)} changed={len(changes)} failed={len(failures)}"
+    )
+
+
+def main() -> None:
+    """Parse CLI arguments and run the async reconciliation."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply", action="store_true", help="persist differences (default: dry-run)"
+    )
+    parser.add_argument("--track-id", type=int, help="reconcile one track")
+    parser.add_argument("--limit", type=int, help="limit records for a test run")
+    args = parser.parse_args()
+    asyncio.run(run(apply=args.apply, track_id=args.track_id, limit=args.limit))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/src/backend/_internal/atproto/records/fm_plyr/track.py
+++ b/backend/src/backend/_internal/atproto/records/fm_plyr/track.py
@@ -10,6 +10,7 @@ from atproto_identity.did.resolver import AsyncDidResolver
 from backend._internal import Session as AuthSession
 from backend._internal.atproto.client import BlobRef, make_pds_request, parse_at_uri
 from backend._internal.atproto.profiles import resolve_dids
+from backend._internal.atproto.self_labels import build_self_labels
 from backend.config import settings
 from backend.models import Track
 
@@ -32,6 +33,7 @@ async def build_track_record(
     support_gate: dict[str, Any] | None = None,
     audio_blob: BlobRef | None = None,
     description: str | None = None,
+    self_labels: list[str] | None = None,
     created_at: datetime | None = None,
 ) -> dict[str, Any]:
     """Build a track record dict for ATProto.
@@ -49,6 +51,7 @@ async def build_track_record(
         support_gate: optional gating config (e.g., {"type": "any"})
         audio_blob: optional blob reference from PDS upload (canonical source when present)
         description: optional track description (liner notes, show notes)
+        self_labels: creator-published ATProto content-warning values
         created_at: optional timestamp (uses now if not provided)
 
     returns:
@@ -90,6 +93,8 @@ async def build_track_record(
         record["supportGate"] = support_gate
     if description:
         record["description"] = description
+    if labels := build_self_labels(self_labels or []):
+        record["labels"] = labels
     if audio_blob:
         record["audioBlob"] = audio_blob
 
@@ -109,6 +114,7 @@ async def create_track_record(
     support_gate: dict[str, Any] | None = None,
     audio_blob: BlobRef | None = None,
     description: str | None = None,
+    self_labels: list[str] | None = None,
     rkey: str | None = None,
     created_at: datetime | None = None,
 ) -> tuple[str, str]:
@@ -132,6 +138,7 @@ async def create_track_record(
         support_gate: optional gating config (e.g., {"type": "any"})
         audio_blob: optional blob reference from PDS upload (canonical source when present)
         description: optional track description (liner notes, show notes)
+        self_labels: creator-published ATProto content-warning values
         rkey: optional explicit record key (TID). uses putRecord when provided
         created_at: optional timestamp for the record (uses now if not provided)
 
@@ -154,6 +161,7 @@ async def create_track_record(
         support_gate=support_gate,
         audio_blob=audio_blob,
         description=description,
+        self_labels=self_labels,
         created_at=created_at,
     )
 
@@ -333,6 +341,7 @@ async def rebuild_track_pds_record(
         image_url=image_url_override or await track.get_image_url(),
         support_gate=track.support_gate,
         description=track.description,
+        self_labels=track.self_labels,
     )
 
     result = await update_record(

--- a/backend/src/backend/_internal/atproto/self_labels.py
+++ b/backend/src/backend/_internal/atproto/self_labels.py
@@ -1,0 +1,79 @@
+"""ATProto creator self-label parsing and record construction."""
+
+import json
+from collections.abc import Iterable
+from typing import Any, cast
+
+SELF_LABELS_TYPE = "com.atproto.label.defs#selfLabels"
+MAX_SELF_LABELS = 10
+MAX_SELF_LABEL_LENGTH = 128
+
+
+def normalize_self_label_values(values: object) -> list[str]:
+    """Return valid, de-duplicated self-label values in source order."""
+    if not isinstance(values, list):
+        return []
+    value_list = cast(list[object], values)
+
+    normalized: list[str] = []
+    for value in value_list[:MAX_SELF_LABELS]:
+        if (
+            not isinstance(value, str)
+            or not value
+            or len(value) > MAX_SELF_LABEL_LENGTH
+        ):
+            continue
+        if value not in normalized:
+            normalized.append(value)
+    return normalized
+
+
+def self_label_values_from_record(labels: object) -> list[str]:
+    """Extract creator values from a `com.atproto.label.defs#selfLabels` object."""
+    if not isinstance(labels, dict):
+        return []
+    label_map = cast(dict[str, object], labels)
+    label_type = label_map.get("$type")
+    if label_type not in (None, SELF_LABELS_TYPE):
+        return []
+    raw_values = label_map.get("values")
+    if not isinstance(raw_values, list):
+        return []
+    values: list[object] = []
+    for entry in cast(list[object], raw_values):
+        if isinstance(entry, dict):
+            values.append(cast(dict[str, object], entry).get("val"))
+    return normalize_self_label_values(values)
+
+
+def build_self_labels(values: Iterable[str]) -> dict[str, Any] | None:
+    """Build the standard ATProto self-label object, or omit it when empty."""
+    normalized = normalize_self_label_values(list(values))
+    if not normalized:
+        return None
+    return {
+        "$type": SELF_LABELS_TYPE,
+        "values": [{"val": value} for value in normalized],
+    }
+
+
+def parse_self_label_values_json(raw: str | None) -> list[str]:
+    """Parse a strict JSON-array form field containing creator label values."""
+    if raw is None:
+        return []
+    try:
+        values = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("self_labels must be a JSON array") from exc
+    if not isinstance(values, list):
+        raise ValueError("self_labels must be a JSON array")
+    if len(values) > MAX_SELF_LABELS:
+        raise ValueError(f"self_labels supports at most {MAX_SELF_LABELS} values")
+    if any(
+        not isinstance(value, str) or not value or len(value) > MAX_SELF_LABEL_LENGTH
+        for value in values
+    ):
+        raise ValueError(
+            f"self_labels values must be non-empty strings up to {MAX_SELF_LABEL_LENGTH} characters"
+        )
+    return normalize_self_label_values(values)

--- a/backend/src/backend/_internal/content_labels.py
+++ b/backend/src/backend/_internal/content_labels.py
@@ -23,10 +23,12 @@ def has_adult_audio_label(labels: Iterable[str]) -> bool:
 
 
 async def get_track_label_values(tracks: Iterable[Track]) -> dict[int, set[str]]:
-    """Fetch active labels for tracks in one labeler request."""
-    tracks_with_uris = [track for track in tracks if track.atproto_record_uri]
+    """Union creator self-labels with active operator labels by track."""
+    track_list = list(tracks)
+    effective = {track.id: set(track.self_labels or []) for track in track_list}
+    tracks_with_uris = [track for track in track_list if track.atproto_record_uri]
     if not tracks_with_uris:
-        return {}
+        return effective
 
     uris = [
         track.atproto_record_uri
@@ -34,10 +36,9 @@ async def get_track_label_values(tracks: Iterable[Track]) -> dict[int, set[str]]
         if track.atproto_record_uri is not None
     ]
     by_uri = await get_moderation_client().get_active_label_values(uris)
-    return {
-        track.id: by_uri.get(track.atproto_record_uri, set())
-        for track in tracks_with_uris
-    }
+    for track in tracks_with_uris:
+        effective[track.id].update(by_uri.get(track.atproto_record_uri, set()))
+    return effective
 
 
 async def viewer_shows_sensitive_audio(

--- a/backend/src/backend/_internal/pds_save_tasks.py
+++ b/backend/src/backend/_internal/pds_save_tasks.py
@@ -156,6 +156,7 @@ async def save_tracks_to_pds(
                         "image_id": track.image_id,
                         "image_url": track.image_url,
                         "support_gate": track.support_gate,
+                        "self_labels": list(track.self_labels or []),
                         "artist_name": track.artist.display_name or track.artist.handle,
                         "created_at": track.created_at,
                         "atproto_record_uri": track.atproto_record_uri,
@@ -225,6 +226,7 @@ async def save_tracks_to_pds(
                         image_url=image_url,
                         support_gate=track_data["support_gate"],
                         audio_blob=blob_ref,
+                        self_labels=track_data["self_labels"],
                     )
                     track_record["createdAt"] = track_data["created_at"].isoformat()
 

--- a/backend/src/backend/_internal/tasks/ingest.py
+++ b/backend/src/backend/_internal/tasks/ingest.py
@@ -18,6 +18,7 @@ from sqlalchemy import delete, select, update
 from sqlalchemy.exc import IntegrityError, OperationalError
 
 from backend._internal.atproto.client import pds_blob_url
+from backend._internal.atproto.self_labels import self_label_values_from_record
 from backend._internal.tasks.hooks import run_post_track_create_hooks
 from backend._internal.tasks.origin_trust import (
     is_trusted_audio_origin,
@@ -308,6 +309,7 @@ async def ingest_track_create(
             r2_url=audio_url if audio_storage in ("r2", "both") else None,
             atproto_record_uri=uri,
             atproto_record_cid=cid,
+            self_labels=self_label_values_from_record(record.get("labels")),
             audio_storage=audio_storage,
             pds_blob_cid=pds_blob_cid,
             publish_state="published",
@@ -382,6 +384,10 @@ async def ingest_track_update(
                 )
         if cid:
             track.atproto_record_cid = cid
+
+        # putRecord events contain the complete record. Absence therefore clears
+        # the creator assertion instead of preserving stale indexed values.
+        track.self_labels = self_label_values_from_record(record.get("labels"))
 
         # audio storage fields
         audio_blob = record.get("audioBlob")

--- a/backend/src/backend/api/albums/mutations.py
+++ b/backend/src/backend/api/albums/mutations.py
@@ -433,6 +433,7 @@ async def update_album(
                     duration=track.duration,
                     features=track.features if track.features else None,
                     image_url=await track.get_image_url(),
+                    self_labels=track.self_labels,
                 )
 
                 _, new_cid = await update_record(

--- a/backend/src/backend/api/audio.py
+++ b/backend/src/backend/api/audio.py
@@ -44,16 +44,21 @@ async def _enforce_content_label_access(
     db: AsyncSession,
     *,
     uri: str | None,
+    self_labels: list[str],
     artist_did: str,
     session: Session | None,
 ) -> None:
     """Require an authenticated opt-in before serving adult-labeled audio."""
-    if not uri:
-        return
+    labels = set(self_labels)
     try:
-        labels = (
-            await get_moderation_client().get_active_label_values([uri], strict=True)
-        ).get(uri, set())
+        if uri:
+            labels.update(
+                (
+                    await get_moderation_client().get_active_label_values(
+                        [uri], strict=True
+                    )
+                ).get(uri, set())
+            )
     except Exception as exc:
         raise HTTPException(
             status_code=503,
@@ -108,6 +113,7 @@ async def stream_audio(
                 Track.is_private,
                 Track.space_uri,
                 Track.atproto_record_uri,
+                Track.self_labels,
             )
             .where(or_(Track.file_id == file_id, Track.original_file_id == file_id))
             .order_by(Track.r2_url.is_not(None).desc(), Track.created_at.desc())
@@ -131,11 +137,13 @@ async def stream_audio(
             is_private,
             space_uri,
             atproto_record_uri,
+            self_labels,
         ) = track_data
 
         await _enforce_content_label_access(
             db,
             uri=atproto_record_uri,
+            self_labels=self_labels,
             artist_did=artist_did,
             session=session,
         )
@@ -299,6 +307,7 @@ async def get_audio_url(
                 Track.is_private,
                 Track.space_uri,
                 Track.atproto_record_uri,
+                Track.self_labels,
             )
             .where(or_(Track.file_id == file_id, Track.original_file_id == file_id))
             .order_by(Track.r2_url.is_not(None).desc(), Track.created_at.desc())
@@ -322,11 +331,13 @@ async def get_audio_url(
             is_private,
             _space_uri,
             atproto_record_uri,
+            self_labels,
         ) = track_data
 
         await _enforce_content_label_access(
             db,
             uri=atproto_record_uri,
+            self_labels=self_labels,
             artist_did=artist_did,
             session=session,
         )

--- a/backend/src/backend/api/tracks/audio_optimize.py
+++ b/backend/src/backend/api/tracks/audio_optimize.py
@@ -103,6 +103,7 @@ class _MetadataState:
     features: list[dict]
     image_url: str | None
     description: str | None
+    self_labels: list[str]
     support_gate: dict | None
     atproto_record_uri: str
 
@@ -183,6 +184,7 @@ async def _refresh_metadata(state: _AudioState) -> _MetadataState:
             features=list(track.features) if track.features else [],
             image_url=await track.get_image_url(),
             description=track.description,
+            self_labels=list(track.self_labels or []),
             support_gate=dict(track.support_gate) if track.support_gate else None,
             atproto_record_uri=track.atproto_record_uri,
         )
@@ -383,6 +385,7 @@ async def optimize_track_audio(
                 support_gate=meta.support_gate,
                 audio_blob=pds_result.blob_ref if pds_result else None,
                 description=meta.description,
+                self_labels=meta.self_labels,
                 created_at=state.created_at,
             )
             _, new_cid = await update_record(

--- a/backend/src/backend/api/tracks/audio_replace.py
+++ b/backend/src/backend/api/tracks/audio_replace.py
@@ -112,6 +112,7 @@ class TrackAudioState:
     features: list[dict]
     image_url: str | None
     description: str | None
+    self_labels: list[str]
     support_gate: dict | None
     created_at: datetime  # original record creation time — must survive replace
 
@@ -178,6 +179,7 @@ async def _load_and_authorize(
             features=list(track.features) if track.features else [],
             image_url=await track.get_image_url(),
             description=track.description,
+            self_labels=list(track.self_labels or []),
             support_gate=dict(track.support_gate) if track.support_gate else None,
             created_at=track.created_at,
         )
@@ -253,6 +255,7 @@ async def _publish_record_update(
         support_gate=state.support_gate,
         audio_blob=pds_result.blob_ref if pds_result else None,
         description=state.description,
+        self_labels=state.self_labels,
         created_at=state.created_at,
     )
 
@@ -555,6 +558,7 @@ async def _refresh_metadata_state(state: TrackAudioState) -> TrackAudioState:
             features=list(track.features) if track.features else [],
             image_url=await track.get_image_url(),
             description=track.description,
+            self_labels=list(track.self_labels or []),
             support_gate=dict(track.support_gate) if track.support_gate else None,
             created_at=state.created_at,
         )

--- a/backend/src/backend/api/tracks/mutations.py
+++ b/backend/src/backend/api/tracks/mutations.py
@@ -30,6 +30,7 @@ from backend._internal.atproto.records import (
     rebuild_track_pds_record,
     update_record,
 )
+from backend._internal.atproto.self_labels import parse_self_label_values_json
 from backend._internal.atproto.spaces.client import delete_space_record
 from backend._internal.atproto.tid import datetime_to_tid
 from backend._internal.audio import AudioFormat
@@ -185,6 +186,10 @@ async def update_track_metadata(
         str | None,
         Form(description="Set to 'true' to exclude from feeds, 'false' to include"),
     ] = None,
+    self_labels: Annotated[
+        str | None,
+        Form(description="JSON array of creator-applied ATProto label values"),
+    ] = None,
 ) -> TrackResponse:
     """Update track metadata (only by owner)."""
     result = await db.execute(
@@ -265,6 +270,15 @@ async def update_track_metadata(
     # visibility; private tracks are rejected earlier with 409)
     if unlisted is not None and track.visibility in ("public", "unlisted"):
         track.visibility = "unlisted" if unlisted.lower() == "true" else "public"
+
+    self_labels_changed = False
+    if self_labels is not None:
+        try:
+            parsed_self_labels = parse_self_label_values_json(self_labels)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        self_labels_changed = parsed_self_labels != track.self_labels
+        track.self_labels = parsed_self_labels
 
     # track album changes for list sync
     old_album_id = track.album_id
@@ -360,6 +374,7 @@ async def update_track_metadata(
         or features is not None
         or image_changed
         or support_gate_changed
+        or self_labels_changed
     )
     if track.atproto_record_uri and metadata_changed:
         try:
@@ -563,6 +578,7 @@ async def restore_track_record(
         duration=track.duration,
         features=track.features if track.features else None,
         image_url=await track.get_image_url(),
+        self_labels=track.self_labels,
     )
     track_record["createdAt"] = track.created_at.isoformat()
 
@@ -742,6 +758,7 @@ async def migrate_track_to_pds(
                 image_url=await track.get_image_url(),
                 support_gate=track.support_gate,
                 audio_blob=blob_ref,
+                self_labels=track.self_labels,
             )
             track_record["createdAt"] = track.created_at.isoformat()
 

--- a/backend/src/backend/api/tracks/revisions.py
+++ b/backend/src/backend/api/tracks/revisions.py
@@ -230,6 +230,7 @@ async def restore_track_revision(
         support_gate=dict(track.support_gate) if track.support_gate else None,
         audio_blob=audio_blob,
         description=track.description,
+        self_labels=track.self_labels,
     )
     # track the effective PDS blob state that will land on the DB row:
     # - if the initial update_record succeeds: revision's own ref (no change)

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -6,7 +6,7 @@ import json
 import logging
 import tempfile
 from collections.abc import AsyncIterable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from io import BytesIO
 from pathlib import Path
 from typing import Annotated, Any, BinaryIO
@@ -41,6 +41,7 @@ from backend._internal.atproto.handles import (
     resolve_featured_artists,
 )
 from backend._internal.atproto.records.fm_plyr.track import build_track_record
+from backend._internal.atproto.self_labels import parse_self_label_values_json
 from backend._internal.atproto.spaces import (
     build_record_uri,
     detect_permissioned_capability,
@@ -118,6 +119,7 @@ class UploadContext:
     album_id: str | None  # new: explicit reference to an existing Album row
     features_json: str | None
     tags: list[str]
+    self_labels: list[str] = field(default_factory=list)
 
     # optional image (already in shared storage as `image_id`, plus computed URLs)
     image_id: str | None = None
@@ -923,6 +925,7 @@ async def _create_records(
             r2_url=sr.r2_url,
             atproto_record_uri=uri,
             atproto_record_cid=None,
+            self_labels=ctx.self_labels,
             created_at=created_at,
             publish_state="pending",
             image_id=image_id,
@@ -975,6 +978,7 @@ async def _create_records(
                 image_url=image_url,
                 audio_blob=pds_result.blob_ref,
                 description=ctx.description,
+                self_labels=ctx.self_labels,
                 created_at=created_at,
             )
             _, atproto_cid = await create_space_record(
@@ -998,6 +1002,7 @@ async def _create_records(
                 support_gate=ctx.support_gate,
                 audio_blob=pds_result.blob_ref if pds_result else None,
                 description=ctx.description,
+                self_labels=ctx.self_labels,
                 rkey=rkey,
                 created_at=created_at,
             )
@@ -1335,6 +1340,7 @@ async def run_track_upload(
     thumbnail_url: str | None,
     support_gate: dict | None,
     auto_tag: bool,
+    self_labels: list[str] | None = None,
     copyright_rights: dict | None = None,
     audio_blob: BlobRef | None = None,
     visibility: str = "public",
@@ -1405,6 +1411,7 @@ async def run_track_upload(
         album_id=album_id,
         features_json=features_json,
         tags=tags,
+        self_labels=self_labels or [],
         description=description,
         image_id=image_id,
         image_url=image_url,
@@ -1446,6 +1453,7 @@ async def schedule_track_upload(ctx: UploadContext) -> None:
         album_id=ctx.album_id,
         features_json=ctx.features_json,
         tags=ctx.tags,
+        self_labels=ctx.self_labels,
         description=ctx.description,
         image_id=ctx.image_id,
         image_url=ctx.image_url,
@@ -1494,6 +1502,10 @@ async def upload_track(
         str | None,
         Form(description="Track description (liner notes, show notes, etc.)"),
     ] = None,
+    self_labels: Annotated[
+        str | None,
+        Form(description="JSON array of creator-applied ATProto label values"),
+    ] = None,
     auto_tag: Annotated[
         str | None,
         Form(description="auto-apply recommended genre tags after classification"),
@@ -1528,6 +1540,11 @@ async def upload_track(
     # validate tags upfront before any processing
     try:
         validated_tags = parse_tags_json(tags)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    try:
+        validated_self_labels = parse_self_label_values_json(self_labels)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -1730,6 +1747,7 @@ async def upload_track(
             album_id=album_id,
             features_json=features,
             tags=validated_tags,
+            self_labels=validated_self_labels,
             description=description,
             image_id=image_id,
             image_url=image_url,

--- a/backend/src/backend/models/track.py
+++ b/backend/src/backend/models/track.py
@@ -77,6 +77,11 @@ class Track(Base):
     r2_url: Mapped[str | None] = mapped_column(String, nullable=True)
     atproto_record_uri: Mapped[str | None] = mapped_column(String, nullable=True)
     atproto_record_cid: Mapped[str | None] = mapped_column(String, nullable=True)
+    # Author-published `com.atproto.label.defs#selfLabels` values. These remain
+    # separate from signed operator labels so provenance stays intact.
+    self_labels: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, default=list, server_default="[]"
+    )
 
     # PDS blob storage (for audio stored on user's PDS)
     audio_storage: Mapped[str] = mapped_column(

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -156,6 +156,7 @@ class TrackResponse(BaseModel):
     pds_blob_cid: str | None = None  # CID if stored on user's PDS
     visibility: str = "public"  # public | unlisted | supporters | private
     unlisted: bool = False  # derived: excluded from discovery feeds
+    self_labels: list[str] = Field(default_factory=list)
     labels: set[str] = Field(default_factory=set)
 
     @classmethod
@@ -250,7 +251,9 @@ class TrackResponse(BaseModel):
                 )
                 gated = not (is_owner or is_supporter)
 
-        labels = content_labels.get(track.id, set()) if content_labels else set()
+        labels = set(track.self_labels or [])
+        if content_labels:
+            labels.update(content_labels.get(track.id, set()))
 
         # Preserve the existing API contract for ordinary and private tracks.
         # Adult-labeled audio is the narrow exception: never expose its backing
@@ -300,5 +303,6 @@ class TrackResponse(BaseModel):
             unlisted=not track.in_discovery,
             copyright_song_uri=track.copyright_song_uri,
             copyright_recording_uri=track.copyright_recording_uri,
+            self_labels=list(track.self_labels or []),
             labels=labels,
         )

--- a/backend/tests/_internal/test_self_labels.py
+++ b/backend/tests/_internal/test_self_labels.py
@@ -1,0 +1,61 @@
+"""Creator self-label parsing, serialization, and effective-label policy."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend._internal.atproto.self_labels import (
+    SELF_LABELS_TYPE,
+    build_self_labels,
+    normalize_self_label_values,
+    parse_self_label_values_json,
+    self_label_values_from_record,
+)
+from backend._internal.content_labels import get_track_label_values
+from backend.models import Track
+
+
+def test_self_label_values_round_trip_and_deduplicate() -> None:
+    labels = build_self_labels(["sexual", "sexual", "porn"])
+
+    assert labels == {
+        "$type": SELF_LABELS_TYPE,
+        "values": [{"val": "sexual"}, {"val": "porn"}],
+    }
+    assert self_label_values_from_record(labels) == ["sexual", "porn"]
+
+
+def test_self_label_parser_rejects_non_array_json() -> None:
+    with pytest.raises(ValueError, match="JSON array"):
+        parse_self_label_values_json('{"val": "sexual"}')
+
+
+def test_normalize_self_labels_preserves_valid_unknown_values() -> None:
+    assert normalize_self_label_values(["sexual", "community:spoiler", 42, ""]) == [
+        "sexual",
+        "community:spoiler",
+    ]
+
+
+async def test_effective_labels_union_creator_and_operator_provenance() -> None:
+    track = Track(
+        id=1177,
+        title="creator labeled",
+        artist_did="did:plc:creator",
+        file_id="creator_labeled",
+        file_type="mp3",
+        atproto_record_uri="at://did:plc:creator/fm.plyr.track/explicit",
+        self_labels=["sexual"],
+    )
+    moderation = AsyncMock()
+    moderation.get_active_label_values.return_value = {
+        track.atproto_record_uri: {"porn", "operator:reviewed"}
+    }
+
+    with patch(
+        "backend._internal.content_labels.get_moderation_client",
+        return_value=moderation,
+    ):
+        values = await get_track_label_values([track])
+
+    assert values[track.id] == {"sexual", "porn", "operator:reviewed"}

--- a/backend/tests/api/test_albums.py
+++ b/backend/tests/api/test_albums.py
@@ -660,6 +660,7 @@ async def test_update_album_title(test_app: FastAPI, db_session: AsyncSession):
         r2_url="https://r2.example.com/audio/test-file-update.mp3",
         atproto_record_uri="at://did:test:user123/fm.plyr.track/track123",
         atproto_record_cid="original_cid",
+        self_labels=["sexual"],
     )
     db_session.add(track)
     await db_session.commit()
@@ -697,6 +698,7 @@ async def test_update_album_title(test_app: FastAPI, db_session: AsyncSession):
     mock_track_update.assert_called_once()
     call_kwargs = mock_track_update.call_args.kwargs
     assert call_kwargs["record"]["album"] == "Updated Title"
+    assert call_kwargs["record"]["labels"]["values"] == [{"val": "sexual"}]
 
     # verify list record update was called with new name
     mock_list_update.assert_called_once()

--- a/backend/tests/api/test_audio.py
+++ b/backend/tests/api/test_audio.py
@@ -193,6 +193,29 @@ async def test_adult_labeled_audio_is_hidden_from_anonymous_viewers(
     assert response.headers["x-content-labels"] == "sexual"
 
 
+async def test_creator_self_labeled_audio_is_hidden_from_anonymous_viewers(
+    test_app: FastAPI,
+    test_track_with_r2_url: Track,
+    db_session: AsyncSession,
+):
+    """A creator assertion gates bytes without an operator label."""
+    test_track_with_r2_url.self_labels = ["sexual"]
+    await db_session.commit()
+    mock_moderation = MagicMock()
+    mock_moderation.get_active_label_values = AsyncMock(return_value={})
+
+    with patch("backend.api.audio.get_moderation_client", return_value=mock_moderation):
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.get(
+                f"/audio/{test_track_with_r2_url.file_id}", follow_redirects=False
+            )
+
+    assert response.status_code == 401
+    assert response.headers["x-content-labels"] == "sexual"
+
+
 async def test_adult_labeled_audio_is_available_after_opt_in(
     test_app: FastAPI,
     test_track_with_r2_url: Track,

--- a/backend/tests/api/test_audio_optimize.py
+++ b/backend/tests/api/test_audio_optimize.py
@@ -554,6 +554,7 @@ async def test_optimize_swaps_wav_to_mp3_preserving_original_and_created_at(
     """happy path: WAV->MP3 swap, lossless original preserved, single PDS blob
     written, record createdAt preserved, interim WAV deleted."""
     track = _wav_track()
+    track.self_labels = ["sexual"]
     db_session.add(track)
     await db_session.commit()
     await db_session.refresh(track)
@@ -594,6 +595,7 @@ async def test_optimize_swaps_wav_to_mp3_preserving_original_and_created_at(
     # the rebuilt record is built with the track's ORIGINAL createdAt, not a
     # fresh one — so the optimization doesn't bump the track to "now".
     assert mocks["build_record"].await_args.kwargs["created_at"] == original_created_at
+    assert mocks["build_record"].await_args.kwargs["self_labels"] == ["sexual"]
 
     # the interim WAV is now orphaned and was deleted
     assert "WAVID" in deleted

--- a/backend/tests/api/test_track_edit_pds_sync.py
+++ b/backend/tests/api/test_track_edit_pds_sync.py
@@ -110,3 +110,32 @@ async def test_editing_track_title_syncs_to_pds(
     # and the edit persisted (no rollback)
     await db_session.refresh(published_track)
     assert published_track.title == "renamed track"
+
+
+async def test_editing_creator_self_label_syncs_to_pds(
+    test_app: FastAPI, db_session: AsyncSession, published_track: Track
+) -> None:
+    pds = AsyncMock(
+        return_value={"uri": published_track.atproto_record_uri, "cid": "bafylabels"}
+    )
+    with patch("backend._internal.atproto.records.fm_plyr.track.make_pds_request", pds):
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.patch(
+                f"/tracks/{published_track.id}",
+                data={"self_labels": '["sexual"]'},
+            )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["self_labels"] == ["sexual"]
+    assert response.json()["labels"] == ["sexual"]
+    assert pds.await_args is not None
+    record = pds.await_args.args[3]["record"]
+    assert record["labels"] == {
+        "$type": "com.atproto.label.defs#selfLabels",
+        "values": [{"val": "sexual"}],
+    }
+
+    await db_session.refresh(published_track)
+    assert published_track.self_labels == ["sexual"]

--- a/backend/tests/api/track_audio_replace/test_pipeline.py
+++ b/backend/tests/api/track_audio_replace/test_pipeline.py
@@ -237,6 +237,7 @@ class TestReplaceOrchestration:
         publish time — different microsecond, assertion fails.
         """
         track = make_track(file_id="OLD")
+        track.self_labels = ["sexual"]
         db_session.add(track)
         await db_session.commit()
         await db_session.refresh(track)
@@ -260,6 +261,7 @@ class TestReplaceOrchestration:
         # `build_track_record` serializes UTC datetimes as `...Z`.
         expected = original_created_at.isoformat().replace("+00:00", "Z")
         assert captured_record["createdAt"] == expected
+        assert captured_record["labels"]["values"] == [{"val": "sexual"}]
 
     async def test_lossless_replace_records_original_file_id(
         self, db_session: AsyncSession, owner: Artist
@@ -602,6 +604,7 @@ def test_track_audio_state_dataclass() -> None:
         features=[],
         image_url=None,
         description=None,
+        self_labels=[],
         support_gate=None,
         created_at=datetime.now(UTC),
     )

--- a/backend/tests/test_jetstream.py
+++ b/backend/tests/test_jetstream.py
@@ -356,6 +356,10 @@ class TestIngestTrackCreate:
             "fileType": "mp3",
             "audioUrl": "https://r2.example.com/js_file_001.mp3",
             "duration": 180,
+            "labels": {
+                "$type": "com.atproto.label.defs#selfLabels",
+                "values": [{"val": "sexual"}],
+            },
             "createdAt": _recent_ts(),
         }
         uri = "at://did:plc:jetstream_test/fm.plyr.track/newtrack1"
@@ -374,6 +378,7 @@ class TestIngestTrackCreate:
         assert track.audio_storage == "r2"
         assert track.extra.get("duration") == 180
         assert track.publish_state == "published"
+        assert track.self_labels == ["sexual"]
 
     async def test_dedup_by_uri(
         self, db_session: AsyncSession, artist: Artist, track: Track
@@ -917,6 +922,60 @@ class TestIngestTrackDelete:
 
 
 class TestIngestTrackUpdate:
+    async def test_replaces_creator_self_labels_from_full_record(
+        self, db_session: AsyncSession, artist: Artist, track: Track
+    ) -> None:
+        """A PDS putRecord replaces the indexed creator assertion."""
+        assert track.atproto_record_uri is not None
+        uri = track.atproto_record_uri
+        track.self_labels = ["sexual"]
+        await db_session.commit()
+
+        await ingest_track_update(
+            did=artist.did,
+            rkey="existing",
+            record={
+                "title": track.title,
+                "labels": {
+                    "$type": "com.atproto.label.defs#selfLabels",
+                    "values": [{"val": "porn"}],
+                },
+            },
+            uri=uri,
+            cid="bafyselflabels",
+        )
+
+        db_session.expire_all()
+        updated = await db_session.scalar(
+            select(Track).where(Track.atproto_record_uri == uri)
+        )
+        assert updated is not None
+        assert updated.self_labels == ["porn"]
+
+    async def test_absent_creator_self_labels_clears_indexed_assertion(
+        self, db_session: AsyncSession, artist: Artist, track: Track
+    ) -> None:
+        """The full replacement record is authoritative when labels are removed."""
+        assert track.atproto_record_uri is not None
+        uri = track.atproto_record_uri
+        track.self_labels = ["sexual"]
+        await db_session.commit()
+
+        await ingest_track_update(
+            did=artist.did,
+            rkey="existing",
+            record={"title": track.title},
+            uri=uri,
+            cid="bafyclearedlabels",
+        )
+
+        db_session.expire_all()
+        updated = await db_session.scalar(
+            select(Track).where(Track.atproto_record_uri == uri)
+        )
+        assert updated is not None
+        assert updated.self_labels == []
+
     async def test_updates_mutable_fields(
         self, db_session: AsyncSession, artist: Artist, track: Track
     ) -> None:

--- a/docs/internal/moderation/atproto-labeler.md
+++ b/docs/internal/moderation/atproto-labeler.md
@@ -10,6 +10,11 @@ the moderation service (`moderation.plyr.fm`) acts as an ATProto labeler — a s
 
 key distinction: **labels are signed data objects, not repository records**. they don't live in a user's repo — they're served directly by the labeler via XRPC endpoints.
 
+creator self-labels are the complementary mechanism: they live inside the
+creator's repository record as `com.atproto.label.defs#selfLabels`. plyr.fm
+preserves the two provenances separately and evaluates their union; the labeler
+must not re-emit a creator assertion as though it were an operator decision.
+
 ## why labels?
 
 from [Bluesky's labeling architecture](https://docs.bsky.app/docs/advanced-guides/moderation):
@@ -150,13 +155,18 @@ the original overview discussed three options. we went with **option B** — the
 |-----|---------|------------|
 | `copyright-violation` | confirmed copyright match | admin dashboard (now), Osprey high-confidence rule (future) |
 | `copyright-review` | needs manual review | Osprey moderate-confidence rule (future) |
-| `sexual` | sexually suggestive or explicit content; global ATProto value | creator self-label or operator |
-| `porn` | pornographic content; global ATProto value | creator self-label or operator |
+| `sexual` | sexually suggestive or explicit content; global ATProto value | creator PDS record and/or operator labeler |
+| `porn` | pornographic content; global ATProto value | creator PDS record and/or operator labeler |
 
 `sexual` and `porn` are deliberately not plyr.fm-specific inventions. They are
 global ATProto label values, and ATProto's media labels apply to audio as well as
 images and video. A label is an assertion; plyr.fm's separate policy layer maps
 both values to the adult-audio preference and keeps anonymous access disabled.
+
+creator removal and labeler negation are intentionally independent. A creator
+can remove only their repo assertion; they cannot clear an operator label by
+editing the track. Likewise, negating an operator label does not rewrite the
+creator's repository.
 
 ### negation labels
 

--- a/docs/internal/moderation/sensitive-content.md
+++ b/docs/internal/moderation/sensitive-content.md
@@ -29,6 +29,9 @@ CREATE TABLE sensitive_images (
 -- user preference
 ALTER TABLE user_preferences ADD COLUMN show_sensitive_artwork BOOLEAN DEFAULT false;
 ALTER TABLE user_preferences ADD COLUMN show_sensitive_audio BOOLEAN DEFAULT false;
+
+-- creator assertions indexed from the track's canonical PDS record
+ALTER TABLE tracks ADD COLUMN self_labels JSONB NOT NULL DEFAULT '[]';
 ```
 
 images can be flagged by either:
@@ -141,12 +144,18 @@ the `sensitive_images` table is currently populated manually by admins. this is 
 1. **perceptual hashing** - hash images at upload time, detect re-uploads of flagged content
 2. **AI detection** - integrate NSFW detection API (AWS Rekognition, Google Vision, etc.)
 3. **user reporting** - let users flag inappropriate content
-4. **artist self-labeling** - let artists mark their own content as sensitive
+4. **creator education** - make the content notice and its consequences clear
 
 ### audio labels
 
-audio uses the existing signed ATProto labeler rather than a parallel NSFW
-table. The canonical global values are:
+audio accepts two independent kinds of assertions and applies one effective
+policy to their union:
+
+- creator self-labels live in the track's canonical PDS record under
+  `com.atproto.label.defs#selfLabels`
+- operator labels are signed assertions from the moderation service
+
+The canonical global values are:
 
 - `sexual`: sexually suggestive or explicit audio
 - `porn`: pornographic audio
@@ -168,12 +177,30 @@ offer finer preferences without relabeling content.
 
 ### current audio process
 
-1. creator self-labels a track or an operator reviews reported audio
-2. the moderation service emits a signed `sexual` or `porn` label against the
-   track AT URI and CID
-3. the backend consumes the active label and applies the listener preference
-4. revocation uses the labeler's normal `neg: true` event rather than deleting
-   history
+1. a creator adds a content notice during upload/edit, or an operator reviews
+   reported audio
+2. creator notices are published with the track record; operator decisions are
+   emitted as signed `sexual` or `porn` labels against its AT URI and CID
+3. the backend indexes creator values, queries active operator values, unions
+   them, and applies the listener preference
+4. removing a creator notice removes only the creator assertion; an independent
+   operator label remains active until the labeler emits its normal `neg: true`
+   event
+
+### self-label reconciliation
+
+Jetstream keeps indexed creator labels current after ordinary PDS writes. To
+reconcile records that predate the database column, read the canonical public
+records in dry-run mode first:
+
+```bash
+cd backend
+uv run scripts/backfill_track_self_labels.py --limit 20
+uv run scripts/backfill_track_self_labels.py --apply
+```
+
+The script never writes to creator repos. It only repairs plyr.fm's index from
+the PDS record and reports fetch failures separately.
 
 ### example: flagging an R2 image
 

--- a/docs/public/artists.md
+++ b/docs/public/artists.md
@@ -40,6 +40,20 @@ your catalog isn't trapped here — other apps can access your tracks without pl
 5. **see it live** — your track is playable immediately and indexed for discovery
 6. **embed it** — copy the embed code to put a player on your website or blog (see [embeds](#embeds) below)
 
+## adult audio and content notices
+
+if a track contains adult or sexual audio, enable **contains adult or sexual
+audio** when uploading it. You can change the notice later in the track editor.
+
+the notice is stored with your track in your ATProto repository. On plyr.fm,
+noticed tracks are hidden from discovery and cannot be played by anonymous
+listeners. Signed-in listeners must explicitly enable sensitive audio in their
+settings. You can still see and manage your own noticed tracks.
+
+removing your notice removes only your own assertion. If a plyr.fm moderator
+independently labeled the track, that operator label and its default-hide policy
+remain until the moderation decision is reversed.
+
 ## artwork guidelines
 
 track artwork is displayed as a square across the app — in lists, the player, and on track pages. for best results:

--- a/frontend/src/lib/components/AlbumUploadForm.svelte
+++ b/frontend/src/lib/components/AlbumUploadForm.svelte
@@ -58,6 +58,7 @@
 			featuredArtists: [],
 			hasUnresolvedFeaturesInput: false,
 			autoTag: false,
+			sensitiveAudio: false,
 			supportGated: false,
 			status: 'pending',
 			error: null,
@@ -130,6 +131,7 @@
 				featuredArtists: [],
 				hasUnresolvedFeaturesInput: false,
 				autoTag: false,
+				sensitiveAudio: false,
 				supportGated: false,
 				status: 'pending',
 				error: null,
@@ -365,6 +367,8 @@
 					},
 					track.title,
 					albumId ?? undefined,
+					undefined, // copyright
+					track.sensitiveAudio ? ['sexual'] : [],
 				);
 			});
 		});

--- a/frontend/src/lib/components/TrackEntryCard.svelte
+++ b/frontend/src/lib/components/TrackEntryCard.svelte
@@ -10,6 +10,7 @@
 		featuredArtists: FeaturedArtist[];
 		hasUnresolvedFeaturesInput: boolean;
 		autoTag: boolean;
+		sensitiveAudio: boolean;
 		supportGated: boolean;
 		status: 'pending' | 'uploading' | 'processing' | 'completed' | 'failed';
 		error: string | null;
@@ -206,6 +207,20 @@
 					onRemove={(did) => onUpdate('featuredArtists', entry.featuredArtists.filter((a) => a.did !== did))}
 					{disabled}
 				/>
+			</div>
+
+			<div class="form-group content-notice">
+				<span class="field-label">content notice</span>
+				<label class="checkbox-label">
+					<input
+						type="checkbox"
+						checked={entry.sensitiveAudio}
+						onchange={(e) => onUpdate('sensitiveAudio', (e.target as HTMLInputElement).checked)}
+						{disabled}
+					/>
+					<span class="checkbox-text">contains adult or sexual audio</span>
+				</label>
+				<p class="gating-note">hidden by default; listeners must opt in to sensitive audio.</p>
 			</div>
 
 			{#if artistProfile?.support_url}
@@ -490,6 +505,20 @@
 		font-size: var(--text-base);
 		color: var(--text-primary);
 		line-height: 1.4;
+	}
+
+	.content-notice {
+		background: color-mix(in srgb, var(--accent) 5%, var(--bg-primary));
+		padding: 1rem;
+		border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border-default));
+		border-radius: var(--radius-sm);
+	}
+
+	.field-label {
+		display: block;
+		margin-bottom: 0.75rem;
+		font-size: var(--text-sm);
+		color: var(--text-secondary);
 	}
 
 	.supporter-gating {

--- a/frontend/src/lib/components/portal/TracksSection.svelte
+++ b/frontend/src/lib/components/portal/TracksSection.svelte
@@ -17,6 +17,7 @@
 
 	// supported audio formats — matches backend AudioFormat enum + AlbumUploadForm
 	const AUDIO_FILE_INPUT_ACCEPT = '.mp3,.wav,.m4a,.aiff,.aif,.flac,audio/mpeg,audio/wav,audio/mp4,audio/aiff,audio/x-aiff,audio/flac';
+	const ADULT_SELF_LABELS = new Set(['sexual', 'porn']);
 
 	type SortMode = 'recent' | 'title' | 'plays';
 
@@ -103,6 +104,10 @@
 	let restorePending = $state(false);
 	let editSupportGate = $state(false);
 	let editUnlisted = $state(false);
+	let editSelfLabels = $state<string[]>([]);
+	let editHasSensitiveAudio = $derived(
+		editSelfLabels.some((label) => ADULT_SELF_LABELS.has(label))
+	);
 	// copyright rights state for the inline edit form — kept in sync with the
 	// CopyrightRightsPanel via bindable props.
 	let editCopyrightEnabled = $state(false);
@@ -150,6 +155,7 @@
 			track.support_gate !== undefined &&
 			track.support_gate.type !== 'copyright';
 		editUnlisted = track.unlisted ?? false;
+		editSelfLabels = [...(track.self_labels ?? [])];
 		// initialize copyright state from the track's persisted URIs.
 		// we don't have the original ISWC/ISRC/masterOwner stored locally — those
 		// live on the PDS records. for now we leave the form blank on open; a
@@ -158,6 +164,14 @@
 		editCopyrightWasEnabled = editCopyrightEnabled;
 		editCopyrightRights = {};
 		fetchRecommendedTags(track.id);
+	}
+
+	function setSensitiveAudio(enabled: boolean) {
+		const nonAdult = editSelfLabels.filter((label) => !ADULT_SELF_LABELS.has(label));
+		const existingAdult = editSelfLabels.filter((label) => ADULT_SELF_LABELS.has(label));
+		editSelfLabels = enabled
+			? [...nonAdult, ...(existingAdult.length > 0 ? existingAdult : ['sexual'])]
+			: nonAdult;
 	}
 
 	async function fetchRecommendedTags(trackId: number) {
@@ -196,6 +210,7 @@
 		editRemoveImage = false;
 		editSupportGate = false;
 		editUnlisted = false;
+		editSelfLabels = [];
 		editCopyrightEnabled = false;
 		editCopyrightWasEnabled = false;
 		editCopyrightRights = {};
@@ -346,6 +361,7 @@
 			}
 		}
 		formData.append('unlisted', editUnlisted ? 'true' : 'false');
+		formData.append('self_labels', JSON.stringify(editSelfLabels));
 		// handle artwork: remove, replace, or leave unchanged
 		if (editRemoveImage) {
 			formData.append('remove_image', 'true');
@@ -708,6 +724,23 @@
 										{/if}
 									</div>
 								{/if}
+								<div class="edit-field-group">
+									<span class="edit-label">content notice</span>
+									<label class="toggle-row">
+										<input
+											type="checkbox"
+											checked={editHasSensitiveAudio}
+											onchange={(event) => setSensitiveAudio((event.target as HTMLInputElement).checked)}
+										/>
+										<span>contains adult or sexual audio</span>
+									</label>
+									<p class="field-hint">
+										this notice travels with the track on ATProto. the track is hidden by default and listeners must opt in to sensitive audio.
+									</p>
+									<p class="field-hint">
+										this changes only your notice. any independent moderation label remains in effect.
+									</p>
+								</div>
 								<div class="edit-field-group">
 									<span class="edit-label">copyright</span>
 									<CopyrightRightsPanel

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -58,6 +58,7 @@ export interface Track {
 	copyright_flagged?: boolean | null; // null = not scanned, false = clear, true = flagged
 	copyright_match?: string | null; // "Title by Artist" of primary match
 	labels?: string[]; // active ATProto moderation labels on the track record
+	self_labels?: string[]; // creator-published ATProto content warnings
 	support_gate?: SupportGate | null; // if set, track requires supporter access
 	gated?: boolean; // true if track is gated AND viewer lacks access
 	original_file_id?: string | null; // original file hash if transcoded

--- a/frontend/src/lib/upload-form-stash.ts
+++ b/frontend/src/lib/upload-form-stash.ts
@@ -19,6 +19,7 @@ export interface TrackFormStash {
 	uploadTags: string[];
 	attestedRights: boolean;
 	autoTag: boolean;
+	sensitiveAudio?: boolean;
 	// single visibility value (public | unlisted | supporters | private) — the
 	// draft must survive a private-media scope-upgrade redirect with its choice intact.
 	visibility: string;

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -118,7 +118,8 @@ class UploaderState {
 		callbacks?: UploadProgressCallback,
 		label?: string,
 		albumId?: string,
-		copyright?: object | null
+		copyright?: object | null,
+		selfLabels: string[] = []
 	): void {
 		const taskId = crypto.randomUUID();
 		const fileSizeMB = file.size / 1024 / 1024;
@@ -169,6 +170,9 @@ class UploaderState {
 		}
 		if (description) {
 			formData.append('description', description);
+		}
+		if (selfLabels.length > 0) {
+			formData.append('self_labels', JSON.stringify(selfLabels));
 		}
 
 		const xhr = new XMLHttpRequest();

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -80,6 +80,7 @@
 	let hasUnresolvedFeaturesInput = $state(false);
 	let attestedRights = $state(false);
 	let autoTag = $state(false);
+	let sensitiveAudio = $state(false);
 	// visibility/access — one mutually-exclusive choice:
 	//   public | unlisted | supporters | private
 	// "private" is only offered when the PDS supports com.atproto.space.* (/auth/me).
@@ -122,6 +123,7 @@
 			uploadTags = stashed.uploadTags;
 			attestedRights = stashed.attestedRights;
 			autoTag = stashed.autoTag;
+			sensitiveAudio = stashed.sensitiveAudio ?? false;
 			visibility = (stashed.visibility ?? 'public') as typeof visibility;
 			clearTrackFormStash();
 			toast.info(
@@ -175,6 +177,7 @@
 			uploadTags: [...uploadTags],
 			attestedRights,
 			autoTag,
+			sensitiveAudio,
 			visibility,
 		};
 	}
@@ -226,6 +229,7 @@
 		const tagsToUpload = [...uploadTags];
 		const uploadVisibility = visibility;
 		const shouldAutoTag = autoTag;
+		const uploadSelfLabels = sensitiveAudio ? ['sexual'] : [];
 		const uploadDescription = description;
 
 		const clearForm = () => {
@@ -238,6 +242,7 @@
 			uploadTags = [];
 			attestedRights = false;
 			autoTag = false;
+			sensitiveAudio = false;
 			visibility = 'public';
 			copyrightEnabled = false;
 			copyrightRights = {};
@@ -289,6 +294,7 @@
 			undefined, // label
 			undefined, // albumId
 			copyrightToSend,
+			uploadSelfLabels,
 		);
 	}
 
@@ -506,6 +512,17 @@
 				bind:rights={copyrightRights}
 				disabled={visibility !== 'public' && visibility !== 'unlisted'}
 			/>
+
+			<fieldset class="form-group content-notice-card">
+				<legend>content notice</legend>
+				<label class="content-notice-row checkbox-label">
+					<input type="checkbox" bind:checked={sensitiveAudio} />
+					<span class="access-body">
+						<span class="checkbox-text">contains adult or sexual audio</span>
+						<span class="access-note">hidden by default; listeners must sign in and choose to hear sensitive audio. the notice travels with this track on ATProto.</span>
+					</span>
+				</label>
+			</fieldset>
 
 			<fieldset class="form-group access-card">
 				<legend>visibility &amp; access</legend>
@@ -867,6 +884,25 @@
 		border: 1px solid var(--border-default);
 		border-radius: var(--radius-sm);
 		min-width: 0;
+	}
+
+	.content-notice-card {
+		padding: 0;
+		border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border-default));
+		border-radius: var(--radius-sm);
+		min-width: 0;
+	}
+
+	.content-notice-card legend {
+		margin-left: 0.75rem;
+		padding: 0 0.4rem;
+		font-size: var(--text-sm);
+		color: var(--text-secondary);
+	}
+
+	.content-notice-row {
+		padding: 0.875rem 1rem;
+		margin: 0;
 	}
 
 	.access-card legend {

--- a/loq.toml
+++ b/loq.toml
@@ -40,7 +40,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1843
+max_lines = 1861
 
 [[rules]]
 path = "backend/src/backend/config.py"
@@ -52,11 +52,11 @@ max_lines = 905
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"
-max_lines = 769
+max_lines = 792
 
 [[rules]]
 path = "backend/tests/api/test_albums.py"
-max_lines = 1579
+max_lines = 1581
 
 [[rules]]
 path = "backend/tests/api/test_list_record_sync.py"
@@ -176,7 +176,7 @@ max_lines = 1299
 
 [[rules]]
 path = "frontend/src/routes/upload/+page.svelte"
-max_lines = 949
+max_lines = 983
 
 [[rules]]
 path = "services/moderation/src/admin.rs"
@@ -212,11 +212,11 @@ max_lines = 544
 
 [[rules]]
 path = "backend/src/backend/_internal/tasks/ingest.py"
-max_lines = 907
+max_lines = 913
 
 [[rules]]
 path = "backend/tests/test_jetstream.py"
-max_lines = 1959
+max_lines = 2018
 
 [[rules]]
 path = "frontend/src/lib/components/embed/CollectionEmbed.svelte"
@@ -240,7 +240,7 @@ max_lines = 823
 
 [[rules]]
 path = "frontend/src/lib/components/TrackEntryCard.svelte"
-max_lines = 571
+max_lines = 600
 
 [[rules]]
 path = "frontend/src/routes/record/+page.svelte"
@@ -248,7 +248,7 @@ max_lines = 701
 
 [[rules]]
 path = "backend/src/backend/api/albums/mutations.py"
-max_lines = 594
+max_lines = 595
 
 [[rules]]
 path = "backend/src/backend/api/lists/playlists.py"
@@ -256,7 +256,7 @@ max_lines = 1086
 
 [[rules]]
 path = "backend/src/backend/api/tracks/audio_replace.py"
-max_lines = 836
+max_lines = 840
 
 [[rules]]
 path = "backend/tests/conftest.py"
@@ -308,7 +308,7 @@ max_lines = 505
 
 [[rules]]
 path = "backend/tests/api/test_audio_optimize.py"
-max_lines = 921
+max_lines = 923
 
 [[rules]]
 path = "frontend/src/lib/components/portal/TracksSection.svelte"
@@ -336,7 +336,7 @@ max_lines = 797
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"
-max_lines = 502
+max_lines = 506
 
 [[rules]]
 path = "frontend/src/routes/track/[[]id[]]/+page.svelte"


### PR DESCRIPTION
## summary

- store creator-published ATProto `selfLabels` separately from signed operator labels and evaluate their union
- add adult-audio content notices to single-track upload, album upload, and portal editing
- preserve self-labels through ingestion and every first-party PDS record rebuild
- gate discovery and audio bytes for creator-labeled tracks using the existing sensitive-audio preference
- add a dry-run-first reconciliation script plus internal and creator-facing documentation

Creator removal changes only the repository assertion. It cannot revoke an independent operator label.

## migration / rollout

1. apply Alembic migration `c8f3a6d9e2b1`
2. deploy backend and frontend
3. dry-run `cd backend && uv run scripts/backfill_track_self_labels.py --limit 20`
4. apply the full reconciliation after inspecting the sample

Queued upload tasks from before deployment remain compatible; the new task argument defaults to no self-labels.

## verification

- `just backend test -q` — 1278 passed, 25 skipped
- focused record-rebuild preservation suite — 71 passed
- `just backend lint`
- `PUBLIC_API_URL=http://localhost:8001 just frontend check`
- commit hooks, frontend tests, and ESLint pass

The local browser reached the frontend but the authenticated upload route could not hydrate because this worktree has no OAuth encryption key configured; no persistent credential was fabricated for that visual check.

Closes #1679
