### PR TITLE
feat(frontend): emit at-tags meta on track, album, playlist, and artist pages

### DIFF
--- a/frontend/src/routes/playlist/[id]/+page.svelte
+++ b/frontend/src/routes/playlist/[id]/+page.svelte
@@ -457,6 +457,14 @@
 		title={playlist.name}
 		href="{API_URL}/oembed?url={encodeURIComponent(`${APP_CANONICAL_URL}/playlist/${playlist.id}`)}"
 	/>
+
+	<!-- at-tags: map this page to its atproto records (https://tangled.org/chrisshank.com/at-tags/) -->
+	{#if playlist.atproto_record_uri}
+		<meta name="at:canonical" content={playlist.atproto_record_uri} />
+	{/if}
+	{#if playlist.owner_did}
+		<meta name="at:author" content="at://{playlist.owner_did}" />
+	{/if}
 </svelte:head>
 
 <Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={handleLogout} />

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -580,6 +580,14 @@ $effect(() => {
 		href="{API_URL}/oembed?url={encodeURIComponent(`${APP_CANONICAL_URL}/track/${track.id}`)}"
 		title="{track.title} - {track.artist}"
 	/>
+
+	<!-- at-tags: map this page to its atproto records (https://tangled.org/chrisshank.com/at-tags/) -->
+	{#if track.atproto_record_uri}
+		<meta name="at:canonical" content={track.atproto_record_uri} />
+	{/if}
+	{#if track.artist_did}
+		<meta name="at:author" content="at://{track.artist_did}" />
+	{/if}
 	{/if}
 </svelte:head>
 

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -397,6 +397,9 @@ $effect(() => {
 		{#if data.artist.avatar_url && !moderation.isSensitive(data.artist.avatar_url)}
 			<meta name="twitter:image" content="{data.artist.avatar_url}" />
 		{/if}
+
+		<!-- at-tags: map this page to its atproto identity (https://tangled.org/chrisshank.com/at-tags/) -->
+		<meta name="at:canonical" content="at://{data.artist.did}" />
 		{/if}
 </svelte:head>
 

--- a/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
@@ -261,6 +261,14 @@
 		href="{API_URL}/oembed?url={encodeURIComponent(`${APP_CANONICAL_URL}/u/${albumMetadata.artist_handle}/album/${albumMetadata.slug}`)}"
 		title="{albumMetadata.title} by {albumMetadata.artist}"
 	/>
+
+	<!-- at-tags: map this page to its atproto records (https://tangled.org/chrisshank.com/at-tags/) -->
+	{#if albumMetadata.list_uri}
+		<meta name="at:canonical" content={albumMetadata.list_uri} />
+	{/if}
+	{#if albumMetadata.artist_did}
+		<meta name="at:author" content="at://{albumMetadata.artist_did}" />
+	{/if}
 </svelte:head>
 
 <Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={() => goto('/login')} />

--- a/loq.toml
+++ b/loq.toml
@@ -340,7 +340,7 @@ max_lines = 506
 
 [[rules]]
 path = "frontend/src/routes/track/[[]id[]]/+page.svelte"
-max_lines = 1783
+max_lines = 1791
 
 [[rules]]
 path = "frontend/src/lib/components/playlist/PlaylistTrackList.svelte"
@@ -357,3 +357,7 @@ max_lines = 601
 [[rules]]
 path = "backend/tests/_internal/test_permissioned_spaces.py"
 max_lines = 634
+
+[[rules]]
+path = "frontend/src/routes/u/[[]handle[]]/+page.svelte"
+max_lines = 1439


### PR DESCRIPTION
plyr.fm pages now declare the atproto records they render, via the [at-tags community proposal](https://tangled.org/chrisshank.com/at-tags/) — `<meta name="at:canonical">` / `<meta name="at:author">` tags that let crawlers, browsers, and resolvers map a web page back to its canonical `at://` URI.

## motivation

In the last few days a wave of Atmosphere apps adopted the proposal (mu.social, semble.so, aturi.to, leaflet.pub, frontpage.fyi; bsky.app has [bluesky-social/social-app#11243](https://github.com/bluesky-social/social-app/pull/11243) open). The proposal supersedes the older `<link rel="alternate" href="at://...">` convention because AT URIs are [not RFC-3986-valid URLs](https://bnewbold.leaflet.pub/3mph4hzvbdc2v) (DIDs in the authority position), so they don't belong in `<link href>`; `<meta content>` is free text. plyr.fm is exactly the kind of app this targets — every track/album/playlist page is backed by a record in the artist's PDS.

<details>
<summary>design & minutiae</summary>

- **track pages**: `at:canonical` = the `fm.plyr.track` record URI (guarded — absent until PDS sync completes), `at:author` = `at://{artist_did}`.
- **album pages**: `at:canonical` = `list_uri`, `at:author` = artist DID.
- **playlist pages**: `at:canonical` = `atproto_record_uri` (null for private playlists → tag omitted), `at:author` = owner DID.
- **artist pages**: `at:canonical` = `at://{did}` — a bare identity URI rather than a profile-record URI, so no NSID is hardcoded in the frontend (NSIDs are environment-aware and live in backend settings). The proposal's reference parser normalizes bare DIDs fine.
- Tags are emitted only from existing page data — no new API calls, no backend changes.
- No head-render tests exist for OG tags either; verification is on staging per existing practice.
- loq limits relaxed for the two files that ticked over their line budgets.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)