### PR TITLE
fix(storage): refcount every media column, not just audio

### DIFF
--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -1046,7 +1046,7 @@ async def _create_records(
                     )
             if image_id:
                 with contextlib.suppress(Exception):
-                    await storage.delete(image_id)
+                    await storage.discard_staged(image_id)
         # else: Jetstream finalized the row — media belongs to the published track
 
         raise UploadPhaseError(f"failed to sync track to ATProto: {err_detail}") from e
@@ -1199,7 +1199,7 @@ async def _cleanup_staged_media_pre_db(
 
     if ctx.image_id:
         with contextlib.suppress(Exception):
-            await storage.delete(ctx.image_id)
+            await storage.discard_staged(ctx.image_id)
 
 
 async def _process_upload_background(ctx: UploadContext) -> None:
@@ -1397,7 +1397,7 @@ async def run_track_upload(
             )
         if image_id:
             with contextlib.suppress(Exception):
-                await storage.delete(image_id)
+                await storage.discard_staged(image_id)
         await job_service.update_progress(
             upload_id,
             JobStatus.FAILED,
@@ -1779,7 +1779,7 @@ async def upload_track(
                 )
             if image_id:
                 with contextlib.suppress(Exception):
-                    await storage.delete(image_id)
+                    await storage.discard_staged(image_id)
             with contextlib.suppress(Exception):
                 await job_service.update_progress(
                     upload_id,

--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -1,7 +1,9 @@
 """cloudflare R2 storage for audio files."""
 
+import operator
 import time
 from collections.abc import AsyncIterator, Callable
+from functools import reduce
 from io import BytesIO
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO
@@ -16,6 +18,8 @@ from sqlalchemy import func, or_, select
 from backend._internal.audio import AudioFormat
 from backend._internal.image import ImageFormat
 from backend.config import settings
+from backend.models.album import Album
+from backend.models.playlist import Playlist
 from backend.models.track import Track
 from backend.storage.keys import AudioKey, ImageKey, InvalidMediaExtension
 from backend.utilities.database import db_session
@@ -28,6 +32,16 @@ STREAM_CHUNK_SIZE = 1024 * 1024
 
 # content-hashed files never change — cache forever
 IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
+
+# every column that can name a stored object. `_reference_count` walks all of
+# them, because a content hash makes "these bytes" and "this row's media"
+# different questions — see its docstring.
+_MEDIA_REFERENCES: list[tuple[type, Callable[[str], object]]] = [
+    (Track, lambda fid: or_(Track.file_id == fid, Track.original_file_id == fid)),
+    (Track, lambda fid: Track.image_id == fid),
+    (Album, lambda fid: Album.image_id == fid),
+    (Playlist, lambda fid: Playlist.image_id == fid),
+]
 
 
 class UploadProgressTracker:
@@ -436,19 +450,25 @@ class R2Storage:
             return int(size) if size is not None else None
 
     async def _reference_count(self, file_id: str) -> int:
-        """how many live tracks point at ``file_id``.
+        """how many live rows point at ``file_id``, across every media column.
 
-        Counts `original_file_id` as well as `file_id`: a track's lossless source
-        is an object too, and a file_id is a content hash, so two rows can name
-        the same bytes through different columns.
+        A file_id is a content hash, so the same bytes are reachable through
+        several columns and several tables: a track's lossless source, an album
+        or playlist cover, another artist's byte-identical upload. Deletion has
+        to ask "does anything still need these bytes", not "does this one column
+        mention them" — the narrower question is what let staged cleanup delete
+        a published track's audio (#1732).
         """
+        totals = [
+            select(func.count())
+            .select_from(model)
+            .where(condition(file_id))
+            .scalar_subquery()
+            for model, condition in _MEDIA_REFERENCES
+        ]
         async with db_session() as db:
-            stmt = (
-                select(func.count())
-                .select_from(Track)
-                .where(or_(Track.file_id == file_id, Track.original_file_id == file_id))
-            )
-            return (await db.execute(stmt)).scalar_one()
+            result = await db.execute(select(reduce(operator.add, totals)))
+            return result.scalar_one()
 
     async def discard_staged(
         self, file_id: str, file_type: str | None = None, *, gated: bool = False

--- a/backend/tests/api/test_upload_storage_cleanup.py
+++ b/backend/tests/api/test_upload_storage_cleanup.py
@@ -91,11 +91,11 @@ class TestPhase1To5FailureDeletesStagedMedia:
 
         # non-gated → audio in public bucket
         discarded = [
-            (c.args[0], c.kwargs["gated"]) for c in mock_discard.call_args_list
+            (c.args[0], c.kwargs.get("gated")) for c in mock_discard.call_args_list
         ]
         assert ("staged-audio-id", False) in discarded
-        deleted_ids = [c.args[0] for c in mock_delete.call_args_list]
-        assert "staged-image-id" in deleted_ids
+        assert ("staged-image-id", None) in discarded
+        mock_delete.assert_not_called()
 
     async def test_gated_audio_deleted_from_private_bucket(self) -> None:
         with (
@@ -119,12 +119,12 @@ class TestPhase1To5FailureDeletesStagedMedia:
         # must route the audio delete to delete_gated. images are
         # never gated.
         discarded = [
-            (c.args[0], c.kwargs["gated"]) for c in mock_discard.call_args_list
+            (c.args[0], c.kwargs.get("gated")) for c in mock_discard.call_args_list
         ]
-        assert discarded == [("staged-audio-id", True)]
-        deleted_public_ids = [c.args[0] for c in mock_delete.call_args_list]
-        assert "staged-audio-id" not in deleted_public_ids
-        assert "staged-image-id" in deleted_public_ids
+        # gated audio routes to the private bucket; images are never gated
+        assert ("staged-audio-id", True) in discarded
+        assert ("staged-image-id", None) in discarded
+        mock_delete.assert_not_called()
 
     async def test_transcoded_failure_deletes_both_sibling_and_original(
         self,
@@ -179,8 +179,8 @@ class TestPhase1To5FailureDeletesStagedMedia:
         discarded = [c.args[0] for c in mock_discard.call_args_list]
         assert "transcoded-mp3-id" in discarded  # the playable sibling
         assert "staged-audio-id" in discarded  # the lossless source
-        deleted_ids = [c.args[0] for c in mock_delete.call_args_list]
-        assert "staged-image-id" in deleted_ids  # the cover art
+        assert "staged-image-id" in discarded  # the cover art
+        mock_delete.assert_not_called()
 
 
 class TestPhase6FailureDefersToCreateRecords:

--- a/backend/tests/storage/test_discard_staged.py
+++ b/backend/tests/storage/test_discard_staged.py
@@ -103,6 +103,34 @@ async def test_discard_staged_keeps_audio_referenced_as_a_lossless_source(
     s3.delete_object.assert_not_awaited()
 
 
+async def test_discard_staged_keeps_cover_art_another_row_still_uses(
+    storage: R2Storage, s3: MagicMock, db_session: AsyncSession
+) -> None:
+    """images are content-hashed too, and were protected by nothing at all.
+
+    The refcount query only ever counted audio columns, so every image in the
+    system was unguarded: two tracks sharing a cover, an album whose tracks
+    inherit its art, or two artists who uploaded the same JPEG.
+    """
+    artist = Artist(did="did:plc:cover", handle="cover.fm", display_name="cover")
+    db_session.add(artist)
+    await db_session.flush()
+    db_session.add(
+        Track(
+            title="keeps its cover",
+            artist_did=artist.did,
+            file_id="some-audio",
+            file_type="mp3",
+            image_id="shared-cover-hash",
+            extra={},
+        )
+    )
+    await db_session.commit()
+
+    assert await storage.discard_staged("shared-cover-hash") is False
+    s3.delete_object.assert_not_awaited()
+
+
 async def test_discard_staged_deletes_a_genuinely_orphaned_object(
     storage: R2Storage, s3: MagicMock, db_session: AsyncSession
 ) -> None:

--- a/docs/internal/retrospectives/2026-07-30-staged-cleanup-deleted-published-audio.md
+++ b/docs/internal/retrospectives/2026-07-30-staged-cleanup-deleted-published-audio.md
@@ -1,0 +1,121 @@
+# retrospective: staged-upload cleanup deleted published tracks' audio (2025-11 → 2026-07-30)
+
+## summary
+
+Twenty tracks across seven artists served no audio. The R2 objects had existed
+and been played — every affected track has `play_count >= 1`, and track 53 had
+59 plays and a like — and were then **deleted by plyr itself**.
+
+A `file_id` is a content hash (`hash_file_chunked(file)[:16]`). So re-uploading a
+file you already published stages the *exact R2 key your live track is served
+from*. Phase 3 of the upload pipeline (`_check_duplicate`) rejects the upload,
+and the orchestrator's failure cleanup then deletes "its" staged object — which
+is the published track's only copy.
+
+The duplicate path is the one failure mode where the staged object is
+**guaranteed** to belong to someone else: you only reach it because a track
+already owns that key.
+
+Found on 2026-07-30 when `@fpst.uk`'s tracks were noticed broken **while the
+operator was streaming live**. Twelve tracks were recovered the same day from
+the artists' PDS blobs (hash-verified byte-identical); eight had no PDS copy and
+are unrecoverable.
+
+## timeline (UTC)
+
+| time | event |
+|---|---|
+| 2025-11-12 | earliest affected track (53, `zzstoatzz.io`) |
+| 2026-07-18 15:18:42 | boulyprod uploads `b9deb36a0475b377.wav`; track 1180 created |
+| 2026-07-18 15:18:44–53 | `R2 stream_file_data` — it plays |
+| 2026-07-18 15:26:56 | same file uploaded again → same content hash, same key |
+| 2026-07-18 15:26:57.4 | `attempting R2 delete` `refcount=1` |
+| 2026-07-18 15:26:57.6 | `R2 file deleted audio/b9deb36a0475b377.wav` — same trace, `run_track_upload` → `_process_upload_background`. Repeats for 1181, 1186, 1187 that afternoon. |
+| 2026-07-30 | reported: "the tracks by this guy also seem broken and are showing in radio", during a live stream |
+| 2026-07-30 | fix released (#1733, `2026.0730.064616`); PDS fallback released (#1734); 12 objects restored from PDS blobs + edge cache purged; 20 broken → 8 |
+
+## root causes
+
+### 1. content-addressed keys give bytes no owner (the bug)
+
+`R2Storage.delete()` skipped only at `refcount > 1`. That threshold is correct
+for *track deletion* — the track being deleted is itself the one reference — and
+wrong for *staged cleanup*, where nothing legitimately references a staged
+object, so any reference at all means the bytes are someone else's.
+
+One function answered two different questions. The refcount also counted only
+`Track.file_id`, never `original_file_id`, and **never any image column at all**.
+
+### 2. the guard's own regression test could not fail
+
+This class of bug had bitten before — `tests/api/test_track_deletion.py` is
+titled "regression tests for banana mix incident", where deleting track 57
+removed the R2 file track 56 was using. The refcount guard was that fix. Its
+test mocked `R2Storage` *whole* and asserted its own stub returned `False`:
+
+```python
+mock_storage.delete = AsyncMock(return_value=False)
+result = await storage.delete(file_id)
+assert result is False
+```
+
+No guard, no query, no threshold. The protection everyone believed in was never
+exercised.
+
+### 3. no playback fallback (why it was fatal, not degraded)
+
+Twelve of the twenty had intact audio in the artist's own PDS the entire time.
+`GET /audio/{file_id}` gated its PDS branch on `audio_storage == "pds"` exactly,
+so a `both` track holding a valid `pds_blob_cid` 404'd anyway. **This is root
+cause #2 of the 2026-06-30 retrospective, unchanged.**
+
+### 4. no detection — for the second time
+
+The 2026-06-30 retrospective closed with:
+
+> **open**: nothing alerts on a track whose `r2_url` object is missing... Not
+> yet built.
+
+It still wasn't. Missing audio surfaces only as a 404 that is indistinguishable
+in logs from a permission denial. Both incidents were found by a human noticing.
+
+## resolution
+
+- **#1733** — `discard_staged()`, which skips at `refcount > 0`; every staged
+  cleanup site routes through it. `delete()` keeps `> 1` for its own semantics,
+  so the two verbs are now distinct and a new call site has to choose.
+- **#1734** — PDS fallback as a last resort before 404, for any track with a
+  blob. Declared-storage precedence unchanged.
+- **#1735** — the refcount counts *every* media column across `Track`, `Album`
+  and `Playlist`, in one query. Images were previously unguarded everywhere;
+  upload rollback now discards cover art by the same rule as audio.
+- `scripts/restore_r2_from_pds.py` and `scripts/audit_media_integrity.py`.
+- `test_refcount_prevents_r2_deletion` rewritten to drive the real guard against
+  the real query, mocking only the S3 boundary.
+
+## recovery
+
+All 12 mirrored tracks restored: blob fetched from the artist's real PDS
+(resolved from the DB, never assumed), `sha256(blob)[:16]` verified to equal the
+`file_id` for all 12, written to `audio-prod`, then the cached 404s purged —
+**restoring the object is not enough**, since the "Cache R2 media assets" rule
+pins a 1-year edge TTL and some edges kept serving the negative response.
+
+Unrecoverable (no PDS copy, `audio_storage="r2"`): 930–934 (`flo.by`), 1136
+(`bismark.blacksky.app`), 831 (`jdhitsolutions.com`), 53 (`zzstoatzz.io`).
+
+## prevention / follow-ups
+
+- **shipped**: the three PRs above, this retrospective, and an integrity script
+  that answers "does the object each row points at exist".
+- **open**: `audit_media_integrity.py` is not scheduled — it needs to run on a
+  cron and page, or this becomes a third incident found by a listener.
+- **open**: `move_audio()` (the gating toggle) still copy-then-deletes with no
+  refcount guard; `prune_revisions` never consults other tracks' `TrackRevision`
+  rows; `audio_optimize`'s abort paths still call `delete()` where they mean
+  `discard_staged()`.
+- **open**: dedup is scoped per-artist (`uploads.py`), so two artists uploading
+  identical bytes legitimately share one object. Serving already assumes that;
+  deletion should be audited against it everywhere.
+- **note**: the eight unrecoverable tracks belong to four artists who have not
+  been told.

--- a/loq.toml
+++ b/loq.toml
@@ -48,7 +48,7 @@ max_lines = 1222
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
-max_lines = 932
+max_lines = 952
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"

--- a/scripts/audit_media_integrity.py
+++ b/scripts/audit_media_integrity.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["boto3", "sqlalchemy[asyncio]", "asyncpg", "pydantic-settings"]
+# ///
+"""report every row whose media object is missing from R2.
+
+Two incidents have now been found by a user rather than by us: the 2026-06-30
+dead-audioUrl ingest, whose retrospective left "nothing alerts on a track whose
+r2_url object is missing" as an open follow-up, and #1732, where staged cleanup
+deleted published tracks' audio and 20 tracks sat broken until one was noticed
+playing on stream.
+
+This is that follow-up. It answers one question — does the object each row
+points at actually exist — and says nothing about why it doesn't. Exit code 1
+when anything is missing, so it can run on a schedule and page.
+
+usage:
+    export ADMIN_DATABASE_URL=...
+    export ADMIN_AWS_ACCESS_KEY_ID=... ADMIN_AWS_SECRET_ACCESS_KEY=...
+    export ADMIN_R2_ENDPOINT_URL=... ADMIN_R2_BUCKET=audio-prod
+    export ADMIN_R2_IMAGE_BUCKET=images-prod
+    uv run scripts/audit_media_integrity.py
+    uv run scripts/audit_media_integrity.py --audio-only
+"""
+
+import argparse
+import asyncio
+import sys
+from collections.abc import Iterator
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+from pydantic_settings import BaseSettings
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+# only rows a listener can actually reach — a private track has no R2 object by
+# design, and a deactivated artist's catalogue is already hidden.
+AUDIO_ROWS = text("""
+    SELECT t.id, a.handle, t.file_id AS media_id, t.file_type AS ext,
+           t.pds_blob_cid IS NOT NULL AS recoverable
+    FROM tracks t
+    JOIN artists a ON a.did = t.artist_did
+    WHERE t.visibility IN ('public', 'supporters')
+      AND t.support_gate IS NULL
+      AND a.deactivated = false
+    ORDER BY t.id
+""")
+
+IMAGE_ROWS = text("""
+    SELECT 'track' AS kind, t.id, a.handle, t.image_id AS media_id
+    FROM tracks t JOIN artists a ON a.did = t.artist_did
+    WHERE t.image_id IS NOT NULL AND a.deactivated = false
+    UNION ALL
+    SELECT 'album', al.id, a.handle, al.image_id
+    FROM albums al JOIN artists a ON a.did = al.artist_did
+    WHERE al.image_id IS NOT NULL
+""")
+
+IMAGE_EXTENSIONS = ("jpg", "jpeg", "png", "webp", "gif")
+
+
+class AdminSettings(BaseSettings):
+    database_url: str
+    aws_access_key_id: str
+    aws_secret_access_key: str
+    r2_endpoint_url: str
+    r2_bucket: str
+    r2_image_bucket: str = ""
+
+    class Config:
+        env_prefix = "ADMIN_"
+
+
+def exists(s3, bucket: str, candidates: Iterator[str]) -> bool:
+    for key in candidates:
+        try:
+            s3.head_object(Bucket=bucket, Key=key)
+            return True
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") not in ("404", "NoSuchKey"):
+                raise
+    return False
+
+
+async def main(audio_only: bool) -> int:
+    settings = AdminSettings()  # type: ignore[call-arg]
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=settings.r2_endpoint_url,
+        aws_access_key_id=settings.aws_access_key_id,
+        aws_secret_access_key=settings.aws_secret_access_key,
+        config=Config(
+            request_checksum_calculation="WHEN_REQUIRED",
+            response_checksum_validation="WHEN_REQUIRED",
+        ),
+    )
+
+    engine = create_async_engine(settings.database_url)
+    async with engine.connect() as conn:
+        audio = list((await conn.execute(AUDIO_ROWS)).mappings())
+        images = [] if audio_only else list((await conn.execute(IMAGE_ROWS)).mappings())
+    await engine.dispose()
+
+    missing_audio = [
+        row
+        for row in audio
+        if not exists(
+            s3, settings.r2_bucket, iter([f"audio/{row['media_id']}.{row['ext']}"])
+        )
+    ]
+    for row in missing_audio:
+        hint = "recoverable from PDS" if row["recoverable"] else "NO PDS COPY"
+        print(f"  audio  track {row['id']:>5}  {row['handle']:<32} {hint}")
+
+    missing_images = []
+    if not audio_only and settings.r2_image_bucket:
+        for row in images:
+            candidates = (f"images/{row['media_id']}.{ext}" for ext in IMAGE_EXTENSIONS)
+            if not exists(s3, settings.r2_image_bucket, candidates):
+                missing_images.append(row)
+                print(f"  image  {row['kind']} {row['id']:>5}  {row['handle']}")
+
+    print(
+        f"\n{len(audio)} audio rows checked, {len(missing_audio)} missing"
+        + (
+            ""
+            if audio_only
+            else f"; {len(images)} image rows checked, {len(missing_images)} missing"
+        )
+    )
+    if unrecoverable := [r for r in missing_audio if not r["recoverable"]]:
+        print(f"{len(unrecoverable)} of the missing audio rows have no PDS copy")
+    return 1 if (missing_audio or missing_images) else 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--audio-only", action="store_true")
+    sys.exit(asyncio.run(main(parser.parse_args().audio_only)))


### PR DESCRIPTION
Phase 3 of the #1732 response: the structural pass. The answer to "did we create a poor environment for ourselves?" is **yes, in one specific way** — and the same bug was still live for images.

**Content-addressed keys give bytes no owner.** `file_id` and `image_id` are content hashes, so "these bytes" and "this row's media" are different questions, and every deletion path was asking the narrow one.

`_reference_count` only counted `Track.file_id` and `original_file_id`. **Images were protected by nothing at all** — not by `delete()`, whose audio-only refcount returns 0 for any image, and not by `delete_image()`, which had no refcount whatsoever. So two tracks sharing a cover, an album whose tracks inherit its art, or two artists who uploaded the same JPEG could each delete the other's object. And `uploads.py` rollback deleted cover art with the raw verb — the exact incident shape, unfixed.

The refcount now walks `Track` (audio **and** image), `Album`, and `Playlist` in a single query, and image rollbacks route through `discard_staged`.

<details>
<summary>the pattern this is the third instance of</summary>

| incident | fix | what it left open |
|---|---|---|
| "banana mix" | the refcount guard | its regression test mocked `R2Storage` whole and asserted its own stub — it exercised no guard (rewritten in #1733) |
| 2026-06-30 dead audioUrl | ingest existence check (#1616) | *"nothing alerts on a track whose `r2_url` object is missing… Not yet built."* |
| #1732 (this one) | `discard_staged` + this PR | see below |

Each time we patched the instance. The class is: **something referenced bytes it didn't own, or trusted a pointer it hadn't verified.** Root cause #2 of the 2026-06-30 retrospective — no playback fallback — was still verbatim true last week, which is why 12 tracks with perfectly good PDS blobs were dead (fixed in #1734).
</details>

<details>
<summary>detection — the follow-up the last retrospective left open</summary>

`scripts/audit_media_integrity.py` answers one question: does the object each row points at actually exist. Exit code 1 when anything is missing, so it can be scheduled and page.

It is deliberately dumb about *why* — that's what made it writable today rather than being deferred a third time.

**It is not yet scheduled.** That's the top open follow-up; without a cron this becomes a third incident found by a listener.
</details>

<details>
<summary>known-remaining hazards, documented rather than silently left</summary>

The retrospective enumerates these rather than pretending the class is closed:

- `move_audio()` (the gating toggle) copy-then-deletes with **no refcount guard** — two tracks sharing a `file_id`, one toggles gating, the other 404s.
- `prune_revisions` never consults *other* tracks' `TrackRevision` rows.
- `audio_optimize`'s abort paths call `delete()` where they mean `discard_staged()`.
- Dedup is scoped per-artist, so two artists sharing bytes is legitimate and expected. Serving already assumes this; deletion should be audited against it everywhere.
</details>

Also adds `docs/internal/retrospectives/2026-07-30-staged-cleanup-deleted-published-audio.md`, including the full recovery record: all 12 restorable tracks verified `sha256(blob)[:16] == file_id` before being written back, and the cached 404s purged — restoring the object alone was **not** enough, since the 1-year edge TTL kept some edges serving the negative response.

**Production status: 20 broken → 8.** The 8 remaining have no PDS copy and are unrecoverable (`flo.by` ×5, `bismark.blacksky.app`, `jdhitsolutions.com`, and track 53). Those four artists have not been told — your call.

Suite: 1401 passed, 25 skipped. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)