### PR TITLE
fix(radio): an artist can't air twice in a row

### DIFF
--- a/backend/src/backend/api/radio/sampler.py
+++ b/backend/src/backend/api/radio/sampler.py
@@ -17,6 +17,12 @@ Turns a scored corpus into a rotation that doesn't let one artist stack it:
   big slice of a single loop. That's a deliberate v1 tradeoff (popular long-form
   content should still feature) and a knob to revisit.
 
+* **Artist spacing:** an artist can't land within ``ARTIST_SPACING`` entries of
+  their own previous one, so back-to-back (or near-back-to-back) plays by the same
+  creator never reach a listener. The airtime budget bounds how *much* an artist
+  gets across a rotation; spacing bounds how *clustered* it is. Spacing relaxes
+  only when no other artist is drawable, so a thin corpus still fills a rotation.
+
 * **Weighted draw without replacement:** tracks are sampled in proportion to their
   lens weight, so the rotation isn't a fixed top-N chart and the long tail turns
   over.
@@ -38,6 +44,7 @@ DEFAULT_TRACK_SECONDS = 180
 ARTIST_AIRTIME_CAP_SECONDS = 20 * 60  # an artist is done once past ~20 min of airtime
 TARGET_ROTATION_SECONDS = 4 * 60 * 60  # aim for ~4 hours of programming per rotation
 EXPLORATION_FRACTION = 0.25  # share of draws that ignore lens weights entirely
+ARTIST_SPACING = 3  # entries an artist must wait before they can air again
 
 
 def rank_decay_weights(ranked_ids: list[int], scale: float) -> dict[int, float]:
@@ -73,6 +80,7 @@ def build_rotation(
     target_seconds: int = TARGET_ROTATION_SECONDS,
     artist_airtime_cap_seconds: int = ARTIST_AIRTIME_CAP_SECONDS,
     exploration: float = EXPLORATION_FRACTION,
+    artist_spacing: int = ARTIST_SPACING,
 ) -> list[Track]:
     """Draw a deterministic, airtime-fair rotation from scored candidates.
 
@@ -86,6 +94,8 @@ def build_rotation(
         artist_airtime_cap_seconds: per-artist airtime budget before they drop out.
         exploration: probability that a draw is uniform over the remaining pool
             instead of lens-weighted, so the tail is reachable.
+        artist_spacing: minimum number of entries between two airings by the same
+            artist; relaxed when no other artist can be drawn.
     """
     pool = [t for t in candidates if weights.get(t.id, 0.0) > 0.0]
     if not pool:
