### PR TITLE
feat(moderation): wire scan flags into the event log, honor overrides

### DIFF
--- a/backend/alembic/versions/2026_07_25_002308_28201f72683d_add_moderation_override_to_tracks.py
+++ b/backend/alembic/versions/2026_07_25_002308_28201f72683d_add_moderation_override_to_tracks.py
@@ -1,0 +1,39 @@
+"""add moderation_override to tracks
+
+Standing operator decision projected from the moderation event log: "allow"
+surfaces a track despite a copyright label, "exclude" keeps it off shared
+surfaces regardless of labels.
+
+Hand-written. Autogenerate additionally proposed dropping the `api_keys` and
+`pending_account_creations` tables, four trigram indexes, and
+`tracks.album_slug` -- drift between the local dev database and the models,
+not intended schema changes. Only the column belongs here.
+
+Revision ID: 28201f72683d
+Revises: 581366546d5c
+Create Date: 2026-07-25 00:23:08.902215
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "28201f72683d"
+down_revision: str | Sequence[str] | None = "581366546d5c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the nullable override column. Null means no standing decision."""
+    op.add_column(
+        "tracks", sa.Column("moderation_override", sa.String(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tracks", "moderation_override")

--- a/backend/src/backend/_internal/clients/moderation.py
+++ b/backend/src/backend/_internal/clients/moderation.py
@@ -481,6 +481,67 @@ class ModerationClient:
             raw_labels = response.json().get("labels", {})
             return {uri: set(vals) for uri, vals in raw_labels.items()}
 
+    async def record_event(
+        self,
+        *,
+        subject_uri: str,
+        action: str,
+        actor: str,
+        subject_track_id: int | None = None,
+        reason: str | None = None,
+        notes: str | None = None,
+    ) -> None:
+        """Append to the moderation event log.
+
+        Best-effort by design: the event log is the review queue and the audit
+        trail, but a scan that cannot reach the labeler must still record its
+        own result. Losing the queue entry is recoverable — the scan row is
+        still flagged — while failing the scan is not.
+        """
+        if not self.auth_token:
+            return
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.post(
+                    f"{self.labeler_url}/internal/events",
+                    json={
+                        "subject_uri": subject_uri,
+                        "subject_track_id": subject_track_id,
+                        "action": action,
+                        "actor": actor,
+                        "reason": reason,
+                        "notes": notes,
+                    },
+                    headers=self._headers(),
+                )
+                response.raise_for_status()
+                logfire.info(
+                    "moderation event recorded",
+                    subject_uri=subject_uri,
+                    action=action,
+                    actor=actor,
+                )
+        except Exception as e:
+            logger.warning("failed to record moderation event: %s", e)
+
+    async def get_moderation_overrides(self) -> dict[str, str]:
+        """Return standing per-subject overrides keyed by AT URI.
+
+        Raises on failure for the same reason `get_active_labels_by_value`
+        does: a reconciliation pass must never read an outage as "no overrides"
+        and quietly drop an operator's decision.
+        """
+        if not self.auth_token:
+            return {}
+
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.get(
+                f"{self.labeler_url}/internal/overrides",
+                headers=self._headers(),
+            )
+            response.raise_for_status()
+            return response.json().get("overrides", {})
+
     async def get_negated_labels(self, uris: list[str]) -> set[str]:
         """check which URIs have an explicit negation (dismissal) label.
 

--- a/backend/src/backend/_internal/content_labels.py
+++ b/backend/src/backend/_internal/content_labels.py
@@ -91,11 +91,31 @@ def discovery_visible_clause(
     viewer opted in — would have leaked copyright-labeled tracks to exactly
     those viewers, because the whole predicate was dropped rather than the
     adult half of it.
+
+    A standing operator override wins over the copyright half. `exclude` hides
+    a track with no label needed; `allow` surfaces one whose copyright label we
+    reviewed and decided not to act on — a cover, say — without having to negate
+    the label and thereby claim the match never happened.
+
+    `allow` deliberately does not override the adult half. That is a listener
+    preference, and an operator deciding what someone else may be shown is a
+    different power than deciding what we host.
     """
-    clause = copyright_visible_clause()
+    labels_ok = copyright_visible_clause()
+    if not shows_sensitive_audio:
+        labels_ok = labels_ok & sensitive_audio_visible_clause(viewer_did)
+
+    # NULL-safe: the column is null for almost every track, and `NOT (NULL =
+    # 'exclude')` is NULL, which a WHERE clause drops. That would have hidden
+    # the entire catalogue.
+    allowed = Track.moderation_override.is_not_distinct_from("allow")
+    not_excluded = Track.moderation_override.is_distinct_from("exclude")
+
     if shows_sensitive_audio:
-        return clause
-    return clause & sensitive_audio_visible_clause(viewer_did)
+        return not_excluded & (allowed | labels_ok)
+    return not_excluded & (
+        (allowed & sensitive_audio_visible_clause(viewer_did)) | labels_ok
+    )
 
 
 async def get_operator_label_values(
@@ -178,8 +198,12 @@ async def filter_sensitive_audio_tracks_for_viewer(
     visible = []
     for track in track_list:
         labels = labels_by_id.get(track.id, set())
-        # copyright applies to everyone; no preference and no owner exemption
-        if has_copyright_label(labels):
+        override = track.moderation_override
+        if override == "exclude":
+            continue
+        # copyright applies to everyone; no preference and no owner exemption,
+        # unless an operator reviewed it and decided to surface it anyway
+        if has_copyright_label(labels) and override != "allow":
             continue
         if (
             shows_sensitive

--- a/backend/src/backend/_internal/moderation.py
+++ b/backend/src/backend/_internal/moderation.py
@@ -165,6 +165,22 @@ async def _store_scan_result(track_id: int, result: Any) -> None:
             match_count=len(scan.matches),
         )
 
+        # open a review item so the flag is visible to a moderator. before the
+        # event log existed this state lived only in copyright_scans, which the
+        # moderation dashboard cannot read — flags were raised into a queue
+        # nobody could see (#1678).
+        if is_flagged and track and track.atproto_record_uri:
+            await get_moderation_client().record_event(
+                subject_uri=track.atproto_record_uri,
+                subject_track_id=track_id,
+                action="flagged_by_scan",
+                actor="service:copyright-scan",
+                reason="fingerprint_match",
+                notes=(
+                    f"{len(scan.matches)} matches, highest score {scan.highest_score}"
+                ),
+            )
+
         # notify admin only — never DM the artist
         if is_flagged and track and track.artist:
             await notification_service.send_copyright_flag_notification(

--- a/backend/src/backend/_internal/tasks/labels.py
+++ b/backend/src/backend/_internal/tasks/labels.py
@@ -37,22 +37,32 @@ async def sync_operator_labels(
     labels_by_uri = await client.get_active_labels_by_value(
         sorted(PROJECTED_LABEL_VALUES)
     )
+    overrides_by_uri = await client.get_moderation_overrides()
 
     async with db_session() as db:
-        # tracks that need updating: currently projected, or newly labeled
+        # tracks that need updating: currently projected, or newly labeled,
+        # or carrying an override in either direction
+        subjects = set(labels_by_uri) | set(overrides_by_uri)
         result = await db.execute(
             select(Track).where(
                 (cast(Track.operator_labels, JSONB) != cast([], JSONB))
-                | Track.atproto_record_uri.in_(labels_by_uri.keys())
+                | Track.moderation_override.isnot(None)
+                | Track.atproto_record_uri.in_(subjects)
             )
         )
         tracks = result.scalars().all()
 
         changed = 0
         for track in tracks:
-            desired = sorted(labels_by_uri.get(track.atproto_record_uri or "", set()))
-            if track.operator_labels != desired:
+            uri = track.atproto_record_uri or ""
+            desired = sorted(labels_by_uri.get(uri, set()))
+            desired_override = overrides_by_uri.get(uri)
+            if (
+                track.operator_labels != desired
+                or track.moderation_override != desired_override
+            ):
                 track.operator_labels = desired
+                track.moderation_override = desired_override
                 changed += 1
 
         if changed:

--- a/backend/src/backend/models/track.py
+++ b/backend/src/backend/models/track.py
@@ -90,6 +90,11 @@ class Track(Base):
     operator_labels: Mapped[list[str]] = mapped_column(
         JSONB, nullable=False, default=list, server_default="[]"
     )
+    # Standing operator decision projected from the moderation event log:
+    # "allow" surfaces the track despite a copyright label, "exclude" keeps it
+    # off shared surfaces regardless of labels. Distinct from negating a label,
+    # which claims the assertion itself was wrong.
+    moderation_override: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # PDS blob storage (for audio stored on user's PDS)
     audio_storage: Mapped[str] = mapped_column(

--- a/backend/tests/api/test_tracks_sensitive_pagination.py
+++ b/backend/tests/api/test_tracks_sensitive_pagination.py
@@ -179,3 +179,45 @@ async def test_trailing_sensitive_tracks_terminate_cleanly(
         listed = await _fetch_all_pages(client, limit=1)
 
     assert [t["title"] for t in listed] == ["Track 3"]
+
+
+async def test_null_override_does_not_hide_the_catalogue(
+    anonymous_app: FastAPI,
+    db_session: AsyncSession,
+    artist: Artist,
+):
+    """moderation_override is null for nearly every track.
+
+    `NOT (NULL = 'exclude')` evaluates to NULL, which a WHERE clause drops, so
+    a naive comparison hid the entire catalogue. The clause uses IS DISTINCT
+    FROM; this asserts ordinary tracks still list.
+    """
+    db_session.add_all([_track(artist, 2), _track(artist, 1)])
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=anonymous_app), base_url="http://test"
+    ) as client:
+        response = await client.get("/tracks/", params={"limit": 10})
+
+    assert response.status_code == 200
+    assert [t["title"] for t in response.json()["tracks"]] == ["Track 2", "Track 1"]
+
+
+async def test_override_exclude_removes_a_track_from_the_feed(
+    anonymous_app: FastAPI,
+    db_session: AsyncSession,
+    artist: Artist,
+):
+    """An operator decision with no label behind it still de-lists."""
+    excluded = _track(artist, 2)
+    excluded.moderation_override = "exclude"
+    db_session.add_all([excluded, _track(artist, 1)])
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=anonymous_app), base_url="http://test"
+    ) as client:
+        response = await client.get("/tracks/", params={"limit": 10})
+
+    assert [t["title"] for t in response.json()["tracks"]] == ["Track 1"]

--- a/backend/tests/test_content_label_policy.py
+++ b/backend/tests/test_content_label_policy.py
@@ -129,3 +129,53 @@ async def test_no_label_gates_the_bytes(db_session: AsyncSession) -> None:
         assert await may_stream_sensitive_audio(
             db_session, labels=labels, artist_did=OWNER, session=None
         )
+
+
+async def test_override_allow_surfaces_a_copyright_labeled_track(
+    db_session: AsyncSession,
+) -> None:
+    """The reason overrides exist: a real match we reviewed and decided to keep.
+
+    Negating the label would claim the match never happened. An override says
+    the assertion stands and we are surfacing it anyway.
+    """
+    cover = await _track(
+        db_session,
+        file_id="ov1",
+        operator_labels=["copyright-violation"],
+    )
+    cover.moderation_override = "allow"
+    await db_session.commit()
+
+    visible, _ = await filter_sensitive_audio_tracks_for_viewer(
+        db_session, [cover], None
+    )
+    assert [t.id for t in visible] == [cover.id]
+
+
+async def test_override_exclude_hides_an_unlabeled_track(
+    db_session: AsyncSession,
+) -> None:
+    """The other direction: keep something off shared surfaces with no label."""
+    track = await _track(db_session, file_id="ov2")
+    track.moderation_override = "exclude"
+    await db_session.commit()
+
+    visible, _ = await filter_sensitive_audio_tracks_for_viewer(
+        db_session, [track], OWNER
+    )
+    assert visible == []
+
+
+async def test_override_allow_does_not_override_a_listeners_adult_preference(
+    db_session: AsyncSession,
+) -> None:
+    """An operator decides what we host, not what someone else may be shown."""
+    adult = await _track(db_session, file_id="ov3", operator_labels=["sexual"])
+    adult.moderation_override = "allow"
+    await db_session.commit()
+
+    visible, _ = await filter_sensitive_audio_tracks_for_viewer(
+        db_session, [adult], VIEWER
+    )
+    assert visible == []

--- a/backend/tests/test_moderation.py
+++ b/backend/tests/test_moderation.py
@@ -833,6 +833,9 @@ async def test_sync_operator_labels_reconciles_projection(
         mock_client.get_active_labels_by_value.return_value = {
             "at://did:plc:labelsync/fm.plyr.track/1": {"sexual"},
         }
+        mock_client.get_moderation_overrides.return_value = {
+            "at://did:plc:labelsync/fm.plyr.track/3": "allow",
+        }
         mock_get_client.return_value = mock_client
 
         await sync_operator_labels()
@@ -844,6 +847,9 @@ async def test_sync_operator_labels_reconciles_projection(
     assert track1.operator_labels == ["sexual"]
     assert track2.operator_labels == []
     assert track3.operator_labels == []
+    # overrides ride the same reconciliation as labels
+    assert track1.moderation_override is None
+    assert track3.moderation_override == "allow"
 
 
 async def test_sync_operator_labels_skips_pass_on_labeler_outage(

--- a/loq.toml
+++ b/loq.toml
@@ -76,7 +76,7 @@ max_lines = 569
 
 [[rules]]
 path = "backend/tests/test_moderation.py"
-max_lines = 945
+max_lines = 951
 
 [[rules]]
 path = "docs/internal/authentication.md"
@@ -352,7 +352,7 @@ max_lines = 512
 
 [[rules]]
 path = "backend/src/backend/_internal/clients/moderation.py"
-max_lines = 601
+max_lines = 662
 
 [[rules]]
 path = "backend/tests/_internal/test_permissioned_spaces.py"

--- a/scripts/backfill_moderation_queue.py
+++ b/scripts/backfill_moderation_queue.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env -S uv run --script --quiet --with-editable=backend
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "httpx",
+#     "pydantic-settings",
+# ]
+# ///
+"""Seed the moderation event log from existing copyright flags.
+
+`copyright_scans.is_flagged` predates the event log, so flags raised before it
+existed are invisible to the review queue. This opens one `flagged_by_scan`
+event per already-flagged track.
+
+It writes only to the moderation service's event log. It sends no
+notifications and cannot: notifying uploaders about flags from months ago
+because a queue was built today would be a bug, not a feature. The notification
+path lives in the backend's scan handler and is not reachable from here.
+
+usage:
+    uv run scripts/backfill_moderation_queue.py --env prod --dry-run
+    uv run scripts/backfill_moderation_queue.py --env prod
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+from typing import Literal
+
+import httpx
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from _moderation import DEFAULT_SERVICE_URL
+
+Environment = Literal["dev", "staging", "prod"]
+ACTOR = "service:backfill"
+
+
+class BackfillSettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env", case_sensitive=False, extra="ignore"
+    )
+
+    dev_database_url: str = Field(default="", validation_alias="DEV_DATABASE_URL")
+    staging_database_url: str = Field(
+        default="", validation_alias="STAGING_DATABASE_URL"
+    )
+    prod_database_url: str = Field(default="", validation_alias="PROD_DATABASE_URL")
+    moderation_service_url: str = Field(
+        default=DEFAULT_SERVICE_URL, validation_alias="MODERATION_SERVICE_URL"
+    )
+    moderation_auth_token: str = Field(
+        default="", validation_alias="MODERATION_AUTH_TOKEN"
+    )
+
+    def database_url(self, env: Environment) -> str:
+        url = {
+            "dev": self.dev_database_url,
+            "staging": self.staging_database_url,
+            "prod": self.prod_database_url,
+        }.get(env, "")
+        if not url:
+            raise ValueError(f"no database URL configured for {env}")
+        if url.startswith("postgresql://"):
+            url = url.replace("postgresql://", "postgresql+asyncpg://", 1)
+        return url.replace("sslmode=require", "ssl=require")
+
+
+async def main(env: Environment, dry_run: bool) -> int:
+    settings = BackfillSettings()
+    if not settings.moderation_auth_token:
+        print("MODERATION_AUTH_TOKEN is required")
+        return 1
+
+    os.environ["DATABASE_URL"] = settings.database_url(env)
+
+    from sqlalchemy import select
+    from sqlalchemy.orm import joinedload
+
+    from backend.models import CopyrightScan, Track
+    from backend.utilities.database import db_session
+
+    async with db_session() as db:
+        rows = (
+            (
+                await db.execute(
+                    select(CopyrightScan, Track)
+                    .join(Track, CopyrightScan.track_id == Track.id)
+                    .options(joinedload(CopyrightScan.track))
+                    .where(
+                        CopyrightScan.is_flagged == True,  # noqa: E712
+                        Track.atproto_record_uri.isnot(None),
+                    )
+                    .order_by(CopyrightScan.scanned_at)
+                )
+            )
+            .unique()
+            .all()
+        )
+
+    print(f"{len(rows)} flagged track(s) with an AT URI\n")
+
+    async with httpx.AsyncClient(
+        base_url=settings.moderation_service_url,
+        headers={"X-Moderation-Key": settings.moderation_auth_token},
+        timeout=30.0,
+    ) as client:
+        # skip subjects already in the log so re-running cannot pile up
+        # duplicate queue entries
+        existing: set[str] = set()
+        queue = await client.get("/admin/queue")
+        queue.raise_for_status()
+        existing = {item["subject_uri"] for item in queue.json().get("items", [])}
+
+        opened = 0
+        for scan, track in rows:
+            uri = track.atproto_record_uri
+            marker = "skip (already open)" if uri in existing else "open"
+            print(
+                f"  [{marker}] track {track.id}: {track.title[:48]!r} "
+                f"({len(scan.matches or [])} matches, {scan.scanned_at:%Y-%m-%d})"
+            )
+            if uri in existing or dry_run:
+                continue
+            r = await client.post(
+                "/internal/events",
+                json={
+                    "subject_uri": uri,
+                    "subject_track_id": track.id,
+                    "action": "flagged_by_scan",
+                    "actor": ACTOR,
+                    "reason": "fingerprint_match",
+                    "notes": (
+                        f"backfilled from copyright_scans #{scan.id}, "
+                        f"scanned {scan.scanned_at:%Y-%m-%d}"
+                    ),
+                },
+            )
+            r.raise_for_status()
+            opened += 1
+
+    if dry_run:
+        print("\ndry run — no events written")
+    else:
+        print(f"\nopened {opened} review item(s); notified nobody")
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env", default="prod", choices=["dev", "staging", "prod"])
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    sys.exit(asyncio.run(main(args.env, args.dry_run)))


### PR DESCRIPTION
Three connections that make #1699's event log load-bearing: scans open review items, overrides reach SQL, and the 13 pre-existing flags get backfilled. Second of three. Refs #1678.

<details>
<summary>scans open review items</summary>

`copyright_scans.is_flagged` lives in the **backend's** database, which the moderation dashboard cannot read. That's why flags never got acted on — they were raised into a queue nobody could see. A flagged scan now records `flagged_by_scan` against the track's AT URI, so the queue lives where the dashboard already looks.

Best-effort by design: a scan that can't reach the labeler still records its own result. Losing a queue entry is recoverable (the scan row is still flagged); failing the scan isn't.
</details>

<details>
<summary>overrides reach SQL</summary>

`sync_operator_labels` now reconciles `tracks.moderation_override` alongside `operator_labels`, and `discovery_visible_clause` honours it:

- **`exclude`** — hidden from shared surfaces regardless of labels
- **`allow`** — surfaces a copyright-labeled track we reviewed and chose to keep

`allow` is the whole reason overrides exist. Without it the only lever against a false positive is negating the label, which claims the match never happened — but "this is a cover, the match is real, and I'm surfacing it anyway" is a different statement.

**`allow` deliberately does not override the adult half.** That's a listener preference, and an operator deciding what someone else may be *shown* is a different power than deciding what we *host*. Test pins it.
</details>

<details>
<summary>the NULL trap (caught by the test suite, worth reading)</summary>

`moderation_override` is null for nearly every track, and `NOT (NULL = 'exclude')` evaluates to **NULL**, which a WHERE clause drops. The first cut of this clause hid the entire catalogue — 12 tests went red at once.

Fixed with `IS DISTINCT FROM` / `IS NOT DISTINCT FROM`, and pinned by `test_null_override_does_not_hide_the_catalogue` so a future edit can't silently reintroduce it.
</details>

<details>
<summary>the migration is hand-written, and why</summary>

`just migrate` autogenerate proposed, in addition to the intended column:

```
op.drop_table('api_keys')
op.drop_table('pending_account_creations')
op.drop_index('ix_tracks_title_trgm')            # + 3 more trigram indexes
op.drop_column('tracks', 'album_slug')
```

That's drift between the local dev database and the models, not intended schema changes — and applying it would have dropped two production tables. The migration was replaced with the single `add_column`, and the docstring records why so the next person doesn't "restore" the rest.
</details>

<details>
<summary>backfill</summary>

`scripts/backfill_moderation_queue.py` opens one `flagged_by_scan` per already-flagged track, skipping subjects already in the queue so re-running can't pile up duplicates.

**It cannot notify anyone**, and that's structural rather than careful: it writes only to the event log, and the notification path lives in the backend's scan handler where this script has no reach. DMing uploaders about December flags because a queue got built today would be a bug.

Not yet run — the service needs this deploy first.
</details>

<details>
<summary>tests</summary>

1314 pass. New: `allow` surfaces a copyright-labeled track, `exclude` hides an unlabeled one, `allow` doesn't override a listener's adult preference, the NULL-override catalogue regression, `exclude` removing a track from the feed, and overrides riding the same reconciliation as labels.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)