### PR TITLE
fix(tracks): sensitive-audio filtering no longer corrupts listing pagination

### DIFF
--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -46,6 +46,11 @@ from .router import router
 
 logger = logging.getLogger(__name__)
 
+# bounds how many extra row batches one request will scan past filtered
+# sensitive tracks before returning a short (possibly empty) page with
+# has_more=true and an advanced cursor
+MAX_SENSITIVE_SCAN_PASSES = 4
+
 
 class TracksListResponse(BaseModel):
     """Response for paginated track listing."""
@@ -174,31 +179,57 @@ async def list_tracks(
         stmt = stmt.where(include_exists)
 
     # apply cursor-based pagination (tracks older than cursor timestamp)
+    cursor_time: datetime | None = None
     if cursor:
         try:
             cursor_time = datetime.fromisoformat(cursor)
-            stmt = stmt.where(Track.created_at < cursor_time)
         except ValueError as e:
             raise HTTPException(status_code=400, detail="invalid cursor format") from e
 
-    # order by created_at desc and fetch one extra to check if there's more
-    stmt = stmt.order_by(Track.created_at.desc()).limit(limit + 1)
-    with logfire.span("db execute tracks query"):
-        result = await db.execute(stmt)
-    with logfire.span("materialize track objects"):
-        tracks = list(result.scalars().all())
+    stmt = stmt.order_by(Track.created_at.desc())
 
-    # The labeler is the content-classification source of truth. Apply adult
-    # audio policy before pagination metadata or serialization so hidden tracks
-    # do not leak through the default/anonymous discovery response.
-    tracks, content_labels = await filter_sensitive_audio_tracks(db, tracks, session)
+    # Adult-audio policy can't live in SQL — labels come partly from the
+    # moderation service — so pagination scans raw rows in batches, skipping
+    # hidden tracks and continuing until the page fills, the feed is exhausted,
+    # or the pass cap is hit. The cursor always advances over raw rows, so
+    # filtered tracks can never truncate the feed or stall its cursor (#1676
+    # regression: filtering before pagination bookkeeping did exactly that).
+    tracks: list[Track] = []
+    content_labels: dict[int, set[str]] = {}
+    scan_cursor = cursor_time
+    has_more = True
+    for _ in range(MAX_SENSITIVE_SCAN_PASSES):
+        batch_stmt = stmt
+        if scan_cursor is not None:
+            batch_stmt = batch_stmt.where(Track.created_at < scan_cursor)
+        batch_stmt = batch_stmt.limit(limit + 1)
+        with logfire.span("db execute tracks query"):
+            result = await db.execute(batch_stmt)
+        with logfire.span("materialize track objects"):
+            batch = list(result.scalars().all())
+        batch_exhausted = len(batch) <= limit
+        batch = batch[:limit]
 
-    # check if there are more results and trim to requested limit
-    if has_more := len(tracks) > limit:
-        tracks = tracks[:limit]
+        visible, batch_labels = await filter_sensitive_audio_tracks(db, batch, session)
+        content_labels.update(batch_labels)
+        visible_ids = {t.id for t in visible}
 
-    # generate next cursor from the last track's created_at
-    next_cursor = tracks[-1].created_at.isoformat() if has_more and tracks else None
+        page_full = False
+        for row in batch:
+            scan_cursor = row.created_at
+            if row.id in visible_ids:
+                tracks.append(row)
+                if len(tracks) >= limit:
+                    page_full = True
+                    break
+        if page_full:
+            has_more = not (batch_exhausted and row is batch[-1])
+            break
+        if batch_exhausted:
+            has_more = False
+            break
+
+    next_cursor = scan_cursor.isoformat() if has_more and scan_cursor else None
 
     # kick off supporter validation early — it makes external HTTP calls that
     # benefit from running concurrently with DB aggregations and PDS resolution

--- a/backend/tests/api/test_tracks_sensitive_pagination.py
+++ b/backend/tests/api/test_tracks_sensitive_pagination.py
@@ -1,0 +1,169 @@
+"""regression tests for #1676: sensitive-audio filtering must not corrupt
+cursor pagination on the track listing (broken has_more / next_cursor for
+anonymous viewers whenever a page contained an adult-labeled track)."""
+
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import get_optional_session
+from backend.main import app
+from backend.models import Artist, Track, get_db
+
+
+@pytest.fixture
+async def artist(db_session: AsyncSession) -> Artist:
+    artist = Artist(
+        did="did:plc:artist123",
+        handle="artist.bsky.social",
+        display_name="Test Artist",
+        pds_url="https://test.pds",
+    )
+    db_session.add(artist)
+    await db_session.commit()
+    return artist
+
+
+def _track(artist: Artist, n: int, *, sensitive: bool = False) -> Track:
+    """build a track; higher n = newer.
+
+    created_at must be after the test's start so the db-clear procedure
+    (which deletes rows newer than the test start time) removes these rows.
+    """
+    return Track(
+        title=f"Track {n}",
+        artist_did=artist.did,
+        file_id=f"file{n}",
+        file_type="mp3",
+        extra={"duration": 60},
+        atproto_record_uri=f"at://did:plc:artist123/fm.plyr.track/t{n}",
+        atproto_record_cid=f"bafy{n}",
+        created_at=datetime.now(UTC) + timedelta(seconds=n),
+        self_labels=["sexual"] if sensitive else None,
+    )
+
+
+@pytest.fixture
+def anonymous_app(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
+    """app with a logged-out viewer and the test db."""
+
+    async def mock_get_optional_session() -> None:
+        return None
+
+    async def mock_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_optional_session] = mock_get_optional_session
+    app.dependency_overrides[get_db] = mock_get_db
+    yield app
+    app.dependency_overrides.clear()
+
+
+async def _fetch_all_pages(
+    client: AsyncClient, limit: int, max_requests: int = 10
+) -> list[dict]:
+    """walk the cursor to exhaustion, returning every listed track."""
+    collected: list[dict] = []
+    cursor: str | None = None
+    for _ in range(max_requests):
+        params: dict[str, str | int] = {"limit": limit}
+        if cursor:
+            params["cursor"] = cursor
+        response = await client.get("/tracks/", params=params)
+        assert response.status_code == 200
+        data = response.json()
+        collected.extend(data["tracks"])
+        if not data["has_more"]:
+            assert data["next_cursor"] is None
+            return collected
+        assert data["next_cursor"] is not None, "has_more=true must come with a cursor"
+        cursor = data["next_cursor"]
+    raise AssertionError("pagination did not terminate")
+
+
+async def test_filtered_track_does_not_end_pagination_early(
+    anonymous_app: FastAPI,
+    db_session: AsyncSession,
+    artist: Artist,
+):
+    """a sensitive track inside a page must not flip has_more to false.
+
+    pre-fix: fetching limit+1 rows then filtering dropped the overflow row's
+    signal, so the first page containing a sensitive track reported
+    has_more=false and everything older silently disappeared for logged-out
+    viewers.
+    """
+    tracks = [
+        _track(artist, 5),
+        _track(artist, 4, sensitive=True),
+        _track(artist, 3),
+        _track(artist, 2),
+        _track(artist, 1),
+    ]
+    db_session.add_all(tracks)
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=anonymous_app), base_url="http://test"
+    ) as client:
+        listed = await _fetch_all_pages(client, limit=2)
+
+    assert [t["title"] for t in listed] == [
+        "Track 5",
+        "Track 3",
+        "Track 2",
+        "Track 1",
+    ]
+
+
+async def test_pages_fill_past_filtered_tracks(
+    anonymous_app: FastAPI,
+    db_session: AsyncSession,
+    artist: Artist,
+):
+    """the scan continues past hidden rows so pages come back full."""
+    tracks = [
+        _track(artist, 4),
+        _track(artist, 3, sensitive=True),
+        _track(artist, 2, sensitive=True),
+        _track(artist, 1),
+    ]
+    db_session.add_all(tracks)
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=anonymous_app), base_url="http://test"
+    ) as client:
+        response = await client.get("/tracks/", params={"limit": 2})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [t["title"] for t in data["tracks"]] == ["Track 4", "Track 1"]
+    assert data["has_more"] is False
+    assert data["next_cursor"] is None
+
+
+async def test_trailing_sensitive_tracks_terminate_cleanly(
+    anonymous_app: FastAPI,
+    db_session: AsyncSession,
+    artist: Artist,
+):
+    """a feed tail of only sensitive tracks ends with has_more=false."""
+    tracks = [
+        _track(artist, 3),
+        _track(artist, 2, sensitive=True),
+        _track(artist, 1, sensitive=True),
+    ]
+    db_session.add_all(tracks)
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=anonymous_app), base_url="http://test"
+    ) as client:
+        listed = await _fetch_all_pages(client, limit=1)
+
+    assert [t["title"] for t in listed] == ["Track 3"]

