### PR TITLE
fix(moderation): flag mixes of copyrighted songs, not just single-song rips

### DIFF
--- a/scripts/scan_tracks_copyright.py
+++ b/scripts/scan_tracks_copyright.py
@@ -148,6 +148,7 @@ async def run_scan(
     dry_run: bool = False,
     limit: int | None = None,
     max_duration: float | None = None,
+    track_ids: list[int] | None = None,
 ) -> None:
     """scan all tracks for copyright."""
     # load settings
@@ -181,15 +182,18 @@ async def run_scan(
     from backend.utilities.database import db_session
 
     async with db_session() as db:
-        # find tracks without scans
+        # find tracks without scans (or the explicitly requested tracks)
         scanned_subq = select(CopyrightScan.track_id)
         stmt = (
             select(Track)
             .options(joinedload(Track.artist))
-            .where(Track.id.notin_(scanned_subq))
             .where(Track.r2_url.isnot(None))
             .order_by(Track.created_at.desc())
         )
+        if track_ids:
+            stmt = stmt.where(Track.id.in_(track_ids))
+        else:
+            stmt = stmt.where(Track.id.notin_(scanned_subq))
 
         if limit:
             stmt = stmt.limit(limit)
@@ -337,13 +341,23 @@ def main() -> None:
         default=None,
         help="skip tracks longer than this many minutes (estimated from file size)",
     )
+    parser.add_argument(
+        "--track-id",
+        type=int,
+        action="append",
+        dest="track_ids",
+        default=None,
+        help="scan this specific track id even if already scanned (repeatable)",
+    )
 
     args = parser.parse_args()
 
     print(f"🔍 copyright scan - {args.env}")
     print("=" * 50)
 
-    asyncio.run(run_scan(args.env, args.dry_run, args.limit, args.max_duration))
+    asyncio.run(
+        run_scan(args.env, args.dry_run, args.limit, args.max_duration, args.track_ids)
+    )
 
 
 if __name__ == "__main__":

--- a/services/moderation/src/audd.rs
+++ b/services/moderation/src/audd.rs
@@ -1,6 +1,6 @@
 //! AuDD audio fingerprinting integration.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use axum::{extract::State, Json};
 use serde::{Deserialize, Serialize};
@@ -24,6 +24,10 @@ pub struct ScanResponse {
     /// The dominant song if one exists (artist - title)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dominant_match: Option<String>,
+    /// Distinct songs each matched across multiple segments — a DJ mix of
+    /// copyrighted material shows several sustained songs even though no
+    /// single one dominates
+    pub sustained_song_count: usize,
     /// Legacy field - always 0 since AudD doesn't return scores
     pub highest_score: i32,
     pub raw_response: serde_json::Value,
@@ -117,15 +121,23 @@ pub async fn scan(
 
     let matches = extract_matches(&audd_response);
     let (dominant_match, dominant_match_pct) = find_dominant_match(&matches);
+    let sustained_song_count = count_sustained_songs(&matches);
 
-    // Flag if any single song dominates the matches (>= threshold % of segments)
-    // This filters out false positives where random segments match different songs
-    let is_flagged = dominant_match_pct >= state.copyright_score_threshold;
+    // Two flagging signals, both using match structure as a confidence proxy
+    // (AudD returns no scores). Random false positives are scattered one-off
+    // matches of unrelated songs and trip neither:
+    // - single-song rip: one song dominates the matched segments
+    // - mix/collage: several distinct songs are each sustained across
+    //   multiple segments, though none dominates (Twitch/YouTube-style
+    //   per-segment detection catches these; the dominant test alone cannot)
+    let is_flagged = dominant_match_pct >= state.copyright_score_threshold
+        || sustained_song_count >= state.copyright_mix_song_threshold;
 
     info!(
         match_count = matches.len(),
         dominant_match_pct,
         dominant_match = dominant_match.as_deref().unwrap_or("none"),
+        sustained_song_count,
         is_flagged,
         "scan complete"
     );
@@ -135,6 +147,7 @@ pub async fn scan(
         is_flagged,
         dominant_match_pct,
         dominant_match,
+        sustained_song_count,
         highest_score: 0, // AudD doesn't return scores
         raw_response,
     }))
