### PR TITLE
fix(player): jam keeps driving playback when radio releases

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -620,8 +620,10 @@
 			// nothing else claimed the element, restage the queue's current track
 			// paused, and let the loader's hydration path restore the saved
 			// position — "stop" means silence, not "resume the queue at full
-			// volume from wherever it was".
-			if (!player.currentTrack && queue.currentTrack) {
+			// volume from wherever it was". a jam session is the exception: jam
+			// state drives playback (below), and intercepting here would leave
+			// this participant paused while the jam plays on without them.
+			if (!jam.active && !player.currentTrack && queue.currentTrack) {
 				player.currentTrack = queue.currentTrack;
 				previousQueueIndex = queue.currentIndex;
 				player.paused = true;

--- a/loq.toml
+++ b/loq.toml
@@ -123,7 +123,7 @@ max_lines = 622
 
 [[rules]]
 path = "frontend/src/lib/components/player/Player.svelte"
-max_lines = 997
+max_lines = 999
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"


### PR DESCRIPTION
follow-up to #1757, restoring a jam expectation it regressed: the new radio-release restage branch ran before the jam sync branch, so stopping radio during an active jam staged the queue track paused — leaving that participant silent while the jam played on. pre-#1757, jam state reclaimed the player and resumed automatically (`shouldAutoPlay = jam.isPlaying && jam.isOutputDevice`).

fix: the restage branch defers to jam (`!jam.active` guard); jam sessions get exactly the pre-#1757 flow back. all other #1757 touchpoints were traced against jam expectations and are unchanged: the progress-persistence guard excluded jam both before and after, and the seek-lifecycle fix is source-agnostic.

honest coverage note: jam has no automated coverage and this path needs a live two-client session to exercise for real; mounting Player.svelte over mocked stores would test the mocks, not the path. the architecture research (#1758) recommends making these transitions explicit, which is where real testability lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)