### PR TITLE
fix(api): rate limit per client instead of per site

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -174,7 +174,7 @@ class LegalSettings(AppSettingsSection):
         description="USPTO DMCA agent registration number",
     )
     terms_last_updated: datetime = Field(
-        default=datetime(2026, 3, 22),
+        default=datetime(2026, 7, 28),
         description="Date the terms/privacy were last materially updated. "
         "Users who accepted before this date will be prompted to re-accept.",
     )

--- a/backend/src/backend/utilities/rate_limit.py
+++ b/backend/src/backend/utilities/rate_limit.py
@@ -1,12 +1,70 @@
-"""Rate limiting utility."""
+"""Rate limiting utility.
+
+Limits are per client. That sounds obvious, but it was not true: the key was
+`get_remote_address`, which reads `request.client.host`, and behind Fly's proxy
+that is the proxy -- the same `172.16.7.50` for every request from every user.
+With shared Redis storage this made `default_limits` a single bucket for the
+entire site, so any one caller could spend everyone's budget. Production peaked
+at 124 requests in a minute against a 100/minute ceiling and returned 298 429s
+on `/radio/state` alone: radio listeners poll every 30 seconds and were knocking
+each other offline.
+
+A global limiter is worse than no limiter for availability, because it turns one
+misbehaving client into a site-wide outage. Hence per-client keying.
+"""
+
+import hashlib
 
 from slowapi import Limiter
-from slowapi.util import get_remote_address
+from starlette.requests import Request
 
 from backend.config import settings
 
