### PR TITLE
feat(radio): artwork-accent wash + CRT treatment on the on-air stage

### DIFF
--- a/frontend/src/lib/components/radio/AccentWash.svelte
+++ b/frontend/src/lib/components/radio/AccentWash.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { ArtworkAccent } from '$lib/utils/artwork-accent';
+	import { themeColorFromAccent } from '$lib/utils/artwork-accent';
+
+	let { accent }: { accent: ArtworkAccent | null } = $props();
+
+	// double-buffered wash: the incoming accent renders on the inactive layer,
+	// then the layers cross-fade — a track change dissolves instead of snapping.
+	let layers = $state<[ArtworkAccent | null, ArtworkAccent | null]>([null, null]);
+	let active = $state<0 | 1>(0);
+	let lastKey = '';
+
+	$effect(() => {
+		const key = accent ? `${accent.primary}|${accent.secondary}` : '';
+		if (key === lastKey) return;
+		lastKey = key;
+		const next = active === 0 ? 1 : 0;
+		layers[next] = accent;
+		// let the new layer paint at opacity 0 before fading it in
+		window.requestAnimationFrame(() => (active = next));
+	});
+
+	// tint mobile browser chrome to match; restore the app default on leave.
+	const DEFAULT_THEME_COLOR = '#0a0a0a';
+	let themeMeta: HTMLMetaElement | null = null;
+	onMount(() => {
+		themeMeta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+		return () => themeMeta?.setAttribute('content', DEFAULT_THEME_COLOR);
+	});
+	$effect(() => {
+		themeMeta?.setAttribute(
+			'content',
+			accent ? themeColorFromAccent(accent) : DEFAULT_THEME_COLOR
+		);
+	});
+
+	function layerStyle(layer: ArtworkAccent | null): string {
+		if (!layer) return 'opacity: 0';
+		return `--wash-a: ${layer.primary}; --wash-b: ${layer.secondary};`;
+	}
+</script>
+
+<div class="ambient" aria-hidden="true">
+	{#each [0, 1] as index (index)}
+		<div class="layer" class:active={active === index && layers[index] !== null} style={layerStyle(layers[index])}></div>
+	{/each}
+</div>
+
+<style>
+	.ambient {
+		position: fixed;
+		inset: 0;
+		z-index: 0;
+		pointer-events: none;
+	}
+
+	/* plain radial gradients only — SVG noise filters band on this backdrop */
+	.layer {
+		position: absolute;
+		inset: 0;
+		opacity: 0;
+		transition: opacity 1.4s ease;
+		background:
+			radial-gradient(
+				90% 55% at 50% 18%,
+				rgb(var(--wash-a, 0 0 0) / 0.16),
+				rgb(var(--wash-a, 0 0 0) / 0.05) 55%,
+				transparent 78%
+			),
+			radial-gradient(
+				60% 40% at 72% 68%,
+				rgb(var(--wash-b, 0 0 0) / 0.08),
+				transparent 70%
+			);
+	}
+
+	.layer.active {
+		opacity: 1;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.layer {
+			transition: opacity 0.4s ease;
+		}
+	}
+</style>

--- a/frontend/src/lib/utils/artwork-accent.ts
+++ b/frontend/src/lib/utils/artwork-accent.ts
@@ -1,0 +1,138 @@
+/**
+ * derive an accent from artwork.
+ *
+ * samples the image on a small canvas and buckets saturated pixels, scoring
+ * each bucket by saturation and closeness to mid-lightness so the pick reads
+ * as "the color of this cover" rather than its darkest or brightest pixel.
+ * monochrome covers fall back to their average tone, lifted slightly so the
+ * wash stays visible on a dark page.
+ *
+ * requires the image host to allow cross-origin reads (`crossorigin`
+ * + `Access-Control-Allow-Origin`); a tainted canvas throws, callers should
+ * treat any throw as "no accent" and keep the neutral look.
+ */
+
+export interface ArtworkAccent {
+	/** space-separated rgb triple, e.g. "190 124 143" */
+	primary: string;
+	secondary: string;
+}
+
+const SAMPLE_SIZE = 28;
+
+function rgbToHsl(
+	red: number,
+	green: number,
+	blue: number
+): { saturation: number; lightness: number } {
+	const r = red / 255;
+	const g = green / 255;
+	const b = blue / 255;
+	const max = Math.max(r, g, b);
+	const min = Math.min(r, g, b);
+	const lightness = (max + min) / 2;
+	if (max === min) return { saturation: 0, lightness };
+	const delta = max - min;
+	const saturation = lightness > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+	return { saturation, lightness };
+}
+
+interface Bucket {
+	red: number;
+	green: number;
+	blue: number;
+	count: number;
+	score: number;
+}
+
+export function extractArtworkAccent(image: HTMLImageElement): ArtworkAccent {
+	const canvas = document.createElement('canvas');
+	canvas.width = SAMPLE_SIZE;
+	canvas.height = SAMPLE_SIZE;
+	const context = canvas.getContext('2d', { willReadFrequently: true });
+	if (!context) throw new Error('canvas 2d context unavailable');
+	context.drawImage(image, 0, 0, SAMPLE_SIZE, SAMPLE_SIZE);
+
+	// throws on a tainted canvas (image host without CORS) — caller's problem
+	const pixels = context.getImageData(0, 0, SAMPLE_SIZE, SAMPLE_SIZE).data;
+
+	const buckets = new Map<string, Bucket>();
+	let neutralRed = 0;
+	let neutralGreen = 0;
+	let neutralBlue = 0;
+	let neutralCount = 0;
+
+	for (let index = 0; index < pixels.length; index += 4) {
+		if (pixels[index + 3] < 180) continue;
+		const red = pixels[index];
+		const green = pixels[index + 1];
+		const blue = pixels[index + 2];
+		const { saturation, lightness } = rgbToHsl(red, green, blue);
+		if (lightness >= 0.12 && lightness <= 0.88) {
+			neutralRed += red;
+			neutralGreen += green;
+			neutralBlue += blue;
+			neutralCount += 1;
+		}
+		if (saturation < 0.22 || lightness < 0.12 || lightness > 0.88) continue;
+
+		const key = `${Math.round(red / 24)}:${Math.round(green / 24)}:${Math.round(blue / 24)}`;
+		const bucket = buckets.get(key) ?? { red: 0, green: 0, blue: 0, count: 0, score: 0 };
+		bucket.red += red;
+		bucket.green += green;
+		bucket.blue += blue;
+		bucket.count += 1;
+		bucket.score += saturation * (1 - Math.abs(lightness - 0.52));
+		buckets.set(key, bucket);
+	}
+
+	const ranked = [...buckets.values()]
+		.map((bucket) => ({
+			red: Math.round(bucket.red / bucket.count),
+			green: Math.round(bucket.green / bucket.count),
+			blue: Math.round(bucket.blue / bucket.count),
+			score: bucket.score * Math.log2(bucket.count + 1)
+		}))
+		.sort((left, right) => right.score - left.score);
+
+	if (ranked.length === 0) {
+		if (neutralCount === 0) throw new Error('no readable pixels');
+		const lift = 24;
+		const red = Math.round(neutralRed / neutralCount);
+		const green = Math.round(neutralGreen / neutralCount);
+		const blue = Math.round(neutralBlue / neutralCount);
+		return {
+			primary: `${red} ${green} ${blue}`,
+			secondary: `${Math.min(255, red + lift)} ${Math.min(255, green + lift)} ${Math.min(255, blue + lift)}`
+		};
+	}
+
+	const primary = ranked[0];
+	const secondary =
+		ranked.find(
+			(candidate) =>
+				Math.abs(candidate.red - primary.red) +
+					Math.abs(candidate.green - primary.green) +
+					Math.abs(candidate.blue - primary.blue) >
+				80
+		) ??
+		ranked[1] ??
+		primary;
+
+	return {
+		primary: `${primary.red} ${primary.green} ${primary.blue}`,
+		secondary: `${secondary.red} ${secondary.green} ${secondary.blue}`
+	};
+}
+
+/**
+ * blend an accent toward a dark base for `meta[name=theme-color]`, so mobile
+ * browser chrome reads as a darkened tint of the cover, not the raw color.
+ */
+export function themeColorFromAccent(accent: ArtworkAccent, base = 0x0a): string {
+	const parts = accent.primary.split(' ').map(Number);
+	if (parts.length !== 3 || !parts.every(Number.isFinite)) return '#0a0a0a';
+	const blend = (channel: number) => Math.round(channel * 0.22 + base * 0.78);
+	const hex = (value: number) => value.toString(16).padStart(2, '0');
+	return `#${hex(blend(parts[0]))}${hex(blend(parts[1]))}${hex(blend(parts[2]))}`;
+}

--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -9,6 +9,9 @@
 	import { radio } from '$lib/radio.svelte';
 	import { horizontalSwipe } from '$lib/horizontal-swipe';
 	import TunerDial from '$lib/components/radio/TunerDial.svelte';
+	import AccentWash from '$lib/components/radio/AccentWash.svelte';
+	import ScrollingText from '$lib/components/ScrollingText.svelte';
+	import { extractArtworkAccent, type ArtworkAccent } from '$lib/utils/artwork-accent';
 	import WaveLoading from '$lib/components/WaveLoading.svelte';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
 	import { IMAGE_WIDTHS, resizedImageUrl } from '$lib/utils/display-image';
@@ -26,6 +29,41 @@
 		const img = event.currentTarget as HTMLImageElement;
 		if (img.naturalHeight > 0) coverRatio = img.naturalWidth / img.naturalHeight;
 	}
