### PR TITLE
fix(radio): station flips must not strand radio silent-but-on-air

### DIFF
--- a/frontend/src/lib/player-radio.test.ts
+++ b/frontend/src/lib/player-radio.test.ts
@@ -71,6 +71,45 @@ describe('playRadio under autoplay policy', () => {
 		await vi.waitFor(() => expect(player.paused).toBe(true));
 		expect(player.radio?.track.id).toBe(1);
 	});
+
+	// a rapid station flip supersedes the first load before its play() settles.
+	// the dead load's rejection must not pause the successor: unguarded, it left
+	// the radio on-air ("stop" shown) but silent (firehose → deep-cuts, 2026-08-04)
+	it('ignores a superseded load play() rejection during a station flip', async () => {
+		let rejectFirst: (err: unknown) => void = () => {};
+		playSpy.mockImplementationOnce(
+			() => new Promise((_, reject) => (rejectFirst = reject))
+		);
+		player.playRadio(nowPlaying(1));
+
+		playSpy.mockResolvedValueOnce(undefined);
+		player.playRadio(nowPlaying(2));
+		expect(player.paused).toBe(false);
+
+		// the first station's play() now rejects — after it was superseded
+		rejectFirst(new DOMException('interrupted by a new load request', 'AbortError'));
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(player.paused).toBe(false);
+		expect(player.radio?.track.id).toBe(2);
+	});
+
+	it('ignores an AbortError even for the current load (a successor owns playback)', async () => {
+		playSpy.mockResolvedValueOnce(undefined);
+		player.playRadio(nowPlaying(1));
+
+		playSpy.mockRejectedValueOnce(
+			new DOMException('interrupted by a new load request', 'AbortError')
+		);
+		player.playRadio(nowPlaying(2));
+		// let the rejection propagate
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(player.paused).toBe(false);
+		expect(player.radio?.track.id).toBe(2);
+	});
 });
 
 // the station-position seek waits on `loadedmetadata` of the radio source. it

--- a/frontend/src/lib/player.svelte.ts
+++ b/frontend/src/lib/player.svelte.ts
@@ -128,16 +128,20 @@ class PlayerState {
 		if (autoplay) {
 			// play immediately (preserve the gesture), then align to station position
 			el.play().catch((err: unknown) => {
+				// a rapid station flip supersedes this load before its play() settles;
+				// the rejection belongs to the DEAD load and must not touch state —
+				// unguarded, it flipped `paused` under the successor and left the
+				// radio on-air but silent (firehose → deep-cuts report, 2026-08-04)
+				if (this.radio !== assigned) return;
+				// the element aborting this play() because a new load started means
+				// a successor owns playback now — nothing to record here either
+				if ((err as { name?: string })?.name === 'AbortError') return;
 				this.paused = true;
 				// autoplay policy blocked a fresh tune-in: roll back to the pre-tune
 				// state so the ui reads "tune in" again instead of a silent on-air
 				// state ("stop" + LIVE). mid-session failures (station flips, track
 				// boundaries) keep radio mode — only the entry is rolled back.
-				if (
-					!wasActive &&
-					this.radio === assigned &&
-					(err as { name?: string })?.name === 'NotAllowedError'
-				) {
+				if (!wasActive && (err as { name?: string })?.name === 'NotAllowedError') {
 					this.radio = null;
 					this.currentTrack = previousTrack;
 				}
@@ -233,7 +237,13 @@ class PlayerState {
 			if (this.radio !== assigned) return; // tuned away while the chunk loaded
 			if (!Hls) return void (this.paused = true);
 			this.attachHls(Hls, el, np, playNative);
-			if (autoplay) el.play().catch(() => (this.paused = true));
+			if (autoplay) {
+				el.play().catch(() => {
+					// same staleness rule as the main play path: only the load that
+					// still owns the element may record its failure
+					if (this.radio === assigned) this.paused = true;
+				});
+			}
 		});
 	}
 


### PR DESCRIPTION
fixes the reported bug: switching stations while tuned in (firehose → deep cuts) paused the audio while the page still showed "stop" (on-air) and the footer showed play.

## diagnosis

logfire spans for the report window show the flip sequence (deep-cuts ↔ firehose ↔ deep-cuts within ~20s, all `/radio/state` 200s — backend healthy), which pointed at the client race: `playRadio`'s `el.play()` **rejection handler ran unguarded** (`player.svelte.ts`). when a station flip supersedes a load before its `play()` settles, the dead load's rejection (`AbortError: interrupted by a new load request`) set `paused = true` under the *successor* — the paused-sync effect then silenced the element while radio mode stayed active. same bug family as #1757's stale seek: work outliving the load it belonged to.

## fix

- the play-rejection catch bails unless its load still owns the element (`this.radio === assigned`) — a superseded load can no longer touch state
- `AbortError` is never recorded even for the current load: the element aborting a play() because a new load started means a successor owns playback
- the deferred-HLS play catch gets the same staleness guard
- the fresh-tune-in `NotAllowedError` rollback behavior is preserved (existing tests still green)

## verification

- two new regression tests express the exact race (first load's play() rejects after a second `playRadio`) — both **fail against the unfixed player** (verified by stashing the fix) and pass with it; suite is 128 green, svelte-check clean

staging first — please flip stations while tuned in (especially firehose ↔ anything, quickly) and confirm audio follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)