### PR TITLE
fix(accounts): the host that emitted #account may not be the account's PDS

### DIFF
--- a/backend/src/backend/_internal/atproto/account_status.py
+++ b/backend/src/backend/_internal/atproto/account_status.py
@@ -39,6 +39,40 @@ INFRASTRUCTURE_STATUSES: Final[frozenset[str]] = frozenset(
 )
 
 
+async def repo_is_live_on_current_pds(did: str) -> bool | None:
+    """ask the DID's *current* PDS whether it serves this repo.
+
+    an `#account` event is emitted by some host, and the lexicon is explicit
+    that this need not be the account's current PDS. the common case in
+    practice is migration: leaving a host deactivates the repo there, so the
+    host you left correctly announces `deactivated` while the account is alive
+    somewhere else. every artist wrongly hidden on plyr got there this way.
+
+    returns True/False when the current PDS answers, None when we cannot tell —
+    and "cannot tell" must never be read as "gone".
+    """
+    import httpx
+
+    from backend._internal.slingshot import resolve_mini_doc_safe
+
+    if not (mini_doc := await resolve_mini_doc_safe(did)):
+        return None
+    if not (pds := mini_doc.get("pds")):
+        return None
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            r = await client.get(
+                f"{pds}/xrpc/com.atproto.sync.getRepoStatus", params={"did": did}
+            )
+        if r.status_code != 200:
+            return None
+        body = r.json()
+        return not hides_content(body.get("active", True), body.get("status"))
+    except Exception:
+        return None
+
+
 def hides_content(active: bool, status: str | None) -> bool:
     """should this account's content drop out of discovery?
 

--- a/backend/src/backend/_internal/tasks/ingest.py
+++ b/backend/src/backend/_internal/tasks/ingest.py
@@ -920,10 +920,32 @@ async def ingest_account_status_change(
     goes dead. on account-level deactivation: clear it, so the frontend doesn't
     render a broken image.
     """
-    from backend._internal.atproto.account_status import hides_content
+    from backend._internal.atproto.account_status import (
+        hides_content,
+        repo_is_live_on_current_pds,
+    )
     from backend._internal.atproto.profile import fetch_user_avatar
 
     hide = hides_content(active, status)
+
+    if hide and await repo_is_live_on_current_pds(did) is True:
+        # the event came from a host this account has left. leaving a PDS
+        # deactivates the repo there, so the old host is telling the truth
+        # about itself and nothing about the person. the event is discarded
+        # outright — including its avatar handling, since nothing about this
+        # artist actually changed.
+        async with db_session() as db:
+            artist = await db.get(Artist, did)
+            if artist and (artist.deactivated or artist.account_status):
+                artist.deactivated = False
+                artist.account_status = None
+                await db.commit()
+        logfire.info(
+            "ingest: ignoring inactive event, repo is live on current PDS",
+            did=did,
+            status=status,
+        )
+        return
 
     async with db_session() as db:
         artist = await db.get(Artist, did)

--- a/backend/tests/test_jetstream.py
+++ b/backend/tests/test_jetstream.py
@@ -2429,3 +2429,70 @@ class TestAccountReactivationOnRepoActivity:
         assert captured == [
             {"did": "did:plc:jetstream_test", "active": False, "status": "throttled"}
         ]
