### PR TITLE
refactor(moderation): call the labeler's /internal surface from the backend

### DIFF
--- a/backend/src/backend/_internal/clients/moderation.py
+++ b/backend/src/backend/_internal/clients/moderation.py
@@ -373,7 +373,7 @@ class ModerationClient:
         try:
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.post(
-                    f"{self.labeler_url}/admin/active-labels",
+                    f"{self.labeler_url}/internal/active-labels",
                     json={"uris": uris_to_fetch},
                     headers=self._headers(),
                 )
@@ -441,7 +441,7 @@ class ModerationClient:
         try:
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.post(
-                    f"{self.labeler_url}/admin/labels",
+                    f"{self.labeler_url}/internal/labels",
                     json={"uris": uris_to_fetch},
                     headers=self._headers(),
                 )
@@ -473,7 +473,7 @@ class ModerationClient:
 
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             response = await client.post(
-                f"{self.labeler_url}/admin/labels-by-value",
+                f"{self.labeler_url}/internal/labels-by-value",
                 json={"values": values},
                 headers=self._headers(),
             )
@@ -506,7 +506,7 @@ class ModerationClient:
         try:
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.post(
-                    f"{self.labeler_url}/admin/negated-labels",
+                    f"{self.labeler_url}/internal/negated-labels",
                     json={"uris": uris},
                     headers=self._headers(),
                 )

--- a/backend/tests/test_moderation.py
+++ b/backend/tests/test_moderation.py
@@ -885,3 +885,61 @@ async def test_sync_operator_labels_skips_pass_on_labeler_outage(
 
     await db_session.refresh(track)
     assert track.operator_labels == ["sexual"]
+
+
+def _labeler_client() -> ModerationClient:
+    return ModerationClient(
+        service_url="https://moderation.test",
+        labeler_url="https://moderation.test",
+        auth_token="test-token",
+        timeout_seconds=5,
+        label_cache_prefix="test:label:",
+        label_cache_ttl_seconds=60,
+    )
+
+
+async def test_label_reads_target_the_internal_surface() -> None:
+    """the labeler's service-to-service endpoints live under /internal, not /admin.
+
+    A wrong prefix 404s, and the discovery-side readers fail *open* on error —
+    so a silent rename regression would quietly stop hiding labeled tracks
+    rather than raising. Assert the requested URL directly (#1691).
+    """
+    client = _labeler_client()
+    uris = ["at://did:plc:test/fm.plyr.track/1"]
+
+    expected = {
+        "/internal/active-labels": lambda: client.get_active_labels(uris),
+        "/internal/labels": lambda: client.get_active_label_values(uris),
+        "/internal/labels-by-value": lambda: client.get_active_labels_by_value(
+            ["sexual"]
+        ),
+        "/internal/negated-labels": lambda: client.get_negated_labels(uris),
+    }
+
+    for path, call in expected.items():
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = Mock(
+                status_code=200,
+                json=Mock(return_value={}),
+                raise_for_status=Mock(),
+            )
+            await call()
+
+        assert mock_post.call_args is not None, f"{path} was never requested"
+        assert mock_post.call_args[0][0] == f"https://moderation.test{path}"
+
+
+async def test_sensitive_images_read_stays_on_the_public_route() -> None:
+    """GET /sensitive-images is public and was never part of the /internal split."""
+    client = _labeler_client()
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = Mock(
+            status_code=200,
+            json=Mock(return_value={"image_ids": [], "urls": []}),
+            raise_for_status=Mock(),
+        )
+        await client.get_sensitive_images()
+
+    assert mock_get.call_args[0][0] == "https://moderation.test/sensitive-images"

--- a/loq.toml
+++ b/loq.toml
@@ -76,7 +76,7 @@ max_lines = 569
 
 [[rules]]
 path = "backend/tests/test_moderation.py"
-max_lines = 887
+max_lines = 945
 
 [[rules]]
 path = "docs/internal/authentication.md"


### PR DESCRIPTION
Second half of #1691: the backend's four label reads now call `/internal/*` instead of the `/admin/*` aliases. #1692 is already deployed with both prefixes live, so this is safe to land immediately.

<details>
<summary>what changed</summary>

Four URLs in `backend/_internal/clients/moderation.py`:

| method | now calls |
|---|---|
| `get_active_labels` | `POST /internal/active-labels` |
| `get_active_label_values` | `POST /internal/labels` |
| `get_active_labels_by_value` | `POST /internal/labels-by-value` |
| `get_negated_labels` | `POST /internal/negated-labels` |

`get_sensitive_images` still calls `GET /sensitive-images` — a separate public route that was never part of the split. The two sensitive-image *write* endpoints moved to `/internal` in #1692 but the backend never called them (operator surface only).
</details>

<details>
<summary>verified against the deployed service</summary>

All six endpoints probed on `moderation.plyr.fm` after #1692 deployed — both prefixes return identical status, auth is enforced, and a bogus path under `/internal` 404s (proving the router is really matching, not swallowing):

```
/active-labels           internal=200 admin=200 (want 200) ok
/labels                  internal=200 admin=200 (want 200) ok
/labels-by-value         internal=200 admin=200 (want 200) ok
/negated-labels          internal=200 admin=200 (want 200) ok
/sensitive-images        internal=400 admin=400 (want 400) ok   # no image_id/url -> validation
/sensitive-images/remove internal=200 admin=200 (want 200) ok   # id=-1 -> no-op
/internal/labels         no-key=401 ok
/internal/nope           control=404 ok
```
</details>

<details>
<summary>tests</summary>

`test_label_reads_target_the_internal_surface` drives all four client methods with only `httpx.AsyncClient.post` mocked (the network boundary, matching the file's existing pattern) and asserts the requested URL. Confirmed failing before the fix by reverting one URL:

```
E  AssertionError: assert 'https://mode...bels-by-value' == 'https://mode...bels-by-value'
```

This is worth asserting rather than trusting: a wrong prefix 404s, and the discovery-side readers **fail open** on error — so a silent rename regression would quietly stop hiding labeled tracks instead of raising. `test_sensitive_images_read_stays_on_the_public_route` pins the one label-adjacent URL that deliberately did *not* move.

`just loq-relax` applied to `test_moderation.py` (945 lines).
</details>

<details>
<summary>deploy ordering</summary>

There is only one moderation service — `plyr-moderation` / `moderation.plyr.fm` — shared by staging and production; `labeler_url` defaults to it in every environment. So #1692's deploy already put `/internal` in front of both. Merging this PR moves the staging backend onto it; production moves at the next `just release`. The `/admin` aliases stay until that release lands, then come out in a follow-up.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)