### PR TITLE
fix(radio): a live station with an empty rotation is still on the air

### DIFF
--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -57,6 +57,17 @@
 </script>
 
 <div class="player-track">
+	<!-- a live broadcast (id 0) has no track page — render it unlinked -->
+	{#if !track.id}
+		<div class="player-artwork">
+			<div class="player-artwork-placeholder">
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1" width="24" height="24">
+					<circle cx="12" cy="12" r="2" />
+					<path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14" />
+				</svg>
+			</div>
+		</div>
+	{:else}
 	<SensitiveImage src={track.image_url || track.album?.image_url}>
 		<a href="/track/{track.id}" class="player-artwork" aria-label={`view ${track.title}`}>
 			{#if (track.image_url || track.album?.image_url) && !imageError}
@@ -76,8 +87,9 @@
 			{/if}
 		</a>
 	</SensitiveImage>
+	{/if}
 	<div class="player-info">
-		{#if isOnTrackDetailPage}
+		{#if isOnTrackDetailPage || !track.id}
 			<div class="player-title" class:scrolling={titleOverflows} bind:this={titleEl}>
 				<span>{track.title}</span>
 			</div>
@@ -99,7 +111,11 @@
 				</svg>
 				<div class="text-container" class:scrolling={artistOverflows}>
 					<span class="artist-inline">
-						<a href="/u/{track.artist_handle}" class="inline-artist">{track.artist}</a>
+						{#if track.artist_handle}
+							<a href="/u/{track.artist_handle}" class="inline-artist">{track.artist}</a>
+						{:else}
+							<span class="inline-artist">{track.artist}</span>
+						{/if}
 						{#if track.features && track.features.length > 0}
 							<span class="features-inline">
 								<span class="features-label">feat.</span>

--- a/frontend/src/lib/radio-live-empty-rotation.test.ts
+++ b/frontend/src/lib/radio-live-empty-rotation.test.ts
@@ -1,0 +1,67 @@
+// a live station with an EMPTY rotation is still on the air. shipped broken
+// once: the page gated its whole on-air block on a rotation entry existing, so
+// `firehose` rendered "no tracks in rotation yet" and could not be tuned in to
+// even while the broadcast was airing.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { radio } from '$lib/radio.svelte';
+import { player } from '$lib/player.svelte';
+import type { RadioState } from '$lib/radio.svelte';
+
+vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
+vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+
+function liveStateWithNoRotation(): RadioState {
+	return {
+		station: 'firehose',
+		station_slug: 'firehose',
+		generated_at: new Date().toISOString(),
+		loop_duration_seconds: 0,
+		current_index: null,
+		current_started_at: null,
+		current_ends_at: null,
+		progress_seconds: 0,
+		current: null,
+		up_next: [],
+		rotation: [],
+		live: {
+			stream_url: 'https://relay.test/live/index.m3u8',
+			kind: 'hls',
+			started_at: '2026-07-30T19:12:32Z'
+		}
+	};
+}
+
+describe('a live station with no rotation', () => {
+	beforeEach(() => {
+		player.audioElement = document.createElement('audio');
+		player.stopRadio();
+		radio.state = null;
+	});
+
+	it('is on the air even though the rotation is empty', () => {
+		radio.state = liveStateWithNoRotation();
+		expect(radio.current).toBeNull();
+		expect(radio.isLive).toBe(true);
+		expect(radio.hasSomethingOnAir).toBe(true);
+	});
+
+	it('can be tuned in to, and airs the broadcast', () => {
+		radio.state = liveStateWithNoRotation();
+		radio.tuneIn();
+		expect(player.radio).not.toBeNull();
+		expect(player.radio?.stream_url).toBe('https://relay.test/live/index.m3u8');
+		expect(player.radio?.live).toBe(true);
+		// display-only entry: id 0 marks it as having no track page to link to
+		expect(player.radio?.track.id).toBe(0);
+		expect(player.radio?.track.title).toBe('firehose');
+	});
+
+	it('is genuinely off air when neither a broadcast nor a rotation exists', () => {
+		const s = liveStateWithNoRotation();
+		radio.state = { ...s, live: null };
+		expect(radio.hasSomethingOnAir).toBe(false);
+		radio.tuneIn();
+		expect(player.radio).toBeNull();
+	});
+});

--- a/frontend/src/lib/radio.svelte.ts
+++ b/frontend/src/lib/radio.svelte.ts
@@ -73,6 +73,17 @@ class Radio {
 		return this.state?.current ?? null;
 	}
 
+	/** a broadcast is preempting the rotation right now. */
+	get isLive(): boolean {
+		return Boolean(this.state?.live);
+	}
+
+	/** is there anything to tune in to — a broadcast, or a rotation entry?
+	 * a live station with an empty rotation is still on the air. */
+	get hasSomethingOnAir(): boolean {
+		return this.isLive || this.current !== null;
+	}
+
 	/** the resolved station metadata for the loaded state */
 	get activeStation(): RadioStation | null {
 		const slug = this.state?.station_slug;
@@ -124,8 +135,8 @@ class Radio {
 		} finally {
 			this.switching = false;
 		}
-		const c = this.current;
-		if (c && player.radio) player.playRadio(this.toNowPlaying(c), { autoplay: !player.paused });
+		const np = this.nowPlaying();
+		if (np && player.radio) player.playRadio(np, { autoplay: !player.paused });
 	}
 
 	/** whether radio is the active player source (single source of truth) */
@@ -216,10 +227,42 @@ class Radio {
 	/** start radio. synchronous (no await) so the caller's gesture is preserved
 	 * for autoplay — call once `current` is loaded (the page gates on it). */
 	tuneIn(): void {
-		const c = this.current;
-		if (!c) return;
-		player.playRadio(this.toNowPlaying(c));
+		const np = this.nowPlaying();
+		if (!np) return;
+		player.playRadio(np);
 		this.startPolling();
+	}
+
+	/** what the player should air: the broadcast if one is live, else the
+	 * rotation entry. a live station with an empty rotation still airs. */
+	private nowPlaying(startAt?: number): RadioNowPlaying | null {
+		const c = this.current;
+		if (c) return this.toNowPlaying(c, startAt);
+		const broadcast = this.state?.live;
+		if (!broadcast) return null;
+		return {
+			track: this.broadcastTrack(),
+			stream_url: broadcast.stream_url,
+			start_at: 0,
+			live: true,
+			streamKind: broadcast.kind
+		};
+	}
+
+	/** a display-only entry for a broadcast with no rotation behind it.
+	 * id 0 marks it as unlinkable — there is no track page for a broadcast. */
+	private broadcastTrack(): Track {
+		return {
+			id: 0,
+			title: this.state?.station ?? 'live',
+			artist: this.activeStation?.description ?? 'live broadcast',
+			artist_handle: '',
+			file_id: '',
+			file_type: 'hls',
+			play_count: 0,
+			album: null,
+			features: []
+		} as Track;
 	}
 
 	stop(): void {
@@ -256,10 +299,12 @@ class Radio {
 			return;
 		}
 		await this.loadState();
-		const c = this.current;
-		if (!c || !player.radio) return;
-		if (player.radio.stream_url !== c.stream_url) {
-			player.playRadio(this.toNowPlaying(c), { autoplay: !player.paused });
+		const np = this.nowPlaying();
+		if (!np || !player.radio) return;
+		// a broadcast starting or ending swaps the source mid-session, same as a
+		// rotation boundary does.
+		if (player.radio.stream_url !== np.stream_url) {
+			player.playRadio(np, { autoplay: !player.paused });
 		}
 	}
 

--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -41,7 +41,7 @@
 	let autoTuned = false;
 	$effect(() => {
 		if (!autoplayRequested || autoTuned) return;
-		if (!radio.current || radio.active) return;
+		if (!radio.hasSomethingOnAir || radio.active) return;
 		autoTuned = true;
 		// play/pause button infinite loops without setTimeout
 		setTimeout(() => radio.tuneIn(), 0);
@@ -137,7 +137,7 @@
 			<div class="status"><WaveLoading size="lg" message="tuning..." /></div>
 		{:else if radio.error}
 			<div class="status error">{radio.error}</div>
-		{:else if radio.current}
+		{:else if radio.hasSomethingOnAir}
 			<div class="radio-player" {@attach horizontalSwipe((dir) => flip(dir === 'left' ? 'next' : 'prev'))}>
 				<div class="station-title">
 					<span class="live">live radio</span>
@@ -167,25 +167,37 @@
 				/>
 				<div class="now-block" class:tuning={radio.switching}>
 				<div class="art-stage">
-					{#if radio.current.artwork_url}
-						<img class="art-bg" src={resizedImageUrl(radio.current.artwork_url, IMAGE_WIDTHS.tile)} alt="" aria-hidden="true" />
+					{#if radio.current}
+						{#if radio.current.artwork_url}
+							<img class="art-bg" src={resizedImageUrl(radio.current.artwork_url, IMAGE_WIDTHS.tile)} alt="" aria-hidden="true" />
+						{/if}
+						<SensitiveImage src={radio.current.artwork_url} tooltipPosition="center">
+							<a class="art-link" href={`/track/${radio.current.id}`} aria-label={`view ${radio.current.title}`}>
+								{#if radio.current.artwork_url}
+									<img src={resizedImageUrl(radio.current.artwork_url, IMAGE_WIDTHS.hero)} alt="" class="art" />
+								{:else}
+									<div class="art fallback"></div>
+								{/if}
+							</a>
+						</SensitiveImage>
+					{:else}
+						<div class="art fallback"></div>
 					{/if}
-					<SensitiveImage src={radio.current.artwork_url} tooltipPosition="center">
-						<a class="art-link" href={`/track/${radio.current.id}`} aria-label={`view ${radio.current.title}`}>
-							{#if radio.current.artwork_url}
-								<img src={resizedImageUrl(radio.current.artwork_url, IMAGE_WIDTHS.hero)} alt="" class="art" />
-							{:else}
-								<div class="art fallback"></div>
-							{/if}
-						</a>
-					</SensitiveImage>
 				</div>
 				<div class="now-meta">
-					<p class="label">{radio.active ? 'on air' : "what's on"}</p>
-					<h2>
-						<a href={`/track/${radio.current.id}`}>{radio.current.title}</a>
-					</h2>
-					<a class="artist" href={`/u/${radio.current.artist_handle}`}>{radio.current.artist}</a>
+					<p class="label">
+						{#if radio.isLive}live{:else if radio.active}on air{:else}what's on{/if}
+					</p>
+					{#if radio.current}
+						<h2>
+							<a href={`/track/${radio.current.id}`}>{radio.current.title}</a>
+						</h2>
+						<a class="artist" href={`/u/${radio.current.artist_handle}`}>{radio.current.artist}</a>
+					{:else}
+						<!-- a broadcast has no track page or uploader to link to -->
+						<h2>{radio.state?.station ?? 'live'}</h2>
+						<span class="artist">{radio.activeStation?.description ?? ''}</span>
+					{/if}
 				</div>
 				</div>
 				<div class="controls">
@@ -199,7 +211,7 @@
 							tune in
 						</button>
 					{/if}
-					{#if auth.isAuthenticated}
+					{#if auth.isAuthenticated && radio.current}
 						{#key radio.current.id}
 							<AddToMenu
 								trackId={radio.current.id}
@@ -211,6 +223,7 @@
 						{/key}
 					{/if}
 				</div>
+				{#if radio.current && !radio.isLive}
 				<div class="progress-wrap">
 					<div class="progress" aria-label="track progress">
 						<div class="progress-fill" style={`width: ${progressPercent}%`}></div>
@@ -220,6 +233,7 @@
 						<span>{formatTime(radio.current.duration)}</span>
 					</div>
 				</div>
+				{/if}
 			</div>
 		{:else}
 			<div class="status">no tracks in rotation yet</div>

--- a/loq.toml
+++ b/loq.toml
@@ -328,7 +328,7 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/[[][[]station[]][]]/+page.svelte"
-max_lines = 955
+max_lines = 969
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"


### PR DESCRIPTION
Shipped broken in #1741. `/radio/firehose` rendered **"no tracks in rotation yet"** with no way to tune in — while the broadcast was airing and `/radio/state.json` was correctly returning it.

The API was right the whole time; the UI never consulted it. The page gated its entire on-air block on a rotation entry existing, and `firehose`'s fallback rotation is empty because waow.tech's segments are `unlisted` and the radio corpus is public-only. I verified two endpoints with curl, saw `live` populated, and called it shipped without loading the page.

## the fix

Live becomes first-class in the store rather than a field only the JSON knew about:

- `radio.isLive` / `radio.hasSomethingOnAir` — a broadcast is on the air whether or not a rotation backs it.
- `nowPlaying()` resolves what to air (broadcast first, else the rotation entry). `tuneIn`, station flips, and poll-sync all route through it, so a broadcast **starting or ending** swaps the source mid-session exactly like a rotation boundary does.
- The page renders a `LIVE` label, drops the progress bar (a broadcast has no duration to scrub) and the track-page links (a broadcast has no track page), and keeps the empty state only for genuinely off-air.
- `TrackInfo` renders the footer entry unlinked when there's no track behind it, instead of pointing at `/track/0`.

<details>
<summary>verified in a real browser — both transports</summary>

Rendered headlessly against the production API:

```
empty state shown : false
tune in button    : 1
label text        : LIVE
progress bar      : 0
```

Native HLS (Safari/iOS shape) — plays straight from `src`:
```
src: https://relay-eval.waow.tech/sonify/live/index.m3u8
readyState: 4, paused: false, currentTime: 5.51, duration: Infinity
```

hls.js (Chrome/Firefox shape, native support disabled) — MSE-driven:
```
src: blob:http://localhost:5175/bb883c1a-...   isBlob: true
readyState: 4, paused: false, currentTime: 18.75
media requests: 2 playlist, 4 segments
```

</details>

<details>
<summary>the regression test fails against the shipped behavior</summary>

Confirmed by reverting the two guards and re-running — 2 of 3 fail, then pass restored. It drives the store the way the page does rather than asserting the fix's own shape.

</details>

## still true, and not fixed here

`firehose`'s off-air fallback is still empty, because those segments are `unlisted`. The station now correctly says it's on the air when it is, and correctly says nothing is on when the stream drops — but there's no archived material behind it. That's a content decision (publish some segments publicly) rather than a code one, and I'd rather leave it visible than paper over it.

Frontend `118 passed`, svelte-check and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)