### PR TITLE
fix(moderation): transparency posts render links as links

### DIFF
--- a/backend/src/backend/_internal/notifications.py
+++ b/backend/src/backend/_internal/notifications.py
@@ -2,11 +2,13 @@
 
 import logging
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 import logfire
-from atproto import AsyncClient, models
+from atproto import AsyncClient, client_utils, models
 
+from backend._internal.transparency import Segment
 from backend.config import settings
 from backend.models import Track
 
@@ -179,7 +181,7 @@ class NotificationService:
                     error_type=error_type,
                 )
 
-    async def post_publicly(self, text: str) -> bool:
+    async def post_publicly(self, segments: Sequence[Segment]) -> bool:
         """Post from the moderation account's own timeline.
 
         Distinct from every other method here, which sends a DM to one
@@ -187,15 +189,33 @@ class NotificationService:
         responsible for having decided the content is publishable (see
         `_internal/transparency`).
 
+        Takes segments rather than a string because Bluesky does not infer
+        links from text. A URL only renders as a link if the record carries a
+        matching `facet` -- a byte range into the UTF-8 encoding of the text.
+        TextBuilder tracks those offsets as it appends, which is why the text
+        is assembled here rather than passed in pre-joined.
+
         Returns whether the post was created, so a caller walking a cursor can
         stop rather than skip past an announcement that never happened.
         """
         if await self.ensure_ready() is None or self.client is None:
             logger.warning("cannot post publicly: notification bot not ready")
             return False
+
+        builder = client_utils.TextBuilder()
+        for segment in segments:
+            if segment.link:
+                builder.link(segment.text, segment.link)
+            else:
+                builder.text(segment.text)
+
         try:
-            await self.client.send_post(text=text)
-            logfire.info("transparency post published", chars=len(text))
+            await self.client.send_post(builder)
+            logfire.info(
+                "transparency post published",
+                chars=len(builder.build_text()),
+                facets=len(builder.build_facets()),
+            )
             return True
         except Exception:
             logger.exception("failed to publish transparency post")

