### PR TITLE
fix(uploads): staged cleanup must never delete a published track's audio

### DIFF
--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -950,10 +950,12 @@ async def _create_records(
             # hash that could collide with a public track's R2 key — never delete.
             if not ctx.private:
                 with contextlib.suppress(Exception):
-                    await storage.delete(sr.file_id, playable_file_type)
+                    await storage.discard_staged(sr.file_id, playable_file_type)
                 if sr.original_file_id and sr.original_file_type:
                     with contextlib.suppress(Exception):
-                        await storage.delete(sr.original_file_id, sr.original_file_type)
+                        await storage.discard_staged(
+                            sr.original_file_id, sr.original_file_type
+                        )
             raise UploadPhaseError(f"database constraint violation: {e!s}") from e
 
         track_id = track.id
@@ -1036,10 +1038,12 @@ async def _create_records(
             # that could collide with a public track's R2 key), so skip it; the
             # orphaned PDS blob is GC'd by the PDS.
             with contextlib.suppress(Exception):
-                await storage.delete(sr.file_id, playable_file_type)
+                await storage.discard_staged(sr.file_id, playable_file_type)
             if sr.original_file_id and sr.original_file_type:
                 with contextlib.suppress(Exception):
-                    await storage.delete(sr.original_file_id, sr.original_file_type)
+                    await storage.discard_staged(
+                        sr.original_file_id, sr.original_file_type
+                    )
             if image_id:
                 with contextlib.suppress(Exception):
                     await storage.delete(image_id)
@@ -1147,14 +1151,16 @@ async def _schedule_post_upload(
 async def _delete_staged_audio(
     file_id: str, file_type: str | None, *, gated: bool
 ) -> None:
-    """suppressed delete for audio bytes the user uploaded to a bucket
+    """suppressed discard for audio bytes the user uploaded to a bucket
     chosen at handler-staging time. `gated` selects the bucket so we
     don't no-op-delete from public when the file actually lives in
     private (or vice versa).
+
+    `discard_staged` rather than `delete`: a file_id is a content hash, so
+    these bytes may already belong to a published track (#1732).
     """
-    delete_fn = storage.delete_gated if gated else storage.delete
     with contextlib.suppress(Exception):
-        await delete_fn(file_id, file_type)
+        await storage.discard_staged(file_id, file_type, gated=gated)
 
 
 async def _cleanup_staged_media_pre_db(

--- a/backend/src/backend/storage/protocol.py
+++ b/backend/src/backend/storage/protocol.py
@@ -65,6 +65,10 @@ class StorageProtocol(Protocol):
 
     async def delete(self, file_id: str, file_type: str | None = None) -> bool: ...
 
+    async def discard_staged(
+        self, file_id: str, file_type: str | None = None, *, gated: bool = False
+    ) -> bool: ...
+
     async def delete_image(self, file_id: str, image_url: str) -> bool: ...
 
     async def save_gated(

--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -11,7 +11,7 @@ import boto3
 import logfire
 from botocore.config import Config
 from botocore.exceptions import ClientError
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 
 from backend._internal.audio import AudioFormat
 from backend._internal.image import ImageFormat
@@ -435,6 +435,46 @@ class R2Storage:
             size = response.get("ContentLength")
             return int(size) if size is not None else None
 
+    async def _reference_count(self, file_id: str) -> int:
+        """how many live tracks point at ``file_id``.
+
+        Counts `original_file_id` as well as `file_id`: a track's lossless source
+        is an object too, and a file_id is a content hash, so two rows can name
+        the same bytes through different columns.
+        """
+        async with db_session() as db:
+            stmt = (
+                select(func.count())
+                .select_from(Track)
+                .where(or_(Track.file_id == file_id, Track.original_file_id == file_id))
+            )
+            return (await db.execute(stmt)).scalar_one()
+
+    async def discard_staged(
+        self, file_id: str, file_type: str | None = None, *, gated: bool = False
+    ) -> bool:
+        """delete an object staged for an upload that never became a track.
+
+        Distinct from `delete()`, which removes the media of a track that is
+        going away and therefore tolerates its own single reference. Nothing
+        references a staged object, so *any* reference means these bytes belong
+        to somebody else and must survive.
+
+        The distinction is load-bearing because a file_id is a content hash: a
+        listener re-uploading a file they already published stages the exact key
+        their live track is served from, and the duplicate check that rejects
+        the upload is itself proof that the object is not ours to delete.
+        """
+        if refcount := await self._reference_count(file_id):
+            logfire.info(
+                "keeping staged object, a live track references it",
+                file_id=file_id,
+                refcount=refcount,
+            )
+            return False
+        delete_fn = self.delete_gated if gated else self.delete
+        return await delete_fn(file_id, file_type)
+
     async def delete(self, file_id: str, file_type: str | None = None) -> bool:
         """delete media file from R2.
 
@@ -448,26 +488,20 @@ class R2Storage:
                       if None, falls back to trying all formats (legacy/images).
         """
         # check refcount before deleting
-        async with db_session() as db:
-            stmt = (
-                select(func.count()).select_from(Track).where(Track.file_id == file_id)
+        refcount = await self._reference_count(file_id)
+        if refcount > 1:
+            logfire.info(
+                "skipping R2 delete, file still referenced",
+                file_id=file_id,
+                refcount=refcount,
             )
-            result = await db.execute(stmt)
-            refcount = result.scalar_one()
+            return False
 
-            if refcount > 1:
-                logfire.info(
-                    "skipping R2 delete, file still referenced",
-                    file_id=file_id,
-                    refcount=refcount,
-                )
-                return False
-
-            if refcount == 0:
-                logfire.warning(
-                    "deleting R2 file with no database references",
-                    file_id=file_id,
-                )
+        if refcount == 0:
+            logfire.warning(
+                "deleting R2 file with no database references",
+                file_id=file_id,
+            )
 
         # safe to delete - only one or zero references
         logfire.info(
@@ -684,20 +718,13 @@ class R2Storage:
 
         # refcount check — same guard as `delete()` so a duplicate gated row
         # doesn't pull the file out from under another track.
-        async with db_session() as db:
-            stmt = (
-                select(func.count()).select_from(Track).where(Track.file_id == file_id)
+        if (refcount := await self._reference_count(file_id)) > 1:
+            logfire.info(
+                "skipping R2 gated delete, file still referenced",
+                file_id=file_id,
+                refcount=refcount,
             )
-            result = await db.execute(stmt)
-            refcount = result.scalar_one()
-
-            if refcount > 1:
-                logfire.info(
-                    "skipping R2 gated delete, file still referenced",
-                    file_id=file_id,
-                    refcount=refcount,
-                )
-                return False
+            return False
 
         async with self._s3_client() as client:
             if file_type:

--- a/backend/tests/api/test_track_deletion.py
+++ b/backend/tests/api/test_track_deletion.py
@@ -7,7 +7,8 @@ tests cover three critical fixes:
 """
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -18,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend._internal import Session, require_auth
 from backend.main import app
 from backend.models import Album, Artist, Track
+from backend.storage.r2 import R2Storage
 
 
 class MockSession(Session):
@@ -164,19 +166,28 @@ async def test_refcount_prevents_r2_deletion(db_session: AsyncSession):
     db_session.add(track2)
     await db_session.commit()
 
-    # try to delete the file
-    # this should be skipped because refcount = 2
-    # mock R2Storage to avoid requiring credentials
-    with patch("backend.storage.r2.R2Storage") as MockR2Storage:
-        mock_storage = AsyncMock()
-        MockR2Storage.return_value = mock_storage
-        mock_storage.delete = AsyncMock(return_value=False)
+    # drive the real guard against the real refcount query, mocking only the
+    # S3 boundary. the previous version of this test mocked R2Storage whole and
+    # asserted its own stub returned False, so it could not have caught a guard
+    # that let a referenced object through — which is exactly what happened in
+    # the staged-cleanup path (#1732).
+    with patch.object(R2Storage, "__init__", lambda self: None):
+        storage = R2Storage()
+    storage.audio_bucket_name = "audio-test"
 
-        storage = MockR2Storage()
-        result = await storage.delete(file_id)
+    s3 = MagicMock()
+    s3.head_object = AsyncMock(return_value={})
+    s3.delete_object = AsyncMock(return_value={})
+    s3.exceptions.NoSuchKey = type("NoSuchKey", (Exception,), {})
 
-        # deletion should be skipped (returns False)
-        assert result is False
+    @asynccontextmanager
+    async def _client(**_: object):
+        yield s3
+
+    storage._s3_client = _client  # type: ignore[method-assign]
+
+    assert await storage.delete(file_id, "mp3") is False
+    s3.delete_object.assert_not_awaited()
 
 
 async def test_atproto_cleanup_on_track_delete(

--- a/backend/tests/api/test_upload_storage_cleanup.py
+++ b/backend/tests/api/test_upload_storage_cleanup.py
@@ -82,18 +82,20 @@ class TestPhase1To5FailureDeletesStagedMedia:
                 AsyncMock(return_value=True),
             ) as mock_delete,
             patch(
-                "backend.api.tracks.uploads.storage.delete_gated",
+                "backend.api.tracks.uploads.storage.discard_staged",
                 AsyncMock(return_value=True),
-            ) as mock_delete_gated,
+            ) as mock_discard,
             patch("backend.api.tracks.uploads.job_service", AsyncMock()),
         ):
             await _process_upload_background(_ctx(gated=False))
 
         # non-gated → audio in public bucket
+        discarded = [
+            (c.args[0], c.kwargs["gated"]) for c in mock_discard.call_args_list
+        ]
+        assert ("staged-audio-id", False) in discarded
         deleted_ids = [c.args[0] for c in mock_delete.call_args_list]
-        assert "staged-audio-id" in deleted_ids
         assert "staged-image-id" in deleted_ids
-        mock_delete_gated.assert_not_called()
 
     async def test_gated_audio_deleted_from_private_bucket(self) -> None:
         with (
@@ -106,9 +108,9 @@ class TestPhase1To5FailureDeletesStagedMedia:
                 AsyncMock(return_value=True),
             ) as mock_delete,
             patch(
-                "backend.api.tracks.uploads.storage.delete_gated",
+                "backend.api.tracks.uploads.storage.discard_staged",
                 AsyncMock(return_value=True),
-            ) as mock_delete_gated,
+            ) as mock_discard,
             patch("backend.api.tracks.uploads.job_service", AsyncMock()),
         ):
             await _process_upload_background(_ctx(gated=True))
