### PR TITLE
fix(tracks): project operator labels into SQL so filtering composes with pagination

### DIFF
--- a/backend/alembic/versions/2026_07_23_123853_581366546d5c_project_operator_labels_onto_tracks.py
+++ b/backend/alembic/versions/2026_07_23_123853_581366546d5c_project_operator_labels_onto_tracks.py
@@ -1,0 +1,38 @@
+"""project operator labels onto tracks
+
+Revision ID: 581366546d5c
+Revises: d4f7a2c9b831
+Create Date: 2026-07-23 12:38:53.980024
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "581366546d5c"
+down_revision: str | Sequence[str] | None = "d4f7a2c9b831"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "tracks",
+        sa.Column(
+            "operator_labels",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default="[]",
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("tracks", "operator_labels")

--- a/backend/src/backend/_internal/clients/moderation.py
+++ b/backend/src/backend/_internal/clients/moderation.py
@@ -459,6 +459,28 @@ class ModerationClient:
                 labels_by_uri.setdefault(uri, set())
             return labels_by_uri
 
+    async def get_active_labels_by_value(
+        self, values: list[str]
+    ) -> dict[str, set[str]]:
+        """Return every URI holding an active label of the given values.
+
+        Powers the operator-label projection sync (`sync_operator_labels`).
+        Raises on labeler failure — a reconciliation pass must never mistake
+        an outage for "nothing is labeled" and clear the projection.
+        """
+        if not values or not self.auth_token:
+            return {}
+
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(
+                f"{self.labeler_url}/admin/labels-by-value",
+                json={"values": values},
+                headers=self._headers(),
+            )
+            response.raise_for_status()
+            raw_labels = response.json().get("labels", {})
+            return {uri: set(vals) for uri, vals in raw_labels.items()}
+
     async def get_negated_labels(self, uris: list[str]) -> set[str]:
         """check which URIs have an explicit negation (dismissal) label.
 

--- a/backend/src/backend/_internal/content_labels.py
+++ b/backend/src/backend/_internal/content_labels.py
@@ -7,7 +7,8 @@ behavior; classifier evidence and moderation workflow state do not belong here.
 
 from collections.abc import Iterable
 
-from sqlalchemy import select
+from sqlalchemy import ColumnElement, select
+from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal.auth.session import Session
@@ -16,20 +17,42 @@ from backend.models import Track, UserPreferences
 
 ADULT_AUDIO_LABELS = frozenset({"sexual", "porn"})
 
+# Label values reconciled onto `tracks.operator_labels` by the
+# sync_operator_labels background task. Only these values may be read from
+# the projection; anything else must be queried from the labeler live.
+PROJECTED_LABEL_VALUES = ADULT_AUDIO_LABELS
+
 
 def has_adult_audio_label(labels: Iterable[str]) -> bool:
     """Return whether labels require the adult-audio preference."""
     return bool(ADULT_AUDIO_LABELS.intersection(labels))
 
 
