### PR TITLE
docs: move published contact addresses to plyr.fm

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -158,7 +158,7 @@ class LegalSettings(AppSettingsSection):
     )
 
     contact_email: str = Field(
-        default="plyrdotfm@proton.me",
+        default="help@plyr.fm",
         description="General contact email",
     )
     privacy_email: str | None = Field(
@@ -166,7 +166,7 @@ class LegalSettings(AppSettingsSection):
         description="Privacy-specific contact email (falls back to contact_email)",
     )
     dmca_email: str | None = Field(
-        default=None,
+        default="dmca@plyr.fm",
         description="DMCA/copyright contact email (falls back to contact_email)",
     )
     dmca_registration_number: str = Field(

--- a/docs/internal/legal/dmca-agent.md
+++ b/docs/internal/legal/dmca-agent.md
@@ -1,0 +1,42 @@
+---
+title: "DMCA designated agent"
+---
+
+registration and renewal tracking for plyr.fm's DMCA designated agent.
+
+contact details are deliberately not recorded here — this repo is public. the
+authoritative copy is the Copyright Office filing, searchable at
+<https://dmca.copyright.gov/osp/>.
+
+## registration
+
+| | |
+|---|---|
+| registration number | DMCA-1069186 |
+| notice address | dmca@plyr.fm |
+| filed | July 27, 2026 |
+| **expires** | **July 27, 2029** |
+
+## renewal
+
+a designation expires and becomes **invalid** three years after registration
+unless renewed — either amend it to correct or update the information, or
+resubmit unchanged to confirm it's still accurate. either action resets the
+three-year clock.
+
+lapsing means losing § 512(c) safe harbor until it's re-filed.
+
+the Copyright Office emails reminders at 90, 60, 30, and 7 days before the
+deadline, but those go to whatever address is on the filing — don't rely on
+them alone.
+
+## outstanding
+
+[§ 512(c)(2)](https://www.law.cornell.edu/uscode/text/17/512) requires the
+agent's **name, address, phone number, and email** to be available publicly on
+the site, not only in the Copyright Office directory. terms §4 currently lists
+name and email only.
+
+pending a non-residential mailing address, at which point the filing gets
+amended (resetting the expiry above) and the site updated to match. see #1715,
+which covers the same page.

--- a/docs/public/index.mdx
+++ b/docs/public/index.mdx
@@ -97,6 +97,6 @@ import HeroWaveform from '../../components/HeroWaveform.astro';
 
 <div class="landing-section" style="text-align: center; margin-top: 4rem;">
   <p style="color: var(--sl-color-gray-3); font-size: 0.8rem;">
-    questions? <a href="mailto:plyrdotfm@proton.me" style="color: var(--sl-color-accent);">plyrdotfm@proton.me</a>
+    questions? <a href="mailto:help@plyr.fm" style="color: var(--sl-color-accent);">help@plyr.fm</a>
   </p>
 </div>

--- a/docs/public/legal/privacy.md
+++ b/docs/public/legal/privacy.md
@@ -58,7 +58,7 @@ you can access, correct, or delete your data through settings. when you delete y
 
 ## 6. security
 
-we use HTTPS, encrypt sensitive data, and use HttpOnly cookies. no system is perfectly secure—report vulnerabilities to plyrdotfm@proton.me.
+we use HTTPS, encrypt sensitive data, and use HttpOnly cookies. no system is perfectly secure—report vulnerabilities to help@plyr.fm.
 
 ## 7. children
 
@@ -70,4 +70,4 @@ we may update this policy. material changes will be posted with notice.
 
 ## contact
 
-questions? plyrdotfm@proton.me
+questions? help@plyr.fm

--- a/docs/public/legal/terms.md
+++ b/docs/public/legal/terms.md
@@ -40,8 +40,8 @@ you agree not to:
 we respond to valid DMCA takedown notices. our designated agent is:
 
 > Nathan Nowack
-> DMCA Registration: DMCA-1069186
-> Email: plyrdotfm@proton.me
+> DMCA Registration: DMCA-1069186 ([U.S. Copyright Office directory](https://dmca.copyright.gov/osp/))
+> Email: dmca@plyr.fm
 
 we terminate accounts of repeat infringers.
 
@@ -63,4 +63,4 @@ we may update these terms. material changes will be posted with notice. continue
 
 ## contact
 
-questions? plyrdotfm@proton.me
+questions? help@plyr.fm

--- a/docs/public/moderation.md
+++ b/docs/public/moderation.md
@@ -129,7 +129,7 @@ uploader and never mention a reporter.
 ## if you think a decision is wrong
 
 use the report control on the track, or email
-[plyrdotfm@proton.me](mailto:plyrdotfm@proton.me).
+[help@plyr.fm](mailto:help@plyr.fm).
 
 decisions are reversible and reversal is recorded the same way the original
 decision was. Two things can happen when we are wrong, and they mean different

--- a/docs/public/sensitive-content.md
+++ b/docs/public/sensitive-content.md
@@ -65,7 +65,7 @@ assertion and does not rewrite that record. Removing one does not remove the
 other. plyr.fm applies the same viewing and playback policy to their union.
 
 if a track is labeled incorrectly, use the report control while viewing it or contact
-[plyrdotfm@proton.me](mailto:plyrdotfm@proton.me).
+[help@plyr.fm](mailto:help@plyr.fm).
 
 ## for developers
 

--- a/docs/public/troubleshooting.md
+++ b/docs/public/troubleshooting.md
@@ -119,4 +119,4 @@ migrating your PDS (e.g. from bsky.social to a self-hosted instance) preserves y
 
 - check [STATUS.md](https://github.com/zzstoatzz/plyr.fm/blob/main/STATUS.md) for known issues and active work
 - open an issue on [GitHub](https://github.com/zzstoatzz/plyr.fm/issues)
-- email [plyrdotfm@proton.me](mailto:plyrdotfm@proton.me)
+- email [help@plyr.fm](mailto:help@plyr.fm)

--- a/frontend/src/routes/terms/+page.svelte
+++ b/frontend/src/routes/terms/+page.svelte
@@ -2,7 +2,7 @@
 	import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
 	import type { PageData } from './$types';
 
-	const FALLBACK_EMAIL = 'plyrdotfm@proton.me';
+	const FALLBACK_EMAIL = 'help@plyr.fm';
 
 	let { data } = $props<{ data: PageData }>();
 
@@ -81,7 +81,11 @@
 			<p>We respond to valid DMCA takedown notices. Our designated agent is:</p>
 			<address class="dmca-agent">
 				Nathan Nowack<br />
-				DMCA Registration: {data.dmcaRegistrationNumber}<br />
+				DMCA Registration: {data.dmcaRegistrationNumber} (<a
+					href="https://dmca.copyright.gov/osp/"
+					target="_blank"
+					rel="noopener">U.S. Copyright Office directory</a
+				>)<br />
 				Email: <a href="mailto:{dmcaEmail}">{dmcaEmail}</a>
 			</address>
 			<p>We terminate accounts of repeat infringers.</p>


### PR DESCRIPTION
Every published address was `plyrdotfm@proton.me`. General contact is now **`help@plyr.fm`**; the DMCA designated agent is **`dmca@plyr.fm`**.

<details>
<summary>infrastructure (already live)</summary>

Cloudflare Email Routing on `plyr.fm`, both addresses forwarding to the same Proton mailbox.

The domain had **no MX, SPF or DMARC** beforehand — checked first, because Email Routing requires Cloudflare's MX and cannot coexist with an external mail server. Nothing was displaced, and the `_atproto` / `_lexicon` TXT records are untouched.

```
MX   plyr.fm  route1/2/3.mx.cloudflare.net
TXT  plyr.fm                     v=spf1 include:_spf.mx.cloudflare.net ~all
TXT  cf2024-1._domainkey.plyr.fm v=DKIM1; …
```

Verified live on `1.1.1.1` and `8.8.8.8`. Destination verified 21:07:56. Catch-all deliberately **disabled** so a typo bounces visibly instead of forwarding silently.
</details>

<details>
<summary>why dmca@ is separate from help@</summary>

It has a statutory function with deadlines attached, so it should be routable and delegable independently of support. It's also now the address on file with the Copyright Office (**DMCA-1069186**) — the registration is the thing we least want to have to re-file, so it gets an address that won't change when support tooling does.

`config.dmca_email` was `None`, falling back to general contact. It's now explicit, so moving support email later can't silently move the DMCA agent address with it.
</details>

<details>
<summary>what is NOT in here, and why</summary>

`FALLBACK_EMAIL` in **`frontend/src/routes/privacy/+page.svelte`** still reads the Proton address.

Changing it trips `check-legal-dates` → requires bumping the privacy "Last updated" date → requires `LegalSettings.terms_last_updated` to follow → which is served via `/config` and compared in `preferences.svelte.ts:99` against `terms_accepted_at`, **re-prompting every existing user to re-accept the terms**.

That's disproportionate for a constant that only renders when `/config` is unreachable — and the address it falls back to still receives mail. Worth batching with the next genuinely material legal change instead.

The hook watches exactly `^frontend/src/routes/privacy/\+page\.svelte$`, so nothing else here is affected; `terms/+page.svelte` updates freely.
</details>

<details>
<summary>also carried</summary>

A Copyright Office directory citation on the agent block, from work done alongside this on the same files. Kept rather than split because it's two lines intermingled in `terms.md`.

Still open and tracked in #1715: § 512(c)(2) wants the agent's **address and phone** on the site too, which is blocked on a non-residential address.
</details>

<details>
<summary>not yet confirmed</summary>

**Mail physically arriving.** Port 25 egress is blocked from my machine — gmail's MX times out identically while port 443 to the same Cloudflare host is open — so I can't send a test. Everything up to the mailbox is verified; the last hop is not.

Worth sending one to both addresses before relying on `dmca@` for anything statutory.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)