### PR TITLE
fix(jetstream): rotate hosts, and detect a host that goes blind on our own collections

### DIFF
--- a/backend/src/backend/_internal/jetstream.py
+++ b/backend/src/backend/_internal/jetstream.py
@@ -80,6 +80,12 @@ class JetstreamConsumer:
         self._last_cursor_flush: float = 0.0
         self._last_did_refresh: float = 0.0
         self._shutdown_event = asyncio.Event()
+        self._host_index = 0
+        # blind-host detection: a host can stay connected and keep delivering
+        # some collections while dropping ours entirely. tracked separately so
+        # "our collections are silent" can be told apart from "the network is".
+        self._last_own_event: float = 0.0
+        self._last_any_event: float = 0.0
 
     def stop(self) -> None:
         """signal the consumer to shut down and unblock the recv loop.
@@ -112,6 +118,11 @@ class JetstreamConsumer:
             if self._shutdown_event.is_set():
                 return
 
+            # every reconnect moves on. a host that just dropped us has no
+            # claim on the next attempt, and rotating costs nothing when it
+            # was healthy — the cursor makes reconnects resumable either way.
+            self._rotate_host()
+
             # exponential backoff with jitter
             jitter = random.uniform(0, backoff * 0.5)
             delay = min(backoff + jitter, settings.jetstream.reconnect_max_seconds)
@@ -128,17 +139,24 @@ class JetstreamConsumer:
         url = self._build_url()
         logger.info("jetstream connecting to %s", url)
 
+        # a fresh connection has not yet proven anything about this host
+        self._last_own_event = 0.0
+        self._last_any_event = 0.0
+
         with logfire.span(
             "jetstream consume",
             known_dids=len(self._known_dids),
             cursor=self._cursor,
+            endpoint=self._current_endpoint(),
         ):
             async with websockets.connect(url, max_size=2**20) as ws:
                 self._ws = ws
                 logfire.info(
                     "jetstream connected",
                     known_dids=len(self._known_dids),
+                    endpoint=self._current_endpoint(),
                 )
+                self._last_own_event = self._last_any_event = time.monotonic()
 
                 async for raw in ws:
                     if self._shutdown_event.is_set():
@@ -149,9 +167,24 @@ class JetstreamConsumer:
                     except (orjson.JSONDecodeError, TypeError):
                         continue
 
+                    self._last_any_event = time.monotonic()
+                    if self._is_own_collection_event(event):
+                        self._last_own_event = self._last_any_event
+
                     await self._process_event(event)
                     await self._maybe_flush_cursor()
                     await self._maybe_refresh_dids()
+
+                    if self._is_blind():
+                        logfire.warn(
+                            "jetstream host is serving other collections but "
+                            "none of ours, rotating",
+                            endpoint=self._current_endpoint(),
+                            silent_seconds=round(
+                                time.monotonic() - self._last_own_event
+                            ),
+                        )
+                        return  # the reconnect loop rotates and resumes
 
     async def _process_event(self, event: dict[str, Any]) -> None:
         """check if event is for a known DID and dispatch to docket task."""
@@ -309,6 +342,57 @@ class JetstreamConsumer:
                 uri=uri,
             )
 
+    def _is_own_collection_event(self, event: dict[str, Any]) -> bool:
+        """did this event come from one of plyr's own lexicons?
+
+        Bluesky's profile collection is excluded deliberately: it is the
+        traffic that made a blind host look alive.
+        """
+        commit = event.get("commit")
+        if not isinstance(commit, dict):
+            return False
+        collection = commit.get("collection", "")
+        return collection != BSKY_PROFILE_COLLECTION and collection in (
+            self._collections
+        )
+
+    def _current_endpoint(self) -> str:
+        """the endpoint for this attempt — pinned URL, or the host in rotation."""
+        if pinned := settings.jetstream.url:
+            return pinned
+        hosts = settings.jetstream.hosts
+        return f"wss://{hosts[self._host_index % len(hosts)]}/subscribe"
+
+    def _rotate_host(self) -> None:
+        """advance to the next host, and rewind the cursor to cover its lag.
+
+        instances are independently positioned in the stream, so the one we
+        move to may be slightly behind the one we left. replaying a little is
+        safe (ingest is ordered by commit rev) — a gap would not be.
+        """
+        if settings.jetstream.url:
+            return  # pinned by config; nothing to rotate through
+        self._host_index += 1
+        if self._cursor is not None:
+            self._cursor -= 10_000_000
+
+    def _is_blind(self) -> bool:
+        """is this host delivering other collections but none of ours?
+
+        the failure this catches never disconnects: jetstream2 kept serving
+        `app.bsky.actor.profile` for 10h on 2026-07-30 while dropping every
+        `fm.plyr.*` event. requiring recent *other* traffic is what separates a
+        blind host from a quiet network — on a genuinely quiet stream both go
+        silent together and we stay put.
+        """
+        timeout = settings.jetstream.blind_host_timeout_seconds
+        if timeout <= 0 or not self._last_own_event or not self._last_any_event:
+            return False
+        now = time.monotonic()
+        return (now - self._last_own_event) > timeout and (
+            now - self._last_any_event
+        ) < (timeout / 2)
+
     def _build_url(self) -> str:
         """build WebSocket URL with query parameters."""
         params = [f"wantedCollections={c}" for c in self._collections]
@@ -316,7 +400,7 @@ class JetstreamConsumer:
             # rewind cursor by 5 seconds for idempotent reprocessing
             rewound = self._cursor - 5_000_000
             params.append(f"cursor={rewound}")
-        return f"{settings.jetstream.url}?{'&'.join(params)}"
+        return f"{self._current_endpoint()}?{'&'.join(params)}"
 
     async def _load_cursor(self) -> None:
         """load cursor from Redis on startup."""

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -973,14 +973,41 @@ class JetstreamSettings(AppSettingsSection):
         default=False,
         description="Enable Jetstream consumer for real-time ATProto event ingestion",
     )
-    url: str = Field(
-        default="wss://jetstream1.us-east.bsky.network/subscribe",
-        # jetstream2 served `app.bsky.actor.profile` normally while emitting
-        # nothing at all for `fm.plyr.*` — 10h of silent blackout on 2026-07-30,
-        # confirmed by subscribing to both instances for the same DID at once
-        # (jetstream1: 10 track commits, jetstream2: zero). A partial view looks
-        # exactly like a quiet network, so prefer the instance that was right.
-        description="Jetstream WebSocket URL",
+    url: str | None = Field(
+        default=None,
+        description=(
+            "Pin a single Jetstream WebSocket URL. Unset (the default) rotates "
+            "through `hosts` on reconnect."
+        ),
+    )
+    hosts: list[str] = Field(
+        # mirrors the default host list in zat's jetstream client. one instance
+        # can serve some collections and silently drop others (jetstream2 did
+        # exactly that for 10h on 2026-07-30), and a partial view is
+        # indistinguishable from a quiet network — so never depend on one.
+        default=[
+            "jetstream1.us-east.bsky.network",
+            "jetstream2.us-east.bsky.network",
+            "jetstream1.us-west.bsky.network",
+            "jetstream2.us-west.bsky.network",
+            "jetstream.waow.tech",
+            "jetstream.fire.hose.cam",
+            "jet.firehose.stream",
+            "sfo.firehose.stream",
+            "nyc.firehose.stream",
+            "london.firehose.stream",
+            "frankfurt.firehose.stream",
+            "chennai.firehose.stream",
+        ],
+        description="Jetstream hosts, tried round-robin on each reconnect",
+    )
+    blind_host_timeout_seconds: float = Field(
+        default=1800.0,
+        description=(
+            "Rotate hosts when no record in our own collections arrives for this "
+            "long while other traffic is still flowing (a host serving some "
+            "collections but not ours). 0 disables the check."
+        ),
     )
     cursor_key: str = Field(
         default="plyr:jetstream:cursor",

--- a/backend/tests/test_jetstream.py
+++ b/backend/tests/test_jetstream.py
@@ -1,5 +1,6 @@
 """tests for Jetstream consumer and ingest tasks."""
 
+import time
 import uuid
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -29,6 +30,7 @@ from backend._internal.tasks.ingest import (
     ingest_track_delete,
     ingest_track_update,
 )
+from backend.config import settings
 from backend.models import Artist, Playlist, Track, TrackComment, TrackLike
 from backend.models.session import UserSession
 
@@ -2682,3 +2684,88 @@ class TestAudioExistenceOnUpdate:
         assert updated is not None
         assert updated.title == "metadata still lands"
         assert updated.r2_url == original
+
+
+# --- host failover (#1739 follow-up) ---
+
+
+class TestHostRotation:
+    """one instance can serve some collections and silently drop others.
+
+    jetstream2 did exactly that for 10h on 2026-07-30 without ever
+    disconnecting, so reconnect-driven rotation alone would not have caught it.
+    """
+
+    def test_rotates_through_configured_hosts(self) -> None:
+        consumer = JetstreamConsumer()
+        with patch.object(settings.jetstream, "url", None):
+            hosts = settings.jetstream.hosts
+            seen = []
+            for _ in range(len(hosts) + 2):
+                seen.append(consumer._current_endpoint())
+                consumer._rotate_host()
+
+        assert seen[0] == f"wss://{hosts[0]}/subscribe"
+        assert seen[1] == f"wss://{hosts[1]}/subscribe"
+        # wraps rather than running off the end
+        assert seen[len(hosts)] == seen[0]
+        assert len(set(seen)) == len(hosts)
+
+    def test_a_pinned_url_is_never_rotated_away_from(self) -> None:
+        consumer = JetstreamConsumer()
+        with patch.object(settings.jetstream, "url", "wss://pinned.example/sub"):
+            consumer._rotate_host()
+            consumer._rotate_host()
+            assert consumer._current_endpoint() == "wss://pinned.example/sub"
+
+    def test_rotation_rewinds_the_cursor_for_instance_lag(self) -> None:
+        """the host we move to may sit behind the one we left."""
+        consumer = JetstreamConsumer()
+        consumer._cursor = 1_000_000_000
+        with patch.object(settings.jetstream, "url", None):
+            consumer._rotate_host()
+        assert consumer._cursor == 1_000_000_000 - 10_000_000
+
+
+class TestBlindHostDetection:
+    def test_other_traffic_flowing_but_ours_silent_is_blind(self) -> None:
+        consumer = JetstreamConsumer()
+        now = time.monotonic()
+        with patch.object(settings.jetstream, "blind_host_timeout_seconds", 1800.0):
+            consumer._last_own_event = now - 3600  # an hour of nothing from us
+            consumer._last_any_event = now - 5  # bsky events still arriving
+            assert consumer._is_blind() is True
+
+    def test_a_quiet_network_is_not_blind(self) -> None:
+        """both silent means no traffic, not a bad host — don't rotate."""
+        consumer = JetstreamConsumer()
+        now = time.monotonic()
+        with patch.object(settings.jetstream, "blind_host_timeout_seconds", 1800.0):
+            consumer._last_own_event = now - 3600
+            consumer._last_any_event = now - 3600
+            assert consumer._is_blind() is False
+
+    def test_recent_own_traffic_is_not_blind(self) -> None:
+        consumer = JetstreamConsumer()
+        now = time.monotonic()
+        with patch.object(settings.jetstream, "blind_host_timeout_seconds", 1800.0):
+            consumer._last_own_event = now - 10
+            consumer._last_any_event = now - 5
+            assert consumer._is_blind() is False
+
+    def test_detection_can_be_disabled(self) -> None:
+        consumer = JetstreamConsumer()
+        now = time.monotonic()
+        with patch.object(settings.jetstream, "blind_host_timeout_seconds", 0.0):
+            consumer._last_own_event = now - 86400
+            consumer._last_any_event = now - 1
+            assert consumer._is_blind() is False
+
+    def test_bsky_profile_events_do_not_count_as_ours(self) -> None:
+        """the exact traffic that made the blind host look alive."""
+        consumer = JetstreamConsumer()
+        bsky = {"commit": {"collection": BSKY_PROFILE_COLLECTION}}
+        ours = {"commit": {"collection": settings.atproto.track_collection}}
+        assert consumer._is_own_collection_event(bsky) is False
+        assert consumer._is_own_collection_event(ours) is True
+        assert consumer._is_own_collection_event({"kind": "identity"}) is False

