### PR TITLE
fix(radio): an empty station must never be a dead end

### DIFF
--- a/frontend/src/lib/radio-live-empty-rotation.test.ts
+++ b/frontend/src/lib/radio-live-empty-rotation.test.ts
@@ -65,3 +65,52 @@ describe('a live station with no rotation', () => {
 		expect(player.radio).toBeNull();
 	});
 });
+
+describe('an empty remembered station must not strand bare /radio', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		radio.state = null;
+		radio.stations = [];
+	});
+
+	it('falls back to the default when the remembered station has nothing on air', async () => {
+		localStorage.setItem('plyr_radio_station', 'firehose');
+		const calls: (string | null)[] = [];
+		vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+			const url = String(input);
+			calls.push(url.includes('station=') ? new URL(url).searchParams.get('station') : null);
+			const empty = url.includes('station=firehose');
+			return new Response(
+				JSON.stringify(
+					empty
+						? { ...liveStateWithNoRotation(), live: null }
+						: { ...liveStateWithNoRotation(), live: null, station_slug: 'loved', current: { id: 1 } }
+				),
+				{ status: 200, headers: { 'content-type': 'application/json' } }
+			);
+		});
+
+		await radio.show(null); // bare /radio
+
+		// asked for the remembered station, found it silent, retried the default
+		expect(calls[0]).toBe('firehose');
+		expect(localStorage.getItem('plyr_radio_station')).toBeNull();
+		// landed on the server default rather than on silence
+		expect(radio.station).toBe('loved');
+	});
+
+	it('respects an explicit /radio/<slug> even when it is off air', async () => {
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(JSON.stringify({ ...liveStateWithNoRotation(), live: null }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' }
+			})
+		);
+
+		await radio.show('firehose');
+
+		// being told a station is off air beats being silently shown a different one
+		expect(radio.station).toBe('firehose');
+		expect(localStorage.getItem('plyr_radio_station')).toBe('firehose');
+	});
+});

--- a/frontend/src/lib/radio.svelte.ts
+++ b/frontend/src/lib/radio.svelte.ts
@@ -134,6 +134,18 @@ class Radio {
 		this.switching = true;
 		try {
 			await this.loadState();
+			// bare /radio restores whatever was last picked. a station can be empty
+			// — a live one goes quiet, and `firehose` has no recorded rotation behind
+			// it — so an implicit restore must not strand the listener on silence.
+			// an explicit /radio/<slug> is respected either way: asking for a station
+			// and being shown another would be worse than being told it is off air.
+			if (slug === null && target !== null && !this.hasSomethingOnAir) {
+				this.station = null;
+				if (typeof localStorage !== 'undefined') {
+					localStorage.removeItem(STATION_STORAGE_KEY);
+				}
+				await this.loadState();
+			}
 		} finally {
 			this.switching = false;
 		}

--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -268,7 +268,18 @@
 				{/if}
 			</div>
 		{:else}
-			<div class="status">no tracks in rotation yet</div>
+			<!-- a station can be legitimately empty: its broadcaster is off air and it
+			     has no recorded rotation behind it. the tuner comes along so this is
+			     never a dead end — the station choice persists, so landing here on a
+			     later visit must still offer a way out. -->
+			<div class="off-air">
+				<TunerDial stations={radio.stations} {activeSlug} onSelect={tuneToStation} />
+				<p class="off-air-label">off air</p>
+				<p class="off-air-detail">
+					nothing is on air on {radio.activeStation?.name ?? 'this station'} right now.
+					pick another above.
+				</p>
+			</div>
 		{/if}
 	</section>
 
@@ -518,6 +529,29 @@
 	/* the artwork "stage" fills the leftover space; a blurred copy of the cover is
 	   the ambient backdrop so wide/tall leftovers look intentional instead of
 	   cropping the square cover into a weird slice */
+	.off-air {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1rem;
+		padding-bottom: clamp(2rem, 8vh, 5rem);
+	}
+
+	.off-air-label {
+		font-size: 0.75rem;
+		letter-spacing: 0.16em;
+		text-transform: uppercase;
+		color: var(--text-secondary);
+		margin: 1rem 0 0;
+	}
+
+	.off-air-detail {
+		margin: 0;
+		color: var(--text-secondary);
+		text-align: center;
+		max-width: 26rem;
+	}
+
 	.art-stage {
 		/* a size container, so the cover can be sized against both of its axes */
 		container-type: size;

--- a/loq.toml
+++ b/loq.toml
@@ -328,7 +328,7 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/[[][[]station[]][]]/+page.svelte"
-max_lines = 1035
+max_lines = 1069
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"


### PR DESCRIPTION
Visiting `/radio/firehose` once persisted it as your station. After that, bare **`/radio`** restored a station that is empty whenever its broadcast stops — and the empty state rendered *without the tuner*, so there was no way back out. Permanent, until you cleared localStorage.

Reproduced in production rather than reasoned about:

```
clean browser                        → loved, works
localStorage=firehose, url /radio    → "no tracks in rotation yet", no tuner
```

That gap is why the API looked healthy and the report looked like "radio is broken" — the other four stations were genuinely fine, which was a useless thing to say to someone whose radio didn't work.

## two fixes

**An implicit restore that lands on silence falls back.** Bare `/radio` resolving a remembered station with nothing on air drops the remembered pick and reloads the default. A choice made once should not strand you later when that station goes quiet.

**An explicit `/radio/<slug>` is still honoured.** Asking for a station and being silently shown a different one would be worse than being told it's off air. So that path keeps the station, but the empty state now says **off air**, names the station, and carries the tuner so it's escapable.

<details>
<summary>verified against the exact broken state</summary>

```
bare /radio with remembered firehose:
  dead end   : false
  recovered  : true          (tune-in button present)
  storage now: null          (bad pick forgotten)

explicit /radio/firehose (off air):
  dead end   : false
  says offair: true
  tuner shown: true
```

Plus all four existing stations re-checked for regressions — cover and tune-in button present, no empty state.

</details>

<details>
<summary>the underlying condition, unchanged</summary>

`firehose` still has no recorded rotation, because waow.tech's segments are `unlisted` and the radio corpus is public-only. This makes that state survivable rather than fixing it. Publishing a few segments publicly would give the station something to fall back to and is a content decision, not a code one.

</details>

Frontend `120 passed`, svelte-check and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)