### PR TITLE
docs: remove exposed Neon credential

### DIFF
--- a/docs/internal/tools/neon.md
+++ b/docs/internal/tools/neon.md
@@ -335,10 +335,8 @@ returns a postgres connection string for use with `psql`, database clients, or a
 - `databaseName` - specific database (defaults to neondb)
 - `roleName` - specific role (defaults to neondb_owner)
 
-**example output** (placeholder values — never commit a real connection string):
-```
-postgresql://<role>:<password>@<endpoint>.<region>.aws.neon.tech/<database>?channel_binding=require&sslmode=require
-```
+Treat the returned connection string as a secret. Never paste it into notes,
+logs, issues, or other tracked files.
 
 ## database environment mapping
 


### PR DESCRIPTION
## What changed

- removed the committed Neon connection-string example from `docs/internal/tools/neon.md`
- replaced it with guidance to treat returned connection strings as secrets and keep them out of tracked files

## Why

Neon detected that the example contained a real credential. The note described
the values as placeholders, but the connection string was live.

This change removes the credential from the current tree. The credential remains
present in Git history, so its password must still be rotated separately.

## Validation

- `git diff --check`
- repository pre-commit hooks (`loq`; non-applicable code checks skipped)
- verified no tracked file in the resulting tree contains a Neon `npg_` credential token
