### PR TITLE
fix(radio): don't take Chrome's word for native HLS

### DIFF
--- a/frontend/src/lib/player-live-radio.test.ts
+++ b/frontend/src/lib/player-live-radio.test.ts
@@ -1,5 +1,5 @@
-// a live broadcast preempts the rotation: no position to resume, and hls.js is
-// only fetched when the browser can't play HLS natively.
+// a live broadcast preempts the rotation: no position to resume, and hls.js
+// drives it wherever hls.js works — native HLS is the fallback, not the default.
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { player, type RadioNowPlaying } from '$lib/player.svelte';
 import type { Track } from '$lib/types';
@@ -9,8 +9,9 @@ vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
 vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
 
 const hlsInstance = { loadSource: vi.fn(), attachMedia: vi.fn(), destroy: vi.fn() };
+let hlsSupported = true;
 class HlsCtor {
-	static isSupported = () => true;
+	static isSupported = () => hlsSupported;
 	loadSource = hlsInstance.loadSource;
 	attachMedia = hlsInstance.attachMedia;
 	destroy = hlsInstance.destroy;
@@ -48,13 +49,16 @@ describe('live radio', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		hlsSupported = true;
 		el = document.createElement('audio');
 		player.audioElement = el;
 		player.stopRadio();
 	});
 