@@ -116,8 +118,10 @@ class TestPhase1To5FailureDeletesStagedMedia:
         # gated → staged audio lives in the private bucket; rollback
         # must route the audio delete to delete_gated. images are
         # never gated.
-        deleted_gated_ids = [c.args[0] for c in mock_delete_gated.call_args_list]
-        assert deleted_gated_ids == ["staged-audio-id"]
+        discarded = [
+            (c.args[0], c.kwargs["gated"]) for c in mock_discard.call_args_list
+        ]
+        assert discarded == [("staged-audio-id", True)]
         deleted_public_ids = [c.args[0] for c in mock_delete.call_args_list]
         assert "staged-audio-id" not in deleted_public_ids
         assert "staged-image-id" in deleted_public_ids
@@ -164,13 +168,18 @@ class TestPhase1To5FailureDeletesStagedMedia:
                 "backend.api.tracks.uploads.storage.delete",
                 AsyncMock(return_value=True),
             ) as mock_delete,
+            patch(
+                "backend.api.tracks.uploads.storage.discard_staged",
+                AsyncMock(return_value=True),
+            ) as mock_discard,
             patch("backend.api.tracks.uploads.job_service", AsyncMock()),
         ):
             await _process_upload_background(_ctx(gated=False))
 
+        discarded = [c.args[0] for c in mock_discard.call_args_list]
+        assert "transcoded-mp3-id" in discarded  # the playable sibling
+        assert "staged-audio-id" in discarded  # the lossless source
         deleted_ids = [c.args[0] for c in mock_delete.call_args_list]
