### PR TITLE
fix(moderation): make labels act, and stop gating permalinks on them

### DIFF
--- a/backend/src/backend/_internal/content_labels.py
+++ b/backend/src/backend/_internal/content_labels.py
@@ -16,16 +16,22 @@ from backend._internal.clients.moderation import get_moderation_client
 from backend.models import Track, UserPreferences
 
 ADULT_AUDIO_LABELS = frozenset({"sexual", "porn"})
+COPYRIGHT_LABELS = frozenset({"copyright-violation"})
 
 # Label values reconciled onto `tracks.operator_labels` by the
 # sync_operator_labels background task. Only these values may be read from
 # the projection; anything else must be queried from the labeler live.
-PROJECTED_LABEL_VALUES = ADULT_AUDIO_LABELS
+PROJECTED_LABEL_VALUES = ADULT_AUDIO_LABELS | COPYRIGHT_LABELS
 
 
 def has_adult_audio_label(labels: Iterable[str]) -> bool:
-    """Return whether labels require the adult-audio preference."""
+    """Return whether labels mark this as adult audio."""
     return bool(ADULT_AUDIO_LABELS.intersection(labels))
+
+
+def has_copyright_label(labels: Iterable[str]) -> bool:
+    """Return whether an operator has asserted a copyright violation."""
+    return bool(COPYRIGHT_LABELS.intersection(labels))
 
 
 def get_track_label_values(tracks: Iterable[Track]) -> dict[int, set[str]]:
@@ -42,17 +48,54 @@ def get_track_label_values(tracks: Iterable[Track]) -> dict[int, set[str]]:
     }
 
 
+def _labeled_with(values: frozenset[str]) -> ColumnElement[bool]:
+    """SQL predicate: the track carries any of these label values."""
+    wanted = array(sorted(values))
+    return Track.self_labels.op("?|")(wanted) | Track.operator_labels.op("?|")(wanted)
+
+
 def sensitive_audio_visible_clause(viewer_did: str | None) -> ColumnElement[bool]:
     """SQL predicate: the track needs no adult-audio opt-in from this viewer.
 
     Callers skip the clause entirely for viewers whose saved preference shows
     sensitive audio (see viewer_shows_sensitive_audio).
     """
-    adult = array(sorted(ADULT_AUDIO_LABELS))
-    labeled = Track.self_labels.op("?|")(adult) | Track.operator_labels.op("?|")(adult)
+    labeled = _labeled_with(ADULT_AUDIO_LABELS)
     if viewer_did is None:
         return ~labeled
     return ~labeled | (Track.artist_did == viewer_did)