@@ -203,13 +216,37 @@ fn parse_timecode_to_ms(timecode: &str) -> Option<i64> {
     }
 }
 
+/// Minimum distinct segments a song must match at to count as sustained.
+/// One-off segment matches are the false-positive mode; a song recognized at
+/// several positions in the file is a real presence.
+const MIN_SEGMENTS_PER_SUSTAINED_SONG: usize = 3;
+
+/// Count distinct songs that are each matched at multiple distinct positions.
+fn count_sustained_songs(matches: &[AuddMatch]) -> usize {
+    let mut song_segments: HashMap<(String, String), HashSet<String>> = HashMap::new();
+    for m in matches {
+        let key = (m.artist.to_lowercase(), m.title.to_lowercase());
+        let segment = m
+            .timecode
+            .clone()
+            .or_else(|| m.offset_ms.map(|o| o.to_string()));
+        if let Some(segment) = segment {
+            song_segments.entry(key).or_default().insert(segment);
+        }
+    }
+    song_segments
+        .values()
+        .filter(|segments| segments.len() >= MIN_SEGMENTS_PER_SUSTAINED_SONG)
+        .count()
+}
+
 /// Find the dominant song in matches (the one that appears most frequently).
 /// Returns (dominant_song_name, percentage_of_total_matches).
 ///
 /// AudD doesn't return confidence scores, so we use match frequency as a proxy:
 /// if the same song matches across many segments of the track, it's likely real.
 /// Random false positives tend to be scattered across different songs.
