### PR TITLE
feat(moderation): point the dashboard at the real review queue

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -196,7 +196,7 @@ max_lines = 526
 
 [[rules]]
 path = "services/moderation/static/admin.css"
-max_lines = 760
+max_lines = 805
 
 [[rules]]
 path = "services/moderation/src/reports.rs"

--- a/services/moderation/static/admin.css
+++ b/services/moderation/static/admin.css
@@ -747,3 +747,59 @@ h1 {
     .notes-input { width: 100%; margin-bottom: 8px; }
     .confirm-step { flex-wrap: wrap; }
 }
+
+/* --- review queue --- */
+
+.actor-section {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+}
+
+.actor-section label {
+    font-weight: 600;
+}
+
+.actor-section input {
+    padding: 6px 10px;
+    border: 1px solid var(--border, #444);
+    border-radius: 4px;
+    background: var(--bg-input, #1a1a1a);
+    color: inherit;
+}
+
+.queue-player {
+    width: 100%;
+    max-width: 560px;
+    height: 160px;
+    border: 0;
+    border-radius: 8px;
+    margin: 12px 0;
+}
+
+.label-chip {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 0.85em;
+    background: rgba(220, 80, 80, 0.18);
+    border: 1px solid rgba(220, 80, 80, 0.45);
+}
+
+.flag-meta .uri {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.8em;
+    opacity: 0.6;
+    word-break: break-all;
+    margin-top: 4px;
+}
+
+.flag-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-top: 10px;
+}

--- a/services/moderation/static/admin.html
+++ b/services/moderation/static/admin.html
@@ -23,9 +23,21 @@
     </div>
 
     <div id="main-content" style="display: none;">
+        <!-- attribution, not authentication: the shared key above is what
+             actually authorises. this records who is claiming the action so
+             the event log is an audit trail rather than anonymous mutations. -->
+        <div class="actor-section">
+            <label for="actor">acting as</label>
+            <input type="text" id="actor" placeholder="your handle" onchange="saveActor()">
+            <span class="muted">recorded on every decision</span>
+        </div>
+
         <nav class="tab-nav">
-            <button class="tab-btn active" data-tab="copyright" onclick="switchTab('copyright')">
-                copyright flags
+            <button class="tab-btn active" data-tab="queue" onclick="switchTab('queue')">
+                review queue
+            </button>
+            <button class="tab-btn" data-tab="copyright" onclick="switchTab('copyright')">
+                copyright labels
             </button>
             <button class="tab-btn" data-tab="reports" onclick="switchTab('reports')">
                 user reports
@@ -35,8 +47,25 @@
             </button>
         </nav>
 
-        <!-- copyright flags tab -->
-        <div id="tab-copyright" class="tab-content active">
+        <!-- review queue tab: everything actually awaiting a decision -->
+        <div id="tab-queue" class="tab-content active">
+            <div class="header-row">
+                <h2>awaiting review</h2>
+                <button class="btn btn-secondary" onclick="loadQueue()">
+                    refresh
+                </button>
+            </div>
+            <p class="muted">
+                scan flags and user reports with no decision recorded yet.
+                listen before deciding — a fingerprint match is not a finding.
+            </p>
+            <div id="queue-list" class="flags-list">
+                <div class="loading">loading...</div>
+            </div>
+        </div>
+
+        <!-- copyright labels tab -->
+        <div id="tab-copyright" class="tab-content">
             <div class="header-row">
                 <h2>flagged tracks</h2>
                 <button class="btn btn-secondary" onclick="refreshFlagsList()">

--- a/services/moderation/static/admin.js
+++ b/services/moderation/static/admin.js
@@ -36,7 +36,7 @@ function authenticate() {
         localStorage.setItem('mod_token', token);
         currentToken = token;
         showMain();
-        htmx.trigger('#flags-list', 'load');
+        loadQueue();
     }
 }
 
@@ -46,8 +46,12 @@ if (savedToken) {
     document.getElementById('auth-token').value = '••••••••';
     currentToken = savedToken;
     showMain();
-    // Trigger load after DOM is ready and htmx is initialized
-    setTimeout(() => htmx.trigger('#flags-list', 'load'), 0);
+    setTimeout(loadQueue, 0);
+}
+
+const savedActor = localStorage.getItem('mod_actor');
+if (savedActor) {
+    document.getElementById('actor').value = savedActor;
 }
 
 // Handle auth errors
@@ -183,9 +187,137 @@ function switchTab(tab) {
     });
 
     // Load data for tab if needed