--- a/backend/src/backend/_internal/tasks/transparency.py
+++ b/backend/src/backend/_internal/tasks/transparency.py
@@ -72,7 +72,7 @@ async def publish_moderation_decisions(
         if post is None:
             skipped += 1
         elif settings.notify.publish_moderation_decisions:
-            if await notification_service.post_publicly(post.text):
+            if await notification_service.post_publicly(post.segments):
                 posted += 1
             else:
                 # stop at the failure so the cursor does not skip past a

--- a/backend/src/backend/_internal/transparency.py
+++ b/backend/src/backend/_internal/transparency.py
@@ -57,17 +57,47 @@ TRACK_URL = "https://plyr.fm/track/{track_id}"
 # closest public explanation of how labels affect what you see.
 POLICY_URL = "https://docs.plyr.fm/sensitive-content"
 
+# operator-supplied, so bounded. the rest of the post is fixed-length.
+REASON_MAX_CHARS = 120
+
+
+@dataclass(frozen=True)
+class Segment:
+    """A run of post text, optionally carrying a link.
+
+    The renderer emits segments rather than a finished string because Bluesky
+    links are not inferred from the text -- they are `facets`, byte ranges
+    attached to the record. A post whose text merely *contains* a URL renders
+    as unclickable plain text, which is what shipped first.
+
+    Keeping segments here rather than building facets directly leaves this
+    module free of atproto imports, so the publishability policy stays testable
+    on its own.
+    """
+
+    text: str
+    link: str | None = None
+
 
 @dataclass(frozen=True)
 class TransparencyPost:
     """A rendered post, plus the event id that produced it."""
 
     event_id: int
-    text: str
+    segments: tuple[Segment, ...]
+
+    @property
+    def text(self) -> str:
+        return "".join(segment.text for segment in self.segments)
 
 
 def is_publishable(event: dict[str, Any]) -> bool:
     return event.get("action") in PUBLISHABLE_ACTIONS
+
+
+def _display(url: str) -> str:
+    """Link text without the scheme, the way Bluesky's own composer shows it."""
+    return url.removeprefix("https://").removeprefix("http://")
 
 
 def render(event: dict[str, Any]) -> TransparencyPost | None:
@@ -77,26 +107,28 @@ def render(event: dict[str, Any]) -> TransparencyPost | None:
     already public and is identified by link; @-mentioning the artist would
     notify and amplify a moderation action against them, which is punishment
     rather than transparency.
+
+    No external embed card either. A card would re-surface the artwork and
+    title of content we just removed, which is the opposite of the point.
     """
     if not is_publishable(event):
         return None
 
-    action = event["action"]
-    lines = [f"moderation: {_HEADLINE[action]}"]
+    segments: list[Segment] = [Segment(f"moderation: {_HEADLINE[event['action']]}")]
 
     if reason := event.get("reason"):
-        lines.append(f"reason: {reason.replace('_', ' ')}")
+        # bounded here rather than by truncating the finished post: facets are
+        # byte offsets into the text, so trimming the assembled string would
+        # leave every link pointing at the wrong range.
+        pretty = reason.replace("_", " ")[:REASON_MAX_CHARS]
+        segments.append(Segment(f"\nreason: {pretty}"))
 
     if track_id := event.get("subject_track_id"):
-        lines.append(TRACK_URL.format(track_id=track_id))
+        url = TRACK_URL.format(track_id=track_id)
+        segments.append(Segment("\n"))
+        segments.append(Segment(_display(url), link=url))
 
-    lines.append("")
-    lines.append(POLICY_URL)
+    segments.append(Segment("\n\n"))
+    segments.append(Segment(_display(POLICY_URL), link=POLICY_URL))
 
-    text = "\n".join(lines)
-    # bluesky's limit is 300 graphemes; these are short by construction, but a
-    # reason string comes from operator input and is not guaranteed to be.
-    if len(text) > 300:
-        text = text[:297] + "..."
-
-    return TransparencyPost(event_id=event["id"], text=text)
+    return TransparencyPost(event_id=event["id"], segments=tuple(segments))

--- a/backend/tests/test_transparency.py
+++ b/backend/tests/test_transparency.py
@@ -14,7 +14,16 @@ from backend._internal.tasks.transparency import (
     CURSOR_KEY,
     publish_moderation_decisions,
 )
-from backend._internal.transparency import PUBLISHABLE_ACTIONS, is_publishable, render
+from backend._internal.transparency import (
+    POLICY_URL,
+    PUBLISHABLE_ACTIONS,
+    is_publishable,
+    render,
+)
+
+
+def _links(post) -> list[str]:
+    return [s.link for s in post.segments if s.link]
 
 
 def _event(action: str, **kwargs) -> dict:
@@ -64,7 +73,8 @@ def test_post_never_names_the_uploader_or_reporter() -> None:
 def test_post_links_the_track_and_states_the_reason() -> None:
     post = render(_event("override_exclude", reason="fingerprint_match", track_id=64))
     assert post is not None
-    assert "https://plyr.fm/track/64" in post.text
+    assert "https://plyr.fm/track/64" in _links(post)
+    assert "plyr.fm/track/64" in post.text
     assert "fingerprint match" in post.text
 
 
@@ -73,18 +83,75 @@ def test_post_links_a_policy_page_that_exists() -> None:
 
     The first cut used plyr.fm/docs/moderation, which 404s.
     """
-    from backend._internal.transparency import POLICY_URL
-
     post = render(_event("takedown"))
     assert post is not None
-    assert POLICY_URL in post.text
+    assert POLICY_URL in _links(post)
     assert "plyr.fm/docs/moderation" not in post.text
 
 
-def test_post_stays_within_the_bluesky_limit() -> None:
-    post = render(_event("takedown", reason="x" * 500))
+def test_every_url_is_a_link_not_bare_text() -> None:
+    """Bluesky does not infer links from text.
+
+    The first cut emitted a plain string, so both URLs rendered as unclickable
+    grey text. A URL that appears in the text must be carried by a segment
+    that also has a link, or it is decoration.
+    """
+    post = render(_event("override_exclude", track_id=1190))
+    assert post is not None
+
+    linked_text = {s.text for s in post.segments if s.link}
+    for segment in post.segments:
+        if segment.link is None:
+            assert "plyr.fm" not in segment.text, (
+                f"{segment.text!r} mentions a URL but carries no link"
+            )
+    assert linked_text == {"plyr.fm/track/1190", "docs.plyr.fm/sensitive-content"}
+
+
+def test_link_text_matches_its_target() -> None:
+    """Display text is the URL minus the scheme, as Bluesky's composer shows it.
+
+    Link text that points somewhere other than where it reads is how phishing
+    works; on a moderation account it would be especially corrosive.
+    """
+    post = render(_event("takedown", track_id=7))
+    assert post is not None
+    for segment in post.segments:
+        if segment.link:
+            assert segment.link.endswith(segment.text)
+            assert segment.link.startswith("https://")
+
+
+def test_byte_offsets_survive_multibyte_reasons() -> None:
+    """Facets index UTF-8 bytes, not characters.
+
+    Segments are assembled in order, so the invariant to hold is that the
+    concatenated text equals the post text -- any drift there would shift
+    every subsequent facet range.
+    """
+    post = render(_event("takedown", reason="dépôt non autorisé — ünïcode", track_id=9))
+    assert post is not None
+    assert "".join(s.text for s in post.segments) == post.text
+    rebuilt = post.text.encode("utf-8")
+    offset = 0
+    for segment in post.segments:
+        chunk = segment.text.encode("utf-8")
+        assert rebuilt[offset : offset + len(chunk)] == chunk
+        offset += len(chunk)
+    assert offset == len(rebuilt)
+
+
+def test_a_long_reason_is_bounded_without_truncating_the_post() -> None:
+    """Trimming the assembled text would corrupt every facet after the cut.
+
+    Facets are byte ranges into the post text, so the variable part is bounded
+    at the source instead.
+    """
+    post = render(_event("takedown", reason="x" * 500, track_id=1))
     assert post is not None
     assert len(post.text) <= 300
+    # the links still terminate the post, so their ranges are intact
+    assert post.segments[-1].link == POLICY_URL
 
 
 async def test_first_run_starts_at_head_and_posts_nothing() -> None:


### PR DESCRIPTION
Both URLs in the first published post rendered as unclickable grey text. Bluesky does not infer links from post text — a URL is only clickable if the record carries a matching **facet**: a byte range into the UTF-8 encoding of the text, pointing at the target.

<details>
<summary>what was wrong</summary>

`send_post(text=...)` with a plain string produces a record with no `facets` array. The text contained URLs; nothing told the client they were links.

```
moderation: removed a track from discovery and radio
reason: e2e verification
https://plyr.fm/track/1190          <- plain text
https://docs.plyr.fm/sensitive-content   <- plain text
```
</details>

<details>
<summary>how it works now</summary>

The renderer emits `Segment(text, link=None)` runs; the publisher assembles them with atproto's `TextBuilder`, which tracks byte offsets as it appends and emits `app.bsky.richtext.facet` entries.

Verified the ranges resolve to exactly the link text:

```
'moderation: removed a track from discovery and radio\nreason: fingerprint match\nplyr.fm/track/1190\n\ndocs.plyr.fm/sensitive-content'

  bytes[79:97]  = 'plyr.fm/track/1190'              -> https://plyr.fm/track/1190
  bytes[99:129] = 'docs.plyr.fm/sensitive-content'  -> https://docs.plyr.fm/sensitive-content
```

Link text is the URL minus its scheme, matching what Bluesky's own composer shows.
</details>

<details>
<summary>the truncation bug this also fixes</summary>

The old length guard trimmed the **assembled** post at 300 chars. With facets that is corrupting: every byte range after the cut would then point at the wrong text, or past the end. A long operator reason would have produced links that read as one thing and pointed at another.

The bound moved onto `reason`, the only operator-supplied part; the rest of the post is fixed-length. `test_a_long_reason_is_bounded_without_truncating_the_post` asserts the policy link still terminates the post intact.
</details>

<details>
<summary>tests</summary>

1336 pass. Four new, aimed at the class of bug rather than the instance:

- **`test_every_url_is_a_link_not_bare_text`** — would have caught the original: any segment mentioning `plyr.fm` without a link fails.
- **`test_link_text_matches_its_target`** — link text must be a suffix of its URL. Text pointing somewhere other than where it reads is how phishing works; on a moderation account that would be especially corrosive.
- **`test_byte_offsets_survive_multibyte_reasons`** — facets index bytes, not characters. Walks the segments against the encoded post to prove no drift with accents and em-dashes.
- **`test_a_long_reason_is_bounded_without_truncating_the_post`**
</details>

<details>
<summary>deliberately not done</summary>

**No external embed card.** It would render the artwork and title of a track we just removed — amplifying the content rather than explaining the action. Facets give clickable links without turning a moderation notice into a promo card.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)