### PR TITLE
refactor(moderation): serve service-to-service endpoints under /internal

### DIFF
--- a/docs/internal/moderation/atproto-labeler.md
+++ b/docs/internal/moderation/atproto-labeler.md
@@ -107,7 +107,15 @@ curl "https://moderation.plyr.fm/xrpc/com.atproto.label.queryLabels?sources=did:
 
 WebSocket endpoint for real-time label streaming. apps can subscribe to receive new labels as they're created (monotonic sequence cursor).
 
-### POST /admin/labels
+## service-to-service endpoints (`/internal/*`)
+
+the endpoints the backend calls live under `/internal`, separate from the
+human-facing `/admin` dashboard, though both are authenticated with the same
+`X-Moderation-Key`. They are also still mounted under `/admin/*` as deprecated
+aliases so the two services can deploy independently; the aliases go away once
+the backend client has moved (#1691).
+
+### POST /internal/labels
 
 the backend uses this generic endpoint to fetch the current active values for
 each subject URI. This is the primary consumer API for discovery and playback
@@ -127,7 +135,7 @@ policy.
 }
 ```
 
-`POST /admin/active-labels` remains as a compatibility projection for the
+`POST /internal/active-labels` remains as a compatibility projection for the
 copyright synchronization task and returns only `copyright-violation` subjects.
 
 current state is the latest event for each `(src, uri, val)` tuple. A historical
@@ -135,7 +143,7 @@ negation does not permanently suppress a newer positive label, and a newer
 negation revokes the positive state without deleting either event.
 
 ```bash
-curl -X POST https://moderation.plyr.fm/admin/active-labels \
+curl -X POST https://moderation.plyr.fm/internal/active-labels \
   -H "X-Moderation-Key: $MODERATION_AUTH_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"uris": ["at://did:plc:abc123/fm.plyr.track/xyz789"]}'

--- a/docs/internal/moderation/overview.md
+++ b/docs/internal/moderation/overview.md
@@ -106,7 +106,7 @@ Both map to the adult-audio preference and default-hide policy. Negation
 creators own self-label assertions in their track records, the moderation
 service owns signed operator assertions, and the backend owns policy:
 
-1. fetch current active values with `POST /admin/labels`
+1. fetch current active values with `POST /internal/labels`
 2. filter adult-labeled tracks from default discovery and collection surfaces
 3. require authenticated opt-in at the audio byte endpoint
 4. always exclude adult audio from shared radio

--- a/docs/internal/tools/agent-access.md
+++ b/docs/internal/tools/agent-access.md
@@ -69,7 +69,7 @@ look up deployments.
 
 | credential | authorizes | does not authorize |
 |---|---|---|
-| `MODERATION_AUTH_TOKEN` | `/emit-label`, `/admin/labels`, reports, and other protected moderation-service endpoints | updating the ATProto labeler service record |
+| `MODERATION_AUTH_TOKEN` | `/emit-label`, `/internal/*`, reports, and other protected moderation-service endpoints | updating the ATProto labeler service record |
 | `MODERATION_BSKY_PASSWORD` | an app-password session for the `moderation.plyr.fm` ATProto account, including its labeler declaration record | protected moderation-service HTTP endpoints |
 | labeler signing key (Fly secret) | cryptographic signing inside `plyr-moderation` | operator login; it must never leave the service |
 

--- a/services/moderation/Cargo.lock
+++ b/services/moderation/Cargo.lock
@@ -1229,6 +1229,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/services/moderation/Cargo.toml
+++ b/services/moderation/Cargo.toml
@@ -27,3 +27,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [dev-dependencies]
+tower = { version = "0.5", features = ["util"] }

--- a/services/moderation/src/main.rs
+++ b/services/moderation/src/main.rs
@@ -86,7 +86,39 @@ async fn main() -> anyhow::Result<()> {
         copyright_mix_song_threshold: config.copyright_mix_song_threshold,
     };
 