+    if (tab === 'queue') {
+        loadQueue();
+    }
     if (tab === 'reports' && !reportsLoaded) {
         reportsLoaded = true;
         refreshReportsList();
+    }
+}
+
+// --- review queue ---
+//
+// The queue the dashboard used to show read *labels*, but post-#703 a scan
+// never emits one, so scan flags were invisible here — raised into a queue
+// nobody could see. This reads the moderation event log instead, which is
+// where both scan flags and user reports now land.
+
+function getActor() {
+    return (document.getElementById('actor')?.value || '').trim();
+}
+
+function saveActor() {
+    localStorage.setItem('mod_actor', getActor());
+}
+
+function escapeHtml(value) {
+    return String(value ?? '').replace(/[&<>"']/g, (c) => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[c]));
+}
+
+async function loadQueue() {
+    const list = document.getElementById('queue-list');
+    list.innerHTML = '<div class="loading">loading...</div>';
+    try {
+        const response = await fetch('/admin/queue', {
+            headers: { 'X-Moderation-Key': currentToken }
+        });
+        if (!response.ok) throw new Error(`${response.status}`);
+        const { items } = await response.json();
+        renderQueue(items || []);
+    } catch (e) {
+        list.innerHTML = `<div class="empty-placeholder"><p>could not load queue (${escapeHtml(e.message)})</p></div>`;
+    }
+}
+
+function renderQueue(items) {
+    const list = document.getElementById('queue-list');
+    if (!items.length) {
+        list.innerHTML = '<div class="empty-placeholder"><p>nothing awaiting review</p>'
+            + '<p class="muted">scan flags and reports appear here until a decision is recorded</p></div>';
+        return;
+    }
+
+    list.innerHTML = items.map((item) => {
+        const uri = escapeHtml(item.subject_uri);
+        const trackId = item.subject_track_id;
+        const labels = (item.labels || []).map(
+            (l) => `<span class="label-chip">${escapeHtml(l)}</span>`
+        ).join(' ') || '<span class="muted">no labels</span>';
+
+        // the real player, so a copyright call can be made by listening
+        const player = trackId
+            ? `<iframe class="queue-player" src="https://plyr.fm/embed/track/${trackId}"
+                       loading="lazy" title="track ${trackId}"></iframe>`
+            : '<p class="muted">no track id — cannot preview</p>';
+
+        const link = trackId
+            ? `<a href="https://plyr.fm/track/${trackId}" target="_blank" rel="noopener">open on plyr.fm</a>`
+            : '';
+
+        return `
+        <div class="flag-card" data-uri="${uri}">
+            <div class="flag-header">
+                <strong>${trackId ? `track ${trackId}` : 'unknown track'}</strong>
+                <span class="muted">opened by ${escapeHtml(item.opened_by)}
+                    · ${new Date(item.opened_at).toLocaleString()}</span>
+            </div>
+            <div class="flag-meta">
+                <div>${labels}</div>
+                ${item.reason ? `<div class="muted">reason: ${escapeHtml(item.reason)}</div>` : ''}
+                ${item.notes ? `<div class="muted">${escapeHtml(item.notes)}</div>` : ''}
+                <div class="uri">${uri}</div>
+            </div>
+            ${player}
+            <div class="flag-actions">
+                <button class="btn btn-secondary"
+                        onclick="decide('${uri}', ${trackId ?? 'null'}, 'acknowledged')">
+                    acknowledge
+                </button>
+                <button class="btn btn-secondary"
+                        onclick="decide('${uri}', ${trackId ?? 'null'}, 'override_allow')">
+                    allow anyway
+                </button>
+                <button class="btn btn-danger"
+                        onclick="decide('${uri}', ${trackId ?? 'null'}, 'override_exclude')">
+                    keep de-listed
+                </button>
+                ${link}
+            </div>
+        </div>`;
+    }).join('');
+}
+
+async function decide(subjectUri, trackId, action) {
+    const actor = getActor();
+    if (!actor) {
+        showToast('set "acting as" first — decisions are attributed', 'error');
+        document.getElementById('actor').focus();
+        return;
+    }
+    const notes = prompt(`notes for "${action}" (optional)`) ?? '';
+    try {
+        const response = await fetch('/admin/events', {
+            method: 'POST',
+            headers: {
+                'X-Moderation-Key': currentToken,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                subject_uri: subjectUri,
+                subject_track_id: trackId,
+                action,
+                actor,
+                notes: notes || null
+            })
+        });
+        if (!response.ok) throw new Error(`${response.status}`);
+        showToast(`recorded ${action}`, 'success');
+        loadQueue();
+    } catch (e) {
+        showToast(`failed: ${e.message}`, 'error');
     }
 }
 


### PR DESCRIPTION
The dashboard could not see its own queue. Last of three. Refs #1678.

<details>
<summary>the bug, measured</summary>

```
pending copyright flags shown in the dashboard: 0
open user reports: 1
tracks with copyright_scans.is_flagged: 13
```

The "copyright flags" tab read **active labels**. Post-#703 a scan never emits a label, so scan flags were structurally invisible — the tab could only ever show pre-#703 leftovers, and once those were retracted it showed zero while thirteen tracks waited.

This is a large part of why the flags never got acted on for seven months. Nobody could see them.
</details>

<details>
<summary>what's new</summary>

- **review queue tab**, reading `/admin/queue` — scan flags and user reports with no decision recorded
- **audio, in the review surface** — each item embeds `plyr.fm/embed/track/{id}`. Deciding whether "acoustic guitar cover of vodka cranberry" is infringement is a listening task; 249 matches tells you almost nothing. Using the existing embed route means the real player with zero CORS work.
- **decisions** — acknowledge / allow anyway / keep de-listed, each posting to the event log
- **"acting as"** — required before any decision, refused when blank, persisted locally

The old tab stays, renamed to "copyright labels", which is what it actually shows.
</details>

<details>
<summary>attribution is not authentication</summary>

The shared key is still what authorises; "acting as" records who is *claiming* the action. That's a real limitation and worth stating plainly rather than implying the log is tamper-proof.

It's still the difference between an audit trail and anonymous mutations — and it's the prerequisite for review not always being you, whether the next reviewer is another human or an agent.
</details>

<details>
<summary>notes</summary>

- All rendered values pass through `escapeHtml` — queue content includes user-supplied report text.
- `loq-relax` on the three static files.
- No backend/API changes; this consumes what #1699 and #1700 built.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)