### PR TITLE
fix(moderation): apply the label context everywhere, and make counts agree

### DIFF
--- a/backend/src/backend/_internal/content_labels.py
+++ b/backend/src/backend/_internal/content_labels.py
@@ -195,6 +195,8 @@ async def filter_sensitive_audio_tracks(
     db: AsyncSession,
     tracks: Iterable[Track],
     session: Session | None,
+    *,
+    context: LabelContext = LabelContext.LIST,
 ) -> tuple[list[Track], dict[int, set[str]]]:
     """Hide adult-labeled tracks unless the viewer opted in or owns them."""
     track_list = list(tracks)
@@ -202,6 +204,7 @@ async def filter_sensitive_audio_tracks(
         db,
         track_list,
         session.did if session else None,
+        context=context,
     )
 
 
@@ -209,8 +212,17 @@ async def filter_sensitive_audio_tracks_for_viewer(
     db: AsyncSession,
     tracks: Iterable[Track],
     viewer_did: str | None,
+    *,
+    context: LabelContext = LabelContext.LIST,
 ) -> tuple[list[Track], dict[int, set[str]]]:
-    """Hide adult-labeled tracks for a viewer identified only by DID."""
+    """Hide adult-labeled tracks for a viewer identified only by DID.
+
+    The app-side twin of `label_visible_clause`, for callers that already hold
+    a list of tracks. Takes the same `context`, so a destination filters the
+    same way whether it was assembled in SQL or in Python -- an album page
+    disagreeing with the artist page above it is exactly the inconsistency
+    this parameter exists to prevent.
+    """
     track_list = list(tracks)
     labels_by_id = get_track_label_values(track_list)
     shows_sensitive = await viewer_did_shows_sensitive_audio(db, viewer_did)