-fn find_dominant_match(matches: &[AuddMatch]) -> (Option<String>, i32) {
+pub(crate) fn find_dominant_match(matches: &[AuddMatch]) -> (Option<String>, i32) {
     if matches.is_empty() {
         return (None, 0);
     }
@@ -231,4 +268,77 @@ fn find_dominant_match(matches: &[AuddMatch]) -> (Option<String>, i32) {
     let dominant_name = format!("{} - {}", dominant_key.0, dominant_key.1);
 
     (Some(dominant_name), pct)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn m(artist: &str, title: &str, timecode: &str) -> AuddMatch {
+        AuddMatch {
+            artist: artist.to_string(),
+            title: title.to_string(),
+            album: None,
+            score: 0,
+            isrc: None,
+            timecode: Some(timecode.to_string()),
+            offset_ms: None,
+        }
+    }
+
+    #[test]
+    fn mix_of_sustained_songs_is_counted() {
+        // a DJ mix: four songs, each recognized at three distinct positions,
+        // none dominating (25% each) — the regression that shipped unflagged
+        let matches: Vec<AuddMatch> = [
+            ("Susumu Yokota", "Song A"),
+            ("Quelle Chris", "Song B"),
+            ("Black Star", "Song C"),
+            ("Madlib", "Song D"),
+        ]
+        .iter()
+        .flat_map(|(artist, title)| {
+            ["00:10", "01:10", "02:10"]
+                .iter()
+                .map(|t| m(artist, title, t))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+        assert_eq!(count_sustained_songs(&matches), 4);
+        let (_, pct) = find_dominant_match(&matches);
+        assert!(pct < 30, "no single song should dominate a mix");
+    }
+
+    #[test]
+    fn single_song_rip_is_not_a_mix() {
+        let matches: Vec<AuddMatch> = (0..10)
+            .map(|i| m("Artist", "Song", &format!("00:{i:02}")))
+            .collect();
+
+        assert_eq!(count_sustained_songs(&matches), 1);
+        let (_, pct) = find_dominant_match(&matches);
+        assert_eq!(pct, 100);
+    }
+
+    #[test]
+    fn scattered_one_off_matches_are_not_sustained() {
+        // the false-positive mode: unrelated songs each matching once
+        let matches: Vec<AuddMatch> = (0..5)
+            .map(|i| m(&format!("Artist {i}"), &format!("Song {i}"), "00:30"))
+            .collect();
+
+        assert_eq!(count_sustained_songs(&matches), 0);
+    }
+
+    #[test]
+    fn repeated_matches_at_one_position_are_not_sustained() {
+        let matches = vec![
+            m("Artist", "Song", "00:30"),
+            m("Artist", "Song", "00:30"),
+            m("Artist", "Song", "00:30"),
+        ];
+
+        assert_eq!(count_sustained_songs(&matches), 0);
+    }
 }

--- a/services/moderation/src/config.rs
+++ b/services/moderation/src/config.rs
@@ -20,6 +20,9 @@ pub struct Config {
     /// Minimum percentage of matches that must belong to a single song to flag (default: 30)
     /// AudD doesn't return confidence scores, so we use match frequency as a proxy.
     pub copyright_score_threshold: i32,
+    /// Minimum count of distinct songs each sustained across multiple segments
+    /// to flag as a mix of copyrighted material (default: 3)
+    pub copyright_mix_song_threshold: usize,
 }
 
 impl Config {
@@ -46,6 +49,10 @@ impl Config {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(30),
+            copyright_mix_song_threshold: env::var("MODERATION_COPYRIGHT_MIX_SONG_THRESHOLD")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(3),
         })
     }
 

--- a/services/moderation/src/main.rs
+++ b/services/moderation/src/main.rs
@@ -83,6 +83,7 @@ async fn main() -> anyhow::Result<()> {
         label_tx,
         claude: claude_client.map(Arc::new),
         copyright_score_threshold: config.copyright_score_threshold,
+        copyright_mix_song_threshold: config.copyright_mix_song_threshold,
     };
 
     let app = Router::new()

--- a/services/moderation/src/state.rs
+++ b/services/moderation/src/state.rs
@@ -26,6 +26,8 @@ pub struct AppState {
     pub claude: Option<Arc<ClaudeClient>>,
     /// Minimum percentage of matches that must belong to a single song to flag
     pub copyright_score_threshold: i32,
+    /// Minimum count of distinct sustained songs to flag as a mix
+    pub copyright_mix_song_threshold: usize,
 }
 
 /// Application error type.


### PR DESCRIPTION
Track 64 was flagged live by both Twitch and YouTube Content ID during a listener's stream (user report, 2026-07-23), but our AudD scan stored `is_flagged: false` — the raw response contained **249 matched segments spanning 00:04–14:07** across dozens of commercial recordings (Susumu Yokota ×23, Quelle Chris ×19, Lil B ×16, Black Star ×14, …). The flagging heuristic only fires when a *single dominant song* covers ≥30% of matched segments, which is structurally blind to DJ mixes/collages where no one song exceeds ~15%.

## change

Add a second signal alongside the dominant-song test: **sustained song count** — the number of distinct songs each matched at ≥3 distinct positions in the file. A scan is now flagged when either:

- one song dominates matched segments (existing rip detector, unchanged), or
- ≥3 distinct songs are each sustained across multiple segments (new mix detector, `MODERATION_COPYRIGHT_MIX_SONG_THRESHOLD`, default 3)

Both signals use match *structure* as the confidence proxy since AudD returns no scores. The false-positive mode the original threshold guards against — scattered one-off matches of unrelated songs — trips neither: a one-off match contributes no sustained song, and repeated matches at the same position don't count as sustained (distinct positions required).

`ScanResponse` gains a `sustained_song_count` field (the backend client parses with `.get`, so it's backward/forward compatible); the scan log line includes it.

<details>
<summary>tests, tooling, non-behaviors</summary>

**Tests** (`audd.rs`): mix of 4 sustained songs counted (with assertion that no song dominates — the exact shipped-unflagged regression shape); single-song rip yields 1 sustained song and 100% dominance; scattered one-offs yield 0; repeated same-position matches yield 0.

**Tooling**: `scripts/scan_tracks_copyright.py` gains a repeatable `--track-id` flag to (re)scan specific tracks even if already scanned — the bulk script previously only walked unscanned tracks newest-first.

**Non-behaviors**: the self-match suppression in the backend (`_store_scan_result`) is keyed on the *dominant* match artist and is unchanged; a mix-flagged scan with no dominant match is never self-suppressed, which is correct — a mix of many artists is not the uploader's own release. Scan-failure fallback ("store as clear") unchanged.

**Follow-up (not in this PR)**: rescan track 64 in prod once deployed, replacing the stale clear row.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)