### PR TITLE
feat(radio): a live broadcast can preempt a station, starting with firehose

### DIFF
--- a/backend/src/backend/api/radio/live.py
+++ b/backend/src/backend/api/radio/live.py
@@ -1,0 +1,96 @@
+"""Is a station's broadcast airing right now?
+
+Polled server-side rather than from each client: the answer is identical for
+everyone, so one request per cache window covers the whole audience instead of
+pointing every listener at the broadcaster's origin.
+
+Fails closed. A broadcaster we cannot reach is treated as off-air, so the
+station falls back to its rotation rather than handing clients a stream URL that
+will not load — dead air is the one outcome radio must never produce.
+"""
+
+import asyncio
+import time
+from dataclasses import dataclass
+
+import httpx
+import logfire
+
+from backend.api.radio.stations import LiveSource
+
+# how long a liveness answer is reused. short enough that going on or off air
+# is noticed promptly, long enough that the broadcaster sees a trickle.
+_CACHE_TTL_SECONDS = 5.0
+_PROBE_TIMEOUT_SECONDS = 3.0
+
+
+@dataclass(frozen=True)
+class LiveBroadcast:
+    """A broadcast confirmed to be airing."""
+
+    stream_url: str
+    kind: str
+    started_at: str | None
+
+
+_cache: dict[str, tuple[float, LiveBroadcast | None]] = {}
+_locks: dict[str, asyncio.Lock] = {}
+
+
+def _lock_for(key: str) -> asyncio.Lock:
+    if key not in _locks:
+        _locks[key] = asyncio.Lock()
+    return _locks[key]
+
+
+async def get_live_broadcast(source: LiveSource | None) -> LiveBroadcast | None:
+    """Return the broadcast if it is airing, else None."""
+    if source is None:
+        return None
+
+    key = source.health_url
+    now = time.monotonic()
+    cached = _cache.get(key)
+    if cached is not None and (now - cached[0]) < _CACHE_TTL_SECONDS:
+        return cached[1]
+
+    # one probe per window even under concurrent requests; whoever loses the
+    # race re-reads the cache the winner just filled.
+    async with _lock_for(key):
+        cached = _cache.get(key)
+        if cached is not None and (time.monotonic() - cached[0]) < _CACHE_TTL_SECONDS:
+            return cached[1]
+
+        result = await _probe(source)
+        _cache[key] = (time.monotonic(), result)
+        return result
+
+
+async def _probe(source: LiveSource) -> LiveBroadcast | None:
+    try:
+        async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_SECONDS) as client:
+            response = await client.get(source.health_url)
+            response.raise_for_status()
+            payload = response.json()
+    except Exception as exc:
+        logfire.warn(
+            "radio: live health probe failed, treating as off-air",
+            health_url=source.health_url,
+            error=str(exc),
+        )
+        return None
+
+    if not isinstance(payload, dict) or payload.get("live") is not True:
+        return None
+
+    started_at = payload.get("started_at")
+    return LiveBroadcast(
+        stream_url=source.stream_url,
+        kind=source.kind,
+        started_at=started_at if isinstance(started_at, str) else None,
+    )
+
+
+def reset_cache() -> None:
+    """Drop memoized liveness — tests only."""
+    _cache.clear()

--- a/backend/src/backend/api/radio/schemas.py
+++ b/backend/src/backend/api/radio/schemas.py
@@ -30,8 +30,25 @@ class RadioTrack(BaseModel):
     liked: bool = False  # whether the requesting (authenticated) user liked it
 
 
+class LiveBroadcastInfo(BaseModel):
+    """A broadcast preempting this station's rotation right now.
+
+    Additive and optional. A client that does not know about it plays the
+    rotation as before — on a station with a live source that means the
+    archived recordings, which is a coherent fallback rather than a broken one.
+    """
+
+    stream_url: str
+    kind: str  # "hls"
+    started_at: str | None = None
+
+
 class RadioStateResponse(BaseModel):
-    """Live radio state response (one station's deterministic loop)."""
+    """Live radio state response (one station's deterministic loop).
+
+    ``live`` preempts: while it is set, the station is airing that broadcast
+    and the rotation fields describe what resumes when it ends.
+    """
 
     station: str
     station_slug: str
