### PR TITLE
feat(radio): a station can credit where its audio comes from

### DIFF
--- a/backend/src/backend/api/radio/schemas.py
+++ b/backend/src/backend/api/radio/schemas.py
@@ -72,6 +72,8 @@ class StationSummary(BaseModel):
     name: str
     description: str
     is_default: bool
+    # where the station's audio comes from, when it comes from elsewhere.
+    source_url: str | None = None
 
 
 class StationsResponse(BaseModel):

--- a/backend/src/backend/api/radio/state.py
+++ b/backend/src/backend/api/radio/state.py
@@ -228,6 +228,7 @@ async def list_stations() -> StationsResponse:
                 name=station.name,
                 description=station.description,
                 is_default=station.slug == stations.DEFAULT_STATION_SLUG,
+                source_url=station.source_url,
             )
             for station in stations.STATIONS
         ],

--- a/backend/src/backend/api/radio/stations.py
+++ b/backend/src/backend/api/radio/stations.py
@@ -86,6 +86,10 @@ class Station:
     corpus_filter: CorpusFilter = field(default=_exclude_slop)
     rank_decay: float = DEFAULT_RANK_DECAY
     exploration: float = DEFAULT_EXPLORATION
+    # where this station comes from, when it comes from somewhere. a station
+    # built out of the local catalog has no such place; one that airs someone
+    # else's broadcast does, and crediting it is the point.
+    source_url: str | None = None
     # when set, this station airs the broadcast whenever it is live and falls
     # back to its rotation when it is not. this tuple is the allowlist: who may
     # preempt is a curation decision, made here, not something a publisher can
@@ -131,6 +135,7 @@ STATIONS: tuple[Station, ...] = (
         slug="firehose",
         name="firehose",
         description="the atproto firehose, sonified live",
+        source_url="https://relay-eval.waow.tech/sonify",
         # off-air, the station plays the archived segments of the same signal,
         # so it stays about the firehose either way rather than becoming a
         # generic music station whenever the broadcast drops.

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -1177,3 +1177,19 @@ class TestLivenessFallsBackToThePlaylist:
         assert result is not None
         assert result.artwork_url == "https://a.test/c.png"
         assert client.get.await_count == 1
+
+
+async def test_a_station_can_credit_where_its_audio_comes_from(
+    radio_app: FastAPI,
+) -> None:
+    """firehose airs someone else's broadcast; the lineup links back to it."""
+    async with AsyncClient(
+        transport=ASGITransport(app=radio_app),
+        base_url="https://radio.plyr.fm",
+    ) as client:
+        response = await client.get("/radio/stations")
+
+    by_slug = {s["slug"]: s for s in response.json()["stations"]}
+    assert by_slug["firehose"]["source_url"] == "https://relay-eval.waow.tech/sonify"
+    # a station built from the local catalog has no elsewhere to point at
+    assert by_slug["loved"]["source_url"] is None

--- a/frontend/src/lib/radio.svelte.ts
+++ b/frontend/src/lib/radio.svelte.ts
@@ -31,6 +31,8 @@ export interface RadioStation {
 	name: string;
 	description: string;
 	is_default: boolean;
+	/** where the station's audio comes from, when it comes from elsewhere */
+	source_url?: string | null;
 }
 
 export interface LiveBroadcast {

--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -226,9 +226,19 @@
 						</h2>
 						<a class="artist" href={`/u/${radio.current.artist_handle}`}>{radio.current.artist}</a>
 					{:else}
-						<!-- a broadcast has no track page or uploader to link to -->
+						<!-- a broadcast has no track page or uploader to link to, but it
+						     does have a source, and crediting it is the point -->
 						<h2>{radio.state?.station ?? 'live'}</h2>
-						<span class="artist">{radio.activeStation?.description ?? ''}</span>
+						{#if radio.activeStation?.source_url}
+							<a
+								class="artist"
+								href={radio.activeStation.source_url}
+								target="_blank"
+								rel="noopener"
+							>{radio.activeStation.description}</a>
+						{:else}
+							<span class="artist">{radio.activeStation?.description ?? ''}</span>
+						{/if}
 					{/if}
 				</div>
 				</div>

--- a/loq.toml
+++ b/loq.toml
@@ -328,11 +328,11 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/[[][[]station[]][]]/+page.svelte"
-max_lines = 1075
+max_lines = 1085
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"
-max_lines = 1179
+max_lines = 1195
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"


### PR DESCRIPTION
`firehose` airs someone else's broadcast, so its description now links to [relay-eval.waow.tech/sonify](https://relay-eval.waow.tech/sonify) — the dashboard the sound is actually made of.

Modelled as `source_url` on the station rather than a link hardcoded for one slug. A station built from the local catalog has no elsewhere to point at (`loved`/`fresh`/`deep-cuts`/`slop` stay `null`); one that airs an external broadcast does, and crediting it is the point. Additive on `/radio/stations`, so older clients ignore it.

<details>
<summary>verified in a browser</summary>

```
link present : true
  text       : the atproto firehose, sonified live
  href       : https://relay-eval.waow.tech/sonify
  target/rel : _blank / noopener
  clickable  : true
cover shown  : true      (the live cover still renders alongside)
```

Backend `1430 passed`, frontend `120 passed`, lint/type-check clean.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)