-	it('uses hls.js when the browser cannot play HLS natively', async () => {
-		vi.spyOn(el, 'canPlayType').mockReturnValue('');
+	it('uses hls.js even where canPlayType claims native HLS support', async () => {
+		// Chrome answers "maybe" for the HLS mime type and then cannot demux the
+		// MPEG-TS segments — trusting it left the station on-air and silent.
+		vi.spyOn(el, 'canPlayType').mockReturnValue('maybe');
 		player.playRadio(live());
 		await vi.waitFor(() => expect(hlsInstance.attachMedia).toHaveBeenCalled());
 		expect(hlsInstance.loadSource).toHaveBeenCalledWith('https://relay.test/live/index.m3u8');
@@ -62,7 +66,17 @@ describe('live radio', () => {
 		expect(el.src).toBe('');
 	});
 
-	it('plays natively on Safari/iOS without loading hls.js', async () => {
+	it('starts playback once hls.js has media, not before the async import', async () => {
+		vi.spyOn(el, 'canPlayType').mockReturnValue('maybe');
+		player.playRadio(live());
+		await vi.waitFor(() => expect(hlsInstance.attachMedia).toHaveBeenCalled());
+		const playOrder = (el.play as ReturnType<typeof vi.fn>).mock.invocationCallOrder;
+		const attachOrder = hlsInstance.attachMedia.mock.invocationCallOrder[0];
+		expect(playOrder.some((order) => order > attachOrder)).toBe(true);
+	});
+
+	it('falls back to native playback where hls.js is unsupported (iOS Safari)', async () => {
+		hlsSupported = false;
 		vi.spyOn(el, 'canPlayType').mockReturnValue('maybe');
 		player.playRadio(live());
 		await vi.waitFor(() => expect(el.src).toContain('index.m3u8'));
@@ -83,7 +97,7 @@ describe('live radio', () => {
 		const np = live();
 		np.start_at = 300; // a stale rotation position must be ignored
 		player.playRadio(np);
-		await vi.waitFor(() => expect(el.src).toContain('index.m3u8'));
+		await vi.waitFor(() => expect(hlsInstance.attachMedia).toHaveBeenCalled());
 		expect(el.currentTime).toBe(0);
 	});
 

--- a/frontend/src/lib/player.svelte.ts
+++ b/frontend/src/lib/player.svelte.ts
@@ -103,7 +103,7 @@ class PlayerState {
 		this.unlockPlayCount();
 		const el = this.audioElement;
 		if (!el) return;
-		void this.attachRadioSource(el, np, assigned);
+		void this.attachRadioSource(el, np, assigned, autoplay);
 		if (autoplay) {
 			// play immediately (preserve the gesture), then align to station position
 			el.play().catch((err: unknown) => {
@@ -137,24 +137,29 @@ class PlayerState {
 
 	/** point the shared element at a radio source, via hls.js when required.
 	 *
-	 * Safari and iOS play HLS natively from `src`; Chrome and Firefox do not, so
-	 * hls.js is imported only when a live station is actually tuned. everyone
-	 * else never downloads it.
+	 * hls.js comes first wherever it works, and native `src` is the fallback —
+	 * not the other way round. `canPlayType('application/vnd.apple.mpegurl')`
+	 * answers "maybe" in Chrome, which cannot actually demux MPEG-TS, so
+	 * trusting it hands the element a playlist it will never decode: on air,
+	 * cover showing, silent. Where hls.js is unsupported (iOS Safari, no MSE)
+	 * native playback is real, and that is exactly the fallback.
+	 *
+	 * hls.js is imported only when a live station is actually tuned.
 	 */
 	private async attachRadioSource(
 		el: HTMLAudioElement,
 		np: RadioNowPlaying,
-		assigned: RadioNowPlaying | null
+		assigned: RadioNowPlaying | null,
+		autoplay: boolean
 	) {
 		this.detachHls();
-		const needsHlsJs =
-			np.live &&
-			np.streamKind === 'hls' &&
-			!el.canPlayType('application/vnd.apple.mpegurl');
-
-		if (!needsHlsJs) {
+		const playNative = () => {
 			el.src = np.stream_url;
 			el.load();
+		};
+
+		if (!np.live || np.streamKind !== 'hls') {
+			playNative();
 			return;
 		}
 
@@ -164,14 +169,20 @@ class PlayerState {
 			// raw object and never equals `this.radio`.
 			if (this.radio !== assigned) return; // tuned away while the chunk loaded
 			if (!Hls.isSupported()) {
-				el.src = np.stream_url;
-				el.load();
+				playNative();
 				return;
 			}
 			const hls = new Hls({ enableWorker: true });
 			this.hls = hls;
 			hls.loadSource(np.stream_url);
 			hls.attachMedia(el);
+			// the gesture's own play() ran against an element with no source yet
+			// (the import is async), so it was rejected. start once media exists.
+			if (autoplay) {
+				el.play().catch(() => {
+					this.paused = true;
+				});
+			}
 		} catch (e) {
 			console.error('failed to load hls.js for live radio:', e);
 			this.paused = true;


### PR DESCRIPTION
The firehose station came up on-air — cover art current, LIVE badge, "stop" button — and played nothing. The live path asked `canPlayType('application/vnd.apple.mpegurl')`, Chrome answered `"maybe"`, and we handed the audio element a playlist whose MPEG-TS segments it cannot demux. hls.js now drives the broadcast wherever hls.js works; native playback is the fallback for the browsers where it's real.

<details>
<summary>what was actually wrong</summary>

`attachRadioSource` treated native HLS as the preferred path and hls.js as the exception:

```ts
const needsHlsJs = np.live && np.streamKind === 'hls'
    && !el.canPlayType('application/vnd.apple.mpegurl');
```

Chrome returns `"maybe"` for that MIME type and cannot play it — a long-standing quirk that is why hls.js's own guidance is to check `Hls.isSupported()` first and fall back to native only when it's false. Under that ordering, iOS Safari (no MSE, real native HLS) still gets the native path, and everything else gets a working one.

Second, smaller bug on the same path: `playRadio` calls `el.play()` synchronously to preserve the user gesture, but `attachRadioSource` is async — the dynamic `import('hls.js')` means that `play()` ran against an element with no source. It now also plays after `attachMedia`.

</details>

<details>
<summary>verification</summary>

Origin was never the problem: `/api/sonify/live` reports `live: true`, the playlist advances (`EXT-X-MEDIA-SEQUENCE` climbing, `PROGRAM-DATE-TIME` seconds old), segments and cover both return 200 with `access-control-allow-origin: *`, and `/radio/state.json?station=firehose` returns the `live` block.

Local dev server against the prod API, tuned in via Playwright:

| | `audio.src` | decoded bytes over 13s |
| --- | --- | --- |
| before | `https://relay-eval.waow.tech/.../index.m3u8` | native path, browser-dependent |
| after | `blob:` (MSE, hls.js) | 18k → 80k → 142k, `currentTime` advancing |

Caveat worth stating: Playwright's bundled Chromium *does* decode the raw playlist, so it does not reproduce the silence — this is not a claimed reproduction of nate's exact browser state. The claim is narrower and sufficient: the old code's correctness depended on a MIME check that is known to lie, and the new code doesn't depend on it at all.

</details>

<details>
<summary>tests</summary>

`player-live-radio.test.ts` had encoded the wrong precedence — its "plays natively on Safari/iOS" case asserted the exact behavior that breaks Chrome. Replaced with:
- hls.js is used *even when* `canPlayType` says `"maybe"`
- native is the fallback only when `Hls.isSupported()` is false
- `play()` is invoked after `attachMedia`, not only before the import resolves

</details>

<details>
<summary>not in scope</summary>

The `firehose` rotation is still empty (0 tracks — waow.tech's segments are `unlisted`), so the station has no off-air fallback. That's a publishing decision, unchanged here.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)