-        assert "transcoded-mp3-id" in deleted_ids  # the playable sibling
-        assert "staged-audio-id" in deleted_ids  # the lossless source
         assert "staged-image-id" in deleted_ids  # the cover art
 
 
@@ -224,9 +233,9 @@ class TestPhase6FailureDefersToCreateRecords:
                 AsyncMock(return_value=True),
             ) as mock_delete,
             patch(
-                "backend.api.tracks.uploads.storage.delete_gated",
+                "backend.api.tracks.uploads.storage.discard_staged",
                 AsyncMock(return_value=True),
-            ) as mock_delete_gated,
+            ) as mock_discard,
             patch("backend.api.tracks.uploads.job_service", AsyncMock()),
         ):
             await _process_upload_background(_ctx(gated=False))
@@ -237,4 +246,4 @@ class TestPhase6FailureDefersToCreateRecords:
         # internal cleanup; we're asserting the orchestrator-level
         # cleanup does NOT fire, regardless of what _create_records does.)
         mock_delete.assert_not_called()
-        mock_delete_gated.assert_not_called()
+        mock_discard.assert_not_called()

--- a/backend/tests/storage/test_discard_staged.py
+++ b/backend/tests/storage/test_discard_staged.py
@@ -1,0 +1,140 @@
+"""regression tests for staged-upload cleanup deleting a published track's audio.
+
+A `file_id` is a content hash, so re-uploading a file you already published
+stages the exact R2 key your live track is served from. The upload then fails
+the duplicate check and the orchestrator cleans up "its" staged object — which
+is the published track's only copy in R2. Four of boulyprod's tracks were
+deleted this way on 2026-07-18; the pattern accounts for 20 broken tracks
+across 7 artists.
+
+`delete()` tolerates a single reference because a track being deleted is itself
+that reference. `discard_staged()` must not: nothing references a genuinely
+staged object.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.models import Artist, Track
+from backend.storage.r2 import R2Storage
+
+PUBLISHED_FILE_ID = "b9deb36a0475b377"
+
+
+@pytest.fixture
+def storage() -> R2Storage:
+    with patch.object(R2Storage, "__init__", lambda self: None):
+        instance = R2Storage()
+    instance.audio_bucket_name = "audio-test"
+    instance.image_bucket_name = "images-test"
+    instance.private_audio_bucket_name = "audio-private-test"
+    return instance
+
+
+@pytest.fixture
+def s3(storage: R2Storage) -> MagicMock:
+    """mock only the S3 boundary, so the refcount query runs for real."""
+    client = MagicMock()
+    client.head_object = AsyncMock(return_value={})
+    client.delete_object = AsyncMock(return_value={})
+    client.exceptions.NoSuchKey = type("NoSuchKey", (Exception,), {})
+
+    @asynccontextmanager
+    async def _client(**_: object):
+        yield client
+
+    storage._s3_client = _client  # type: ignore[method-assign]
+    return client
+
+
+@pytest.fixture
+async def published_track(db_session: AsyncSession) -> Track:
+    artist = Artist(
+        did="did:plc:boulyprod",
+        handle="boulyprod.eurosky.social",
+        display_name="boulyprod",
+    )
+    db_session.add(artist)
+    await db_session.flush()
+    track = Track(
+        title="published",
+        artist_did=artist.did,
+        file_id=PUBLISHED_FILE_ID,
+        file_type="wav",
+        extra={},
+    )
+    db_session.add(track)
+    await db_session.commit()
+    return track
+
+
+async def test_discard_staged_keeps_a_published_tracks_audio(
+    storage: R2Storage, s3: MagicMock, published_track: Track
+) -> None:
+    """the re-upload case: the staged key is already a live track's audio."""
+    assert await storage.discard_staged(PUBLISHED_FILE_ID, "wav") is False
+    s3.delete_object.assert_not_awaited()
+
+
+async def test_discard_staged_keeps_audio_referenced_as_a_lossless_source(
+    storage: R2Storage, s3: MagicMock, db_session: AsyncSession
+) -> None:
+    """a track's `original_file_id` is an object too, and refcount must see it."""
+    artist = Artist(did="did:plc:woody", handle="woody.fm", display_name="woody")
+    db_session.add(artist)
+    await db_session.flush()
+    db_session.add(
+        Track(
+            title="optimized",
+            artist_did=artist.did,
+            file_id="the-mp3-rendition",
+            file_type="mp3",
+            original_file_id=PUBLISHED_FILE_ID,
+            original_file_type="aif",
+            extra={},
+        )
+    )
+    await db_session.commit()
+
+    assert await storage.discard_staged(PUBLISHED_FILE_ID, "aif") is False
+    s3.delete_object.assert_not_awaited()
+
+
+async def test_discard_staged_deletes_a_genuinely_orphaned_object(
+    storage: R2Storage, s3: MagicMock, db_session: AsyncSession
+) -> None:
+    """cleanup still works when the upload really did leave an orphan."""
+    assert await storage.discard_staged("no-track-points-here", "wav") is True
+    s3.delete_object.assert_awaited_once()
+
+
+async def test_upload_cleanup_keeps_a_published_tracks_audio(
+    storage: R2Storage, s3: MagicMock, published_track: Track
+) -> None:
+    """the real call site: the upload orchestrator's staged-media cleanup.
+
+    This is the path that ran on 2026-07-18 — phase 3 rejected the re-upload as
+    a duplicate, and cleanup then deleted the duplicate's audio.
+    """
+    from backend.api.tracks.uploads import _delete_staged_audio
+
+    with patch("backend.api.tracks.uploads.storage", storage):
+        await _delete_staged_audio(PUBLISHED_FILE_ID, "wav", gated=False)
+
+    s3.delete_object.assert_not_awaited()
+
+
+async def test_delete_still_removes_the_media_of_the_track_being_deleted(
+    storage: R2Storage, s3: MagicMock, published_track: Track
+) -> None:
+    """the contrast that makes the two verbs distinct.
+
+    `delete()` sees the same refcount of 1 and proceeds — correct for track
+    deletion, and precisely the behaviour that destroyed audio when the staged
+    cleanup path borrowed it.
+    """
+    assert await storage.delete(PUBLISHED_FILE_ID, "wav") is True
+    s3.delete_object.assert_awaited_once()