+
+	// ambient accent from the on-air artwork. loads a thumbnail with CORS and
+	// samples it; any failure (host without ACAO, tainted canvas, no artwork)
+	// means no accent — the page keeps its neutral look.
+	let accent = $state<ArtworkAccent | null>(null);
+	let onAirArtworkUrl = $derived(
+		radio.current?.artwork_url ?? radio.state?.live?.artwork_url ?? null
+	);
+	$effect(() => {
+		const src = onAirArtworkUrl && resizedImageUrl(onAirArtworkUrl, IMAGE_WIDTHS.thumb);
+		if (!src) {
+			accent = null;
+			return;
+		}
+		let cancelled = false;
+		const image = new window.Image();
+		image.crossOrigin = 'anonymous';
+		image.src = src;
+		image.onload = () => {
+			if (cancelled) return;
+			try {
+				accent = extractArtworkAccent(image);
+			} catch {
+				accent = null;
+			}
+		};
+		image.onerror = () => {
+			if (!cancelled) accent = null;
+		};
+		return () => {
+			cancelled = true;
+			image.onload = null;
+			image.onerror = null;
+		};
+	});
 
 	// the URL path is the source of truth for the selected station (bookmarkable).
 	// `/radio` (no slug) shows the remembered/default station; `/radio/<slug>` pins it.