@@ -100,15 +110,32 @@ def build_rotation(
     total_seconds = 0
 
     while remaining and len(rotation) < max_tracks and total_seconds < target_seconds:
+        # drawing from an eligible subset rather than drawing-then-rejecting keeps
+        # a dominant artist from burning the draws that should have aired others.
+        blocked = {t.artist_did for t in rotation[-artist_spacing:]}
+        eligible = [
+            idx
+            for idx, t in enumerate(remaining)
+            if artist_airtime.get(t.artist_did, 0) < artist_airtime_cap_seconds
+            and t.artist_did not in blocked
+        ]
+        if not eligible:
+            eligible = [
+                idx
+                for idx, t in enumerate(remaining)
+                if artist_airtime.get(t.artist_did, 0) < artist_airtime_cap_seconds
+            ]
+        if not eligible:
+            break
+
         if rng.random() < exploration:
-            chosen_idx = rng.randrange(len(remaining))
+            chosen_idx = eligible[rng.randrange(len(eligible))]
         else:
-            chosen_idx = _weighted_pick(rng, remaining_weights)
+            chosen_idx = eligible[
+                _weighted_pick(rng, [remaining_weights[idx] for idx in eligible])
+            ]
         track = remaining.pop(chosen_idx)
         remaining_weights.pop(chosen_idx)
-
-        if artist_airtime.get(track.artist_did, 0) >= artist_airtime_cap_seconds:
-            continue  # this artist has already used their airtime budget
 
         seconds = _track_seconds(track)
         rotation.append(track)
@@ -117,7 +144,29 @@ def build_rotation(
         )
         total_seconds += seconds
 
+    # the rotation is a loop, so its tail plays into its head: trim trailing
+    # entries that would collide across that seam.
+    # a corpus too thin to satisfy spacing at all (one artist) has no seam to fix,
+    # and trimming it would only shorten the loop.
+    for _ in range(artist_spacing):
+        if (
+            len(rotation) <= artist_spacing + 1
+            or len({t.artist_did for t in rotation}) < 2
+            or not _seam_collides(rotation, artist_spacing)
+        ):
+            break
+        rotation.pop()
+
     return rotation
+
+
+def _seam_collides(rotation: list[Track], artist_spacing: int) -> bool:
+    """Whether the loop's tail repeats an artist within ``artist_spacing`` of its head."""
+    return any(
+        rotation[-tail].artist_did == rotation[head].artist_did
+        for tail in range(1, artist_spacing + 1)
+        for head in range(artist_spacing - tail + 1)
+    )
 
 
 def _weighted_pick(rng: random.Random, weights: list[float]) -> int:

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -15,7 +15,11 @@ from backend.api.radio import cache as radio_cache
 from backend.api.radio import lenses
 from backend.api.radio import state as radio_state
 from backend.api.radio.lenses import LensContext
-from backend.api.radio.sampler import build_rotation, rank_decay_weights
+from backend.api.radio.sampler import (
+    ARTIST_SPACING,
+    build_rotation,
+    rank_decay_weights,
+)
 from backend.api.radio.schemas import RadioTrack
 from backend.config import settings
 from backend.main import app
@@ -321,6 +325,42 @@ def test_exploration_floor_reaches_the_dormant_tail() -> None:
     assert max(weighted_only) < 150  # the tail is unreachable without the floor
     assert max(with_floor) > 500
     assert len(with_floor) > len(weighted_only)
+
+
+def test_rotation_never_stacks_one_artist_back_to_back() -> None:
+    """no artist airs twice within the spacing window, including across the loop seam.
+
+    Regression: the airtime cap bounded an artist's *total* share but not its
+    clustering, so a heavily-liked creator could air several tracks in a row.
+    """
+    corpus = [
+        _sampler_track(i, artist_did="did:plc:hog" if i < 30 else f"did:plc:a{i}")
+        for i in range(60)
+    ]
+    weights = rank_decay_weights([t.id for t in corpus], 12.0)
+    for period in range(20):
+        rotation = build_rotation(
+            corpus,
+            weights,
+            station_slug="loved",
+            period=str(period),
+            max_tracks=40,
+        )
+        dids = [t.artist_did for t in rotation]
+        looped = dids + dids[:ARTIST_SPACING]  # the rotation replays from the top
+        for start in range(len(dids)):
+            window = looped[start : start + ARTIST_SPACING + 1]
+            assert len(set(window)) == len(window), f"{period}: {window}"
+
+
+def test_rotation_still_fills_when_one_artist_owns_the_corpus() -> None:
+    """spacing relaxes rather than starving the rotation on a thin corpus."""
+    corpus = [_sampler_track(i, artist_did="did:plc:solo") for i in range(10)]
+    weights = rank_decay_weights([t.id for t in corpus], 12.0)
+    rotation = build_rotation(
+        corpus, weights, station_slug="loved", period="0", max_tracks=40
+    )
+    assert len(rotation) > 1
 
 
 async def test_rotation_is_deterministic_within_a_period(

--- a/loq.toml
+++ b/loq.toml
@@ -332,7 +332,7 @@ max_lines = 955
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"
-max_lines = 797
+max_lines = 837
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"


### PR DESCRIPTION
The radio could play the same artist several tracks back to back (observed on `loved`, on stream). The per-artist airtime cap bounded how *much* of a rotation one creator got, but nothing bounded how *clustered* it was — with a heavily-weighted artist, a weighted draw without replacement happily pulled six of their tracks in a row.

`build_rotation` now draws only from artists outside a 3-entry spacing window, and repairs the loop's tail→head seam (the rotation replays from the top, so the last entries are neighbors of the first).

<details>
<summary>details</summary>

- **Draw from an eligible subset, don't draw-then-reject.** The old loop popped a track and `continue`d if its artist was over budget, so a dominant artist burned draws that should have aired someone else. Eligibility (under airtime budget, outside the spacing window) is now computed before the draw; both the weighted path and the exploration floor draw from it.
- **Spacing relaxes, never starves.** If no artist outside the window is drawable, the window is dropped for that draw — a single-artist corpus still fills a rotation.
- **Seam repair is bounded.** At most `artist_spacing` trailing entries are trimmed, and only when the rotation has more than one artist, so a thin corpus isn't shortened for a seam it can't satisfy.

Measured on a synthetic corpus (30 tracks from one artist + 30 singles, 20 rotation periods): longest same-artist run **6 → 1**.

Regression tests: `test_rotation_never_stacks_one_artist_back_to_back` (asserts every circular window of `ARTIST_SPACING + 1` entries has distinct artists, across 20 periods) and `test_rotation_still_fills_when_one_artist_owns_the_corpus`.

Not addressed here: the airtime cap still lets one long mix be a large share of a single loop — deliberate, and unchanged.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)