--- a/loq.toml
+++ b/loq.toml
@@ -40,7 +40,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1862
+max_lines = 1868
 
 [[rules]]
 path = "backend/src/backend/config.py"
@@ -48,7 +48,7 @@ max_lines = 1222
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
-max_lines = 905
+max_lines = 932
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"
@@ -224,7 +224,7 @@ max_lines = 650
 
 [[rules]]
 path = "backend/tests/api/test_track_deletion.py"
-max_lines = 574
+max_lines = 585
 
 [[rules]]
 path = "backend/tests/api/test_top_tracks.py"


### PR DESCRIPTION
We have been deleting listeners' audio. 20 tracks across 7 artists are broken in production right now, and the trigger is the most natural thing a user can do: re-upload a file when the first attempt looks stuck.

**A `file_id` is a content hash.** So a re-upload of the same file stages the *exact R2 key the published track is served from*. Phase 3 (`_check_duplicate`) then rejects the upload, and the orchestrator's failure cleanup deletes "its" staged object — which is the published track's only copy.

The duplicate path is the one failure mode where the staged object is **guaranteed** to belong to someone else: you only reach it because a track already owns that key.

<details>
<summary>the trace that proves it — boulyprod, track 1180, 2026-07-18</summary>

| time | event |
|---|---|
| 15:18:42 | `uploading to R2` → `audio/b9deb36a0475b377.wav` (15.9 MB) |
| 15:18:43 | `R2 upload complete` → track 1180 created |
| 15:18:44, 15:18:53 | `R2 stream_file_data` — it played |
| **15:26:56** | same file uploaded again → same content hash, same key |
| 15:26:57.4 | `attempting R2 delete` `refcount=1` |
| **15:26:57.6** | `R2 file deleted` `audio/b9deb36a0475b377.wav` |

