### PR TITLE
fix(ingest): a re-delivered commit must not overwrite newer state

### DIFF
--- a/.status_history/2026-07.md
+++ b/.status_history/2026-07.md
@@ -75,6 +75,29 @@ then with **no link facets at all** — Bluesky does not infer links from text, 
 both URLs rendered as unclickable grey text. The disabled-but-logging mode
 caught the first; you caught the second.
 
+#### at-tags meta + copyright mix detection (#1689, #1690, July 23–24)
+
+track, album, playlist, and artist pages emit at-tags meta (#1690). Copyright
+scanning now flags mixes of copyrighted songs rather than only single-song rips
+(#1689) — a sustained-match count threshold, so a DJ mix stitched from several
+commercial tracks no longer slips through a per-song score gate.
+
+#### operator labels projected into SQL (#1688, July 23 — release `2026.0723.190620`)
+
+logged-out pagination of the home feed had been broken since #1676 (July 16):
+adult-label visibility could not be expressed in SQL — operator labels lived
+only in the moderation service, reachable per-request over HTTP — so #1676
+filtered app-side *after* the query, which corrupts cursor bookkeeping. Any page
+containing a labeled track reported `has_more: false` and everything older
+silently vanished. Fixed at the storage layer rather than the symptom: a
+`tracks.operator_labels` JSONB column, reconciled every 5 minutes by a docket
+Perpetual task against a new `/labels-by-value` labeler endpoint, following the
+`copyright_scans.is_flagged` precedent. Visibility is a WHERE clause again and
+pagination is back to plain `limit + 1`. The sync client **raises** on labeler
+failure so an outage can never be read as "nothing is labeled" and wipe the
+projection; byte-serving authorization still queries the labeler live. ~12
+filter call sites stopped making transitive HTTP calls.
+
 #### adult-audio labels + sensitive-content policy (#1676, #1677, #1682, July 16–17)
 
 **why**: explicit long-form audio reached fresh radio while the ATProto labeler

--- a/STATUS.md
+++ b/STATUS.md
@@ -47,6 +47,42 @@ plyr.fm should become:
 
 ### July 2026
 
+#### the firehose does not promise order (#1736, July 30 — not yet released)
+
+**why**: a continuous publisher was replacing the audio on three unlisted tracks
+every five minutes, and the player started showing `0:00 / 0:00` with a pause
+button. The first suspects were all wrong: the retention cap (#1732), the
+staged-cleanup incident (#1733/#1734), and a frontend race in `Player.svelte`.
+
+The PDS records were correct the whole time — the right `audioUrl` at a CID unchanged
+for half an hour, with no plyr write since. Yet ingest received **37 `track.update`
+events for one URI**, carrying *different historical* record values: the row's `r2_url`
+read the 06:32 revision at 07:05, the 06:37 revision at 07:11, and the current one at
+07:22. A repo's commit history was being re-emitted upstream (confined to that one repo
+— zero events for any other DID in 40 min), and ingest applied each state as if current.
+
+**what shipped**: commits are ordered by repo `rev` — a TID, monotonic per repo,
+and unlike jetstream's `time_us` it survives re-delivery (`time_us` is stamped on
+receipt, so it cannot tell a replay from a fresh write). An update at or below the
+applied rev is refused. The #1616 existence check now runs on the update path, and
+prune reference-safety considers the URL a row actually *serves*.
+
+**technical notes**:
+- **the ingest doc claimed all tasks are idempotent under cursor rewind.** True for
+  create and delete, which dedupe by AT-URI; false for update. It also justified
+  skipping the existence check on update because "an update can only mutate an
+  already-ingested track" — which is exactly what got corrupted.
+- **the damage is not the transient wrong audio.** A replayed `r2_url` can name a blob
+  since pruned as an old revision: `/audio/{file_id}` 307s to a dead key, the element
+  never loads metadata, and the 1-year edge TTL caches the 404. Prune couldn't see it
+  either — its reference set was `file_id`s, while the served object is named by `r2_url`.
+- **it corrupts metadata too.** Track 1201's title regressed by an hour while its cover
+  and audio stayed current; the guard rejects the whole commit, so nothing can regress.
+- **not fixed by ignoring `audioUrl` on update.** plyr honors record updates because
+  [@cinny.bun.how](https://bsky.app/profile/cinny.bun.how) pointed out in March 2026
+  (#1068–#1076) that writing to a PDS without listening is not how the protocol works.
+  The bug was trusting delivery *order*, not trusting the record.
+
 #### an artist can't air twice in a row (#1730, July 29 — release `2026.0729.213641`)
 
 **why**: the `loved` station played the same artist three tracks in a row,
@@ -312,50 +348,12 @@ fork, but Ozone wants to own the labeler DID we already run, adds a VPS and
 Postgres, and its UI targets Bluesky posts rather than audio — borrowing its
 event-log model instead.
 
-#### moderation service boundary + a fail-open label cache (#1691–#1695, July 24–25 — release `2026.0725.035625`)
+#### the July 23–25 moderation + labels cluster (#1688–#1695, July 23–25)
 
-the moderation service's `/admin/*` prefix mixed two unrelated consumers behind
-one auth middleware — the htmx dashboard a human opens, and the hot-path
-endpoints the backend calls. The six service-to-service endpoints moved to
-`/internal/*` (#1692, #1693), served from one route table nested at both
-prefixes so the deprecated aliases cannot drift; the operator surface
-deliberately stayed put, and the three moderation scripts collapsed onto one
-shared client (#1694, −146/+25).
-
-**the thing worth remembering**: verifying the rename end-to-end on staging
-surfaced a fail-open window unrelated to it. The label cache is keyed by subject
-URI and is **viewer-independent**, so one playback by anyone caches "no labels"
-for everyone; `emit_label` invalidates only for labels *the backend* emitted,
-and operators emit straight to the labeler. A track labeled while its cache
-entry was warm kept serving audio for the full 300s TTL — on the one endpoint
-designed to fail closed. A `subscribeLabels` consumer now invalidates each
-subject as the labeler commits it (#1695), measured at **0.8s instead of ~300s**,
-reading the stream rather than having the labeler call back so the dependency
-points one way. Full detail, including the `POST /admin/batches` empty-list
-lesson, in `.status_history/2026-07.md`.
-
-#### at-tags meta + copyright mix detection (#1689, #1690, July 23–24)
-
-track, album, playlist, and artist pages emit at-tags meta (#1690). Copyright
-scanning now flags mixes of copyrighted songs rather than only single-song rips
-(#1689) — a sustained-match count threshold, so a DJ mix stitched from several
-commercial tracks no longer slips through a per-song score gate.
-
-#### operator labels projected into SQL (#1688, July 23 — release `2026.0723.190620`)
-
-logged-out pagination of the home feed had been broken since #1676 (July 16):
-adult-label visibility could not be expressed in SQL — operator labels lived
-only in the moderation service, reachable per-request over HTTP — so #1676
-filtered app-side *after* the query, which corrupts cursor bookkeeping. Any page
-containing a labeled track reported `has_more: false` and everything older
-silently vanished. Fixed at the storage layer rather than the symptom: a
-`tracks.operator_labels` JSONB column, reconciled every 5 minutes by a docket
-Perpetual task against a new `/labels-by-value` labeler endpoint, following the
-`copyright_scans.is_flagged` precedent. Visibility is a WHERE clause again and
-pagination is back to plain `limit + 1`. The sync client **raises** on labeler
-failure so an outage can never be read as "nothing is labeled" and wipe the
-projection; byte-serving authorization still queries the labeler live. ~12
-filter call sites stopped making transitive HTTP calls.
+See `.status_history/2026-07.md` — the `/internal/*` service boundary and the
+fail-open label cache (#1691–#1695), operator labels projected into SQL (#1688,
+which fixed a week of broken logged-out pagination), and at-tags meta +
+copyright mix detection (#1689, #1690).
 
 #### adult-audio labels + sensitive-content policy (#1676, #1677, #1682, July 16–17)
 
@@ -460,6 +458,10 @@ See `.status_history/` for detailed history, one file per month:
 **next**: remove the `/admin/*` machine-endpoint aliases now that prod calls `/internal/*` (#1691); re-enable `test_private_media.py` somewhere that has the local postgres/redis fixtures (it is excluded from the staging-facing workflow). which surfaces beyond albums/playlists count as queueable contexts (artist catalogs #1353, feeds/search). publish the five record lexicons (`fm.plyr.track`, `.like`, `.comment`, `.list`, `.actor.profile`) with a docs-quality pass on each (next phase after #1569); a production smoke-test harness for private media (file-types × visibilities, fully inert — no DM/listing/stats — per prod release); enable the `copyright-paradigm` flag for own DID and start dogfooding on prod; co-writer / publisher editing UI for `additionalInterestedParties` (backend plumbed end-to-end, frontend deferred); prefill ISWC/ISRC/masterOwner on the portal edit form (we only have the URIs locally, not field contents); fly worker tcp health check (running-but-stuck symptom detector); upstream `atproto_oauth.OAuthClient` body-factory support (lets us drop `_signed_streaming_post`); deploy-docs sanity check; `config.py` decomposition.
 
 ### known issues
+- **track 1201's indexed title is an hour stale** (#1736): the PDS record says `07:42–07:47`, plyr's row says `06:47–06:49`. The artist's data is fine; our index is wrong, from a replayed commit. Re-applying the current record fixes it — a production write, not yet done.
+- **the rev guard has a one-event window on existing rows** (#1736): `atproto_record_rev` starts `NULL` everywhere, and ingest applies-and-learns rather than rejecting when it has no baseline (rejecting would drop legitimate updates). So the first update per track after release is itself unordered. Backfilling revs from each PDS record would close it.
+- **comment and list updates are still unordered** (#1736): the same last-writer-wins defect exists in `ingest_comment_update` and `ingest_list_update`. Only the track path was fixed, because that is the one that can strand audio bytes.
+- **`_reference_count` cannot see `r2_url`** (#1735/#1736): the refcount that guards deletion matches `file_id`-shaped columns, so it cannot protect a row whose `r2_url` and `file_id` name different objects. `prune_revisions` now compensates locally; the general fix belongs in `_MEDIA_REFERENCES`.
 - **the account-status reconciliation script has not been run against prod** (#1729): a dry run reports 5 artists whose `account_status` reason is `NULL` and would be filled in, with zero flags changed. Until it runs, those rows say an artist is hidden without saying why.
 - **13 tracks await triage in the review queue**, including track 64 (user report #5 from @vicwalker.dev.br). They are visible and playable in the dashboard now; nobody has made a call on any of them. A fingerprint match is not a finding — several read as covers or remixes the uploader performed.
 - **no per-actor authentication**: the moderation service trusts one shared `MODERATION_AUTH_TOKEN`, so the event log's `actor` is a claim rather than a verified identity. This is the gate on letting an agent *act* rather than propose, and on review genuinely not always being one person.
@@ -607,4 +609,4 @@ see the [contributing guide](https://docs.plyr.fm/contributing/) for setup instr
 
 ---
 
-this is a living document. last updated 2026-07-29 (**identity is not a single host's opinion**. Documented #1725–#1729: a broken avatar on @brookie.blog led to five live artists — 12 tracks — hidden from radio, feeds, and for-you, because an `#account` event describes *the host that emitted it*, not the person, and leaving a PDS makes the host you left report you deactivated. All five had migrated. Fixed at three levels: `hides_content(active, status)` so infrastructure statuses hide nobody, asking the current PDS instead of a cached one, and registering `ingest_identity_update` — the task that maintains that cache, which had never once executed in production. Bluesky avatars now mirror through jetstream (#1726), and a tag containing a slash resolves (#1725). Also #1730: the radio's per-artist airtime cap bounded how *much* one artist got but not how *clustered*, so `loved` played the same artist three in a row on stream — draws are now artist-spaced, longest run 6 → 1. Corrected the stale note that #1718 was staging-only; it reached prod in `2026.0729.193914`. New known issue: the account-status reconciliation script hasn't been run against prod, so 5 hidden artists carry a `NULL` reason.) previously 2026-07-28 (**where a label reaches, and operational hygiene**. Documented #1709–#1713: the `LabelContext.LIST` vs `VIEW` split, which stopped adult labels from hiding tracks on the artist's own detail page — labels shape discovery, not destinations — applied the context at every filtering call site so counts agree with the rows they count, and published one accurate public answer at docs.plyr.fm/moderation. Also #1716/#1718: published contact moved to `help@plyr.fm` / `dmca@plyr.fm` with the DMCA agent filing updated and the privacy policy corrected to describe what is actually collected; and rate limits keyed per client rather than per site, closing a bug where Fly's proxy address made `default_limits` one bucket for the entire site (298 429s on `/radio/state`). New known issue: the DMCA surface is incomplete (#1715) — no published notice requirements, no counter-notice procedure, no repeat-infringer counter. #1718 is verified on staging but not yet released to prod.) previously 2026-07-25 (**status maintenance for the July 2–25 window**. Archived the July 1–17 entries to `.status_history/2026-07.md` and collapsed the November 2025–May 2026 cross-references, since STATUS.md had gone over its 500-line ceiling. Backfilled the previously undocumented July 10–23 cluster: the **operator-label SQL projection** #1688, which fixed a week of broken logged-out pagination caused by app-side filtering after #1676; **playlist composite covers** #1663–#1665/#1675; **edge artwork renditions** #1672 (5.3MB JPEGs were being served into a 400px hero and 40px thumbnails); the **July 14 radio compute incident** #1671, where rebuilding the rotation on every poll saturated prod Neon compute; and **queue polish** #1667–#1670. Removed the integration-suite known issue — it is green again after five weeks red (#1660/#1661, 22 passed). Recorded the podcast recap for July 2–25.) previously 2026-07-25 (**labels that act** #1697 — `copyright-violation` now de-lists from radio and discovery instead of doing nothing, and adult labels stopped gating audio bytes so creators' permalinks work for signed-out listeners; the organizing idea is that a label is a portable assertion while enforcement is local hosting policy, which is why adult defers to the listener and copyright cannot. Retracted the ten pre-#703 public labels. Traced the asymmetry to the 2026-01-02 legal review, whose "flag it and act on it" half was deferred in #703 and never built. New known issues: no per-track override, and three flagged-but-unlabeled tracks needing triage). previously 2026-07-25 (documented the July 23–25 window and the `2026.0725.035625` prod release: the **moderation service boundary** #1691–#1694 — service-to-service endpoints moved to `/internal/*` with `/admin/*` aliases for one deploy cycle, the operator surface deliberately left in place, and the three moderation scripts collapsed onto one shared client; the **fail-open label cache** #1695 — found while verifying the rename end-to-end on staging, a URI-keyed viewer-independent cache meant an operator-emitted label had no effect on audio byte authorization for up to 300s, now closed to ~0.8s by a `subscribeLabels` subscriber; plus **at-tags meta** #1690 and **copyright mix detection** #1689. New known issue: negation recovery still waits on the ~5-minute `operator_labels` projection sync). previously 2026-07-20 (aligned private media with ATProto permissioned-data Proposal 0016: canonical addresses, space-type/permission-set separation, client attestations, host resolution, and sync read foundations; #1684). previously 2026-07-16 (documented the sensitive-audio response, labeler rollout, affected tracks 1177–1179, and the access/operator-tooling gaps). earlier entries (2026-07-09 and before) are preserved in `.status_history/2026-07.md`.
+this is a living document. last updated 2026-07-30 (**the firehose does not promise order**. Documented #1736: a continuous publisher's tracks started showing `0:00 / 0:00`, and the cause was none of the obvious suspects — not the retention cap (#1732), not the staged-cleanup incident (#1733/#1734), not a frontend race. The PDS records were correct throughout; a repo's commit history was re-emitted upstream and `ingest_track_update` applied each replayed state as current, walking one track's `r2_url` back to a 19-minute-old revision and another's title back by an hour. Commits are now ordered by repo `rev`, which survives re-delivery where jetstream's `time_us` does not. The doc's claim that all ingest tasks are idempotent under cursor rewind held for create and delete but never for update. Also extended the #1616 existence check to the update path and made prune reference-safety consider the URL a row actually serves. New known issues: track 1201's indexed title is stale pending a production write, the guard has a one-event window on rows with no recorded rev, comment/list updates are still unordered, and `_reference_count` cannot see `r2_url`.) previously 2026-07-29 (**identity is not a single host's opinion**. Documented #1725–#1729: a broken avatar on @brookie.blog led to five live artists — 12 tracks — hidden from radio, feeds, and for-you, because an `#account` event describes *the host that emitted it*, not the person, and leaving a PDS makes the host you left report you deactivated. All five had migrated. Fixed at three levels: `hides_content(active, status)` so infrastructure statuses hide nobody, asking the current PDS instead of a cached one, and registering `ingest_identity_update` — the task that maintains that cache, which had never once executed in production. Bluesky avatars now mirror through jetstream (#1726), and a tag containing a slash resolves (#1725). Also #1730: the radio's per-artist airtime cap bounded how *much* one artist got but not how *clustered*, so `loved` played the same artist three in a row on stream — draws are now artist-spaced, longest run 6 → 1. Corrected the stale note that #1718 was staging-only; it reached prod in `2026.0729.193914`. New known issue: the account-status reconciliation script hasn't been run against prod, so 5 hidden artists carry a `NULL` reason.) previously 2026-07-28 (**where a label reaches, and operational hygiene**. Documented #1709–#1713: the `LabelContext.LIST` vs `VIEW` split, which stopped adult labels from hiding tracks on the artist's own detail page — labels shape discovery, not destinations — applied the context at every filtering call site so counts agree with the rows they count, and published one accurate public answer at docs.plyr.fm/moderation. Also #1716/#1718: published contact moved to `help@plyr.fm` / `dmca@plyr.fm` with the DMCA agent filing updated and the privacy policy corrected to describe what is actually collected; and rate limits keyed per client rather than per site, closing a bug where Fly's proxy address made `default_limits` one bucket for the entire site (298 429s on `/radio/state`). New known issue: the DMCA surface is incomplete (#1715) — no published notice requirements, no counter-notice procedure, no repeat-infringer counter. #1718 is verified on staging but not yet released to prod.) previously 2026-07-25 (**status maintenance for the July 2–25 window**. Archived the July 1–17 entries to `.status_history/2026-07.md` and collapsed the November 2025–May 2026 cross-references, since STATUS.md had gone over its 500-line ceiling. Backfilled the previously undocumented July 10–23 cluster: the **operator-label SQL projection** #1688, which fixed a week of broken logged-out pagination caused by app-side filtering after #1676; **playlist composite covers** #1663–#1665/#1675; **edge artwork renditions** #1672 (5.3MB JPEGs were being served into a 400px hero and 40px thumbnails); the **July 14 radio compute incident** #1671, where rebuilding the rotation on every poll saturated prod Neon compute; and **queue polish** #1667–#1670. Removed the integration-suite known issue — it is green again after five weeks red (#1660/#1661, 22 passed). Recorded the podcast recap for July 2–25.) previously 2026-07-25 (**labels that act** #1697 — `copyright-violation` now de-lists from radio and discovery instead of doing nothing, and adult labels stopped gating audio bytes so creators' permalinks work for signed-out listeners; the organizing idea is that a label is a portable assertion while enforcement is local hosting policy, which is why adult defers to the listener and copyright cannot. Retracted the ten pre-#703 public labels. Traced the asymmetry to the 2026-01-02 legal review, whose "flag it and act on it" half was deferred in #703 and never built. New known issues: no per-track override, and three flagged-but-unlabeled tracks needing triage). previously 2026-07-25 (documented the July 23–25 window and the `2026.0725.035625` prod release: the **moderation service boundary** #1691–#1694 — service-to-service endpoints moved to `/internal/*` with `/admin/*` aliases for one deploy cycle, the operator surface deliberately left in place, and the three moderation scripts collapsed onto one shared client; the **fail-open label cache** #1695 — found while verifying the rename end-to-end on staging, a URI-keyed viewer-independent cache meant an operator-emitted label had no effect on audio byte authorization for up to 300s, now closed to ~0.8s by a `subscribeLabels` subscriber; plus **at-tags meta** #1690 and **copyright mix detection** #1689. New known issue: negation recovery still waits on the ~5-minute `operator_labels` projection sync). previously 2026-07-20 (aligned private media with ATProto permissioned-data Proposal 0016: canonical addresses, space-type/permission-set separation, client attestations, host resolution, and sync read foundations; #1684). previously 2026-07-16 (documented the sensitive-audio response, labeler rollout, affected tracks 1177–1179, and the access/operator-tooling gaps). earlier entries (2026-07-09 and before) are preserved in `.status_history/2026-07.md`.

--- a/backend/alembic/versions/2026_07_30_031018_4aaed6c819f1_add_atproto_record_rev_to_tracks.py
+++ b/backend/alembic/versions/2026_07_30_031018_4aaed6c819f1_add_atproto_record_rev_to_tracks.py
@@ -1,0 +1,29 @@
+"""add atproto_record_rev to tracks
+
+Revision ID: 4aaed6c819f1
+Revises: 82a75e0ecf9f
+Create Date: 2026-07-30 03:10:18.194959
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4aaed6c819f1"
+down_revision: str | Sequence[str] | None = "82a75e0ecf9f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("tracks", sa.Column("atproto_record_rev", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("tracks", "atproto_record_rev")

--- a/backend/src/backend/_internal/jetstream.py
+++ b/backend/src/backend/_internal/jetstream.py
@@ -214,6 +214,7 @@ class JetstreamConsumer:
         rkey = commit.get("rkey", "")
         record = commit.get("record")
         cid = commit.get("cid")
+        rev = commit.get("rev")
 
         # update cursor from event time_us
         if time_us := event.get("time_us"):
@@ -230,6 +231,7 @@ class JetstreamConsumer:
             record=record,
             uri=uri,
             cid=cid,
+            rev=rev,
         )
 
     async def _dispatch(
@@ -241,6 +243,7 @@ class JetstreamConsumer:
         record: dict[str, Any] | None,
         uri: str,
         cid: str | None,
+        rev: str | None = None,
     ) -> None:
         """dispatch event to the appropriate ingest task via docket."""
         docket = get_docket()
@@ -295,6 +298,8 @@ class JetstreamConsumer:
             if operation in ("create", "update"):
                 kwargs["record"] = record or {}
                 kwargs["cid"] = cid
+                if record_type == "track":
+                    kwargs["rev"] = rev
             await docket.add(task)(**kwargs)
             logfire.info(
                 "jetstream dispatched {record_type}.{operation}",

--- a/backend/src/backend/_internal/tasks/ingest.py
+++ b/backend/src/backend/_internal/tasks/ingest.py
@@ -46,6 +46,21 @@ class SubjectNotFoundError(Exception):
     """referenced subject (track) not yet indexed — triggers retry."""
 
 
+def _is_stale_commit(incoming_rev: str | None, applied_rev: str | None) -> bool:
+    """has a commit at or before `applied_rev` already been applied?
+
+    Repo revs are TIDs — monotonic per repo and lexicographically sortable, so
+    a plain string compare orders them. A repo can re-emit its commit history
+    (observed in production: 37 `track.update` events for one URI whose record
+    had not changed in half an hour), and jetstream's `time_us` is stamped on
+    receipt so it cannot distinguish a replay from a fresh write. Without this
+    the older state wins and the track points at audio it no longer owns.
+    """
+    if not incoming_rev or not applied_rev:
+        return False
+    return incoming_rev <= applied_rev
+
+
 async def _audio_object_exists(audio_url: str) -> bool:
     """HEAD the R2 object a plyr-CDN audioUrl points at.
 
@@ -149,6 +164,7 @@ async def ingest_track_create(
     record: dict,
     uri: str,
     cid: str | None,
+    rev: str | None = None,
     retry: ExponentialRetry = _INGEST_RETRY,
     concurrency: ConcurrencyLimit = ConcurrencyLimit("did", max_concurrent=3),  # noqa: B008
 ) -> None:
@@ -160,6 +176,7 @@ async def ingest_track_create(
         record: the ATProto record data
         uri: the AT URI (at://did/collection/rkey)
         cid: content identifier
+        rev: repo commit rev, recorded so later updates can be ordered
     """
     if errors := validate_record("fm.plyr.track", record):
         logfire.warn("ingest: invalid track record, skipping", uri=uri, errors=errors)
@@ -192,6 +209,7 @@ async def ingest_track_create(
             if existing_track.publish_state == "pending":
                 # upload path reserved this row — finalize it
                 existing_track.atproto_record_cid = cid
+                existing_track.atproto_record_rev = rev
                 existing_track.publish_state = "published"
                 await db.commit()
                 await db.refresh(existing_track)
@@ -314,6 +332,7 @@ async def ingest_track_create(
             r2_url=audio_url if audio_storage in ("r2", "both") else None,
             atproto_record_uri=uri,
             atproto_record_cid=cid,
+            atproto_record_rev=rev,
             self_labels=self_label_values_from_record(record.get("labels")),
             audio_storage=audio_storage,
             pds_blob_cid=pds_blob_cid,
@@ -358,9 +377,15 @@ async def ingest_track_update(
     record: dict,
     uri: str,
     cid: str | None,
+    rev: str | None = None,
     retry: ExponentialRetry = _INGEST_RETRY,
 ) -> None:
-    """update mutable fields on an existing track."""
+    """update mutable fields on an existing track.
+
+    `rev` orders the commit against what's already applied — see
+    `_is_stale_commit`. It is optional so an event missing it still updates
+    (unordered, as before) rather than being silently dropped.
+    """
     if errors := validate_record("fm.plyr.track", record, partial=True):
         logfire.warn("ingest: invalid track record, skipping", uri=uri, errors=errors)
         return
@@ -372,6 +397,15 @@ async def ingest_track_update(
         track = result.scalar_one_or_none()
         if not track:
             logger.debug("ingest_track_update: track %s not found, skipping", uri)
+            return
+
+        if _is_stale_commit(rev, track.atproto_record_rev):
+            logfire.info(
+                "ingest: skipping superseded track commit",
+                uri=uri,
+                incoming_rev=rev,
+                applied_rev=track.atproto_record_rev,
+            )
             return
 
         if title := record.get("title"):
@@ -389,6 +423,8 @@ async def ingest_track_update(
                 )
         if cid:
             track.atproto_record_cid = cid
+        if rev:
+            track.atproto_record_rev = rev
 
         # putRecord events contain the complete record. Absence therefore clears
         # the creator assertion instead of preserving stale indexed values.
@@ -402,6 +438,18 @@ async def ingest_track_update(
         if audio_url and not await is_trusted_audio_origin(audio_url, artist_did=did):
             logfire.warn(
                 "ingest: stripping untrusted audioUrl on update",
+                uri=uri,
+                audio_url=audio_url,
+            )
+            audio_url = None
+
+        # origin trust is not existence — same reasoning as the create path.
+        # create has HEADed the object since #1616; update had not, justified by
+        # "an update can only mutate an already-ingested track", but an
+        # already-ingested track is precisely what a stale audioUrl corrupts.
+        if audio_url and not await _audio_object_exists(audio_url):
+            logfire.warn(
+                "ingest: audioUrl has no backing R2 object on update, ignoring",
                 uri=uri,
                 audio_url=audio_url,
             )

--- a/backend/src/backend/_internal/track_revisions.py
+++ b/backend/src/backend/_internal/track_revisions.py
@@ -12,6 +12,8 @@ the cap, never silently corrupts the live audio pointer.
 """
 
 import logging
+from pathlib import PurePosixPath
+from urllib.parse import urlparse
 
 from sqlalchemy import select
 
@@ -20,6 +22,19 @@ from backend.storage import storage
 from backend.utilities.database import db_session
 
 logger = logging.getLogger(__name__)
+
+
+def _file_ids_in_url(audio_url: str | None) -> set[str]:
+    """the storage key an audio URL names, as a one-or-zero-element set.
+
+    A URL is only a reliable pointer when it names one of our own keys; the
+    stem is that key. Anything else (a PDS blob URL, a foreign origin) yields
+    nothing, which is correct — we don't own those bytes either way.
+    """
+    if not audio_url:
+        return set()
+    stem = PurePosixPath(urlparse(audio_url).path).stem
+    return {stem} if stem else set()
 
 
 async def prune_revisions(track_id: int) -> None:
@@ -53,10 +68,16 @@ async def prune_revisions(track_id: int) -> None:
             in_use_original_file_ids: set[str] = set()
             if track:
                 in_use_file_ids.add(track.file_id)
+                # the object a track actually *serves* is named by its audio
+                # URL, which can name a different key than `file_id` — a
+                # firehose commit can repoint one without the other (#1736).
+                # keying only on `file_id` would let us delete the live blob.
+                in_use_file_ids |= _file_ids_in_url(track.r2_url)
                 if track.original_file_id:
                     in_use_original_file_ids.add(track.original_file_id)
             for keeper in keepers:
                 in_use_file_ids.add(keeper.file_id)
+                in_use_file_ids |= _file_ids_in_url(keeper.audio_url)
                 if keeper.original_file_id:
                     in_use_original_file_ids.add(keeper.original_file_id)
 

--- a/backend/src/backend/models/track.py
+++ b/backend/src/backend/models/track.py
@@ -77,6 +77,12 @@ class Track(Base):
     r2_url: Mapped[str | None] = mapped_column(String, nullable=True)
     atproto_record_uri: Mapped[str | None] = mapped_column(String, nullable=True)
     atproto_record_cid: Mapped[str | None] = mapped_column(String, nullable=True)
+    # Repo commit `rev` (a TID) of the last record state applied to this row.
+    # The firehose gives no ordering or exactly-once guarantee, so a re-emitted
+    # historical commit can arrive after a newer one; `rev` is monotonic per
+    # repo and survives re-delivery, which `time_us` does not (jetstream stamps
+    # that on receipt). Ingest refuses to apply a commit at or below this.
+    atproto_record_rev: Mapped[str | None] = mapped_column(String, nullable=True)
     # Author-published `com.atproto.label.defs#selfLabels` values. These remain
     # separate from signed operator labels so provenance stays intact.
     self_labels: Mapped[list[str]] = mapped_column(

--- a/backend/tests/api/track_audio_replace/test_revisions.py
+++ b/backend/tests/api/track_audio_replace/test_revisions.py
@@ -51,6 +51,39 @@ def _add_revision(
 class TestPruneRevisions:
     """verify retention cap + blob deletion behavior."""
 
+    async def test_blob_named_only_by_r2_url_is_never_deleted(
+        self, db_session: AsyncSession, owner: Artist
+    ) -> None:
+        """#1736: the served object is named by `r2_url`, not always `file_id`.
+
+        a firehose commit can repoint one without the other. keying
+        reference-safety on `file_id` alone let pruning delete live audio.
+        """
+        from datetime import UTC, datetime, timedelta
+
+        track = make_track(file_id="CURRENT")
+        # divergent row: serves SERVED, while file_id says CURRENT
+        track.r2_url = "https://audio.example/SERVED.mp3"
+        db_session.add(track)
+        await db_session.commit()
+        await db_session.refresh(track)
+
+        base = datetime.now(UTC) - timedelta(hours=1)
+        for i in range(MAX_REVISIONS_PER_TRACK + 1):
+            rev = _add_revision(track.id, file_id="SERVED" if i == 0 else f"REV-{i}")
+            rev.created_at = base + timedelta(minutes=i)
+            db_session.add(rev)
+        await db_session.commit()
+
+        with patch(
+            "backend._internal.track_revisions.storage.delete",
+            AsyncMock(return_value=True),
+        ) as mock_delete:
+            await prune_revisions(track.id)
+
+        deleted = {call.args[0] for call in mock_delete.call_args_list}
+        assert "SERVED" not in deleted
+
     async def test_under_cap_is_a_noop(
         self, db_session: AsyncSession, owner: Artist
     ) -> None:

--- a/backend/tests/test_jetstream.py
+++ b/backend/tests/test_jetstream.py
@@ -2496,3 +2496,189 @@ class TestMigratedPdsIsNotDeactivation:
 
         await db_session.refresh(artist)
         assert artist.deactivated is True
+
+
+# --- commit ordering (#1736) ---
+
+
+class TestStaleCommitGuard:
+    """the firehose can re-deliver a repo's commit history.
+
+    observed in production 2026-07-30: 37 `track.update` events for one URI
+    whose PDS record had not changed in half an hour, walking `r2_url` back to
+    a 19-minute-old revision while `file_id` stayed correct. `rev` is monotonic
+    per repo and survives re-delivery; `time_us` does not.
+    """
+
+    async def test_replayed_older_commit_does_not_overwrite_newer(
+        self, db_session: AsyncSession, artist: Artist, track: Track
+    ) -> None:
+        assert track.atproto_record_uri is not None
+        uri = track.atproto_record_uri
+
+        await ingest_track_update(
+            did=artist.did,
+            rkey="existing",
+            record={"title": "current", "audioUrl": "https://r2.example.com/new.mp3"},
+            uri=uri,
+            cid="bafynew",
+            rev="3mrtqf7ut6s22",
+        )
+
+        # the same repo re-emits an earlier commit
+        await ingest_track_update(
+            did=artist.did,
+            rkey="existing",
+            record={"title": "stale", "audioUrl": "https://r2.example.com/old.mp3"},
+            uri=uri,
+            cid="bafyold",
+            rev="3mrtaaaaaaa22",
+        )
+
+        db_session.expire_all()
+        updated = await db_session.scalar(
+            select(Track).where(Track.atproto_record_uri == uri)
+        )
+        assert updated is not None
+        assert updated.title == "current"
+        assert updated.r2_url == "https://r2.example.com/new.mp3"
+        assert updated.atproto_record_rev == "3mrtqf7ut6s22"
+
+    async def test_redelivery_of_the_same_commit_is_a_noop(
+        self, db_session: AsyncSession, artist: Artist, track: Track
+    ) -> None:
+        assert track.atproto_record_uri is not None
+        uri = track.atproto_record_uri
+        rev = "3mrtqf7ut6s22"
+
+        for title in ("applied", "should not land"):
+            await ingest_track_update(
+                did=artist.did,
+                rkey="existing",
+                record={"title": title},
+                uri=uri,
+                cid="bafysame",
+                rev=rev,
+            )
+
+        db_session.expire_all()
+        updated = await db_session.scalar(
+            select(Track).where(Track.atproto_record_uri == uri)
+        )
+        assert updated is not None
+        assert updated.title == "applied"
+
+    async def test_newer_commit_still_applies(
+        self, db_session: AsyncSession, artist: Artist, track: Track
+    ) -> None:
+        assert track.atproto_record_uri is not None
+        uri = track.atproto_record_uri
+
+        for rev, title in (("3mrtaaaaaaa22", "first"), ("3mrtqf7ut6s22", "second")):
+            await ingest_track_update(
+                did=artist.did,
+                rkey="existing",
+                record={"title": title},
+                uri=uri,
+                cid=f"bafy{rev}",
+                rev=rev,
+            )
+
+        db_session.expire_all()
+        updated = await db_session.scalar(
+            select(Track).where(Track.atproto_record_uri == uri)
+        )
+        assert updated is not None
+        assert updated.title == "second"
+        assert updated.atproto_record_rev == "3mrtqf7ut6s22"
+
+    async def test_update_without_rev_still_applies(
+        self, db_session: AsyncSession, artist: Artist, track: Track
+    ) -> None:
+        """a missing rev must not silently drop the update (unordered, as before)."""
+        assert track.atproto_record_uri is not None
+        uri = track.atproto_record_uri
+        track.atproto_record_rev = "3mrtqf7ut6s22"
+        await db_session.commit()
+
+        await ingest_track_update(
+            did=artist.did,
+            rkey="existing",
+            record={"title": "applied anyway"},
+            uri=uri,
+            cid="bafynorev",
+            rev=None,
+        )
+
+        db_session.expire_all()
+        updated = await db_session.scalar(
+            select(Track).where(Track.atproto_record_uri == uri)
+        )
+        assert updated is not None
+        assert updated.title == "applied anyway"
+
+    async def test_create_records_the_rev_as_a_baseline(
+        self, db_session: AsyncSession, artist: Artist
+    ) -> None:
+        """without a baseline the first replayed update would win."""
+        rkey = f"baseline_{uuid.uuid4().hex[:8]}"
+        uri = f"at://{artist.did}/fm.plyr.track/{rkey}"
+
+        await ingest_track_create(
+            did=artist.did,
+            rkey=rkey,
+            record={
+                "title": "created",
+                "artist": "Test Artist",
+                "fileId": "baseline_file",
+                "fileType": "mp3",
+                "audioUrl": "https://r2.example.com/baseline.mp3",
+                "duration": 120,
+                "createdAt": _recent_ts(),
+            },
+            uri=uri,
+            cid="bafybaseline",
+            rev="3mrtqf7ut6s22",
+        )
+
+        db_session.expire_all()
+        created = await db_session.scalar(
+            select(Track).where(Track.atproto_record_uri == uri)
+        )
+        assert created is not None
+        assert created.atproto_record_rev == "3mrtqf7ut6s22"
+
+
+class TestAudioExistenceOnUpdate:
+    async def test_update_ignores_audio_url_with_no_backing_object(
+        self,
+        db_session: AsyncSession,
+        artist: Artist,
+        track: Track,
+        _mock_audio_object_exists: MagicMock,
+    ) -> None:
+        """a replayed url can name a blob already pruned as an old revision."""
+        assert track.atproto_record_uri is not None
+        uri = track.atproto_record_uri
+        original = track.r2_url
+        _mock_audio_object_exists.return_value = False
+
+        await ingest_track_update(
+            did=artist.did,
+            rkey="existing",
+            record={
+                "title": "metadata still lands",
+                "audioUrl": "https://r2.example.com/pruned.mp3",
+            },
+            uri=uri,
+            cid="bafypruned",
+            rev="3mrtqf7ut6s22",
+        )
+
+        db_session.expire_all()
+        updated = await db_session.scalar(
+            select(Track).where(Track.atproto_record_uri == uri)
+        )
+        assert updated is not None
+        assert updated.title == "metadata still lands"
+        assert updated.r2_url == original

--- a/backend/tests/test_origin_trust.py
+++ b/backend/tests/test_origin_trust.py
@@ -305,10 +305,14 @@ class TestOriginValidationOnUpdate:
         updated = result.scalar_one()
         assert updated.image_url == "https://images.example.com/original.jpg"
 
+    @patch(
+        "backend._internal.tasks.ingest._audio_object_exists",
+        AsyncMock(return_value=True),
+    )
     async def test_trusted_audio_url_accepted(
         self, db_session: AsyncSession, artist: Artist, track: Track
     ) -> None:
-        """trusted audioUrl is accepted on update."""
+        """trusted audioUrl backed by a real object is accepted on update."""
         assert track.atproto_record_uri is not None
         uri = track.atproto_record_uri
 

--- a/docs/internal/architecture/jetstream-ingest.md
+++ b/docs/internal/architecture/jetstream-ingest.md
@@ -14,9 +14,10 @@ ingest.py`.
 2. for each commit/identity/account event it dispatches a docket task —
    `ingest_track_create` / `_update` / `_delete`, the like/comment/list
    equivalents, and `ingest_identity_update` / `ingest_account_status_change`.
-3. each task resolves the event into the DB. all tasks are **idempotent**
-   (dedupe by AT-URI or unique constraint) so a cursor rewind replaying events
-   is safe.
+3. each task resolves the event into the DB. create and delete are **idempotent**
+   by AT-URI or unique constraint. update cannot be — applying a record twice is
+   only safe if the second copy is not *older*, so track updates are ordered by
+   commit `rev` (see "re-delivery" below).
 
 the consumer runs in its **own fly process group** (not the docket worker loop) —
 it was starving as a worker task. see `runbooks/worker-silence-alert.md` and the
@@ -85,8 +86,35 @@ record landed as `audio_storage="both"` with an `r2_url` that `404`d forever on
 playback. See the retrospective and `backend/audio-streaming.md`.
 
 > `ingest_track_update` strips an untrusted `audioUrl` but (unlike create) never
-> rejects the whole update, and does not currently run the existence check — an
-> update can only mutate an already-ingested track.
+> rejects the whole update. It **does** run the existence check, as of #1736 —
+> the earlier reasoning ("an update can only mutate an already-ingested track")
+> was wrong, because an already-ingested track is exactly what a stale URL
+> corrupts.
+
+## re-delivery: the firehose does not promise order
+
+The firehose offers no ordering or exactly-once guarantee. A repo can re-emit its
+commit history, and jetstream's `time_us` is stamped **on receipt**, so it cannot
+distinguish a replay from a fresh write.
+
+`ingest_track_update` therefore orders commits by the repo `rev` on the commit
+(a TID: monotonic per repo, lexicographically sortable, and authored by the PDS
+so it survives re-delivery). The last applied rev is stored on
+`tracks.atproto_record_rev`; an update at or below it is refused and logged as
+`ingest: skipping superseded track commit`.
+
+Two properties worth knowing:
+
+- **No baseline means no ordering.** A row whose `atproto_record_rev` is `NULL`
+  accepts the next update unconditionally and records its rev. Applying-and-learning
+  beats rejecting, which would silently drop legitimate edits from clients.
+- **Only the track path is guarded.** `ingest_comment_update` and
+  `ingest_list_update` remain last-writer-wins. Track was fixed first because it
+  is the one that can strand audio bytes.
+
+This is the fix for the 2026-07-30 replay incident, where a re-emitted repo
+history walked one track's `r2_url` back to a 19-minute-old revision and another's
+title back by an hour, while both PDS records were correct throughout.
 
 ## other guards
 

--- a/loq.toml
+++ b/loq.toml
@@ -212,11 +212,11 @@ max_lines = 544
 
 [[rules]]
 path = "backend/src/backend/_internal/tasks/ingest.py"
-max_lines = 1044
+max_lines = 1092
 
 [[rules]]
 path = "backend/tests/test_jetstream.py"
-max_lines = 2498
+max_lines = 2684
 
 [[rules]]
 path = "frontend/src/lib/components/embed/CollectionEmbed.svelte"
@@ -268,7 +268,7 @@ max_lines = 612
 
 [[rules]]
 path = "backend/tests/api/track_audio_replace/test_revisions.py"
-max_lines = 672
+max_lines = 705
 
 [[rules]]
 path = "frontend/src/routes/embed/track/[[]id[]]/+page.svelte"


### PR DESCRIPTION
The firehose gives no ordering or exactly-once guarantee, but `ingest_track_update` applied any delivered commit as if it were current. A repo re-emitted its commit history and ingest replayed it onto live rows — track 1200's `r2_url` walked back to a 19-minute-old revision while `file_id` and the PDS record both stayed correct, and track 1201's title regressed by an hour. Commits are now ordered by repo `rev`, which survives re-delivery where jetstream's `time_us` does not.

Closes #1736.

<details>
<summary>how this was diagnosed, and why the obvious suspects were wrong</summary>

The symptom was `0:00 / 0:00` with a pause button on tracks whose audio a continuous publisher replaces every five minutes. Three plausible causes were investigated and eliminated:

- **the retention cap (#1732)** — real limitation, unrelated to playback.
- **the staged-cleanup incident (#1733/#1734)** — the timing coincided; the mechanism didn't.
- **a frontend race in `Player.svelte`** — the source-resolution freshness check only compares track `id`, not `file_id`, which looks like the bug. It isn't: the backend was handing out a stale redirect for a stable `file_id`, so no frontend check would have helped.

What settled it was reading the PDS record directly and cross-checking plyr's own write log:

- the record served the correct `audioUrl` at a CID unchanged since `06:51:40Z`;
- plyr's last write to that track was `06:51:40Z` — nothing after;
- yet ingest received **37 `track.update` events** for that URI between 06:48:54 and 07:21:43, with no reconnect during the 07:19–07:21 burst;
- the events carried *different historical* values — `r2_url` read the 06:32 revision at 07:05, the 06:37 revision at 07:11, the current one at 07:22;
- every dispatched event in a 40-minute window belonged to one repo (four rkeys, ×37/×9/×4/×3), zero for any other DID.

Record correct + no local write + update events still arriving ⇒ replay. The row self-healed only because the replay happened to end on the newest commit.

</details>

<details>
<summary>design: why `rev`, and why not just ignore <code>audioUrl</code></summary>

**Why `rev`.** It's a TID — monotonic per repo, lexicographically sortable, and authored by the PDS, so it survives re-delivery. `time_us` cannot work: jetstream stamps it on receipt, so a replayed commit gets a fresh one. Comparing the record CID alone cannot work either: replayed historical commits carry *different* content and therefore different CIDs. Verified `commit.rev` is actually present on the wire before building on it.

**Why not ignore `audioUrl` on update.** plyr honors record updates because [@cinny.bun.how](https://bsky.app/profile/cinny.bun.how) pointed out in March 2026 (#1068–#1076) that writing records to a PDS without listening for them is not how the protocol works. That principle is intact here. The defect was trusting delivery *order*, not trusting the record — so the fix is ordering, and it lands in one place for every field rather than special-casing audio.

**Why the guard rejects the whole commit.** Track 1201 showed the reason: its cover and audio stayed current while its title regressed. Guarding only audio fields would have left that.

</details>

<details>
<summary>the two adjacent fixes</summary>

**`_audio_object_exists` now runs on update.** Create has HEADed the object since #1616; update didn't, justified in the architecture doc as "an update can only mutate an already-ingested track." An already-ingested track is precisely what got corrupted. A replayed URL can name a blob already pruned as an old revision, and with the 1-year edge TTL on `audio.plyr.fm` that 404 caches.

**Prune reference-safety considers the URL a row serves.** `prune_revisions` built its in-use set from `track.file_id` and keeper `file_id`s, but the object actually served is named by `r2_url`. On a divergent row those differ, and pruning would delete the live blob. Note this is *not* covered by `_reference_count` from #1735 — that matches `file_id`-shaped columns and cannot see a URL.

</details>

<details>
<summary>deferred, with reasons</summary>

- **the cross-tenant `audioUrl` rule.** Origin trust admits only plyr's public CDN, so no foreign origin is reachable — but `file_id`s aren't secret, so a record can name *another track's* object, and both the origin and existence checks pass. Costs are misattribution (plays/scrobbles on the wrong track) and a clean record serving bytes from a de-listed track, since `copyright-violation` de-lists by URI while the content-addressed object stays reachable. Gated audio is a separate bucket and private media is byte-proxied, so exposure is limited to already-public bytes. Fixing it means ruling that an ingested `audioUrl` may not name an object another track claims — that changes what a foreign record is *permitted to say*, which deserves an explicit decision rather than riding along in a bugfix.
- **`ingest_comment_update` / `ingest_list_update`** have the same last-writer-wins defect. Track was fixed first because it is the one that can strand audio bytes.
- **backfilling `atproto_record_rev`.** It starts `NULL` everywhere, and ingest applies-and-learns rather than rejecting when it has no baseline — rejecting would drop legitimate client edits. So the first update per track after release is itself unordered; from the second on it's guarded. Backfilling from each PDS record would close that window.
- **repairing track 1201's stale title.** The PDS record says `07:42–07:47`, our row says `06:47–06:49`. The artist's data is fine; our index is wrong. That's a production write, so it's flagged in known issues rather than done here.
- **`_MEDIA_REFERENCES` gaining `r2_url` awareness.** The general home for the divergent-row hazard, but it means editing refcount logic that landed hours ago in #1735.

</details>

<details>
<summary>intentional non-behaviors</summary>

- An update with **no** `rev` still applies, unordered — pinned by `test_update_without_rev_still_applies`. Silently dropping an update because an event lacked a field would be worse than the bug.
- Re-delivery of the **same** rev is a no-op, not an error.
- A **newer** rev always applies; the guard is `<=`, not equality.
- The migration adds one nullable column and nothing else. Autogenerate also proposed dropping `api_keys`, `pending_account_creations`, and several indexes from local-DB drift — all removed by hand.
- STATUS.md needed 4 lines to fit its ceiling; the July 23–25 cluster was archived to `.status_history/2026-07.md` (#1691–#1695 was already duplicated there) rather than relaxing the limit, since prose is what that ceiling is for.

</details>

## verification

- `1408 passed, 25 skipped`; lint and type-check clean.
- The two ordering tests were confirmed to **fail** with the guard stubbed out, so they exercise the real path rather than restating it.
- `commit.rev` confirmed present on a live jetstream connection before relying on it.
- The three affected production tracks were re-read from their PDS and compared against the DB to establish which values were actually wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
