### PR TITLE
fix(moderation): transparency posts linked a 404

### DIFF
--- a/backend/src/backend/_internal/transparency.py
+++ b/backend/src/backend/_internal/transparency.py
@@ -52,6 +52,10 @@ _HEADLINE = {
 }
 
 TRACK_URL = "https://plyr.fm/track/{track_id}"
+# every post carries this, so a dead link would be a dead link on all of them.
+# `docs.plyr.fm/moderation` does not exist; the sensitive-content guide is the
+# closest public explanation of how labels affect what you see.
+POLICY_URL = "https://docs.plyr.fm/sensitive-content"
 
 
 @dataclass(frozen=True)
@@ -87,7 +91,7 @@ def render(event: dict[str, Any]) -> TransparencyPost | None:
         lines.append(TRACK_URL.format(track_id=track_id))
 
     lines.append("")
-    lines.append("plyr.fm/docs/moderation")
+    lines.append(POLICY_URL)
 
     text = "\n".join(lines)
     # bluesky's limit is 300 graphemes; these are short by construction, but a

--- a/backend/tests/test_transparency.py
+++ b/backend/tests/test_transparency.py
@@ -68,6 +68,19 @@ def test_post_links_the_track_and_states_the_reason() -> None:
     assert "fingerprint match" in post.text
 
 
+def test_post_links_a_policy_page_that_exists() -> None:
+    """Every post carries this link, so a dead one is dead on all of them.
+
+    The first cut used plyr.fm/docs/moderation, which 404s.
+    """
+    from backend._internal.transparency import POLICY_URL
+
+    post = render(_event("takedown"))
+    assert post is not None
+    assert POLICY_URL in post.text
+    assert "plyr.fm/docs/moderation" not in post.text
+
+
 def test_post_stays_within_the_bluesky_limit() -> None:
     post = render(_event("takedown", reason="x" * 500))
     assert post is not None


### PR DESCRIPTION
Every transparency post carries a policy link, so a dead one is dead on all of them. `plyr.fm/docs/moderation` 404s; `docs.plyr.fm/sensitive-content` is the closest public explanation of how labels affect what you see, and returns 200.

Caught by reading the rendered post from the production verification pass **before** publishing was enabled:

```
moderation: removed a track
reason: e2e verification
https://plyr.fm/track/1188

plyr.fm/docs/moderation      <- 404
```

That's exactly what the disabled-but-logging mode is for — the pipeline ran end to end in prod and produced real output to inspect, with nothing reaching the timeline.

Test pins the working URL and asserts the broken one can't come back.

Worth noting for later: a dedicated public moderation policy page would be a better target than the sensitive-content guide, which only covers the adult half. That belongs in the docs pass.