+# Fly terminates the connection and forwards the caller's address in a header;
+# `request.client.host` is Fly's own proxy. X-Forwarded-For is the fallback:
+# its leftmost entry is the original client, the rest are proxies.
+_CLIENT_IP_HEADER = "fly-client-ip"
+_FORWARDED_FOR_HEADER = "x-forwarded-for"
+
+
+def _hashed(value: str) -> str:
+    """Short digest, so a raw session token never becomes a Redis key."""
+    return hashlib.sha256(value.encode()).hexdigest()[:32]
+
+
+def client_ip(request: Request) -> str:
+    """The caller's address, or a stable placeholder when it cannot be found."""
+    if fly_ip := request.headers.get(_CLIENT_IP_HEADER):
+        return fly_ip.strip()
+    if forwarded := request.headers.get(_FORWARDED_FOR_HEADER):
+        if first := forwarded.split(",")[0].strip():
+            return first
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+def rate_limit_key(request: Request) -> str:
+    """Identify the caller, preferring session over network address.
+
+    A session follows the person rather than the network, so it is both more
+    accurate and better for privacy: an authenticated request never has its IP
+    used for anything. The identifier is hashed because it is a bearer
+    credential, and a Redis key is not the place for one.
+
+    An IP is the key only for anonymous callers, where nothing else identifies
+    them. It is used transiently -- as a key carrying the window's TTL -- and is
+    never written to the database or the logs.
+    """
+    if session_id := request.cookies.get("session_id"):
+        return f"s:{_hashed(session_id)}"
+    if authorization := request.headers.get("authorization"):
+        return f"t:{_hashed(authorization)}"
+    return f"ip:{client_ip(request)}"
+
+
 limiter = Limiter(
-    key_func=get_remote_address,
+    key_func=rate_limit_key,
     enabled=settings.rate_limit.enabled,
     default_limits=[settings.rate_limit.default_limit],
     storage_uri=settings.docket.url or "memory://",

--- a/backend/tests/utilities/test_rate_limit_key.py
+++ b/backend/tests/utilities/test_rate_limit_key.py
@@ -1,0 +1,100 @@
+"""Rate limits must be per client, not per site.
+
+The bug these pin: the key was `request.client.host`, which behind Fly's proxy
+is the proxy. Every user shared one bucket, so a single caller could exhaust the
+site's budget -- 298 429s on /radio/state, from listeners polling every 30s and
+knocking each other offline.
+"""
+
+from starlette.requests import Request
+
+from backend.utilities.rate_limit import client_ip, rate_limit_key
+
+
+def _request(
+    headers: dict[str, str] | None = None, *, peer: str = "172.16.7.50"
+) -> Request:
+    raw = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": raw,
+            "client": (peer, 1234),
+            "scheme": "https",
+            "server": ("api.plyr.fm", 443),
+            "query_string": b"",
+        }
+    )
+
+
+def test_two_anonymous_callers_get_different_keys() -> None:
+    """The whole point: distinct clients must not share a bucket."""
+    a = rate_limit_key(_request({"Fly-Client-IP": "203.0.113.10"}))
+    b = rate_limit_key(_request({"Fly-Client-IP": "198.51.100.20"}))
+    assert a != b
+
+
+def test_the_proxy_address_is_not_the_key() -> None:
+    """Both requests arrive from the same Fly proxy; that must not merge them."""
+    a = rate_limit_key(_request({"Fly-Client-IP": "203.0.113.10"}, peer="172.16.7.50"))
+    b = rate_limit_key(_request({"Fly-Client-IP": "198.51.100.20"}, peer="172.16.7.50"))
+    assert "172.16.7.50" not in a
+    assert a != b
+
+
+def test_session_beats_ip_so_authenticated_users_are_keyed_by_identity() -> None:
+    """An authenticated request should never be keyed on its network address.
+
+    Two requests from the same session on different networks are one caller.
+    """
+    home = rate_limit_key(
+        _request({"Cookie": "session_id=abc123", "Fly-Client-IP": "203.0.113.10"})
+    )
+    cafe = rate_limit_key(
+        _request({"Cookie": "session_id=abc123", "Fly-Client-IP": "198.51.100.20"})
+    )
+    assert home == cafe
+    assert "203.0.113" not in home
+
+
+def test_sharing_a_network_does_not_share_a_budget_when_signed_in() -> None:
+    """Two people behind one NAT must not throttle each other."""
+    one = rate_limit_key(
+        _request({"Cookie": "session_id=aaa", "Fly-Client-IP": "203.0.113.10"})
+    )
+    two = rate_limit_key(
+        _request({"Cookie": "session_id=bbb", "Fly-Client-IP": "203.0.113.10"})
+    )
+    assert one != two
+
+
+def test_bearer_tokens_are_keyed_separately() -> None:
+    a = rate_limit_key(_request({"Authorization": "Bearer aaa"}))
+    b = rate_limit_key(_request({"Authorization": "Bearer bbb"}))
+    assert a != b
+
+
+def test_credentials_are_never_used_raw_as_a_key() -> None:
+    """Redis keys are not a place to put a bearer credential."""
+    key = rate_limit_key(_request({"Cookie": "session_id=super-secret-value"}))
+    assert "super-secret-value" not in key
+    token = rate_limit_key(_request({"Authorization": "Bearer super-secret-token"}))
+    assert "super-secret-token" not in token
+
+
+def test_forwarded_for_uses_the_leftmost_entry() -> None:
+    """The client is first; the rest are proxies that must not become the key."""
+    ip = client_ip(
+        _request({"X-Forwarded-For": "203.0.113.10, 70.41.3.18, 150.172.238.178"})
+    )
+    assert ip == "203.0.113.10"
+
+
+def test_fly_header_wins_over_forwarded_for() -> None:
+    """X-Forwarded-For is client-settable; Fly's own header is not."""
+    ip = client_ip(
+        _request({"Fly-Client-IP": "203.0.113.10", "X-Forwarded-For": "1.2.3.4"})
+    )
+    assert ip == "203.0.113.10"

--- a/docs/public/legal/privacy.md
+++ b/docs/public/legal/privacy.md
@@ -5,7 +5,7 @@ description: "how plyr.fm handles your data"
 
 > **note:** the source of truth is `frontend/src/routes/privacy/+page.svelte`. this markdown is a plain-text mirror for reference.
 
