### PR TITLE
feat(upload): pick track artwork from your luminframe image records

### DIFF
--- a/frontend/src/lib/components/ArtworkField.svelte
+++ b/frontend/src/lib/components/ArtworkField.svelte
@@ -1,0 +1,223 @@
+<script lang="ts">
+	import LuminframePicker from '$lib/components/LuminframePicker.svelte';
+	import { getServerConfig } from '$lib/config';
+	import { toast } from '$lib/toast.svelte';
+
+	interface Props {
+		/** signed-in user's DID — enables the luminframe source when present. */
+		did?: string;
+		/** the chosen artwork. bindable; setting it to null from outside resets the field. */
+		file?: File | null;
+	}
+
+	let { did, file = $bindable(null) }: Props = $props();
+
+	let previewUrl = $state<string | null>(null);
+	let source = $state<'file' | 'luminframe' | null>(null);
+	let inputEl = $state<HTMLInputElement | null>(null);
+
+	// the parent can clear the slot (post-submit reset) by setting `file` to
+	// null; sweep up this component's residue when that happens externally.
+	$effect(() => {
+		if (file === null && previewUrl) {
+			URL.revokeObjectURL(previewUrl);
+			previewUrl = null;
+			source = null;
+			if (inputEl) inputEl.value = '';
+		}
+	});
+
+	async function validateSize(selected: File): Promise<boolean> {
+		try {
+			const config = await getServerConfig();
+			const sizeMB = selected.size / (1024 * 1024);
+			if (sizeMB > config.max_image_size_mb) {
+				toast.error(`image too large (${sizeMB.toFixed(1)}MB). max: ${config.max_image_size_mb}MB`);
+				return false;
+			}
+		} catch (_e) {
+			console.error('failed to validate image size:', _e);
+		}
+		return true;
+	}
+
+	// the one place artwork is set, whichever source it came from. the slot
+	// holds exactly one image, so every set clears the other source's residue:
+	// the object URL, and the native input's own filename display.
+	function setFile(selected: File | null, from?: 'file' | 'luminframe') {
+		if (previewUrl) URL.revokeObjectURL(previewUrl);
+		previewUrl = selected ? URL.createObjectURL(selected) : null;
+		source = selected ? (from ?? null) : null;
+		file = selected;
+		if (inputEl && from !== 'file') inputEl.value = '';
+	}
+
+	async function handleInputChange(e: Event) {
+		const target = e.target as HTMLInputElement;
+		if (target.files && target.files[0]) {
+			const selected = target.files[0];
+
+			if (!(await validateSize(selected))) {
+				target.value = '';
+				setFile(null);
+				return;
+			}
+
+			setFile(selected, 'file');
+		}
+	}
+
+	async function handleLuminframeSelect(selected: File) {
+		if (!(await validateSize(selected))) return;
+		setFile(selected, 'luminframe');
+	}
+</script>
+
+<span class="artwork-label" id="artwork-label">artwork (optional)</span>
+<!-- two ways to fill one slot, presented as peers. the native
+     input stays in the DOM (it does the file dialog) but the
+     visible affordance is a button that matches the picker's. -->
+<div class="artwork-sources" role="group" aria-labelledby="artwork-label">
+	<button type="button" class="source-btn" onclick={() => inputEl?.click()}>
+		{file ? 'replace with a file' : 'choose a file'}
+	</button>
+	{#if did}
+		<LuminframePicker {did} onSelect={handleLuminframeSelect} />
+	{/if}
+</div>
+<input
+	bind:this={inputEl}
+	id="image-input"
+	type="file"
+	accept="image/*"
+	tabindex="-1"
+	aria-hidden="true"
+	class="hidden-file-input"
+	onchange={handleInputChange}
+/>
+<p class="format-hint">supported: jpg, png, webp, gif</p>
+{#if file}
+	<div class="artwork-chosen">
+		{#if previewUrl}
+			<img class="artwork-preview" src={previewUrl} alt="chosen artwork preview" />
+		{/if}
+		<div class="artwork-meta">
+			<p class="file-info">
+				{file.name} ({(file.size / 1024 / 1024).toFixed(2)} MB)
+			</p>
+			<p class="artwork-source">
+				from {source === 'luminframe' ? 'luminframe' : 'your device'}
+			</p>
+		</div>
+		<button
+			type="button"
+			class="artwork-remove"
+			onclick={() => setFile(null)}
+			title="remove artwork"
+			aria-label="remove artwork"
+		>
+			<svg
+				width="16"
+				height="16"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+			>
+				<line x1="18" y1="6" x2="6" y2="18"></line>
+				<line x1="6" y1="6" x2="18" y2="18"></line>
+			</svg>
+		</button>
+	</div>
+{/if}
+
+<style>
+	.artwork-label {
+		display: block;
+		margin-bottom: 0.5rem;
+	}
+
+	.artwork-sources {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.source-btn {
+		padding: 0.5rem 0.875rem;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-md);
+		color: var(--text-secondary);
+		font-family: inherit;
+		font-size: var(--text-sm);
+		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.source-btn:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	/* the input still opens the file dialog; the button above is its face */
+	.hidden-file-input {
+		display: none;
+	}
+
+	.format-hint {
+		margin-top: 0.25rem;
+		font-size: var(--text-sm);
+		color: var(--text-tertiary);
+	}
+
+	.artwork-chosen {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		margin-top: 0.75rem;
+	}
+
+	.artwork-preview {
+		width: 3.5rem;
+		height: 3.5rem;
+		object-fit: cover;
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--border-subtle);
+		flex-shrink: 0;
+	}
+
+	.artwork-meta {
+		min-width: 0;
+	}
+
+	.file-info {
+		margin-top: 0;
+		font-size: var(--text-sm);
+		color: var(--text-muted);
+		overflow-wrap: anywhere;
+	}
+
+	.artwork-source {
+		margin-top: 0.125rem;
+		font-size: var(--text-xs);
+		color: var(--text-tertiary);
+	}
+
+	.artwork-remove {
+		margin-left: auto;
+		display: flex;
+		align-items: center;
+		padding: 0.375rem;
+		background: none;
+		border: none;
+		color: var(--text-tertiary);
+		cursor: pointer;
+		flex-shrink: 0;
+	}
+
+	.artwork-remove:hover {
+		color: var(--text-primary);
+	}
+</style>

--- a/frontend/src/lib/components/LuminframePicker.svelte
+++ b/frontend/src/lib/components/LuminframePicker.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import {
 		fetchLuminframeImageAsFile,
+		hasLuminframeImages,
 		listLuminframeImages,
 		type LuminframeImage
 	} from '$lib/utils/luminframe';
@@ -14,6 +16,18 @@
 	}
 
 	let { did, onSelect, disabled = false }: Props = $props();
+
+	// only offer the picker when the account actually has luminframe images —
+	// the same shape as other capability-gated options on the upload form
+	// (permissioned spaces, supporter links). until the probe answers, this
+	// component renders nothing.
+	let available = $state(false);
+
+	onMount(() => {
+		hasLuminframeImages(did).then((has) => {
+			available = has;
+		});
+	});
 
 	let dialogEl = $state<HTMLDialogElement>();
 	let open = $state(false);
@@ -62,6 +76,13 @@
 		if (event.target === dialogEl) requestClose();
 	}
 
+	function handleCancel(event: Event) {
+		// the native cancel event fires on ESC before the dialog closes; block
+		// it while a blob download is in flight so `open` can't desync from
+		// the dialog's real state (same guard as ConfirmDialog).
+		if (fetchingUri) event.preventDefault();
+	}
+
 	async function pick(image: LuminframeImage) {
 		if (fetchingUri) return;
 		fetchingUri = image.uri;
@@ -79,14 +100,17 @@
 	}
 </script>
 
-<button type="button" class="luminframe-btn" {disabled} onclick={openPicker}>
-	choose from luminframe
-</button>
+{#if available}
+	<button type="button" class="luminframe-btn" {disabled} onclick={openPicker}>
+		choose from luminframe
+	</button>
+{/if}
 
 <dialog
 	bind:this={dialogEl}
 	class="luminframe-dialog"
 	aria-label="choose a luminframe image"
+	oncancel={handleCancel}
 	onclose={requestClose}
 	onclick={handleBackdropClick}
 >

--- a/frontend/src/lib/components/LuminframePicker.svelte
+++ b/frontend/src/lib/components/LuminframePicker.svelte
@@ -1,0 +1,268 @@
+<script lang="ts">
+	import {
+		fetchLuminframeImageAsFile,
+		listLuminframeImages,
+		type LuminframeImage
+	} from '$lib/utils/luminframe';
+
+	interface Props {
+		/** the signed-in user's DID — whose repo to list images from. */
+		did: string;
+		/** called with the chosen image wrapped as a File, ready for upload. */
+		onSelect: (file: File) => void;
+		disabled?: boolean;
+	}
+
+	let { did, onSelect, disabled = false }: Props = $props();
+
+	let dialogEl = $state<HTMLDialogElement>();
+	let open = $state(false);
+	let loading = $state(false);
+	let loaded = $state(false);
+	let error = $state<string | null>(null);
+	let images = $state<LuminframeImage[]>([]);
+	// uri of the image currently being downloaded, so only its tile spins
+	let fetchingUri = $state<string | null>(null);
+
+	$effect(() => {
+		if (!dialogEl) return;
+		if (open && !dialogEl.open) {
+			dialogEl.showModal();
+		} else if (!open && dialogEl.open) {
+			dialogEl.close();
+		}
+	});
+
+	async function load() {
+		loading = true;
+		error = null;
+		try {
+			images = await listLuminframeImages(did);
+			loaded = true;
+		} catch (e) {
+			console.error('failed to load luminframe images:', e);
+			error = 'could not load images from your PDS';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function openPicker() {
+		open = true;
+		if (!loaded && !loading) load();
+	}
+
+	function requestClose() {
+		if (fetchingUri) return;
+		open = false;
+	}
+
+	function handleBackdropClick(event: MouseEvent) {
+		// clicking the ::backdrop dispatches a click whose target is the <dialog>
+		if (event.target === dialogEl) requestClose();
+	}
+
+	async function pick(image: LuminframeImage) {
+		if (fetchingUri) return;
+		fetchingUri = image.uri;
+		error = null;
+		try {
+			const file = await fetchLuminframeImageAsFile(image);
+			onSelect(file);
+			open = false;
+		} catch (e) {
+			console.error('failed to fetch luminframe image:', e);
+			error = 'could not fetch that image — try another or retry';
+		} finally {
+			fetchingUri = null;
+		}
+	}
+</script>
+
+<button type="button" class="luminframe-btn" {disabled} onclick={openPicker}>
+	choose from luminframe
+</button>
+
+<dialog
+	bind:this={dialogEl}
+	class="luminframe-dialog"
+	aria-label="choose a luminframe image"
+	onclose={requestClose}
+	onclick={handleBackdropClick}
+>
+	<div class="modal-header">
+		<h3>your luminframe images</h3>
+		<button type="button" class="close-btn" onclick={requestClose} aria-label="close">
+			&times;
+		</button>
+	</div>
+	<div class="modal-body">
+		{#if loading}
+			<p class="state-note">loading images from your PDS...</p>
+		{:else if error}
+			<p class="state-note error">{error}</p>
+			<button type="button" class="retry-btn" onclick={load}>retry</button>
+		{:else if images.length === 0}
+			<p class="state-note">
+				no luminframe images in your repo yet — make some at
+				<a href="https://luminframe.com" target="_blank" rel="noopener">luminframe.com</a>
+			</p>
+		{:else}
+			<div class="image-grid">
+				{#each images as image (image.uri)}
+					<button
+						type="button"
+						class="image-tile"
+						class:fetching={fetchingUri === image.uri}
+						disabled={fetchingUri !== null}
+						onclick={() => pick(image)}
+						title={image.title ?? image.alt ?? 'luminframe image'}
+					>
+						<img src={image.imageUrl} alt={image.alt ?? image.title ?? ''} loading="lazy" />
+						{#if fetchingUri === image.uri}
+							<span class="tile-overlay">fetching...</span>
+						{/if}
+					</button>
+				{/each}
+			</div>
+		{/if}
+	</div>
+</dialog>
+
+<style>
+	.luminframe-btn,
+	.retry-btn {
+		padding: 0.5rem 0.875rem;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-md);
+		color: var(--text-secondary);
+		font-family: inherit;
+		font-size: var(--text-sm);
+		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.luminframe-btn:hover:not(:disabled),
+	.retry-btn:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.luminframe-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.luminframe-dialog {
+		background: var(--bg-primary);
+		color: inherit;
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-xl);
+		padding: 0;
+		width: 100%;
+		max-width: 560px;
+		box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+	}
+
+	.luminframe-dialog::backdrop {
+		background: rgba(0, 0, 0, 0.5);
+	}
+
+	.modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 1.25rem 1.5rem;
+		border-bottom: 1px solid var(--border-default);
+	}
+
+	.modal-header h3 {
+		font-size: var(--text-xl);
+		font-weight: 600;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.close-btn {
+		background: none;
+		border: none;
+		color: var(--text-secondary);
+		font-size: var(--text-xl);
+		line-height: 1;
+		cursor: pointer;
+		padding: 0.25rem;
+	}
+
+	.close-btn:hover {
+		color: var(--text-primary);
+	}
+
+	.modal-body {
+		padding: 1.5rem;
+		max-height: 60vh;
+		overflow-y: auto;
+	}
+
+	.state-note {
+		margin: 0;
+		color: var(--text-secondary);
+		font-size: var(--text-base);
+		line-height: 1.5;
+	}
+
+	.state-note.error {
+		color: var(--error);
+		margin-bottom: 0.75rem;
+	}
+
+	.state-note a {
+		color: var(--accent);
+	}
+
+	.image-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+		gap: 0.75rem;
+	}
+
+	.image-tile {
+		position: relative;
+		padding: 0;
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-md);
+		background: var(--bg-secondary);
+		aspect-ratio: 1;
+		overflow: hidden;
+		cursor: pointer;
+		transition: border-color 0.15s;
+	}
+
+	.image-tile:hover:not(:disabled),
+	.image-tile.fetching {
+		border-color: var(--accent);
+	}
+
+	.image-tile:disabled:not(.fetching) {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.image-tile img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	.tile-overlay {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(0, 0, 0, 0.55);
+		color: white;
+		font-size: var(--text-sm);
+	}
+</style>

--- a/frontend/src/lib/components/LuminframePicker.svelte
+++ b/frontend/src/lib/components/LuminframePicker.svelte
@@ -17,11 +17,11 @@
 
 	let { did, onSelect, disabled = false }: Props = $props();
 
-	// only offer the picker when the account actually has luminframe images —
-	// the same shape as other capability-gated options on the upload form
-	// (permissioned spaces, supporter links). until the probe answers, this
-	// component renders nothing.
-	let available = $state(false);
+	// probe the account's luminframe collection once: accounts with images get
+	// the picker, accounts without get a quiet link to go make some — the same
+	// shape as other capability-gated options on the upload form (permissioned
+	// spaces, supporter links). until the probe answers, render nothing.
+	let available = $state<boolean | null>(null);
 
 	onMount(() => {
 		hasLuminframeImages(did).then((has) => {
@@ -104,6 +104,10 @@
 	<button type="button" class="luminframe-btn" {disabled} onclick={openPicker}>
 		choose from luminframe
 	</button>
+{:else if available === false}
+	<a class="luminframe-link" href="https://luminframe.com" target="_blank" rel="noopener">
+		create cover art with luminframe
+	</a>
 {/if}
 
 <dialog
@@ -176,6 +180,17 @@
 	.luminframe-btn:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
+	}
+
+	.luminframe-link {
+		font-size: var(--text-sm);
+		color: var(--text-tertiary);
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+
+	.luminframe-link:hover {
+		color: var(--accent);
 	}
 
 	.luminframe-dialog {

--- a/frontend/src/lib/utils/luminframe.test.ts
+++ b/frontend/src/lib/utils/luminframe.test.ts
@@ -183,13 +183,15 @@ describe('fetchLuminframeImageAsFile', () => {
 		aspectRatio: { width: 800, height: 600 }
 	};
 
+	// DOM test environments disagree on how Response coerces binary bodies
+	// (some stringify them), so these mocks hand back the Blob directly —
+	// `blob()` is the only body accessor the code under test uses.
+	function blobResponse(blob: Blob): Response {
+		return { ok: true, status: 200, blob: async () => blob } as Response;
+	}
+
 	it('wraps the blob as a File named after the record rkey', async () => {
-		mockFetch(
-			() =>
-				new Response(new Uint8Array([1, 2, 3]), {
-					headers: { 'Content-Type': 'image/webp' }
-				})
-		);
+		mockFetch(() => blobResponse(new Blob([new Uint8Array([1, 2, 3])], { type: 'image/webp' })));
 		const file = await fetchLuminframeImageAsFile(image);
 		expect(file.name).toBe('luminframe-3lcabcdef.webp');
 		expect(file.type).toBe('image/webp');
@@ -197,11 +199,8 @@ describe('fetchLuminframeImageAsFile', () => {
 	});
 
 	it('falls back to the record mime type when the PDS serves a generic one', async () => {
-		mockFetch(
-			() =>
-				new Response(new Uint8Array([1]), {
-					headers: { 'Content-Type': 'application/octet-stream' }
-				})
+		mockFetch(() =>
+			blobResponse(new Blob([new Uint8Array([1])], { type: 'application/octet-stream' }))
 		);
 		const file = await fetchLuminframeImageAsFile(image);
 		expect(file.name).toBe('luminframe-3lcabcdef.webp');
@@ -209,12 +208,7 @@ describe('fetchLuminframeImageAsFile', () => {
 	});
 
 	it('collapses unknown image types to png so name and type agree', async () => {
-		mockFetch(
-			() =>
-				new Response(new Uint8Array([1]), {
-					headers: { 'Content-Type': 'image/avif' }
-				})
-		);
+		mockFetch(() => blobResponse(new Blob([new Uint8Array([1])], { type: 'image/avif' })));
 		const file = await fetchLuminframeImageAsFile(image);
 		expect(file.name).toBe('luminframe-3lcabcdef.png');
 		expect(file.type).toBe('image/png');

--- a/frontend/src/lib/utils/luminframe.test.ts
+++ b/frontend/src/lib/utils/luminframe.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	fetchLuminframeImageAsFile,
+	listLuminframeImages,
+	recordToImage,
+	resolvePdsEndpoint,
+	type LuminframeImage
+} from './luminframe';
+
+const DID = 'did:plc:abc123';
+const PDS = 'https://pds.example.com';
+
+const RECORD = {
+	uri: `at://${DID}/com.luminframe.image/3lcabcdef`,
+	value: {
+		image: {
+			$type: 'blob',
+			ref: { $link: 'bafkreiblob' },
+			mimeType: 'image/webp',
+			size: 12345
+		},
+		title: 'sunset remix',
+		alt: 'a glitched sunset',
+		createdAt: '2026-07-01T00:00:00Z',
+		aspectRatio: { width: 800, height: 600 }
+	}
+};
+
+function mockFetch(handler: (url: string) => Promise<Response> | Response) {
+	const spy = vi.fn((input: RequestInfo | URL) => {
+		return Promise.resolve(handler(String(input)));
+	});
+	vi.stubGlobal('fetch', spy);
+	return spy;
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('recordToImage', () => {
+	it('shapes a listRecords entry into a picker item with a getBlob URL', () => {
+		const image = recordToImage(RECORD, DID, PDS);
+		expect(image).toEqual({
+			uri: RECORD.uri,
+			imageUrl: `${PDS}/xrpc/com.atproto.sync.getBlob?did=did%3Aplc%3Aabc123&cid=bafkreiblob`,
+			mimeType: 'image/webp',
+			title: 'sunset remix',
+			alt: 'a glitched sunset',
+			createdAt: '2026-07-01T00:00:00Z',
+			aspectRatio: { width: 800, height: 600 }
+		});
+	});
+
+	it('drops records with no image blob', () => {
+		expect(recordToImage({ uri: RECORD.uri, value: {} }, DID, PDS)).toBeNull();
+	});
+});
+
+describe('resolvePdsEndpoint', () => {
+	it('resolves did:plc via plc.directory', async () => {
+		mockFetch((url) => {
+			expect(url).toBe(`https://plc.directory/${DID}`);
+			return Response.json({
+				service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: PDS }]
+			});
+		});
+		expect(await resolvePdsEndpoint(DID)).toBe(PDS);
+	});
+
+	it('resolves did:web via .well-known', async () => {
+		mockFetch((url) => {
+			expect(url).toBe('https://pds.example.com/.well-known/did.json');
+			return Response.json({
+				service: [{ id: '#atproto_pds', serviceEndpoint: PDS }]
+			});
+		});
+		expect(await resolvePdsEndpoint('did:web:pds.example.com')).toBe(PDS);
+	});
+
+	it('returns null for unknown did methods and network failures', async () => {
+		expect(await resolvePdsEndpoint('did:key:zabc')).toBeNull();
+		mockFetch(() => {
+			throw new Error('network down');
+		});
+		expect(await resolvePdsEndpoint(DID)).toBeNull();
+	});
+});
+
+describe('listLuminframeImages', () => {
+	it('lists records from the resolved PDS and skips blobless entries', async () => {
+		mockFetch((url) => {
+			if (url.startsWith('https://plc.directory/')) {
+				return Response.json({
+					service: [{ id: '#atproto_pds', serviceEndpoint: PDS }]
+				});
+			}
+			expect(url).toContain(`${PDS}/xrpc/com.atproto.repo.listRecords`);
+			expect(url).toContain('collection=com.luminframe.image');
+			return Response.json({
+				records: [RECORD, { uri: 'at://x/com.luminframe.image/empty', value: {} }]
+			});
+		});
+		const images = await listLuminframeImages(DID);
+		expect(images).toHaveLength(1);
+		expect(images[0].uri).toBe(RECORD.uri);
+	});
+
+	it('follows the cursor across pages', async () => {
+		let page = 0;
+		mockFetch((url) => {
+			if (url.startsWith('https://plc.directory/')) {
+				return Response.json({
+					service: [{ id: '#atproto_pds', serviceEndpoint: PDS }]
+				});
+			}
+			page += 1;
+			if (page === 1) {
+				expect(url).not.toContain('cursor=');
+				return Response.json({
+					records: Array.from({ length: 100 }, (_, i) => ({
+						...RECORD,
+						uri: `${RECORD.uri}${i}`
+					})),
+					cursor: 'next-page'
+				});
+			}
+			expect(url).toContain('cursor=next-page');
+			return Response.json({ records: [RECORD] });
+		});
+		const images = await listLuminframeImages(DID);
+		expect(images).toHaveLength(101);
+	});
+
+	it('returns [] when the PDS cannot be resolved', async () => {
+		mockFetch(() => Response.json({ service: [] }));
+		expect(await listLuminframeImages(DID)).toEqual([]);
+	});
+});
+
+describe('fetchLuminframeImageAsFile', () => {
+	const image: LuminframeImage = {
+		uri: `at://${DID}/com.luminframe.image/3lcabcdef`,
+		imageUrl: `${PDS}/xrpc/com.atproto.sync.getBlob?did=${DID}&cid=bafkreiblob`,
+		mimeType: 'image/webp',
+		createdAt: '2026-07-01T00:00:00Z',
+		aspectRatio: { width: 800, height: 600 }
+	};
+
+	it('wraps the blob as a File named after the record rkey', async () => {
+		mockFetch(
+			() =>
+				new Response(new Uint8Array([1, 2, 3]), {
+					headers: { 'Content-Type': 'image/webp' }
+				})
+		);
+		const file = await fetchLuminframeImageAsFile(image);
+		expect(file.name).toBe('luminframe-3lcabcdef.webp');
+		expect(file.type).toBe('image/webp');
+		expect(file.size).toBe(3);
+	});
+
+	it('falls back to the record mime type when the PDS serves a generic one', async () => {
+		mockFetch(
+			() =>
+				new Response(new Uint8Array([1]), {
+					headers: { 'Content-Type': 'application/octet-stream' }
+				})
+		);
+		const file = await fetchLuminframeImageAsFile(image);
+		expect(file.name).toBe('luminframe-3lcabcdef.webp');
+		expect(file.type).toBe('image/webp');
+	});
+
+	it('throws on a failed blob fetch', async () => {
+		mockFetch(() => new Response(null, { status: 404 }));
+		await expect(fetchLuminframeImageAsFile(image)).rejects.toThrow('404');
+	});
+});

--- a/frontend/src/lib/utils/luminframe.test.ts
+++ b/frontend/src/lib/utils/luminframe.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
 	fetchLuminframeImageAsFile,
+	hasLuminframeImages,
 	listLuminframeImages,
 	recordToImage,
 	resolvePdsEndpoint,
@@ -139,6 +140,40 @@ describe('listLuminframeImages', () => {
 	});
 });
 
+describe('hasLuminframeImages', () => {
+	it('is true when the collection has at least one record', async () => {
+		mockFetch((url) => {
+			if (url.startsWith('https://plc.directory/')) {
+				return Response.json({
+					service: [{ id: '#atproto_pds', serviceEndpoint: PDS }]
+				});
+			}
+			expect(url).toContain('limit=1');
+			return Response.json({ records: [RECORD] });
+		});
+		expect(await hasLuminframeImages(DID)).toBe(true);
+	});
+
+	it('is false for an empty collection, an unresolvable PDS, or a failed probe', async () => {
+		mockFetch((url) =>
+			url.startsWith('https://plc.directory/')
+				? Response.json({ service: [{ id: '#atproto_pds', serviceEndpoint: PDS }] })
+				: Response.json({ records: [] })
+		);
+		expect(await hasLuminframeImages(DID)).toBe(false);
+
+		mockFetch(() => Response.json({ service: [] }));
+		expect(await hasLuminframeImages(DID)).toBe(false);
+
+		mockFetch((url) =>
+			url.startsWith('https://plc.directory/')
+				? Response.json({ service: [{ id: '#atproto_pds', serviceEndpoint: PDS }] })
+				: new Response(null, { status: 500 })
+		);
+		expect(await hasLuminframeImages(DID)).toBe(false);
+	});
+});
+
 describe('fetchLuminframeImageAsFile', () => {
 	const image: LuminframeImage = {
 		uri: `at://${DID}/com.luminframe.image/3lcabcdef`,
@@ -171,6 +206,18 @@ describe('fetchLuminframeImageAsFile', () => {
 		const file = await fetchLuminframeImageAsFile(image);
 		expect(file.name).toBe('luminframe-3lcabcdef.webp');
 		expect(file.type).toBe('image/webp');
+	});
+
+	it('collapses unknown image types to png so name and type agree', async () => {
+		mockFetch(
+			() =>
+				new Response(new Uint8Array([1]), {
+					headers: { 'Content-Type': 'image/avif' }
+				})
+		);
+		const file = await fetchLuminframeImageAsFile(image);
+		expect(file.name).toBe('luminframe-3lcabcdef.png');
+		expect(file.type).toBe('image/png');
 	});
 
 	it('throws on a failed blob fetch', async () => {

--- a/frontend/src/lib/utils/luminframe.ts
+++ b/frontend/src/lib/utils/luminframe.ts
@@ -123,6 +123,30 @@ export async function listLuminframeImages(did: string): Promise<LuminframeImage
 	return images;
 }
 
+/**
+ * whether the user has any luminframe images at all — one limit=1 probe.
+ * the upload form uses this to decide whether to offer the picker, the same
+ * way other capabilities (permissioned spaces, supporter links) only surface
+ * when the account actually has them.
+ */
+export async function hasLuminframeImages(did: string): Promise<boolean> {
+	const pds = await resolvePdsEndpoint(did);
+	if (!pds) return false;
+	const params = new URLSearchParams({
+		repo: did,
+		collection: LUMINFRAME_COLLECTION,
+		limit: '1'
+	});
+	try {
+		const response = await fetch(`${pds}/xrpc/com.atproto.repo.listRecords?${params}`);
+		if (!response.ok) return false;
+		const data: { records?: unknown[] } = await response.json();
+		return (data.records ?? []).length > 0;
+	} catch {
+		return false;
+	}
+}
+
 const EXTENSION_BY_MIME: Record<string, string> = {
 	'image/jpeg': 'jpg',
 	'image/png': 'png',
@@ -141,11 +165,12 @@ export async function fetchLuminframeImageAsFile(image: LuminframeImage): Promis
 		throw new Error(`failed to fetch image from your PDS (${response.status})`);
 	}
 	const blob = await response.blob();
-	// prefer the mime type the PDS actually served; fall back to the record's
-	const mimeType = blob.type?.startsWith('image/') ? blob.type : image.mimeType;
-	const ext = EXTENSION_BY_MIME[mimeType] ?? 'png';
+	// prefer the mime type the PDS actually served; fall back to the record's.
+	// types we don't know collapse to png, so name and type always agree.
+	const served = blob.type?.startsWith('image/') ? blob.type : image.mimeType;
+	const mimeType = served in EXTENSION_BY_MIME ? served : 'image/png';
 	const rkey = image.uri.split('/').pop() ?? 'image';
-	return new File([blob], `luminframe-${rkey}.${ext}`, {
-		type: mimeType in EXTENSION_BY_MIME ? mimeType : 'image/png'
+	return new File([blob], `luminframe-${rkey}.${EXTENSION_BY_MIME[mimeType]}`, {
+		type: mimeType
 	});
 }

--- a/frontend/src/lib/utils/luminframe.ts
+++ b/frontend/src/lib/utils/luminframe.ts
@@ -1,0 +1,151 @@
+/**
+ * pick images from the user's own `com.luminframe.image` records as cover art.
+ *
+ * luminframe (https://luminframe.com) is an atproto image editor that saves
+ * finished edits to the author's repo. those records aren't indexed by any
+ * appview we can query, so we resolve the DID to its PDS and read the
+ * collection directly — same pattern as `utils/atprotofans.ts`. records and
+ * blobs are public, so no auth or extra OAuth scope is needed.
+ */
+
+export const LUMINFRAME_COLLECTION = 'com.luminframe.image';
+
+export interface LuminframeImage {
+	/** at:// URI of the source record. */
+	uri: string;
+	/** public getBlob URL for the rendered image. */
+	imageUrl: string;
+	/** blob mime type as recorded on the PDS, e.g. "image/png". */
+	mimeType: string;
+	title?: string;
+	alt?: string;
+	createdAt: string;
+	aspectRatio: { width: number; height: number };
+}
+
+interface DidDocService {
+	id: string;
+	serviceEndpoint?: string;
+}
+
+/** resolve a DID to its atproto PDS endpoint (did:plc and did:web), or null. */
+export async function resolvePdsEndpoint(did: string): Promise<string | null> {
+	let docUrl: string;
+	if (did.startsWith('did:plc:')) {
+		docUrl = `https://plc.directory/${did}`;
+	} else if (did.startsWith('did:web:')) {
+		const host = did.slice('did:web:'.length).split(':')[0];
+		docUrl = `https://${host}/.well-known/did.json`;
+	} else {
+		return null;
+	}
+	try {
+		const didDoc = await fetch(docUrl).then((r) => r.json());
+		const services: DidDocService[] = didDoc?.service ?? [];
+		return services.find((s) => s.id.endsWith('atproto_pds'))?.serviceEndpoint ?? null;
+	} catch {
+		return null;
+	}
+}
+
+interface RawBlobRef {
+	ref?: { $link?: string };
+	mimeType?: string;
+}
+
+interface RawLuminframeRecord {
+	uri: string;
+	value?: {
+		image?: RawBlobRef;
+		title?: string;
+		alt?: string;
+		createdAt?: string;
+		aspectRatio?: { width?: number; height?: number };
+	};
+}
+
+/** shape one listRecords entry into a picker item, or null if it has no image blob. */
+export function recordToImage(
+	record: RawLuminframeRecord,
+	did: string,
+	pds: string
+): LuminframeImage | null {
+	const blobCid = record.value?.image?.ref?.$link;
+	if (!blobCid) return null;
+	const params = new URLSearchParams({ did, cid: blobCid });
+	return {
+		uri: record.uri,
+		imageUrl: `${pds}/xrpc/com.atproto.sync.getBlob?${params}`,
+		mimeType: record.value?.image?.mimeType ?? 'image/png',
+		title: record.value?.title,
+		alt: record.value?.alt,
+		createdAt: record.value?.createdAt ?? '',
+		aspectRatio: {
+			width: record.value?.aspectRatio?.width ?? 1,
+			height: record.value?.aspectRatio?.height ?? 1
+		}
+	};
+}
+
+/** how many records to request per listRecords page. */
+const PAGE_SIZE = 100;
+/** stop paginating after this many records — a picker, not an archive browser. */
+const MAX_RECORDS = 300;
+
+/**
+ * list the user's luminframe images, newest first (listRecords returns
+ * reverse rkey order and rkeys are TIDs). returns [] when the collection
+ * is empty or the PDS can't be resolved.
+ */
+export async function listLuminframeImages(did: string): Promise<LuminframeImage[]> {
+	const pds = await resolvePdsEndpoint(did);
+	if (!pds) return [];
+
+	const images: LuminframeImage[] = [];
+	let cursor: string | undefined;
+	while (images.length < MAX_RECORDS) {
+		const params = new URLSearchParams({
+			repo: did,
+			collection: LUMINFRAME_COLLECTION,
+			limit: String(PAGE_SIZE)
+		});
+		if (cursor) params.set('cursor', cursor);
+		const response = await fetch(`${pds}/xrpc/com.atproto.repo.listRecords?${params}`);
+		if (!response.ok) break;
+		const data: { records?: RawLuminframeRecord[]; cursor?: string } = await response.json();
+		for (const record of data.records ?? []) {
+			const image = recordToImage(record, did, pds);
+			if (image) images.push(image);
+		}
+		cursor = data.cursor;
+		if (!cursor || (data.records ?? []).length < PAGE_SIZE) break;
+	}
+	return images;
+}
+
+const EXTENSION_BY_MIME: Record<string, string> = {
+	'image/jpeg': 'jpg',
+	'image/png': 'png',
+	'image/webp': 'webp',
+	'image/gif': 'gif'
+};
+
+/**
+ * download a luminframe image blob and wrap it as a File, so it can travel
+ * the exact same path as artwork chosen from disk (validation, R2 storage,
+ * thumbnails, and moderation all apply unchanged).
+ */
+export async function fetchLuminframeImageAsFile(image: LuminframeImage): Promise<File> {
+	const response = await fetch(image.imageUrl);
+	if (!response.ok) {
+		throw new Error(`failed to fetch image from your PDS (${response.status})`);
+	}
+	const blob = await response.blob();
+	// prefer the mime type the PDS actually served; fall back to the record's
+	const mimeType = blob.type?.startsWith('image/') ? blob.type : image.mimeType;
+	const ext = EXTENSION_BY_MIME[mimeType] ?? 'png';
+	const rkey = image.uri.split('/').pop() ?? 'image';
+	return new File([blob], `luminframe-${rkey}.${ext}`, {
+		type: mimeType in EXTENSION_BY_MIME ? mimeType : 'image/png'
+	});
+}

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -518,7 +518,6 @@
 				<p class="format-hint">supported: jpg, png, webp, gif</p>
 				{#if auth.user}
 					<div class="luminframe-row">
-						<span class="format-hint">or</span>
 						<LuminframePicker
 							did={auth.user.did}
 							onSelect={handleLuminframeSelect}
@@ -810,14 +809,7 @@
 	}
 
 	.luminframe-row {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
 		margin-top: 0.5rem;
-	}
-
-	.luminframe-row .format-hint {
-		margin-top: 0;
 	}
 
 	.char-count {

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -75,6 +75,9 @@
 	let albumTitle = $state("");
 	let file = $state<File | null>(null);
 	let imageFile = $state<File | null>(null);
+	let imagePreviewUrl = $state<string | null>(null);
+	let imageSource = $state<"file" | "luminframe" | null>(null);
+	let imageInputEl = $state<HTMLInputElement | null>(null);
 	let featuredArtists = $state<FeaturedArtist[]>([]);
 	let uploadTags = $state<string[]>([]);
 	let description = $state("");
@@ -238,7 +241,7 @@
 			albumTitle = "";
 			description = "";
 			file = null;
-			imageFile = null;
+			setImageFile(null);
 			featuredArtists = [];
 			uploadTags = [];
 			attestedRights = false;
@@ -347,6 +350,17 @@
 		return true;
 	}
 
+	// the one place artwork is set, whichever source it came from. the slot
+	// holds exactly one image, so every set clears the other source's residue:
+	// the object URL, and the native input's own filename display.
+	function setImageFile(selected: File | null, source?: "file" | "luminframe") {
+		if (imagePreviewUrl) URL.revokeObjectURL(imagePreviewUrl);
+		imagePreviewUrl = selected ? URL.createObjectURL(selected) : null;
+		imageSource = selected ? (source ?? null) : null;
+		imageFile = selected;
+		if (imageInputEl && source !== "file") imageInputEl.value = "";
+	}
+
 	async function handleImageChange(e: Event) {
 		const target = e.target as HTMLInputElement;
 		if (target.files && target.files[0]) {
@@ -354,24 +368,17 @@
 
 			if (!(await validateImageSize(selected))) {
 				target.value = "";
-				imageFile = null;
+				setImageFile(null);
 				return;
 			}
 
-			imageFile = selected;
+			setImageFile(selected, "file");
 		}
 	}
 
-	// artwork picked from the user's luminframe records rather than disk.
-	// clear the native input so a previously-chosen disk file doesn't linger
-	// in the input UI while `imageFile` points at the luminframe image.
 	async function handleLuminframeSelect(selected: File) {
 		if (!(await validateImageSize(selected))) return;
-		const imageInput = document.getElementById(
-			"image-input",
-		) as HTMLInputElement | null;
-		if (imageInput) imageInput.value = "";
-		imageFile = selected;
+		setImageFile(selected, "luminframe");
 	}
 
 	async function logout() {
@@ -508,30 +515,83 @@
 			</div>
 
 			<div class="form-group">
-				<label for="image-input">artwork (optional)</label>
-				<input
-					id="image-input"
-					type="file"
-					accept="image/*"
-					onchange={handleImageChange}
-				/>
-				<p class="format-hint">supported: jpg, png, webp, gif</p>
-				{#if auth.user}
-					<div class="luminframe-row">
+				<span class="artwork-label" id="artwork-label">artwork (optional)</span>
+				<!-- two ways to fill one slot, presented as peers. the native
+				     input stays in the DOM (it does the file dialog) but the
+				     visible affordance is a button that matches the picker's. -->
+				<div
+					class="artwork-sources"
+					role="group"
+					aria-labelledby="artwork-label"
+				>
+					<button
+						type="button"
+						class="source-btn"
+						onclick={() => imageInputEl?.click()}
+					>
+						{imageFile ? "replace with a file" : "choose a file"}
+					</button>
+					{#if auth.user}
 						<LuminframePicker
 							did={auth.user.did}
 							onSelect={handleLuminframeSelect}
 						/>
-					</div>
-				{/if}
+					{/if}
+				</div>
+				<input
+					bind:this={imageInputEl}
+					id="image-input"
+					type="file"
+					accept="image/*"
+					tabindex="-1"
+					aria-hidden="true"
+					class="hidden-file-input"
+					onchange={handleImageChange}
+				/>
+				<p class="format-hint">supported: jpg, png, webp, gif</p>
 				{#if imageFile}
-					<p class="file-info">
-						{imageFile.name} ({(
-							imageFile.size /
-							1024 /
-							1024
-						).toFixed(2)} MB)
-					</p>
+					<div class="artwork-chosen">
+						{#if imagePreviewUrl}
+							<img
+								class="artwork-preview"
+								src={imagePreviewUrl}
+								alt="chosen artwork preview"
+							/>
+						{/if}
+						<div class="artwork-meta">
+							<p class="file-info">
+								{imageFile.name} ({(
+									imageFile.size /
+									1024 /
+									1024
+								).toFixed(2)} MB)
+							</p>
+							<p class="artwork-source">
+								from {imageSource === "luminframe"
+									? "luminframe"
+									: "your device"}
+							</p>
+						</div>
+						<button
+							type="button"
+							class="artwork-remove"
+							onclick={() => setImageFile(null)}
+							title="remove artwork"
+							aria-label="remove artwork"
+						>
+							<svg
+								width="16"
+								height="16"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+							>
+								<line x1="18" y1="6" x2="6" y2="18"></line>
+								<line x1="6" y1="6" x2="18" y2="18"></line>
+							</svg>
+						</button>
+					</div>
 				{/if}
 			</div>
 
@@ -808,10 +868,6 @@
 		color: var(--text-tertiary);
 	}
 
-	.luminframe-row {
-		margin-top: 0.5rem;
-	}
-
 	.char-count {
 		font-size: var(--text-xs);
 		color: var(--text-tertiary);
@@ -822,6 +878,97 @@
 		margin-top: 0.5rem;
 		font-size: var(--text-sm);
 		color: var(--text-muted);
+	}
+
+	.artwork-label {
+		display: block;
+		margin-bottom: 0.5rem;
+	}
+
+	.artwork-sources {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	/* width/weight/hover undo the page-wide `button` rule below, which
+	   otherwise leaks full-width accent styling into these; the child
+	   LuminframePicker button is out of this page's scope and unaffected,
+	   so without the undo the two "peer" buttons render differently */
+	.source-btn {
+		width: auto;
+		padding: 0.5rem 0.875rem;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-md);
+		color: var(--text-secondary);
+		font-family: inherit;
+		font-size: var(--text-sm);
+		font-weight: 400;
+		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.source-btn:hover:not(:disabled) {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+		transform: none;
+	}
+
+	/* the input still opens the file dialog; the button above is its face */
+	.hidden-file-input {
+		display: none;
+	}
+
+	.artwork-chosen {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		margin-top: 0.75rem;
+	}
+
+	.artwork-preview {
+		width: 3.5rem;
+		height: 3.5rem;
+		object-fit: cover;
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--border-subtle);
+		flex-shrink: 0;
+	}
+
+	.artwork-meta {
+		min-width: 0;
+	}
+
+	.artwork-meta .file-info {
+		margin-top: 0;
+		overflow-wrap: anywhere;
+	}
+
+	.artwork-source {
+		margin-top: 0.125rem;
+		font-size: var(--text-xs);
+		color: var(--text-tertiary);
+	}
+
+	.artwork-remove {
+		width: auto;
+		margin-left: auto;
+		display: flex;
+		align-items: center;
+		padding: 0.375rem;
+		background: none;
+		border: none;
+		color: var(--text-tertiary);
+		cursor: pointer;
+		flex-shrink: 0;
+	}
+
+	.artwork-remove:hover:not(:disabled) {
+		background: none;
+		color: var(--text-primary);
+		transform: none;
 	}
 
 	button {

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -9,7 +9,7 @@
 	import WaveLoading from "$lib/components/WaveLoading.svelte";
 	import TagInput from "$lib/components/TagInput.svelte";
 	import CopyrightRightsPanel from "$lib/components/CopyrightRightsPanel.svelte";
-	import LuminframePicker from "$lib/components/LuminframePicker.svelte";
+	import ArtworkField from "$lib/components/ArtworkField.svelte";
 	import type { TrackRights } from "$lib/components/CopyrightRightsPanel.svelte";
 	import type { FeaturedArtist, AlbumSummary, Artist } from "$lib/types";
 	import { API_URL, getServerConfig } from "$lib/config";
@@ -75,9 +75,6 @@
 	let albumTitle = $state("");
 	let file = $state<File | null>(null);
 	let imageFile = $state<File | null>(null);
-	let imagePreviewUrl = $state<string | null>(null);
-	let imageSource = $state<"file" | "luminframe" | null>(null);
-	let imageInputEl = $state<HTMLInputElement | null>(null);
 	let featuredArtists = $state<FeaturedArtist[]>([]);
 	let uploadTags = $state<string[]>([]);
 	let description = $state("");
@@ -241,7 +238,7 @@
 			albumTitle = "";
 			description = "";
 			file = null;
-			setImageFile(null);
+			imageFile = null;
 			featuredArtists = [];
 			uploadTags = [];
 			attestedRights = false;
@@ -332,53 +329,6 @@
 
 			file = selected;
 		}
-	}
-
-	async function validateImageSize(selected: File): Promise<boolean> {
-		try {
-			const config = await getServerConfig();
-			const sizeMB = selected.size / (1024 * 1024);
-			if (sizeMB > config.max_image_size_mb) {
-				toast.error(
-					`image too large (${sizeMB.toFixed(1)}MB). max: ${config.max_image_size_mb}MB`,
-				);
-				return false;
-			}
-		} catch (_e) {
-			console.error("failed to validate image size:", _e);
-		}
-		return true;
-	}
-
-	// the one place artwork is set, whichever source it came from. the slot
-	// holds exactly one image, so every set clears the other source's residue:
-	// the object URL, and the native input's own filename display.
-	function setImageFile(selected: File | null, source?: "file" | "luminframe") {
-		if (imagePreviewUrl) URL.revokeObjectURL(imagePreviewUrl);
-		imagePreviewUrl = selected ? URL.createObjectURL(selected) : null;
-		imageSource = selected ? (source ?? null) : null;
-		imageFile = selected;
-		if (imageInputEl && source !== "file") imageInputEl.value = "";
-	}
-
-	async function handleImageChange(e: Event) {
-		const target = e.target as HTMLInputElement;
-		if (target.files && target.files[0]) {
-			const selected = target.files[0];
-
-			if (!(await validateImageSize(selected))) {
-				target.value = "";
-				setImageFile(null);
-				return;
-			}
-
-			setImageFile(selected, "file");
-		}
-	}
-
-	async function handleLuminframeSelect(selected: File) {
-		if (!(await validateImageSize(selected))) return;
-		setImageFile(selected, "luminframe");
 	}
 
 	async function logout() {
@@ -515,84 +465,7 @@
 			</div>
 
 			<div class="form-group">
-				<span class="artwork-label" id="artwork-label">artwork (optional)</span>
-				<!-- two ways to fill one slot, presented as peers. the native
-				     input stays in the DOM (it does the file dialog) but the
-				     visible affordance is a button that matches the picker's. -->
-				<div
-					class="artwork-sources"
-					role="group"
-					aria-labelledby="artwork-label"
-				>
-					<button
-						type="button"
-						class="source-btn"
-						onclick={() => imageInputEl?.click()}
-					>
-						{imageFile ? "replace with a file" : "choose a file"}
-					</button>
-					{#if auth.user}
-						<LuminframePicker
-							did={auth.user.did}
-							onSelect={handleLuminframeSelect}
-						/>
-					{/if}
-				</div>
-				<input
-					bind:this={imageInputEl}
-					id="image-input"
-					type="file"
-					accept="image/*"
-					tabindex="-1"
-					aria-hidden="true"
-					class="hidden-file-input"
-					onchange={handleImageChange}
-				/>
-				<p class="format-hint">supported: jpg, png, webp, gif</p>
-				{#if imageFile}
-					<div class="artwork-chosen">
-						{#if imagePreviewUrl}
-							<img
-								class="artwork-preview"
-								src={imagePreviewUrl}
-								alt="chosen artwork preview"
-							/>
-						{/if}
-						<div class="artwork-meta">
-							<p class="file-info">
-								{imageFile.name} ({(
-									imageFile.size /
-									1024 /
-									1024
-								).toFixed(2)} MB)
-							</p>
-							<p class="artwork-source">
-								from {imageSource === "luminframe"
-									? "luminframe"
-									: "your device"}
-							</p>
-						</div>
-						<button
-							type="button"
-							class="artwork-remove"
-							onclick={() => setImageFile(null)}
-							title="remove artwork"
-							aria-label="remove artwork"
-						>
-							<svg
-								width="16"
-								height="16"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-							>
-								<line x1="18" y1="6" x2="6" y2="18"></line>
-								<line x1="6" y1="6" x2="18" y2="18"></line>
-							</svg>
-						</button>
-					</div>
-				{/if}
+				<ArtworkField did={auth.user?.did} bind:file={imageFile} />
 			</div>
 
 			<CopyrightRightsPanel
@@ -878,97 +751,6 @@
 		margin-top: 0.5rem;
 		font-size: var(--text-sm);
 		color: var(--text-muted);
-	}
-
-	.artwork-label {
-		display: block;
-		margin-bottom: 0.5rem;
-	}
-
-	.artwork-sources {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		gap: 0.5rem;
-	}
-
-	/* width/weight/hover undo the page-wide `button` rule below, which
-	   otherwise leaks full-width accent styling into these; the child
-	   LuminframePicker button is out of this page's scope and unaffected,
-	   so without the undo the two "peer" buttons render differently */
-	.source-btn {
-		width: auto;
-		padding: 0.5rem 0.875rem;
-		background: var(--bg-secondary);
-		border: 1px solid var(--border-default);
-		border-radius: var(--radius-md);
-		color: var(--text-secondary);
-		font-family: inherit;
-		font-size: var(--text-sm);
-		font-weight: 400;
-		cursor: pointer;
-		transition: all 0.15s;
-	}
-
-	.source-btn:hover:not(:disabled) {
-		background: var(--bg-hover);
-		color: var(--text-primary);
-		transform: none;
-	}
-
-	/* the input still opens the file dialog; the button above is its face */
-	.hidden-file-input {
-		display: none;
-	}
-
-	.artwork-chosen {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		margin-top: 0.75rem;
-	}
-
-	.artwork-preview {
-		width: 3.5rem;
-		height: 3.5rem;
-		object-fit: cover;
-		border-radius: var(--radius-sm);
-		border: 1px solid var(--border-subtle);
-		flex-shrink: 0;
-	}
-
-	.artwork-meta {
-		min-width: 0;
-	}
-
-	.artwork-meta .file-info {
-		margin-top: 0;
-		overflow-wrap: anywhere;
-	}
-
-	.artwork-source {
-		margin-top: 0.125rem;
-		font-size: var(--text-xs);
-		color: var(--text-tertiary);
-	}
-
-	.artwork-remove {
-		width: auto;
-		margin-left: auto;
-		display: flex;
-		align-items: center;
-		padding: 0.375rem;
-		background: none;
-		border: none;
-		color: var(--text-tertiary);
-		cursor: pointer;
-		flex-shrink: 0;
-	}
-
-	.artwork-remove:hover:not(:disabled) {
-		background: none;
-		color: var(--text-primary);
-		transform: none;
 	}
 
 	button {

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -9,6 +9,7 @@
 	import WaveLoading from "$lib/components/WaveLoading.svelte";
 	import TagInput from "$lib/components/TagInput.svelte";
 	import CopyrightRightsPanel from "$lib/components/CopyrightRightsPanel.svelte";
+	import LuminframePicker from "$lib/components/LuminframePicker.svelte";
 	import type { TrackRights } from "$lib/components/CopyrightRightsPanel.svelte";
 	import type { FeaturedArtist, AlbumSummary, Artist } from "$lib/types";
 	import { API_URL, getServerConfig } from "$lib/config";
@@ -330,28 +331,47 @@
 		}
 	}
 
+	async function validateImageSize(selected: File): Promise<boolean> {
+		try {
+			const config = await getServerConfig();
+			const sizeMB = selected.size / (1024 * 1024);
+			if (sizeMB > config.max_image_size_mb) {
+				toast.error(
+					`image too large (${sizeMB.toFixed(1)}MB). max: ${config.max_image_size_mb}MB`,
+				);
+				return false;
+			}
+		} catch (_e) {
+			console.error("failed to validate image size:", _e);
+		}
+		return true;
+	}
+
 	async function handleImageChange(e: Event) {
 		const target = e.target as HTMLInputElement;
 		if (target.files && target.files[0]) {
 			const selected = target.files[0];
 
-			try {
-				const config = await getServerConfig();
-				const sizeMB = selected.size / (1024 * 1024);
-				if (sizeMB > config.max_image_size_mb) {
-					toast.error(
-						`image too large (${sizeMB.toFixed(1)}MB). max: ${config.max_image_size_mb}MB`,
-					);
-					target.value = "";
-					imageFile = null;
-					return;
-				}
-			} catch (_e) {
-				console.error("failed to validate image size:", _e);
+			if (!(await validateImageSize(selected))) {
+				target.value = "";
+				imageFile = null;
+				return;
 			}
 
 			imageFile = selected;
 		}
+	}
+
+	// artwork picked from the user's luminframe records rather than disk.
+	// clear the native input so a previously-chosen disk file doesn't linger
+	// in the input UI while `imageFile` points at the luminframe image.
+	async function handleLuminframeSelect(selected: File) {
+		if (!(await validateImageSize(selected))) return;
+		const imageInput = document.getElementById(
+			"image-input",
+		) as HTMLInputElement | null;
+		if (imageInput) imageInput.value = "";
+		imageFile = selected;
 	}
 
 	async function logout() {
@@ -496,6 +516,15 @@
 					onchange={handleImageChange}
 				/>
 				<p class="format-hint">supported: jpg, png, webp, gif</p>
+				{#if auth.user}
+					<div class="luminframe-row">
+						<span class="format-hint">or</span>
+						<LuminframePicker
+							did={auth.user.did}
+							onSelect={handleLuminframeSelect}
+						/>
+					</div>
+				{/if}
 				{#if imageFile}
 					<p class="file-info">
 						{imageFile.name} ({(
@@ -778,6 +807,17 @@
 		margin-top: 0.25rem;
 		font-size: var(--text-sm);
 		color: var(--text-tertiary);
+	}
+
+	.luminframe-row {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-top: 0.5rem;
+	}
+
+	.luminframe-row .format-hint {
+		margin-top: 0;
 	}
 
 	.char-count {

--- a/loq.toml
+++ b/loq.toml
@@ -175,7 +175,7 @@ max_lines = 1299
 
 [[rules]]
 path = "frontend/src/routes/upload/+page.svelte"
-max_lines = 983
+max_lines = 1015
 
 [[rules]]
 path = "services/moderation/src/admin.rs"

--- a/loq.toml
+++ b/loq.toml
@@ -175,7 +175,7 @@ max_lines = 1299
 
 [[rules]]
 path = "frontend/src/routes/upload/+page.svelte"
-max_lines = 1015
+max_lines = 1162
 
 [[rules]]
 path = "services/moderation/src/admin.rs"

--- a/loq.toml
+++ b/loq.toml
@@ -175,7 +175,7 @@ max_lines = 1299
 
 [[rules]]
 path = "frontend/src/routes/upload/+page.svelte"
-max_lines = 1162
+max_lines = 983
 
 [[rules]]
 path = "services/moderation/src/admin.rs"


### PR DESCRIPTION
## Demo vid
https://ihkgojiseqpwinwdowvm.supabase.co/storage/v1/object/public/natespilmanblog/2026-08-07/Luminframe%20plyr%20PR%20demo%20vid.mov

## why

[luminframe](https://luminframe.com) is an atproto image editor that saves finished edits as `com.luminframe.image` records in the author's repo. if you've made art there, it should be one click to use it as cover art — your images already live on your PDS, plyr just needs to look.

it's also a small proof of the atproto pitch in STATUS.md: records written by one app, read by another, no integration API between them.

## what

- `frontend/src/lib/utils/luminframe.ts` — resolves the signed-in user's DID to their PDS (same pattern as `utils/atprotofans.ts`, plus `did:web`), lists `com.luminframe.image` records via public `listRecords`, and wraps a chosen blob as a `File`
- `frontend/src/lib/components/LuminframePicker.svelte` — "choose from luminframe" button + native `<dialog>` grid (follows `ConfirmDialog`'s top-layer pattern, including its ESC-while-pending guard), with loading/empty/error states
- the button only renders for accounts that actually have luminframe images (a `limit=1` probe on mount) — same capability-gated shape as the private-media and supporters-only options; accounts without any get a quiet "create cover art with luminframe" link instead, so the doorway exists in both directions
- wired into the upload form's artwork field only. the picked image travels the exact same path as a file chosen from disk, so size validation, R2 storage, thumbnailing, and image moderation all apply unchanged — no backend changes, no new OAuth scopes (records and blobs are public reads)
- `frontend/src/lib/components/ArtworkField.svelte` — the artwork field, redesigned and extracted whole so the two sources read as peers: the native file input hides behind a matching button, one setter owns the slot, and a thumbnail preview shows what's chosen (with source + remove). the upload page's side of the diff is just the wiring (`bind:file`), and the page stays under its existing loq budget

follow-ups if this lands well: the portal track-edit artwork editor, album covers, and playlist covers all accept a `File` the same way, so `ArtworkField` (or the picker alone) drops in.

## testing

- `bun run test` — 14 new unit tests for the util (PDS resolution incl. `did:web`, record shaping, cursor pagination, blob→File incl. generic content-type fallback); `bun run check` and `bun run lint` clean
- verified end-to-end on a full local stack (postgres + redis + minio + docket worker + OAuth via https tunnel): signed in with my real account, picked one of my luminframe images on the upload form, and the track published — artwork stored + thumbnailed, `track` record written to my PDS under the dev namespace, cover art rendering on the track page
- demo video coming as a comment
- note: the pre-existing `player-repeat.test.ts` failures reproduce on a clean `main` checkout on my machine; untouched by this change

## ai assistance

built with claude code (the auto-attribution on the commit is accurate); I've reviewed and understand the change.


