### PR TITLE
fix(moderation): invalidate the label cache from the labeler stream

### DIFF
--- a/backend/src/backend/_internal/label_stream.py
+++ b/backend/src/backend/_internal/label_stream.py
@@ -1,0 +1,177 @@
+"""Subscriber for the labeler's `com.atproto.label.subscribeLabels` stream.
+
+The backend caches a track's active label values in redis for
+`moderation.label_cache_ttl_seconds`. That cache is keyed by subject URI and is
+viewer-independent, so a single playback populates it for everyone. Caching the
+*absence* of a label is what makes this dangerous: when an operator emits a
+label through the labeler UI, a script, or curl, the backend keeps answering
+"no labels" until the entry expires, and the audio byte endpoint -- which is
+supposed to fail closed -- serves adult audio to anonymous listeners for up to
+the full TTL.
+
+`ModerationClient.emit_label` already invalidates on the way out, but it only
+covers labels the backend itself emitted, which is the path operators do not
+use. This consumer closes the gap at the source: every label the labeler
+commits is broadcast on its subscription stream, so the backend invalidates the
+subject's cache entries within milliseconds no matter who wrote the label.
+
+Reading the stream instead of having the labeler call back into the backend
+keeps the dependency pointing one way (backend -> moderation), which matters
+because a single labeler serves both the staging and production backends.
+"""
+
+import asyncio
+import contextlib
+import logging
+import random
+import time
+from typing import Any
+
+import logfire
+import orjson
+import websockets
+from websockets.asyncio.client import ClientConnection
+
+from backend._internal.clients.moderation import get_moderation_client
+from backend.config import settings
+from backend.utilities.redis import get_async_redis_client
+
+logger = logging.getLogger(__name__)
+
+
+class LabelStreamConsumer:
+    """Invalidates the backend's label cache as the labeler commits labels."""
+
+    def __init__(self) -> None:
+        self._ws: ClientConnection | None = None
+        self._cursor: int | None = None
+        self._last_cursor_flush: float = 0.0
+        self._shutdown_event = asyncio.Event()
+
+    def stop(self) -> None:
+        """Signal shutdown and unblock the recv loop by closing the socket."""
+        self._shutdown_event.set()
+        ws = self._ws
+        if ws is not None:
+            with contextlib.suppress(Exception):
+                asyncio.get_running_loop().create_task(ws.close())
+
+    async def run(self) -> None:
+        """Main loop with auto-reconnect and exponential backoff."""
+        backoff = settings.moderation.label_stream_reconnect_base_seconds
+
+        while not self._shutdown_event.is_set():
+            try:
+                await self._load_cursor()
+                await self._connect_and_consume()
+            except asyncio.CancelledError:
+                logger.info("label stream consumer cancelled")
+                await self._flush_cursor()
+                return
+            except Exception:
+                logger.exception("label stream consumer error, reconnecting")
+
+            if self._shutdown_event.is_set():
+                return
+
+            jitter = random.uniform(0, backoff * 0.5)
+            delay = min(
+                backoff + jitter, settings.moderation.label_stream_reconnect_max_seconds
+            )
+            logger.info("label stream reconnecting in %.1fs", delay)
+            try:
+                await asyncio.wait_for(self._shutdown_event.wait(), timeout=delay)
+                return
+            except TimeoutError:
+                pass
+            backoff = min(
+                backoff * 2, settings.moderation.label_stream_reconnect_max_seconds
+            )
+
+    async def _connect_and_consume(self) -> None:
+        url = self._build_url()
+        logger.info("label stream connecting to %s", url)
+
+        with logfire.span("label stream consume", cursor=self._cursor):
+            async with websockets.connect(url, max_size=2**20) as ws:
+                self._ws = ws
+                logfire.info("label stream connected", cursor=self._cursor)
+
+                async for raw in ws:
+                    if self._shutdown_event.is_set():
+                        return
+                    try:
+                        message = orjson.loads(raw)
+                    except (orjson.JSONDecodeError, TypeError):
+                        continue
+                    await self._process_message(message)
+                    await self._maybe_flush_cursor()
+
+    async def _process_message(self, message: dict[str, Any]) -> None:
+        """Invalidate every subject named by a committed label event.
+
+        Negations invalidate exactly like positives: a stale cached *presence*
+        keeps a track hidden after a moderator cleared it, which is the
+        fail-closed direction but still wrong.
+        """
+        labels = message.get("labels") or []
+        client = get_moderation_client()
+
+        for label in labels:
+            if uri := label.get("uri"):
+                await client.invalidate_cache(uri)
+                logfire.info(
+                    "label cache invalidated from stream",
+                    uri=uri,
+                    val=label.get("val"),
+                    neg=bool(label.get("neg")),
+                )
+
+        if (seq := message.get("seq")) is not None:
+            self._cursor = int(seq)
+
+    def _build_url(self) -> str:
+        base = settings.moderation.label_stream_url or _ws_url(
+            settings.moderation.labeler_url
+        )
+        url = f"{base}/xrpc/com.atproto.label.subscribeLabels"
+        if self._cursor is not None:
+            # rewind one sequence so a label committed as the socket dropped is
+            # replayed; invalidation is idempotent, so re-processing is free.
+            url = f"{url}?cursor={max(self._cursor - 1, 0)}"
+        return url
+
+    async def _load_cursor(self) -> None:
+        try:
+            redis = get_async_redis_client()
+            if raw := await redis.get(settings.moderation.label_stream_cursor_key):
+                self._cursor = int(raw)
+                logger.info("label stream resuming from cursor %d", self._cursor)
+        except Exception as e:
+            logger.warning("could not load label stream cursor: %s", e)
+
+    async def _maybe_flush_cursor(self) -> None:
+        interval = settings.moderation.label_stream_cursor_flush_seconds
+        if time.monotonic() - self._last_cursor_flush >= interval:
+            await self._flush_cursor()
+
+    async def _flush_cursor(self) -> None:
+        if self._cursor is None:
+            return
+        try:
+            redis = get_async_redis_client()
+            await redis.set(
+                settings.moderation.label_stream_cursor_key, str(self._cursor)
+            )
+            self._last_cursor_flush = time.monotonic()
+        except Exception as e:
+            logger.warning("could not flush label stream cursor: %s", e)
+
+
+def _ws_url(http_url: str) -> str:
+    """Map the labeler's HTTP origin onto its websocket scheme."""
+    if http_url.startswith("https://"):
+        return "wss://" + http_url[len("https://") :]
+    if http_url.startswith("http://"):
+        return "ws://" + http_url[len("http://") :]
+    return http_url

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -764,6 +764,37 @@ class ModerationSettings(AppSettingsSection):
         default=True,
         description="Enable image moderation via Claude vision on upload",
     )