--- a/loq.toml
+++ b/loq.toml
@@ -44,7 +44,7 @@ max_lines = 1868
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 1227
+max_lines = 1254
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
@@ -216,7 +216,7 @@ max_lines = 1092
 
 [[rules]]
 path = "backend/tests/test_jetstream.py"
-max_lines = 2684
+max_lines = 2771
 
 [[rules]]
 path = "frontend/src/lib/components/embed/CollectionEmbed.svelte"


### PR DESCRIPTION
Pinning one jetstream instance made a single upstream a hard dependency. #1739 swapped *which* instance we depend on; this removes the dependency. Failover between hosts is table stakes for a firehose client — [zat's](https://tangled.sh/@zat.dev/zat) has carried it all along, and this brings plyr to parity plus the detector that today's outage actually needed.

**Rotation** — the same 12 hosts zat defaults to, round-robin on each reconnect, with the cursor rewound 10s on switch because instances are independently positioned in the stream (replaying a little is safe now that ingest is ordered by commit rev, #1736; a gap would not be). `JETSTREAM_URL` still pins a single endpoint when you want one, and pinning disables rotation rather than fighting it.

**But rotation alone would not have caught the outage that prompted this.** jetstream2 never disconnected. It stayed up for 10 hours serving `app.bsky.actor.profile` at 39–73/hour while dropping every `fm.plyr.*` event, so there was no error to trigger a reconnect and nothing to fail over *from*. A partial view is indistinguishable from a quiet network if you only track "did anything arrive".

So the consumer now tracks **our own collections separately from all traffic**:

- other events arriving while ours stay silent past `blind_host_timeout_seconds` (default 30 min) → the host is blind, rotate.
- both silent → the network is quiet, stay put.

Bluesky's profile collection is deliberately excluded from "ours", because it is precisely the traffic that made the blind host look alive.

<details>
<summary>false positives, and why they're cheap</summary>

A genuinely quiet half-hour where *only* Bluesky profile events arrive would rotate once unnecessarily. That costs one reconnect; the cursor makes it resumable, and ingest is idempotent by URI for creates/deletes and rev-ordered for updates. Rotating away from a healthy host is strictly cheaper than sitting blind on a broken one for ten hours.

The threshold is a setting, and `0` disables the check.

</details>

<details>
<summary>still not covered</summary>

Nothing alerts a human. The consumer will now heal itself, but ten hours of silence produced no page, and the `logfire.warn` this adds is a breadcrumb rather than an alarm. A Logfire alert on "zero `fm.plyr.*` dispatches in N minutes" is the remaining gap and wants its own change.

</details>

## verification

`1416 passed, 25 skipped`; lint and type-check clean. Eight new tests cover rotation (including wraparound, cursor rewind, and pinned-URL immunity) and the blind detector's four cases — blind, quiet-network, healthy, and disabled — plus that Bluesky profile traffic doesn't count as ours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)