### PR TITLE
docs(legal): say what we actually do with your data

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -174,7 +174,7 @@ class LegalSettings(AppSettingsSection):
         description="USPTO DMCA agent registration number",
     )
     terms_last_updated: datetime = Field(
-        default=datetime(2026, 3, 22),
+        default=datetime(2026, 7, 28),
         description="Date the terms/privacy were last materially updated. "
         "Users who accepted before this date will be prompted to re-accept.",
     )

--- a/docs/public/legal/privacy.md
+++ b/docs/public/legal/privacy.md
@@ -5,7 +5,7 @@ description: "how plyr.fm handles your data"
 
 > **note:** the source of truth is `frontend/src/routes/privacy/+page.svelte`. this markdown is a plain-text mirror for reference.
 
-**last updated:** march 22, 2026
+**last updated:** july 28, 2026
 
 plyr.fm ("we", "us", or "our") is an audio streaming application built on the [AT Protocol](https://atproto.com). this privacy policy applies to the instance at https://plyr.fm (the "site").
 
@@ -27,7 +27,9 @@ plyr.fm uses the AT Protocol for identity and social features. this has importan
 
 **you provide:** your AT Protocol identity when you sign in, audio files and metadata you upload, and preferences like accent color.
 
-**automatically:** play counts, IP addresses, browser info, and session cookies for authentication.
+**automatically:** play counts, browser info, and session cookies for authentication.
+
+**we do not store your IP address.** our hosting and CDN providers see it in order to route your request, as any web service's do, but plyr.fm keeps no record of it in our database or our logs.
 
 ## 3. how we use it
 
@@ -37,7 +39,7 @@ we use your data to provide the service, maintain your session, and improve the 
 
 we use:
 
-- [Cloudflare](https://cloudflare.com) - CDN, storage (R2)
+- [Cloudflare](https://cloudflare.com) - CDN, storage (R2), and email forwarding for our contact addresses
 - [Fly.io](https://fly.io) - backend hosting
 - [Neon](https://neon.tech) - database
 - [Logfire](https://logfire.pydantic.dev) - error monitoring

--- a/frontend/src/routes/privacy/+page.svelte
+++ b/frontend/src/routes/privacy/+page.svelte
@@ -2,7 +2,7 @@
 	import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
 	import type { PageData } from './$types';
 
-	const FALLBACK_EMAIL = 'plyrdotfm@proton.me';
+	const FALLBACK_EMAIL = 'help@plyr.fm';
 
 	let { data } = $props<{ data: PageData }>();
 
@@ -18,7 +18,7 @@
 <div class="legal-container">
 	<article class="legal-content">
 		<h1>Privacy Policy</h1>
-		<p class="last-updated">Last updated: March 22, 2026</p>
+		<p class="last-updated">Last updated: July 28, 2026</p>
 
 		<p class="intro">
 			{APP_NAME} ("we", "us", or "our") is an audio streaming application built on the
@@ -65,8 +65,11 @@
 			<h2>2. Data We Collect</h2>
 			<p><strong>You provide:</strong> Your AT Protocol identity when you sign in, audio files
 				and metadata you upload, and preferences like accent color.</p>
-			<p><strong>Automatically:</strong> Play counts, IP addresses, browser info, and
-				session cookies for authentication.</p>
+			<p><strong>Automatically:</strong> Play counts, browser info, and session cookies
+				for authentication.</p>
+			<p><strong>We do not store your IP address.</strong> Our hosting and CDN providers
+				see it in order to route your request, as any web service's do, but plyr.fm
+				keeps no record of it in our database or our logs.</p>
 		</section>
 
 		<section>
@@ -79,7 +82,7 @@
 			<h2>4. Third Parties</h2>
 			<p>We use:</p>
 			<ul>
-				<li><strong><a href="https://cloudflare.com" target="_blank" rel="noopener">Cloudflare</a></strong> - CDN, storage (R2)</li>
+				<li><strong><a href="https://cloudflare.com" target="_blank" rel="noopener">Cloudflare</a></strong> - CDN, storage (R2), and email forwarding for our contact addresses</li>
 				<li><strong><a href="https://fly.io" target="_blank" rel="noopener">Fly.io</a></strong> - backend hosting</li>
 				<li><strong><a href="https://neon.tech" target="_blank" rel="noopener">Neon</a></strong> - database</li>
 				<li><strong><a href="https://logfire.pydantic.dev" target="_blank" rel="noopener">Logfire</a></strong> - error monitoring</li>


### PR DESCRIPTION
The privacy policy claimed we collect IP addresses. **We don't** — and checking rather than assuming was the point.

<details>
<summary>how I verified it</summary>

**Database:** no `inet`/`cidr` column, and no column whose name contains "ip", anywhere in the production schema. (The only matches were `description`.)

**Logfire:** every request, across every route, records the same `net.peer.ip`:

```
172.16.7.50   /radio/state          1466
172.16.7.50   /tracks/{track_id}     456
172.16.7.50   /now-playing/          246
172.16.7.50   /queue/                209
…
```

That's RFC1918 space — Fly's internal proxy, identical for every user. No client IPs reach our logs.

The line was boilerplate. Overclaiming what you collect is its own small harm: it tells people to assume a retention risk that doesn't exist, and it makes the rest of the policy less credible.
</details>

<details>
<summary>what changed</summary>

- **§2** now states what's actually collected, plus the nuance that hosting and CDN providers necessarily *see* an IP to route a request even though we keep no record of it. That's more honest than either the old overclaim or a bare "we don't collect IPs".
- **§4** adds Cloudflare email forwarding, which is new since contact addresses moved to `plyr.fm` and does handle message contents.
- Both the svelte source of truth and the markdown mirror.
</details>

<details>
<summary>this one re-prompts users, deliberately</summary>

A material change to what the policy says about data collection, so the dates move and `terms_last_updated` follows — which prompts existing users to re-accept.

That prompt is exactly why the `FALLBACK_EMAIL` constant here was left stale in #1716. It's no longer worth deferring when the policy is genuinely changing, so it's corrected in the same pass rather than requiring a second re-prompt later.
</details>

<details>
<summary>not in this PR</summary>

**Rate limiting is effectively global, not per-client.** `slowapi` keys on `get_remote_address`, and uvicorn runs without `--proxy-headers`, so every request looks like `172.16.7.50` — the same fact that proves we don't log IPs also means one heavy client can consume the limit for everyone. Operational, not legal; flagged separately rather than bundled.

**`we terminate accounts of repeat infringers`** stays as written. It's the § 512(i) policy statement safe harbor wants, and softening it would be worse; the gap is implementation, which is a behavior change to discuss first.

**§ 512(c)(2) agent address and phone** still absent — blocked on a non-residential address, tracked in #1715.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)