### PR TITLE
fix(tags): a tag containing a slash is reachable

### DIFF
--- a/backend/src/backend/api/tracks/tags.py
+++ b/backend/src/backend/api/tracks/tags.py
@@ -54,7 +54,10 @@ class TagTracksResponse(BaseModel):
     created_by_handle: str | None = None
 
 
-@router.get("/tags/{tag_name}")
+# `:path` because a tag may contain a slash -- "7/4", "funk / soul". The client
+# percent-encodes it, but the ASGI layer decodes once before routing, so a plain
+# `{tag_name}` never matches and the request 404s in the router rather than here.
+@router.get("/tags/{tag_name:path}")
 async def get_tracks_by_tag(
     tag_name: str,
     db: Annotated[AsyncSession, Depends(get_db)],

--- a/backend/tests/api/test_tag_lookup_with_slash.py
+++ b/backend/tests/api/test_tag_lookup_with_slash.py
@@ -1,0 +1,159 @@
+"""a tag containing a slash must be reachable.
+
+The bug this pins (#1662): "7/4" and "funk / soul" are legitimate tags -- a time
+signature and a genre pair -- but neither could be opened. The frontend
+percent-encodes the name, and the ASGI layer decodes it once *before* routing, so
+`/tracks/tags/7%2F4` arrives as `/tracks/tags/7/4` and matches no route. The
+request 404s in the router, before the handler that would have found the tag.
+
+Slash is the only character with this problem: `?`, `#`, `%` and space all survive
+the decode and reach the handler intact, which is why this is a routing fix and not
+an encoding one. The tests below request the path the server actually sees -- with
+a literal slash -- because that is what the decode produces.
+"""
+
+from collections.abc import Generator
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import Session, get_optional_session
+from backend.main import app
+from backend.models import Artist, Tag, Track, TrackTag, get_db
+
+
+@pytest.fixture
+async def artist(db_session: AsyncSession) -> Artist:
+    artist = Artist(
+        did="did:plc:slashartist",
+        handle="slash.bsky.social",
+        display_name="Slash Artist",
+        pds_url="https://test.pds",
+    )
+    db_session.add(artist)
+    await db_session.commit()
+    await db_session.refresh(artist)
+    return artist
+
+
+@pytest.fixture
+async def time_signature_tag(db_session: AsyncSession, artist: Artist) -> Tag:
+    """the tag from the original report."""
+    tag = Tag(name="7/4", created_by_did=artist.did)
+    db_session.add(tag)
+    await db_session.commit()
+    await db_session.refresh(tag)
+    return tag
+
+
+@pytest.fixture
+async def tagged_track(
+    db_session: AsyncSession, artist: Artist, time_signature_tag: Tag
+) -> Track:
+    track = Track(
+        title="Seven Four",
+        artist_did=artist.did,
+        file_id="sevenfour123",
+        file_type="mp3",
+        extra={"duration": 297},
+        atproto_record_uri="at://did:plc:slashartist/fm.plyr.track/sevenfour123",
+        atproto_record_cid="bafysevenfour123",
+    )
+    db_session.add(track)
+    await db_session.flush()
+    db_session.add(TrackTag(track_id=track.id, tag_id=time_signature_tag.id))
+    await db_session.commit()
+    await db_session.refresh(track)
+    return track
+
+
+@pytest.fixture
+def test_app(db_session: AsyncSession) -> Generator[FastAPI, None, None]:
+    async def mock_get_optional_session() -> Session | None:
+        return None
+
+    async def mock_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_optional_session] = mock_get_optional_session
+    app.dependency_overrides[get_db] = mock_get_db
+    yield app
+    app.dependency_overrides.clear()
+
+
+async def test_tag_with_slash_resolves(test_app: FastAPI, tagged_track: Track) -> None:
+    """The regression: this 404'd in the router before the fix."""
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get("/tracks/tags/7/4")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["tag"]["name"] == "7/4"
+    assert [t["title"] for t in body["tracks"]] == ["Seven Four"]
+
+
+async def test_tag_with_spaces_around_slash_resolves(
+    test_app: FastAPI, db_session: AsyncSession, artist: Artist
+) -> None:
+    """The other affected tag in production: 'funk / soul'."""
+    db_session.add(Tag(name="funk / soul", created_by_did=artist.did))
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get("/tracks/tags/funk / soul")
+
+    assert response.status_code == 200
+    assert response.json()["tag"]["name"] == "funk / soul"
+
+
+async def test_a_missing_tag_still_reports_the_full_name(test_app: FastAPI) -> None:
+    """The 404 must name what was actually looked up, not a truncated prefix.
+
+    A greedy `:path` that stopped at the slash would report "7" here, which would
+    send the next person debugging this in the wrong direction.
+    """
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get("/tracks/tags/9/8")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "tag '9/8' not found"
+
+
+async def test_ordinary_tags_are_unaffected(
+    test_app: FastAPI, db_session: AsyncSession, artist: Artist
+) -> None:
+    """`:path` must not change how a normal tag resolves."""
+    db_session.add(Tag(name="jazz", created_by_did=artist.did))
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get("/tracks/tags/jazz")
+
+    assert response.status_code == 200
+    assert response.json()["tag"]["name"] == "jazz"
+
+
+async def test_the_tag_list_endpoint_still_routes(
+    test_app: FastAPI, db_session: AsyncSession, artist: Artist
+) -> None:
+    """`/tags/{name:path}` is greedy; it must not swallow `/tags` itself."""
+    db_session.add(Tag(name="ambient", created_by_did=artist.did))
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get("/tracks/tags")
+
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)