+
+
+class TestMigratedPdsIsNotDeactivation:
+    """leaving a PDS deactivates the repo on the host you left.
+
+    every artist wrongly hidden on plyr got there this way: their old
+    bsky-hosted PDS emitted `active=false status=deactivated` — true of that
+    host — while the account was alive on a PDS they had moved to. twelve more
+    were one reconciliation run away from the same fate.
+    """
+
+    async def test_inactive_event_ignored_when_current_pds_serves_repo(
+        self, db_session: AsyncSession, artist: Artist
+    ) -> None:
+        artist.avatar_url = "https://cdn.bsky.app/img/avatar/plain/x/bafkrei@jpeg"
+        await db_session.commit()
+
+        with patch(
+            "backend._internal.atproto.account_status.repo_is_live_on_current_pds",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await ingest_account_status_change(
+                did=artist.did, active=False, status="deactivated"
+            )
+
+        await db_session.refresh(artist)
+        assert artist.deactivated is False
+        assert artist.account_status is None
+        assert artist.avatar_url is not None
+
+    async def test_genuine_deactivation_still_hides(
+        self, db_session: AsyncSession, artist: Artist
+    ) -> None:
+        """the current PDS agrees the repo is gone — hide, as before."""
+        with patch(
+            "backend._internal.atproto.account_status.repo_is_live_on_current_pds",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            await ingest_account_status_change(
+                did=artist.did, active=False, status="deactivated"
+            )
+
+        await db_session.refresh(artist)
+        assert artist.deactivated is True
+        assert artist.account_status == "deactivated"
+
+    async def test_unresolvable_pds_does_not_rescue(
+        self, db_session: AsyncSession, artist: Artist
+    ) -> None:
+        """`None` means "cannot tell", which must not be read as "still live".
+
+        otherwise a slingshot outage would silently stop all deactivations from
+        applying — the mirror of the bug being fixed.
+        """
+        with patch(
+            "backend._internal.atproto.account_status.repo_is_live_on_current_pds",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            await ingest_account_status_change(
+                did=artist.did, active=False, status="deactivated"
+            )
+
+        await db_session.refresh(artist)
+        assert artist.deactivated is True

--- a/loq.toml
+++ b/loq.toml
@@ -212,11 +212,11 @@ max_lines = 544
 
 [[rules]]
 path = "backend/src/backend/_internal/tasks/ingest.py"
-max_lines = 1022
+max_lines = 1044
 
 [[rules]]
 path = "backend/tests/test_jetstream.py"
-max_lines = 2431
+max_lines = 2498
 
 [[rules]]
 path = "frontend/src/lib/components/embed/CollectionEmbed.svelte"

--- a/scripts/backfill_account_status.py
+++ b/scripts/backfill_account_status.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env -S uv run --script --quiet
-"""backfill Artist.deactivated by checking each account's PDS status.
+"""reconcile Artist.deactivated against each account's *current* PDS.
 
 going forward, #account firehose events keep Artist.deactivated current (see
-ingest_account_status_change). but accounts that deactivated *before* that flag
-existed won't emit a new event, so their content (incl. dead audio) keeps showing
-up in discovery. this script resolves each artist's PDS and asks
-com.atproto.sync.getRepoStatus whether the account is active, then sets the flag.
+ingest_account_status_change). this script exists to repair drift.
+
+the PDS is always resolved fresh from plc.directory, never from the cached
+`Artist.pds_url`. that cache is exactly what goes stale when someone migrates,
+and the host they left reports their repo as `deactivated` — truthfully about
+itself, and misleadingly about them. asking the stale host is how this script
+once proposed hiding twelve live artists who had simply moved to their own PDS.
 
 usage:
     uv run scripts/backfill_account_status.py --dry-run
@@ -40,7 +43,7 @@ async def _resolve_pds(client: httpx.AsyncClient, did: str) -> str | None:
 
 
 async def _is_deactivated(
-    client: httpx.AsyncClient, did: str, pds_url: str | None
+    client: httpx.AsyncClient, did: str, _pds_url: str | None = None
 ) -> bool | None:
     """True/False if known, None if we couldn't determine (left unchanged).
 
@@ -50,7 +53,7 @@ async def _is_deactivated(
     """
     from backend._internal.atproto.account_status import hides_content
 
-    pds = pds_url or await _resolve_pds(client, did)
+    pds = await _resolve_pds(client, did)
     if not pds:
         return None
     try:


### PR DESCRIPTION
#1727 fixed what an account status *means*. This fixes **which host we believe** — and corrects the story I told in that PR.

Verifying the release turned up the actual cause of every wrongly-hidden artist. It was not PDS flapping. It was **migration**.

## what was really happening

Leaving a PDS deactivates the repo on the host you left. That host then emits `#account active=false status=deactivated` — truthfully about itself, and misleadingly about the person. All five hidden artists had moved from a Bluesky-hosted PDS to an independent one:

```
brookie.blog          shiitake.us-east.host.bsky.network -> pds.pckt.cafe
vicwalker.dev.br      porcini.us-east.host.bsky.network  -> caramelo.social.br
duplicake.fyi         coral.us-east.host.bsky.network    -> eurosky.social
distraction.engineer  woodear.us-west.host.bsky.network  -> northsky.social
```

Each old host still answers `active=false, status=deactivated`; each new host answers `active=true`.

This is precisely the sentence #1727 quoted, now with a body count:

> the status is at the host which emitted the event, **not necessarily that at the currently active PDS**

**Correction to #1727:** I attributed the hidden artists to PDS churn, citing DIDs flipping active false→true within 45 seconds. Those flips are real and in the logs, but they are *not* what hid these five. Migration is. The 45-second flapping was a separate signal I over-generalized from. The fix in #1727 stands — `throttled`/`desynchronized` still must never hide anyone — but its account of *this* incident was wrong.

There's also a nasty interaction worth naming: `Artist.pds_url` was stale precisely **because** `ingest_identity_update` — the task that maintains it — was dropped unregistered until #1726. PDS migration fires `#identity`, which would have updated the cache. So one bug kept the cache pointing at the host that would go on to report them deactivated.

## the near miss

The reconciliation script asked the *cached* PDS. A dry run against production proposed:

```
15 artists need updating   (all False -> True)
```

**12 of those 15 had simply moved to their own PDS and were alive.** Running it would have hidden twelve more live artists — the exact bug, applied in bulk. Caught because it was dry-run first.

## what this changes

<details>
<summary>ask the current host, and never let "cannot tell" mean "gone"</summary>

**`repo_is_live_on_current_pds(did)`** resolves the DID's current PDS via slingshot and asks `getRepoStatus` directly. An account-level inactive event is discarded when the current PDS still serves the repo — discarded *outright*, including the avatar handling, since nothing about the artist actually changed. (First cut fell through to the reactivation branch and let a failed avatar fetch null the avatar; a test caught it.)

`None` means "cannot tell" and never rescues. Otherwise a slingshot outage would silently stop every deactivation from applying — the mirror image of the bug being fixed. `test_unresolvable_pds_does_not_rescue` pins that.

**The script resolves PDS fresh from `plc.directory`**, never from `Artist.pds_url`. That cache is exactly what goes stale on migration.
</details>

## verified against production

After deploying #1727 and running the corrected script:

| | |
|---|---|
| live artists un-hidden | 4 |
| genuinely-deactivated artists correctly flagged | 3 |
| live artists the old script would have hidden | 12 (avoided) |

All four are back in the discovery listing, confirmed through the API:

```
brookie.blog          'hi', 'Atomic Song '
vicwalker.dev.br      'Horror soundtrack'
duplicake.fyi         'Roll with QT'
distraction.engineer  "We must obey the atomic bomb (a 1950's PSA edit)"
```

**Still hidden, deliberately:** `breadbrowser.bsky.social` (7 tracks). They migrated to `rose.madebydanny.uk`, which is currently unreachable, so we cannot verify — and "cannot tell" doesn't rescue. It self-heals when that host returns, or on their next commit or login (#1727).

Suite: **1391 passed, 25 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)