### PR TITLE
fix(audio): fall back to the artist's PDS when R2 has no object

### DIFF
--- a/backend/src/backend/api/audio.py
+++ b/backend/src/backend/api/audio.py
@@ -144,12 +144,21 @@ async def stream_audio(
             )
 
     # get URL for the requested file (original or transcoded)
-    url = await storage.get_url(
+    if url := await storage.get_url(
         serve_file_id, file_type="audio", extension=serve_file_type
-    )
-    if not url:
-        raise HTTPException(status_code=404, detail="audio file not found")
-    return RedirectResponse(url=url)
+    ):
+        return RedirectResponse(url=url)
+
+    # R2 has nothing. For anything we mirrored, the artist's own PDS holds a
+    # copy that is by definition still theirs — serve it rather than 404. Since
+    # #1732 deleted R2 objects out from under published tracks, a missing bucket
+    # copy is our failure, not evidence the audio is gone.
+    if pds_blob_cid and (artist_pds_url := await _resolve_pds_url(artist_did)):
+        return RedirectResponse(
+            url=pds_blob_url(artist_pds_url, artist_did, pds_blob_cid)
+        )
+
+    raise HTTPException(status_code=404, detail="audio file not found")
 
 
 async def _check_gate_access(
@@ -339,13 +348,22 @@ async def get_audio_url(
             )
 
     # otherwise, resolve it
-    url = await storage.get_url(
+    if url := await storage.get_url(
         serve_file_id, file_type="audio", extension=serve_file_type
-    )
-    if not url:
-        raise HTTPException(status_code=404, detail="audio file not found")
+    ):
+        return AudioUrlResponse(
+            url=url, file_id=serve_file_id, file_type=serve_file_type
+        )
 
-    return AudioUrlResponse(url=url, file_id=serve_file_id, file_type=serve_file_type)
+    # R2 has nothing — fall back to the artist's own copy (see `stream_audio`).
+    if pds_blob_cid and (artist_pds_url := await _resolve_pds_url(artist_did)):
+        return AudioUrlResponse(
+            url=pds_blob_url(artist_pds_url, artist_did, pds_blob_cid),
+            file_id=serve_file_id,
+            file_type=serve_file_type,
+        )
+
+    raise HTTPException(status_code=404, detail="audio file not found")
 
 
 def _relay_headers(resp) -> dict[str, str]:

--- a/backend/tests/api/test_audio.py
+++ b/backend/tests/api/test_audio.py
@@ -753,6 +753,83 @@ class TestAudioPdsRedirect:
         assert f"did={artist.did}" in location
         assert f"cid={pds_track.pds_blob_cid}" in location
 
+    async def test_mirrored_track_falls_back_to_pds_when_r2_is_empty(
+        self, db_session: AsyncSession, client: object
+    ) -> None:
+        """a mirrored track whose R2 object went missing serves from the PDS.
+
+        Regression: #1732 deleted R2 objects out from under published tracks.
+        The PDS branch used to require `audio_storage == "pds"` exactly, so a
+        `both` track with an intact blob 404'd anyway — 12 tracks across three
+        artists were dead in the player while their audio sat in their own PDS.
+        """
+        from fastapi.testclient import TestClient
+
+        assert isinstance(client, TestClient)
+
+        artist = Artist(
+            did="did:plc:mirrored",
+            handle="mirrored.bsky.social",
+            display_name="Mirrored Artist",
+            pds_url=self.PDS_URL,
+        )
+        db_session.add(artist)
+        await db_session.flush()
+
+        track = Track(
+            title="R2 copy deleted",
+            file_id="mirrored_file_001",
+            file_type="wav",
+            artist_did=artist.did,
+            r2_url=None,
+            audio_storage="both",
+            pds_blob_cid="bafymirroredcid",
+        )
+        db_session.add(track)
+        await db_session.commit()
+
+        with patch("backend.api.audio.storage.get_url", AsyncMock(return_value=None)):
+            response = client.get(f"/audio/{track.file_id}", follow_redirects=False)
+
+        assert response.status_code == 307
+        location = response.headers["location"]
+        assert "com.atproto.sync.getBlob" in location
+        assert f"cid={track.pds_blob_cid}" in location
+
+    async def test_track_with_no_copy_anywhere_still_404s(
+        self, db_session: AsyncSession, client: object
+    ) -> None:
+        """the fallback must not paper over a track we genuinely lost."""
+        from fastapi.testclient import TestClient
+
+        assert isinstance(client, TestClient)
+
+        artist = Artist(
+            did="did:plc:noblob",
+            handle="noblob.bsky.social",
+            display_name="No Blob",
+            pds_url=self.PDS_URL,
+        )
+        db_session.add(artist)
+        await db_session.flush()
+        db_session.add(
+            Track(
+                title="gone",
+                file_id="noblob_file_001",
+                file_type="wav",
+                artist_did=artist.did,
+                r2_url=None,
+                audio_storage="r2",
+                pds_blob_cid=None,
+            )
+        )
+        await db_session.commit()
+
+        with patch("backend.api.audio.storage.get_url", AsyncMock(return_value=None)):
+            response = client.get("/audio/noblob_file_001", follow_redirects=False)
+
+        assert response.status_code == 404
+
     async def test_gated_pds_redirect(
         self,
         db_session: AsyncSession,

--- a/loq.toml
+++ b/loq.toml
@@ -52,7 +52,7 @@ max_lines = 932
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"
-max_lines = 809
+max_lines = 886
 
 [[rules]]
 path = "backend/tests/api/test_albums.py"

--- a/scripts/restore_r2_from_pds.py
+++ b/scripts/restore_r2_from_pds.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["httpx", "boto3", "sqlalchemy[asyncio]", "asyncpg", "pydantic-settings"]
+# ///
+"""restore R2 audio objects from the artist's PDS blob.
+
+For tracks we mirrored to both R2 and the artist's PDS, the PDS copy is the one
+that survived #1732 — staged-upload cleanup deleted R2 objects out from under
+published tracks. The blob is the same bytes the artist uploaded, so copying it
+back restores the CDN path without touching a single database row.
+
+Tracks with no `pds_blob_cid` are reported and skipped: there is nothing to
+restore from, and inventing a substitute would be worse than a dead link.
+
+usage:
+    export ADMIN_DATABASE_URL=...
+    export ADMIN_AWS_ACCESS_KEY_ID=... ADMIN_AWS_SECRET_ACCESS_KEY=...
+    export ADMIN_R2_ENDPOINT_URL=... ADMIN_R2_BUCKET=audio-prod
+    uv run scripts/restore_r2_from_pds.py --dry-run
+    uv run scripts/restore_r2_from_pds.py
+"""
+
+import argparse
+import asyncio
+import sys
+
+import boto3
+import httpx
+from botocore.config import Config
+from botocore.exceptions import ClientError
+from pydantic_settings import BaseSettings
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+CANDIDATES = text("""
+    SELECT t.id, t.file_id, t.file_type, t.pds_blob_cid, t.artist_did,
+           a.handle, a.pds_url
+    FROM tracks t
+    JOIN artists a ON a.did = t.artist_did
+    WHERE t.pds_blob_cid IS NOT NULL
+      AND t.visibility IN ('public', 'supporters')
+      AND a.deactivated = false
+    ORDER BY t.id
+""")
+
+
+class AdminSettings(BaseSettings):
+    database_url: str
+    aws_access_key_id: str
+    aws_secret_access_key: str
+    r2_endpoint_url: str
+    r2_bucket: str
+
+    class Config:
+        env_prefix = "ADMIN_"
+
+
+def blob_url(pds_url: str, did: str, cid: str) -> str:
+    return f"{pds_url}/xrpc/com.atproto.sync.getBlob?did={did}&cid={cid}"
+
+
+async def main(dry_run: bool, only_ids: set[int] | None) -> int:
+    settings = AdminSettings()  # type: ignore[call-arg]
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=settings.r2_endpoint_url,
+        aws_access_key_id=settings.aws_access_key_id,
+        aws_secret_access_key=settings.aws_secret_access_key,
+        config=Config(
+            request_checksum_calculation="WHEN_REQUIRED",
+            response_checksum_validation="WHEN_REQUIRED",
+        ),
+    )
+
+    engine = create_async_engine(settings.database_url)
+    async with engine.connect() as conn:
+        rows = list((await conn.execute(CANDIDATES)).mappings())
+    await engine.dispose()
+
+    if only_ids:
+        rows = [r for r in rows if r["id"] in only_ids]
+
+    missing, restored, failed = [], [], []
+    async with httpx.AsyncClient(timeout=120.0, follow_redirects=True) as http:
+        for row in rows:
+            key = f"audio/{row['file_id']}.{row['file_type']}"
+            try:
+                s3.head_object(Bucket=settings.r2_bucket, Key=key)
+                continue  # R2 already has it
+            except ClientError as e:
+                if e.response.get("Error", {}).get("Code") not in ("404", "NoSuchKey"):
+                    raise
+
+            missing.append(row)
+            label = f"track {row['id']} ({row['handle']}) -> {key}"
+            if dry_run:
+                print(f"  would restore {label}")
+                continue
+
+            try:
+                resp = await http.get(
+                    blob_url(row["pds_url"], row["artist_did"], row["pds_blob_cid"])
+                )
+                resp.raise_for_status()
+                s3.put_object(
+                    Bucket=settings.r2_bucket,
+                    Key=key,
+                    Body=resp.content,
+                    CacheControl="public, max-age=31536000, immutable",
+                )
+            except Exception as exc:  # noqa: BLE001 — report, don't abort the batch
+                failed.append((row, exc))
+                print(f"  FAILED {label}: {exc}")
+            else:
+                restored.append(row)
+                print(f"  restored {label} ({len(resp.content):,} bytes)")
+
+    print(f"\n{len(rows)} mirrored tracks checked, {len(missing)} missing from R2")
+    if not dry_run:
+        print(f"{len(restored)} restored, {len(failed)} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--ids", help="comma-separated track ids to limit the run to", default=""
+    )
+    args = parser.parse_args()
+    ids = {int(i) for i in args.ids.split(",") if i.strip()} or None
+    sys.exit(asyncio.run(main(args.dry_run, ids)))


### PR DESCRIPTION
Phase 2 of the #1732 data-loss response: un-break the artists we broke. Twelve of the twenty afflicted tracks have their audio sitting intact in the artist's own PDS — this makes us serve it.

**A missing bucket copy is our failure, not evidence the audio is gone.** The PDS branch required `audio_storage == "pds"` *exactly*, so a `both` track holding a valid `pds_blob_cid` 404'd anyway. That's the whole thesis of the project inverted: the artist has their audio, and we told the listener it didn't exist.

Verified against production before writing this — all 12 blobs return 200 with correct sizes and content types (`audio/mpeg`, `audio/vnd.wave`, `audio/x-flac`).

<details>
<summary>precedence, and what did not change</summary>

The declared-storage precedence is untouched. A track that says `audio_storage="pds"` still goes to its PDS *before* R2 is consulted — I briefly reordered these and `test_pds_redirect` caught it (a PDS-only track started serving from a stale R2 object). The fallback is strictly a last resort, added between "R2 has nothing" and the 404:

1. private → byte proxy
2. gated → `_handle_gated_audio`
3. cached `r2_url` fast path (no per-request HEAD, unchanged)
4. `audio_storage == "pds"` → PDS
5. `storage.get_url` → R2
6. **new:** any `pds_blob_cid` → PDS
7. 404

Applied to both `stream_audio` (307) and `get_audio_url` (JSON).

A track with no copy anywhere still 404s — `test_track_with_no_copy_anywhere_still_404s` pins that the fallback doesn't paper over genuine loss.
</details>

<details>
<summary>restoring the CDN copies</summary>

The fallback makes those 12 playable immediately, but every play then hits the artist's PDS (`eurosky.social`, `jellybaby.us-east.host.bsky.network`) instead of our CDN — uncached, slower, and leaning on infrastructure that isn't ours.

`scripts/restore_r2_from_pds.py` copies the blob back to R2. It **touches no database rows** — the bytes are content-addressed, so restoring the object makes the existing `r2_url` correct again. Follows the `ADMIN_*` env pattern from `delete_track.py`, defaults to reporting, and has `--dry-run` plus `--ids`.

It skips anything without a `pds_blob_cid` and reports it: there is nothing to restore from, and inventing a substitute would be worse than a dead link.

**I have not run it** — it needs prod R2 write credentials.
</details>

Still outstanding: the 8 tracks with no PDS copy (flo.by ×5, bismark.blacksky.app, jdhitsolutions.com, and track 53 — `zzstoatzz.io`). Those bytes are genuinely gone; the fallback correctly leaves them 404ing, and what to tell those artists is a call I'm not making unilaterally.

Suite: 1400 passed, 25 skipped. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)