-**last updated:** march 22, 2026
+**last updated:** july 28, 2026
 
 plyr.fm ("we", "us", or "our") is an audio streaming application built on the [AT Protocol](https://atproto.com). this privacy policy applies to the instance at https://plyr.fm (the "site").
 
@@ -27,7 +27,9 @@ plyr.fm uses the AT Protocol for identity and social features. this has importan
 
 **you provide:** your AT Protocol identity when you sign in, audio files and metadata you upload, and preferences like accent color.
 
-**automatically:** play counts, IP addresses, browser info, and session cookies for authentication.
+**automatically:** play counts, browser info, and session cookies for authentication.
+
+**we do not store your IP address.** our hosting and CDN providers see it in order to route your request, as any web service's do, but plyr.fm keeps no record of it in our database or our logs.
 
 ## 3. how we use it
 
@@ -37,7 +39,7 @@ we use your data to provide the service, maintain your session, and improve the 
 
 we use:
 
-- [Cloudflare](https://cloudflare.com) - CDN, storage (R2)
+- [Cloudflare](https://cloudflare.com) - CDN, storage (R2), and email forwarding for our contact addresses
 - [Fly.io](https://fly.io) - backend hosting
 - [Neon](https://neon.tech) - database
 - [Logfire](https://logfire.pydantic.dev) - error monitoring

--- a/docs/public/legal/privacy.md
+++ b/docs/public/legal/privacy.md
@@ -29,7 +29,9 @@ plyr.fm uses the AT Protocol for identity and social features. this has importan
 
 **automatically:** play counts, browser info, and session cookies for authentication.
 
-**we do not store your IP address.** our hosting and CDN providers see it in order to route your request, as any web service's do, but plyr.fm keeps no record of it in our database or our logs.
+**we do not store your IP address.** our hosting and CDN providers see it in order to route your request, as any web service's do, but plyr.fm writes it to neither our database nor our logs.
+
+when you are signed out, we use your IP address transiently to apply rate limits, so that one visitor cannot degrade the service for everyone. it is held only for the length of the limit window and is never retained. when you are signed in we use your session instead, and your IP is not used at all.
 
 ## 3. how we use it
 

--- a/frontend/src/routes/privacy/+page.svelte
+++ b/frontend/src/routes/privacy/+page.svelte
@@ -69,7 +69,11 @@
 				for authentication.</p>
 			<p><strong>We do not store your IP address.</strong> Our hosting and CDN providers
 				see it in order to route your request, as any web service's do, but plyr.fm
-				keeps no record of it in our database or our logs.</p>
+				writes it to neither our database nor our logs.</p>
+			<p>When you are signed out, we use your IP address transiently to apply rate
+				limits, so that one visitor cannot degrade the service for everyone. It is
+				held only for the length of the limit window and is never retained. When you
+				are signed in we use your session instead, and your IP is not used at all.</p>
 		</section>
 
 		<section>

--- a/frontend/src/routes/privacy/+page.svelte
+++ b/frontend/src/routes/privacy/+page.svelte
@@ -2,7 +2,7 @@
 	import { APP_NAME, APP_CANONICAL_URL } from '$lib/branding';
 	import type { PageData } from './$types';
 
-	const FALLBACK_EMAIL = 'plyrdotfm@proton.me';
+	const FALLBACK_EMAIL = 'help@plyr.fm';
 
 	let { data } = $props<{ data: PageData }>();
 
@@ -18,7 +18,7 @@
 <div class="legal-container">
 	<article class="legal-content">
 		<h1>Privacy Policy</h1>
-		<p class="last-updated">Last updated: March 22, 2026</p>
+		<p class="last-updated">Last updated: July 28, 2026</p>
 
 		<p class="intro">
 			{APP_NAME} ("we", "us", or "our") is an audio streaming application built on the
@@ -65,8 +65,11 @@
 			<h2>2. Data We Collect</h2>
 			<p><strong>You provide:</strong> Your AT Protocol identity when you sign in, audio files
 				and metadata you upload, and preferences like accent color.</p>
-			<p><strong>Automatically:</strong> Play counts, IP addresses, browser info, and
-				session cookies for authentication.</p>
+			<p><strong>Automatically:</strong> Play counts, browser info, and session cookies
+				for authentication.</p>
+			<p><strong>We do not store your IP address.</strong> Our hosting and CDN providers
+				see it in order to route your request, as any web service's do, but plyr.fm
+				keeps no record of it in our database or our logs.</p>
 		</section>
 
 		<section>
@@ -79,7 +82,7 @@
 			<h2>4. Third Parties</h2>
 			<p>We use:</p>
 			<ul>
-				<li><strong><a href="https://cloudflare.com" target="_blank" rel="noopener">Cloudflare</a></strong> - CDN, storage (R2)</li>
+				<li><strong><a href="https://cloudflare.com" target="_blank" rel="noopener">Cloudflare</a></strong> - CDN, storage (R2), and email forwarding for our contact addresses</li>
 				<li><strong><a href="https://fly.io" target="_blank" rel="noopener">Fly.io</a></strong> - backend hosting</li>
 				<li><strong><a href="https://neon.tech" target="_blank" rel="noopener">Neon</a></strong> - database</li>
 				<li><strong><a href="https://logfire.pydantic.dev" target="_blank" rel="noopener">Logfire</a></strong> - error monitoring</li>


### PR DESCRIPTION
The rate limiter was keyed on `get_remote_address` → `request.client.host` → **Fly's proxy**. Every request from every user reported `172.16.7.50`. With shared Redis storage, `default_limits` was **one 100/minute bucket for the entire site**.

Supersedes #1717, which is closed — this carries its commit plus the fix, so users re-accept once rather than twice.

<details>
<summary>this was already breaking production</summary>

A global limiter is worse than no limiter, because it converts one caller into a site-wide outage. That was happening by accident:

```
peak requests/minute:  124, 123, 101      (ceiling: 100)
429s returned:         298 on /radio/state, 33 on /
```

The radio player polls every 30 seconds, so concurrent listeners were spending each other's budget and knocking each other offline.
</details>

<details>
<summary>why not solve it at the edge</summary>

I assumed Cloudflare could absorb this without us touching IPs. It can't — `api.plyr.fm` resolves to `66.241.125.204` and returns `server: Fly/…` with no `cf-ray`. It's a **direct Fly Anycast address, not proxied**. Only `plyr.fm` sits behind Cloudflare.

Routing the API through CF is a much larger change (streaming, CORS, jam WebSockets) and isn't the fix for this.
</details>

<details>
<summary>the key</summary>

**Session when there is one, client address when there isn't.**

A session identifies the person rather than the network, which is both more accurate and better for privacy:

- two people behind one NAT no longer share a budget
- one person on two networks isn't counted twice
- an authenticated request never has its IP used for anything

Hashed, because a bearer credential doesn't belong in a Redis key. `Fly-Client-IP` is preferred over `X-Forwarded-For` since the latter is client-settable.
</details>

<details>
<summary>privacy wording, in the same commit</summary>

Keying anonymous callers on IP is transient processing — a Redis key carrying the window's TTL — not retention. The policy now says exactly that, including that signed-in users' IPs aren't used at all.

Shipping it separately would mean either a policy that describes a system we don't have, or a second re-acceptance prompt. Both are worse.
</details>

<details>
<summary>tests</summary>

1352 pass. 8 new, and I verified they discriminate — reverting the key function to `request.client.host` fails 4 of them:

- two anonymous callers get different keys
- the proxy address is never the key
- session beats IP, so one person on two networks is one bucket
- two sessions behind one IP are two buckets
- credentials never appear raw in a key
- `X-Forwarded-For` uses the leftmost entry; `Fly-Client-IP` wins over it
</details>

<details>
<summary>what I'll verify on staging before this goes to prod</summary>

That `Fly-Client-IP` is actually populated end to end — the unit tests prove the key function, not the deployment. The check: exhaust the 10/minute auth limit anonymously, then immediately issue a request carrying a session. Under the old global key both would 429; under this one, only the first should.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)