@@ -138,6 +176,8 @@
 
 <Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={handleLogout} />
 
+<AccentWash {accent} />
+
 <main class="radio-page">
 	<div class="tuner">
 	<section class="station">
@@ -146,6 +186,17 @@
 		{:else if radio.error}
 			<div class="status error">{radio.error}</div>
 		{:else if radio.hasSomethingOnAir}
+			<!-- broadcast-set treatment over the on-air artwork: scanline texture, a
+			     slow sweep, a vignette, and a scan-load wipe on track change. purely
+			     decorative; reduced-motion stills the animated pieces. -->
+			{#snippet crtOverlays()}
+				{#key radio.current?.id ?? activeSlug}
+					<div class="crt-scanload" aria-hidden="true"></div>
+				{/key}
+				<div class="crt-scanlines" aria-hidden="true"></div>
+				<div class="crt-sweep" aria-hidden="true"></div>
+				<div class="crt-vignette" aria-hidden="true"></div>
+			{/snippet}
 			<div class="radio-player" {@attach horizontalSwipe((dir) => flip(dir === 'left' ? 'next' : 'prev'))}>
 				<div class="station-title">
 					<span class="live">live radio</span>
@@ -191,6 +242,7 @@
 								{:else}
 									<div class="art fallback"></div>
 								{/if}
+								{@render crtOverlays()}
 							</a>
 						</SensitiveImage>
 					{:else if radio.state?.live?.artwork_url}
@@ -202,6 +254,7 @@
 								class="art"
 								onload={readCoverRatio}
 							/>
+							{@render crtOverlays()}
 						</div>
 					{:else}
 						<!-- no cover published for this broadcast: a placeholder sized like
@@ -213,6 +266,7 @@
 									<path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14" />
 								</svg>
 							</div>
+							{@render crtOverlays()}
 						</div>
 					{/if}
 				</div>
@@ -222,7 +276,7 @@
 					</p>
 					{#if radio.current}
 						<h2>
-							<a href={`/track/${radio.current.id}`}>{radio.current.title}</a>
+							<a href={`/track/${radio.current.id}`}><ScrollingText text={radio.current.title} trigger="always" /></a>
 						</h2>
 						<a class="artist" href={`/u/${radio.current.artist_handle}`}>{radio.current.artist}</a>
 					{:else}
@@ -327,6 +381,8 @@
 <style>
 	.radio-page {
 		position: relative;
+		/* sit above the fixed ambient wash */
+		z-index: 1;
 		max-width: 980px;
 		/* the global header has a 2rem margin-bottom; cancel most of it so the tuner
 		   sits just under the header (a small breathing gap, not a dead band) */
@@ -650,6 +706,125 @@
 		transform: translateY(-1px);
 	}
 
+	/* ── CRT treatment ──────────────────────────────────────────────────────
+	   the on-air artwork reads as a broadcast monitor: hairline scanlines, a
+	   slow phosphor sweep, a corner vignette, and a scan-load wipe whenever
+	   the on-air track changes. all layers are pure CSS gradients (no SVG
+	   noise — it bands), pointer-events: none, and clipped by .art-link. */
+	.crt-scanlines,
+	.crt-sweep,
+	.crt-vignette,
+	.crt-scanload {
+		position: absolute;
+		inset: 0;
+		border-radius: inherit;
+		pointer-events: none;
+		z-index: 2;
+	}
+
+	.crt-scanlines {
+		background: repeating-linear-gradient(
+			0deg,
+			rgba(0, 0, 0, 0.16) 0px,
+			rgba(0, 0, 0, 0.16) 1px,
+			transparent 1px,
+			transparent 3px
+		);
+		opacity: 0.5;
+	}
+
+	/* a faint highlight band drifting down the tube */
+	.crt-sweep {
+		overflow: hidden;
+	}
+
+	.crt-sweep::before {
+		content: '';
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: -30%;
+		height: 22%;
+		background: linear-gradient(
+			to bottom,
+			transparent,
+			rgba(255, 255, 255, 0.045) 50%,
+			transparent
+		);
+		animation: crt-sweep-drift 9s linear infinite;
+	}
+
+	@keyframes crt-sweep-drift {
+		to {
+			transform: translateY(590%);
+		}
+	}
+
+	.crt-vignette {
+		background: radial-gradient(
+			120% 120% at 50% 50%,
+			transparent 58%,
+			rgba(0, 0, 0, 0.22) 100%
+		);
+	}
+
+	/* one-shot wipe when the on-air track changes: a bright scanline sweeps
+	   down once, trailing a brief dim, then the layer goes inert */
+	.crt-scanload {
+		overflow: hidden;
+		animation: crt-scanload-fade 0.9s ease-out forwards;
+	}
+
+	.crt-scanload::before {
+		content: '';
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: -12%;
+		height: 10%;
+		background: linear-gradient(
+			to bottom,
+			transparent,
+			rgba(255, 255, 255, 0.28) 55%,
+			rgba(255, 255, 255, 0.06)
+		);
+		animation: crt-scanload-sweep 0.65s ease-in forwards;
+	}
+
+	@keyframes crt-scanload-sweep {
+		to {
+			transform: translateY(1150%);
+		}
+	}
+
+	@keyframes crt-scanload-fade {
+		0% {
+			background: rgba(0, 0, 0, 0.35);
+		}
+		60% {
+			background: rgba(0, 0, 0, 0.08);
+		}
+		100% {
+			background: transparent;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.crt-sweep::before,
+		.crt-scanload,
+		.crt-scanload::before {
+			animation: none;
+		}
+
+		.crt-scanload {
+			background: transparent;
+		}
+
+		.crt-scanload::before {
+			content: none;
+		}
+	}
+
 	.art.fallback {
 		background:
 			linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 45%),
@@ -687,14 +862,16 @@
 		margin: 0;
 		font-size: clamp(1.5rem, 4.6vw, 2.65rem);
 		line-height: 1.1;
-		/* long titles (e.g. DJ-set names with dates) must not blow up the
-		   fixed-height layout: wrap hard, then clamp to two lines with an ellipsis */
+		/* long titles must not blow up the fixed-height layout: track titles
+		   stay on one line and marquee (ScrollingText); the broadcast fallback
+		   below has no marquee, so it still wraps */
 		overflow-wrap: anywhere;
-		display: -webkit-box;
-		-webkit-box-orient: vertical;
-		-webkit-line-clamp: 2;
-		line-clamp: 2;
 		overflow: hidden;
+	}
+
+	.now-meta h2 a {
+		display: block;
+		max-width: 100%;
 	}
 
 	.now-meta h2 a {

--- a/loq.toml
+++ b/loq.toml
@@ -327,7 +327,7 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/[[][[]station[]][]]/+page.svelte"
-max_lines = 1085
+max_lines = 1262
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"


### PR DESCRIPTION
part of #1752 (phase 1). `/radio` now takes its ambient light from the on-air artwork, and the artwork itself gets a broadcast-monitor treatment: scanlines, a slow sweep, a vignette, and a scan-load wipe on track change.

## motivation

adopted from [sister-radio](https://tangled.org/okami.mom/sister-radio)'s listener page (see #1752): the two ideas that give a radio page a physical, "receiver in a lit room" feel without touching playback or backend behavior.

## design

**artwork-accent wash** (`lib/utils/artwork-accent.ts`, `lib/components/radio/AccentWash.svelte`)
- accent extraction samples the on-air artwork thumbnail on a 28×28 canvas, buckets saturated pixels, and scores by saturation × closeness to mid-lightness; monochrome covers fall back to their lifted average tone
- the wash is a fixed full-page layer of two plain radial gradients (primary top glow, secondary lower-right), **double-buffered**: a new accent paints on the hidden layer and cross-fades in over 1.4s, so track changes dissolve instead of snapping
- `meta[name=theme-color]` is tinted to the accent blended 78% toward `#0a0a0a`, so mobile browser chrome reads as a darkened tint of the cover; restored to the default on route leave
- no SVG noise filters anywhere (ambient banding regression)

**CRT treatment** (page-scoped CSS, overlays rendered inside each `.art-link` variant via a snippet so they hug the cover, not the full-width stage)
- hairline scanlines + corner vignette (static), a faint sweep band drifting down on a 9s loop, and a one-shot scan-load wipe keyed on the on-air track id
- `prefers-reduced-motion` stills the sweep and removes the wipe entirely

**marquee titles**: long track titles now stay on one line and reuse the existing `ScrollingText` component (`trigger="always"`) instead of the previous 2-line clamp; the live-broadcast fallback heading (plain text, no component) keeps wrapping.

## ⚠️ deferred dependency: images CORS

accent extraction requires reading artwork pixels cross-origin, and `images.plyr.fm` / `images-stg.plyr.fm` currently send **no `Access-Control-Allow-Origin` header** (verified with GET + Origin against both the raw object and the `/cdn-cgi/image/` transform path). until that header exists, the wash and theme-color simply never activate — the CORS-tagged image load fails, `accent` stays `null`, and the page keeps today's neutral look (verified locally: the failure path is silent apart from the browser's CORS console notice). the CRT treatment and marquee do not depend on CORS and work immediately.

enabling it is a one-line response-header rule (or R2 bucket CORS policy) on the images hosts — held for explicit sign-off since it's a production cloudflare change.

## intentional non-behaviors

- no coupling to the ambient **weather** theme (`lib/ambient.svelte.ts`): the weather layer lives on `body::after` and tints design tokens; this wash is a page-local layer above it. they compose rather than interact.
- extraction failure of any kind (no artwork, tainted canvas, decode error) is always "no accent", never an error surface.
- nothing about playback, rotation, or the radio API changes.

## verification

- `just frontend check`, eslint, and component tests (123) green; loq relaxed for the page rather than golfed
- rendered locally against the prod API: CRT layers visible on the on-air art, wash verified by forcing a layer (CORS blocks the real path locally, same as prod for now), marquee verified to engage only on measured overflow with computed duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)