### PR TITLE
fix(jetstream): consume from jetstream1 — jetstream2 had a partial view

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -974,7 +974,12 @@ class JetstreamSettings(AppSettingsSection):
         description="Enable Jetstream consumer for real-time ATProto event ingestion",
     )
     url: str = Field(
-        default="wss://jetstream2.us-east.bsky.network/subscribe",
+        default="wss://jetstream1.us-east.bsky.network/subscribe",
+        # jetstream2 served `app.bsky.actor.profile` normally while emitting
+        # nothing at all for `fm.plyr.*` — 10h of silent blackout on 2026-07-30,
+        # confirmed by subscribing to both instances for the same DID at once
+        # (jetstream1: 10 track commits, jetstream2: zero). A partial view looks
+        # exactly like a quiet network, so prefer the instance that was right.
         description="Jetstream WebSocket URL",
     )
     cursor_key: str = Field(

--- a/loq.toml
+++ b/loq.toml
@@ -44,7 +44,7 @@ max_lines = 1868
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 1222
+max_lines = 1227
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"


### PR DESCRIPTION
`fm.plyr.*` ingest was dead for 10 hours — zero dispatches since 07:22 UTC — while `app.bsky.actor.profile` events kept flowing at 39–73/hour, so the consumer looked healthy throughout. Switching the default host restores it.

**The diagnosis, in order of elimination:**

- `waow.tech` is active and correctly registered on its PDS — the consumer's `_known_dids` filter was not excluding it.
- `relay1.us-east.bsky.network` reported a **byte-identical** latest commit to the PDS itself (same CID, same rev). The commits reach the relay.
- Subscribing to `fm.plyr.track` network-wide for 6 minutes on jetstream2 returned **zero** commits — during which the publisher wrote 6 records and the repo rev advanced (`3mruyszhnldzk` → `3mruz3vonskzq`). A controlled negative, not a quiet window.
- Subscribing to **both** instances for the same DID over one window: **jetstream1 → 10 `fm.plyr.track` commits, jetstream2 → nothing.**

This also reframes the #1736 replay burst as the same instance degrading before it went silent.

<details>
<summary>what this does not fix</summary>

A host swap moves the single point of failure rather than removing it. Reconnect-based failover would not have helped here — the socket was healthy and delivering *other* collections, so there was nothing to fail over *from*. Detecting this needs a staleness alarm on our own collections ("connected, but zero `fm.plyr.*` dispatches in N minutes"), which is a separate change and worth its own issue. Ten hours of silence with no alert is the real finding.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)