-    let app = Router::new()
+    let app = build_router(state, auth_token);
+
+    let addr: SocketAddr = format!("{}:{}", config.host, config.port)
+        .parse()
+        .map_err(|e| anyhow!("invalid bind addr: {e}"))?;
+    info!(%addr, "moderation service listening");
+
+    let listener = TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+/// Service-to-service endpoints the backend calls.
+///
+/// Served under `/internal`, and — for one deploy cycle — also under the
+/// legacy `/admin` prefix so the backend and this service can deploy
+/// independently. Remove the `/admin` mount once the backend client has
+/// moved (#1691).
+fn machine_api() -> Router<AppState> {
+    Router::new()
+        .route("/active-labels", post(admin::get_active_labels))
+        .route("/labels", post(admin::get_label_values))
+        .route("/labels-by-value", post(admin::get_labels_by_value))
+        .route("/negated-labels", post(admin::get_negated_labels))
+        .route("/sensitive-images", post(admin::add_sensitive_image))
+        .route(
+            "/sensitive-images/remove",
+            post(admin::remove_sensitive_image),
+        )
+}
+
+fn build_router(state: AppState, auth_token: Option<String>) -> Router {
+    Router::new()
         // Landing page
         .route("/", get(handlers::landing))
         // Health check
@@ -99,6 +131,9 @@ async fn main() -> anyhow::Result<()> {
         .route("/scan-image", post(handlers::scan_image))
         // Label emission (internal API)
         .route("/emit-label", post(handlers::emit_label))
+        // Service-to-service API
+        .nest("/internal", machine_api())
+        .nest("/admin", machine_api())
         // Admin UI and API
         .route("/admin", get(admin::admin_ui))
         .route("/admin/flags", get(admin::list_flagged))
@@ -106,15 +141,6 @@ async fn main() -> anyhow::Result<()> {
         .route("/admin/resolve", post(admin::resolve_flag))
         .route("/admin/resolve-htmx", post(admin::resolve_flag_htmx))
         .route("/admin/context", post(admin::store_context))
-        .route("/admin/active-labels", post(admin::get_active_labels))
-        .route("/admin/labels", post(admin::get_label_values))
-        .route("/admin/labels-by-value", post(admin::get_labels_by_value))
-        .route("/admin/negated-labels", post(admin::get_negated_labels))
-        .route("/admin/sensitive-images", post(admin::add_sensitive_image))
-        .route(
-            "/admin/sensitive-images/remove",
-            post(admin::remove_sensitive_image),
-        )
         .route("/admin/batches", post(admin::create_batch))
         // User reports
         .route("/reports", post(reports::create_report))
@@ -140,14 +166,88 @@ async fn main() -> anyhow::Result<()> {
         .layer(middleware::from_fn(move |req, next| {
             auth::auth_middleware(req, next, auth_token.clone())
         }))
-        .with_state(state);
+        .with_state(state)
+}
 
-    let addr: SocketAddr = format!("{}:{}", config.host, config.port)
-        .parse()
-        .map_err(|e| anyhow!("invalid bind addr: {e}"))?;
-    info!(%addr, "moderation service listening");
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
 
-    let listener = TcpListener::bind(addr).await?;
-    axum::serve(listener, app).await?;
-    Ok(())
+    use super::*;
+
+    /// (path, body) for every service-to-service endpoint, relative to its prefix.
+    const MACHINE_ENDPOINTS: &[(&str, &str)] = &[
+        ("/active-labels", r#"{"uris":[]}"#),
+        ("/labels", r#"{"uris":[]}"#),
+        ("/labels-by-value", r#"{"values":[]}"#),
+        ("/negated-labels", r#"{"uris":[]}"#),
+        ("/sensitive-images", r#"{"image_id":"x"}"#),
+        ("/sensitive-images/remove", r#"{"id":1}"#),
+    ];
+
+    const TOKEN: &str = "test-token";
+
+    fn test_state() -> AppState {
+        AppState {
+            audd_api_token: String::new(),
+            audd_api_url: String::new(),
+            db: None,
+            signer: None,
+            label_tx: None,
+            claude: None,
+            copyright_score_threshold: 50,
+            copyright_mix_song_threshold: 3,
+        }
+    }
+
+    async fn post(path: &str, body: &str, token: Option<&str>) -> StatusCode {
+        let mut req = Request::post(path).header("content-type", "application/json");
+        if let Some(token) = token {
+            req = req.header("X-Moderation-Key", token);
+        }
+        build_router(test_state(), Some(TOKEN.to_string()))
+            .oneshot(req.body(Body::from(body.to_string())).unwrap())
+            .await
+            .unwrap()
+            .status()
+    }
+
+    /// Both prefixes must reach the same handler for the whole deploy-overlap
+    /// window: the backend still calls `/admin/*` until its client moves.
+    #[tokio::test]
+    async fn machine_endpoints_are_served_under_both_prefixes() {
+        for (path, body) in MACHINE_ENDPOINTS {
+            for prefix in ["/internal", "/admin"] {
+                let status = post(&format!("{prefix}{path}"), body, Some(TOKEN)).await;
+                assert_eq!(
+                    status,
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "{prefix}{path} should reach the handler (503 = no labeler db in tests)"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn machine_endpoints_require_the_moderation_key() {
+        for (path, body) in MACHINE_ENDPOINTS {
+            let status = post(&format!("/internal{path}"), body, None).await;
+            assert_eq!(status, StatusCode::UNAUTHORIZED, "/internal{path}");
+        }
+    }
+
+    /// The moderator UI is unaffected by the split.
+    #[tokio::test]
+    async fn admin_ui_routes_still_resolve() {
+        let status = build_router(test_state(), Some(TOKEN.to_string()))
+            .oneshot(Request::get("/admin/flags").body(Body::empty()).unwrap())
+            .await
+            .unwrap()
+            .status();
+        assert_ne!(status, StatusCode::NOT_FOUND);
+    }
 }


### PR DESCRIPTION
The moderation service's six hot-path, backend-called endpoints now live under `/internal/*` instead of sharing the `/admin/*` prefix with the human htmx dashboard. They stay mounted at `/admin/*` as deprecated aliases so the two services can keep deploying independently; the backend client moves in a follow-up PR.

Refs #1691.

<details>
<summary>what moved</summary>

| endpoint | consumer |
|---|---|
| `POST /internal/labels` | audio authorization, `/tracks/me` (hot path) |
| `POST /internal/labels-by-value` | operator-label projection sync (#1688) |
| `POST /internal/negated-labels` | copyright resolution sync |
| `POST /internal/active-labels` | copyright compatibility projection |
| `POST /internal/sensitive-images` | sensitive-image writes |
| `POST /internal/sensitive-images/remove` | sensitive-image writes |

`/admin/*` keeps the moderator UI plus its script-facing JSON siblings (`/admin/flags`, `/admin/resolve`, `/admin/context`, `/admin/batches`).
</details>

<details>
<summary>design notes</summary>

- **one route table, two mounts.** `machine_api()` returns a `Router<AppState>` nested at both `/internal` and `/admin`, so the alias can't drift from the canonical surface and removing it is a one-line deletion.
- **auth is unchanged.** `/internal/*` isn't in the middleware's public-path list, so it requires `X-Moderation-Key` exactly as `/admin/*` did. Distinct UI-vs-service tokens remain optional future work, per the issue.
- **`main()` split into `build_router(state, auth_token)`** so the routing table is testable without binding a socket.
- **the aliases matter.** After #1688 merged, the backend worker restarted before the moderation deploy finished and 404'd `/admin/labels-by-value` for one sync cycle. Renaming without the overlap window would reproduce that in the other direction, on the audio-authorization hot path — which fails *closed*.
</details>

<details>
<summary>tests</summary>

Three tests in `main.rs` over a table of the six endpoints:
- every endpoint resolves under **both** prefixes (503 from the handler, not 404 from the router)
- `/internal/*` rejects a request with no `X-Moderation-Key` (401)
- `/admin/flags` still resolves, i.e. the moderator UI is unaffected by the nesting

Adds `tower` as a dev-dependency for `oneshot`.
</details>

<details>
<summary>deliberate non-changes</summary>

- **`backend/_internal/clients/moderation.py` still calls `/admin/*`.** That's the point of the alias — the URL swap is a separate PR merged only after this service deploys.
- **`/admin/flags`, `/admin/resolve`, `/admin/context`, `/admin/batches` stayed put** even though only scripts call them (`moderation_loop.py`, `moderation_agent.py`, `backfill_label_context.py`). The issue enumerated six endpoints; these are operator-driven rather than steady-state service traffic, and moving them would churn scripts for no deploy-safety gain. Easy to fold in later if you'd rather `/internal` mean "not a browser".
- **no `cargo fmt` sweep.** Running it reformatted five untouched files past their loq limits; reverted to keep the diff to the rename.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)