-async def get_track_label_values(tracks: Iterable[Track]) -> dict[int, set[str]]:
-    """Union creator self-labels with active operator labels by track."""
-    track_list = list(tracks)
-    effective = {track.id: set(track.self_labels or []) for track in track_list}
-    operator = await get_operator_label_values(track_list)
-    for track_id, values in operator.items():
-        effective[track_id].update(values)
-    return effective
+def get_track_label_values(tracks: Iterable[Track]) -> dict[int, set[str]]:
+    """Union creator self-labels with projected operator labels by track.
+
+    Reads only track columns — operator labels come from the projection kept
+    fresh by sync_operator_labels, not a live labeler query. Authorization
+    paths (streaming bytes) must not use this; they query the labeler with
+    strict=True instead.
+    """
+    return {
+        track.id: set(track.self_labels or []) | set(track.operator_labels or [])
+        for track in tracks
+    }
+
+
+def sensitive_audio_visible_clause(viewer_did: str | None) -> ColumnElement[bool]:
+    """SQL predicate: the track needs no adult-audio opt-in from this viewer.
+
+    Callers skip the clause entirely for viewers whose saved preference shows
+    sensitive audio (see viewer_shows_sensitive_audio).
+    """
+    adult = array(sorted(ADULT_AUDIO_LABELS))
+    labeled = Track.self_labels.op("?|")(adult) | Track.operator_labels.op("?|")(adult)
+    if viewer_did is None:
+        return ~labeled
+    return ~labeled | (Track.artist_did == viewer_did)
 
 
 async def get_operator_label_values(
@@ -106,7 +129,7 @@ async def filter_sensitive_audio_tracks_for_viewer(
 ) -> tuple[list[Track], dict[int, set[str]]]:
     """Hide adult-labeled tracks for a viewer identified only by DID."""
     track_list = list(tracks)
-    labels_by_id = await get_track_label_values(track_list)
+    labels_by_id = get_track_label_values(track_list)
     if await viewer_did_shows_sensitive_audio(db, viewer_did):
         return track_list, labels_by_id
 

--- a/backend/src/backend/_internal/tasks/__init__.py
+++ b/backend/src/backend/_internal/tasks/__init__.py
@@ -24,6 +24,7 @@ from backend._internal.tasks.hooks import (
     invalidate_tracks_discovery_cache,
     run_post_track_create_hooks,
 )
+from backend._internal.tasks.labels import sync_operator_labels
 from backend._internal.tasks.moderation import (
     scan_image_moderation,
     schedule_image_moderation_scan,
@@ -95,6 +96,7 @@ def _build_background_tasks() -> list:
     return [
         scan_copyright,
         sync_copyright_resolutions,
+        sync_operator_labels,
         process_export,
         sync_atproto,
         scrobble_to_teal,
@@ -191,5 +193,6 @@ __all__ = [
     "sync_album_list",
     "sync_atproto",
     "sync_copyright_resolutions",
+    "sync_operator_labels",
     "warm_follow_graph",
 ]

--- a/backend/src/backend/_internal/tasks/labels.py
+++ b/backend/src/backend/_internal/tasks/labels.py
@@ -1,0 +1,69 @@
+"""operator-label projection sync.
+
+the labeler (moderation service) is the source of truth for operator labels,
+but discovery queries need label state in SQL to filter and paginate sanely.
+this task reconciles `tracks.operator_labels` against the labeler the same
+way sync_copyright_resolutions reconciles copyright flags.
+"""
+
+import logging
+from datetime import timedelta
+
+import logfire
+from docket import Perpetual
+from sqlalchemy import cast, select
+from sqlalchemy.dialects.postgresql import JSONB
+
+from backend._internal.content_labels import PROJECTED_LABEL_VALUES
+from backend.models import Track
+from backend.utilities.database import db_session
+
+logger = logging.getLogger(__name__)
+
+
+async def sync_operator_labels(
+    perpetual: Perpetual = Perpetual(every=timedelta(minutes=5), automatic=True),  # noqa: B008
+) -> None:
+    """reconcile projected operator labels with the labeler.
+
+    asks the labeler for every URI holding an active label of a projected
+    value, then updates `tracks.operator_labels` to match — both applying
+    new labels and clearing negated ones. raises (skipping the pass) if the
+    labeler is unreachable, so an outage can never clear the projection.
+    """
+    from backend._internal.clients.moderation import get_moderation_client
+
+    client = get_moderation_client()
+    labels_by_uri = await client.get_active_labels_by_value(
+        sorted(PROJECTED_LABEL_VALUES)
+    )
+
+    async with db_session() as db:
+        # tracks that need updating: currently projected, or newly labeled
+        result = await db.execute(
+            select(Track).where(
+                (cast(Track.operator_labels, JSONB) != cast([], JSONB))
+                | Track.atproto_record_uri.in_(labels_by_uri.keys())
+            )
+        )
+        tracks = result.scalars().all()
+
+        changed = 0
+        for track in tracks:
+            desired = sorted(labels_by_uri.get(track.atproto_record_uri or "", set()))
+            if track.operator_labels != desired:
+                track.operator_labels = desired
+                changed += 1
+
+        if changed:
+            await db.commit()
+            logfire.info(
+                "sync_operator_labels: updated {count} tracks",
+                count=changed,
+                labeled_uris=len(labels_by_uri),
+            )
+        else:
+            logfire.debug(
+                "sync_operator_labels: projection in sync",
+                labeled_uris=len(labels_by_uri),
+            )

--- a/backend/src/backend/api/radio/corpus.py
+++ b/backend/src/backend/api/radio/corpus.py
@@ -32,7 +32,7 @@ async def load_corpus(db: AsyncSession) -> list[Track]:
     )
     result = await db.execute(stmt)
     tracks = list(result.scalars().all())
-    labels_by_id = await get_track_label_values(tracks)
+    labels_by_id = get_track_label_values(tracks)
     # Radio is a shared wall-clock rotation, including anonymous embeds. It
     # cannot vary by listener preference, so adult audio never enters it.
     return [

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -18,6 +18,8 @@ from backend._internal import get_optional_session, get_supported_artists, requi
 from backend._internal.content_labels import (
     filter_sensitive_audio_tracks,
     get_operator_label_values,
+    get_track_label_values,
+    sensitive_audio_visible_clause,
 )
 from backend.config import settings
 from backend.models import (
@@ -111,6 +113,7 @@ async def list_tracks(
     # get authenticated user's liked tracks and preferences
     liked_track_ids: set[int] | None = None
     hidden_tags: list[str] = list(DEFAULT_HIDDEN_TAGS)
+    shows_sensitive_audio = False
 
     if session:
         liked_result = await db.execute(
@@ -125,6 +128,8 @@ async def list_tracks(
         prefs = prefs_result.scalar_one_or_none()
         if prefs and prefs.hidden_tags is not None:
             hidden_tags = prefs.hidden_tags
+        if prefs:
+            shows_sensitive_audio = bool(prefs.show_sensitive_audio)
 
     stmt = (
         select(Track)
@@ -173,6 +178,13 @@ async def list_tracks(
         )
         stmt = stmt.where(include_exists)
 
+    # adult-audio visibility lives in SQL (self labels + projected operator
+    # labels), so filtering composes with cursor pagination instead of
+    # corrupting it (#1676 regression: app-side filtering broke has_more)
+    if not shows_sensitive_audio:
+        viewer = session.did if session else None
+        stmt = stmt.where(sensitive_audio_visible_clause(viewer))
+
     # apply cursor-based pagination (tracks older than cursor timestamp)
     if cursor:
         try:
@@ -188,17 +200,13 @@ async def list_tracks(
     with logfire.span("materialize track objects"):
         tracks = list(result.scalars().all())
 
-    # The labeler is the content-classification source of truth. Apply adult
-    # audio policy before pagination metadata or serialization so hidden tracks
-    # do not leak through the default/anonymous discovery response.
-    tracks, content_labels = await filter_sensitive_audio_tracks(db, tracks, session)
-
     # check if there are more results and trim to requested limit
     if has_more := len(tracks) > limit:
         tracks = tracks[:limit]
 
     # generate next cursor from the last track's created_at
     next_cursor = tracks[-1].created_at.isoformat() if has_more and tracks else None
+    content_labels = get_track_label_values(tracks)
 
     # kick off supporter validation early — it makes external HTTP calls that
     # benefit from running concurrently with DB aggregations and PDS resolution

--- a/backend/src/backend/api/tracks/playback.py
+++ b/backend/src/backend/api/tracks/playback.py
@@ -109,11 +109,11 @@ async def _resolve_track(
     ):
         liked_track_ids = {track.id}
 
-    like_counts, track_tags, content_labels = await asyncio.gather(
+    like_counts, track_tags = await asyncio.gather(
         get_like_counts(db, [track.id]),
         get_track_tags(db, [track.id]),
-        get_track_label_values([track]),
     )
+    content_labels = get_track_label_values([track])
 
     return await TrackResponse.from_track(
         track,

--- a/backend/src/backend/models/track.py
+++ b/backend/src/backend/models/track.py
@@ -82,6 +82,14 @@ class Track(Base):
     self_labels: Mapped[list[str]] = mapped_column(
         JSONB, nullable=False, default=list, server_default="[]"
     )
+    # Active operator label values projected from the labeler so visibility
+    # can be enforced in SQL. The labeler stays the source of truth; the
+    # sync_operator_labels background task reconciles this every few minutes
+    # for the values it manages. Authorization paths must not read this —
+    # they query the labeler live (see may_stream_sensitive_audio).
+    operator_labels: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, default=list, server_default="[]"
+    )
 
     # PDS blob storage (for audio stored on user's PDS)
     audio_storage: Mapped[str] = mapped_column(

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -251,7 +251,11 @@ class TrackResponse(BaseModel):
         active_operator_labels = (
             set(operator_labels.get(track.id, set())) if operator_labels else set()
         )
-        labels = set(track.self_labels or []) | active_operator_labels
+        labels = (
+            set(track.self_labels or [])
+            | set(track.operator_labels or [])
+            | active_operator_labels
+        )
         if content_labels:
             labels.update(content_labels.get(track.id, set()))
 

--- a/backend/tests/_internal/test_self_labels.py
+++ b/backend/tests/_internal/test_self_labels.py
@@ -40,7 +40,7 @@ def test_normalize_self_labels_preserves_valid_unknown_values() -> None:
     ]
 
 
-async def test_effective_labels_union_creator_and_operator_provenance() -> None:
+async def test_operator_label_values_query_labeler_live() -> None:
     track = Track(
         id=1177,
         title="creator labeled",
@@ -60,7 +60,22 @@ async def test_effective_labels_union_creator_and_operator_provenance() -> None:
         return_value=moderation,
     ):
         operator_values = await get_operator_label_values([track])
-        values = await get_track_label_values([track])
 
     assert operator_values[track.id] == {"porn", "operator:reviewed"}
-    assert values[track.id] == {"sexual", "porn", "operator:reviewed"}
+
+
+def test_effective_labels_union_creator_and_projected_operator_provenance() -> None:
+    """get_track_label_values reads only columns — self labels union the
+    operator-label projection, with no live labeler query."""
+    track = Track(
+        id=1178,
+        title="creator labeled",
+        artist_did="did:plc:creator",
+        file_id="creator_labeled",
+        file_type="mp3",
+        atproto_record_uri="at://did:plc:creator/fm.plyr.track/explicit",
+        self_labels=["sexual"],
+        operator_labels=["porn"],
+    )
+
+    assert get_track_label_values([track])[track.id] == {"sexual", "porn"}

--- a/backend/tests/api/test_tracks_sensitive_pagination.py
+++ b/backend/tests/api/test_tracks_sensitive_pagination.py
@@ -1,0 +1,181 @@
+"""regression tests for #1676: sensitive-audio filtering must not corrupt
+cursor pagination on the track listing (broken has_more / next_cursor for
+anonymous viewers whenever a page contained an adult-labeled track).
+
+visibility is enforced in SQL via self_labels and the operator-label
+projection (tracks.operator_labels), so filtering composes with pagination.
+"""
+
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import get_optional_session
+from backend.main import app
+from backend.models import Artist, Track, get_db
+
+
+@pytest.fixture
+async def artist(db_session: AsyncSession) -> Artist:
+    artist = Artist(
+        did="did:plc:artist123",
+        handle="artist.bsky.social",
+        display_name="Test Artist",
+        pds_url="https://test.pds",
+    )
+    db_session.add(artist)
+    await db_session.commit()
+    return artist
+
+
+def _track(
+    artist: Artist,
+    n: int,
+    *,
+    self_labels: list[str] | None = None,
+    operator_labels: list[str] | None = None,
+) -> Track:
+    """build a track; higher n = newer.
+
+    created_at must be after the test's start so the db-clear procedure
+    (which deletes rows newer than the test start time) removes these rows.
+    """
+    return Track(
+        title=f"Track {n}",
+        artist_did=artist.did,
+        file_id=f"file{n}",
+        file_type="mp3",
+        extra={"duration": 60},
+        atproto_record_uri=f"at://did:plc:artist123/fm.plyr.track/t{n}",
+        atproto_record_cid=f"bafy{n}",
+        created_at=datetime.now(UTC) + timedelta(seconds=n),
+        self_labels=self_labels or [],
+        operator_labels=operator_labels or [],
+    )
+
+
+@pytest.fixture
+def anonymous_app(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
+    """app with a logged-out viewer and the test db."""
+
+    async def mock_get_optional_session() -> None:
+        return None
+
+    async def mock_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_optional_session] = mock_get_optional_session
+    app.dependency_overrides[get_db] = mock_get_db
+    yield app
+    app.dependency_overrides.clear()
+
+
+async def _fetch_all_pages(
+    client: AsyncClient, limit: int, max_requests: int = 10
+) -> list[dict]:
+    """walk the cursor to exhaustion, returning every listed track."""
+    collected: list[dict] = []
+    cursor: str | None = None
+    for _ in range(max_requests):
+        params: dict[str, str | int] = {"limit": limit}
+        if cursor:
+            params["cursor"] = cursor
+        response = await client.get("/tracks/", params=params)
+        assert response.status_code == 200
+        data = response.json()
+        collected.extend(data["tracks"])
+        if not data["has_more"]:
+            assert data["next_cursor"] is None
+            return collected
+        assert data["next_cursor"] is not None, "has_more=true must come with a cursor"
+        cursor = data["next_cursor"]
+    raise AssertionError("pagination did not terminate")
+
+
+async def test_filtered_track_does_not_end_pagination_early(
+    anonymous_app: FastAPI,
+    db_session: AsyncSession,
+    artist: Artist,
+):
+    """a sensitive track inside a page must not flip has_more to false.
+
+    pre-fix: the endpoint fetched limit+1 rows then filtered app-side, so a
+    page containing a sensitive track lost its overflow signal, reported
+    has_more=false, and everything older silently disappeared for logged-out
+    viewers.
+    """
+    tracks = [
+        _track(artist, 5),
+        _track(artist, 4, self_labels=["sexual"]),
+        _track(artist, 3),
+        _track(artist, 2),
+        _track(artist, 1),
+    ]
+    db_session.add_all(tracks)
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=anonymous_app), base_url="http://test"
+    ) as client:
+        listed = await _fetch_all_pages(client, limit=2)
+
+    assert [t["title"] for t in listed] == [
+        "Track 5",
+        "Track 3",
+        "Track 2",
+        "Track 1",
+    ]
+
+
+async def test_projected_operator_labels_filter_in_sql(
+    anonymous_app: FastAPI,
+    db_session: AsyncSession,
+    artist: Artist,
+):
+    """operator-labeled tracks (via the projection) page identically to
+    self-labeled ones: full pages, correct has_more, no gaps."""
+    tracks = [
+        _track(artist, 4),
+        _track(artist, 3, operator_labels=["porn"]),
+        _track(artist, 2, operator_labels=["sexual"]),
+        _track(artist, 1),
+    ]
+    db_session.add_all(tracks)
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=anonymous_app), base_url="http://test"
+    ) as client:
+        response = await client.get("/tracks/", params={"limit": 2})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [t["title"] for t in data["tracks"]] == ["Track 4", "Track 1"]
+    assert data["has_more"] is False
+    assert data["next_cursor"] is None
+
+
+async def test_trailing_sensitive_tracks_terminate_cleanly(
+    anonymous_app: FastAPI,
+    db_session: AsyncSession,
+    artist: Artist,
+):
+    """a feed tail of only sensitive tracks ends with has_more=false."""
+    tracks = [
+        _track(artist, 3),
+        _track(artist, 2, self_labels=["sexual"]),
+        _track(artist, 1, operator_labels=["porn"]),
+    ]
+    db_session.add_all(tracks)
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=anonymous_app), base_url="http://test"
+    ) as client:
+        listed = await _fetch_all_pages(client, limit=1)
+
+    assert [t["title"] for t in listed] == ["Track 3"]

--- a/backend/tests/test_moderation.py
+++ b/backend/tests/test_moderation.py
@@ -779,3 +779,109 @@ async def test_create_report_invalid_reason(report_test_app: FastAPI) -> None:
         )
 
     assert response.status_code == 422  # validation error
+
+
+async def test_sync_operator_labels_reconciles_projection(
+    db_session: AsyncSession,
+) -> None:
+    """the projection sync both applies newly active labels and clears
+    negated ones, matching the labeler's by-value snapshot exactly."""
+    from backend._internal.tasks import sync_operator_labels
+
+    artist = Artist(
+        did="did:plc:labelsync",
+        handle="labelsync.bsky.social",
+        display_name="Label Sync User",
+    )
+    db_session.add(artist)
+    await db_session.commit()
+
+    # track 1: newly labeled in the labeler, projection empty
+    track1 = Track(
+        title="Newly Labeled",
+        file_id="labelsync_1",
+        file_type="mp3",
+        artist_did=artist.did,
+        atproto_record_uri="at://did:plc:labelsync/fm.plyr.track/1",
+        operator_labels=[],
+    )
+    # track 2: projection stale — label was negated in the labeler
+    track2 = Track(
+        title="Negated",
+        file_id="labelsync_2",
+        file_type="mp3",
+        artist_did=artist.did,
+        atproto_record_uri="at://did:plc:labelsync/fm.plyr.track/2",
+        operator_labels=["sexual"],
+    )
+    # track 3: unlabeled and unprojected — must remain untouched
+    track3 = Track(
+        title="Untouched",
+        file_id="labelsync_3",
+        file_type="mp3",
+        artist_did=artist.did,
+        atproto_record_uri="at://did:plc:labelsync/fm.plyr.track/3",
+        operator_labels=[],
+    )
+    db_session.add_all([track1, track2, track3])
+    await db_session.commit()
+
+    with patch(
+        "backend._internal.clients.moderation.get_moderation_client"
+    ) as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.get_active_labels_by_value.return_value = {
+            "at://did:plc:labelsync/fm.plyr.track/1": {"sexual"},
+        }
+        mock_get_client.return_value = mock_client
+
+        await sync_operator_labels()
+
+    await db_session.refresh(track1)
+    await db_session.refresh(track2)
+    await db_session.refresh(track3)
+
+    assert track1.operator_labels == ["sexual"]
+    assert track2.operator_labels == []
+    assert track3.operator_labels == []
+
+
+async def test_sync_operator_labels_skips_pass_on_labeler_outage(
+    db_session: AsyncSession,
+) -> None:
+    """an unreachable labeler must never clear the projection."""
+    from backend._internal.tasks import sync_operator_labels
+
+    artist = Artist(
+        did="did:plc:labeloutage",
+        handle="labeloutage.bsky.social",
+        display_name="Label Outage User",
+    )
+    db_session.add(artist)
+    await db_session.commit()
+
+    track = Track(
+        title="Projected",
+        file_id="labeloutage_1",
+        file_type="mp3",
+        artist_did=artist.did,
+        atproto_record_uri="at://did:plc:labeloutage/fm.plyr.track/1",
+        operator_labels=["sexual"],
+    )
+    db_session.add(track)
+    await db_session.commit()
+
+    with patch(
+        "backend._internal.clients.moderation.get_moderation_client"
+    ) as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.get_active_labels_by_value.side_effect = httpx.ConnectError(
+            "labeler down"
+        )
+        mock_get_client.return_value = mock_client
+
+        with pytest.raises(httpx.ConnectError):
+            await sync_operator_labels()
+
+    await db_session.refresh(track)
+    assert track.operator_labels == ["sexual"]

--- a/loq.toml
+++ b/loq.toml
@@ -32,7 +32,7 @@ max_lines = 923
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
-max_lines = 616
+max_lines = 624
 
 [[rules]]
 path = "backend/src/backend/api/tracks/mutations.py"
@@ -76,7 +76,7 @@ max_lines = 569
 
 [[rules]]
 path = "backend/tests/test_moderation.py"
-max_lines = 781
+max_lines = 887
 
 [[rules]]
 path = "docs/internal/authentication.md"
@@ -180,11 +180,11 @@ max_lines = 983
 
 [[rules]]
 path = "services/moderation/src/admin.rs"
-max_lines = 743
+max_lines = 773
 
 [[rules]]
 path = "services/moderation/src/db.rs"
-max_lines = 1303
+max_lines = 1336
 
 [[rules]]
 path = "frontend/src/lib/components/FeedbackModal.svelte"
@@ -352,7 +352,7 @@ max_lines = 512
 
 [[rules]]
 path = "backend/src/backend/_internal/clients/moderation.py"
-max_lines = 579
+max_lines = 601
 
 [[rules]]
 path = "backend/tests/_internal/test_permissioned_spaces.py"

--- a/services/moderation/src/admin.rs
+++ b/services/moderation/src/admin.rs
@@ -111,6 +111,12 @@ pub struct LabelValuesResponse {
     pub labels: HashMap<String, Vec<String>>,
 }
 
+/// Request for all URIs currently holding an active label of the given values.
+#[derive(Debug, Deserialize)]
+pub struct LabelsByValueRequest {
+    pub values: Vec<String>,
+}
+
 /// Response with URIs that have an explicit negation (dismissal) label.
 #[derive(Debug, Serialize)]
 pub struct NegatedLabelsResponse {
@@ -345,6 +351,30 @@ pub async fn get_label_values(
 
     let mut labels: HashMap<String, Vec<String>> = HashMap::new();
     for (uri, val) in db.get_active_label_values(&request.uris).await? {
+        labels.entry(uri).or_default().push(val);
+    }
+
+    Ok(Json(LabelValuesResponse { labels }))
+}
+
+/// Get every URI currently holding an active label of the requested values.
+///
+/// Powers the backend's label projection sync: unlike `get_label_values`,
+/// which answers for a caller-supplied URI list, this scans the labeler's
+/// state so the backend can reconcile without shipping its whole catalog.
+pub async fn get_labels_by_value(
+    State(state): State<AppState>,
+    Json(request): Json<LabelsByValueRequest>,
+) -> Result<Json<LabelValuesResponse>, AppError> {
+    let db = state.db.as_ref().ok_or(AppError::LabelerNotConfigured)?;
+
+    tracing::debug!(
+        value_count = request.values.len(),
+        "querying active labels by value"
+    );
+
+    let mut labels: HashMap<String, Vec<String>> = HashMap::new();
+    for (uri, val) in db.get_active_labels_by_value(&request.values).await? {
         labels.entry(uri).or_default().push(val);
     }
 

--- a/services/moderation/src/db.rs
+++ b/services/moderation/src/db.rs
@@ -676,6 +676,39 @@ impl LabelDb {
             .map(|s| s.unwrap_or(0))
     }
 
+    /// Get every URI holding an active label of the given values.
+    ///
+    /// Same event-sourced resolution as `get_active_label_values`, but keyed
+    /// by value instead of URI so callers can reconcile projections without
+    /// knowing which URIs might be labeled.
+    pub async fn get_active_labels_by_value(
+        &self,
+        values: &[String],
+    ) -> Result<Vec<(String, String)>, sqlx::Error> {
+        if values.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        sqlx::query_as::<_, (String, String)>(
+            r#"
+            SELECT uri, val
+            FROM (
+                SELECT DISTINCT ON (src, uri, val)
+                       src, uri, val, neg, exp, seq
+                FROM labels
+                WHERE val = ANY($1)
+                ORDER BY src, uri, val, seq DESC
+            ) current_labels
+            WHERE neg = false
+              AND (exp IS NULL OR exp > NOW())
+            ORDER BY uri, val
+            "#,
+        )
+        .bind(values)
+        .fetch_all(&self.pool)
+        .await
+    }
+
     /// Get the current active label values for a set of URIs.
     ///
     /// Label state is event-sourced: the newest event for each

--- a/services/moderation/src/main.rs
+++ b/services/moderation/src/main.rs
@@ -107,6 +107,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/admin/context", post(admin::store_context))
         .route("/admin/active-labels", post(admin::get_active_labels))
         .route("/admin/labels", post(admin::get_label_values))
+        .route("/admin/labels-by-value", post(admin::get_labels_by_value))
         .route("/admin/negated-labels", post(admin::get_negated_labels))
         .route("/admin/sensitive-images", post(admin::add_sensitive_image))
         .route(


### PR DESCRIPTION
Logged-out pagination of the home-page latest feed has been broken since #1676 (July 16): any page containing an adult-labeled track reported `has_more: false` early and everything older silently disappeared. Root cause: adult-audio visibility could not be expressed in SQL (operator labels lived only in the moderation service, reachable per-request over HTTP), forcing #1676 to filter app-side after the query — which corrupts cursor pagination bookkeeping. This PR fixes the storage layer instead of the symptom: operator labels are projected into the main DB, visibility becomes a WHERE clause, and pagination stays the simple `limit + 1` it always was.

## design

**Projection, following the existing copyright precedent.** `copyright_scans.is_flagged` already mirrors labeler state into the app DB via a 5-minute reconciliation task (`sync_copyright_resolutions`). Adult labels now get the same treatment:

- **moderation service**: new `/admin/labels-by-value` endpoint — every URI holding an active label of the requested values, resolved with the same event-sourced `DISTINCT ON … seq DESC` semantics as the by-URI query. This exists because a projection sync can't know which URIs to ask about; the by-URI endpoint can't drive one.
- **backend**: new `tracks.operator_labels` JSONB column (migration included) + `sync_operator_labels`, a docket Perpetual task (5 min) that reconciles the column against the labeler snapshot — applying new labels and clearing negated ones. The client method raises on labeler failure so an outage can never be mistaken for "nothing is labeled" and wipe the projection.
- **policy boundary** (`content_labels.py`): `get_track_label_values` now reads columns only (self labels ∪ projection) and is synchronous; new `sensitive_audio_visible_clause(viewer_did)` expresses the visibility rule in SQL (`?|` on both label columns, owner exception).

**The actual bug fix** is then two lines of substance in `/tracks/` listing: apply the clause unless the viewer's saved preference shows sensitive audio (read from the prefs row the endpoint already fetched). `has_more`/`next_cursor` logic is untouched from its pre-#1676 form.

**What stays live**: byte-serving authorization (`/audio`) keeps querying the labeler with `strict=True` — the projection is for discovery only, and the column docstring says so. `get_operator_label_values` (artist portal `/tracks/me`) also stays live for freshness.

**Freshness**: discovery surfaces previously saw labels through a 300s redis cache; the 5-minute sync cadence is equivalent. All ~12 `filter_sensitive_audio_tracks` call sites (search, albums, subsonic, queue, jams, radio, likes, playback, lists, for-you) keep their signatures but stop making HTTP calls transitively — they now read the projection.

<details>
<summary>tests, rollout, intentional non-behaviors, deferred scope</summary>

**Tests**
- `test_tracks_sensitive_pagination.py`: drives `/tracks/` anonymously through full cursor walks; covers self-labeled and operator-projected tracks, mid-feed and trailing. The two substantive tests fail against the pre-fix listing logic (verified by reverting `listing.py` alone).
- `test_moderation.py`: `sync_operator_labels` applies new labels, clears negated ones, leaves untouched rows alone; a labeler outage raises and leaves the projection intact.
- `test_self_labels.py`: split the effective-label test into the live path (`get_operator_label_values`) and the column path (`get_track_label_values`).

**Rollout ordering**: the sync task calls the new labeler endpoint, so the moderation service must deploy before or with the backend (staging auto-deploy handles both). On first deploy the projection starts empty; operator-labeled tracks are visible in discovery until the first sync pass completes (the Perpetual task runs at worker startup, so seconds-to-minutes — comparable to the 300s cache staleness already tolerated, and byte-serving stays gated live throughout).

**Intentional non-behaviors**
- response shapes unchanged; anonymous first-page discovery cache (60s TTL) unaffected and self-heals within a minute of any sync.
- cursor semantics unchanged (ISO timestamp, strict `<`).
- no frontend changes — pages are always full now, so the infinite-scroll sentinel needs no guard.
- `PROJECTED_LABEL_VALUES` currently equals `ADULT_AUDIO_LABELS`; the projection only carries values the sync manages.

**Deferred**
- `/tracks/top` can undercount below `limit` when ranked tracks are filtered — pre-existing (same undercount already existed for unlisted tracks, cf. #1245/#1246), cosmetic, and the ranking query would need a tracks join to fix. Its filtering now reads the projection, so no HTTP.
- for-you pages can come back short after filtering (offset cursor is sound, no stall); filling them is a recommendation-pipeline concern.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)