@@ -226,7 +238,8 @@ async def filter_sensitive_audio_tracks_for_viewer(
         if has_copyright_label(labels) and override != "allow":
             continue
         if (
-            shows_sensitive
+            context is LabelContext.VIEW
+            or shows_sensitive
             or track.artist_did == viewer_did
             or not has_adult_audio_label(labels)
         ):

--- a/backend/src/backend/_internal/queue.py
+++ b/backend/src/backend/_internal/queue.py
@@ -13,7 +13,10 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
-from backend._internal.content_labels import filter_sensitive_audio_tracks_for_viewer
+from backend._internal.content_labels import (
+    LabelContext,
+    filter_sensitive_audio_tracks_for_viewer,
+)
 from backend.config import settings
 from backend.models import QueueState, Track, UserPreferences
 from backend.schemas import TrackResponse
@@ -350,8 +353,12 @@ class QueueService:
             if track:
                 tracks_in_order.append(track)
 
+        # your own queue is the strongest destination there is: you put these
+        # here. A track silently disappearing from it because it was labeled
+        # after you queued it is worse than showing it -- you already chose it.
+        # Copyright still removes it, since that is not yours to waive.
         tracks_in_order, labels_by_id = await filter_sensitive_audio_tracks_for_viewer(
-            db, tracks_in_order, viewer_did
+            db, tracks_in_order, viewer_did, context=LabelContext.VIEW
         )
 
         # batch backfill image URLs for legacy records

--- a/backend/src/backend/api/albums/listing.py
+++ b/backend/src/backend/api/albums/listing.py
@@ -12,7 +12,11 @@ from sqlalchemy.orm import selectinload
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session
 from backend._internal.atproto.records import fetch_list_item_uris
-from backend._internal.content_labels import filter_sensitive_audio_tracks
+from backend._internal.content_labels import (
+    LabelContext,
+    copyright_visible_clause,
+    filter_sensitive_audio_tracks,
+)
 from backend._internal.track_visibility import track_visible_filter, viewer_did
 from backend.models import Album, Artist, Track, TrackLike, get_db
 from backend.schemas import TrackResponse
@@ -54,10 +58,23 @@ async def list_albums(
             func.coalesce(func.sum(Track.play_count), 0).label("total_plays"),
         )
         .join(Artist, Album.artist_did == Artist.did)
-        # count only public tracks — albums that exist solely because of private
-        # uploads have a zero public count and drop out via the having clause
+        # count only tracks the album view will actually show. Private uploads
+        # drop out via the having clause; copyright-labeled and
+        # override-excluded tracks are counted out too, because a card
+        # promising three tracks over a page that lists two is the mismatch
+        # that made the artist page unreadable (#1709).
+        #
+        # Deliberately viewer-independent: adult labels are a preference, and
+        # a per-viewer count could not be cached or agreed on. In a VIEW
+        # context the album shows them anyway, so the count is right.
         .outerjoin(
-            Track, and_(Track.album_id == Album.id, Track.visibility != "private")
+            Track,
+            and_(
+                Track.album_id == Album.id,
+                Track.visibility != "private",
+                copyright_visible_clause(),
+                Track.moderation_override.is_distinct_from("exclude"),
+            ),
         )
         .group_by(Album.id, Artist.did)
         .having(func.count(Track.id) > 0)
@@ -193,8 +210,9 @@ async def get_album(
         # no ATProto record - order by created_at
         ordered_tracks = sorted(all_tracks, key=lambda t: t.created_at)
 
+    # an album someone opened is a destination, not a surface we chose
     tracks, labels_by_id = await filter_sensitive_audio_tracks(
-        db, ordered_tracks, session
+        db, ordered_tracks, session, context=LabelContext.VIEW
     )
     track_ids = [track.id for track in tracks]
 

--- a/backend/src/backend/api/lists/hydration.py
+++ b/backend/src/backend/api/lists/hydration.py
@@ -4,7 +4,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from backend._internal.content_labels import filter_sensitive_audio_tracks_for_viewer
+from backend._internal.content_labels import (
+    LabelContext,
+    filter_sensitive_audio_tracks_for_viewer,
+)
 from backend._internal.track_visibility import track_visible_filter
 from backend.models import Track, TrackLike
 from backend.schemas import TrackResponse
@@ -31,8 +34,9 @@ async def hydrate_tracks_from_uris(
         # a private track referenced by a list hydrates only for its owner
         .where(track_visible_filter(session_did))
     )
+    # a playlist someone opened is a destination
     all_tracks, labels_by_id = await filter_sensitive_audio_tracks_for_viewer(
-        db, track_result.scalars().all(), session_did
+        db, track_result.scalars().all(), session_did, context=LabelContext.VIEW
     )
     track_by_uri = {t.atproto_record_uri: t for t in all_tracks}
 

--- a/backend/src/backend/api/subsonic/browsing.py
+++ b/backend/src/backend/api/subsonic/browsing.py
@@ -13,7 +13,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from backend._internal import Session
-from backend._internal.content_labels import filter_sensitive_audio_tracks_for_viewer
+from backend._internal.content_labels import (
+    LabelContext,
+    filter_sensitive_audio_tracks_for_viewer,
+)
 from backend._internal.track_visibility import track_visible_filter
 from backend.api.subsonic.endpoints import Params, _require, _rest, _run, _song
 from backend.api.subsonic.responses import ERROR_NOT_FOUND, SubsonicError
@@ -126,7 +129,7 @@ async def get_album(request: Request) -> Response:
                 .order_by(Track.created_at)
             )
             tracks, _ = await filter_sensitive_audio_tracks_for_viewer(
-                db, track_result.scalars().all(), None
+                db, track_result.scalars().all(), None, context=LabelContext.VIEW
             )
         songs = [_song(track) for track in tracks]
         return {

--- a/backend/src/backend/api/subsonic/endpoints.py
+++ b/backend/src/backend/api/subsonic/endpoints.py
@@ -17,7 +17,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from backend._internal import Session
-from backend._internal.content_labels import filter_sensitive_audio_tracks_for_viewer
+from backend._internal.content_labels import (
+    LabelContext,
+    filter_sensitive_audio_tracks_for_viewer,
+)
 from backend._internal.tasks import schedule_teal_scrobble
 from backend._internal.track_visibility import track_visible_filter
 from backend.api.lists.playlists import _can_view, _read_playlist_items
@@ -155,12 +158,15 @@ async def _tracks_by_uris(
         .where(Track.atproto_record_uri.in_(uris))
         .where(track_visible_filter(session_did))
     )
+    # a playlist's contents are a destination. The viewer is None because a
+    # Subsonic client authenticates with a developer token rather than a
+    # session, so there is no preference to read -- which is exactly why this
+    # must not depend on one.
     visible, _ = await filter_sensitive_audio_tracks_for_viewer(
-        # Subsonic's redirect cannot carry the plyr.fm cookie required by the
-        # audio endpoint, so adult audio stays hidden on this surface.
         db,
         result.scalars().all(),
         None,
+        context=LabelContext.VIEW,
     )
     by_uri = {t.atproto_record_uri: t for t in visible}
     return [by_uri[uri] for uri in uris if uri in by_uri]
@@ -181,7 +187,7 @@ async def _track_by_id(params: Params, session_did: str | None) -> Track:
         )
         if track := result.scalar_one_or_none():
             visible, _ = await filter_sensitive_audio_tracks_for_viewer(
-                db, [track], None
+                db, [track], None, context=LabelContext.VIEW
             )
             if visible:
                 return track

--- a/backend/src/backend/api/tracks/likes.py
+++ b/backend/src/backend/api/tracks/likes.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import selectinload
 
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session, require_auth
-from backend._internal.content_labels import filter_sensitive_audio_tracks
+from backend._internal.content_labels import LabelContext, filter_sensitive_audio_tracks
 from backend._internal.tasks import (
     schedule_pds_create_like,
     schedule_pds_delete_like,
@@ -74,7 +74,7 @@ async def list_liked_tracks(
 
     result = await db.execute(stmt)
     tracks, labels_by_id = await filter_sensitive_audio_tracks(
-        db, result.scalars().all(), auth_session
+        db, result.scalars().all(), auth_session, context=LabelContext.VIEW
     )
 
     liked_track_ids = {track.id for track in tracks}

--- a/backend/src/backend/api/users.py
+++ b/backend/src/backend/api/users.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from backend._internal import Session, get_optional_session
-from backend._internal.content_labels import filter_sensitive_audio_tracks
+from backend._internal.content_labels import LabelContext, filter_sensitive_audio_tracks
 from backend._internal.track_visibility import track_visible_filter, viewer_did
 from backend.models import Artist, Track, TrackLike, get_db
 from backend.schemas import TrackResponse
@@ -68,7 +68,7 @@ async def get_user_liked_tracks(
 
     track_result = await db.execute(stmt)
     tracks, labels_by_id = await filter_sensitive_audio_tracks(
-        db, track_result.scalars().all(), session
+        db, track_result.scalars().all(), session, context=LabelContext.VIEW
     )
 
     # get current user's liked track IDs if authenticated

--- a/backend/tests/test_content_label_policy.py
+++ b/backend/tests/test_content_label_policy.py
@@ -9,13 +9,14 @@ They differ in *who decides*, and that is the whole design:
 Neither gates the audio bytes. See `docs/internal/moderation/label-policy.md`.
 """
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal.content_labels import (
     COPYRIGHT_LABELS,
     PROJECTED_LABEL_VALUES,
     LabelContext,
+    copyright_visible_clause,
     filter_sensitive_audio_tracks_for_viewer,
     has_copyright_label,
     label_visible_clause,
@@ -296,3 +297,49 @@ async def test_app_side_filter_keeps_copyright_hidden_in_view(
         db_session, [infringing, plain], VIEWER, context=LabelContext.VIEW
     )
     assert {t.id for t in shown} == {plain.id}
+
+
+async def test_album_card_count_matches_what_the_album_will_show(
+    db_session: AsyncSession,
+) -> None:
+    """A card promising more tracks than the page lists is the reported bug.
+
+    The count is viewer-independent on purpose, so it excludes only what no
+    viewer can see: copyright labels and exclude overrides. Adult-labeled
+    tracks stay counted because a VIEW context shows them.
+    """
+    from backend.models import Album
+
+    keep = await _track(db_session, file_id="cnt1")  # also creates the artist
+    album = Album(title="Mixed", artist_did=OWNER, slug="mixed")
+    db_session.add(album)
+    await db_session.flush()
+
+    adult = await _track(db_session, file_id="cnt2", operator_labels=["sexual"])
+    infringing = await _track(
+        db_session, file_id="cnt3", operator_labels=["copyright-violation"]
+    )
+    excluded = await _track(db_session, file_id="cnt4")
+    excluded.moderation_override = "exclude"
+    for t in (keep, adult, infringing, excluded):
+        t.album_id = album.id
+    await db_session.commit()
+
+    counted = (
+        await db_session.execute(
+            select(func.count(Track.id)).where(
+                Track.album_id == album.id,
+                Track.visibility != "private",
+                copyright_visible_clause(),
+                Track.moderation_override.is_distinct_from("exclude"),
+            )
+        )
+    ).scalar_one()
+
+    shown, _ = await filter_sensitive_audio_tracks_for_viewer(
+        db_session,
+        [keep, adult, infringing, excluded],
+        None,
+        context=LabelContext.VIEW,
+    )
+    assert counted == len(shown) == 2

--- a/backend/tests/test_content_label_policy.py
+++ b/backend/tests/test_content_label_policy.py
@@ -259,3 +259,40 @@ async def test_exclude_override_hides_in_every_context(
         assert await _visible(db_session, context, shows_sensitive=True) == {
             plain.id
         }, context
+
+
+async def test_app_side_filter_honours_view_context(db_session: AsyncSession) -> None:
+    """The Python filter and the SQL clause must agree on a destination.
+
+    An album disagreeing with the artist page above it is precisely the
+    inconsistency the context parameter exists to prevent — before this, the
+    SQL path knew about VIEW and the app-side path did not.
+    """
+    labeled = await _track(db_session, file_id="ctx1", operator_labels=["sexual"])
+    plain = await _track(db_session, file_id="ctx2")
+    await db_session.commit()
+
+    shown, _ = await filter_sensitive_audio_tracks_for_viewer(
+        db_session, [labeled, plain], VIEWER, context=LabelContext.VIEW
+    )
+    assert {t.id for t in shown} == {labeled.id, plain.id}
+
+    hidden, _ = await filter_sensitive_audio_tracks_for_viewer(
+        db_session, [labeled, plain], VIEWER, context=LabelContext.LIST
+    )
+    assert {t.id for t in hidden} == {plain.id}
+
+
+async def test_app_side_filter_keeps_copyright_hidden_in_view(
+    db_session: AsyncSession,
+) -> None:
+    infringing = await _track(
+        db_session, file_id="ctx3", operator_labels=["copyright-violation"]
+    )
+    plain = await _track(db_session, file_id="ctx4")
+    await db_session.commit()
+
+    shown, _ = await filter_sensitive_audio_tracks_for_viewer(
+        db_session, [infringing, plain], VIEWER, context=LabelContext.VIEW
+    )
+    assert {t.id for t in shown} == {plain.id}

--- a/frontend/src/lib/feedback.svelte.ts
+++ b/frontend/src/lib/feedback.svelte.ts
@@ -96,7 +96,8 @@ class FeedbackState {
 
 		try {
 			const response = await fetch(
-				`${API_URL}/search/?q=${encodeURIComponent(query)}&limit=8`
+				`${API_URL}/search/?q=${encodeURIComponent(query)}&limit=8`,
+				{ credentials: 'include' }
 			);
 
 			if (!response.ok) {

--- a/frontend/src/lib/likers-sheet.svelte.ts
+++ b/frontend/src/lib/likers-sheet.svelte.ts
@@ -33,7 +33,9 @@ class LikersSheetState {
 
 	private async fetchLikers(trackId: number) {
 		try {
-			const response = await fetch(`${API_URL}/tracks/${trackId}/likes`);
+			const response = await fetch(`${API_URL}/tracks/${trackId}/likes`, {
+				credentials: 'include'
+			});
 			if (!response.ok) throw new Error(`failed to fetch likers: ${response.status}`);
 			const data = await response.json();
 			const users: LikerData[] = data.users || [];

--- a/frontend/src/lib/search.svelte.ts
+++ b/frontend/src/lib/search.svelte.ts
@@ -242,7 +242,8 @@ class SearchState {
 
 		try {
 			const response = await fetch(
-				`${API_URL}/search/?q=${encodeURIComponent(query)}&limit=10`
+				`${API_URL}/search/?q=${encodeURIComponent(query)}&limit=10`,
+				{ credentials: 'include' }
 			);
 
 			if (!response.ok) {
@@ -277,7 +278,8 @@ class SearchState {
 
 		try {
 			const response = await fetch(
-				`${API_URL}/search/semantic?q=${encodeURIComponent(query)}&limit=10`
+				`${API_URL}/search/semantic?q=${encodeURIComponent(query)}&limit=10`,
+				{ credentials: 'include' }
 			);
 
 			if (!response.ok) {

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -206,7 +206,9 @@
 		if (!track) return;
 		loadingComments = true;
 		try {
-			const response = await fetch(`${API_URL}/tracks/${track.id}/comments`);
+			const response = await fetch(`${API_URL}/tracks/${track.id}/comments`, {
+				credentials: 'include'
+			});
 			if (response.ok) {
 				const data = await response.json();
 				comments = data.comments;

--- a/loq.toml
+++ b/loq.toml
@@ -340,7 +340,7 @@ max_lines = 506
 
 [[rules]]
 path = "frontend/src/routes/track/[[]id[]]/+page.svelte"
-max_lines = 1791
+max_lines = 1793
 
 [[rules]]
 path = "frontend/src/lib/components/playlist/PlaylistTrackList.svelte"


### PR DESCRIPTION
The audit after #1709 found the same defect in three more shapes. All four fixed here.

<details>
<summary>1. search was the reported bug, on a bigger surface</summary>

`lib/search.svelte.ts` sent no credentials on either the keyword or semantic path, so the backend saw an anonymous viewer. Measured on production:

```
search "valerie", anonymous:      4 results
search "valerie", authenticated:  7 results   ← the 3 labeled episodes
```

An opted-in listener was missing adult-labeled tracks from **Cmd+K**. Same cause in the feedback track picker.
</details>

<details>
<summary>2. two private-media reads, same cause</summary>

- `/tracks/{id}/comments` calls `ensure_track_visible(track, viewer_did(session))` → without a session, **an owner 404s on comments on their own private track.** This is the private-media known issue already in STATUS.md; that fetch is the cause.
- `/tracks/{id}/likes` gates private likers on `viewer_did(session) != artist_did` → **an owner can't see who liked their own private track.** Not previously documented.
</details>

<details>
<summary>3. the context model only existed in half the codebase</summary>

`filter_sensitive_audio_tracks` had **no context parameter**, so #1709 named LIST/VIEW in the SQL path and left the app-side path unaware. These are destinations and now say so:

| call site | context |
|---|---|
| album detail | VIEW |
| playlist hydration | VIEW |
| liked tracks (`users.py`, `tracks/likes.py`) | VIEW |
| subsonic `getAlbum`, playlist contents, `getSong` | VIEW |
| subsonic `getRandomSongs` | **LIST** — a shuffle feed is a surface we chose |
| search, for-you, `/tracks/`, `/top` | LIST |

An album disagreeing with the artist page above it is exactly the inconsistency the parameter exists to prevent.
</details>

<details>
<summary>4. counts came from an unfiltered aggregate</summary>

The album card count was `func.count(Track.id)` filtered only on `visibility != 'private'`. That's how a card promised **3 tracks** over a page that listed **0**:

```
album, anonymous:      metadata track_count: 3, tracks returned: 0
album, authenticated:  3 and 3
```

The count now excludes copyright-labeled and override-excluded tracks. **Deliberately viewer-independent** — adult labels are a preference, a per-viewer count couldn't be cached or agreed on, and in a VIEW context the album shows them anyway, so the count is right either way.
</details>

<details>
<summary>a stale rationale removed</summary>

The subsonic path carried:

> Subsonic's redirect cannot carry the plyr.fm cookie required by the audio endpoint, so adult audio stays hidden on this surface.

That endpoint stopped requiring a cookie in #1697. The comment now explains the real reason the viewer is `None` there: a Subsonic client authenticates with a developer token rather than a session, so there is no preference to read — which is why it must not depend on one.
</details>

<details>
<summary>audit summary</summary>

164 API fetches, 39 without credentials. Every one traced to its endpoint's auth dependency:

- **4 genuinely degraded** — fixed here
- **35 harmless** — no session dependency (`/config`, `/stats`, `/radio/stations`, `/tracks/tags`, `/albums/{handle}`, `/activity`, …), or SSR loaders that structurally cannot send cookies and are correct for destinations, or `/radio/state` in the embed where radio excludes adult audio for everyone regardless

Verification that nothing degrading remains is scripted in the commit history.
</details>

<details>
<summary>tests</summary>

1342 pass. New coverage: the app-side filter honours VIEW, keeps copyright hidden in VIEW, and the SQL and Python paths agree on a destination. `svelte-check` clean.
</details>

<details>
<summary>what changes for signed-out visitors</summary>

Albums, playlists, liked lists, and subsonic browsing now show adult-labeled tracks to everyone, matching the artist page. That follows the call you already made for artist pages — destinations show what's there — but it is a visible change beyond the reported bug, so worth an explicit look before merge.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)