### PR DESCRIPTION
`7/4` and `funk / soul` are legitimate tags — a time signature and a genre pair — and neither could be opened. Reported in #1662. One-line routing fix.

**Not the tag system, the router.** The frontend does `encodeURIComponent("7/4")` → `/tracks/tags/7%2F4`, but the ASGI layer decodes percent-escapes *once before routing*, so the path becomes `/tracks/tags/7/4` and matches no route. The request 404s in the router, never reaching the handler. That's why the page could print the name it claimed not to find: SvelteKit resolved `params.name` to `7/4` correctly, the backend 404'd, and `+page.server.ts` renders any 404 as `tag "${params.name}" not found`.

```python
-@router.get("/tags/{tag_name}")
+@router.get("/tags/{tag_name:path}")
```

<details>
<summary>how the character set was narrowed, and what the tests pin</summary>

Probed each suspect against production. Only slash breaks, because it's the only one that's structurally a path separator:

| sent | reaches handler as | |
|---|---|---|
| `jaz%2Fz` | — | **404 in the router** |
| `jaz%3Fz` | `jaz?z` | ok |
| `jaz%23z` | `jaz#z` | ok |
| `jaz%25z` | `jaz%z` | ok |
| `jaz%20z` | `jaz z` | ok |

So this is a routing fix, not an encoding one — no frontend change needed.

The tests request the path the server actually sees (with a literal slash), because that is what the decode produces. Pre-fix, exactly the three slash tests fail with the router's bare `Not Found` — the production symptom — and the two controls pass.

Two of the five guard the fix rather than the bug, since `:path` is greedy:
- a missing `9/8` must report the whole name, not a truncated `9` — otherwise the next person debugging this gets sent the wrong way
- `/tracks/tags` (the list endpoint) must still route, not be swallowed by the wildcard

**Production impact:** two affected tags. `funk / soul` has 2 tracks and starts resolving. `7/4` currently has none — it was created 2026-07-11, hit the 404 on the 12th, and was later removed from its track — so it will render as an empty tag page. That is the same behaviour as the other 20 orphan tag rows on prod (280 tags, 21 with no tracks), so this is consistent rather than a new edge case. Whether an empty tag should 404 at all is a separate product call, deliberately not made here.
</details>

No closing keyword — leaving #1662 for you to close.