### PR TITLE
fix(radio): station must not compress under the rotation deck

### DIFF
--- a/frontend/src/routes/radio/[[station]]/+page.svelte
+++ b/frontend/src/routes/radio/[[station]]/+page.svelte
@@ -489,11 +489,12 @@
 	}
 
 	.station {
-		/* content-sized: growing here absorbed all viewport slack, pinning the
-		   rotation deck to the container's bottom edge with a dead band between.
-		   the deck now follows the player; slack falls below both. */
-		flex: 0 1 auto;
-		min-height: 0;
+		/* content-sized, and never compressed: growing here absorbed all viewport
+		   slack, pinning the rotation deck to the container's bottom edge with a
+		   dead band between; shrinking let a short viewport (docked player)
+		   squeeze the station so the progress bar spilled out underneath the
+		   deck. hold intrinsic height — the page scrolls when it must. */
+		flex: 0 0 auto;
 		/* fixed-width column so the dial + controls never resize with the
 		   (height-driven) artwork — the artwork is capped to this width too */
 		width: min(100%, 30rem);

--- a/loq.toml
+++ b/loq.toml
@@ -327,7 +327,7 @@ max_lines = 612
 
 [[rules]]
 path = "frontend/src/routes/radio/[[][[]station[]][]]/+page.svelte"
-max_lines = 1283
+max_lines = 1284
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"


### PR DESCRIPTION
regression from #1754, reported on prod: on short viewports (especially with the footer player docked, which subtracts `--player-height` from the fixed-height tuner container), `.station { flex: 0 1 auto; min-height: 0 }` allowed the station column to compress below its content height. its overflow — the progress bar and times — then rendered underneath the rotation deck.

fix: `.station { flex: 0 0 auto }` (no shrink, no `min-height: 0`). the station always holds its intrinsic height; when the container is shorter than the content, `.radio-page`'s existing `overflow-y: auto` scrolls instead of overlapping. the #1754 improvement (deck follows the player instead of pinning to the viewport bottom) is preserved.

verified in-browser at 1280×700 with `--player-height: 72px` forced (the failing configuration): progress-bar bottom 464px vs deck top 473px — no overlap, measured via boundingClientRect, plus screenshot. tall viewports are unchanged (no shrink needed when content fits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)