### PR TITLE
fix(radio): stop radio toggling from eating the queue

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -120,10 +120,27 @@
 		}
 	});
 
-	// sync playback position to queue for persistence (skip in jam mode — server owns position)
+	// sync playback position to queue for persistence. only while the element is
+	// actually wired to the current queue track: in jam mode the server owns the
+	// position; in radio mode the element's clock is the station's; and in the
+	// gap around a source swap (tuning out of radio, hydration before attach)
+	// the element still reads the OLD source's time — persisting any of those
+	// overwrites the listener's saved queue position with garbage that then
+	// syncs to the server.
 	$effect(() => {
-		if (!jam.active) {
-			queue.progressMs = Math.round(player.currentTime * 1000);
+		// read the position FIRST: it is this effect's re-run trigger, and a
+		// guard that short-circuits before reading it would never subscribe
+		const positionMs = Math.round(player.currentTime * 1000);
+		if (
+			!jam.active &&
+			!player.radio &&
+			player.currentTrack &&
+			attachedTrackId === player.currentTrack.id &&
+			// a pending restore reads progressMs on `loadeddata`; persisting the
+			// element's transient 0 before that would erase the saved position
+			positionRestored
+		) {
+			queue.progressMs = positionMs;
 		}
 	});
 
@@ -375,15 +392,18 @@
 		audio.addEventListener(
 			'loadeddata',
 			() => {
-				// restore position on initial hydration only
+				// restore the saved position (hydration, or re-staging the queue
+				// after radio releases the player). always mark the attempt done —
+				// with nothing to restore there is still nothing pending, and
+				// progress persistence stays paused until this flips true.
 				if (!positionRestored && queue.progressMs > 0 && player.audioElement) {
 					const positionSec = queue.progressMs / 1000;
 					// don't restore if near the end (within 5s of duration)
 					if (player.duration === 0 || positionSec < player.duration - 5) {
 						player.audioElement.currentTime = positionSec;
 					}
-					positionRestored = true;
 				}
+				positionRestored = true;
 				isLoadingTrack = false;
 				// unlock play counting now that new audio is ready
 				// (prevents spurious fires from stale currentTime during transitions)
@@ -582,10 +602,34 @@
 	let previousQueueIndex = $state<number>(-1);
 	let shouldAutoPlay = $state(false);
 
+	// whether the player is coming out of radio mode this flush — set while radio
+	// holds the player, consumed by the sync below so releasing back to the queue
+	// restages the listener's track paused instead of blasting into playback.
+	let leavingRadio = false;
+
 	$effect(() => {
 		// radio owns the player while active — don't let passive queue syncs
 		// (cross-tab, refetch, hydration) pull a track in underneath it.
-		if (player.radio) return;
+		if (player.radio) {
+			leavingRadio = true;
+			return;
+		}
+		if (leavingRadio) {
+			leavingRadio = false;
+			// radio released the player (stop, or a queue action took over). when
+			// nothing else claimed the element, restage the queue's current track
+			// paused, and let the loader's hydration path restore the saved
+			// position — "stop" means silence, not "resume the queue at full
+			// volume from wherever it was".
+			if (!player.currentTrack && queue.currentTrack) {
+				player.currentTrack = queue.currentTrack;
+				previousQueueIndex = queue.currentIndex;
+				player.paused = true;
+				shouldAutoPlay = false;
+				positionRestored = false;
+				return;
+			}
+		}
 		// in jam mode, jam state drives the player directly
 		if (jam.active && jam.currentTrack) {
 			const trackChanged = jam.currentTrack.id !== player.currentTrack?.id;

--- a/frontend/src/lib/player-radio.test.ts
+++ b/frontend/src/lib/player-radio.test.ts
@@ -21,8 +21,8 @@ function track(id: number): Track {
 	};
 }
 
-function nowPlaying(id: number): RadioNowPlaying {
-	return { track: track(id), stream_url: `https://audio.test/${id}.mp3`, start_at: 0 };
+function nowPlaying(id: number, startAt = 0): RadioNowPlaying {
+	return { track: track(id), stream_url: `https://audio.test/${id}.mp3`, start_at: startAt };
 }
 
 const blocked = () =>
@@ -70,6 +70,50 @@ describe('playRadio under autoplay policy', () => {
 		player.playRadio(nowPlaying(1));
 		await vi.waitFor(() => expect(player.paused).toBe(true));
 		expect(player.radio?.track.id).toBe(1);
+	});
+});
+
+// the station-position seek waits on `loadedmetadata` of the radio source. it
+// must never fire against whatever the element plays NEXT: left attached after
+// stopping radio, it seeked the listener's queue track to min(station position,
+// duration) — the end of the track — which fired `ended` and ate the queue one
+// track at a time on every radio toggle.
+describe('station-position seek lifecycle', () => {
+	function setDuration(el: HTMLAudioElement, seconds: number): void {
+		Object.defineProperty(el, 'duration', { value: seconds, configurable: true });
+	}
+
+	it('seeks the radio source to the station position on metadata', () => {
+		playSpy.mockResolvedValue(undefined);
+		const el = player.audioElement!;
+		setDuration(el, 3600);
+		player.playRadio(nowPlaying(1, 1200));
+		el.dispatchEvent(new Event('loadedmetadata'));
+		expect(el.currentTime).toBe(1200);
+	});
+
+	it('does not seek the next source after radio stops', () => {
+		playSpy.mockResolvedValue(undefined);
+		const el = player.audioElement!;
+		player.playRadio(nowPlaying(1, 1200));
+		player.stopRadio();
+
+		// the element now loads a 200s queue track; its metadata arriving must
+		// not trigger the stale station seek (which would clamp to 200 = ended)
+		setDuration(el, 200);
+		el.currentTime = 0;
+		el.dispatchEvent(new Event('loadedmetadata'));
+		expect(el.currentTime).toBe(0);
+	});
+
+	it('drops the pending seek when tuning to another station', () => {
+		playSpy.mockResolvedValue(undefined);
+		const el = player.audioElement!;
+		player.playRadio(nowPlaying(1, 1200));
+		player.playRadio(nowPlaying(2, 300));
+		setDuration(el, 3600);
+		el.dispatchEvent(new Event('loadedmetadata'));
+		expect(el.currentTime).toBe(300);
 	});
 });
 

--- a/frontend/src/lib/player.svelte.ts
+++ b/frontend/src/lib/player.svelte.ts
@@ -44,6 +44,12 @@ class PlayerState {
 	/** live hls.js instance, when a broadcast needs one. not reactive — it is a
 	 * teardown handle, never rendered. */
 	private hls: { destroy(): void } | null = null;
+	/** pending station-position seek, waiting on the radio source's metadata.
+	 * tracked so it can be removed the moment the element points anywhere else —
+	 * left attached, it fires on the NEXT source (a queue track after stopping
+	 * radio) and seeks it to min(station position, duration): the end of the
+	 * track, which then fires `ended` and eats the queue one track at a time. */
+	private radioSeek: (() => void) | null = null;
 	/** hls.js itself, once fetched, plus the in-flight fetch. cached so a tune-in
 	 * can attach synchronously inside the tap that asked for it. */
 	private hlsModule: HlsModule | null = null;
@@ -117,6 +123,7 @@ class PlayerState {
 		this.unlockPlayCount();
 		const el = this.audioElement;
 		if (!el) return;
+		this.clearRadioSeek(el);
 		void this.attachRadioSource(el, np, assigned, autoplay);
 		if (autoplay) {
 			// play immediately (preserve the gesture), then align to station position
@@ -141,12 +148,27 @@ class PlayerState {
 		// a broadcast has no position to resume — it is wherever it is.
 		if (np.live) return;
 		const seek = () => {
+			this.radioSeek = null;
+			// tuned away or stopped while metadata loaded — this seek belongs to a
+			// source the element no longer plays.
+			if (this.radio !== assigned) return;
 			if (np.start_at > 0 && Number.isFinite(el.duration)) {
 				el.currentTime = Math.min(np.start_at, el.duration);
 			}
 		};
 		if (el.readyState >= 1) seek();
-		else el.onloadedmetadata = seek;
+		else {
+			this.radioSeek = seek;
+			el.addEventListener('loadedmetadata', seek, { once: true });
+		}
+	}
+
+	/** drop any pending station-position seek so it can't fire against a source
+	 * it wasn't meant for. */
+	private clearRadioSeek(el: HTMLAudioElement) {
+		if (!this.radioSeek) return;
+		el.removeEventListener('loadedmetadata', this.radioSeek);
+		this.radioSeek = null;
 	}
 
 	/** fetch hls.js ahead of a tune-in, so attaching can happen synchronously.
@@ -248,7 +270,10 @@ class PlayerState {
 	stopRadio() {
 		this.radio = null;
 		this.paused = true;
-		this.audioElement?.pause();
+		if (this.audioElement) {
+			this.audioElement.pause();
+			this.clearRadioSeek(this.audioElement);
+		}
 		this.detachHls();
 	}
 

--- a/loq.toml
+++ b/loq.toml
@@ -123,7 +123,7 @@ max_lines = 622
 
 [[rules]]
 path = "frontend/src/lib/components/player/Player.svelte"
-max_lines = 987
+max_lines = 997
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"


### PR DESCRIPTION
fixes the reported bug where toggling tune-in/stop (or switching stations) while a queue exists made the player "eagerly consume a bunch of songs and skip them" — audibly starting and skipping through up-next / the next-from-For-You tail.

## root cause (reproduced live in dev, all three confirmed with direct state inspection)

1. **stale station seek** (the cascade): `playRadio` waited for the radio source's metadata with a bare `el.onloadedmetadata = seek` and never removed it. after stopping radio, the queue track that re-attaches fires `loadedmetadata` → the stale handler seeks it to `min(station_position, duration)`. station positions (minutes–hours) always exceed a track's length, so the track lands **on its own end**, fires `ended` almost immediately, `queue.next()` advances, the still-armed pattern repeats on the next track — consuming the queue one track per boundary. observed directly: after one stop, the queue track sat at `currentTime === duration` (345.84/345.84) with a live `onloadedmetadata` handler, and a spurious `POST /tracks/{id}/play` fired.
2. **queue position corruption**: the progress-persistence effect had no radio guard, so while radio played, `queue.progressMs` tracked the *station's* clock (observed: 1,155,307ms — 19 minutes — while a 3-minute queue track was current). signed in, that garbage syncs to the server queue.
3. **stop meant play**: when radio released the player, the queue→player sync pulled the queue track in with autoplay armed, so "stop" could start queue playback.

## fix

- the station seek is now a tracked `{ once: true }` listener, removed on every new `playRadio` and on `stopRadio`, and self-guarded (`this.radio !== assigned`) so a late arrival can't fire against a source it wasn't meant for
- progress persists only while the audio element is actually wired to the current queue track (`attachedTrackId` match), radio/jam are inactive, and no position restore is pending — the transient 0 between source swaps can no longer erase the saved position (the persist effect also now reads `player.currentTime` unconditionally: a guard that short-circuited before reading it never subscribed and silently stopped persisting)
- radio release re-stages the queue's current track **paused** at its saved position (the restore path reuses the existing hydration mechanism)

## verification

- regression tests in `player-radio.test.ts` (station-position seek lifecycle): the key test **fails against the unfixed player** (verified by stashing the fix) and passes with it
- live in dev against the prod API, driving the real UI: play a track to ~5s → tune in (radio seeks to station position correctly) → stop → queue track re-staged paused at its saved position → repeated toggles are idempotent; no `ended` events, no track churn, no play-count spam, `progressMs` stays sane throughout
- full suite: 126 tests, svelte-check, eslint green

## deferred

- `queue.play()`/`pause()`/`next()` are still wired to the OS media-session handlers while radio is active (lock-screen "next" pokes the queue under radio); harmless to the queue's contents but worth a look separately

**staging only** — please verify the radio ↔ queue feel on stg before prod release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)