+
+
+def copyright_visible_clause() -> ColumnElement[bool]:
+    """SQL predicate: the track carries no active copyright-violation label.
+
+    Unlike adult audio, this takes no viewer and honours no preference. Adult
+    labels are a rendering default a listener may override for themselves;
+    a copyright assertion is about whether *we* should keep surfacing the
+    track from our own storage, which no listener preference can answer.
+
+    Deliberately not owner-exempt on shared surfaces. Creators still see and
+    manage their own flagged tracks — the owner library (`list_my_tracks`)
+    filters on artist_did alone and never applies this clause.
+    """
+    return ~_labeled_with(COPYRIGHT_LABELS)
+
+
+def discovery_visible_clause(
+    viewer_did: str | None, *, shows_sensitive_audio: bool
+) -> ColumnElement[bool]:
+    """SQL predicate for any shared surface: feeds, search, radio, collections.
+
+    Composes both label families so callers cannot accidentally apply one and
+    not the other. The previous shape — skip the adult clause entirely when the
+    viewer opted in — would have leaked copyright-labeled tracks to exactly
+    those viewers, because the whole predicate was dropped rather than the
+    adult half of it.
+    """
+    clause = copyright_visible_clause()
+    if shows_sensitive_audio:
+        return clause
+    return clause & sensitive_audio_visible_clause(viewer_did)
 
 
 async def get_operator_label_values(
@@ -130,15 +173,20 @@ async def filter_sensitive_audio_tracks_for_viewer(
     """Hide adult-labeled tracks for a viewer identified only by DID."""
     track_list = list(tracks)
     labels_by_id = get_track_label_values(track_list)
-    if await viewer_did_shows_sensitive_audio(db, viewer_did):
-        return track_list, labels_by_id
+    shows_sensitive = await viewer_did_shows_sensitive_audio(db, viewer_did)
 
-    visible = [
-        track
-        for track in track_list
-        if track.artist_did == viewer_did
-        or not has_adult_audio_label(labels_by_id.get(track.id, set()))
-    ]
+    visible = []
+    for track in track_list:
+        labels = labels_by_id.get(track.id, set())
+        # copyright applies to everyone; no preference and no owner exemption
+        if has_copyright_label(labels):
+            continue
+        if (
+            shows_sensitive
+            or track.artist_did == viewer_did
+            or not has_adult_audio_label(labels)
+        ):
+            visible.append(track)
     return visible, labels_by_id
 
 
@@ -149,11 +197,16 @@ async def may_stream_sensitive_audio(
     artist_did: str,
     session: Session | None,
 ) -> bool:
-    """Authorize a labeled audio stream for its owner or an opted-in adult."""
-    if not has_adult_audio_label(labels):
-        return True
-    if session is None:
-        return False
-    if session.did == artist_did:
-        return True
-    return await viewer_shows_sensitive_audio(db, session)
+    """Adult labels never gate the bytes themselves.
+
+    They are a rendering default for shared surfaces, not an access control.
+    Requiring a session here looked like age verification but was not — any
+    account satisfied it, and plyr verifies nobody's age — while breaking the
+    thing it cost most: a creator sharing a direct link to their own work with
+    someone who is not signed in.
+
+    Listeners still control what they are *shown*: adult-labeled tracks stay
+    out of radio, feeds, search, and collections unless they opt in. Clients
+    that want to warn before playing read the labels off the response.
+    """
+    return True

--- a/backend/src/backend/_internal/label_stream.py
+++ b/backend/src/backend/_internal/label_stream.py
@@ -108,27 +108,55 @@ class LabelStreamConsumer:
                     await self._maybe_flush_cursor()
 
     async def _process_message(self, message: dict[str, Any]) -> None:
-        """Invalidate every subject named by a committed label event.
+        """Refresh policy state for every subject named by a committed label.
 
-        Negations invalidate exactly like positives: a stale cached *presence*
-        keeps a track hidden after a moderator cleared it, which is the
-        fail-closed direction but still wrong.
+        Two things go stale when a label lands, and the projection is the one
+        that matters. `tracks.operator_labels` is what the SQL discovery and
+        radio filters read, so until it catches up a copyright-labeled track
+        keeps playing on radio -- and reconciling that on the five-minute
+        sync is a long time to keep broadcasting an asserted infringement.
+        The redis cache is refreshed too; it is cheap and keeps the two from
+        disagreeing.
+
+        Negations are handled identically to positives. A stale projection
+        keeps a track suppressed after a moderator cleared it, which is the
+        safe direction but still wrong.
         """
         labels = message.get("labels") or []
         client = get_moderation_client()
 
+        touched = False
         for label in labels:
             if uri := label.get("uri"):
                 await client.invalidate_cache(uri)
+                touched = True
                 logfire.info(
-                    "label cache invalidated from stream",
+                    "label committed",
                     uri=uri,
                     val=label.get("val"),
                     neg=bool(label.get("neg")),
                 )
 
+        if touched:
+            await self._refresh_projection()
+
         if (seq := message.get("seq")) is not None:
             self._cursor = int(seq)
+
+    async def _refresh_projection(self) -> None:
+        """Reconcile tracks.operator_labels now instead of on the next sync.
+
+        Reuses the perpetual task's own body so the stream cannot drift from
+        the scheduled reconciliation. A failure here is logged and dropped:
+        the five-minute sync remains the backstop, and losing the fast path
+        must never take down the consumer.
+        """
+        from backend._internal.tasks.labels import sync_operator_labels
+
+        try:
+            await sync_operator_labels()
+        except Exception:
+            logger.exception("label stream could not refresh the projection")
 
     def _build_url(self) -> str:
         base = settings.moderation.label_stream_url or _ws_url(

--- a/backend/src/backend/api/audio.py
+++ b/backend/src/backend/api/audio.py
@@ -5,13 +5,10 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import or_, select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, get_optional_session, validate_supporter
 from backend._internal.atproto.client import pds_blob_url
 from backend._internal.atproto.spaces.client import SpaceAccessError, open_space_blob
-from backend._internal.clients.moderation import get_moderation_client
-from backend._internal.content_labels import may_stream_sensitive_audio
 from backend.config import settings
 from backend.models import Artist, Track
 from backend.storage import storage
@@ -40,42 +37,11 @@ class AudioUrlResponse(BaseModel):
     file_type: str | None
 
 
-async def _enforce_content_label_access(
-    db: AsyncSession,
-    *,
-    uri: str | None,
-    self_labels: list[str],
-    artist_did: str,
-    session: Session | None,
-) -> None:
-    """Require an authenticated opt-in before serving adult-labeled audio."""
-    labels = set(self_labels)
-    try:
-        if uri:
-            labels.update(
-                (
-                    await get_moderation_client().get_active_label_values(
-                        [uri], strict=True
-                    )
-                ).get(uri, set())
-            )
-    except Exception as exc:
-        raise HTTPException(
-            status_code=503,
-            detail="content safety service temporarily unavailable",
-        ) from exc
-    if await may_stream_sensitive_audio(
-        db,
-        labels=labels,
-        artist_did=artist_did,
-        session=session,
-    ):
-        return
-    raise HTTPException(
-        status_code=401 if session is None else 403,
-        detail="sensitive audio is hidden; enable it in settings to listen",
-        headers={"X-Content-Labels": ",".join(sorted(labels))},
-    )
+# Content labels no longer gate audio bytes. Adult labels are a rendering
+# default for shared surfaces (see content_labels.may_stream_sensitive_audio),
+# and a copyright label removes a track from discovery and radio rather than
+# from its own permalink. Dropping the check also removes a strict labeler
+# round trip -- and its 503 failure mode -- from every audio request.
 
 
 @router.head("/{file_id}")
@@ -112,8 +78,6 @@ async def stream_audio(
                 Track.pds_blob_cid,
                 Track.is_private,
                 Track.space_uri,
-                Track.atproto_record_uri,
-                Track.self_labels,
             )
             .where(or_(Track.file_id == file_id, Track.original_file_id == file_id))
             .order_by(Track.r2_url.is_not(None).desc(), Track.created_at.desc())
@@ -136,17 +100,7 @@ async def stream_audio(
             pds_blob_cid,
             is_private,
             space_uri,
-            atproto_record_uri,
-            self_labels,
         ) = track_data
-
-        await _enforce_content_label_access(
-            db,
-            uri=atproto_record_uri,
-            self_labels=self_labels,
-            artist_did=artist_did,
-            session=session,
-        )
 
     # private media lives in a permissioned space — proxy the bytes through the
     # owner's space credential (can't redirect: the browser has no credential).
@@ -306,8 +260,6 @@ async def get_audio_url(
                 Track.pds_blob_cid,
                 Track.is_private,
                 Track.space_uri,
-                Track.atproto_record_uri,
-                Track.self_labels,
             )
             .where(or_(Track.file_id == file_id, Track.original_file_id == file_id))
             .order_by(Track.r2_url.is_not(None).desc(), Track.created_at.desc())
@@ -330,17 +282,7 @@ async def get_audio_url(
             pds_blob_cid,
             is_private,
             _space_uri,
-            atproto_record_uri,
-            self_labels,
         ) = track_data
-
-        await _enforce_content_label_access(
-            db,
-            uri=atproto_record_uri,
-            self_labels=self_labels,
-            artist_did=artist_did,
-            session=session,
-        )
 
     # private media is proxied through the permissioned-space credential path,
     # so the cacheable "url" is this backend's own stream endpoint (which holds

--- a/backend/src/backend/api/radio/corpus.py
+++ b/backend/src/backend/api/radio/corpus.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import selectinload
 from backend._internal.content_labels import (
     get_track_label_values,
     has_adult_audio_label,
+    has_copyright_label,
 )
 from backend.models import Artist, Track
 
@@ -35,8 +36,12 @@ async def load_corpus(db: AsyncSession) -> list[Track]:
     labels_by_id = get_track_label_values(tracks)
     # Radio is a shared wall-clock rotation, including anonymous embeds. It
     # cannot vary by listener preference, so adult audio never enters it.
+    # Copyright-labeled tracks are excluded for a different reason: radio is
+    # us actively broadcasting, which is the surface we least want to be
+    # serving an asserted infringement from (user report #5, track 64).
     return [
         track
         for track in tracks
         if not has_adult_audio_label(labels_by_id.get(track.id, set()))
+        and not has_copyright_label(labels_by_id.get(track.id, set()))
     ]

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -16,10 +16,10 @@ from sqlalchemy.orm import selectinload
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session, get_supported_artists, require_auth
 from backend._internal.content_labels import (
+    discovery_visible_clause,
     filter_sensitive_audio_tracks,
     get_operator_label_values,
     get_track_label_values,
-    sensitive_audio_visible_clause,
 )
 from backend.config import settings
 from backend.models import (
@@ -178,12 +178,17 @@ async def list_tracks(
         )
         stmt = stmt.where(include_exists)
 
-    # adult-audio visibility lives in SQL (self labels + projected operator
-    # labels), so filtering composes with cursor pagination instead of
-    # corrupting it (#1676 regression: app-side filtering broke has_more)
-    if not shows_sensitive_audio:
-        viewer = session.did if session else None
-        stmt = stmt.where(sensitive_audio_visible_clause(viewer))
+    # label visibility lives in SQL (self labels + projected operator labels),
+    # so filtering composes with cursor pagination instead of corrupting it
+    # (#1676 regression: app-side filtering broke has_more). Always applied:
+    # the copyright half honours no preference, so this must not be skipped
+    # for viewers who opted into sensitive audio.
+    stmt = stmt.where(
+        discovery_visible_clause(
+            session.did if session else None,
+            shows_sensitive_audio=shows_sensitive_audio,
+        )
+    )
 
     # apply cursor-based pagination (tracks older than cursor timestamp)
     if cursor:

--- a/backend/tests/api/test_audio.py
+++ b/backend/tests/api/test_audio.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, get_optional_session, require_auth
 from backend.main import app
-from backend.models import Artist, Track, UserPreferences
+from backend.models import Artist, Track
 
 
 @pytest.fixture
@@ -166,90 +166,107 @@ async def test_stream_audio_file_not_in_storage(
     assert response.json()["detail"] == "audio file not found"
 
 
-async def test_adult_labeled_audio_is_hidden_from_anonymous_viewers(
+async def test_adult_labeled_audio_plays_for_anonymous_listeners(
     test_app: FastAPI,
     test_track_with_r2_url: Track,
     db_session: AsyncSession,
 ):
-    """A global sexual label must gate the bytes, not only discovery UI."""
+    """An operator adult label must not break a shared permalink.
+
+    Adult labels are a rendering default for shared surfaces, not an access
+    control. Requiring a session here read as age verification but was not --
+    any account satisfied it -- while breaking a creator sharing their own
+    work with someone signed out.
+    """
     test_track_with_r2_url.atproto_record_uri = (
         "at://did:plc:artist123/fm.plyr.feed.track/adult-track"
     )
     await db_session.commit()
-    mock_moderation = MagicMock()
-    mock_moderation.get_active_label_values = AsyncMock(
-        return_value={test_track_with_r2_url.atproto_record_uri: {"sexual"}}
-    )
 
-    with patch("backend.api.audio.get_moderation_client", return_value=mock_moderation):
-        async with AsyncClient(
-            transport=ASGITransport(app=test_app), base_url="http://test"
-        ) as client:
-            response = await client.get(
-                f"/audio/{test_track_with_r2_url.file_id}", follow_redirects=False
-            )
-
-    assert response.status_code == 401
-    assert response.headers["x-content-labels"] == "sexual"
-
-
-async def test_creator_self_labeled_audio_is_hidden_from_anonymous_viewers(
-    test_app: FastAPI,
-    test_track_with_r2_url: Track,
-    db_session: AsyncSession,
-):
-    """A creator assertion gates bytes without an operator label."""
-    test_track_with_r2_url.self_labels = ["sexual"]
-    await db_session.commit()
-    mock_moderation = MagicMock()
-    mock_moderation.get_active_label_values = AsyncMock(return_value={})
-
-    with patch("backend.api.audio.get_moderation_client", return_value=mock_moderation):
-        async with AsyncClient(
-            transport=ASGITransport(app=test_app), base_url="http://test"
-        ) as client:
-            response = await client.get(
-                f"/audio/{test_track_with_r2_url.file_id}", follow_redirects=False
-            )
-
-    assert response.status_code == 401
-    assert response.headers["x-content-labels"] == "sexual"
-
-
-async def test_adult_labeled_audio_is_available_after_opt_in(
-    test_app: FastAPI,
-    test_track_with_r2_url: Track,
-    mock_session: Session,
-    db_session: AsyncSession,
-):
-    """Authenticated listeners may opt into adult-labeled audio independently."""
-    test_track_with_r2_url.atproto_record_uri = (
-        "at://did:plc:artist123/fm.plyr.feed.track/adult-track"
-    )
-    db_session.add(UserPreferences(did=mock_session.did, show_sensitive_audio=True))
-    await db_session.commit()
-    mock_moderation = MagicMock()
-    mock_moderation.get_active_label_values = AsyncMock(
-        return_value={test_track_with_r2_url.atproto_record_uri: {"sexual"}}
-    )
-    test_app.dependency_overrides[get_optional_session] = lambda: mock_session
-
-    try:
-        with patch(
-            "backend.api.audio.get_moderation_client", return_value=mock_moderation
-        ):
-            async with AsyncClient(
-                transport=ASGITransport(app=test_app), base_url="http://test"
-            ) as client:
-                response = await client.get(
-                    f"/audio/{test_track_with_r2_url.file_id}",
-                    follow_redirects=False,
-                )
-    finally:
-        test_app.dependency_overrides.pop(get_optional_session, None)
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            f"/audio/{test_track_with_r2_url.file_id}", follow_redirects=False
+        )
 
     assert response.status_code == 307
     assert response.headers["location"] == test_track_with_r2_url.r2_url
+
+
+async def test_creator_self_labeled_audio_plays_for_anonymous_listeners(
+    test_app: FastAPI,
+    test_track_with_r2_url: Track,
+    db_session: AsyncSession,
+):
+    """A creator's own content notice does not gate their own permalink."""
+    test_track_with_r2_url.self_labels = ["sexual"]
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            f"/audio/{test_track_with_r2_url.file_id}", follow_redirects=False
+        )
+
+    assert response.status_code == 307
+
+
+async def test_copyright_labeled_audio_still_plays_from_its_permalink(
+    test_app: FastAPI,
+    test_track_with_r2_url: Track,
+    db_session: AsyncSession,
+):
+    """Copyright de-lists from shared surfaces; it does not block the bytes.
+
+    Takedown is a deliberate human step. An automatic label -- which may be a
+    cover or a remix the uploader performed -- must not silently break the
+    uploader's own link.
+    """
+    test_track_with_r2_url.operator_labels = ["copyright-violation"]
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            f"/audio/{test_track_with_r2_url.file_id}", follow_redirects=False
+        )
+
+    assert response.status_code == 307
+
+
+async def test_audio_does_not_query_the_labeler(
+    test_app: FastAPI,
+    test_track_with_r2_url: Track,
+    db_session: AsyncSession,
+):
+    """The byte path no longer depends on the labeler being reachable.
+
+    It previously issued a strict label read per request and returned 503 when
+    the labeler was down. Nothing about serving bytes needs label state now.
+    """
+    test_track_with_r2_url.atproto_record_uri = (
+        "at://did:plc:artist123/fm.plyr.feed.track/adult-track"
+    )
+    await db_session.commit()
+    client_factory = MagicMock(
+        side_effect=AssertionError("audio must not call the labeler")
+    )
+
+    with patch(
+        "backend._internal.clients.moderation.get_moderation_client", client_factory
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.get(
+                f"/audio/{test_track_with_r2_url.file_id}", follow_redirects=False
+            )
+
+    assert response.status_code == 307
+    client_factory.assert_not_called()
 
 
 # tests for /audio/{file_id}/url endpoint (offline caching, requires auth)

--- a/backend/tests/test_content_label_policy.py
+++ b/backend/tests/test_content_label_policy.py
@@ -1,0 +1,131 @@
+"""Policy tests for the two label families.
+
+They differ in *who decides*, and that is the whole design:
+
+- adult labels are a rendering default a listener may override for themselves
+- a copyright label is an assertion about whether we should keep surfacing a
+  track from our own storage, which no listener preference can answer
+
+Neither gates the audio bytes. See `docs/internal/moderation/label-policy.md`.
+"""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal.content_labels import (
+    COPYRIGHT_LABELS,
+    PROJECTED_LABEL_VALUES,
+    filter_sensitive_audio_tracks_for_viewer,
+    has_copyright_label,
+    may_stream_sensitive_audio,
+)
+from backend.models import Artist, Track, UserPreferences
+
+OWNER = "did:plc:owner"
+VIEWER = "did:plc:viewer"
+
+
+async def _track(
+    db: AsyncSession,
+    *,
+    file_id: str,
+    operator_labels: list[str] | None = None,
+    self_labels: list[str] | None = None,
+    artist_did: str = OWNER,
+) -> Track:
+    if not await db.get(Artist, artist_did):
+        db.add(
+            Artist(
+                did=artist_did,
+                handle=f"{artist_did[-5:]}.test",
+                display_name=artist_did[-5:],
+            )
+        )
+        await db.flush()
+    track = Track(
+        title=f"track {file_id}",
+        artist_did=artist_did,
+        file_id=file_id,
+        file_type="audio/mpeg",
+        visibility="public",
+        operator_labels=operator_labels or [],
+        self_labels=self_labels or [],
+    )
+    db.add(track)
+    await db.flush()
+    return track
+
+
+def test_copyright_is_projected_so_sql_filters_can_read_it() -> None:
+    """Discovery filters read tracks.operator_labels, not the labeler."""
+    assert COPYRIGHT_LABELS <= PROJECTED_LABEL_VALUES
+
+
+def test_copyright_label_recognised() -> None:
+    assert has_copyright_label({"copyright-violation"})
+    assert not has_copyright_label({"sexual"})
+
+
+async def test_copyright_hides_from_shared_surfaces_for_everyone(
+    db_session: AsyncSession,
+) -> None:
+    """Including the uploader: radio and feeds are us broadcasting, not their library."""
+    flagged = await _track(
+        db_session, file_id="cr1", operator_labels=["copyright-violation"]
+    )
+    clean = await _track(db_session, file_id="cr2")
+    await db_session.commit()
+
+    for viewer in (None, VIEWER, OWNER):
+        visible, _ = await filter_sensitive_audio_tracks_for_viewer(
+            db_session, [flagged, clean], viewer
+        )
+        assert [t.id for t in visible] == [clean.id], f"viewer={viewer}"
+
+
+async def test_sensitive_opt_in_does_not_reveal_copyright_tracks(
+    db_session: AsyncSession,
+) -> None:
+    """The regression the composed clause exists to prevent.
+
+    The old shape skipped the whole visibility predicate for viewers who
+    opted into sensitive audio, so folding copyright into that predicate
+    without composing it would have leaked to exactly those viewers.
+    """
+    flagged = await _track(
+        db_session, file_id="cr3", operator_labels=["copyright-violation"]
+    )
+    db_session.add(UserPreferences(did=VIEWER, show_sensitive_audio=True))
+    await db_session.commit()
+
+    visible, _ = await filter_sensitive_audio_tracks_for_viewer(
+        db_session, [flagged], VIEWER
+    )
+    assert visible == []
+
+
+async def test_adult_stays_a_viewer_preference(db_session: AsyncSession) -> None:
+    adult = await _track(db_session, file_id="ad1", operator_labels=["sexual"])
+    await db_session.commit()
+
+    anon, _ = await filter_sensitive_audio_tracks_for_viewer(db_session, [adult], None)
+    assert anon == []
+
+    owner, _ = await filter_sensitive_audio_tracks_for_viewer(
+        db_session, [adult], OWNER
+    )
+    assert [t.id for t in owner] == [adult.id]
+
+    db_session.add(UserPreferences(did=VIEWER, show_sensitive_audio=True))
+    await db_session.commit()
+    opted_in, _ = await filter_sensitive_audio_tracks_for_viewer(
+        db_session, [adult], VIEWER
+    )
+    assert [t.id for t in opted_in] == [adult.id]
+
+
+async def test_no_label_gates_the_bytes(db_session: AsyncSession) -> None:
+    """Both families de-list; neither denies a permalink."""
+    for labels in ({"sexual"}, {"porn"}, {"copyright-violation"}, set()):
+        assert await may_stream_sensitive_audio(
+            db_session, labels=labels, artist_did=OWNER, session=None
+        )

--- a/docs/internal/moderation/copyright-worklist-2026-07-25.md
+++ b/docs/internal/moderation/copyright-worklist-2026-07-25.md
@@ -1,0 +1,63 @@
+# copyright worklist — snapshot 2026-07-25
+
+State captured immediately **before** retracting the pre-#703 public labels, so
+the worklist survives the retraction. Negating a label causes
+`sync_copyright_resolutions` to clear `is_flagged` for that URI (`tasks/copyright.py`,
+#1615), so the review queue itself cannot be trusted to remember these after the
+retraction lands. `copyright_scans.matches` is untouched either way — this file
+preserves queue *membership*, not evidence.
+
+## why these labels are being retracted
+
+The 2026-01-02 legal review concluded that public "potential violation" labels
+we have not acted on create knowledge without action, which is the wrong side of
+safe harbor. `df0c0dae` (#703) stopped *emitting* new ones but never retracted
+the existing ones, so ten signed labels stayed publicly queryable via
+`com.atproto.label.queryLabels` — no auth required — for roughly seven months.
+
+Retraction is the interim step. Re-application happens through the enforcement
+pipeline once a label actually does something.
+
+## tracks with active public `copyright-violation` labels (retracted)
+
+| track | title | visibility | matches | first labeled |
+|---|---|---|---|---|
+| 55 | Up The Mountain | public | 23 | 2025-12 |
+| 58 | not a rickroll | public | 36 | 2025-12 |
+| 94 | acoustic guitar cover of vodka cranberry (one take) | public | 20 | 2025-12 |
+| 103 | mid 123 | public | 22 | 2025-12 |
+| 117 | KMC - I Feel So Fine (infyplay Remix) V3 | public | 42 | 2025-12 |
+| 120 | Exostate - Without Warning (infyplay remix) v2 | public | 53 | 2025-12 |
+| 155 | 03 Hangover | public | 3 | 2025-12 |
+| 157 | 05 Las Vegas Dealer | public | 3 | 2025-12 |
+| 239 | 09 Green Bud On The Flower | public | 15 | 2025-12 |
+| 260 | 06 Southern Flavor | public | 23 | 2025-12 |
+
+## flagged internally, never labeled
+
+These carry `copyright_scans.is_flagged` with no label, so the retraction does
+not touch them. They remain in the review queue.
+
+| track | title | visibility | matches | scanned |
+|---|---|---|---|---|
+| 64 | Free everyone, fuck the state, life finds a way. | public | 249 | 2026-07-23 |
+| 1098 | The Ballad of Hollis Brown | public | 165 | 2026-07-03 |
+| 1173 | Here | public | 1 | 2026-07-12 |
+
+Track 64 is the subject of user report #5 (@vicwalker.dev.br, 2026-07-23) — the
+first genuine user report on the platform. `highest_score = 0` with 249 matches
+is #1689's mix detection working correctly: no single song dominates a mix, so
+the per-song score stays 0 while the sustained-song count trips the flag.
+
+## triage note
+
+Several entries read like covers, remixes, or jokes rather than infringement
+("acoustic guitar cover of…", "not a rickroll", two tracks self-labeled
+"(infyplay remix)"). Re-application must not treat a fingerprint match as a
+finding — a cover the uploader performed is a match and not a violation.
+
+## explicitly not done here
+
+No uploader was notified. Notifying people about flags from December because a
+pipeline was built in July would be a bug, not a feature. Any future
+notification must fire on new events only, never on backfill.

--- a/docs/internal/moderation/label-policy.md
+++ b/docs/internal/moderation/label-policy.md
@@ -1,0 +1,117 @@
+# label policy
+
+How plyr.fm turns signed labels into behavior. Grounded in the only two label
+families we actually have — adult audio and copyright — because a policy
+invented ahead of its cases tends to be wrong about both.
+
+## two layers
+
+**The label is a portable assertion.** Signed, published, and queryable by
+anyone through `com.atproto.label.queryLabels` and `subscribeLabels`. Any
+client reading `fm.plyr.track` can subscribe to our labeler and decide for
+itself what to render. We do not get to decide that for them, and should not
+try to.
+
+**Enforcement is plyr-local hosting policy.** What *we* do on *our* surfaces
+with *our* storage. Keyed off the label, but not the same thing as the label,
+and not binding on anyone else.
+
+Conflating these is what produced the previous state, where "we labeled it"
+and "we did something about it" were assumed to be one step and turned out to
+be zero.
+
+## the two families differ in who decides
+
+| | adult (`sexual`, `porn`) | copyright (`copyright-violation`) |
+|---|---|---|
+| what it asserts | this is adult content | someone claims this infringes |
+| who decides on rendering | **the listener** | **us** |
+| listener preference | `show_sensitive_audio` opts in | none — no preference can answer it |
+| feeds, search, collections | hidden unless opted in or owner | hidden for everyone |
+| radio | never | never |
+| owner's own library | always visible | always visible |
+| audio bytes / permalink | **plays** | **plays** |
+| takedown | n/a | deliberate human step, never automatic |
+
+**Adult is a rendering default.** A listener may override it for themselves.
+This is the case that genuinely defers to the reader.
+
+**Copyright is a hosting obligation.** We serve the bytes from our own R2, so
+the duty to act on knowledge is ours and no reader preference discharges it.
+De-listing is the cheap, reversible action that discharges it; takedown is not
+automatic because a fingerprint match is not a finding — a cover the uploader
+performed matches, and so does a remix they made.
+
+## why neither gates the bytes
+
+Adult labels used to return `401` for anonymous listeners at the audio
+endpoint. That looked like age verification and was not: **any** account
+satisfied it, and plyr verifies nobody's age. What it reliably did was break a
+creator sharing a direct link to their own work with someone signed out. The
+gate cost creators real utility and bought the appearance of a safeguard.
+
+Copyright does not gate bytes either, for a different reason: de-listing is
+automatic and reversible, but making an uploader's permalink dead on an
+automated fingerprint match is neither.
+
+Removing the gate also deleted a strict labeler read — and its `503` failure
+mode — from every audio request.
+
+## composing the SQL predicate
+
+`discovery_visible_clause()` composes both families and every shared surface
+uses it. The previous shape skipped the visibility predicate *entirely* for
+viewers who had opted into sensitive audio:
+
+```python
+if not shows_sensitive_audio:
+    stmt = stmt.where(sensitive_audio_visible_clause(viewer))
+```
+
+Folding copyright into that predicate without composing it would have leaked
+copyright-labeled tracks to exactly the viewers who opted into sensitive
+audio. A regression test pins this.
+
+Filtering stays in SQL so it composes with cursor pagination — app-side
+filtering broke `has_more` in #1676.
+
+## freshness
+
+`tracks.operator_labels` is the projection the SQL filters read, reconciled by
+`sync_operator_labels` every five minutes. The `subscribeLabels` consumer
+(`_internal/label_stream.py`) refreshes it as labels commit, so a copyright
+label de-lists in seconds rather than minutes — five minutes is a long time to
+keep broadcasting an asserted infringement on radio. The perpetual sync remains
+the backstop; if the stream refresh fails it is logged and dropped.
+
+## history
+
+The asymmetry this document resolves was not drift. The 2026-01-02 legal review
+concluded that public "potential violation" labels we have not acted on create
+knowledge without action:
+
+> safe harbor requires action when you have knowledge — public labels =
+> knowledge. either don't flag it, or flag it and act on it.
+
+`df0c0dae` (#703) did the first half — it stopped auto-emitting labels — and
+deferred the second with "for future use when we build the notification +
+action pipeline." That pipeline was not built, and ten already-published labels
+were never retracted, so the exact configuration the review warned about stayed
+live for roughly seven months. They were retracted on 2026-07-25; see
+`copyright-worklist-2026-07-25.md`.
+
+Adult enforcement was built separately in July (#1676–#1683) during a live
+incident, end-to-end, because it had to work that day. Two systems built under
+opposite pressures, never reconciled until now.
+
+## deliberately not done
+
+**No automatic uploader notification.** Building a notification pipeline and
+pointing it at a backlog would DM people about flags from December. Any
+notification must fire on new events only, never on backfill.
+
+**No per-track override yet.** Today the only lever against a false positive is
+negating the label, which conflates "this assertion is wrong" with "this
+assertion is right and I am allowing it anyway." Those are different statements
+and the second one has nowhere to live. That needs a moderation event log —
+subject, actor, action, reason, timestamp — which is the next piece of work.

--- a/loq.toml
+++ b/loq.toml
@@ -32,7 +32,7 @@ max_lines = 923
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
-max_lines = 624
+max_lines = 629
 
 [[rules]]
 path = "backend/src/backend/api/tracks/mutations.py"
@@ -52,7 +52,7 @@ max_lines = 905
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"
-max_lines = 792
+max_lines = 809
 
 [[rules]]
 path = "backend/tests/api/test_albums.py"


### PR DESCRIPTION
Two label families had opposite defects. Adult labels blocked audio bytes for anonymous listeners — breaking creators' share links — while copyright labels did nothing at all. Both are fixed by separating what a label *asserts* from what we *do* about it.

Resolves the enforcement half of user report #5 (@vicwalker.dev.br, track 64). Refs #1678. Policy written up in `docs/internal/moderation/label-policy.md`.

<details>
<summary>the history, because it explains the shape</summary>

This wasn't drift. The 2026-01-02 legal review concluded:

> safe harbor requires action when you have knowledge — public labels = knowledge. **either don't flag it, or flag it and act on it.**

`df0c0dae` (#703) did the first half — stopped auto-emitting labels — and deferred the second with *"for future use when we build the notification + action pipeline."* That pipeline was never built. Six months later `copyright-violation` was still inert, so the review queue had no terminal action.

Meanwhile adult enforcement was built fresh in July (#1676–#1683) during a live incident, end-to-end, because it had to work that day. Two systems built under opposite pressures, never reconciled — which is how the label with real legal exposure ended up doing nothing while the label with none did the most.

Separately: ten already-published copyright labels were never retracted, so the exact configuration the review warned about stayed publicly queryable for ~7 months. **Retracted 2026-07-25** (seq 728–737, zero active remaining), worklist snapshotted in `copyright-worklist-2026-07-25.md` first, because negating a label makes `sync_copyright_resolutions` clear `is_flagged` (#1615) and the queue would have forgotten them.
</details>

<details>
<summary>the model: assertion vs. enforcement</summary>

**The label is a portable assertion** — signed, public, queryable. Any client reading `fm.plyr.track` subscribes and decides what to render. Not ours to decide for them.

**Enforcement is plyr-local hosting policy** — what we do on our surfaces with our storage. Keyed off the label, not the same thing as it, not binding on anyone else.

The two families then differ in *who decides*:

| | adult (`sexual`,`porn`) | copyright |
|---|---|---|
| who decides rendering | **the listener** | **us** |
| listener preference | `show_sensitive_audio` | none can answer it |
| feeds / search / collections | hidden unless opted in or owner | hidden for everyone |
| radio | never | never |
| owner's own library | visible | visible |
| **audio permalink** | **plays** | **plays** |
| takedown | n/a | deliberate human step |

Adult is a rendering default a listener may override. Copyright is a hosting obligation — we serve the bytes, so the duty to act on knowledge is ours and no reader preference discharges it. De-listing is the cheap reversible action that discharges it.
</details>

<details>
<summary>why neither gates bytes</summary>

The adult gate looked like age verification and wasn't: **any** account satisfied it, and plyr verifies nobody's age. What it reliably did was break a creator sharing their own work with someone signed out.

Copyright doesn't gate bytes either, for a different reason — a fingerprint match is not a finding. Several currently-flagged tracks read as covers or remixes the uploader performed ("acoustic guitar cover of…", two self-described "(infyplay remix)"). Killing a permalink on an automated match isn't reversible in the way de-listing is.

Removing the gate also deletes a strict labeler read — and its `503` failure mode — from every audio request, plus two now-unused columns from that hot query.
</details>

<details>
<summary>the composition bug this avoids</summary>

The old call site skipped the visibility predicate *entirely* for opted-in viewers:

```python
if not shows_sensitive_audio:
    stmt = stmt.where(sensitive_audio_visible_clause(viewer))
```

Folding copyright into that predicate without composing it would have leaked copyright-labeled tracks to exactly the viewers who opted into sensitive audio. `discovery_visible_clause()` composes both families and is always applied; `test_sensitive_opt_in_does_not_reveal_copyright_tracks` pins it.
</details>

<details>
<summary>the subscriber, re-justified</summary>

#1695 invalidated the redis label cache. But the SQL discovery filters read `tracks.operator_labels` — the projection — **not** that cache. So once bytes stopped being gated, the subscriber as built would have been dead weight.

It now refreshes the projection, which is what actually drives enforcement: a copyright label de-lists in seconds instead of on the 5-minute sync. Five minutes is a long time to keep broadcasting an asserted infringement on radio. The perpetual sync stays the backstop; a failed stream refresh is logged and dropped rather than killing the consumer.
</details>

<details>
<summary>tests</summary>

1309 pass. New `test_content_label_policy.py` covers copyright hidden from everyone including the owner, the opt-in leak regression, adult remaining a preference, and no family gating bytes. `test_audio.py`'s three adult-gating tests were rewritten — they encoded the behavior being changed — plus a new one asserting the byte path never calls the labeler at all.
</details>

<details>
<summary>deliberately not done</summary>

- **No uploader notification.** Pointing a new notification pipeline at a backlog would DM people about December flags. Any notification must fire on new events only.
- **No per-track override yet.** Today the only lever against a false positive is negating the label, which conflates "this assertion is wrong" with "it's right and I'm allowing it anyway." Those need a moderation event log (subject, actor, action, reason, timestamp) — agreed as the next piece.
- **Not adopting Ozone.** Acorn's moderation is a customized Ozone fork; Ozone wants to own the labeler DID we already run, adds a VPS + Postgres, and its UI targets Bluesky posts. Borrowing its event-log model instead.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)