### PR TITLE
docs: one accurate answer for how labels affect visibility

### DIFF
--- a/backend/tests/test_content_label_policy.py
+++ b/backend/tests/test_content_label_policy.py
@@ -343,3 +343,30 @@ async def test_album_card_count_matches_what_the_album_will_show(
         context=LabelContext.VIEW,
     )
     assert counted == len(shown) == 2
+
+
+async def test_owner_sees_their_own_adult_track_but_not_their_own_copyright_one(
+    db_session: AsyncSession,
+) -> None:
+    """The owner exemption is scoped to the adult branch.
+
+    Documented in label-policy.md, and easy to trip over: a check run as the
+    owner passes whether or not the context split works. Pinned here so the
+    documented rule and the code cannot drift.
+    """
+    adult = await _track(db_session, file_id="own1", operator_labels=["sexual"])
+    infringing = await _track(
+        db_session, file_id="own2", operator_labels=["copyright-violation"]
+    )
+    await db_session.commit()
+
+    # OWNER, on a LIST surface, preference off
+    shown, _ = await filter_sensitive_audio_tracks_for_viewer(
+        db_session, [adult, infringing], OWNER, context=LabelContext.LIST
+    )
+    assert {t.id for t in shown} == {adult.id}, (
+        "owner sees their own adult track, but never their own copyright one"
+    )
+
+    # a non-owner sees neither
+    assert await _visible(db_session, LabelContext.LIST, shows_sensitive=False) == set()

--- a/docs/internal/moderation/label-policy.md
+++ b/docs/internal/moderation/label-policy.md
@@ -83,6 +83,58 @@ excluding only private ones, because an artist page shows their catalogue.
 Labels were the outlier in a function that had settled the question six lines
 earlier.
 
+### every filtering site, and its context
+
+verified against the code; if you change one, change this table.
+
+| call site | context |
+|---|---|
+| `tracks/listing.py` list_tracks | **VIEW** when `artist_did`, else LIST |
+| `tracks/listing.py` top tracks | LIST |
+| `search.py` keyword + semantic | LIST |
+| `for_you.py` | LIST |
+| `radio/corpus.py` | excluded outright, both families, no viewer |
+| `albums/listing.py` detail | **VIEW** |
+| `lists/hydration.py` | **VIEW** |
+| `users.py` public likes | **VIEW** |
+| `tracks/likes.py` own likes | **VIEW** |
+| `_internal/queue.py` | **VIEW** |
+| `subsonic/browsing.py` getAlbum | **VIEW** |
+| `subsonic/browsing.py` getRandomSongs | LIST |
+| `subsonic/endpoints.py` playlist, getSong | **VIEW** |
+| `_internal/jams.py` | LIST |
+| `tracks/listing.py` list_my_tracks | no label filter at all |
+
+`list_my_tracks` filters on `artist_did` alone, which is why a creator's portal
+always shows their whole catalogue.
+
+**jams are LIST on purpose.** A jam is a shared synchronized room like radio.
+Its filter is per-viewer, so participants can already see different queues —
+a product question worth raising on its own rather than changing silently.
+
+**Subsonic passes `viewer=None`.** A Subsonic client authenticates with a
+developer token rather than a session, so there is no preference to read. In a
+VIEW context that is fine; `getRandomSongs` is a shuffle feed and stays LIST,
+which means adult audio never reaches it.
+
+### the owner exemption
+
+`sensitive_audio_visible_clause` returns `~labeled | (Track.artist_did ==
+viewer_did)`, and the app-side filter has the matching `or track.artist_did ==
+viewer_did`. So **an owner sees their own adult-labeled tracks in every
+context**, regardless of preference.
+
+it is scoped to the adult branch only: an owner does *not* see their own
+copyright-labeled track in a LIST surface, because that is a hosting decision
+rather than a preference. Radio has no viewer at all, so the exemption cannot
+apply there either.
+
+this rule is easy to trip over when testing. A check run as the track's owner
+passes whether or not the context split works — verify with an anonymous or
+non-owner viewer.
+
+### the rules
+
 adult labels apply only in `LIST`. Filtering an artist's own page made it
 misrepresent their catalogue — it rendered "4 tracks" above a list of one —
 and disagreed with the album page one level deeper, which showed everything.

--- a/docs/public/artists.md
+++ b/docs/public/artists.md
@@ -51,6 +51,8 @@ signed-in listener has enabled sensitive audio in their settings. **Your own
 artist page still lists them, and a direct link still plays for anyone** — the
 notice changes where your track surfaces, not whether someone you send it to
 can hear it, and not how your catalogue looks to someone who came to find you.
+You always see your own noticed tracks, whatever your own settings say. See
+[moderation](/moderation) for exactly which surfaces are affected.
 
 removing your notice removes only your own assertion. If a plyr.fm moderator
 independently labeled the track, that operator label and its default-hide policy

--- a/docs/public/moderation.md
+++ b/docs/public/moderation.md
@@ -51,21 +51,58 @@ copyright claim is our responsibility and no listener setting can waive it.
 
 ## where a label applies
 
-a label changes where a track *surfaces*, not whether you can reach what you
-went looking for. The distinction is between two kinds of place:
+A label changes **where a track surfaces**, never whether you can reach
+something you went looking for. Two kinds of place:
 
-- **surfaces we choose for you** — the home feed, search results,
-  recommendations, radio. Adult labels filter here.
-- **places you navigated to** — an artist's page, an album, a track's own
-  link. These show what is there.
+- **surfaces we choose for you** — the home feed, search, recommendations,
+  radio. Labels filter here.
+- **places you navigated to** — an artist's page, an album, a playlist,
+  someone's likes, your queue, a track's own link. These show what is there.
 