@@ -44,6 +61,7 @@ class RadioStateResponse(BaseModel):
     current: RadioTrack | None
     up_next: list[RadioTrack]
     rotation: list[RadioTrack]
+    live: LiveBroadcastInfo | None = None
 
 
 class StationSummary(BaseModel):

--- a/backend/src/backend/api/radio/state.py
+++ b/backend/src/backend/api/radio/state.py
@@ -19,9 +19,11 @@ from backend.api.radio import stations
 from backend.api.radio.cache import get_rotation
 from backend.api.radio.corpus import load_corpus
 from backend.api.radio.lenses import LensContext
+from backend.api.radio.live import get_live_broadcast
 from backend.api.radio.router import router
 from backend.api.radio.sampler import build_rotation, rank_decay_weights
 from backend.api.radio.schemas import (
+    LiveBroadcastInfo,
     RadioStateResponse,
     RadioTrack,
     StationsResponse,
@@ -257,6 +259,11 @@ async def radio_state(
     current_index, progress, started_at, ends_at = _live_window(now, rotation)
     current = rotation[current_index] if current_index is not None else None
 
+    # the rotation is still computed and still described even while a broadcast
+    # preempts it — the loop is the clock, and it keeps running so that whatever
+    # resumes afterwards lands where wall-clock time says it should.
+    broadcast = await get_live_broadcast(resolved.live)
+
     return RadioStateResponse(
         station=resolved.name,
         station_slug=resolved.slug,
@@ -269,4 +276,13 @@ async def radio_state(
         current=current,
         up_next=_up_next(rotation, current_index),
         rotation=rotation,
+        live=(
+            LiveBroadcastInfo(
+                stream_url=broadcast.stream_url,
+                kind=broadcast.kind,
+                started_at=broadcast.started_at,
+            )
+            if broadcast
+            else None
+        ),
     )

--- a/backend/src/backend/api/radio/stations.py
+++ b/backend/src/backend/api/radio/stations.py
@@ -37,12 +37,43 @@ def _only_slop(track: Track, tags: set[str]) -> bool:
     return _has_hidden_tag(tags) and track.artist.handle != PLYR_FM_ACCOUNT_HANDLE
 
 
+# the account broadcasting the sonified firehose; its published segments are
+# what the station airs when the live stream is down.
+FIREHOSE_PUBLISHER_HANDLE = "waow.tech"
+
+
+def _only_firehose_publisher(track: Track, tags: set[str]) -> bool:
+    return track.artist.handle == FIREHOSE_PUBLISHER_HANDLE
+
+
 # how far down a station's lens ranking the sampler meaningfully reaches: weights
 # decay as exp(-rank/scale), so roughly the top ~3*scale ranks carry the station.
 DEFAULT_RANK_DECAY = 12.0
 # share of draws that ignore the lens and pick uniformly from the un-drawn pool,
 # so the dormant tail cycles through instead of never airing.
 DEFAULT_EXPLORATION = 0.25
+
+
+@dataclass(frozen=True)
+class LiveSource:
+    """A broadcast that preempts a station's rotation while it is airing.
+
+    Live is deliberately *not* a rotation entry. The rotation is a loop whose
+    position is derived from wall-clock time (`epoch % loop_duration`), which is
+    what lets every listener compute the same "now playing" with no server
+    state. A broadcast has no known duration, so putting one in the loop would
+    leave it with no period and dissolve that property.
+
+    Modelling it as preemption keeps the loop running as the clock it is — a
+    live show interrupts automation, and when it ends automation resumes
+    wherever it has got to, exactly like real radio.
+
+    `health_url` answers "is this airing right now" without pulling media.
+    """
+
+    stream_url: str
+    health_url: str
+    kind: str = "hls"
 
 
 @dataclass(frozen=True)
@@ -55,6 +86,11 @@ class Station:
     corpus_filter: CorpusFilter = field(default=_exclude_slop)
     rank_decay: float = DEFAULT_RANK_DECAY
     exploration: float = DEFAULT_EXPLORATION
+    # when set, this station airs the broadcast whenever it is live and falls
+    # back to its rotation when it is not. this tuple is the allowlist: who may
+    # preempt is a curation decision, made here, not something a publisher can
+    # assert about themselves.
+    live: LiveSource | None = None
 
 
 STATIONS: tuple[Station, ...] = (
@@ -90,6 +126,21 @@ STATIONS: tuple[Station, ...] = (
         description="ai-generated tracks",
         lens=lenses.loved,
         corpus_filter=_only_slop,
+    ),
+    Station(
+        slug="firehose",
+        name="firehose",
+        description="the atproto firehose, sonified live",
+        # off-air, the station plays the archived segments of the same signal,
+        # so it stays about the firehose either way rather than becoming a
+        # generic music station whenever the broadcast drops.
+        lens=lenses.fresh,
+        corpus_filter=_only_firehose_publisher,
+        exploration=0.0,
+        live=LiveSource(
+            stream_url="https://relay-eval.waow.tech/sonify/live/index.m3u8",
+            health_url="https://relay-eval.waow.tech/api/sonify/live",
+        ),
     ),
 )
 

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -12,7 +13,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, get_optional_session
 from backend.api.radio import cache as radio_cache
-from backend.api.radio import lenses
+from backend.api.radio import lenses, stations
+from backend.api.radio import live as radio_live
 from backend.api.radio import state as radio_state
 from backend.api.radio.lenses import LensContext
 from backend.api.radio.sampler import (
@@ -466,7 +468,7 @@ async def test_stations_endpoint_lists_lineup(radio_app: FastAPI) -> None:
     data = response.json()
     assert data["default_slug"] == "loved"
     slugs = {s["slug"] for s in data["stations"]}
-    assert slugs == {"loved", "fresh", "deep-cuts", "slop"}
+    assert slugs == {"loved", "fresh", "deep-cuts", "slop", "firehose"}
     default = next(s for s in data["stations"] if s["slug"] == "loved")
     assert default["is_default"] is True
 
@@ -835,3 +837,191 @@ async def test_concurrent_cache_misses_build_once(
     assert builds == 1
     assert all(rotation == results[0] for rotation in results)
     assert all(rotation[0].id == 1 for rotation in results)
+
+
+# --- the firehose station: live preempts, rotation is the fallback ---
+
+
+@pytest.fixture(autouse=True)
+def _clear_live_cache() -> Generator[None, None, None]:
+    radio_live.reset_cache()
+    yield
+    radio_live.reset_cache()
+
+
+def _firehose_station() -> stations.Station:
+    station = stations.get_station("firehose")
+    assert station is not None
+    return station
+
+
+async def test_live_broadcast_preempts_but_rotation_still_resolves(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    """while airing, `live` is set — and the loop keeps running underneath it.
+
+    the rotation is what resumes when the broadcast ends, so it must still be
+    described rather than blanked out.
+    """
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
+    radio_artist.handle = stations.FIREHOSE_PUBLISHER_HANDLE
+    await _create_track(
+        db_session, radio_artist, title="segment", file_id="seg", created_at=now
+    )
+    await db_session.commit()
+
+    broadcast = radio_live.LiveBroadcast(
+        stream_url="https://example.test/live/index.m3u8",
+        kind="hls",
+        started_at="2026-07-30T19:12:32Z",
+    )
+    with patch.object(radio_live, "_probe", AsyncMock(return_value=broadcast)):
+        async with AsyncClient(
+            transport=ASGITransport(app=radio_app),
+            base_url="https://radio.plyr.fm",
+        ) as client:
+            response = await client.get(
+                "/radio/state.json", params={"station": "firehose"}
+            )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["live"]["stream_url"] == "https://example.test/live/index.m3u8"
+    assert body["live"]["kind"] == "hls"
+    # the clock underneath is untouched
+    assert body["current"] is not None
+    assert body["loop_duration_seconds"] > 0
+
+
+async def test_off_air_falls_back_to_the_rotation(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
+    radio_artist.handle = stations.FIREHOSE_PUBLISHER_HANDLE
+    await _create_track(
+        db_session, radio_artist, title="segment", file_id="seg", created_at=now
+    )
+    await db_session.commit()
+
+    with patch.object(radio_live, "_probe", AsyncMock(return_value=None)):
+        async with AsyncClient(
+            transport=ASGITransport(app=radio_app),
+            base_url="https://radio.plyr.fm",
+        ) as client:
+            response = await client.get(
+                "/radio/state.json", params={"station": "firehose"}
+            )
+
+    body = response.json()
+    assert body["live"] is None
+    assert body["current"]["title"] == "segment"
+
+
+async def test_an_unreachable_broadcaster_is_off_air_not_an_error(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    """fail closed: never hand a client a stream URL that won't load."""
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
+    radio_artist.handle = stations.FIREHOSE_PUBLISHER_HANDLE
+    await _create_track(
+        db_session, radio_artist, title="segment", file_id="seg", created_at=now
+    )
+    await db_session.commit()
+
+    async def _boom(source: stations.LiveSource) -> None:
+        raise RuntimeError("connection refused")
+
+    with patch.object(radio_live.httpx, "AsyncClient", side_effect=_boom):
+        async with AsyncClient(
+            transport=ASGITransport(app=radio_app),
+            base_url="https://radio.plyr.fm",
+        ) as client:
+            response = await client.get(
+                "/radio/state.json", params={"station": "firehose"}
+            )
+
+    assert response.status_code == 200
+    assert response.json()["live"] is None
+
+
+async def test_stations_without_a_live_source_never_probe(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    """the other four stations must not pay for this feature."""
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
+    await _create_track(
+        db_session, radio_artist, title="t", file_id="t", created_at=now
+    )
+    await db_session.commit()
+
+    probe = AsyncMock(return_value=None)
+    with patch.object(radio_live, "_probe", probe):
+        async with AsyncClient(
+            transport=ASGITransport(app=radio_app),
+            base_url="https://radio.plyr.fm",
+        ) as client:
+            response = await client.get(
+                "/radio/state.json", params={"station": "loved"}
+            )
+
+    assert response.json()["live"] is None
+    probe.assert_not_awaited()
+
+
+async def test_liveness_is_cached_across_requests(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    """one probe per window regardless of audience size."""
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
+    radio_artist.handle = stations.FIREHOSE_PUBLISHER_HANDLE
+    await _create_track(
+        db_session, radio_artist, title="segment", file_id="seg", created_at=now
+    )
+    await db_session.commit()
+
+    probe = AsyncMock(return_value=None)
+    with patch.object(radio_live, "_probe", probe):
+        async with AsyncClient(
+            transport=ASGITransport(app=radio_app),
+            base_url="https://radio.plyr.fm",
+        ) as client:
+            for _ in range(4):
+                await client.get("/radio/state.json", params={"station": "firehose"})
+
+    assert probe.await_count == 1
+
+
+async def test_the_firehose_station_only_airs_its_publisher(
+    db_session: AsyncSession,
+) -> None:
+    """off-air fallback stays about the firehose, not arbitrary music."""
+    station = _firehose_station()
+    mine = MagicMock(spec=Track)
+    mine.artist.handle = stations.FIREHOSE_PUBLISHER_HANDLE
+    theirs = MagicMock(spec=Track)
+    theirs.artist.handle = "someone.else"
+    assert station.corpus_filter(mine, set()) is True
+    assert station.corpus_filter(theirs, set()) is False
+
+
+async def test_firehose_station_is_in_the_lineup(radio_app: FastAPI) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=radio_app),
+        base_url="https://radio.plyr.fm",
+    ) as client:
+        response = await client.get("/radio/stations")
+
+    slugs = [s["slug"] for s in response.json()["stations"]]
+    assert "firehose" in slugs
+    # it must not become the default — that is what every legacy client gets
+    assert response.json()["default_slug"] != "firehose"

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -8,6 +8,7 @@
         "@atproto/api": "^0.18.7",
         "@opentelemetry/auto-instrumentations-web": "^0.59.0",
         "@pydantic/logfire-browser": "^0.14.0",
+        "hls.js": "^1.6.16",
         "svelte-portal": "^2.2.1",
       },
       "devDependencies": {
@@ -1061,6 +1062,8 @@
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hls.js": ["hls.js@1.6.16", "", {}, "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
 		"@atproto/api": "^0.18.7",
 		"@opentelemetry/auto-instrumentations-web": "^0.59.0",
 		"@pydantic/logfire-browser": "^0.14.0",
+		"hls.js": "^1.6.16",
 		"svelte-portal": "^2.2.1"
 	}
 }

--- a/frontend/src/lib/player-live-radio.test.ts
+++ b/frontend/src/lib/player-live-radio.test.ts
@@ -1,0 +1,97 @@
+// a live broadcast preempts the rotation: no position to resume, and hls.js is
+// only fetched when the browser can't play HLS natively.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { player, type RadioNowPlaying } from '$lib/player.svelte';
+import type { Track } from '$lib/types';
+
+vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
+vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+
+const hlsInstance = { loadSource: vi.fn(), attachMedia: vi.fn(), destroy: vi.fn() };
+class HlsCtor {
+	static isSupported = () => true;
+	loadSource = hlsInstance.loadSource;
+	attachMedia = hlsInstance.attachMedia;
+	destroy = hlsInstance.destroy;
+}
+vi.mock('hls.js', () => ({ default: HlsCtor }));
+
+function track(): Track {
+	return {
+		id: 1,
+		title: 'firehose',
+		artist: 'waow.tech',
+		artist_handle: 'waow.tech',
+		file_id: '',
+		file_type: 'mp3',
+		play_count: 0
+	};
+}
+
+function live(): RadioNowPlaying {
+	return {
+		track: track(),
+		stream_url: 'https://relay.test/live/index.m3u8',
+		start_at: 0,
+		live: true,
+		streamKind: 'hls'
+	};
+}
+
+function recorded(): RadioNowPlaying {
+	return { track: track(), stream_url: 'https://audio.test/seg.mp3', start_at: 42 };
+}
+
+describe('live radio', () => {
+	let el: HTMLAudioElement;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		el = document.createElement('audio');
+		player.audioElement = el;
+		player.stopRadio();
+	});
+
+	it('uses hls.js when the browser cannot play HLS natively', async () => {
+		vi.spyOn(el, 'canPlayType').mockReturnValue('');
+		player.playRadio(live());
+		await vi.waitFor(() => expect(hlsInstance.attachMedia).toHaveBeenCalled());
+		expect(hlsInstance.loadSource).toHaveBeenCalledWith('https://relay.test/live/index.m3u8');
+		// the element's own src is left alone — hls.js drives it via MSE
+		expect(el.src).toBe('');
+	});
+
+	it('plays natively on Safari/iOS without loading hls.js', async () => {
+		vi.spyOn(el, 'canPlayType').mockReturnValue('maybe');
+		player.playRadio(live());
+		await vi.waitFor(() => expect(el.src).toContain('index.m3u8'));
+		expect(hlsInstance.attachMedia).not.toHaveBeenCalled();
+	});
+
+	it('never loads hls.js for a recorded rotation entry', async () => {
+		vi.spyOn(el, 'canPlayType').mockReturnValue('');
+		player.playRadio(recorded());
+		await vi.waitFor(() => expect(el.src).toContain('seg.mp3'));
+		expect(hlsInstance.attachMedia).not.toHaveBeenCalled();
+	});
+
+	it('does not seek a live broadcast — it is wherever it is', async () => {
+		vi.spyOn(el, 'canPlayType').mockReturnValue('maybe');
+		Object.defineProperty(el, 'duration', { value: 600, configurable: true });
+		Object.defineProperty(el, 'readyState', { value: 1, configurable: true });
+		const np = live();
+		np.start_at = 300; // a stale rotation position must be ignored
+		player.playRadio(np);
+		await vi.waitFor(() => expect(el.src).toContain('index.m3u8'));
+		expect(el.currentTime).toBe(0);
+	});
+
+	it('tears the hls instance down when radio stops', async () => {
+		vi.spyOn(el, 'canPlayType').mockReturnValue('');
+		player.playRadio(live());
+		await vi.waitFor(() => expect(hlsInstance.attachMedia).toHaveBeenCalled());
+		player.stopRadio();
+		expect(hlsInstance.destroy).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/lib/player.svelte.ts
+++ b/frontend/src/lib/player.svelte.ts
@@ -11,6 +11,10 @@ export interface RadioNowPlaying {
 	stream_url: string;
 	/** station position to resume at (seconds) */
 	start_at: number;
+	/** a broadcast is airing: unbounded, no position to resume, no scrubbing */
+	live?: boolean;
+	/** transport for `stream_url` when live (currently only "hls") */
+	streamKind?: string;
 }
 
 interface RadioPlaybackOptions {
@@ -27,6 +31,9 @@ class PlayerState {
 	// when non-null, the player is in radio mode (overrides currentTrack)
 	radio = $state<RadioNowPlaying | null>(null);
 	audioElement = $state<HTMLAudioElement | undefined>(undefined);
+	/** live hls.js instance, when a broadcast needs one. not reactive — it is a
+	 * teardown handle, never rendered. */
+	private hls: { destroy(): void } | null = null;
 	paused = $state(true);
 
 	currentTime = $state(0);
@@ -96,8 +103,7 @@ class PlayerState {
 		this.unlockPlayCount();
 		const el = this.audioElement;
 		if (!el) return;
-		el.src = np.stream_url;
-		el.load();
+		void this.attachRadioSource(el, np, assigned);
 		if (autoplay) {
 			// play immediately (preserve the gesture), then align to station position
 			el.play().catch((err: unknown) => {
@@ -118,6 +124,8 @@ class PlayerState {
 		} else {
 			el.pause();
 		}
+		// a broadcast has no position to resume — it is wherever it is.
+		if (np.live) return;
 		const seek = () => {
 			if (np.start_at > 0 && Number.isFinite(el.duration)) {
 				el.currentTime = Math.min(np.start_at, el.duration);
@@ -127,10 +135,65 @@ class PlayerState {
 		else el.onloadedmetadata = seek;
 	}
 
+	/** point the shared element at a radio source, via hls.js when required.
+	 *
+	 * Safari and iOS play HLS natively from `src`; Chrome and Firefox do not, so
+	 * hls.js is imported only when a live station is actually tuned. everyone
+	 * else never downloads it.
+	 */
+	private async attachRadioSource(
+		el: HTMLAudioElement,
+		np: RadioNowPlaying,
+		assigned: RadioNowPlaying | null
+	) {
+		this.detachHls();
+		const needsHlsJs =
+			np.live &&
+			np.streamKind === 'hls' &&
+			!el.canPlayType('application/vnd.apple.mpegurl');
+
+		if (!needsHlsJs) {
+			el.src = np.stream_url;
+			el.load();
+			return;
+		}
+
+		try {
+			const { default: Hls } = await import('hls.js');
+			// compare against the $state proxy captured at tune-in — `np` is the
+			// raw object and never equals `this.radio`.
+			if (this.radio !== assigned) return; // tuned away while the chunk loaded
+			if (!Hls.isSupported()) {
+				el.src = np.stream_url;
+				el.load();
+				return;
+			}
+			const hls = new Hls({ enableWorker: true });
+			this.hls = hls;
+			hls.loadSource(np.stream_url);
+			hls.attachMedia(el);
+		} catch (e) {
+			console.error('failed to load hls.js for live radio:', e);
+			this.paused = true;
+		}
+	}
+
+	/** tear down any hls.js instance so its buffers and timers stop. */
+	private detachHls() {
+		if (!this.hls) return;
+		try {
+			this.hls.destroy();
+		} catch (e) {
+			console.error('failed to destroy hls instance:', e);
+		}
+		this.hls = null;
+	}
+
 	stopRadio() {
 		this.radio = null;
 		this.paused = true;
 		this.audioElement?.pause();
+		this.detachHls();
 	}
 
 	incrementPlayCount() {

--- a/frontend/src/lib/radio.svelte.ts
+++ b/frontend/src/lib/radio.svelte.ts
@@ -33,6 +33,12 @@ export interface RadioStation {
 	is_default: boolean;
 }
 
+export interface LiveBroadcast {
+	stream_url: string;
+	kind: string;
+	started_at: string | null;
+}
+
 export interface RadioState {
 	station: string;
 	station_slug: string;
@@ -45,6 +51,8 @@ export interface RadioState {
 	current: RadioTrack | null;
 	up_next: RadioTrack[];
 	rotation: RadioTrack[];
+	/** set while a broadcast preempts the rotation. absent on older servers. */
+	live?: LiveBroadcast | null;
 }
 
 const POLL_INTERVAL_MS = 30000;
@@ -159,6 +167,18 @@ class Radio {
 			album: null,
 			features: []
 		};
+		// a broadcast preempts the rotation: air the stream, but keep rendering the
+		// rotation entry so the strip still has a title and artwork to show.
+		const broadcast = this.state?.live;
+		if (broadcast) {
+			return {
+				track: { ...track, title: this.state?.station ?? track.title },
+				stream_url: broadcast.stream_url,
+				start_at: 0, // live has no position to resume
+				live: true,
+				streamKind: broadcast.kind
+			};
+		}
 		return {
 			track,
 			stream_url: c.stream_url,

--- a/loq.toml
+++ b/loq.toml
@@ -332,7 +332,7 @@ max_lines = 955
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"
-max_lines = 837
+max_lines = 1029
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"


### PR DESCRIPTION
Adds **`firehose`** — the atproto firehose sonified, aired live from relay-eval — and the preemption model that makes live audio a property of the radio we already have rather than a second kind of radio.

## why preemption, and not a rotation entry

The rotation is a loop whose position is *derived*:

```python
loop_offset = epoch_seconds % loop_duration
```

That is why every listener computes the same "now playing" with no server state, and why `/radio/state` is cacheable. A broadcast has no known duration — put one in the loop and `loop_duration` is undefined, the period is gone, and the stateless derivation goes with it.

So live doesn't join the loop; it **interrupts** it. The loop keeps running as the clock it is, and when the broadcast ends the rotation resumes wherever wall-clock time has got to. That's also just how radio works: a live show interrupts automation, and automation comes back mid-song.

The practical payoff is that nothing about stations, lenses, the sampler, or the airtime-fairness work from #1525 changes. `Station` gains one optional field.

## decisions worth flagging

**The station stays about the firehose when off-air.** It falls back to the archived segments of the same signal, not the general corpus — a station called `firehose` playing arbitrary music the moment the stream drops would be incoherent with its own name.

**`live` is additive on the response.** `RadioTrack`/`RadioStateResponse` are a public contract consumed by external clients, so a client that predates this field plays the rotation exactly as before. On this station that means the recorded fallback — a coherent degrade rather than a broken one.

**The health probe is server-side and cached (5s).** One request per window covers the entire audience instead of pointing every listener at the broadcaster's origin. It **fails closed**: a broadcaster we can't reach is treated as off-air, because dead air is the one thing radio must never produce — better the rotation than a stream URL that won't load.

**The allowlist is the `STATIONS` tuple.** Who may preempt is a curation decision made in code, not something a publisher asserts about themselves. That's deliberate: live audio can't be fingerprinted before it airs, and the whole moderation pipeline assumes a stored file. Opening this up is a separate decision, gated on moderation rather than inherited from this change.

<details>
<summary>hls.js, and why it costs nothing for most people</summary>

Safari and iOS play HLS natively from `src`; Chrome and Firefox don't. hls.js is `import()`ed only when a live station is actually tuned on a browser without native support — the other four stations and all queue playback never touch it. The instance is destroyed on stop and on re-tune so its buffers and timers don't leak.

Two behaviours pinned by tests because they're easy to get wrong: a live broadcast is never seeked (`start_at` is ignored — it is wherever it is), and a recorded rotation entry never loads hls.js even on a browser that would need it for HLS.

</details>

<details>
<summary>a bug the tests caught</summary>

The freshness check in the async attach path compared against the raw `RadioNowPlaying`, but `$state` proxies the assigned object — so `this.radio !== np` was always true and the attach bailed every time. Same trap the existing `playRadio` code already comments about. Now compares against the captured proxy.

</details>

<details>
<summary>verified against the live broadcaster</summary>

Independently checked before building, rather than trusting the handoff:

- health reports `live: true` with a fresh `last_segment_at`, CORS `*`
- playlist is well-formed, `TARGETDURATION:4`, carries `PROGRAM-DATE-TIME`, `no-cache`
- **segments** serve CORS `*` — the one that matters, since hls.js fetches them via XHR
- a segment decodes as AAC-LC, 48 kHz, mono, ~99 kbps, 3.968 s
- media sequence advanced 129 → 131 over 9 s, so it is genuinely live
- mean volume −23.2 dB / max −11.6 dB, so it is signal rather than silence

</details>

## verification

Backend `1423 passed, 25 skipped`; frontend `115 passed`; ruff, ty, svelte-check, eslint all clean.

New coverage: live preempts while the loop underneath still resolves; off-air falls back to the recorded segments; an unreachable broadcaster is off-air rather than a 500; stations without a live source never probe; the probe is cached across requests; the station only airs its publisher; and it's in the lineup without becoming the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)