### PR TITLE
feat(radio): a broadcast carries its own cover

### DIFF
--- a/backend/src/backend/api/radio/live.py
+++ b/backend/src/backend/api/radio/live.py
@@ -31,6 +31,7 @@ class LiveBroadcast:
     stream_url: str
     kind: str
     started_at: str | None
+    artwork_url: str | None = None
 
 
 _cache: dict[str, tuple[float, LiveBroadcast | None]] = {}
@@ -83,11 +84,17 @@ async def _probe(source: LiveSource) -> LiveBroadcast | None:
     if not isinstance(payload, dict) or payload.get("live") is not True:
         return None
 
-    started_at = payload.get("started_at")
+    def _str(key: str) -> str | None:
+        value = payload.get(key)
+        return value if isinstance(value, str) and value else None
+
     return LiveBroadcast(
         stream_url=source.stream_url,
         kind=source.kind,
-        started_at=started_at if isinstance(started_at, str) else None,
+        started_at=_str("started_at"),
+        # the broadcaster owns its own artwork — a sonification renders a cover
+        # per interval, so this changes while the stream stays put.
+        artwork_url=_str("artwork_url"),
     )
 
 

--- a/backend/src/backend/api/radio/schemas.py
+++ b/backend/src/backend/api/radio/schemas.py
@@ -41,6 +41,7 @@ class LiveBroadcastInfo(BaseModel):
     stream_url: str
     kind: str  # "hls"
     started_at: str | None = None
+    artwork_url: str | None = None
 
 
 class RadioStateResponse(BaseModel):

--- a/backend/src/backend/api/radio/state.py
+++ b/backend/src/backend/api/radio/state.py
@@ -281,6 +281,7 @@ async def radio_state(
                 stream_url=broadcast.stream_url,
                 kind=broadcast.kind,
                 started_at=broadcast.started_at,
+                artwork_url=broadcast.artwork_url,
             )
             if broadcast
             else None

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -1025,3 +1025,69 @@ async def test_firehose_station_is_in_the_lineup(radio_app: FastAPI) -> None:
     assert "firehose" in slugs
     # it must not become the default — that is what every legacy client gets
     assert response.json()["default_slug"] != "firehose"
