### PR TITLE
Reduce repetitive frontend chrome

### DIFF
--- a/frontend/src/lib/components/TagFilter.svelte
+++ b/frontend/src/lib/components/TagFilter.svelte
@@ -32,22 +32,6 @@
 			})
 	);
 
-	/** deterministic hue from tag name (0–360) */
-	function tagHue(name: string): number {
-		let hash = 0;
-		for (let i = 0; i < name.length; i++) {
-			hash = name.charCodeAt(i) + ((hash << 5) - hash);
-		}
-		return ((hash % 360) + 360) % 360;
-	}
-
-	function chipStyle(name: string, selected: boolean): string {
-		const hue = tagHue(name);
-		if (selected) {
-			return `--chip-hue: ${hue}; background: hsl(${hue} 60% 50% / 0.2); border-color: hsl(${hue} 55% 55%); color: hsl(${hue} 70% 75%);`;
-		}
-		return `--chip-hue: ${hue}; border-color: hsl(${hue} 30% 40% / 0.4); color: hsl(${hue} 30% 70%);`;
-	}
 
 	onMount(async () => {
 		try {
@@ -89,7 +73,7 @@
 				type="button"
 				class="chip"
 				class:selected={selectedTags.has(tag.name)}
-				style={chipStyle(tag.name, selectedTags.has(tag.name))}
+				aria-pressed={selectedTags.has(tag.name)}
 				onclick={() => toggle(tag.name)}
 			>
 				{tag.name}
@@ -122,10 +106,10 @@
 		gap: 0.25rem;
 		padding: 0.3rem 0.7rem;
 		background: transparent;
-		border: 1px solid var(--border-subtle);
+		border: 1px solid transparent;
 		color: var(--text-secondary);
-		border-radius: var(--radius-xl);
-		font-size: var(--text-xs);
+		border-radius: var(--radius-full);
+		font-size: var(--text-sm);
 		font-family: inherit;
 		cursor: pointer;
 		transition: all 0.15s;
@@ -134,17 +118,25 @@
 	}
 
 	.chip:hover {
-		background: hsl(var(--chip-hue, 0) 50% 50% / 0.1);
-		border-color: hsl(var(--chip-hue, 0) 50% 55%);
+		background: var(--bg-hover);
+		color: var(--text-primary);
 	}
 
 	.chip.selected {
+		background: var(--accent);
+		border-color: var(--accent);
+		color: var(--accent-contrast);
 		font-weight: 600;
+	}
+
+	.chip:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
 	}
 
 	.count {
 		opacity: 0.6;
-		font-size: 0.65rem;
+		font-size: inherit;
 	}
 
 	.clear-chip {

--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -457,15 +457,13 @@
 		display: flex;
 		align-items: center;
 		gap: 0.75rem;
-		background: var(--track-bg, var(--bg-secondary));
-		border: 1px solid var(--track-border, var(--border-subtle));
+		background: transparent;
+		border: 1px solid transparent;
 		border-radius: var(--radius-md);
 		padding: 1rem;
-		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 		transition:
-			box-shadow 0.2s ease-out,
 			background 0.15s ease-out,
-			border-color 0.15s ease-out;
+			box-shadow 0.15s ease-out;
 	}
 
 	.track-index {
@@ -478,36 +476,25 @@
 	}
 
 	.track-container:hover {
-		background: var(--track-bg-hover, var(--bg-tertiary));
-		border-color: color-mix(in srgb, var(--accent) 15%, var(--track-border-hover, var(--border-default)));
-		box-shadow:
-			0 1px 3px rgba(0, 0, 0, 0.06),
-			0 0 8px color-mix(in srgb, var(--accent) 8%, transparent);
+		background: color-mix(in srgb, var(--bg-hover) 70%, transparent);
 	}
 
 	.track-container:active {
-		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+		background: var(--bg-hover);
 		transition-duration: 0.08s;
 	}
 
 	.track-container.playing {
-		background: color-mix(in srgb, var(--accent) 10%, var(--track-bg-playing, var(--bg-tertiary)));
-		border-color: color-mix(in srgb, var(--accent) 20%, var(--track-border, var(--border-subtle)));
+		background: color-mix(in srgb, var(--accent) 8%, transparent);
+		box-shadow: inset 2px 0 var(--accent);
 	}
 
 	.track-container.lossless {
-		border-color: color-mix(in srgb, var(--accent) 12%, var(--track-border, var(--border-subtle)));
-		box-shadow:
-			0 1px 2px rgba(0, 0, 0, 0.04),
-			inset 0 0 0 1px color-mix(in srgb, var(--accent) 6%, transparent);
+		box-shadow: none;
 	}
 
-	.track-container.lossless:hover {
-		border-color: color-mix(in srgb, var(--accent) 18%, var(--track-border-hover, var(--border-default)));
-		box-shadow:
-			0 1px 3px rgba(0, 0, 0, 0.06),
-			0 0 8px color-mix(in srgb, var(--accent) 8%, transparent),
-			inset 0 0 0 1px color-mix(in srgb, var(--accent) 10%, transparent);
+	.track-container.lossless.playing {
+		box-shadow: inset 2px 0 var(--accent);
 	}
 
 	/* elevate entire track container when likers tooltip is open

--- a/frontend/src/routes/activity/+page.svelte
+++ b/frontend/src/routes/activity/+page.svelte
@@ -382,27 +382,14 @@
 		--type-color: var(--border-subtle);
 		display: flex; align-items: center; gap: 0.875rem;
 		padding: 0.75rem 1rem; position: relative;
-		background: color-mix(in srgb, var(--track-bg) 85%, transparent);
-		backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
-		border: 1px solid var(--glass-border, var(--track-border));
-		border-radius: var(--radius-md);
-		transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease;
-	}
-	/* neon glow accent — follows card border-radius */
-	.event-item::before {
-		content: ''; position: absolute; inset: 0;
-		border-radius: inherit; pointer-events: none;
+		background: color-mix(in srgb, var(--bg-secondary) 82%, transparent);
+		border: 0;
 		border-left: 2px solid var(--type-color);
-		box-shadow: inset 4px 0 8px -2px color-mix(in srgb, var(--type-color) 30%, transparent);
+		border-radius: var(--radius-sm);
+		transition: background 0.15s ease;
 	}
 	.event-item:hover {
-		background: color-mix(in srgb, var(--track-bg-hover) 90%, transparent);
-		border-color: color-mix(in srgb, var(--type-color) 20%, var(--glass-border, var(--track-border)));
-		transform: translateY(-1px);
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15), 0 0 20px color-mix(in srgb, var(--type-color) 10%, transparent);
-	}
-	.event-item:hover::before {
-		box-shadow: inset 6px 0 12px -2px color-mix(in srgb, var(--type-color) 50%, transparent);
+		background: var(--bg-hover);
 	}
 	.event-item.like { --type-color: #e0607e; }
 	.event-item.track { --type-color: var(--accent); }


### PR DESCRIPTION
## What changed

- replace per-tag rainbow outlines with neutral filters and a single accent-selected state
- add `aria-pressed` and an explicit keyboard focus treatment to tag filters
- remove decorative borders and glows from vertical track rows while retaining a clear playing state
- simplify activity events to flat rows with meaningful event-color markers

## Why

Repeated translucent borders, multicolor pills, and stacked glow treatments were flattening the visual hierarchy. This keeps plyr.fm's serif identity, accent color, ambient background, and structural hairlines while making repeated content quieter.

## Validation

- `PUBLIC_API_URL=http://localhost:8001 just frontend check`
- `just frontend test` (110 tests)
- pre-commit hooks, including Svelte check, ESLint, frontend tests, and loq
- visual review of `/` and `/activity` in dark mode
- selected tag interaction verified with `aria-pressed="true"`