One trace, `run_track_upload` → `_process_upload_background`. It happened three more times that afternoon (1181, 1186, 1187).
</details>

## the fix

`delete()` tolerates a single reference because a track being deleted *is* that reference. Staged cleanup must not: nothing references a genuinely staged object, so **any** reference means the bytes are someone else's.

- **`discard_staged()`** — skips at `refcount > 0`, and counts `original_file_id` as well as `file_id` (a track's lossless source is an object too, and a content hash can be reached through either column). Every staged-audio cleanup site now routes through it.
- `delete()` keeps its `> 1` threshold, which is correct for its own semantics. The two verbs are now distinct so a future call site has to choose.

<details>
<summary>why the guard didn't already catch this, and a test that couldn't have caught it</summary>

This class of bug has bitten before — `tests/api/test_track_deletion.py` is titled "regression tests for banana mix incident", where deleting track 57 removed the R2 file track 56 was using. The refcount guard was that fix.

But `test_refcount_prevents_r2_deletion` mocked `R2Storage` **whole** and asserted that its own stub returned `False`:

```python
mock_storage.delete = AsyncMock(return_value=False)
result = await storage.delete(file_id)
assert result is False
```

It exercised no guard, no query, no threshold. This PR rewrites it to drive the real `delete()` against the real refcount query with only the S3 boundary mocked.

New tests in `tests/storage/test_discard_staged.py` cover: the re-upload case, the `original_file_id` case, a genuinely orphaned object still being collected, the real upload call site (`_delete_staged_audio`), and a contrast test pinning that `delete()` still removes the media of the track being deleted — the behaviour that destroyed audio when the staged path borrowed it.

Verified the call-site test fails against the old code (`1 failed, 4 passed`) before it passes against the new.
</details>

**Not in this PR:** recovering the 20 afflicted tracks (12 are restorable from the artists' PDS blobs, verified intact; 8 have no PDS copy), and the structural pass on whether the storage layer invites this class of mistake. Both follow.

Suite: 1398 passed, 25 skipped. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)