### PR TITLE
fix(radio): don't spend the tap's autoplay permission on a module fetch

### DIFF
--- a/frontend/src/lib/player-live-radio.test.ts
+++ b/frontend/src/lib/player-live-radio.test.ts
@@ -50,6 +50,9 @@ describe('live radio', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		hlsSupported = true;
+		// the player is a module singleton — start every case with a cold module
+		// so the preload-warmed path is only exercised where it's the subject.
+		Object.assign(player, { hlsModule: null, hlsLoad: null });
 		el = document.createElement('audio');
 		player.audioElement = el;
 		player.stopRadio();
@@ -73,6 +76,24 @@ describe('live radio', () => {
 		const playOrder = (el.play as ReturnType<typeof vi.fn>).mock.invocationCallOrder;
 		const attachOrder = hlsInstance.attachMedia.mock.invocationCallOrder[0];
 		expect(playOrder.some((order) => order > attachOrder)).toBe(true);
+	});
+
+	it('attaches synchronously once preloaded, keeping the tap gesture intact', async () => {
+		// mobile only honours a play() in the same task as the tap, so a warmed
+		// module must not push the attach onto a later microtask.
+		vi.spyOn(el, 'canPlayType').mockReturnValue('maybe');
+		await player.preloadHls();
+		vi.clearAllMocks();
+		player.playRadio(live());
+		expect(hlsInstance.attachMedia).toHaveBeenCalled(); // no await
+		expect(el.play).toHaveBeenCalledTimes(1); // the gesture's own play, not a replay
+	});
+
+	it('disables remote playback so iOS ManagedMediaSource will attach', async () => {
+		vi.spyOn(el, 'canPlayType').mockReturnValue('maybe');
+		player.playRadio(live());
+		await vi.waitFor(() => expect(hlsInstance.attachMedia).toHaveBeenCalled());
+		expect(el.disableRemotePlayback).toBe(true);
 	});
 
 	it('falls back to native playback where hls.js is unsupported (iOS Safari)', async () => {

--- a/frontend/src/lib/player.svelte.ts
+++ b/frontend/src/lib/player.svelte.ts
@@ -21,6 +21,16 @@ interface RadioPlaybackOptions {
 	autoplay?: boolean;
 }
 
+/** the slice of hls.js's default export the player uses. */
+type HlsModule = {
+	isSupported(): boolean;
+	new (config: { enableWorker: boolean }): {
+		loadSource(url: string): void;
+		attachMedia(el: HTMLMediaElement): void;
+		destroy(): void;
+	};
+};
+
 // natural timeupdate steps are sub-second; a larger jump is a seek, scrub, or a
 // restored hydration position — none of which is listened time.
 const PLAY_PROGRESS_SEEK_THRESHOLD_S = 5;
@@ -34,6 +44,10 @@ class PlayerState {
 	/** live hls.js instance, when a broadcast needs one. not reactive — it is a
 	 * teardown handle, never rendered. */
 	private hls: { destroy(): void } | null = null;
+	/** hls.js itself, once fetched, plus the in-flight fetch. cached so a tune-in
+	 * can attach synchronously inside the tap that asked for it. */
+	private hlsModule: HlsModule | null = null;
+	private hlsLoad: Promise<HlsModule | null> | null = null;
 	paused = $state(true);
 
 	currentTime = $state(0);
@@ -135,23 +149,44 @@ class PlayerState {
 		else el.onloadedmetadata = seek;
 	}
 
+	/** fetch hls.js ahead of a tune-in, so attaching can happen synchronously.
+	 *
+	 * Mobile autoplay policy only honours a play() that runs in the same task as
+	 * the tap. Awaiting the dynamic import inside the tap handler spends that
+	 * permission, so the module is warmed as soon as the station's state says a
+	 * broadcast is live — long before anyone taps. Idempotent; the in-flight
+	 * promise is shared. Callers that don't have a live HLS source never call
+	 * this and never download the chunk.
+	 */
+	preloadHls(): Promise<HlsModule | null> {
+		this.hlsLoad ??= import('hls.js')
+			.then(({ default: Hls }) => (this.hlsModule = Hls as unknown as HlsModule))
+			.catch((e: unknown) => {
+				console.error('failed to load hls.js for live radio:', e);
+				this.hlsLoad = null; // let a later tune-in retry
+				return null;
+			});
+		return this.hlsLoad;
+	}
+
 	/** point the shared element at a radio source, via hls.js when required.
 	 *
 	 * hls.js comes first wherever it works, and native `src` is the fallback —
 	 * not the other way round. `canPlayType('application/vnd.apple.mpegurl')`
 	 * answers "maybe" in Chrome, which cannot actually demux MPEG-TS, so
 	 * trusting it hands the element a playlist it will never decode: on air,
-	 * cover showing, silent. Where hls.js is unsupported (iOS Safari, no MSE)
-	 * native playback is real, and that is exactly the fallback.
+	 * cover showing, silent. Where hls.js is unsupported native playback is
+	 * real, and that is exactly the fallback.
 	 *
-	 * hls.js is imported only when a live station is actually tuned.
+	 * Synchronous whenever `preloadHls()` has already resolved, which is what
+	 * keeps the tap's autoplay permission intact on mobile.
 	 */
-	private async attachRadioSource(
+	private attachRadioSource(
 		el: HTMLAudioElement,
 		np: RadioNowPlaying,
 		assigned: RadioNowPlaying | null,
 		autoplay: boolean
-	) {
+	): void {
 		this.detachHls();
 		const playNative = () => {
 			el.src = np.stream_url;
@@ -163,30 +198,40 @@ class PlayerState {
 			return;
 		}
 
-		try {
-			const { default: Hls } = await import('hls.js');
+		if (this.hlsModule) {
+			this.attachHls(this.hlsModule, el, np, playNative);
+			return;
+		}
+
+		// cold module: the tap's own play() will have failed against a sourceless
+		// element, so replay it once media exists.
+		void this.preloadHls().then((Hls) => {
 			// compare against the $state proxy captured at tune-in — `np` is the
 			// raw object and never equals `this.radio`.
 			if (this.radio !== assigned) return; // tuned away while the chunk loaded
-			if (!Hls.isSupported()) {
-				playNative();
-				return;
-			}
-			const hls = new Hls({ enableWorker: true });
-			this.hls = hls;
-			hls.loadSource(np.stream_url);
-			hls.attachMedia(el);
-			// the gesture's own play() ran against an element with no source yet
-			// (the import is async), so it was rejected. start once media exists.
-			if (autoplay) {
-				el.play().catch(() => {
-					this.paused = true;
-				});
-			}
-		} catch (e) {
-			console.error('failed to load hls.js for live radio:', e);
-			this.paused = true;
+			if (!Hls) return void (this.paused = true);
+			this.attachHls(Hls, el, np, playNative);
+			if (autoplay) el.play().catch(() => (this.paused = true));
+		});
+	}
+
+	private attachHls(
+		Hls: HlsModule,
+		el: HTMLAudioElement,
+		np: RadioNowPlaying,
+		playNative: () => void
+	): void {
+		if (!Hls.isSupported()) {
+			playNative();
+			return;
 		}
+		// iOS drives HLS through ManagedMediaSource, which the platform refuses to
+		// hand to an element that still advertises AirPlay.
+		el.disableRemotePlayback = true;
+		const hls = new Hls({ enableWorker: true });
+		this.hls = hls;
+		hls.loadSource(np.stream_url);
+		hls.attachMedia(el);
 	}
 
 	/** tear down any hls.js instance so its buffers and timers stop. */

--- a/frontend/src/lib/radio.svelte.ts
+++ b/frontend/src/lib/radio.svelte.ts
@@ -232,6 +232,9 @@ class Radio {
 			this.state = await response.json();
 			this.station = this.state?.station_slug ?? this.station;
 			this.error = null;
+			// warm hls.js now so tuning in can attach inside the tap itself —
+			// mobile only grants autoplay to a play() in the gesture's own task.
+			if (this.state?.live?.kind === 'hls') void player.preloadHls();
 		} catch (e) {
 			console.error('failed to load radio state:', e);
 			this.error = 'radio is off air right now';


### PR DESCRIPTION
Live radio worked on desktop and not on mobile: the station read **stop**, and nothing played. Mobile only honours a `play()` that runs in the same task as the tap, and #1749's tune-in awaited `import('hls.js')` before the element had any media — so the permission was gone by the time there was something to play. hls.js is now warmed as soon as the station's state reports a live broadcast, so attaching happens synchronously inside the gesture.

<details>
<summary>reproduction</summary>

WebKit under iPhone 14 emulation, `/radio/firehose`, tap "tune in":

| | hls.js fetched before the tap | after 9s |
| --- | --- | --- |
| production (#1749) | no | `paused: true`, `readyState: 1`, console looping `playback failed: AbortError` |
| this branch | yes | `paused: false`, `readyState: 4`, `currentTime: 19` |

Desktop Chromium is unchanged: `blob:` MSE source, `currentTime` 18s, 78k decoded bytes.

</details>

<details>
<summary>what changed</summary>

- `player.preloadHls()` — idempotent, shares the in-flight promise, caches the module. Called from `radio.svelte.ts` when `state.live.kind === 'hls'`. Stations without a live HLS source never call it and never download the chunk, so the lazy-loading property #1749 wanted is intact.
- `attachRadioSource` is synchronous when the module is warm. The cold path is kept — it replays `play()` after `attachMedia` — it just isn't the path mobile takes any more.
- `el.disableRemotePlayback = true` before `attachMedia`. iOS drives HLS through ManagedMediaSource, which the platform refuses to hand to an element still advertising AirPlay. WebKit emulation reports `ManagedMediaSource in window`, so this path is real there.

</details>

<details>
<summary>tests</summary>

- a warmed module attaches with no `await`, and `play()` is called exactly once (the gesture's own — no replay)
- `disableRemotePlayback` is set before attach
- `beforeEach` resets the module cache: `player` is a singleton, so without it the warm path leaks into cases meant to exercise the cold one

</details>

<details>
<summary>noticed, not fixed</summary>

The failing tune-in logged `[player] playback failed: AbortError` on a loop rather than once — something retries a failed radio play indefinitely. Harmless once playback works, but it's why the failure was noisy rather than silent, and it deserves its own look.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)