### PR TITLE
docs: record the label context model

### DIFF
--- a/docs/internal/moderation/label-policy.md
+++ b/docs/internal/moderation/label-policy.md
@@ -64,17 +64,53 @@ Filtering depends on *where* a track appears, not only what it carries.
 search, radio, recommendations. `LabelContext.VIEW` is a page they navigated
 to: an artist's catalogue, a collection.
 
-this mirrors ATProto's own moderation contexts, where the same content is
-filtered from a feed (`contentList`) but shown when opened directly
-(`contentView`). Bluesky's client makes that call per render; we make it per
-query, because our filtering has to live in SQL to compose with cursor
-pagination (#1676).
+this mirrors ATProto's own moderation contexts. From the
+[moderation API docs](https://github.com/bluesky-social/atproto/blob/main/packages/api/docs/moderation.md):
+
+> a post might be blurred in a feed (`contentList`) but fully visible when
+> opened directly (`contentView`)
+
+Bluesky's client makes that call per render, because its server ships labels
+and `moderateProfile(x, opts)` returns `filter` / `blur` / `alert` / `inform`
+for the UI to apply. We make it per query instead, because our filtering has to
+live in SQL to compose with cursor pagination (#1676). Same distinction,
+different layer — worth knowing when reading their code, since the shape does
+not transfer directly.
+
+**the deciding argument was local, though.** `list_tracks` had *already* made
+this call for visibility: an artist-scoped query lists unlisted tracks,
+excluding only private ones, because an artist page shows their catalogue.
+Labels were the outlier in a function that had settled the question six lines
+earlier.
 
 adult labels apply only in `LIST`. Filtering an artist's own page made it
 misrepresent their catalogue — it rendered "4 tracks" above a list of one —
 and disagreed with the album page one level deeper, which showed everything.
 Copyright applies in **every** context: a hosting obligation is not discharged
 by the listener having already found the artist.
+
+### why this also fixed an authentication problem
+
+the artist page could not know the viewer. Its server load runs on the frontend
+host, and the session cookie is host-only on the API origin, so the browser
+never delivers it there and there is nothing to forward — `55438aa3` (#284)
+tried exactly that in November 2025 and abandoned it, leaving the
+`no cookie available on frontend host` comment behind as the conclusion.
+
+widening the cookie to `.plyr.fm` would make forwarding possible and is the
+wrong trade: the session would then be sent to `audio.plyr.fm` and
+`images.plyr.fm`, which are R2 custom domains, on every artwork and audio
+request — session material into a storage service and its logs, and
+cookie-bearing requests are the shape most likely to defeat the 1-year edge
+cache rule on exactly those assets. Staging subdomains would receive production
+sessions too.
+
+not filtering a VIEW context dissolves the problem rather than working around
+it: the anonymous server render and the hydrated client render produce the same
+list, so there is no divergence to authenticate away. Client-side fetches still
+need `credentials: 'include'` for genuinely personalized data such as liked
+state — a cross-origin fetch sends no cookies without it, which is why the
+album page worked and the artist page did not.
 
 ## composing the SQL predicate
 

--- a/docs/public/artists.md
+++ b/docs/public/artists.md
@@ -46,11 +46,11 @@ if a track contains adult or sexual audio, enable **contains adult or sexual
 audio** when uploading it. You can change the notice later in the track editor.
 
 the notice is stored with your track in your ATProto repository. On plyr.fm,
-noticed tracks are hidden from discovery unless a signed-in listener has
-enabled sensitive audio in their settings. **A direct link to the track still
-plays for anyone** — the notice changes where your track appears, not whether
-someone you share it with can hear it. You can still see and manage your own
-noticed tracks.
+noticed tracks are hidden from discovery feeds, search, and radio unless a
+signed-in listener has enabled sensitive audio in their settings. **Your own
+artist page still lists them, and a direct link still plays for anyone** — the
+notice changes where your track surfaces, not whether someone you send it to
+can hear it, and not how your catalogue looks to someone who came to find you.
 
 removing your notice removes only your own assertion. If a plyr.fm moderator
 independently labeled the track, that operator label and its default-hide policy

--- a/docs/public/moderation.md
+++ b/docs/public/moderation.md
@@ -33,7 +33,8 @@ not plyr.fm inventions.
   Subsonic browsing unless you enable **sensitive audio** in settings
 - never in shared radio, for anyone — radio is one synchronized stream, so no
   single listener's preference can decide what everyone else hears
-- **a direct link plays for anyone**
+- **still listed on the artist's own page**, and **a direct link plays for
+  anyone**
 
 see [sensitive content](/sensitive-content) for the settings.
 
@@ -47,6 +48,24 @@ copyright claim is our responsibility and no listener setting can waive it.
   remixes, and an artist's own catalogue all match — so being flagged does not
   break the uploader's own link
 - removal from plyr.fm is a separate, deliberate decision made by a person
+
+## where a label applies
+
+a label changes where a track *surfaces*, not whether you can reach what you
+went looking for. The distinction is between two kinds of place:
+
+- **surfaces we choose for you** — the home feed, search results,
+  recommendations, radio. Adult labels filter here.
+- **places you navigated to** — an artist's page, an album, a track's own
+  link. These show what is there.
+
+this mirrors how the AT Protocol itself models moderation, where the same post
+can be hidden in a feed but visible when you open it. Hiding part of an
+artist's catalogue on their own page would misrepresent their work to someone
+who had already gone looking for them.
+
+copyright is the exception: it applies everywhere, because it is about what we
+are willing to keep serving rather than about what you would rather see.
 
 ## what gets published, and what does not
 

--- a/docs/public/sensitive-content.md
+++ b/docs/public/sensitive-content.md
@@ -37,6 +37,8 @@ when a creator self-labels a track or a trusted labeler applies either value:
 
 - it is omitted from discovery, search, recommendations, public collections,
   queues, Subsonic browsing, and shared radio by default
+- **the artist's own page still lists it.** Those surfaces are places we chose
+  to put something in front of you; an artist's page is somewhere you went
 - **a direct link still plays, for anyone.** The label changes where a track
   appears, not whether it can be reached
 - the creator can always see and play their own track


### PR DESCRIPTION
Follows #1709. A label changes *where* a track surfaces, not whether you can reach what you went looking for — and none of the docs said so.

<details>
<summary>public</summary>

The pages said "hidden from discovery" without distinguishing the two kinds of place. A creator reading them couldn't tell whether their own artist page still showed their catalogue — which is precisely the confusion that got reported.

- **`moderation.md`** gains a "where a label applies" section: surfaces we choose for you (feed, search, recommendations, radio) filter; places you navigated to (artist page, album, a track's link) show what's there. Copyright is the exception, because it's about what we're willing to keep serving rather than what you'd rather see.
- **`sensitive-content.md`** and **`artists.md`** now say the artist's own page still lists noticed tracks. For a creator that's the material fact: the notice doesn't change how your catalogue looks to someone who came to find you.
</details>

<details>
<summary>internal</summary>

`label-policy.md` records the lineage — ATProto's `contentList`/`contentView`, quoted — and the part that matters when reading Bluesky's code: **their client applies moderation per render, we apply it per query**, because our filtering has to live in SQL to compose with cursor pagination. Same distinction, different layer; the shape doesn't transfer directly.

It also records the argument that actually settled it, which was local rather than borrowed: `list_tracks` had **already** made this call for visibility six lines earlier — an artist-scoped query lists unlisted tracks, excluding only private. Labels were the outlier in a function that had answered the question already.

New section on the SSR authentication finding, so it isn't rediscovered a third time: a server load can't see the session (host-only cookie on the API origin), #284 tried forwarding it in Nov 2025 and abandoned it, and widening the cookie to `.plyr.fm` would send sessions to the R2 asset domains on every artwork and audio request.
</details>

<details>
<summary>verified in production first</summary>

Release `2026.0725.172537`, anonymous requests:

```
artist page:      4 tracks  (1179/1178/1177 labels=['sexual'], 1055 labels=[])
anonymous feed:   adult-labeled tracks — none (correct)
fresh radio:      adult-labeled tracks — none (correct)
```

Destination shows, discovery filters. The docs now describe that.

Docs site builds. Harness memory updated with the context model and the SSR constraint.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)