### PR TITLE
fix(radio): close the dead band under the cover, and don't trust one liveness bit

### DIFF
--- a/backend/src/backend/api/radio/live.py
+++ b/backend/src/backend/api/radio/live.py
@@ -10,8 +10,10 @@ will not load — dead air is the one outcome radio must never produce.
 """
 
 import asyncio
+import re
 import time
 from dataclasses import dataclass
+from datetime import UTC, datetime
 
 import httpx
 import logfire
@@ -22,6 +24,10 @@ from backend.api.radio.stations import LiveSource
 # is noticed promptly, long enough that the broadcaster sees a trickle.
 _CACHE_TTL_SECONDS = 5.0
 _PROBE_TIMEOUT_SECONDS = 3.0
+# how stale the newest segment may be before the stream counts as stopped.
+# generous next to a typical 4s segment: a slow encoder tick is not an outage.
+_SEGMENT_FRESHNESS_SECONDS = 45.0
+_PROGRAM_DATE_TIME = re.compile(r"^#EXT-X-PROGRAM-DATE-TIME:(.+)$", re.MULTILINE)
 
 
 @dataclass(frozen=True)
@@ -81,12 +87,24 @@ async def _probe(source: LiveSource) -> LiveBroadcast | None:
         )
         return None
 
-    if not isinstance(payload, dict) or payload.get("live") is not True:
+    if not isinstance(payload, dict):
         return None
 
     def _str(key: str) -> str | None:
         value = payload.get(key)
         return value if isinstance(value, str) and value else None
+
+    if payload.get("live") is not True:
+        # a broadcaster can report itself down while its playlist keeps
+        # advancing — observed 2026-07-30, stream healthy and `live: false`.
+        # the playlist is what a listener actually plays, so it gets the last
+        # word before we tell anyone the station is off air.
+        if not await _playlist_is_advancing(source.stream_url):
+            return None
+        logfire.info(
+            "radio: broadcaster reports down but its playlist is live, airing it",
+            health_url=source.health_url,
+        )
 
     return LiveBroadcast(
         stream_url=source.stream_url,
@@ -96,6 +114,36 @@ async def _probe(source: LiveSource) -> LiveBroadcast | None:
         # per interval, so this changes while the stream stays put.
         artwork_url=_str("artwork_url"),
     )
+
+
+async def _playlist_is_advancing(playlist_url: str) -> bool:
+    """is the stream still producing segments?
+
+    Ground truth for "can someone hear this right now" is the playlist, not a
+    status field beside it. A live playlist carries no ENDLIST and stamps each
+    segment with a wall-clock time; if the newest one is recent, audio exists.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_SECONDS) as client:
+            response = await client.get(playlist_url)
+            response.raise_for_status()
+            body = response.text
+    except Exception:
+        return False
+
+    if "#EXT-X-ENDLIST" in body:
+        return False  # the broadcaster closed the stream out
+    stamps = _PROGRAM_DATE_TIME.findall(body)
+    if not stamps:
+        return False
+    try:
+        newest = datetime.fromisoformat(stamps[-1].strip().replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if newest.tzinfo is None:
+        newest = newest.replace(tzinfo=UTC)
+    age = (datetime.now(UTC) - newest).total_seconds()
+    return age <= _SEGMENT_FRESHNESS_SECONDS
 
 
 def reset_cache() -> None:

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -1091,3 +1091,89 @@ async def test_a_broadcast_without_artwork_is_still_valid(
             )
 
     assert response.json()["live"]["artwork_url"] is None
+
+
+# --- the playlist gets the last word on liveness ---
+
+
+def _playlist(*, age_seconds: float, ended: bool = False, stamped: bool = True) -> str:
+    stamp = (datetime.now(UTC) - timedelta(seconds=age_seconds)).isoformat()
+    lines = ["#EXTM3U", "#EXT-X-VERSION:3", "#EXT-X-TARGETDURATION:4"]
+    lines.append("#EXTINF:3.99,")
+    if stamped:
+        lines.append(f"#EXT-X-PROGRAM-DATE-TIME:{stamp}")
+    lines.append("segment-000000001.ts")
+    if ended:
+        lines.append("#EXT-X-ENDLIST")
+    return "\n".join(lines)
+
+
+def _health_client(payload: dict, playlist: str | None = None) -> MagicMock:
+    """stub httpx.AsyncClient: health json first, playlist text after."""
+    health = MagicMock()
+    health.json.return_value = payload
+    health.raise_for_status.return_value = None
+    health.text = ""
+    pl = MagicMock()
+    pl.raise_for_status.return_value = None
+    pl.text = playlist or ""
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.get = AsyncMock(side_effect=[health, pl])
+    return client
+
+
+class TestLivenessFallsBackToThePlaylist:
+    """a broadcaster reported itself down while its playlist kept advancing.
+
+    observed 2026-07-30: `{"live": false}` with MEDIA-SEQUENCE climbing and
+    segments decoding fine. the listener could have heard it; the station said
+    off air. the playlist is what actually gets played, so it decides.
+    """
+
+    async def test_advancing_playlist_overrides_a_down_report(self) -> None:
+        radio_live.reset_cache()
+        source = stations.LiveSource(
+            stream_url="https://relay.test/live/index.m3u8",
+            health_url="https://relay.test/health",
+        )
+        client = _health_client({"live": False}, _playlist(age_seconds=3))
+        with patch.object(radio_live.httpx, "AsyncClient", return_value=client):
+            result = await radio_live.get_live_broadcast(source)
+        assert result is not None
+        assert result.stream_url == "https://relay.test/live/index.m3u8"
+
+    async def test_a_stale_playlist_stays_off_air(self) -> None:
+        radio_live.reset_cache()
+        source = stations.LiveSource(
+            stream_url="https://relay.test/live/index.m3u8",
+            health_url="https://relay.test/health",
+        )
+        client = _health_client({"live": False}, _playlist(age_seconds=600))
+        with patch.object(radio_live.httpx, "AsyncClient", return_value=client):
+            assert await radio_live.get_live_broadcast(source) is None
+
+    async def test_an_ended_playlist_stays_off_air(self) -> None:
+        radio_live.reset_cache()
+        source = stations.LiveSource(
+            stream_url="https://relay.test/live/index.m3u8",
+            health_url="https://relay.test/health",
+        )
+        client = _health_client({"live": False}, _playlist(age_seconds=1, ended=True))
+        with patch.object(radio_live.httpx, "AsyncClient", return_value=client):
+            assert await radio_live.get_live_broadcast(source) is None
+
+    async def test_a_healthy_report_never_fetches_the_playlist(self) -> None:
+        """the second opinion is only for a *negative* report."""
+        radio_live.reset_cache()
+        source = stations.LiveSource(
+            stream_url="https://relay.test/live/index.m3u8",
+            health_url="https://relay.test/health",
+        )
+        client = _health_client({"live": True, "artwork_url": "https://a.test/c.png"})
+        with patch.object(radio_live.httpx, "AsyncClient", return_value=client):
+            result = await radio_live.get_live_broadcast(source)
+        assert result is not None
+        assert result.artwork_url == "https://a.test/c.png"
+        assert client.get.await_count == 1

--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -461,7 +461,11 @@
 
 	/* the swappable station content — artwork + title — fades while tuning */
 	.now-block {
-		flex: 1 1 auto;
+		/* content-sized. it used to grow and centre, which was invisible while the
+		   artwork stretched to fill the leftover space — once covers were sized to
+		   their own ratio, that growth became a dead band under the title. slack
+		   belongs below the controls, per `.tuner`'s flex-start. */
+		flex: 0 0 auto;
 		min-height: 0;
 		display: flex;
 		flex-direction: column;
@@ -553,10 +557,12 @@
 	}
 
 	.art-stage {
-		/* a size container, so the cover can be sized against both of its axes */
-		container-type: size;
-		flex: 1 1 auto;
-		min-height: clamp(7rem, 22vh, 18rem);
+		--cover-max-height: clamp(7rem, 42vh, 26rem);
+		/* hug the cover exactly: don't grow (that left a dead band between the
+		   artwork and the title once covers stopped being stretched to fit) and
+		   don't shrink below it (that let a wide cover overlap the title). */
+		flex: 0 0 auto;
+		min-height: 0;
 		width: 100%;
 		position: relative;
 		display: flex;
@@ -594,13 +600,13 @@
 		z-index: 1;
 		flex: 0 0 auto;
 		display: block;
-		/* fit inside the stage at the cover's own ratio: take the full height
-		   unless that would overflow the width, in which case width wins.
-		   percentage max-heights can't express this — they don't resolve against
-		   an auto-height parent, which is how a square cover became a tall slice. */
-		height: min(100cqh, calc(100cqw / var(--cover-ratio, 1)));
+		/* sized from the column width and a viewport cap, at the cover's own
+		   ratio — so a square cover reads square and a widescreen one reads wide,
+		   neither cropped. driven by width rather than the stage's height,
+		   because the stage now hugs this box instead of the other way round. */
+		width: min(100%, calc(var(--cover-max-height) * var(--cover-ratio, 1)));
 		aspect-ratio: var(--cover-ratio, 1);
-		width: auto;
+		height: auto;
 		text-decoration: none;
 		border-radius: var(--radius-md);
 		overflow: hidden;
@@ -1057,12 +1063,12 @@
 		.radio-player { gap: 0.4rem; }
 		.now-block { gap: 0.35rem; }
 		.now-meta h2 { font-size: clamp(1.35rem, 4.2vh, 2rem); }
-		.art-stage { min-height: clamp(5rem, 15vh, 11rem); }
+		.art-stage { --cover-max-height: clamp(5rem, 15vh, 11rem); }
 	}
 
 	@media (max-height: 560px) {
 		.now-meta h2 { font-size: 1.2rem; }
-		.art-stage { min-height: 4.5rem; }
+		.art-stage { --cover-max-height: 4.5rem; }
 		/* no room for the deck on a very short screen */
 		.station-board { display: none; }
 	}

--- a/loq.toml
+++ b/loq.toml
@@ -328,11 +328,11 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/[[][[]station[]][]]/+page.svelte"
-max_lines = 1069
+max_lines = 1075
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"
-max_lines = 1093
+max_lines = 1179
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"


### PR DESCRIPTION
Two follow-ups to the cover-sizing change, both found by looking at the page.

## the gap under the cover — mine, and it hit every station

Stopping covers from stretching left behind the space they used to fill. `.art-stage` kept `flex: 1 1 auto` and `.now-block` grew and centred — invisible while artwork stretched to fill the leftover, a large dead band under the title once it didn't.

Both are now content-sized, so slack falls **below** the controls, which is what `.tuner`'s `justify-content: flex-start` already said it wanted ("any slack falls below, never above"). The cover is sized from the column width and a viewport cap at its own ratio, rather than from the stage's height — that inversion is what lets the stage hug it.

Measured across 4 stations × 3 viewports:

```
cover -> title :  7-15px
title -> cta   :  6-14px
overlap        :  none
cta in view    :  everywhere
```

## a single status bit shouldn't be able to take a station off air

The broadcaster reported `live: false` for ~40 minutes while its playlist kept advancing and its segments decoded fine:

```
MEDIA-SEQUENCE 1019 -> 1023 over 12s
newest segment: HTTP 200, 55,272 bytes, 3.968s of AAC
health:         {"live": false}
```

plyr believed it and showed OFF AIR over audio anyone could have played. relay-eval has since fixed the endpoint (`472791e` — `live` now derives from the newest segment in the playlist, verified here: `live: true` with `last_segment_at` advancing every 8s). But the failure mode is worth designing out, because the playlist is what a listener actually plays and the status field is a description of it.

So a **negative** report now gets a second opinion: no `#EXT-X-ENDLIST`, and a `PROGRAM-DATE-TIME` on the newest segment within 45s means it airs. A **positive** report is still trusted immediately with no extra fetch — pinned by a test that asserts the playlist is never fetched in that case.

<details>
<summary>verification</summary>

Backend `1429 passed`, frontend `120 passed`, ruff/ty/svelte-check/eslint clean.

New coverage: an advancing playlist overrides a down report; a stale playlist stays off air; an `ENDLIST` playlist stays off air; a healthy report never fetches the playlist. The helper was also run against the real stream while it was mis-reporting, and returned `True` — i.e. plyr would have kept airing it.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)