### PR TITLE
feat(moderation): user reports open review items

### DIFF
--- a/backend/src/backend/api/moderation.py
+++ b/backend/src/backend/api/moderation.py
@@ -7,10 +7,13 @@ from typing import Literal
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, require_auth
 from backend._internal.clients.moderation import get_moderation_client
 from backend._internal.notifications import notification_service
+from backend.models import Track, get_db
 from backend.utilities.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
@@ -67,6 +70,7 @@ async def create_report(
     request: Request,
     body: CreateReportRequest,
     session: Session = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
 ) -> CreateReportResponse:
     """submit a content report.
 
@@ -76,6 +80,15 @@ async def create_report(
     """
     client = get_moderation_client()
 
+    # the moderation event log is keyed by subject URI, so a track report only
+    # opens a review item if we resolve the URI here. without it a report lands
+    # in the reports tab alone and never reaches the queue a moderator works.
+    target_uri: str | None = None
+    if body.target_type == "track" and body.target_id.isdigit():
+        target_uri = await db.scalar(
+            select(Track.atproto_record_uri).where(Track.id == int(body.target_id))
+        )
+
     try:
         result = await client.create_report(
             reporter_did=session.did,
@@ -84,6 +97,7 @@ async def create_report(
             target_id=body.target_id,
             target_name=body.target_name,
             target_url=body.target_url,
+            target_uri=target_uri,
             reason=body.reason.value,
             description=body.description,
             screenshot_url=body.screenshot_url,

--- a/backend/tests/test_moderation.py
+++ b/backend/tests/test_moderation.py
@@ -949,3 +949,78 @@ async def test_sensitive_images_read_stays_on_the_public_route() -> None:
         await client.get_sensitive_images()
 
     assert mock_get.call_args[0][0] == "https://moderation.test/sensitive-images"
+
+
+async def test_track_report_carries_the_at_uri(
+    report_test_app: FastAPI, db_session: AsyncSession
+) -> None:
+    """A track report must resolve its subject URI.
+
+    The moderation event log is keyed by subject URI, so without this a report
+    lands in the reports tab alone and never opens a review item — which is how
+    the first real user report sat open while the queue read empty.
+    """
+    from httpx import ASGITransport, AsyncClient
+
+    artist = Artist(
+        did="did:plc:reporturi",
+        handle="reporturi.test",
+        display_name="Report URI",
+    )
+    db_session.add(artist)
+    await db_session.flush()
+    track = Track(
+        title="Reported Track",
+        file_id="reporturi_1",
+        file_type="mp3",
+        artist_did=artist.did,
+        atproto_record_uri="at://did:plc:reporturi/fm.plyr.track/abc",
+    )
+    db_session.add(track)
+    await db_session.commit()
+
+    with patch("backend.api.moderation.get_moderation_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.create_report.return_value = CreateReportResult(report_id=1)
+        mock_get_client.return_value = mock_client
+
+        async with AsyncClient(
+            transport=ASGITransport(app=report_test_app), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/moderation/reports",
+                json={
+                    "target_type": "track",
+                    "target_id": str(track.id),
+                    "reason": "copyright",
+                },
+            )
+
+    assert response.status_code == 200
+    assert (
+        mock_client.create_report.call_args.kwargs["target_uri"]
+        == "at://did:plc:reporturi/fm.plyr.track/abc"
+    )
+
+
+async def test_non_track_report_has_no_uri_to_resolve(
+    report_test_app: FastAPI,
+) -> None:
+    """Tags and comments have no AT URI; the report still succeeds."""
+    from httpx import ASGITransport, AsyncClient
+
+    with patch("backend.api.moderation.get_moderation_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.create_report.return_value = CreateReportResult(report_id=2)
+        mock_get_client.return_value = mock_client
+
+        async with AsyncClient(
+            transport=ASGITransport(app=report_test_app), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/moderation/reports",
+                json={"target_type": "tag", "target_id": "7", "reason": "abuse"},
+            )
+
+    assert response.status_code == 200
+    assert mock_client.create_report.call_args.kwargs["target_uri"] is None

--- a/loq.toml
+++ b/loq.toml
@@ -76,7 +76,7 @@ max_lines = 569
 
 [[rules]]
 path = "backend/tests/test_moderation.py"
-max_lines = 951
+max_lines = 1026
 
 [[rules]]
 path = "docs/internal/authentication.md"
@@ -200,7 +200,7 @@ max_lines = 805
 
 [[rules]]
 path = "services/moderation/src/reports.rs"
-max_lines = 523
+max_lines = 544
 
 [[rules]]
 path = "scripts/moderation_agent.py"

--- a/services/moderation/src/reports.rs
+++ b/services/moderation/src/reports.rs
@@ -137,6 +137,27 @@ pub async fn create_report(
         "user report created"
     );
 
+    // Open a review item so the report lands in the same queue as scan flags.
+    // Without this a report only ever appears in its own tab, which is how the
+    // first real user report on the platform sat open while the queue read
+    // empty. Track reports carry an AT URI; other target types do not yet, and
+    // the event log is keyed by subject URI, so those stay reports-only for now.
+    if let Some(subject_uri) = req.target_uri.as_deref() {
+        let event = crate::events::RecordEventRequest {
+            subject_uri: subject_uri.to_string(),
+            subject_track_id: req.target_id.parse::<i64>().ok(),
+            action: crate::events::ModerationAction::Reported,
+            actor: format!("user:{}", req.reporter_did),
+            reason: Some(req.reason.clone()),
+            notes: req.description.clone(),
+        };
+        // Best effort: the report is already stored, and losing the queue entry
+        // must not turn a successful report into an error for the reporter.
+        if let Err(e) = db.record_event(&event).await {
+            tracing::warn!(error = %e, report_id = report.id, "could not open review item");
+        }
+    }
+
     Ok(Json(CreateReportResponse {
         report_id: report.id,
     }))


### PR DESCRIPTION
A user report landed in its own tab and nowhere else — which is how the first real report on the platform sat `open` while the review queue read empty. Refs #1678.

<details>
<summary>two halves of the same gap</summary>

**The moderation service** didn't record an event when a report came in, so reports never entered the queue that #1699 built.

**The backend never sent `target_uri`.** The event log is keyed by subject URI, so even with the first half fixed, a track report had nothing to key on — the existing report row has `target_uri: null`. The backend now resolves the track's AT URI when forwarding.

Both were needed; either alone is a no-op.
</details>

<details>
<summary>failure behavior</summary>

Recording the event is best-effort on both sides. The report is already stored by then, and losing a queue entry must not turn a successful report into an error for the person who filed it.

Non-track targets (tags, comments, artists) have no AT URI yet, so they stay reports-only rather than being given a synthetic subject.
</details>

<details>
<summary>tests</summary>

1316 pass. New: a track report carries its resolved AT URI, and a non-track report succeeds with `target_uri: None`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)