### PR TITLE
fix(artists): an artist page shows their whole catalogue

### DIFF
--- a/backend/src/backend/_internal/content_labels.py
+++ b/backend/src/backend/_internal/content_labels.py
@@ -6,6 +6,7 @@ behavior; classifier evidence and moderation workflow state do not belong here.
 """
 
 from collections.abc import Iterable
+from enum import StrEnum
 
 from sqlalchemy import ColumnElement, select
 from sqlalchemy.dialects.postgresql import array
@@ -81,41 +82,60 @@ def copyright_visible_clause() -> ColumnElement[bool]:
     return ~_labeled_with(COPYRIGHT_LABELS)
 
 
-def discovery_visible_clause(
-    viewer_did: str | None, *, shows_sensitive_audio: bool
-) -> ColumnElement[bool]:
-    """SQL predicate for any shared surface: feeds, search, radio, collections.
+class LabelContext(StrEnum):
+    """Where a track is being rendered.
 
-    Composes both label families so callers cannot accidentally apply one and
-    not the other. The previous shape — skip the adult clause entirely when the
-    viewer opted in — would have leaked copyright-labeled tracks to exactly
-    those viewers, because the whole predicate was dropped rather than the
-    adult half of it.
-
-    A standing operator override wins over the copyright half. `exclude` hides
-    a track with no label needed; `allow` surfaces one whose copyright label we
-    reviewed and decided not to act on — a cover, say — without having to negate
-    the label and thereby claim the match never happened.
-
-    `allow` deliberately does not override the adult half. That is a listener
-    preference, and an operator deciding what someone else may be shown is a
-    different power than deciding what we host.
+    Mirrors ATProto's moderation contexts, where the same content is filtered
+    from a feed (`contentList`) but shown when opened directly (`contentView`).
+    Bluesky's client makes this distinction per render; we make it per query,
+    because our filtering has to live in SQL to compose with cursor pagination
+    (#1676).
     """
-    labels_ok = copyright_visible_clause()
-    if not shows_sensitive_audio:
-        labels_ok = labels_ok & sensitive_audio_visible_clause(viewer_did)
 
+    #: a surface where we choose what to put in front of someone — feeds,
+    #: search, radio, recommendations
+    LIST = "list"
+    #: a page someone navigated to — an artist's catalogue, a collection.
+    #: They already found it; hiding part of it misrepresents what is there.
+    VIEW = "view"
+
+
+def label_visible_clause(
+    viewer_did: str | None,
+    *,
+    shows_sensitive_audio: bool,
+    context: LabelContext = LabelContext.LIST,
+) -> ColumnElement[bool]:
+    """SQL predicate for showing a track, given where it is being shown.
+
+    Composes both label families and the operator override in one place so a
+    caller cannot apply one and not the others. An earlier shape skipped the
+    whole predicate for viewers who opted into sensitive audio, which would
+    have leaked copyright-labeled tracks to exactly those viewers.
+
+    `exclude` hides a track with no label needed. `allow` surfaces one whose
+    copyright label we reviewed and decided not to act on — a cover, say —
+    without negating the label and thereby claiming the match never happened.
+    `allow` deliberately does not lift the adult half: that is a listener
+    preference, and an operator deciding what someone else may be *shown* is a
+    different power from deciding what we *host*.
+    """
     # NULL-safe: the column is null for almost every track, and `NOT (NULL =
     # 'exclude')` is NULL, which a WHERE clause drops. That would have hidden
     # the entire catalogue.
     allowed = Track.moderation_override.is_not_distinct_from("allow")
     not_excluded = Track.moderation_override.is_distinct_from("exclude")
 