-this mirrors how the AT Protocol itself models moderation, where the same post
-can be hidden in a feed but visible when you open it. Hiding part of an
-artist's catalogue on their own page would misrepresent their work to someone
-who had already gone looking for them.
+this mirrors how the AT Protocol models moderation, where the same post can be
+hidden in a feed but visible when you open it.
 
-copyright is the exception: it applies everywhere, because it is about what we
-are willing to keep serving rather than about what you would rather see.
+### the full picture
+
+| where | adult (`sexual`, `porn`) | copyright |
+|---|---|---|
+| home feed, search, for you | hidden unless you opt in | hidden |
+| radio | never, for anyone | never |
+| artist page | **shown** | hidden |
+| album, playlist | **shown** | hidden |
+| someone's likes | **shown** | hidden |
+| your queue | **shown** | hidden |
+| a track's own link, and playback | **plays** | **plays** |
+| your own uploads, in your portal | **shown** | **shown** |
+| Subsonic browsing | **shown** | hidden |
+| Subsonic shuffle | hidden | hidden |
+| listening rooms (jams) | hidden unless you opt in | hidden |
+
+radio and jams are shared, synchronized surfaces: one listener's preference
+cannot decide what everyone else hears, so adult audio stays out.
+
+### two rules worth stating plainly
+
+**you always see your own adult-labeled tracks.** On any surface, whatever your
+settings say. A label on your own upload never hides it from you — except in
+radio, which is shared, and except for copyright, which is not a preference.
+
+**a copyright label is not a preference.** No setting reveals a
+copyright-labeled track, including for the person who uploaded it, because it
+is about what we are willing to keep serving rather than about what you would
+rather see. Playback from a direct link still works: a fingerprint match is not
+a finding, and covers and remixes match.
+
+### operator overrides
+
+sometimes we review a label and decide the behavior should differ from the
+default:
+
+- **allow** — the label is right, and we are surfacing the track anyway. The
+  usual outcome for a cover or a licensed remix. It lifts copyright filtering;
+  it never overrides your adult-content preference, because what you are shown
+  is your call, not ours.
+- **exclude** — kept off shared surfaces with no label needed.
 
 ## what gets published, and what does not
 

--- a/docs/public/sensitive-content.md
+++ b/docs/public/sensitive-content.md
@@ -35,10 +35,15 @@ as well as images or video.
 
 when a creator self-labels a track or a trusted labeler applies either value:
 
-- it is omitted from discovery, search, recommendations, public collections,
-  queues, Subsonic browsing, and shared radio by default
-- **the artist's own page still lists it.** Those surfaces are places we chose
-  to put something in front of you; an artist's page is somewhere you went
+- it is omitted from the home feed, search, recommendations, and shared radio
+  by default
+- **it is still listed on the artist's page, in albums and playlists, in
+  someone's likes, and in your queue** — places you navigated to show what is
+  there
+- **you always see your own adult-labeled tracks**, whatever your settings say
+
+[moderation](/moderation) has the full surface-by-surface table, including how
+copyright labels differ.
 - **a direct link still plays, for anyone.** The label changes where a track
   appears, not whether it can be reached
 - the creator can always see and play their own track


### PR DESCRIPTION
There was no single place to point someone who asks *"will my labeled track show up in X?"*. Each public page described a slice, and two rules that surprised me while testing weren't written down anywhere.

<details>
<summary>the canonical answer</summary>

`docs.plyr.fm/moderation` now carries the full table:

| where | adult | copyright |
|---|---|---|
| home feed, search, for you | hidden unless you opt in | hidden |
| radio | never, for anyone | never |
| artist page | **shown** | hidden |
| album, playlist | **shown** | hidden |
| someone's likes | **shown** | hidden |
| your queue | **shown** | hidden |
| a track's own link, and playback | **plays** | **plays** |
| your own uploads, in your portal | **shown** | **shown** |
| Subsonic browsing | **shown** | hidden |
| Subsonic shuffle | hidden | hidden |
| listening rooms (jams) | hidden unless you opt in | hidden |

Every row verified against the code, not written from memory. `sensitive-content.md` and `artists.md` now defer here instead of each repeating a partial version.
</details>

<details>
<summary>two rules nobody had written down</summary>

**You always see your own adult-labeled tracks** — any surface, whatever your settings say. Except radio, which is shared, and except copyright, which isn't a preference.

I found this by tripping on it: my first staging verification ran as the track's owner and passed regardless of whether the change worked. `sensitive_audio_visible_clause` returns `~labeled | (Track.artist_did == viewer_did)`, and the exemption is scoped to the adult branch — so an owner does **not** see their own copyright-labeled track in a feed.

**A copyright label is not a preference.** No setting reveals one, including for the uploader, because it's about what we're willing to keep serving rather than what you'd rather see. The permalink still plays: a fingerprint match is not a finding, and covers and remixes match.
</details>

<details>
<summary>internal</summary>

`label-policy.md` gains the table of **every filtering call site and its context**, so the docs can be checked against the code rather than trusted. Also records why jams stay LIST (a shared synchronized room whose per-viewer filter already means participants can see different queues — a product question, not something to change silently) and why Subsonic passes no viewer (developer-token auth, so there's no preference to read).
</details>

<details>
<summary>test</summary>

1344 pass. New regression pins the owner exemption in both directions — owner sees their own adult track, never their own copyright one, and a non-owner sees neither. That's the rule most likely to make a future test pass for the wrong reason.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)