+    label_stream_enabled: bool = Field(
+        default=True,
+        description=(
+            "Subscribe to the labeler's subscribeLabels stream and invalidate "
+            "the label cache as labels are committed, so operator-emitted "
+            "labels take effect without waiting out label_cache_ttl_seconds"
+        ),
+    )
+    label_stream_url: str = Field(
+        default="",
+        description=(
+            "WebSocket origin for the labeler stream. Empty derives it from "
+            "labeler_url."
+        ),
+    )
+    label_stream_cursor_key: str = Field(
+        default="plyr:label-stream:cursor",
+        description="Redis key for persisting the label stream cursor",
+    )
+    label_stream_cursor_flush_seconds: int = Field(
+        default=10,
+        description="How often to flush the label stream cursor to Redis",
+    )
+    label_stream_reconnect_base_seconds: float = Field(
+        default=1.0,
+        description="Base delay for exponential backoff on reconnect",
+    )
+    label_stream_reconnect_max_seconds: float = Field(
+        default=60.0,
+        description="Maximum delay for exponential backoff on reconnect",
+    )
 
 
 class TranscoderSettings(AppSettingsSection):

--- a/backend/src/backend/jetstream.py
+++ b/backend/src/backend/jetstream.py
@@ -24,6 +24,7 @@ import signal
 
 from backend._internal.background import docket_client_lifespan
 from backend._internal.jetstream import JetstreamConsumer