-    if shows_sensitive_audio:
-        return not_excluded & (allowed | labels_ok)
-    return not_excluded & (
-        (allowed & sensitive_audio_visible_clause(viewer_did)) | labels_ok
-    )
+    # copyright is a hosting obligation, so it applies in every context and
+    # only an explicit operator decision lifts it
+    visible = allowed | copyright_visible_clause()
+
+    # adult labels are a rendering default, so they apply only where we are
+    # choosing what to surface
+    if context is LabelContext.LIST and not shows_sensitive_audio:
+        visible = visible & sensitive_audio_visible_clause(viewer_did)
+
+    return not_excluded & visible
 
 
 async def get_operator_label_values(

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import selectinload
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session, get_supported_artists, require_auth
 from backend._internal.content_labels import (
+    copyright_visible_clause,
     discovery_visible_clause,
     filter_sensitive_audio_tracks,
     get_operator_label_values,
@@ -180,15 +181,29 @@ async def list_tracks(
 
     # label visibility lives in SQL (self labels + projected operator labels),
     # so filtering composes with cursor pagination instead of corrupting it
-    # (#1676 regression: app-side filtering broke has_more). Always applied:
-    # the copyright half honours no preference, so this must not be skipped
-    # for viewers who opted into sensitive audio.
-    stmt = stmt.where(
-        discovery_visible_clause(
-            session.did if session else None,
-            shows_sensitive_audio=shows_sensitive_audio,
+    # (#1676 regression: app-side filtering broke has_more).
+    #
+    # An artist-scoped listing is a *destination*, not discovery: you are on
+    # someone's page because you already found them. Filtering it makes an
+    # artist's own page misrepresent their catalogue, and it disagreed with the
+    # album page one level deeper, which shows everything. Adult labels govern
+    # where a track surfaces, not whether you can see what you navigated to --
+    # the same reason a labeled track's permalink plays.
+    #
+    # Copyright still applies here. That is a hosting obligation rather than a
+    # rendering default, so no amount of "I already found this artist" changes
+    # it, and neither does a listener preference.
+    if artist_did:
+        stmt = stmt.where(copyright_visible_clause()).where(
+            Track.moderation_override.is_distinct_from("exclude")
         )
-    )
+    else:
+        stmt = stmt.where(
+            discovery_visible_clause(
+                session.did if session else None,
+                shows_sensitive_audio=shows_sensitive_audio,
+            )
+        )
 
     # apply cursor-based pagination (tracks older than cursor timestamp)
     if cursor:

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -16,11 +16,11 @@ from sqlalchemy.orm import selectinload
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session, get_supported_artists, require_auth
 from backend._internal.content_labels import (
-    copyright_visible_clause,
-    discovery_visible_clause,
+    LabelContext,
     filter_sensitive_audio_tracks,
     get_operator_label_values,
     get_track_label_values,
+    label_visible_clause,
 )
 from backend.config import settings
 from backend.models import (
@@ -179,31 +179,17 @@ async def list_tracks(
         )
         stmt = stmt.where(include_exists)
 
-    # label visibility lives in SQL (self labels + projected operator labels),
-    # so filtering composes with cursor pagination instead of corrupting it
-    # (#1676 regression: app-side filtering broke has_more).
-    #
-    # An artist-scoped listing is a *destination*, not discovery: you are on
-    # someone's page because you already found them. Filtering it makes an
-    # artist's own page misrepresent their catalogue, and it disagreed with the
-    # album page one level deeper, which shows everything. Adult labels govern
-    # where a track surfaces, not whether you can see what you navigated to --
-    # the same reason a labeled track's permalink plays.
-    #
-    # Copyright still applies here. That is a hosting obligation rather than a
-    # rendering default, so no amount of "I already found this artist" changes
-    # it, and neither does a listener preference.
-    if artist_did:
-        stmt = stmt.where(copyright_visible_clause()).where(
-            Track.moderation_override.is_distinct_from("exclude")
+    # label visibility lives in SQL so filtering composes with cursor
+    # pagination instead of corrupting it (#1676: app-side filtering broke
+    # has_more). An artist-scoped listing is a page someone navigated to, not a
+    # surface we chose to put in front of them.
+    stmt = stmt.where(
+        label_visible_clause(
+            session.did if session else None,
+            shows_sensitive_audio=shows_sensitive_audio,
+            context=LabelContext.VIEW if artist_did else LabelContext.LIST,
         )
-    else:
-        stmt = stmt.where(
-            discovery_visible_clause(
-                session.did if session else None,
-                shows_sensitive_audio=shows_sensitive_audio,
-            )
-        )
+    )
 
     # apply cursor-based pagination (tracks older than cursor timestamp)
     if cursor:

--- a/backend/tests/test_content_label_policy.py
+++ b/backend/tests/test_content_label_policy.py
@@ -9,19 +9,38 @@ They differ in *who decides*, and that is the whole design:
 Neither gates the audio bytes. See `docs/internal/moderation/label-policy.md`.
 """
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal.content_labels import (
     COPYRIGHT_LABELS,
     PROJECTED_LABEL_VALUES,
+    LabelContext,
     filter_sensitive_audio_tracks_for_viewer,
     has_copyright_label,
+    label_visible_clause,
     may_stream_sensitive_audio,
 )
 from backend.models import Artist, Track, UserPreferences
 
 OWNER = "did:plc:owner"
 VIEWER = "did:plc:viewer"
+
+
+async def _visible(
+    db: AsyncSession, context: LabelContext, *, shows_sensitive: bool
+) -> set[int]:
+    """Track ids the SQL predicate admits for this artist in this context."""
+    rows = await db.execute(
+        select(Track)
+        .where(Track.artist_did == OWNER)
+        .where(
+            label_visible_clause(
+                VIEWER, shows_sensitive_audio=shows_sensitive, context=context
+            )
+        )
+    )
+    return {track.id for track in rows.scalars().all()}
 
 
 async def _track(
@@ -181,77 +200,62 @@ async def test_override_allow_does_not_override_a_listeners_adult_preference(
     assert visible == []
 
 
-async def test_artist_scoped_listing_is_a_destination_not_discovery(
+async def test_view_context_shows_the_whole_catalogue(
     db_session: AsyncSession,
 ) -> None:
-    """An artist's own page shows their whole catalogue.
+    """A page someone navigated to shows what is on it.
 
-    You are on someone's page because you already found them, so hiding their
-    adult-labeled tracks there makes the page misrepresent the catalogue — and
-    it disagreed with the album page one level deeper, which shows everything.
-    Regression for the artist page rendering "4 tracks" above a list of one.
+    Mirrors ATProto's contentList/contentView split: filtered from a feed,
+    shown when opened directly. Regression for the artist page rendering
+    "4 tracks" above a list of one.
     """
-    from sqlalchemy import select
-
-    from backend._internal.content_labels import (
-        copyright_visible_clause,
-        sensitive_audio_visible_clause,
-    )
-
     labeled = await _track(db_session, file_id="dest1", operator_labels=["sexual"])
     plain = await _track(db_session, file_id="dest2")
     await db_session.commit()
 
-    # what the artist page now asks for: copyright only, no viewer preference
-    rows = (
-        (
-            await db_session.execute(
-                select(Track)
-                .where(Track.artist_did == OWNER)
-                .where(copyright_visible_clause())
-            )
-        )
-        .scalars()
-        .all()
-    )
-    assert {t.id for t in rows} == {labeled.id, plain.id}
-
-    # a discovery surface still hides it from a viewer who has not opted in
-    discovery = (
-        (
-            await db_session.execute(
-                select(Track)
-                .where(Track.artist_did == OWNER)
-                .where(sensitive_audio_visible_clause(VIEWER))
-            )
-        )
-        .scalars()
-        .all()
-    )
-    assert {t.id for t in discovery} == {plain.id}
+    assert await _visible(db_session, LabelContext.VIEW, shows_sensitive=False) == {
+        labeled.id,
+        plain.id,
+    }
 
 
-async def test_copyright_still_hides_on_an_artist_page(
+async def test_list_context_still_hides_adult_from_a_viewer_who_opted_out(
     db_session: AsyncSession,
 ) -> None:
-    """ "I already found this artist" does not discharge a hosting obligation."""
-    from sqlalchemy import select
-
-    from backend._internal.content_labels import copyright_visible_clause
-
-    await _track(db_session, file_id="dest3", operator_labels=["copyright-violation"])
+    labeled = await _track(db_session, file_id="dest3", operator_labels=["sexual"])
     plain = await _track(db_session, file_id="dest4")
     await db_session.commit()
 
-    rows = (
-        (
-            await db_session.execute(
-                select(Track)
-                .where(Track.artist_did == OWNER)
-                .where(copyright_visible_clause())
-            )
-        )
-        .scalars()
-        .all()
-    )
-    assert {t.id for t in rows} == {plain.id}
+    assert await _visible(db_session, LabelContext.LIST, shows_sensitive=False) == {
+        plain.id
+    }
+    assert await _visible(db_session, LabelContext.LIST, shows_sensitive=True) == {
+        labeled.id,
+        plain.id,
+    }
+
+
+async def test_copyright_hides_in_every_context(db_session: AsyncSession) -> None:
+    """ "I already found this artist" does not discharge a hosting obligation."""
+    await _track(db_session, file_id="dest5", operator_labels=["copyright-violation"])
+    plain = await _track(db_session, file_id="dest6")
+    await db_session.commit()
+
+    for context in (LabelContext.LIST, LabelContext.VIEW):
+        assert await _visible(db_session, context, shows_sensitive=True) == {
+            plain.id
+        }, context
+
+
+async def test_exclude_override_hides_in_every_context(
+    db_session: AsyncSession,
+) -> None:
+    hidden = await _track(db_session, file_id="dest7")
+    hidden.moderation_override = "exclude"
+    plain = await _track(db_session, file_id="dest8")
+    await db_session.commit()
+
+    for context in (LabelContext.LIST, LabelContext.VIEW):
+        assert await _visible(db_session, context, shows_sensitive=True) == {
+            plain.id
+        }, context

--- a/backend/tests/test_content_label_policy.py
+++ b/backend/tests/test_content_label_policy.py
@@ -179,3 +179,79 @@ async def test_override_allow_does_not_override_a_listeners_adult_preference(
         db_session, [adult], VIEWER
     )
     assert visible == []
+
+
+async def test_artist_scoped_listing_is_a_destination_not_discovery(
+    db_session: AsyncSession,
+) -> None:
+    """An artist's own page shows their whole catalogue.
+
+    You are on someone's page because you already found them, so hiding their
+    adult-labeled tracks there makes the page misrepresent the catalogue — and
+    it disagreed with the album page one level deeper, which shows everything.
+    Regression for the artist page rendering "4 tracks" above a list of one.
+    """
+    from sqlalchemy import select
+
+    from backend._internal.content_labels import (
+        copyright_visible_clause,
+        sensitive_audio_visible_clause,
+    )
+
+    labeled = await _track(db_session, file_id="dest1", operator_labels=["sexual"])
+    plain = await _track(db_session, file_id="dest2")
+    await db_session.commit()
+
+    # what the artist page now asks for: copyright only, no viewer preference
+    rows = (
+        (
+            await db_session.execute(
+                select(Track)
+                .where(Track.artist_did == OWNER)
+                .where(copyright_visible_clause())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {t.id for t in rows} == {labeled.id, plain.id}
+
+    # a discovery surface still hides it from a viewer who has not opted in
+    discovery = (
+        (
+            await db_session.execute(
+                select(Track)
+                .where(Track.artist_did == OWNER)
+                .where(sensitive_audio_visible_clause(VIEWER))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {t.id for t in discovery} == {plain.id}
+
+
+async def test_copyright_still_hides_on_an_artist_page(
+    db_session: AsyncSession,
+) -> None:
+    """ "I already found this artist" does not discharge a hosting obligation."""
+    from sqlalchemy import select
+
+    from backend._internal.content_labels import copyright_visible_clause
+
+    await _track(db_session, file_id="dest3", operator_labels=["copyright-violation"])
+    plain = await _track(db_session, file_id="dest4")
+    await db_session.commit()
+
+    rows = (
+        (
+            await db_session.execute(
+                select(Track)
+                .where(Track.artist_did == OWNER)
+                .where(copyright_visible_clause())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {t.id for t in rows} == {plain.id}

--- a/docs/internal/moderation/label-policy.md
+++ b/docs/internal/moderation/label-policy.md
@@ -57,11 +57,30 @@ automated fingerprint match is neither.
 Removing the gate also deleted a strict labeler read — and its `503` failure
 mode — from every audio request.
 
+## context: where a track is being rendered
+
+Filtering depends on *where* a track appears, not only what it carries.
+`LabelContext.LIST` is a surface we chose to put in front of someone — feeds,
+search, radio, recommendations. `LabelContext.VIEW` is a page they navigated
+to: an artist's catalogue, a collection.
+
+this mirrors ATProto's own moderation contexts, where the same content is
+filtered from a feed (`contentList`) but shown when opened directly
+(`contentView`). Bluesky's client makes that call per render; we make it per
+query, because our filtering has to live in SQL to compose with cursor
+pagination (#1676).
+
+adult labels apply only in `LIST`. Filtering an artist's own page made it
+misrepresent their catalogue — it rendered "4 tracks" above a list of one —
+and disagreed with the album page one level deeper, which showed everything.
+Copyright applies in **every** context: a hosting obligation is not discharged
+by the listener having already found the artist.
+
 ## composing the SQL predicate
 
-`discovery_visible_clause()` composes both families and every shared surface
-uses it. The previous shape skipped the visibility predicate *entirely* for
-viewers who had opted into sensitive audio:
+`label_visible_clause()` composes both families, the override, and the context,
+and every shared surface uses it. An earlier shape skipped the visibility
+predicate *entirely* for viewers who had opted into sensitive audio:
 
 ```python
 if not shows_sensitive_audio:

--- a/frontend/src/routes/u/[handle]/+page.server.ts
+++ b/frontend/src/routes/u/[handle]/+page.server.ts
@@ -19,7 +19,13 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 
 		const artist: Artist = await artistResponse.json();
 
-		// fetch artist's tracks server-side (no cookie available on frontend host)
+		// The session cookie is host-only on the API origin, so the browser never
+		// sends it here and there is nothing to forward -- #284 tried exactly that
+		// and abandoned it. This render is therefore always the anonymous view.
+		//
+		// That is fine now only because an artist-scoped listing no longer filters
+		// on viewer preference: SSR and the hydrated client agree, so there is no
+		// flash of a shorter list.
 		const tracksResponse = await fetch(`${API_URL}/tracks/?artist_did=${artist.did}&limit=5`);
 		let tracks: Track[] = [];
 		let hasMoreTracks = false;

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -116,7 +116,9 @@ $effect(() => {
 		const minDisplayTime = 300; // minimum 300ms to avoid flicker
 
 		try {
-			const response = await fetch(`${API_URL}/artists/${artist.did}/analytics`);
+			const response = await fetch(`${API_URL}/artists/${artist.did}/analytics`, {
+				credentials: 'include'
+			});
 			if (response.ok) {
 				analytics = await response.json();
 			}
@@ -154,7 +156,9 @@ $effect(() => {
 		if (!artist?.did) return;
 
 		try {
-			const response = await fetch(`${API_URL}/lists/playlists/by-artist/${artist.did}`);
+			const response = await fetch(`${API_URL}/lists/playlists/by-artist/${artist.did}`, {
+				credentials: 'include'
+			});
 			if (response.ok) {
 				publicPlaylists = await response.json();
 			}
@@ -270,7 +274,8 @@ $effect(() => {
 		loadingMoreTracks = true;
 		try {
 			const response = await fetch(
-				`${API_URL}/tracks/?artist_did=${artist.did}&cursor=${encodeURIComponent(nextCursor)}&limit=10`
+				`${API_URL}/tracks/?artist_did=${artist.did}&cursor=${encodeURIComponent(nextCursor)}&limit=10`,
+				{ credentials: 'include' }
 			);
 			if (response.ok) {
 				const data = await response.json();

--- a/loq.toml
+++ b/loq.toml
@@ -32,7 +32,7 @@ max_lines = 923
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
-max_lines = 629
+max_lines = 644
 
 [[rules]]
 path = "backend/src/backend/api/tracks/mutations.py"
@@ -360,4 +360,4 @@ max_lines = 634
 
 [[rules]]
 path = "frontend/src/routes/u/[[]handle[]]/+page.svelte"
-max_lines = 1439
+max_lines = 1444


### PR DESCRIPTION
The artist page rendered **"4 tracks" above a list of one**, for a signed-in listener with sensitive audio enabled. Two causes — and **the global SSR credential forwarding we discussed is not the right fix.** Evidence below.

Not merging; this is for your review.

<details>
<summary>why the page was unauthenticated at both layers</summary>

**Server load can't send a session, structurally.** The cookie is set with no `domain`, so it's host-only on `api.plyr.fm`. The browser never sends it to `plyr.fm`, and the SvelteKit server has nothing to forward.

**This was already tried.** `55438aa3` (#284, Nov 2025) began as *"fix: forward session cookie in artist page server load for liked state"* and ended as *"fix: hydrate artist tracks client side"* — the same PR. The comment `// no cookie available on frontend host` was **added by that commit**, as its conclusion.

**Client fetches then omitted credentials too**, so hydration couldn't correct the anonymous render — a cross-origin fetch sends no cookies without `credentials: 'include'`. The album page one level deeper *does* pass them, which is the entire reason it behaved correctly and this page didn't.

Confirmed in prod: tracks 1177/1178/1179 carry `sexual`; 1055 doesn't. You were seeing the signed-out view while signed in.
</details>

<details>
<summary>why NOT global SSR credential forwarding</summary>

Making it work requires widening the cookie to `.plyr.fm`. That sends the session to **every** subdomain, including `audio.plyr.fm` and `images.plyr.fm` — R2 custom domains. Session material would ride on every artwork thumbnail and audio request into a storage service and its logs, and `stg.plyr.fm` / `api-stg.plyr.fm` would receive production sessions.

It also risks the "Cache R2 media assets" edge rule: cookie-bearing requests are exactly the shape treated as uncacheable, on the assets where the 1-year TTL matters most.

A display bug traded for a credential-scope and caching regression. Didn't do it.
</details>

<details>
<summary>what bluesky-social/social-app taught this PR</summary>

Their server ships **labels**; the client applies moderation via `moderateProfile(x, opts)`, returning `filter` / `blur` / `alert` / `inform`. Crucially, that decision is **per context** — and ATProto already names the distinction I'd invented ad hoc:

> a post might be blurred in a feed (`contentList`) but fully visible when opened directly (`contentView`)

That is exactly destination-vs-discovery. So the first cut's `if artist_did:` became `LabelContext.LIST | VIEW`, and the rule now reads as "list surfaces filter, destinations don't" instead of a magic branch. Their client decides per render; we decide per query, because our filtering has to live in SQL to compose with cursor pagination (#1676).

Sources: [moderation API docs](https://github.com/bluesky-social/atproto/blob/main/packages/api/docs/moderation.md), [stackable moderation](https://bsky.social/about/blog/03-12-2024-stackable-moderation).
</details>

<details>
<summary>cruft removed from my own first cut</summary>

- **a duplicated override check** — the artist branch re-inlined `moderation_override.is_distinct_from("exclude")`, which already lived inside the clause it was bypassing. Two copies of one rule, guaranteed to drift.
- **`discovery_visible_clause` + the special case** collapsed into one `label_visible_clause`, so there is a single place where families, override, and context compose.
- **twelve lines of policy prose at a call site**, moved into the policy module and its doc where the rest already lives.
</details>

<details>
<summary>behavior</summary>

| context | opted in | adult filtered | copyright filtered |
|---|---|---|---|
| LIST | no | ✅ | ✅ |
| LIST | yes | — | ✅ |
| VIEW | either | — | ✅ |

Copyright applies in **every** context — a hosting obligation isn't discharged by having already found the artist. `exclude` overrides hide everywhere; `allow` lifts copyright but never the adult half.

Verified the compiled predicate contains the adult clause exactly when context is LIST and the viewer hasn't opted in.

Client fetches now pass `credentials: 'include'`, matching the album page.

Side effect worth having: **SSR and hydration now agree.** The anonymous server render and the client render produce the same list, so no flash of a shorter list, and the count matches the rows — the SSR limitation stops mattering here rather than being papered over.
</details>

<details>
<summary>tests</summary>

1340 pass. Rewritten around the context concept: VIEW shows the whole catalogue; LIST still hides adult from a viewer who opted out and shows it to one who opted in; copyright hides in every context; `exclude` hides in every context. `svelte-check` clean.

One CI note: `build backend image` failed once in `set up docker buildx` — booting buildkit timed out pulling `moby/buildkit:buildx-stable-1` from Docker Hub, before any of this code is touched. Registry reachability, not the change; re-ran and it passed.
</details>

<details>
<summary>what I have not done</summary>

The other ten `+page.server.ts` loaders share the structural limitation — their SSR render is always the anonymous view. For most (track, playlist, tag, radio, embeds) that's now *correct*, since destination pages shouldn't filter. But I haven't audited each for personalization that silently degrades, and that deserves its own pass.

I also left the app-side `filter_sensitive_audio_tracks` path (albums, liked) unchanged. An album page is arguably a VIEW context too, but it currently behaves correctly for opted-in viewers and changing it would alter what signed-out album visitors see — a separate decision from the bug you reported.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)