### PR TITLE
docs: correct the moderation docs after the label-policy change

### DIFF
--- a/backend/src/backend/_internal/transparency.py
+++ b/backend/src/backend/_internal/transparency.py
@@ -53,9 +53,7 @@ _HEADLINE = {
 
 TRACK_URL = "https://plyr.fm/track/{track_id}"
 # every post carries this, so a dead link would be a dead link on all of them.
-# `docs.plyr.fm/moderation` does not exist; the sensitive-content guide is the
-# closest public explanation of how labels affect what you see.
-POLICY_URL = "https://docs.plyr.fm/sensitive-content"
+POLICY_URL = "https://docs.plyr.fm/moderation"
 
 # operator-supplied, so bounded. the rest of the post is fixed-length.
 REASON_MAX_CHARS = 120

--- a/backend/tests/test_transparency.py
+++ b/backend/tests/test_transparency.py
@@ -81,7 +81,8 @@ def test_post_links_the_track_and_states_the_reason() -> None:
 def test_post_links_a_policy_page_that_exists() -> None:
     """Every post carries this link, so a dead one is dead on all of them.
 
-    The first cut used plyr.fm/docs/moderation, which 404s.
+    The first cut used plyr.fm/docs/moderation, which 404d; it then pointed at
+    the sensitive-content guide, which only covers the adult half.
     """
     post = render(_event("takedown"))
     assert post is not None
@@ -105,7 +106,7 @@ def test_every_url_is_a_link_not_bare_text() -> None:
             assert "plyr.fm" not in segment.text, (
                 f"{segment.text!r} mentions a URL but carries no link"
             )
-    assert linked_text == {"plyr.fm/track/1190", "docs.plyr.fm/sensitive-content"}
+    assert linked_text == {"plyr.fm/track/1190", "docs.plyr.fm/moderation"}
 
 
 def test_link_text_matches_its_target() -> None:

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -58,6 +58,8 @@ organized knowledge base for plyr.fm development.
 
 ### moderation
 - **[moderation/](./moderation/)** - copyright detection, sensitive content, labeler
+  - [label policy](./moderation/label-policy.md) - what each label family does, and who decides
+  - [event log](./moderation/event-log.md) - review queue, overrides, audit trail, transparency posts
 
 ### testing
 - **[testing/](./testing/)** - pytest patterns, parallel execution

--- a/docs/internal/moderation/atproto-labeler.md
+++ b/docs/internal/moderation/atproto-labeler.md
@@ -153,6 +153,12 @@ curl -X POST https://moderation.plyr.fm/internal/active-labels \
 
 the admin dashboard is an htmx UI served directly by the Rust moderation service at `/admin`. it's auth-protected via `X-Moderation-Key`.
 
+its primary tab is the **review queue**, which reads the
+[moderation event log](event-log.md) rather than labels. The older
+"copyright labels" tab still lists active labels, but that is a view of
+assertions, not of work: post-#703 a scan never emits a label, so a
+labels-backed queue cannot show a scan flag at all.
+
 ### what it shows
 
 - list of flagged tracks with status (pending/resolved)
@@ -270,30 +276,41 @@ if labeler isn't configured, `/emit-label` returns an error and the admin dashbo
 
 ## integration with backend
 
-the backend interacts with the labeler in three ways:
+the backend interacts with the labeler in four ways:
 
 1. **generic label cache** (`_internal/clients/moderation.py`): fetches complete active value sets via `POST /internal/labels`. used for discovery and playback policy.
 
 2. **copyright compatibility**: `POST /internal/active-labels` and `/internal/negated-labels` drive the legacy copyright synchronization task.
 
-3. **strict byte authorization**: the audio endpoint requires a current label
-   check and returns `503` rather than serving possibly adult audio when the
-   labeler cannot be reached.
+3. **decisions and overrides**: `POST /internal/events` records scan flags,
+   `GET /internal/overrides` feeds the projection, and the events cursor
+   endpoints drive transparency publishing. See [event log](event-log.md).
 
 4. **label stream subscriber** (`_internal/label_stream.py`): a websocket
-   consumer on `subscribeLabels` that invalidates a subject's cached label
-   values as soon as the labeler commits a label.
+   consumer on `subscribeLabels` that refreshes the `tracks.operator_labels`
+   projection — and the label cache — as soon as the labeler commits a label.
+
+the audio byte endpoint does **not** query the labeler. It once did, strictly,
+returning `503` when the labeler was unreachable; removing the adult gate
+removed that read and its failure mode from every audio request.
 
 ### why the subscriber exists
 
-the label cache is keyed by subject URI and is viewer-independent, so a single
-playback populates it for every listener. caching the *absence* of a label is
-the dangerous half: before the subscriber, a label emitted by an operator (the
-dashboard, a script, curl — anything other than the backend's own
-`emit_label`, which invalidates on the way out) had no effect on audio
-authorization until the entry expired. measured on staging, an anonymous
-listener kept streaming a freshly `sexual`-labeled track for the full
-`label_cache_ttl_seconds`.
+**the original reason is now historical.** The label cache is keyed by subject
+URI and viewer-independent, so a single playback populated it for every
+listener, and caching the *absence* of a label meant an operator-emitted label
+had no effect on audio authorization until the entry expired. Measured on
+staging, an anonymous listener kept streaming a freshly `sexual`-labeled track
+for the full `label_cache_ttl_seconds`.
+
+that particular exposure no longer exists, because labels stopped gating audio
+bytes at all. What the subscriber does now matters more: it refreshes
+`tracks.operator_labels`, which is what the SQL discovery filters actually read.
+A copyright label de-lists in about a second instead of waiting on the
+five-minute `sync_operator_labels` pass — and five minutes is a long time to
+keep broadcasting an asserted infringement on radio. Invalidating only the redis
+cache, as the first cut did, would have become dead weight: the filters never
+read that cache.
 
 the backend reads the stream rather than having the labeler call back into the
 backend, which keeps the dependency pointing one way. that matters here: one
@@ -310,13 +327,13 @@ keeps a track hidden after a moderator cleared it. that is the fail-closed
 direction, but it is still wrong.
 
 the backend does **not** call `/emit-label` directly. labels are emitted by an
-operator or the copyright dashboard. A first-class generic-label operator UI or
-CLI remains a tooling gap.
+operator or the copyright dashboard.
 
-the cache includes empty label sets. After an urgent label write, invalidate the
-label, discovery, album, and radio caches using the runbook or wait for their
-TTL; otherwise a newly labeled track can remain in a previously serialized
-response temporarily.
+**no manual cache invalidation.** The subscriber handles it. If enforcement has
+not landed within a minute, check that the subscriber is connected (Logfire,
+`message ILIKE '%label stream%'`) before reaching for anything manual — a
+disconnected subscriber falls back to the five-minute reconciliation, so the
+effect is late rather than lost.
 
 ## troubleshooting
 

--- a/docs/internal/moderation/event-log.md
+++ b/docs/internal/moderation/event-log.md
@@ -1,0 +1,119 @@
+---
+title: "moderation event log"
+---
+
+`moderation_events` in the `plyr-moderation` Neon project. Append-only; state is
+derived from the latest relevant event per subject, the same way label state is.
+
+## why it exists
+
+labels record what we *assert* about content. Nothing recorded what we *did*, or
+who did it. That gap had four consequences that looked like four separate
+missing features:
+
+- **no override.** The only lever against a false positive was negating the
+  label, which forces you to claim the assertion was wrong in order to change
+  the behaviour. "The match is real, it's a cover, surface it anyway" had
+  nowhere to live.
+- **no queue.** `copyright_scans.is_flagged` lives in the *backend* database,
+  which the moderation dashboard cannot read. Flags were raised into a queue
+  nobody could see — which is most of why thirteen tracks sat unreviewed.
+- **no audit trail.** Every action was anonymous.
+- **nothing for an agent to propose.** A reviewable proposed action needs
+  somewhere to be proposed.
+
+one table covers all four.
+
+## shape
+
+```
+moderation_events
+  id                BIGSERIAL, monotonic — also the publisher cursor
+  subject_uri       AT URI (the key; reports must resolve one to enqueue)
+  subject_track_id  plyr track id when known
+  action            see below
+  actor             who — required, rejected when blank
+  reason / notes
+  created_at
+```
+
+## actions
+
+| action | opens review | closes review | published |
+|---|---|---|---|
+| `flagged_by_scan` | ✅ | | |
+| `reported` | ✅ | | |
+| `label_applied` | | | ✅ |
+| `label_negated` | | | ✅ |
+| `acknowledged` | | ✅ | |
+| `override_allow` | | ✅ | ✅ |
+| `override_exclude` | | ✅ | ✅ |
+| `override_clear` | | | |
+| `takedown` | | ✅ | ✅ |
+
+**emitting a label neither opens nor closes review.** Labelling a track states
+what we assert; it is not the same as deciding you are finished with it.
+Collapsing those two is how an empty queue came to mean "no work".
+
+`override_clear` withdraws a previous decision and leaves the subject wherever
+it was.
+
+## derived state
+
+**queue** — subjects whose most recent opening event has no closing event after
+it. Re-opening falls out for free: a fresh report on a previously acknowledged
+track has a higher id than the acknowledgement, so it surfaces again.
+
+**overrides** — the latest `override_*` per subject wins. Projected onto
+`tracks.moderation_override` by `sync_operator_labels` and read by
+`discovery_visible_clause`.
+
+## attribution is not authentication
+
+`actor` is required on every write, but the service still trusts a single shared
+`MODERATION_AUTH_TOKEN`. So this records a *claim* about who acted, only as good
+as that key.
+
+that is deliberate and worth stating precisely: it is the difference between an
+audit trail and a pile of anonymous mutations, and it is the prerequisite for
+telling a human reviewer, a second human, and an agent apart. **Real per-actor
+authentication is the next foundational step, and it is what actually gates
+letting an agent act rather than propose.**
+
+## endpoints
+
+service-to-service, on `/internal` (never aliased under `/admin` — those aliases
+exist only for routes predating #1691):
+
+- `POST /internal/events` — the backend records scan flags
+- `GET /internal/overrides` — for the projection
+- `GET /internal/events-since?after_id=&limit=` — publisher cursor walk
+- `GET /internal/events-head` — start a cursor at "now" instead of replaying
+
+operator surface:
+
+- `GET /admin/queue`
+- `POST /admin/events`
+- `POST /admin/subject-events` — full history for one subject
+
+## transparency publishing
+
+`publish_moderation_decisions` (backend, every 2 min) walks the log from a redis
+cursor and posts publishable decisions to
+[@moderation.plyr.fm](https://bsky.app/profile/moderation.plyr.fm). It lives in
+the backend because the Bluesky session already does, and reading the log on a
+timer keeps the dependency pointing one way.
+
+two properties matter more than throughput:
+
+- **it cannot backfill.** On first run the cursor initialises to the log's head.
+  Announcing decisions from months ago because a publisher shipped today is the
+  same mistake as DMing uploaders about old flags.
+- **it is off unless enabled.** `NOTIFY_PUBLISH_MODERATION_DECISIONS`, set on
+  `relay-api` only — staging shares the Bluesky account. When off the task still
+  runs and logs each rendered post, which is how the pipeline gets verified
+  before anything reaches the timeline.
+
+a failed post stops the batch rather than advancing past an announcement that
+never happened. Posts carry `app.bsky.richtext.facet` link facets; a URL in post
+text is not a link without one.

--- a/docs/internal/moderation/overview.md
+++ b/docs/internal/moderation/overview.md
@@ -106,14 +106,21 @@ Both map to the adult-audio preference and default-hide policy. Negation
 creators own self-label assertions in their track records, the moderation
 service owns signed operator assertions, and the backend owns policy:
 
-1. fetch current active values with `POST /internal/labels`
+1. project active values onto `tracks.operator_labels` (`sync_operator_labels`,
+   refreshed immediately by the `subscribeLabels` consumer)
 2. filter adult-labeled tracks from default discovery and collection surfaces
-3. require authenticated opt-in at the audio byte endpoint
-4. always exclude adult audio from shared radio
+   unless the viewer opted in or owns the track
+3. filter copyright-labeled tracks from those surfaces for everyone — no
+   preference, no owner exemption
+4. always exclude both from shared radio
 
-the byte endpoint checks labels strictly and returns `503` when the labeler is
-unavailable. Discovery fails open on a labeler outage; authorization fails
-closed.
+**labels do not gate audio bytes.** Neither family does. The adult gate was
+removed because it read as age verification without being one, and copyright
+de-lists rather than blocks because a fingerprint match is not a finding. That
+also removed a strict labeler read, and its `503`, from every audio request.
+
+see [label policy](label-policy.md) for who decides what, and why the two
+families differ.
 
 ## key technical details
 
@@ -127,20 +134,43 @@ the meaningful signal is **dominant match percentage**: what fraction of audio s
 
 the Rust service flags a track when `dominant_match_pct >= MODERATION_COPYRIGHT_SCORE_THRESHOLD` (default: 30%).
 
-**known issue**: `fly.toml` sets `MODERATION_SCORE_THRESHOLD=70` but the Rust code reads `MODERATION_COPYRIGHT_SCORE_THRESHOLD` — different env var name. the threshold has been the default 30% all along, not the intended 70%.
+the env var name mismatch that once made this silently 30% is fixed —
+`fly.toml` and `config.rs` both use `MODERATION_COPYRIGHT_SCORE_THRESHOLD`, so
+production runs at the intended 70%.
 
-### admin dashboard
+a mix of several copyrighted songs trips a separate check
+(`MODERATION_COPYRIGHT_MIX_SONG_THRESHOLD`, #1689): no single song dominates a
+DJ mix, so the per-song percentage stays low while the count of sustained
+distinct songs is the signal.
 
-the admin dashboard lives on the Rust moderation service itself (option B from the original design discussion). it's an htmx UI at `/admin` that:
+### the review queue
 
-- lists flagged tracks with match details
-- shows track title, artist, environment badge, match count
-- allows resolving false positives (emits negation label)
-- supports batch review workflows
+the dashboard's primary tab reads the **moderation event log**, not labels. it
+previously read active labels, which meant scan flags were structurally
+invisible: post-#703 a scan never emits a label, so the queue rendered empty
+while flagged tracks accumulated. see [event log](event-log.md).
 
-### DM notifications
+each queue item embeds `plyr.fm/embed/track/{id}` so a copyright call is made by
+listening. Decisions — acknowledge, allow anyway, keep de-listed — post back to
+the event log and require an `acting as` handle.
 
-when a scan flags a track, the backend sends a DM to the admin via ATProto notifications (`notification_service.send_copyright_flag_notification`). this includes track title, artist handle, and match details. the DM is informational — it prompts the admin to review in the dashboard.
+### decisions and overrides
+
+negating a label says the assertion was wrong. An **override** says the
+assertion stands and we are surfacing the track anyway, which is the usual
+outcome for a cover or a remix. Those are different statements and both are
+recorded.
+
+### notifications
+
+when a scan flags a track the backend DMs the operator
+(`notification_service.send_copyright_flag_notification`) and opens a review
+item. **uploaders are never notified automatically** — and any future
+notification must fire on new events only, never on a backfill.
+
+decisions that change what the public can see are published to
+[@moderation.plyr.fm](https://bsky.app/profile/moderation.plyr.fm); flags and
+reports are not. see [label policy](label-policy.md).
 
 ## related documentation
 

--- a/docs/internal/runbooks/moderating-sensitive-audio.md
+++ b/docs/internal/runbooks/moderating-sensitive-audio.md
@@ -3,9 +3,17 @@ title: "moderating sensitive audio"
 ---
 
 use this runbook when an operator confirms that a track contains sexual or
-pornographic audio and it must be hidden from default and anonymous playback.
-The durable action is a signed ATProto label. `visibility = 'unlisted'` is not a
-moderation state and must not be the final fix.
+pornographic audio and must be hidden from default surfaces. The durable action
+is a signed ATProto label. `visibility = 'unlisted'` is not a moderation state
+and must not be the final fix.
+
+**adult labels do not block playback.** They keep a track out of discovery,
+search, collections, and radio unless a signed-in listener opted in. A direct
+link still plays, for anyone. Requiring an account to press play looked like an
+age check but was not — any account satisfied it — while breaking a creator's
+ability to share their own work. See
+[label policy](/moderation/label-policy/). If you need a track to stop being
+reachable at all, that is a takedown, not a label.
 
 ## 1. prove access first
 
@@ -78,19 +86,24 @@ the response must contain a sequence number, the expected URI/CID/value, and
 the plyr.fm labeler DID. Never log the signature or authorization header in an
 incident note.
 
-## 5. invalidate cached empty-label results
+## 5. cache invalidation happens on its own
 
-the backend caches complete active-label sets, including an empty set, for five
-minutes. Discovery, album, and radio responses also have caches. In an urgent
-moderation action, invalidate them instead of waiting for TTL expiry:
+**no manual Redis purge.** The backend subscribes to the labeler's
+`subscribeLabels` stream and refreshes both the label cache and the
+`tracks.operator_labels` projection as each label commits — measured at under a
+second, versus the five-minute TTL it used to wait out. See
+`backend/_internal/label_stream.py`.
+
+if enforcement has not taken effect after a minute, check that the subscriber is
+connected before reaching for anything manual:
 
 ```bash
-fly ssh console -a relay-api -g app -C \
-  "uv run --no-sync python -c \"import os, redis; r=redis.Redis.from_url(os.environ['REDIS_URL']); keys=['plyr:copyright-label:values:$URI','plyr:copyright-label:$URI','plyr:tracks:discovery:v2']; keys += list(r.scan_iter(match='plyr:radio:rotation:v2:*')); keys += list(r.scan_iter(match='plyr:album:v2:*')); print({'deleted': r.delete(*keys), 'targeted': len(keys)})\""
+# expect a recent "label stream connected" for the environment in question
 ```
 
-the historical `plyr:copyright-label:` prefix now stores generic label values;
-the name is legacy, not evidence that only copyright is cached.
+query Logfire for `message ILIKE '%label stream%'`. A disconnected subscriber
+falls back to the five-minute `sync_operator_labels` pass, so the effect still
+lands; it is late, not lost.
 
 ## 6. verify the assertion and policy
 
@@ -106,13 +119,12 @@ curl -fsS -G \
 then verify product enforcement:
 
 ```bash
-# direct metadata remains public but carries the label and protected audio URL
+# direct metadata remains public and carries the label
 curl -fsS "https://api.plyr.fm/tracks/$TRACK_ID" \
-  | jq '{id, visibility, unlisted, labels, r2_url}'
+  | jq '{id, visibility, unlisted, labels}'
 
-# signed-out playback must be denied and identify the policy label
-curl -sS -D - -o /dev/null "https://api.plyr.fm/audio/$FILE_ID" \
-  | rg -i '^(HTTP/|x-content-labels:)'
+# the permalink must still play — a label is not an access control
+curl -sS -o /dev/null -w '%{http_code}\n' "https://api.plyr.fm/audio/$FILE_ID"
 
 # the track must not be in anonymous discovery or fresh radio
 curl -fsS 'https://api.plyr.fm/tracks/?limit=100' \
@@ -125,7 +137,8 @@ expected results:
 
 - track metadata: `visibility: "public"`, `unlisted: false`, and the label in
   `labels`
-- audio: `401` plus `X-Content-Labels` for a signed-out request
+- audio: `307` — the permalink still resolves. A `401` here would mean the
+  byte-level gate was reintroduced, which is a regression, not enforcement
 - discovery and radio: empty arrays
 
 also search for the title/creator when the incident began in search, an album,
@@ -146,7 +159,33 @@ curl -fsS -X POST https://moderation.plyr.fm/emit-label \
     '{uri: $uri, cid: $cid, val: $val, neg: true}')"
 ```
 
-repeat cache invalidation and verification after the negation.
+verify after the negation the same way. Negation clears through the same
+subscriber, so again there is nothing to purge by hand.
+
+**negating is not the only correction.** A negation says the assertion was
+wrong. If the label is right but the track should stay up anyway — a cover, a
+licensed remix — record an `override_allow` decision instead, which keeps the
+assertion honest and still surfaces the track. See
+[label policy](/moderation/label-policy/).
+
+## record the decision
+
+every action belongs in the moderation event log, which is the review queue,
+the audit trail, and the input to the public transparency post. Emitting a
+label alone leaves no record of *who* decided or *why*:
+
+```bash
+curl -fsS -X POST https://moderation.plyr.fm/admin/events \
+  -H "X-Moderation-Key: $MODERATION_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data "$(jq -cn --arg uri "$URI" --argjson tid "$TRACK_ID" \
+    '{subject_uri: $uri, subject_track_id: $tid, action: "label_applied",
+      actor: "your.handle", reason: "adult_audio", notes: "..."}')"
+```
+
+`actor` is required. In practice use the dashboard at
+`https://moderation.plyr.fm/admin`, which records this for you and plays the
+track so a call can be made by listening.
 
 ## emergency visibility changes
 

--- a/docs/internal/tools/agent-access.md
+++ b/docs/internal/tools/agent-access.md
@@ -78,6 +78,17 @@ for the required variable by name without printing its value. If
 `MODERATION_AUTH_TOKEN` is unavailable for an operator action, stop and request
 that capability instead of trying unrelated credentials.
 
+`MODERATION_AUTH_TOKEN` is a single shared key: it authorises, but it does not
+identify. Every write to the moderation event log therefore carries an `actor`
+you supply, which is attribution rather than authentication — a claim about who
+acted, only as trustworthy as the key. Use a name that says what you are
+(`service:copyright-scan`, a handle, `verification:...`), never a generic one.
+
+`NOTIFY_PUBLISH_MODERATION_DECISIONS` on `relay-api` makes moderation decisions
+post publicly from the moderation account. It is deliberately absent on
+`relay-api-staging`, which shares that Bluesky account — setting it there would
+post about test data.
+
 ## production deployment choices
 
 - backend or migration changes: `just release`

--- a/docs/public/artists.md
+++ b/docs/public/artists.md
@@ -46,9 +46,11 @@ if a track contains adult or sexual audio, enable **contains adult or sexual
 audio** when uploading it. You can change the notice later in the track editor.
 
 the notice is stored with your track in your ATProto repository. On plyr.fm,
-noticed tracks are hidden from discovery and cannot be played by anonymous
-listeners. Signed-in listeners must explicitly enable sensitive audio in their
-settings. You can still see and manage your own noticed tracks.
+noticed tracks are hidden from discovery unless a signed-in listener has
+enabled sensitive audio in their settings. **A direct link to the track still
+plays for anyone** — the notice changes where your track appears, not whether
+someone you share it with can hear it. You can still see and manage your own
+noticed tracks.
 
 removing your notice removes only your own assertion. If a plyr.fm moderator
 independently labeled the track, that operator label and its default-hide policy

--- a/docs/public/moderation.md
+++ b/docs/public/moderation.md
@@ -1,0 +1,91 @@
+---
+title: "moderation"
+description: "what plyr.fm labels, what a label actually does, and how to appeal one"
+---
+
+plyr.fm publishes moderation decisions from
+[@moderation.plyr.fm](https://bsky.app/profile/moderation.plyr.fm). This page
+explains what those decisions mean.
+
+## labels are assertions, not deletions
+
+a label is a signed, public statement about a track — anyone can read them
+through the AT Protocol
+[`com.atproto.label.queryLabels`](https://docs.bsky.app/docs/api/com-atproto-label-query-labels)
+endpoint, and any client can subscribe to plyr.fm's labeler and decide for
+itself what to do with them.
+
+what *we* do with a label on our own surfaces is a separate thing, and it is
+only binding on us. Another client reading the same label is free to render it
+differently.
+
+## two kinds of label, two different rules
+
+the difference is who gets to decide.
+
+### adult audio — `sexual`, `porn`
+
+a rendering default that **you** control. These are
+[standard AT Protocol values](https://github.com/bluesky-social/atproto/blob/main/packages/api/definitions/labels.json),
+not plyr.fm inventions.
+
+- hidden from discovery, search, recommendations, collections, queues, and
+  Subsonic browsing unless you enable **sensitive audio** in settings
+- never in shared radio, for anyone — radio is one synchronized stream, so no
+  single listener's preference can decide what everyone else hears
+- **a direct link plays for anyone**
+
+see [sensitive content](/sensitive-content) for the settings.
+
+### copyright — `copyright-violation`
+
+not a preference. plyr.fm stores and serves the audio, so acting on a credible
+copyright claim is our responsibility and no listener setting can waive it.
+
+- removed from discovery and radio for everyone
+- **a direct link still plays.** A fingerprint match is not a finding — covers,
+  remixes, and an artist's own catalogue all match — so being flagged does not
+  break the uploader's own link
+- removal from plyr.fm is a separate, deliberate decision made by a person
+
+## what gets published, and what does not
+
+the moderation account posts **actions we took**, never suspicions we hold.
+
+published:
+
+- a track removed
+- a track removed from discovery and radio
+- a label applied
+- a label withdrawn
+
+not published:
+
+- a track being flagged by our copyright scanner
+- a user report being filed
+- a review that concluded no action was needed
+
+the reason is the same in each case: announcing that something *might* be a
+problem, before anyone has decided whether it is, marks an uploader for
+something that may well turn out to be their own work. Posts never name the
+uploader and never mention a reporter.
+
+## if you think a decision is wrong
+
+use the report control on the track, or email
+[plyrdotfm@proton.me](mailto:plyrdotfm@proton.me).
+
+decisions are reversible and reversal is recorded the same way the original
+decision was. Two things can happen when we are wrong, and they mean different
+things:
+
+- **the label is withdrawn** — the assertion itself was mistaken
+- **the label stands and the track is surfaced anyway** — the match was real
+  but not a violation, which is the usual outcome for a cover or a remix
+
+## federation
+
+plyr.fm can remove a track from plyr.fm. It cannot remove it from other AT
+Protocol services that may have copies, and it does not delete anything from
+your own repository. Labels we publish travel to whoever subscribes to our
+labeler; what those services do with them is their decision, not ours.

--- a/docs/public/sensitive-content.md
+++ b/docs/public/sensitive-content.md
@@ -37,10 +37,14 @@ when a creator self-labels a track or a trusted labeler applies either value:
 
 - it is omitted from discovery, search, recommendations, public collections,
   queues, Subsonic browsing, and shared radio by default
-- a direct link can still explain that the track exists, but playback requires
-  a signed-in listener who enabled **sensitive audio**
-- signed-out audio requests are rejected
+- **a direct link still plays, for anyone.** The label changes where a track
+  appears, not whether it can be reached
 - the creator can always see and play their own track
+
+signing in and enabling **sensitive audio** changes what you are *shown*. It has
+never been an age check — any account satisfied it, and plyr.fm does not verify
+anyone's age — so requiring one to press play cost creators the ability to share
+their own work with a signed-out listener and bought nothing in return.
 
 shared radio excludes adult-labeled tracks for everyone, including listeners
 who opted in. Radio is a public, synchronized surface where one listener's
@@ -59,16 +63,14 @@ if a track is labeled incorrectly, use the report control while viewing it or co
 ## for developers
 
 track responses include creator provenance in `self_labels`, active plyr.fm
-moderation provenance in `operator_labels` on creator-owned track listings,
-and the effective union in `labels`. For adult-labeled tracks, the audio URL points at plyr.fm's
-protected `/audio/{file_id}` endpoint instead of a public CDN URL. Clients must
-not cache or bypass that endpoint.
+moderation provenance in `operator_labels` on creator-owned track listings, and
+the effective union in `labels`.
 
-the endpoint returns:
+labels do not gate `/audio/{file_id}`. A client that wants to warn before
+playing should read the labels from the track response and decide for itself —
+which is the point: the assertion is published, and what to do about it is
+yours to choose.
 
-- `401` for a signed-out request
-- `403` for a signed-in listener who has not opted in
-- `503` when the content-safety service is unavailable and access cannot be
-  checked safely
-
-denied responses include `X-Content-Labels` with the active policy label.
+listing endpoints apply plyr.fm's own default (hide unless the viewer opted in
+or owns the track). That default is ours, not the network's; other clients
+reading the same labels are free to render them differently.

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -16,6 +16,7 @@ export default defineConfig({
         { slug: "listeners" },
         { slug: "artists" },
         { slug: "sensitive-content" },
+        { slug: "moderation" },
         {
           label: "developers",
           items: [


### PR DESCRIPTION
A pass over public docs, internal docs, and harness memory for anything the moderation arc invalidated. The public page was actively wrong about how playback works.

<details>
<summary>public: sensitive-content.md was telling listeners the opposite of the truth</summary>

It still said adult-labeled audio "cannot be played by anonymous listeners", that "signed-out audio requests are rejected", and documented the endpoint as returning `401` / `403` / `503` with an `X-Content-Labels` header.

None of that has been true since #1697. A direct link plays for anyone, and `/audio/{file_id}` doesn't consult labels at all. Corrected, with the reasoning stated plainly: requiring an account looked like an age check but wasn't one — any account satisfied it — so it cost creators the ability to share their own work and bought nothing.

`artists.md` had the same claim in the upload-notice section.
</details>

<details>
<summary>public: new moderation policy page</summary>

`docs.plyr.fm/moderation`. Every transparency post carries a policy link, and it was pointing at the sensitive-content guide — which covers only the adult half and says nothing about copyright de-listing, i.e. the thing most posts will be about.

Covers: labels as portable assertions vs. our local enforcement; the two families and who decides in each; **what gets published and what doesn't**, with the reasoning (announcing a flag marks an uploader for something that may turn out to be their own work); and appeals — including that a *withdrawn label* and a *standing label with an override* mean different things. Posts now link here.
</details>

<details>
<summary>internal: the runbook taught a workflow that no longer exists</summary>

`moderating-sensitive-audio.md` had operators purging Redis by hand via a `fly ssh` one-liner. The subscribeLabels consumer does that automatically now — the step is replaced with how to confirm the subscriber is connected, and the note that a disconnected one degrades to the 5-minute reconciliation (late, not lost).

Its verification step also expected `401` on the permalink. That would now be a **regression**, not enforcement, so it expects `307` and says so. Added a step for recording the decision in the event log, since emitting a label alone leaves no record of who decided or why.
</details>

<details>
<summary>internal: docs predating the event log</summary>

- new `moderation/event-log.md` — actions, derived queue/override state, endpoints, transparency publishing, and why attribution isn't authentication
- `overview.md` — enforcement steps corrected (no byte gate, copyright de-lists for everyone); dashboard section rewritten around the queue
- `atproto-labeler.md` — the subscriber's original rationale is now historical; what it actually does is refresh the projection, which is what the SQL filters read
- `agent-access.md` — the shared key authorises but does not identify, hence `actor`; plus the prod-only publishing flag
</details>

<details>
<summary>a stale "known issue" that was fixed</summary>

`overview.md` warned that `fly.toml` set `MODERATION_SCORE_THRESHOLD` while the Rust read `MODERATION_COPYRIGHT_SCORE_THRESHOLD`, so "the threshold has been the default 30% all along". Both now use the same name — verified in `config.rs` and `fly.toml` — so production really runs at 70%. Replaced with a note on the separate mix threshold from #1689.
</details>

<details>
<summary>harness memory</summary>

Two stored facts had become wrong and would have misled me later:

- **operator-label projection** said "auth paths still query labeler live" and "never read the projection for authorization" — there is no label-based authorization at all now. Rewritten around the assertion/enforcement split, with the NULL-override trap recorded.
- **copyright self-match** still described `sync_copyright_resolutions` as an unfixed bug with the lesson "never trust `is_flagged`". Fixed in #1615; noted the new corollary that negating a label clears its flag, which is why bulk retraction needs a worklist snapshot first.

Added one for the event log. Docs site builds; 1336 tests pass.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)