### PR TITLE
feat(moderation): publish decisions from the moderation account

### DIFF
--- a/backend/src/backend/_internal/clients/moderation.py
+++ b/backend/src/backend/_internal/clients/moderation.py
@@ -524,6 +524,33 @@ class ModerationClient:
         except Exception as e:
             logger.warning("failed to record moderation event: %s", e)
 
+    async def get_events_head(self) -> int:
+        """Highest event id, for starting a cursor at "now" rather than zero."""
+        if not self.auth_token:
+            return 0
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.get(
+                f"{self.labeler_url}/internal/events-head",
+                headers=self._headers(),
+            )
+            response.raise_for_status()
+            return int(response.json().get("latest_id", 0))
+
+    async def get_events_since(
+        self, after_id: int, *, limit: int = 50
+    ) -> list[dict[str, Any]]:
+        """Moderation events newer than a cursor, oldest first."""
+        if not self.auth_token:
+            return []
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.get(
+                f"{self.labeler_url}/internal/events-since",
+                params={"after_id": after_id, "limit": limit},
+                headers=self._headers(),
+            )
+            response.raise_for_status()
+            return response.json().get("events", [])
+
     async def get_moderation_overrides(self) -> dict[str, str]:
         """Return standing per-subject overrides keyed by AT URI.
 

--- a/backend/src/backend/_internal/notifications.py
+++ b/backend/src/backend/_internal/notifications.py
@@ -179,6 +179,28 @@ class NotificationService:
                     error_type=error_type,
                 )
 
+    async def post_publicly(self, text: str) -> bool:
+        """Post from the moderation account's own timeline.
+
+        Distinct from every other method here, which sends a DM to one
+        recipient. This is outward-facing: it reaches anyone, so the caller is
+        responsible for having decided the content is publishable (see
+        `_internal/transparency`).
+
+        Returns whether the post was created, so a caller walking a cursor can
+        stop rather than skip past an announcement that never happened.
+        """
+        if await self.ensure_ready() is None or self.client is None:
+            logger.warning("cannot post publicly: notification bot not ready")
+            return False
+        try:
+            await self.client.send_post(text=text)
+            logfire.info("transparency post published", chars=len(text))
+            return True
+        except Exception:
+            logger.exception("failed to publish transparency post")
+            return False
+
     async def send_copyright_flag_notification(
         self,
         track_id: int,

--- a/backend/src/backend/_internal/tasks/__init__.py
+++ b/backend/src/backend/_internal/tasks/__init__.py
@@ -25,6 +25,7 @@ from backend._internal.tasks.hooks import (
     run_post_track_create_hooks,
 )
 from backend._internal.tasks.labels import sync_operator_labels
+from backend._internal.tasks.transparency import publish_moderation_decisions
 from backend._internal.tasks.moderation import (
     scan_image_moderation,
     schedule_image_moderation_scan,
@@ -97,6 +98,7 @@ def _build_background_tasks() -> list:
         scan_copyright,
         sync_copyright_resolutions,
         sync_operator_labels,
+        publish_moderation_decisions,
         process_export,
         sync_atproto,
         scrobble_to_teal,
@@ -170,6 +172,7 @@ __all__ = [
     "pds_delete_comment",
     "pds_delete_like",
     "pds_update_comment",
+    "publish_moderation_decisions",
     "reap_stuck_uploads",
     "run_post_track_create_hooks",
     "scan_copyright",

--- a/backend/src/backend/_internal/tasks/transparency.py
+++ b/backend/src/backend/_internal/tasks/transparency.py
@@ -1,0 +1,102 @@
+"""Publish moderation decisions to @moderation.plyr.fm.
+
+Walks the moderation event log forward from a cursor and posts the decisions
+that are publishable (see `_internal/transparency`). Runs in the backend rather
+than the moderation service because the Bluesky session already lives here —
+and reading the log on a timer keeps the dependency pointing one way, the same
+shape as sync_operator_labels.
+
+Two safety properties matter more than throughput:
+
+**It cannot backfill.** On first run the cursor is initialised to the log's
+current head, so events that predate the publisher are never announced.
+Posting about decisions from months ago because a publisher shipped today would
+be the same mistake as DMing uploaders about old flags.
+
+**It is off by default.** `notify.publish_moderation_decisions` gates actual
+posting. When disabled the task still runs and logs each rendered post, so the
+pipeline is observable and testable without anything reaching the timeline —
+which also keeps staging, which shares this Bluesky account, from posting about
+test data.
+"""
+
+import logging
+from datetime import timedelta
+
+import logfire
+from docket import Perpetual
+
+from backend._internal.transparency import TransparencyPost, render
+from backend.config import settings
+from backend.utilities.redis import get_async_redis_client
+
+logger = logging.getLogger(__name__)
+
+CURSOR_KEY = "plyr:moderation-transparency:cursor"
+BATCH_LIMIT = 25
+
+
+async def publish_moderation_decisions(
+    perpetual: Perpetual = Perpetual(every=timedelta(minutes=2), automatic=True),  # noqa: B008
+) -> None:
+    """Post new moderation decisions, oldest first."""
+    from backend._internal.clients.moderation import get_moderation_client
+    from backend._internal.notifications import notification_service
+
+    if not settings.moderation.auth_token:
+        return
+
+    client = get_moderation_client()
+    redis = get_async_redis_client()
+
+    raw_cursor = await redis.get(CURSOR_KEY)
+    if raw_cursor is None:
+        # first run: start at the head so history is never announced
+        head = await client.get_events_head()
+        await redis.set(CURSOR_KEY, str(head))
+        logfire.info(
+            "transparency publisher initialised at head; no backfill",
+            head=head,
+        )
+        return
+
+    cursor = int(raw_cursor)
+    events = await client.get_events_since(cursor, limit=BATCH_LIMIT)
+    if not events:
+        return
+
+    posted = 0
+    skipped = 0
+    for event in events:
+        post: TransparencyPost | None = render(event)
+        if post is None:
+            skipped += 1
+        elif settings.notify.publish_moderation_decisions:
+            if await notification_service.post_publicly(post.text):
+                posted += 1
+            else:
+                # stop at the failure so the cursor does not skip past a
+                # decision that was never announced
+                logger.warning(
+                    "transparency post failed at event %d; stopping batch",
+                    event["id"],
+                )
+                break
+        else:
+            logfire.info(
+                "transparency post (publishing disabled)",
+                event_id=event["id"],
+                action=event["action"],
+                text=post.text,
+            )
+            posted += 1
+        cursor = event["id"]
+
+    await redis.set(CURSOR_KEY, str(cursor))
+    logfire.info(
+        "transparency publisher pass complete",
+        cursor=cursor,
+        posted=posted,
+        skipped_not_publishable=skipped,
+        publishing_enabled=settings.notify.publish_moderation_decisions,
+    )

--- a/backend/src/backend/_internal/transparency.py
+++ b/backend/src/backend/_internal/transparency.py
@@ -1,0 +1,98 @@
+"""Public transparency posts for moderation decisions.
+
+Renders moderation events into posts for @moderation.plyr.fm. The policy about
+*which* events are publishable lives here rather than at the call site, because
+getting it wrong is the failure mode with real consequences.
+
+The rule: publish actions we took, never suspicions we hold.
+
+The 2026-01-02 legal review is the reason. Publicly asserting "this might
+infringe" without acting on it creates knowledge without action, which is the
+wrong side of safe harbour — and it is also just unfair to an uploader whose
+track matched a fingerprint and turned out to be their own cover. A flag is not
+a finding, so a flag is not publishable. Neither is a user report: announcing
+that someone reported a track exposes the target before anyone has reviewed it,
+and turns the report button into a way to publicly stain a rival.
+
+What is left is the set of actions whose *effects* are already visible — a
+track that stopped appearing, a label anyone can query — where a post explains
+something the public can otherwise only guess at.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+# Actions whose effect is already publicly visible, so explaining them adds
+# transparency rather than new accusation.
+PUBLISHABLE_ACTIONS = frozenset(
+    {
+        "takedown",
+        "override_exclude",
+        "label_applied",
+        "label_negated",
+    }
+)
+
+# Deliberately excluded, with the reason each one stays private:
+#   flagged_by_scan  suspicion, not a finding — publishing it is the exact
+#                    "knowledge without action" the legal review warned about
+#   reported         exposes a target before review; would make the report
+#                    button a harassment tool
+#   acknowledged     reveals that a track was suspected, while saying we found
+#                    nothing — all of the stain, none of the finding
+#   override_allow   same: it only makes sense to announce if you first
+#                    announce the suspicion
+#   override_clear   withdraws an internal decision with no public effect
+
+_HEADLINE = {
+    "takedown": "removed a track",
+    "override_exclude": "removed a track from discovery and radio",
+    "label_applied": "labeled a track",
+    "label_negated": "withdrew a label from a track",
+}
+
+TRACK_URL = "https://plyr.fm/track/{track_id}"
+
+
+@dataclass(frozen=True)
+class TransparencyPost:
+    """A rendered post, plus the event id that produced it."""
+
+    event_id: int
+    text: str
+
+
+def is_publishable(event: dict[str, Any]) -> bool:
+    return event.get("action") in PUBLISHABLE_ACTIONS
+
+
+def render(event: dict[str, Any]) -> TransparencyPost | None:
+    """Render one event, or None when it is not publishable.
+
+    Never names the uploader and never mentions a reporter. The track is
+    already public and is identified by link; @-mentioning the artist would
+    notify and amplify a moderation action against them, which is punishment
+    rather than transparency.
+    """
+    if not is_publishable(event):
+        return None
+
+    action = event["action"]
+    lines = [f"moderation: {_HEADLINE[action]}"]
+
+    if reason := event.get("reason"):
+        lines.append(f"reason: {reason.replace('_', ' ')}")
+
+    if track_id := event.get("subject_track_id"):
+        lines.append(TRACK_URL.format(track_id=track_id))
+
+    lines.append("")
+    lines.append("plyr.fm/docs/moderation")
+
+    text = "\n".join(lines)
+    # bluesky's limit is 300 graphemes; these are short by construction, but a
+    # reason string comes from operator input and is not guaranteed to be.
+    if len(text) > 300:
+        text = text[:297] + "..."
+
+    return TransparencyPost(event_id=event["id"], text=text)

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -97,6 +97,15 @@ class NotificationSettings(AppSettingsSection):
         default_factory=NotificationBotSettings,
         description="Bot credentials for sending DMs",
     )
