### PR TITLE
fix(moderation): clarify creator label controls

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -70,6 +70,12 @@ the backend applies policy to the union and preserves the notice across every
 first-party record rebuild. Existing PDS records have a dry-run-first
 reconciliation path.
 
+the first UX follow-up makes that provenance visible to creators when an
+independent adult-audio label remains active, gives every portal edit field a
+distinct control surface, fixes the empty copyright heading for users without
+that feature, and adds a reproducible Storybook edit-state fixture to the
+accessibility gate.
+
 **operator lesson**: the incident exposed an access/runbook gap.
 `MODERATION_AUTH_TOKEN` emits labels, while `MODERATION_BSKY_PASSWORD` only
 updates the labeler account declaration; Neon label data lives in the separate

--- a/backend/src/backend/_internal/content_labels.py
+++ b/backend/src/backend/_internal/content_labels.py
@@ -26,9 +26,21 @@ async def get_track_label_values(tracks: Iterable[Track]) -> dict[int, set[str]]
     """Union creator self-labels with active operator labels by track."""
     track_list = list(tracks)
     effective = {track.id: set(track.self_labels or []) for track in track_list}
+    operator = await get_operator_label_values(track_list)
+    for track_id, values in operator.items():
+        effective[track_id].update(values)
+    return effective
+
+
+async def get_operator_label_values(
+    tracks: Iterable[Track],
+) -> dict[int, set[str]]:
+    """Return active operator labels without creator self-labels."""
+    track_list = list(tracks)
+    operator = {track.id: set() for track in track_list}
     tracks_with_uris = [track for track in track_list if track.atproto_record_uri]
     if not tracks_with_uris:
-        return effective
+        return operator
 
     uris = [
         track.atproto_record_uri
@@ -37,8 +49,8 @@ async def get_track_label_values(tracks: Iterable[Track]) -> dict[int, set[str]]
     ]
     by_uri = await get_moderation_client().get_active_label_values(uris)
     for track in tracks_with_uris:
-        effective[track.id].update(by_uri.get(track.atproto_record_uri, set()))
-    return effective
+        operator[track.id].update(by_uri.get(track.atproto_record_uri, set()))
+    return operator
 
 
 async def viewer_shows_sensitive_audio(

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -15,7 +15,10 @@ from sqlalchemy.orm import selectinload
 
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session, get_supported_artists, require_auth
-from backend._internal.content_labels import filter_sensitive_audio_tracks
+from backend._internal.content_labels import (
+    filter_sensitive_audio_tracks,
+    get_operator_label_values,
+)
 from backend.config import settings
 from backend.models import (
     Artist,
@@ -496,16 +499,20 @@ async def list_my_tracks(
 
     # batch fetch copyright info and tags
     track_ids = [track.id for track in tracks]
-    copyright_info, track_tags = await asyncio.gather(
+    copyright_info, track_tags, operator_labels = await asyncio.gather(
         get_copyright_info(db, track_ids),
         get_track_tags(db, track_ids),
+        get_operator_label_values(tracks),
     )
 
     # fetch all track responses concurrently
     track_responses = await asyncio.gather(
         *[
             TrackResponse.from_track(
-                track, copyright_info=copyright_info, track_tags=track_tags
+                track,
+                copyright_info=copyright_info,
+                track_tags=track_tags,
+                operator_labels=operator_labels,
             )
             for track in tracks
         ]

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -157,6 +157,7 @@ class TrackResponse(BaseModel):
     visibility: str = "public"  # public | unlisted | supporters | private
     unlisted: bool = False  # derived: excluded from discovery feeds
     self_labels: list[str] = Field(default_factory=list)
+    operator_labels: set[str] = Field(default_factory=set)
     labels: set[str] = Field(default_factory=set)
 
     @classmethod
@@ -172,6 +173,7 @@ class TrackResponse(BaseModel):
         viewer_did: str | None = None,
         supported_artist_dids: set[str] | None = None,
         content_labels: dict[int, set[str]] | None = None,
+        operator_labels: dict[int, set[str]] | None = None,
     ) -> "TrackResponse":
         """build track response from Track model.
 
@@ -251,7 +253,10 @@ class TrackResponse(BaseModel):
                 )
                 gated = not (is_owner or is_supporter)
 
-        labels = set(track.self_labels or [])
+        active_operator_labels = (
+            set(operator_labels.get(track.id, set())) if operator_labels else set()
+        )
+        labels = set(track.self_labels or []) | active_operator_labels
         if content_labels:
             labels.update(content_labels.get(track.id, set()))
 
@@ -304,5 +309,6 @@ class TrackResponse(BaseModel):
             copyright_song_uri=track.copyright_song_uri,
             copyright_recording_uri=track.copyright_recording_uri,
             self_labels=list(track.self_labels or []),
+            operator_labels=active_operator_labels,
             labels=labels,
         )

--- a/backend/tests/_internal/test_self_labels.py
+++ b/backend/tests/_internal/test_self_labels.py
@@ -11,7 +11,10 @@ from backend._internal.atproto.self_labels import (
     parse_self_label_values_json,
     self_label_values_from_record,
 )
-from backend._internal.content_labels import get_track_label_values
+from backend._internal.content_labels import (
+    get_operator_label_values,
+    get_track_label_values,
+)
 from backend.models import Track
 
 
@@ -56,6 +59,8 @@ async def test_effective_labels_union_creator_and_operator_provenance() -> None:
         "backend._internal.content_labels.get_moderation_client",
         return_value=moderation,
     ):
+        operator_values = await get_operator_label_values([track])
         values = await get_track_label_values([track])
 
+    assert operator_values[track.id] == {"porn", "operator:reviewed"}
     assert values[track.id] == {"sexual", "porn", "operator:reviewed"}

--- a/backend/tests/api/test_my_tracks_search_sort.py
+++ b/backend/tests/api/test_my_tracks_search_sort.py
@@ -10,6 +10,7 @@ covers:
 
 from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -145,6 +146,25 @@ async def test_blank_q_is_no_filter(
 
     data = await _get(test_app, "?q=%20%20")  # whitespace only
     assert data["total"] == 2
+
+
+async def test_creator_track_response_separates_operator_labels(
+    test_app: FastAPI, db_session: AsyncSession, artist: Artist
+) -> None:
+    track = await _make_track(
+        db_session, title="Independently labeled", file_id="operator_label"
+    )
+    track.self_labels = ["sexual"]
+    await db_session.commit()
+
+    operator_labels = AsyncMock(return_value={track.id: {"sexual", "porn"}})
+    with patch("backend.api.tracks.listing.get_operator_label_values", operator_labels):
+        data = await _get(test_app)
+
+    response_track = data["tracks"][0]
+    assert response_track["self_labels"] == ["sexual"]
+    assert set(response_track["operator_labels"]) == {"sexual", "porn"}
+    assert set(response_track["labels"]) == {"sexual", "porn"}
 
 
 async def test_sort_title_alphabetical(

--- a/docs/public/sensitive-content.md
+++ b/docs/public/sensitive-content.md
@@ -58,8 +58,9 @@ if a track is labeled incorrectly, use the report control while viewing it or co
 
 ## for developers
 
-track responses include creator provenance in `self_labels` and the effective
-union in `labels`. For adult-labeled tracks, the audio URL points at plyr.fm's
+track responses include creator provenance in `self_labels`, active plyr.fm
+moderation provenance in `operator_labels` on creator-owned track listings,
+and the effective union in `labels`. For adult-labeled tracks, the audio URL points at plyr.fm's
 protected `/audio/{file_id}` endpoint instead of a public CDN URL. Clients must
 not cache or bypass that endpoint.
 

--- a/frontend/src/lib/components/TrackEntryCard.svelte
+++ b/frontend/src/lib/components/TrackEntryCard.svelte
@@ -218,7 +218,7 @@
 						onchange={(e) => onUpdate('sensitiveAudio', (e.target as HTMLInputElement).checked)}
 						{disabled}
 					/>
-					<span class="checkbox-text">contains adult or sexual audio</span>
+					<span class="checkbox-text">contains sexually explicit audio</span>
 				</label>
 				<p class="gating-note">hidden by default; listeners must opt in to sensitive audio.</p>
 			</div>

--- a/frontend/src/lib/components/portal/TracksSection.stories.svelte
+++ b/frontend/src/lib/components/portal/TracksSection.stories.svelte
@@ -1,0 +1,49 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { fn, userEvent } from 'storybook/test';
+	import TracksSection from './TracksSection.svelte';
+	import type { Track } from '$lib/types';
+
+	const track: Track = {
+		id: 1177,
+		title: 'Midnight transmission',
+		artist: 'Demo artist',
+		artist_handle: 'demo.plyr.fm',
+		artist_did: 'did:plc:demoartist',
+		file_id: 'midnight-transmission',
+		file_type: 'wav',
+		play_count: 42,
+		created_at: '2026-07-17T00:00:00Z',
+		description: 'A long-form late-night broadcast.',
+		tags: ['spoken-word'],
+		features: [],
+		audio_storage: 'pds',
+		self_labels: ['sexual'],
+		operator_labels: ['sexual'],
+		labels: ['sexual']
+	};
+
+	const { Story } = defineMeta({
+		title: 'portal/TracksSection',
+		component: TracksSection,
+		parameters: { layout: 'padded' },
+		play: async ({ canvas }) => {
+			await userEvent.click(canvas.getByRole('button', { name: 'edit' }));
+		},
+		args: {
+			tracks: [track],
+			tracksTotal: 1,
+			tracksHasMore: false,
+			loadingTracks: false,
+			loadingMoreTracks: false,
+			albums: [],
+			atprotofansEligible: true,
+			onLoadMore: fn(),
+			onTracksChanged: fn(async () => undefined)
+		}
+	});
+</script>
+
+<!-- Open the editor with the edit button; this fixture includes both creator
+     and operator adult labels so the provenance state stays reproducible. -->
+<Story name="Creator track" />

--- a/frontend/src/lib/components/portal/TracksSection.svelte
+++ b/frontend/src/lib/components/portal/TracksSection.svelte
@@ -1190,7 +1190,7 @@
 
 	.suggested-label {
 		font-size: var(--text-xs, 0.75rem);
-		color: var(--text-muted);
+		color: var(--text-tertiary);
 		letter-spacing: 0.02em;
 		white-space: nowrap;
 		flex-shrink: 0;

--- a/frontend/src/lib/components/portal/TracksSection.svelte
+++ b/frontend/src/lib/components/portal/TracksSection.svelte
@@ -174,6 +174,10 @@
 			: nonAdult;
 	}
 
+	function hasOperatorSensitiveLabel(track: Track): boolean {
+		return (track.operator_labels ?? []).some((label) => ADULT_SELF_LABELS.has(label));
+	}
+
 	async function fetchRecommendedTags(trackId: number) {
 		loadingRecommendedTags = true;
 		recommendedTags = [];
@@ -707,7 +711,7 @@
 									</div>
 								</div>
 								{#if atprotofansEligible || (track.support_gate && track.support_gate.type !== 'copyright')}
-									<div class="edit-field-group">
+									<div class="edit-field-group access-field">
 										<span class="edit-label">supporter access</span>
 										<label class="toggle-row">
 											<input
@@ -724,7 +728,7 @@
 										{/if}
 									</div>
 								{/if}
-								<div class="edit-field-group">
+								<div class="edit-field-group content-notice-field">
 									<span class="edit-label">content notice</span>
 									<label class="toggle-row">
 										<input
@@ -732,24 +736,28 @@
 											checked={editHasSensitiveAudio}
 											onchange={(event) => setSensitiveAudio((event.target as HTMLInputElement).checked)}
 										/>
-										<span>contains adult or sexual audio</span>
+										<span>contains sexually explicit audio</span>
 									</label>
 									<p class="field-hint">
 										this notice travels with the track on ATProto. the track is hidden by default and listeners must opt in to sensitive audio.
 									</p>
-									<p class="field-hint">
-										this changes only your notice. any independent moderation label remains in effect.
-									</p>
+									{#if hasOperatorSensitiveLabel(track)}
+										<div class="moderation-status" role="status">
+											<strong>plyr.fm moderation notice active</strong>
+											<span>removing your notice will not make this track visible by default because an independent moderation label remains in effect.</span>
+										</div>
+									{:else}
+										<p class="field-hint">
+											this changes only your notice. moderators can apply a separate notice when needed.
+										</p>
+									{/if}
 								</div>
-								<div class="edit-field-group">
-									<span class="edit-label">copyright</span>
-									<CopyrightRightsPanel
-										bind:enabled={editCopyrightEnabled}
-										bind:rights={editCopyrightRights}
-										disabled={editSupportGate}
-									/>
-								</div>
-								<div class="edit-field-group">
+								<CopyrightRightsPanel
+									bind:enabled={editCopyrightEnabled}
+									bind:rights={editCopyrightRights}
+									disabled={editSupportGate}
+								/>
+								<div class="edit-field-group access-field">
 									<span class="edit-label">visibility</span>
 									<label class="toggle-row">
 										<input
@@ -1144,14 +1152,33 @@
 	.edit-fields {
 		display: flex;
 		flex-direction: column;
-		gap: 0.75rem;
+		gap: 0.875rem;
 		flex: 1;
 	}
 
 	.edit-field-group {
 		display: flex;
 		flex-direction: column;
-		gap: 0.5rem;
+		gap: 0.625rem;
+		padding: 1rem;
+		background: color-mix(in srgb, var(--bg-primary) 78%, var(--bg-tertiary));
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-base);
+		transition: border-color 0.15s, background 0.15s;
+	}
+
+	.edit-field-group:focus-within {
+		background: var(--bg-primary);
+		border-color: color-mix(in srgb, var(--accent) 55%, var(--border-default));
+	}
+
+	.content-notice-field {
+		border-left: 3px solid var(--accent);
+		background: color-mix(in srgb, var(--accent) 6%, var(--bg-primary));
+	}
+
+	.access-field {
+		background: color-mix(in srgb, var(--bg-primary) 88%, var(--bg-tertiary));
 	}
 
 	.suggested-tags-row {
@@ -1197,7 +1224,9 @@
 
 	.edit-label {
 		font-size: var(--text-sm);
-		color: var(--text-secondary);
+		font-weight: 600;
+		letter-spacing: 0.015em;
+		color: var(--text-primary);
 	}
 
 	.toggle-row {
@@ -1218,7 +1247,26 @@
 	.field-hint {
 		font-size: var(--text-sm);
 		color: var(--text-tertiary);
-		margin-top: 0.25rem;
+		line-height: 1.45;
+		margin: 0;
+	}
+
+	.moderation-status {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		padding: 0.75rem 0.875rem;
+		background: color-mix(in srgb, var(--accent) 10%, var(--bg-primary));
+		border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border-subtle));
+		border-radius: var(--radius-base);
+		font-size: var(--text-sm);
+		line-height: 1.45;
+		color: var(--text-secondary);
+	}
+
+	.moderation-status strong {
+		color: var(--text-primary);
+		font-weight: 600;
 	}
 
 	.field-hint a {
@@ -1554,7 +1602,7 @@
 		align-items: center;
 		gap: 0.5rem;
 		padding: 0.75rem 1rem;
-		color: var(--text-muted);
+		color: var(--text-tertiary);
 	}
 
 	.artwork-empty span {
@@ -1599,7 +1647,7 @@
 
 	.audio-current-label {
 		font-size: var(--text-sm);
-		color: var(--text-muted);
+		color: var(--text-tertiary);
 	}
 
 	.audio-selected {
@@ -1711,7 +1759,7 @@
 		flex-basis: 100%;
 		margin: 0.35rem 0 0;
 		font-size: var(--text-xs);
-		color: var(--text-muted);
+		color: var(--text-tertiary);
 	}
 
 	.edit-input:focus {
@@ -1784,7 +1832,11 @@
 		}
 
 		.edit-fields {
-			gap: 0.6rem;
+			gap: 0.75rem;
+		}
+
+		.edit-field-group {
+			padding: 0.875rem;
 		}
 
 		.edit-label {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -59,6 +59,7 @@ export interface Track {
 	copyright_match?: string | null; // "Title by Artist" of primary match
 	labels?: string[]; // active ATProto moderation labels on the track record
 	self_labels?: string[]; // creator-published ATProto content warnings
+	operator_labels?: string[]; // active labels independently applied by plyr.fm moderation
 	support_gate?: SupportGate | null; // if set, track requires supporter access
 	gated?: boolean; // true if track is gated AND viewer lacks access
 	original_file_id?: string | null; // original file hash if transcoded

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -701,6 +701,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 								type="checkbox"
 								checked={showSensitiveContent}
 								indeterminate={showSensitiveArtwork !== showSensitiveAudio}
+								aria-label="show all sensitive content"
 								onchange={(e) => saveShowSensitiveContent((e.target as HTMLInputElement).checked)}
 							/>
 							<span class="toggle-slider"></span>
@@ -718,6 +719,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 								<input
 									type="checkbox"
 									checked={showSensitiveArtwork}
+									aria-label="show sensitive artwork"
 									onchange={(e) => saveShowSensitiveArtwork((e.target as HTMLInputElement).checked)}
 								/>
 								<span class="toggle-slider"></span>
@@ -733,6 +735,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 								<input
 									type="checkbox"
 									checked={showSensitiveAudio}
+									aria-label="show sensitive audio"
 									onchange={(e) => saveShowSensitiveAudio((e.target as HTMLInputElement).checked)}
 								/>
 								<span class="toggle-slider"></span>

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -518,7 +518,7 @@
 				<label class="content-notice-row checkbox-label">
 					<input type="checkbox" bind:checked={sensitiveAudio} />
 					<span class="access-body">
-						<span class="checkbox-text">contains adult or sexual audio</span>
+						<span class="checkbox-text">contains sexually explicit audio</span>
 						<span class="access-note">hidden by default; listeners must sign in and choose to hear sensitive audio. the notice travels with this track on ATProto.</span>
 					</span>
 				</label>

--- a/loq.toml
+++ b/loq.toml
@@ -32,7 +32,7 @@ max_lines = 923
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
-max_lines = 609
+max_lines = 616
 
 [[rules]]
 path = "backend/src/backend/api/tracks/mutations.py"
@@ -160,7 +160,7 @@ max_lines = 3961
 
 [[rules]]
 path = "frontend/src/routes/settings/+page.svelte"
-max_lines = 1785
+max_lines = 1788
 
 [[rules]]
 path = "frontend/src/routes/track/\\[id\\]/+page.svelte"
@@ -312,7 +312,7 @@ max_lines = 923
 
 [[rules]]
 path = "frontend/src/lib/components/portal/TracksSection.svelte"
-max_lines = 1833
+max_lines = 1879
 
 [[rules]]
 path = "frontend/src/lib/components/portal/SharesSection.svelte"


### PR DESCRIPTION
## what changed

- separates active operator labels from creator self-labels in `/tracks/me` so the portal can show real moderation provenance
- tells creators when removing their own notice will not restore default visibility
- gives every track-edit field a distinct bordered surface, with stronger labels and a focused content-notice treatment
- removes the empty copyright heading for accounts without that feature
- renames the creator control to “contains sexually explicit audio”
- adds accessible names to the parent and child sensitive-content switches
- adds a Storybook creator-track fixture that opens the edit form and exercises operator-label state
- documents the new `operator_labels` response field

## why

The edit form rendered as one uninterrupted column, making unrelated controls difficult to distinguish. The creator notice also could not explain whether an independent moderation label was active because the API exposed only creator labels and the effective union.

## impact

Creators get a clearer, responsive editor and an authoritative warning when moderator-applied adult-audio policy remains in force. Listener behavior and label enforcement are unchanged.

## validation

- full pre-commit suite
- backend lint
- targeted backend tests: 21 passed
- frontend unit tests: 110 passed
- Storybook Chromium accessibility gate: 34 passed
- Svelte check: 0 errors / 0 warnings
- docs build
- visual review at desktop and 390px mobile widths