### PR TITLE
chore(accounts): self-review cleanup on the account-status work

### DIFF
--- a/backend/src/backend/_internal/atproto/account_status.py
+++ b/backend/src/backend/_internal/atproto/account_status.py
@@ -17,6 +17,10 @@ came to hide an artist's catalogue.
 
 from typing import Final
 
+import httpx
+
+from backend._internal.slingshot import resolve_mini_doc_safe
+
 # the account itself is gone or withdrawn — by the person, or by their host.
 # hiding their content follows from the account's own state.
 ACCOUNT_LEVEL_STATUSES: Final[frozenset[str]] = frozenset(
@@ -39,6 +43,19 @@ INFRASTRUCTURE_STATUSES: Final[frozenset[str]] = frozenset(
 )
 
 
+def hides_content(active: bool, status: str | None) -> bool:
+    """should this account's content drop out of discovery?
+
+    only for account-level states. an infrastructure status never hides
+    anyone, and neither does an `active=false` with no reason given — the
+    field is optional in the lexicon, and "some host said no, and wouldn't
+    say why" is not grounds for removing someone's music from the platform.
+    """
+    if active:
+        return False
+    return status in ACCOUNT_LEVEL_STATUSES
+
+
 async def repo_is_live_on_current_pds(did: str) -> bool | None:
     """ask the DID's *current* PDS whether it serves this repo.
 
@@ -51,10 +68,6 @@ async def repo_is_live_on_current_pds(did: str) -> bool | None:
     returns True/False when the current PDS answers, None when we cannot tell —
     and "cannot tell" must never be read as "gone".
     """
-    import httpx
-
-    from backend._internal.slingshot import resolve_mini_doc_safe
-
     if not (mini_doc := await resolve_mini_doc_safe(did)):
         return None
     if not (pds := mini_doc.get("pds")):
@@ -71,16 +84,3 @@ async def repo_is_live_on_current_pds(did: str) -> bool | None:
         return not hides_content(body.get("active", True), body.get("status"))
     except Exception:
         return None
-
-
-def hides_content(active: bool, status: str | None) -> bool:
-    """should this account's content drop out of discovery?
-
-    only for account-level states. an infrastructure status never hides
-    anyone, and neither does an `active=false` with no reason given — the
-    field is optional in the lexicon, and "some host said no, and wouldn't
-    say why" is not grounds for removing someone's music from the platform.
-    """
-    if active:
-        return False
-    return status in ACCOUNT_LEVEL_STATUSES

--- a/backend/src/backend/_internal/tasks/ingest.py
+++ b/backend/src/backend/_internal/tasks/ingest.py
@@ -17,6 +17,10 @@ from docket import ConcurrencyLimit, ExponentialRetry
 from sqlalchemy import delete, select, update
 from sqlalchemy.exc import IntegrityError, OperationalError
 
+from backend._internal.atproto.account_status import (
+    hides_content,
+    repo_is_live_on_current_pds,
+)
 from backend._internal.atproto.client import pds_blob_url
 from backend._internal.atproto.profile import avatar_url_from_profile_record
 from backend._internal.atproto.self_labels import self_label_values_from_record
@@ -920,10 +924,6 @@ async def ingest_account_status_change(
     goes dead. on account-level deactivation: clear it, so the frontend doesn't
     render a broken image.
     """
-    from backend._internal.atproto.account_status import (
-        hides_content,
-        repo_is_live_on_current_pds,
-    )
     from backend._internal.atproto.profile import fetch_user_avatar
 
     hide = hides_content(active, status)

--- a/backend/tests/test_jetstream.py
+++ b/backend/tests/test_jetstream.py
@@ -2447,7 +2447,7 @@ class TestMigratedPdsIsNotDeactivation:
         await db_session.commit()
 
         with patch(
-            "backend._internal.atproto.account_status.repo_is_live_on_current_pds",
+            "backend._internal.tasks.ingest.repo_is_live_on_current_pds",
             new_callable=AsyncMock,
             return_value=True,
         ):
@@ -2465,7 +2465,7 @@ class TestMigratedPdsIsNotDeactivation:
     ) -> None:
         """the current PDS agrees the repo is gone — hide, as before."""
         with patch(
-            "backend._internal.atproto.account_status.repo_is_live_on_current_pds",
+            "backend._internal.tasks.ingest.repo_is_live_on_current_pds",
             new_callable=AsyncMock,
             return_value=False,
         ):
@@ -2486,7 +2486,7 @@ class TestMigratedPdsIsNotDeactivation:
         applying — the mirror of the bug being fixed.
         """
         with patch(
-            "backend._internal.atproto.account_status.repo_is_live_on_current_pds",
+            "backend._internal.tasks.ingest.repo_is_live_on_current_pds",
             new_callable=AsyncMock,
             return_value=None,
         ):

--- a/scripts/backfill_account_status.py
+++ b/scripts/backfill_account_status.py
@@ -42,9 +42,7 @@ async def _resolve_pds(client: httpx.AsyncClient, did: str) -> str | None:
     return None
 
 
-async def _is_deactivated(
-    client: httpx.AsyncClient, did: str, _pds_url: str | None = None
-) -> bool | None:
+async def _is_deactivated(client: httpx.AsyncClient, did: str) -> bool | None:
     """True/False if known, None if we couldn't determine (left unchanged).
 
     uses the same `hides_content` rule as the firehose path, so a one-shot
@@ -78,7 +76,7 @@ async def main() -> None:
     args = parser.parse_args()
 
     async with db_session() as db:
-        stmt = select(Artist.did, Artist.pds_url, Artist.deactivated)
+        stmt = select(Artist.did, Artist.deactivated)
         if args.did:
             stmt = stmt.where(Artist.did == args.did)
         if args.limit:
@@ -91,14 +89,14 @@ async def main() -> None:
 
     async with httpx.AsyncClient(timeout=20) as client:
 
-        async def check(did: str, pds_url: str | None, current: bool) -> None:
+        async def check(did: str, current: bool) -> None:
             async with sem:
-                deactivated = await _is_deactivated(client, did, pds_url)
+                deactivated = await _is_deactivated(client, did)
             if deactivated is not None and deactivated != current:
                 changed.append((did, deactivated))
                 logger.info("  %s: deactivated %s -> %s", did, current, deactivated)
 
-        await asyncio.gather(*(check(d, p, bool(c)) for d, p, c in rows))
+        await asyncio.gather(*(check(d, bool(c)) for d, c in rows))
 
     logger.info("%d artists need updating", len(changed))
     if args.dry_run or not changed:

--- a/scripts/backfill_account_status.py
+++ b/scripts/backfill_account_status.py
@@ -23,6 +23,7 @@ import logging
 import httpx
 from sqlalchemy import select
 
+from backend._internal.atproto.account_status import hides_content
 from backend.models import Artist
 from backend.utilities.database import db_session
 
@@ -42,15 +43,15 @@ async def _resolve_pds(client: httpx.AsyncClient, did: str) -> str | None:
     return None
 
 
-async def _is_deactivated(client: httpx.AsyncClient, did: str) -> bool | None:
-    """True/False if known, None if we couldn't determine (left unchanged).
+async def _repo_status(
+    client: httpx.AsyncClient, did: str
+) -> tuple[bool, str | None] | None:
+    """(hidden, status) if known, None if we couldn't determine.
 
     uses the same `hides_content` rule as the firehose path, so a one-shot
     reconciliation can never disagree with the live events about what an
     inactive repo means.
     """
-    from backend._internal.atproto.account_status import hides_content
-
     pds = await _resolve_pds(client, did)
     if not pds:
         return None
@@ -61,7 +62,8 @@ async def _is_deactivated(client: httpx.AsyncClient, did: str) -> bool | None:
         if r.status_code != 200:
             return None
         body = r.json()
-        return hides_content(body.get("active", True), body.get("status"))
+        active, status = body.get("active", True), body.get("status")
+        return hides_content(active, status), None if active else status
     except Exception as e:
         logger.warning("  getRepoStatus failed %s: %s", did, e)
         return None
@@ -76,7 +78,7 @@ async def main() -> None:
     args = parser.parse_args()
 
     async with db_session() as db:
-        stmt = select(Artist.did, Artist.deactivated)
+        stmt = select(Artist.did, Artist.deactivated, Artist.account_status)
         if args.did:
             stmt = stmt.where(Artist.did == args.did)
         if args.limit:
@@ -85,28 +87,34 @@ async def main() -> None:
 
     logger.info("checking %d artists (concurrency=%d)", len(rows), args.concurrency)
     sem = asyncio.Semaphore(args.concurrency)
-    changed: list[tuple[str, bool]] = []
+    changed: list[tuple[str, bool, str | None]] = []
 
     async with httpx.AsyncClient(timeout=20) as client:
 
-        async def check(did: str, current: bool) -> None:
+        async def check(did: str, current: bool, current_status: str | None) -> None:
             async with sem:
-                deactivated = await _is_deactivated(client, did)
-            if deactivated is not None and deactivated != current:
-                changed.append((did, deactivated))
-                logger.info("  %s: deactivated %s -> %s", did, current, deactivated)
+                result = await _repo_status(client, did)
+            if result is None:
+                return
+            deactivated, status = result
+            if deactivated != current or status != current_status:
+                changed.append((did, deactivated, status))
+                logger.info(
+                    "  %s: deactivated %s -> %s (%s)", did, current, deactivated, status
+                )
 
-        await asyncio.gather(*(check(d, bool(c)) for d, c in rows))
+        await asyncio.gather(*(check(d, bool(c), st) for d, c, st in rows))
 
     logger.info("%d artists need updating", len(changed))
     if args.dry_run or not changed:
         return
 
     async with db_session() as db:
-        for did, deactivated in changed:
+        for did, deactivated, status in changed:
             artist = await db.get(Artist, did)
             if artist:
                 artist.deactivated = deactivated
+                artist.account_status = status
         await db.commit()
     logger.info("updated %d artists", len(changed))
 


### PR DESCRIPTION
Cleanup found by reviewing my own diff after #1728 merged. **No behavior change** except the last item, which fills in data the column was added for.

The first commit was pushed to #1728 a moment after it merged, so it missed the boat — it's cherry-picked here.

## what was weird

**Deferred imports for no reason.** `httpx` and `resolve_mini_doc_safe` were imported *inside* `repo_is_live_on_current_pds`, and `account_status` inside `ingest_account_status_change`. `slingshot` imports only stdlib and httpx, so there's no cycle to break, and AGENTS.md is explicit that deferred imports are for circular imports only. Hoisted to module scope; the test patch targets move with the binding (`tasks.ingest.repo_is_live_on_current_pds` rather than the defining module).

I verified the moved patch targets didn't quietly make those tests vacuous — stubbing the guard out still fails `test_inactive_event_ignored_when_current_pds_serves_repo`.

**A vestigial parameter.** `_is_deactivated` kept a `_pds_url` argument it no longer read, purely so the call site wouldn't have to change. Removed, along with the now-unused `Artist.pds_url` in the script's query — reading that column is precisely the thing #1728 stopped doing, so continuing to select it was misleading.

**Function order.** `repo_is_live_on_current_pds` sat above `hides_content`, which it calls. Swapped so the module reads top-down.

## the one real gap

#1727 added `account_status` so a hidden artist can be *explained* rather than just believed. But the reconciliation script only ever wrote `deactivated` — so every artist it hid carried a `NULL` reason. The column existed and the path that most needed it didn't populate it.

`_repo_status` now returns `(hidden, status)`, and the script reconciles both — including for artists whose `deactivated` value is already correct, which is the only way the existing rows get a reason at all.

Verified against production:

```
5 artists need updating     ← all "deactivated True -> True (deactivated)"
```

Reasons recorded, zero flags changed. I have not applied it; it's a one-liner to run after merge.

## verification

Suite: **1391 passed, 25 skipped**. Lint clean.

Production after #1728 shipped as `2026.0729.193914` (deploy success, `/health` 200), last 25 minutes:

| | |
|---|---|
| `Unknown task` drops | **0** (was 35 over two weeks) |
| avatars auto-mirrored from Bluesky | **6** |
| bsky profile commits dispatched | 19 |
| exceptions attributable to this work | **0** |

The six production exceptions in that window were signed-out `/auth/me` 401s, label-stream websocket reconnects, and one album 404 — all pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)