--- a/frontend/src/lib/tracks.svelte.ts
+++ b/frontend/src/lib/tracks.svelte.ts
@@ -116,21 +116,35 @@ class TracksCache {
 
 		this.loadingMore = true;
 		try {
-			const url = new URL(`${API_URL}/tracks/`);
-			url.searchParams.set('cursor', this.nextCursor);
-			for (const tag of this.activeTags) {
-				url.searchParams.append('tags', tag);
+			// a page can come back empty with has_more=true when every scanned
+			// row was filtered server-side (e.g. sensitive audio); follow the
+			// cursor a few times so infinite scroll doesn't stall on the gap —
+			// the intersection observer won't refire if nothing new renders
+			for (let attempt = 0; attempt < 3; attempt++) {
+				const cursor = this.nextCursor;
+				if (!cursor) {
+					break;
+				}
+				const url = new URL(`${API_URL}/tracks/`);
+				url.searchParams.set('cursor', cursor);
+				for (const tag of this.activeTags) {
+					url.searchParams.append('tags', tag);
+				}
+
+				const response = await fetch(url.toString(), {
+					credentials: 'include'
+				});
+				const data: TracksApiResponse = await response.json();
+
+				// append new tracks to existing list
+				this.tracks = [...this.tracks, ...data.tracks];
+				this.nextCursor = data.next_cursor;
+				this.hasMore = data.has_more;
+
+				if (data.tracks.length > 0 || !this.hasMore || !this.nextCursor) {
+					break;
+				}
 			}
-
-			const response = await fetch(url.toString(), {
-				credentials: 'include'
-			});
-			const data: TracksApiResponse = await response.json();
-
-			// append new tracks to existing list
-			this.tracks = [...this.tracks, ...data.tracks];
-			this.nextCursor = data.next_cursor;
-			this.hasMore = data.has_more;
 
 			this.persistToStorage();
 		} catch (e) {

--- a/loq.toml
+++ b/loq.toml
@@ -32,7 +32,7 @@ max_lines = 923
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
-max_lines = 616
+max_lines = 647
 
 [[rules]]
 path = "backend/src/backend/api/tracks/mutations.py"


### PR DESCRIPTION
Logged-out pagination of the home-page latest feed has been broken since #1676 (July 16): any page containing an adult-labeled track reported `has_more: false` early and everything older silently disappeared. This restructures `/tracks/` so filtering can never corrupt pagination bookkeeping.

## why it broke

#1676 applies `filter_sensitive_audio_tracks` to the `limit + 1` raw rows **before** the `has_more` / `next_cursor` computation. For viewers without the sensitive-audio opt-in (all anonymous viewers), filtered rows shrink the batch below `limit + 1`, so:

- `has_more` flipped to false while older tracks still existed — infinite scroll just stopped
- `next_cursor` was derived from the filtered list, so page boundaries drifted

Logged-in users who own the labeled tracks (or opted in) never hit the filter, which is why it only reproduced logged out.

## design

The adult-audio predicate can't be pushed into SQL — labels come partly from the moderation service over HTTP. So the listing now scans raw rows in batches:

- each pass fetches `limit + 1` raw rows after the scan cursor, filters them app-side, and appends visible rows until the page fills
- the cursor always advances over **raw** rows, so filtered tracks can neither truncate the feed nor stall the cursor
- a pass cap (`MAX_SENSITIVE_SCAN_PASSES = 4`) bounds worst-case DB/moderation round-trips per request; if it's hit, the response returns a short page with `has_more: true` and an advanced cursor, so clients still make progress
- the common case (no filtered rows in the page) is exactly one query and one moderation call, same as before

Frontend (`tracks.svelte.ts`): `fetchMore` now follows the cursor up to 3 times when a page comes back empty with `has_more: true`. The infinite-scroll sentinel is an IntersectionObserver, which won't refire if nothing new renders — without this, a fully-filtered gap (possible only when the pass cap is hit) could stall scrolling.

<details>
<summary>tests, non-behaviors, deferred scope</summary>

**Tests** (`test_tracks_sensitive_pagination.py`): drive the real endpoint anonymously with `self_labels`-labeled tracks (moderation client is unconfigured in tests, so labels are pure DB — no mocking). The first two tests fail on pre-fix `main`; the third guards clean termination on an all-sensitive feed tail. Track `created_at` values are now-relative because the test DB clear procedure only deletes rows newer than the test start.

**Intentional non-behaviors:**
- response shape is unchanged; the anonymous first-page discovery cache is unaffected
- cursor semantics are unchanged (ISO timestamp, strict `<`); pre-existing equal-timestamp edge is untouched
- `for_you.py` already computes `has_more`/cursor before filtering, so it's sound and untouched

**Deferred:**
- `/tracks/top` can undercount below `limit` when top tracks are filtered (not paginated, cosmetic only)
- for-you pages can also come back short after filtering; its offset cursor is correct so no stall, and the for-you cache path wasn't touched here

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)