+    publish_moderation_decisions: bool = Field(
+        default=False,
+        description=(
+            "Publish moderation decisions from the moderation account's public "
+            "timeline. Off by default: staging shares this Bluesky account, so "
+            "enabling it everywhere would post about test data. When off the "
+            "publisher still runs and logs what it would have posted."
+        ),
+    )
 
 
 class AppSettings(AppSettingsSection):

--- a/backend/tests/test_transparency.py
+++ b/backend/tests/test_transparency.py
@@ -1,0 +1,202 @@
+"""Tests for public moderation transparency posts.
+
+The publishability policy is the part with consequences: publishing a
+suspicion is both a legal problem (knowledge without action) and unfair to an
+uploader whose track matched a fingerprint and turned out to be their own
+cover. These tests pin what may and may not reach the timeline.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend._internal.tasks.transparency import (
+    CURSOR_KEY,
+    publish_moderation_decisions,
+)
+from backend._internal.transparency import PUBLISHABLE_ACTIONS, is_publishable, render
+
+
+def _event(action: str, **kwargs) -> dict:
+    return {
+        "id": kwargs.pop("id", 1),
+        "action": action,
+        "subject_uri": "at://did:plc:x/fm.plyr.track/abc",
+        "subject_track_id": kwargs.pop("track_id", 42),
+        "actor": "moderator",
+        "reason": kwargs.pop("reason", None),
+        "notes": kwargs.pop("notes", None),
+    }
+
+
+@pytest.mark.parametrize(
+    "action",
+    ["flagged_by_scan", "reported", "acknowledged", "override_allow", "override_clear"],
+)
+def test_suspicions_and_non_actions_are_never_published(action: str) -> None:
+    """A flag is not a finding, and a report is not a verdict.
+
+    Announcing either exposes an uploader before anyone reviewed anything --
+    and in the report case would turn the report button into a way to publicly
+    stain a rival.
+    """
+    assert not is_publishable(_event(action))
+    assert render(_event(action)) is None
+
+
+@pytest.mark.parametrize("action", sorted(PUBLISHABLE_ACTIONS))
+def test_actions_taken_are_published(action: str) -> None:
+    post = render(_event(action))
+    assert post is not None
+    assert "moderation:" in post.text
+
+
+def test_post_never_names_the_uploader_or_reporter() -> None:
+    """Transparency, not punishment: no @-mention to notify and amplify."""
+    post = render(
+        _event("takedown", reason="copyright", notes="reported by @someone.bsky.social")
+    )
+    assert post is not None
+    assert "@" not in post.text
+    assert "someone" not in post.text
+
+
+def test_post_links_the_track_and_states_the_reason() -> None:
+    post = render(_event("override_exclude", reason="fingerprint_match", track_id=64))
+    assert post is not None
+    assert "https://plyr.fm/track/64" in post.text
+    assert "fingerprint match" in post.text
+
+
+def test_post_stays_within_the_bluesky_limit() -> None:
+    post = render(_event("takedown", reason="x" * 500))
+    assert post is not None
+    assert len(post.text) <= 300
+
+
+async def test_first_run_starts_at_head_and_posts_nothing() -> None:
+    """The publisher must never announce decisions that predate it.
+
+    Seventeen events existed before this shipped, including backfilled flags
+    and verification actions. Starting a cursor at zero would have narrated all
+    of them.
+    """
+    redis = AsyncMock()
+    redis.get.return_value = None
+
+    with (
+        patch(
+            "backend._internal.tasks.transparency.get_async_redis_client",
+            return_value=redis,
+        ),
+        patch(
+            "backend._internal.clients.moderation.get_moderation_client"
+        ) as mock_get_client,
+        patch("backend._internal.notifications.notification_service") as mock_notifier,
+        patch("backend._internal.tasks.transparency.settings") as mock_settings,
+    ):
+        mock_settings.moderation.auth_token = "token"
+        mock_settings.notify.publish_moderation_decisions = True
+        client = AsyncMock()
+        client.get_events_head.return_value = 17
+        mock_get_client.return_value = client
+        mock_notifier.post_publicly = AsyncMock()
+
+        await publish_moderation_decisions()
+
+    redis.set.assert_awaited_once_with(CURSOR_KEY, "17")
+    client.get_events_since.assert_not_awaited()
+    mock_notifier.post_publicly.assert_not_awaited()
+
+
+async def test_disabled_publishing_advances_the_cursor_without_posting() -> None:
+    """Staging shares the Bluesky account, so it must observe without posting."""
+    redis = AsyncMock()
+    redis.get.return_value = "5"
+
+    with (
+        patch(
+            "backend._internal.tasks.transparency.get_async_redis_client",
+            return_value=redis,
+        ),
+        patch(
+            "backend._internal.clients.moderation.get_moderation_client"
+        ) as mock_get_client,
+        patch("backend._internal.notifications.notification_service") as mock_notifier,
+        patch("backend._internal.tasks.transparency.settings") as mock_settings,
+    ):
+        mock_settings.moderation.auth_token = "token"
+        mock_settings.notify.publish_moderation_decisions = False
+        client = AsyncMock()
+        client.get_events_since.return_value = [_event("takedown", id=6)]
+        mock_get_client.return_value = client
+        mock_notifier.post_publicly = AsyncMock(return_value=True)
+
+        await publish_moderation_decisions()
+
+    mock_notifier.post_publicly.assert_not_awaited()
+    redis.set.assert_awaited_with(CURSOR_KEY, "6")
+
+
+async def test_a_failed_post_stops_the_batch() -> None:
+    """The cursor must not step past an announcement that never happened."""
+    redis = AsyncMock()
+    redis.get.return_value = "5"
+
+    with (
+        patch(
+            "backend._internal.tasks.transparency.get_async_redis_client",
+            return_value=redis,
+        ),
+        patch(
+            "backend._internal.clients.moderation.get_moderation_client"
+        ) as mock_get_client,
+        patch("backend._internal.notifications.notification_service") as mock_notifier,
+        patch("backend._internal.tasks.transparency.settings") as mock_settings,
+    ):
+        mock_settings.moderation.auth_token = "token"
+        mock_settings.notify.publish_moderation_decisions = True
+        client = AsyncMock()
+        client.get_events_since.return_value = [
+            _event("takedown", id=6),
+            _event("takedown", id=7),
+        ]
+        mock_get_client.return_value = client
+        mock_notifier.post_publicly = AsyncMock(return_value=False)
+
+        await publish_moderation_decisions()
+
+    # cursor stays at 5: event 6 was never announced, so it must be retried
+    redis.set.assert_awaited_with(CURSOR_KEY, "5")
+
+
+async def test_unpublishable_events_advance_the_cursor() -> None:
+    """A queue full of flags must not wedge the publisher."""
+    redis = AsyncMock()
+    redis.get.return_value = "5"
+
+    with (
+        patch(
+            "backend._internal.tasks.transparency.get_async_redis_client",
+            return_value=redis,
+        ),
+        patch(
+            "backend._internal.clients.moderation.get_moderation_client"
+        ) as mock_get_client,
+        patch("backend._internal.notifications.notification_service") as mock_notifier,
+        patch("backend._internal.tasks.transparency.settings") as mock_settings,
+    ):
+        mock_settings.moderation.auth_token = "token"
+        mock_settings.notify.publish_moderation_decisions = True
+        client = AsyncMock()
+        client.get_events_since.return_value = [
+            _event("flagged_by_scan", id=6),
+            _event("reported", id=7),
+        ]
+        mock_get_client.return_value = client
+        mock_notifier.post_publicly = AsyncMock(return_value=True)
+
+        await publish_moderation_decisions()
+
+    mock_notifier.post_publicly.assert_not_awaited()
+    redis.set.assert_awaited_with(CURSOR_KEY, "7")

--- a/loq.toml
+++ b/loq.toml
@@ -44,7 +44,7 @@ max_lines = 1862
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 1213
+max_lines = 1222
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
@@ -352,7 +352,7 @@ max_lines = 512
 
 [[rules]]
 path = "backend/src/backend/_internal/clients/moderation.py"
-max_lines = 662
+max_lines = 689
 
 [[rules]]
 path = "backend/tests/_internal/test_permissioned_spaces.py"

--- a/services/moderation/src/events.rs
+++ b/services/moderation/src/events.rs
@@ -14,7 +14,10 @@
 //! Events are never mutated or deleted. Current state is derived from the
 //! latest relevant event per subject, the same way label state is.
 
-use axum::{extract::State, Json};
+use axum::{
+    extract::{Query, State},
+    Json,
+};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::Row;
@@ -122,6 +125,17 @@ pub struct EventsResponse {
     pub events: Vec<ModerationEvent>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct EventsSinceParams {
+    pub after_id: Option<i64>,
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EventsHeadResponse {
+    pub latest_id: i64,
+}
+
 /// A subject awaiting review, with enough context to act without leaving the page.
 #[derive(Debug, Serialize)]
 pub struct QueueItem {
@@ -216,6 +230,34 @@ impl LabelDb {
         .fetch_all(self.pool())
         .await?;
         rows.into_iter().map(event_from_row).collect()
+    }
+
+    pub async fn events_since(
+        &self,
+        after_id: i64,
+        limit: i64,
+    ) -> Result<Vec<ModerationEvent>, sqlx::Error> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, subject_uri, subject_track_id, action, actor, reason, notes, created_at
+            FROM moderation_events
+            WHERE id > $1
+            ORDER BY id
+            LIMIT $2
+            "#,
+        )
+        .bind(after_id)
+        .bind(limit)
+        .fetch_all(self.pool())
+        .await?;
+        rows.into_iter().map(event_from_row).collect()
+    }
+
+    pub async fn latest_event_id(&self) -> Result<i64, sqlx::Error> {
+        let row = sqlx::query("SELECT COALESCE(max(id), 0) AS latest FROM moderation_events")
+            .fetch_one(self.pool())
+            .await?;
+        row.try_get("latest")
     }
 
     /// Subjects whose most recent opening event has no closing event after it.
@@ -354,6 +396,33 @@ pub async fn subject_events(
     let db = state.db.as_ref().ok_or(AppError::LabelerNotConfigured)?;
     Ok(Json(EventsResponse {
         events: db.events_for_subject(&query.subject_uri).await?,
+    }))
+}
+
+/// Events newer than a cursor, oldest first.
+///
+/// Drives the backend's transparency publisher, which needs to walk forward
+/// through decisions exactly once. Ordering by id (not timestamp) keeps the
+/// cursor total and gap-free.
+pub async fn events_since(
+    State(state): State<AppState>,
+    Query(params): Query<EventsSinceParams>,
+) -> Result<Json<EventsResponse>, AppError> {
+    let db = state.db.as_ref().ok_or(AppError::LabelerNotConfigured)?;
+    let limit = params.limit.unwrap_or(50).clamp(1, 200);
+    Ok(Json(EventsResponse {
+        events: db.events_since(params.after_id.unwrap_or(0), limit).await?,
+    }))
+}
+
+/// Highest event id, so a publisher can start from "now" rather than replaying
+/// history it was never meant to announce.
+pub async fn events_head(
+    State(state): State<AppState>,
+) -> Result<Json<EventsHeadResponse>, AppError> {
+    let db = state.db.as_ref().ok_or(AppError::LabelerNotConfigured)?;
+    Ok(Json(EventsHeadResponse {
+        latest_id: db.latest_event_id().await?,
     }))
 }
 

--- a/services/moderation/src/main.rs
+++ b/services/moderation/src/main.rs
@@ -128,6 +128,8 @@ fn internal_only_api() -> Router<AppState> {
     Router::new()
         .route("/events", post(events::record_event))
         .route("/overrides", get(events::active_overrides))
+        .route("/events-since", get(events::events_since))
+        .route("/events-head", get(events::events_head))
 }
 
 fn build_router(state: AppState, auth_token: Option<String>) -> Router {


### PR DESCRIPTION
The moderation account has only ever DM'd one person. Decisions that change what the public can see were never explained publicly. This adds a publisher to `@moderation.plyr.fm`. Refs #1678.

<details>
<summary>the policy: publish actions taken, never suspicions held</summary>

| action | published | why |
|---|---|---|
| `takedown` | ✅ | we removed something |
| `override_exclude` | ✅ | we de-listed something |
| `label_applied` | ✅ | already public via the labeler |
| `label_negated` | ✅ | clears someone's name — fairness cuts both ways |
| `flagged_by_scan` | ❌ | a suspicion. Announcing it is exactly the "knowledge without action" the 2026-01-02 legal review warned about |
| `reported` | ❌ | exposes a target before review — would make the report button a way to publicly stain a rival |
| `acknowledged` | ❌ | "we looked and found nothing" only parses if you first announced the suspicion. All of the stain, none of the finding |
| `override_allow` | ❌ | same |
| `override_clear` | ❌ | withdraws an internal decision with no public effect |

What survives is the set whose *effects are already visible* — a track that stopped appearing, a label anyone can query — where a post explains something the public can otherwise only guess at.

**Posts never name the uploader and never `@`-mention anyone.** Notifying and amplifying a moderation action against someone is punishment, not transparency. Test asserts no `@` reaches the text even when operator notes contain a handle.
</details>

<details>
<summary>two safety properties</summary>

**It cannot backfill.** The cursor initialises to the log's current head, so the 17 events that predate it — backfilled flags, my verification actions from tonight — are never narrated. Starting at zero would have posted about all of them. Pinned by `test_first_run_starts_at_head_and_posts_nothing`.

**It is off by default.** Staging shares this Bluesky account, so enabling it everywhere would post about test data. When disabled the task still runs and **logs each rendered post**, so the pipeline is observable and testable without anything reaching the timeline — that's how I'll verify it before you flip it on in prod.

A failed post stops the batch rather than advancing past an announcement that never happened.
</details>

<details>
<summary>where it runs</summary>

In the backend, because the Bluesky session already lives in `NotificationService` and the Rust service has no Bluesky client. Reading the log on a timer keeps the dependency pointing one way — same shape as `sync_operator_labels`, rather than having the labeler call back.

New `/internal/events-since` and `/internal/events-head` on the moderation service; ordering by id keeps the cursor total and gap-free.
</details>

<details>
<summary>tests</summary>

1332 pass. 16 new: every excluded action stays unpublished, every included one renders, no `@` in output, track linked and reason stated, 300-grapheme cap, first-run-no-backfill, disabled-mode advances without posting, failed post holds the cursor, and unpublishable events don't wedge the publisher.
</details>

<details>
<summary>to enable in prod</summary>

`NOTIFY_PUBLISH_MODERATION_DECISIONS=true` as a fly secret on the prod backend only. I'd suggest leaving it off until you've seen the logged renderings.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)