+from backend._internal.label_stream import LabelStreamConsumer
 from backend.config import settings
 from backend.utilities.observability import (
     configure_observability,
@@ -39,17 +40,24 @@ logger = logging.getLogger(__name__)
 
 
 async def _run() -> None:
-    """run the jetstream consumer until SIGINT/SIGTERM."""
+    """run the stream consumers until SIGINT/SIGTERM."""
     if not settings.jetstream.enabled:
         logger.info("jetstream disabled, exiting")
         return
 
     loop = asyncio.get_running_loop()
-    consumer = JetstreamConsumer()
+    consumers: list[JetstreamConsumer | LabelStreamConsumer] = [JetstreamConsumer()]
+
+    # the label subscriber lives here rather than in `worker` for the same
+    # reason jetstream does: the worker's blocking tasks starve a WebSocket
+    # keepalive. it is cheap to co-locate -- both consumers only hold a socket.
+    if settings.moderation.label_stream_enabled:
+        consumers.append(LabelStreamConsumer())
 
     def request_stop(sig_name: str) -> None:
-        logger.info("received %s, stopping jetstream consumer", sig_name)
-        consumer.stop()
+        logger.info("received %s, stopping stream consumers", sig_name)
+        for consumer in consumers:
+            consumer.stop()
 
     loop.add_signal_handler(signal.SIGTERM, lambda: request_stop("SIGTERM"))
     loop.add_signal_handler(signal.SIGINT, lambda: request_stop("SIGINT"))
@@ -58,8 +66,8 @@ async def _run() -> None:
         # a docket client (no Worker) so the consumer can enqueue ingest
         # tasks; the dedicated `worker` process runs the Worker that drains them.
         async with docket_client_lifespan():
-            logger.info("jetstream process ready")
-            await consumer.run()
+            logger.info("stream process ready (%d consumers)", len(consumers))
+            await asyncio.gather(*(consumer.run() for consumer in consumers))
     finally:
         loop.remove_signal_handler(signal.SIGTERM)
         loop.remove_signal_handler(signal.SIGINT)

--- a/backend/tests/test_label_stream.py
+++ b/backend/tests/test_label_stream.py
@@ -1,0 +1,88 @@
+"""Tests for the labeler subscribeLabels consumer.
+
+The consumer exists to close a fail-open window: the label cache is keyed by
+subject URI and viewer-independent, so one playback caches "no labels" for
+everyone, and an operator-emitted label had no effect on audio authorization
+until that entry expired. These tests pin the invalidation behavior, not the
+socket plumbing.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from backend._internal.label_stream import LabelStreamConsumer, _ws_url
+
+
+def _label(uri: str, val: str = "sexual", *, neg: bool = False) -> dict[str, object]:
+    return {"uri": uri, "val": val, "neg": neg, "src": "did:plc:labeler"}
+
+
+async def test_committed_label_invalidates_its_subject() -> None:
+    consumer = LabelStreamConsumer()
+    uri = "at://did:plc:abc/fm.plyr.track/xyz"
+
+    with patch(
+        "backend._internal.label_stream.get_moderation_client"
+    ) as mock_get_client:
+        client = AsyncMock()
+        mock_get_client.return_value = client
+        await consumer._process_message({"seq": 7, "labels": [_label(uri)]})
+
+    client.invalidate_cache.assert_awaited_once_with(uri)
+
+
+async def test_negation_invalidates_too() -> None:
+    """A stale cached *presence* keeps a track hidden after a moderator cleared it."""
+    consumer = LabelStreamConsumer()
+    uri = "at://did:plc:abc/fm.plyr.track/xyz"
+
+    with patch(
+        "backend._internal.label_stream.get_moderation_client"
+    ) as mock_get_client:
+        client = AsyncMock()
+        mock_get_client.return_value = client
+        await consumer._process_message({"seq": 8, "labels": [_label(uri, neg=True)]})
+
+    client.invalidate_cache.assert_awaited_once_with(uri)
+
+
+async def test_every_subject_in_a_batched_message_is_invalidated() -> None:
+    consumer = LabelStreamConsumer()
+    uris = [f"at://did:plc:abc/fm.plyr.track/{n}" for n in range(3)]
+
+    with patch(
+        "backend._internal.label_stream.get_moderation_client"
+    ) as mock_get_client:
+        client = AsyncMock()
+        mock_get_client.return_value = client
+        await consumer._process_message({"seq": 9, "labels": [_label(u) for u in uris]})
+
+    assert [c.args[0] for c in client.invalidate_cache.await_args_list] == uris
+
+
+async def test_cursor_advances_to_the_message_sequence() -> None:
+    consumer = LabelStreamConsumer()
+
+    with patch(
+        "backend._internal.label_stream.get_moderation_client"
+    ) as mock_get_client:
+        mock_get_client.return_value = AsyncMock()
+        await consumer._process_message({"seq": 42, "labels": []})
+
+    assert consumer._cursor == 42
+
+
+async def test_reconnect_rewinds_one_sequence() -> None:
+    """Replaying the last event is free -- invalidation is idempotent."""
+    consumer = LabelStreamConsumer()
+    consumer._cursor = 42
+
+    assert consumer._build_url().endswith("subscribeLabels?cursor=41")
+
+
+async def test_first_connect_has_no_cursor() -> None:
+    assert LabelStreamConsumer()._build_url().endswith("subscribeLabels")
+
+
+def test_labeler_origin_maps_to_websocket_scheme() -> None:
+    assert _ws_url("https://moderation.plyr.fm") == "wss://moderation.plyr.fm"
+    assert _ws_url("http://localhost:8083") == "ws://localhost:8083"

--- a/docs/internal/moderation/atproto-labeler.md
+++ b/docs/internal/moderation/atproto-labeler.md
@@ -272,13 +272,42 @@ if labeler isn't configured, `/emit-label` returns an error and the admin dashbo
 
 the backend interacts with the labeler in three ways:
 
-1. **generic label cache** (`_internal/clients/moderation.py`): fetches complete active value sets via `POST /admin/labels`. used for discovery and playback policy.
+1. **generic label cache** (`_internal/clients/moderation.py`): fetches complete active value sets via `POST /internal/labels`. used for discovery and playback policy.
 
-2. **copyright compatibility**: `POST /admin/active-labels` and `/admin/negated-labels` drive the legacy copyright synchronization task.
+2. **copyright compatibility**: `POST /internal/active-labels` and `/internal/negated-labels` drive the legacy copyright synchronization task.
 
 3. **strict byte authorization**: the audio endpoint requires a current label
    check and returns `503` rather than serving possibly adult audio when the
    labeler cannot be reached.
+
+4. **label stream subscriber** (`_internal/label_stream.py`): a websocket
+   consumer on `subscribeLabels` that invalidates a subject's cached label
+   values as soon as the labeler commits a label.
+
+### why the subscriber exists
+
+the label cache is keyed by subject URI and is viewer-independent, so a single
+playback populates it for every listener. caching the *absence* of a label is
+the dangerous half: before the subscriber, a label emitted by an operator (the
+dashboard, a script, curl — anything other than the backend's own
+`emit_label`, which invalidates on the way out) had no effect on audio
+authorization until the entry expired. measured on staging, an anonymous
+listener kept streaming a freshly `sexual`-labeled track for the full
+`label_cache_ttl_seconds`.
+
+the backend reads the stream rather than having the labeler call back into the
+backend, which keeps the dependency pointing one way. that matters here: one
+labeler serves both the staging and production backends, so a callback would
+need the labeler to know about every backend deployment.
+
+the subscriber runs in the `jetstream` process group. it is co-located with the
+firehose consumer for the reason that consumer is isolated in the first place —
+the `worker` process's blocking tasks starve websocket keepalives — and both
+consumers only hold a socket, so sharing an event loop is cheap.
+
+negations invalidate exactly like positive labels: a stale cached *presence*
+keeps a track hidden after a moderator cleared it. that is the fail-closed
+direction, but it is still wrong.
 
 the backend does **not** call `/emit-label` directly. labels are emitted by an
 operator or the copyright dashboard. A first-class generic-label operator UI or

--- a/loq.toml
+++ b/loq.toml
@@ -44,7 +44,7 @@ max_lines = 1862
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 1182
+max_lines = 1213
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"


### PR DESCRIPTION
An operator-emitted label had no effect on audio byte authorization until the label cache expired — up to `label_cache_ttl_seconds` (300s) of anonymous listeners streaming a track that was just labeled `sexual`. A `subscribeLabels` consumer now invalidates each subject as the labeler commits it.

Found while verifying #1691 end-to-end on staging. Refs #1678.

<details>
<summary>why it fails open</summary>

The cache is keyed by **subject URI** and is **viewer-independent**, so a single playback by anyone populates it for everyone. Caching the *absence* of a label is the dangerous half — absence is what grants access.

`ModerationClient.emit_label` already calls `invalidate_cache` on the way out, but that only covers labels the backend itself emitted. Operators don't use that path: they emit through the moderator dashboard, a script, or curl, straight to the labeler. Those writes were invisible to the backend's cache.

The audio endpoint is explicitly designed to fail closed — it returns `503` rather than serve possibly-adult audio when the labeler is unreachable. The cache quietly inverted that for a 5-minute window.

**Reproduced on staging.** Uploaded a track, streamed it once as its owner (enough to populate the cache), emitted a real signed `sexual` label, then requested the audio bytes anonymously:

```
=== emitting a real signed sexual label
  emitted seq=724
  [ok] labeler reports the label active

=== audio authorization must now fail closed for anonymous listeners
  [FAIL] anonymous audio refused (got 307)      <- served, not refused
```

With no prior playback the same sequence correctly returns `401` with `X-Content-Labels: sexual`, which is what isolated the cache as the cause.
</details>

<details>
<summary>why a subscriber rather than a callback or a shorter TTL</summary>

- **Not a labeler → backend callback.** There is one labeler serving *both* the staging and production backends, so a callback would require the labeler to know about every backend deployment, and it inverts the dependency direction (#1691 was about clarifying exactly this boundary). Reading the stream keeps it pointing one way.
- **Not a shorter TTL on absence.** It bounds the window rather than closing it, and it multiplies labeler reads on the audio hot path, where nearly all traffic is for unlabeled tracks.
- **The stream already exists** on both sides: the labeler implements `subscribeLabels` with a monotonic cursor and backfill, and the backend already runs a websocket consumer of this exact shape.
</details>

<details>
<summary>where it runs</summary>

In the existing `jetstream` fly process group — **no new infrastructure**. It's co-located with the firehose consumer for the same reason that consumer was isolated from `worker` in the first place (`fly.toml`: the worker's blocking tasks starved the websocket keepalive, dropping the connection every ~50s). Both consumers only hold a socket, so sharing an event loop is cheap.

Cursor persists to redis; reconnect rewinds one sequence, since invalidation is idempotent. Gated by `moderation.label_stream_enabled` (default on).
</details>

<details>
<summary>tests</summary>

7 tests in `test_label_stream.py` driving `_process_message` with only the moderation client mocked: positive labels invalidate, **negations invalidate too** (a stale cached *presence* keeps a track hidden after a moderator cleared it — fail-closed, but still wrong), batched messages invalidate every subject, the cursor advances, reconnect rewinds by one, and the labeler origin maps to the right websocket scheme.
</details>

<details>
<summary>deliberate non-changes</summary>

- **The `operator_labels` projection still syncs on its own ~5-minute interval.** Measured at 301s on staging. That projection drives SQL-side discovery filtering, which is the fail-*open* direction, so it isn't part of this fix — but it does mean recovery after a negation is bounded by the sync, not by this subscriber. Worth a follow-up to have the stream nudge the projection for the affected subject.
- **Does not implement all of #1678**, which asks for a full operator command with URI/CID confirmation, audit trail, verification, and retry semantics. This fixes the invalidation half that made the incident's manual Redis purge necessary.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)