+
+
+async def test_a_broadcast_carries_its_own_artwork(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    """the broadcaster owns its cover — a sonification renders one per interval."""
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
+    radio_artist.handle = stations.FIREHOSE_PUBLISHER_HANDLE
+    await _create_track(
+        db_session, radio_artist, title="segment", file_id="seg", created_at=now
+    )
+    await db_session.commit()
+
+    payload = {
+        "live": True,
+        "started_at": "2026-07-30T19:12:32Z",
+        "artwork_url": "https://relay.test/sonify/live/cover.png",
+    }
+    response_stub = MagicMock()
+    response_stub.json.return_value = payload
+    response_stub.raise_for_status.return_value = None
+    client_stub = MagicMock()
+    client_stub.__aenter__ = AsyncMock(return_value=client_stub)
+    client_stub.__aexit__ = AsyncMock(return_value=False)
+    client_stub.get = AsyncMock(return_value=response_stub)
+
+    with patch.object(radio_live.httpx, "AsyncClient", return_value=client_stub):
+        async with AsyncClient(
+            transport=ASGITransport(app=radio_app),
+            base_url="https://radio.plyr.fm",
+        ) as client:
+            response = await client.get(
+                "/radio/state.json", params={"station": "firehose"}
+            )
+
+    live = response.json()["live"]
+    assert live["artwork_url"] == "https://relay.test/sonify/live/cover.png"
+
+
+async def test_a_broadcast_without_artwork_is_still_valid(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
+    radio_artist.handle = stations.FIREHOSE_PUBLISHER_HANDLE
+    await _create_track(
+        db_session, radio_artist, title="segment", file_id="seg", created_at=now
+    )
+    await db_session.commit()
+
+    broadcast = radio_live.LiveBroadcast(
+        stream_url="https://relay.test/live/index.m3u8", kind="hls", started_at=None
+    )
+    with patch.object(radio_live, "_probe", AsyncMock(return_value=broadcast)):
+        async with AsyncClient(
+            transport=ASGITransport(app=radio_app),
+            base_url="https://radio.plyr.fm",
+        ) as client:
+            response = await client.get(
+                "/radio/state.json", params={"station": "firehose"}
+            )
+
+    assert response.json()["live"]["artwork_url"] is None

--- a/frontend/src/lib/radio.svelte.ts
+++ b/frontend/src/lib/radio.svelte.ts
@@ -37,6 +37,8 @@ export interface LiveBroadcast {
 	stream_url: string;
 	kind: string;
 	started_at: string | null;
+	/** the broadcaster's own cover, when it publishes one */
+	artwork_url?: string | null;
 }
 
 export interface RadioState {
@@ -259,6 +261,7 @@ class Radio {
 			artist_handle: '',
 			file_id: '',
 			file_type: 'hls',
+			image_url: this.state?.live?.artwork_url ?? undefined,
 			play_count: 0,
 			album: null,
 			features: []

--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -18,6 +18,14 @@
 	let { data }: { data: PageData } = $props();
 
 	const endpoint = `${API_URL}/radio/state`;
+	// the cover's own aspect ratio, read on load. drives the frame so a square
+	// cover reads square and a widescreen one reads wide — see `.art-link`.
+	let coverRatio = $state(1);
+
+	function readCoverRatio(event: Event) {
+		const img = event.currentTarget as HTMLImageElement;
+		if (img.naturalHeight > 0) coverRatio = img.naturalWidth / img.naturalHeight;
+	}
 
 	// the URL path is the source of truth for the selected station (bookmarkable).
 	// `/radio` (no slug) shows the remembered/default station; `/radio/<slug>` pins it.
@@ -166,7 +174,7 @@
 					onSelect={tuneToStation}
 				/>
 				<div class="now-block" class:tuning={radio.switching}>
-				<div class="art-stage">
+				<div class="art-stage" style={`--cover-ratio: ${coverRatio}`}>
 					{#if radio.current}
 						{#if radio.current.artwork_url}
 							<img class="art-bg" src={resizedImageUrl(radio.current.artwork_url, IMAGE_WIDTHS.tile)} alt="" aria-hidden="true" />
@@ -174,7 +182,12 @@
 						<SensitiveImage src={radio.current.artwork_url} tooltipPosition="center">
 							<a class="art-link" href={`/track/${radio.current.id}`} aria-label={`view ${radio.current.title}`}>
 								{#if radio.current.artwork_url}
-									<img src={resizedImageUrl(radio.current.artwork_url, IMAGE_WIDTHS.hero)} alt="" class="art" />
+									<img
+									src={resizedImageUrl(radio.current.artwork_url, IMAGE_WIDTHS.hero)}
+									alt=""
+									class="art"
+									onload={readCoverRatio}
+								/>
 								{:else}
 									<div class="art fallback"></div>
 								{/if}
@@ -183,7 +196,12 @@
 					{:else if radio.state?.live?.artwork_url}
 						<img class="art-bg" src={radio.state.live.artwork_url} alt="" aria-hidden="true" />
 						<div class="art-link">
-							<img src={radio.state.live.artwork_url} alt="" class="art" />
+							<img
+								src={radio.state.live.artwork_url}
+								alt=""
+								class="art"
+								onload={readCoverRatio}
+							/>
 						</div>
 					{:else}
 						<!-- no cover published for this broadcast: a placeholder sized like
@@ -501,6 +519,8 @@
 	   the ambient backdrop so wide/tall leftovers look intentional instead of
 	   cropping the square cover into a weird slice */
 	.art-stage {
+		/* a size container, so the cover can be sized against both of its axes */
+		container-type: size;
 		flex: 1 1 auto;
 		min-height: clamp(7rem, 22vh, 18rem);
 		width: 100%;
@@ -529,16 +549,24 @@
 		pointer-events: none;
 	}
 
-	/* foreground cover: a contained square (never cropped to a slice) */
+	/* foreground cover: fits inside the stage at its own aspect ratio, never
+	   cropped. sizing is driven by the image rather than a fixed square box —
+	   `height: 100%` used to resolve against the stage and beat `aspect-ratio`,
+	   so a square cover came out as a tall slice on a tall viewport. shrink-
+	   wrapping the image means a square cover reads square, a widescreen one
+	   reads wide, and neither loses edges. */
 	.art-link {
 		position: relative;
 		z-index: 1;
 		flex: 0 0 auto;
 		display: block;
-		height: 100%;
+		/* fit inside the stage at the cover's own ratio: take the full height
+		   unless that would overflow the width, in which case width wins.
+		   percentage max-heights can't express this — they don't resolve against
+		   an auto-height parent, which is how a square cover became a tall slice. */
+		height: min(100cqh, calc(100cqw / var(--cover-ratio, 1)));
+		aspect-ratio: var(--cover-ratio, 1);
 		width: auto;
-		max-width: 100%;
-		aspect-ratio: 1 / 1;
 		text-decoration: none;
 		border-radius: var(--radius-md);
 		overflow: hidden;
@@ -557,7 +585,9 @@
 		display: block;
 		width: 100%;
 		height: 100%;
-		object-fit: cover;
+		/* `contain` is belt-and-braces: the box already matches the image's ratio,
+		   so there is nothing to crop or letterbox. */
+		object-fit: contain;
 		border-radius: var(--radius-md);
 		box-shadow: 0 0.75rem 2.5rem rgba(0, 0, 0, 0.34);
 		transition:
@@ -580,9 +610,9 @@
 	   square. a placeholder has none, so drive this one from width and cap it —
 	   otherwise it stretches to whatever vertical space the stage has. */
 	.art-link.art-tile-live {
-		height: auto;
+		/* no intrinsic size to shrink-wrap, so give it one */
 		width: min(100%, 18rem);
-		max-height: 100%;
+		height: auto;
 		aspect-ratio: 1 / 1;
 	}
 

--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -180,8 +180,22 @@
 								{/if}
 							</a>
 						</SensitiveImage>
+					{:else if radio.state?.live?.artwork_url}
+						<img class="art-bg" src={radio.state.live.artwork_url} alt="" aria-hidden="true" />
+						<div class="art-link">
+							<img src={radio.state.live.artwork_url} alt="" class="art" />
+						</div>
 					{:else}
-						<div class="art fallback"></div>
+						<!-- no cover published for this broadcast: a placeholder sized like
+						     one, rather than a rectangle stretched over the whole stage. -->
+						<div class="art-link art-tile-live" aria-hidden="true">
+							<div class="art fallback live-art">
+								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round">
+									<circle cx="12" cy="12" r="2" />
+									<path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14" />
+								</svg>
+							</div>
+						</div>
 					{/if}
 				</div>
 				<div class="now-meta">
@@ -560,6 +574,28 @@
 		background:
 			linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 45%),
 			var(--bg-secondary);
+	}
+
+	/* the cover path is height-driven, which needs an intrinsic image to stay
+	   square. a placeholder has none, so drive this one from width and cap it —
+	   otherwise it stretches to whatever vertical space the stage has. */
+	.art-link.art-tile-live {
+		height: auto;
+		width: min(100%, 18rem);
+		max-height: 100%;
+		aspect-ratio: 1 / 1;
+	}
+
+	.art.live-art {
+		display: grid;
+		place-items: center;
+		color: var(--text-secondary);
+	}
+
+	.art.live-art svg {
+		width: 38%;
+		height: 38%;
+		opacity: 0.55;
 	}
 
 	.now-meta {

--- a/loq.toml
+++ b/loq.toml
@@ -328,7 +328,7 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/[[][[]station[]][]]/+page.svelte"
-max_lines = 1005
+max_lines = 1035
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"

--- a/loq.toml
+++ b/loq.toml
@@ -328,11 +328,11 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/[[][[]station[]][]]/+page.svelte"
-max_lines = 969
+max_lines = 1005
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"
-max_lines = 1029
+max_lines = 1093
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"


### PR DESCRIPTION
`/radio/firehose` showed a large empty tile, and I started tuning the whitespace around it. Wrong instinct — **there should be a cover.** A broadcast is a thing on the air; it should carry artwork like anything else. This adds the place to put it.

`artwork_url` flows from the broadcaster's health payload → `LiveBroadcast` → `live` on the radio state → the player, and renders through the **normal** cover path, ambient blurred backdrop and all. It's read per-probe rather than baked into the station config, because a sonification renders a new cover each interval while the stream URL stays put.

The placeholder stays, demoted to what it should always have been: what you see when a broadcaster genuinely publishes no art. It's now sized like a cover instead of stretched over the whole stage — but with a real cover the stage fills as usual and the layout question disappears entirely.

<details>
<summary>verified both paths in a browser</summary>

With a cover injected into the response, to prove the render path before asking relay-eval to publish one:

```
cover rendered   : true
placeholder gone : true
ambient bg       : true
```

Without one, across three viewports — the placeholder is a square tile, not a stretched rectangle:

```
935x1274 : tile 288x288  square=true
1440x900 : tile 288x288  square=true
390x844  : tile 288x288  square=true
```

</details>

## the other half is relay-eval's

Nothing publishes `artwork_url` yet, so today this still renders the placeholder. The ask is small — the publisher already renders a cover per interval for its tracks (`rsvg-convert` is in its deploy path); it needs a stable URL for the *current* one, exposed on `/api/sonify/live` alongside `playlist_url`. Writing that up separately for you to forward.

Backend `1425 passed`, frontend `118 passed`, ruff/ty/svelte-check/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)