### PR TITLE
feat: /atlas — a 2D semantic map of the catalog

### DIFF
--- a/.github/workflows/build-atlas.yml
+++ b/.github/workflows/build-atlas.yml
@@ -1,0 +1,36 @@
+# rebuild the /atlas semantic map and upload it to the stats bucket
+#
+# the /atlas page fetches this JSON via the backend's /stats/atlas proxy,
+# so the map stays fresh as tracks are uploaded (same pattern as costs).
+#
+# required secrets:
+#   NEON_DATABASE_URL_PRD - production database URL
+#   TURBOPUFFER_API_KEY   - vector store with the CLAP embeddings
+#   ANTHROPIC_API_KEY     - LLM-refined cluster labels
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / R2_ENDPOINT_URL - stats bucket
+
+name: build atlas
+
+on:
+  schedule:
+    - cron: "17 9 * * *" # daily
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: build and upload atlas.json
+        run: uv run scripts/build_atlas.py --upload
+        env:
+          ATLAS_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL_PRD }}
+          TURBOPUFFER_API_KEY: ${{ secrets.TURBOPUFFER_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ simple-build.log
 # status-maintenance audio + transcript (carried between workflow phases as artifacts, never committed)
 update.wav
 podcast_script.txt
+frontend/static/atlas.json
+atlas.json

--- a/backend/src/backend/api/stats.py
+++ b/backend/src/backend/api/stats.py
@@ -76,3 +76,31 @@ async def get_costs() -> Response:
         media_type="application/json",
         headers={"Cache-Control": "public, max-age=3600"},
     )
+
+
+@router.get("/atlas")
+async def get_atlas() -> Response:
+    """proxy the atlas JSON from R2 to avoid CORS issues.
+
+    atlas.json is rebuilt daily by a GitHub Action (scripts/build_atlas.py)
+    and uploaded to the stats bucket. this endpoint proxies it so the /atlas
+    page can fetch without CORS.
+    """
+    atlas_url = settings.storage.atlas_json_url
+    if not atlas_url:
+        raise HTTPException(status_code=404, detail="atlas not configured")
+
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.get(atlas_url, timeout=10)
+            resp.raise_for_status()
+        except httpx.HTTPError as e:
+            raise HTTPException(
+                status_code=502, detail=f"failed to fetch atlas: {e}"
+            ) from e
+
+    return Response(
+        content=resp.content,
+        media_type="application/json",
+        headers={"Cache-Control": "public, max-age=900"},
+    )

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -365,6 +365,11 @@ class StorageSettings(AppSettingsSection):
         validation_alias="COSTS_JSON_URL",
         description="URL for public costs dashboard JSON",
     )
+    atlas_json_url: str = Field(
+        default="https://pub-68f2c7379f204d81bdf65152b0ff0207.r2.dev/atlas.json",
+        validation_alias="ATLAS_JSON_URL",
+        description="URL for the /atlas semantic map JSON",
+    )
 
     @computed_field
     @property

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -44,6 +44,10 @@ export default [
 				location: 'readonly',
 				history: 'readonly',
 				crypto: 'readonly',
+				Image: 'readonly',
+				MutationObserver: 'readonly',
+				requestAnimationFrame: 'readonly',
+				performance: 'readonly',
 				// svelte 5 runes
 				$state: 'readonly',
 				$derived: 'readonly',

--- a/frontend/src/routes/atlas/+page.svelte
+++ b/frontend/src/routes/atlas/+page.svelte
@@ -1,0 +1,283 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { API_URL } from '$lib/config';
+	import { player } from '$lib/player.svelte';
+	import type { Track } from '$lib/types';
+	import { AtlasRenderer, type AtlasData, type AtlasPoint } from './renderer';
+
+	let canvasEl: HTMLCanvasElement;
+	let renderer: AtlasRenderer | null = null;
+
+	let loading = $state(true);
+	let loadError = $state('');
+	let stats = $state('');
+	let tooltip = $state<{
+		visible: boolean;
+		x: number;
+		y: number;
+		title: string;
+		meta: string;
+		kind: 'track' | 'artist';
+	}>({ visible: false, x: 0, y: 0, title: '', meta: '', kind: 'track' });
+	let starting = $state<number | null>(null);
+
+	async function playPoint(point: AtlasPoint): Promise<void> {
+		starting = point.id;
+		try {
+			const response = await fetch(`${API_URL}/tracks/${point.id}`, {
+				credentials: 'include'
+			});
+			if (!response.ok) {
+				console.error('atlas: failed to load track', point.id, response.status);
+				return;
+			}
+			const track: Track = await response.json();
+			player.playTrack(track);
+		} catch (e) {
+			console.error('atlas: failed to start playback', e);
+		} finally {
+			starting = null;
+		}
+	}
+
+	function placeTooltip(sx: number, sy: number): { x: number; y: number } {
+		const pad = 12;
+		const width = 260;
+		let x = sx + 16;
+		if (x + width > window.innerWidth - pad) x = sx - width - 16;
+		return { x: Math.max(pad, x), y: Math.max(pad, sy - 60) };
+	}
+
+	onMount(() => {
+		renderer = new AtlasRenderer(canvasEl, {
+			onHover: (point, sx, sy) => {
+				if (!point) {
+					if (tooltip.kind === 'track') tooltip.visible = false;
+					return;
+				}
+				const pos = placeTooltip(sx, sy);
+				tooltip = {
+					visible: true,
+					x: pos.x,
+					y: pos.y,
+					title: point.title,
+					meta: `${point.artist} · ${point.plays} ${point.plays === 1 ? 'play' : 'plays'}`,
+					kind: 'track'
+				};
+			},
+			onHoverArtist: (artist, sx, sy) => {
+				if (!artist) {
+					if (tooltip.kind === 'artist') tooltip.visible = false;
+					return;
+				}
+				const pos = placeTooltip(sx, sy);
+				tooltip = {
+					visible: true,
+					x: pos.x,
+					y: pos.y,
+					title: artist.name,
+					meta: `@${artist.handle} · ${artist.count} tracks`,
+					kind: 'artist'
+				};
+			},
+			onActivate: (point) => void playPoint(point),
+			onActivateArtist: (artist) => void goto(`/u/${artist.handle}`)
+		});
+
+		// the live map comes from /stats/atlas (rebuilt daily); the static
+		// fallback exists for local dev, where a gitignored copy of
+		// atlas.json can sit in frontend/static
+		fetch(`${API_URL}/stats/atlas`)
+			.then((r) => {
+				if (r.ok) return r.json();
+				return fetch('/atlas.json').then((fallback) => {
+					if (!fallback.ok) throw new Error(`atlas: ${r.status}`);
+					return fallback.json();
+				});
+			})
+			.then((data: AtlasData) => {
+				renderer?.setData(data);
+				stats = `${data.meta.nTracks} tracks · ${data.clusters.coarse.length} regions · ${data.clusters.fine.length} clusters`;
+				loading = false;
+			})
+			.catch((e: unknown) => {
+				console.error('atlas: failed to load data', e);
+				loadError = 'failed to load the atlas';
+				loading = false;
+			});
+
+		return () => renderer?.destroy();
+	});
+</script>
+
+<svelte:head>
+	<title>atlas · plyr.fm</title>
+	<meta name="robots" content="noindex, nofollow" />
+	<meta
+		name="description"
+		content="a 2D semantic map of the plyr.fm catalog — tracks clustered by how they sound"
+	/>
+</svelte:head>
+
+<div class="atlas-page">
+	<header class="atlas-header">
+		<div>
+			<h1>atlas</h1>
+			<p class="subtitle">the catalog, mapped by sound — zoom in, click a track to play it</p>
+		</div>
+		{#if stats}
+			<span class="stats">{stats}</span>
+		{/if}
+	</header>
+
+	<div class="stage">
+		<canvas bind:this={canvasEl}></canvas>
+		{#if loading}
+			<div class="overlay">charting the catalog…</div>
+		{:else if loadError}
+			<div class="overlay">{loadError}</div>
+		{/if}
+		{#if starting !== null}
+			<div class="starting">starting playback…</div>
+		{/if}
+		{#if tooltip.visible}
+			<div class="tooltip" style="left: {tooltip.x}px; top: {tooltip.y}px">
+				<span class="tooltip-title">{tooltip.title}</span>
+				<span class="tooltip-meta">{tooltip.meta}</span>
+				<span class="tooltip-hint">
+					{tooltip.kind === 'track' ? 'click to play' : 'click for profile'}
+				</span>
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.atlas-page {
+		display: flex;
+		flex-direction: column;
+		height: calc(
+			100vh - var(--header-height, 0px) - var(--player-height, 0px) -
+				env(safe-area-inset-bottom, 0px)
+		);
+		overflow: hidden;
+	}
+
+	@supports (height: 100dvh) {
+		.atlas-page {
+			height: calc(
+				100dvh - var(--header-height, 0px) - var(--player-height, 0px) -
+					env(safe-area-inset-bottom, 0px)
+			);
+		}
+	}
+
+	.atlas-header {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		padding: 0.75rem 1rem 0.5rem;
+		flex-wrap: wrap;
+	}
+
+	h1 {
+		font-size: var(--text-page-heading, 1.4rem);
+		margin: 0;
+	}
+
+	.subtitle {
+		margin: 0.1rem 0 0;
+		color: var(--text-tertiary);
+		font-size: var(--text-sm, 0.85rem);
+	}
+
+	.stats {
+		color: var(--text-muted, #666);
+		font-size: var(--text-sm, 0.8rem);
+		font-family: monospace;
+	}
+
+	.stage {
+		position: relative;
+		flex: 1;
+		min-height: 0;
+	}
+
+	canvas {
+		display: block;
+		width: 100%;
+		height: 100%;
+		touch-action: none;
+		cursor: grab;
+	}
+
+	.overlay {
+		position: absolute;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		color: var(--text-tertiary);
+		font-family: monospace;
+		font-size: var(--text-sm, 0.85rem);
+		pointer-events: none;
+	}
+
+	.starting {
+		position: absolute;
+		top: 0.75rem;
+		left: 50%;
+		transform: translateX(-50%);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-subtle, #282828);
+		border-radius: 6px;
+		padding: 0.3rem 0.8rem;
+		font-size: var(--text-sm, 0.8rem);
+		color: var(--text-secondary);
+		pointer-events: none;
+	}
+
+	.tooltip {
+		position: absolute;
+		max-width: 260px;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-default, #333);
+		border-radius: 6px;
+		padding: 0.5rem 0.7rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.15rem;
+		pointer-events: none;
+		z-index: 5;
+	}
+
+	.tooltip-title {
+		color: var(--text-primary);
+		font-size: var(--text-sm, 0.85rem);
+		font-weight: 600;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.tooltip-meta {
+		color: var(--text-tertiary);
+		font-size: var(--text-xs, 0.75rem);
+	}
+
+	.tooltip-hint {
+		color: var(--text-muted, #666);
+		font-size: var(--text-xs, 0.7rem);
+	}
+
+	@media (max-width: 600px) {
+		.atlas-header {
+			padding: 0.6rem 0.8rem 0.4rem;
+		}
+
+		.stats {
+			display: none;
+		}
+	}
+</style>

--- a/frontend/src/routes/atlas/renderer.ts
+++ b/frontend/src/routes/atlas/renderer.ts
@@ -1,0 +1,1171 @@
+/**
+ * canvas renderer for the /atlas page — a 2D semantic map of the catalog.
+ *
+ * adapted from pub-search's atlas (pub-search.waow.tech/atlas): sprite-stamped
+ * points over a spatial grid, cluster "lantern" nebulae, and one shared
+ * label-collision economy placed in priority order. plyr-specific choices:
+ * every point takes its fine cluster's hue (there is no platform dimension
+ * here), and at high zoom tracks resolve into their actual cover art, drawn
+ * plain — artwork is the artist's presentation, never decorated.
+ */
+
+export interface AtlasPoint {
+	x: number;
+	y: number;
+	id: number;
+	title: string;
+	artist: string;
+	handle: string;
+	thumb: string;
+	plays: number;
+	likes: number;
+	clusterCoarse: number;
+	clusterFine: number;
+	core: boolean;
+}
+
+export interface AtlasCluster {
+	id: number;
+	label: string;
+	cx: number;
+	cy: number;
+	count: number;
+	parent?: number;
+	// computed client-side
+	radius?: number;
+	lantern?: { x: number; y: number; r: number } | null;
+}
+
+export interface AtlasArtist {
+	did: string;
+	handle: string;
+	name: string;
+	avatar: string;
+	cx: number;
+	cy: number;
+	count: number;
+}
+
+export interface AtlasData {
+	points: AtlasPoint[];
+	clusters: { coarse: AtlasCluster[]; fine: AtlasCluster[] };
+	artists: AtlasArtist[];
+	meta: { generatedAt: string; nTracks: number };
+}
+
+export interface AtlasCallbacks {
+	onHover: (point: AtlasPoint | null, sx: number, sy: number) => void;
+	onHoverArtist: (artist: AtlasArtist | null, sx: number, sy: number) => void;
+	onActivate: (point: AtlasPoint) => void;
+	onActivateArtist: (artist: AtlasArtist) => void;
+}
+
+const HUE_STEPS = 24;
+const TUNE = {
+	nebula: {
+		alpha: 0.2,
+		spread: 3.0,
+		minHaloPx: 40,
+		growRefZoom: 2,
+		maxHaloPx: 340,
+		varBase: 0.7,
+		varRange: 0.3,
+		inStart: 1.7,
+		inRange: 1.2,
+		outStart: 26,
+		outRange: 10
+	},
+	coarse: { alphaDark: 0.13, alphaLight: 0.1, outStart: 1.8, outRange: 1.0 },
+	hueDark: { core: [0.55, 0.72], mid: [0.5, 0.52], edge: [0.45, 0.34] } as const,
+	hueLight: { core: [0.55, 0.45], mid: [0.5, 0.6], edge: [0.45, 0.75] } as const,
+	labels: { titles: { s: 5, l: 14 }, coarse: { s: 5, l: 10 }, fine: { s: 6, l: 16 }, artists: { s: 3, l: 8 } },
+	covers: { start: 14, range: 8, budget: { s: 18, l: 36 }, maxPx: 72, minPx: 10 }
+};
+
+function clamp01(x: number): number {
+	return x < 0 ? 0 : x > 1 ? 1 : x;
+}
+function fadeIn(zoom: number, start: number, range: number): number {
+	return clamp01((zoom - start) / range);
+}
+function fadeOut(zoom: number, start: number, range: number): number {
+	return 1 - clamp01((zoom - start) / range);
+}
+function hash01(id: number): number {
+	let x = (id * 2654435761) >>> 0;
+	x ^= x >>> 15;
+	x = (x * 2246822519) >>> 0;
+	x ^= x >>> 13;
+	return (x >>> 0) / 4294967296;
+}
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+	if (s === 0) {
+		const v = Math.round(l * 255);
+		return [v, v, v];
+	}
+	const f = (p: number, q: number, t: number): number => {
+		if (t < 0) t += 1;
+		if (t > 1) t -= 1;
+		if (t < 1 / 6) return p + (q - p) * 6 * t;
+		if (t < 1 / 2) return q;
+		if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+		return p;
+	};
+	const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+	const p = 2 * l - q;
+	return [
+		Math.round(f(p, q, h + 1 / 3) * 255),
+		Math.round(f(p, q, h) * 255),
+		Math.round(f(p, q, h - 1 / 3) * 255)
+	];
+}
+function rgba(rgb: [number, number, number], a: number): string {
+	return `rgba(${rgb[0]},${rgb[1]},${rgb[2]},${a})`;
+}
+function easeOutCubic(t: number): number {
+	return 1 - Math.pow(1 - t, 3);
+}
+
+interface HueColors {
+	core: [number, number, number];
+	mid: [number, number, number];
+	edge: [number, number, number];
+}
+
+export class AtlasRenderer {
+	private canvas: HTMLCanvasElement;
+	private ctx: CanvasRenderingContext2D;
+	private cb: AtlasCallbacks;
+	private data: AtlasData | null = null;
+
+	private dpr = 1;
+	private W = 0;
+	private H = 0;
+	private view = { zoom: 1, panX: 0, panY: 0, minZoom: 0.5, maxZoom: 120, dirty: true };
+	private frameRequested = false;
+	private destroyed = false;
+
+	// typed arrays for the hot path
+	private px: Float32Array = new Float32Array(0);
+	private py: Float32Array = new Float32Array(0);
+	private hueStep: Uint8Array = new Uint8Array(0);
+	private fineArr: Uint16Array = new Uint16Array(0);
+	private popOrder: Int32Array = new Int32Array(0);
+	private grid: Map<string, number[]> = new Map();
+	private readonly cellSize = 0.02;
+
+	// cached per frame
+	private scale = 1;
+	private cx = 0;
+	private cy = 0;
+	private dark = true;
+
+	// sprite caches
+	private dotSprites = new Map<number, HTMLCanvasElement>();
+	private starSprites = new Map<string, HTMLCanvasElement>();
+	private haloSprites = new Map<string, HTMLCanvasElement>();
+	private spriteTheme = '';
+	private hueCache = new Map<number, HueColors>();
+
+	// cover art
+	private coverImages = new Map<number, HTMLImageElement>();
+	private coverFailed = new Set<number>();
+	private coverLoading = new Set<number>();
+	private coverLoadCount = 0;
+
+	// artist avatars
+	private avatarImages = new Map<string, HTMLImageElement>();
+	private avatarFailed = new Set<string>();
+
+	// interaction
+	private hovered = -1;
+	private hoveredArtist = -1;
+	private selected = -1;
+	private dragging = false;
+	private dragStartX = 0;
+	private dragStartY = 0;
+	private dragStartPanX = 0;
+	private dragStartPanY = 0;
+	private pinchStartDist = 0;
+	private pinchStartZoom = 1;
+	private pinchMidX = 0;
+	private pinchMidY = 0;
+	private touches = new Map<number, { x: number; y: number }>();
+	private touchMoved = false;
+	private readonly isTouch =
+		typeof window !== 'undefined' && ('ontouchstart' in window || navigator.maxTouchPoints > 0);
+	private readonly hitRadius = this.isTouch ? 36 : 18;
+
+	// fly-to animation
+	private animating = false;
+	private animFrom = { zoom: 1, panX: 0, panY: 0 };
+	private animTo = { zoom: 1, panX: 0, panY: 0 };
+	private animStart = 0;
+	private readonly animMs = 600;
+
+	private themeObserver: MutationObserver | null = null;
+	private resizeHandler = () => this.resize();
+	private removeListeners: (() => void)[] = [];
+
+	constructor(canvas: HTMLCanvasElement, callbacks: AtlasCallbacks) {
+		this.canvas = canvas;
+		const ctx = canvas.getContext('2d');
+		if (!ctx) throw new Error('canvas 2d context unavailable');
+		this.ctx = ctx;
+		this.cb = callbacks;
+		this.dpr = window.devicePixelRatio || 1;
+		this.readTheme();
+		this.themeObserver = new MutationObserver(() => {
+			this.readTheme();
+			this.markDirty();
+		});
+		this.themeObserver.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ['class']
+		});
+		window.addEventListener('resize', this.resizeHandler);
+		this.bindInput();
+		this.resize();
+	}
+
+	setData(data: AtlasData): void {
+		this.data = data;
+		const n = data.points.length;
+		this.px = new Float32Array(n);
+		this.py = new Float32Array(n);
+		this.hueStep = new Uint8Array(n);
+		this.fineArr = new Uint16Array(n);
+		this.grid = new Map();
+		const pop = new Float32Array(n);
+		for (let i = 0; i < n; i++) {
+			const p = data.points[i];
+			this.px[i] = p.x;
+			this.py[i] = p.y;
+			this.fineArr[i] = p.clusterFine;
+			this.hueStep[i] = Math.floor(hash01(p.clusterFine) * HUE_STEPS) % HUE_STEPS;
+			pop[i] = Math.log(1 + p.plays) + 2 * Math.log(1 + p.likes);
+			const key = `${Math.floor(p.x / this.cellSize)},${Math.floor(p.y / this.cellSize)}`;
+			let cell = this.grid.get(key);
+			if (!cell) {
+				cell = [];
+				this.grid.set(key, cell);
+			}
+			cell.push(i);
+		}
+		this.popOrder = new Int32Array(n);
+		for (let i = 0; i < n; i++) this.popOrder[i] = i;
+		const order = Array.from(this.popOrder);
+		order.sort((a, b) => pop[b] - pop[a]);
+		this.popOrder.set(order);
+		this.computeClusterGeometry(data.clusters.coarse, 'clusterCoarse');
+		this.computeClusterGeometry(data.clusters.fine, 'clusterFine');
+		this.fitToData();
+		this.markDirty();
+	}
+
+	destroy(): void {
+		this.destroyed = true;
+		this.themeObserver?.disconnect();
+		window.removeEventListener('resize', this.resizeHandler);
+		for (const off of this.removeListeners) off();
+	}
+
+	flyTo(x: number, y: number, zoom: number): void {
+		this.animFrom = { zoom: this.view.zoom, panX: this.view.panX, panY: this.view.panY };
+		this.animTo = { zoom, panX: -x, panY: -y };
+		this.animStart = performance.now();
+		this.animating = true;
+		this.scheduleFrame();
+	}
+
+	// --- geometry ---
+
+	private fitToData(): void {
+		if (!this.px.length) return;
+		let xMin = Infinity;
+		let xMax = -Infinity;
+		let yMin = Infinity;
+		let yMax = -Infinity;
+		for (let i = 0; i < this.px.length; i++) {
+			if (this.px[i] < xMin) xMin = this.px[i];
+			if (this.px[i] > xMax) xMax = this.px[i];
+			if (this.py[i] < yMin) yMin = this.py[i];
+			if (this.py[i] > yMax) yMax = this.py[i];
+		}
+		const spanX = Math.max(0.01, xMax - xMin);
+		const spanY = Math.max(0.01, yMax - yMin);
+		const base = Math.min(this.W, this.H) * 0.42;
+		const zoom = Math.min((0.9 * this.W) / (spanX * base), (0.86 * this.H) / (spanY * base));
+		this.view.zoom = Math.max(this.view.minZoom, Math.min(4, zoom));
+		this.view.panX = -(xMin + xMax) / 2;
+		this.view.panY = -(yMin + yMax) / 2;
+	}
+
+	private computeClusterGeometry(
+		clusters: AtlasCluster[],
+		key: 'clusterCoarse' | 'clusterFine'
+	): void {
+		if (!this.data) return;
+		const byId = new Map<number, AtlasCluster>();
+		const members = new Map<number, number[]>();
+		for (const cl of clusters) {
+			byId.set(cl.id, cl);
+			members.set(cl.id, []);
+		}
+		for (let i = 0; i < this.data.points.length; i++) {
+			members.get(this.data.points[i][key])?.push(i);
+		}
+		for (const cl of clusters) {
+			const idx = members.get(cl.id) ?? [];
+			if (!idx.length) {
+				cl.radius = 0.03;
+				cl.lantern = null;
+				continue;
+			}
+			let distSum = 0;
+			for (const i of idx) {
+				distSum += Math.hypot(this.px[i] - cl.cx, this.py[i] - cl.cy);
+			}
+			cl.radius = (distSum / idx.length) * 2 || 0.03;
+			// lantern: weighted center of members within the trimmed radius,
+			// sized by RMS spread — the light sits where the tracks are
+			const kept = idx.filter(
+				(i) => Math.hypot(this.px[i] - cl.cx, this.py[i] - cl.cy) <= (cl.radius ?? 0.03)
+			);
+			const use = kept.length ? kept : idx;
+			let mx = 0;
+			let my = 0;
+			for (const i of use) {
+				mx += this.px[i];
+				my += this.py[i];
+			}
+			mx /= use.length;
+			my /= use.length;
+			let sum2 = 0;
+			for (const i of use) {
+				const dx = this.px[i] - mx;
+				const dy = this.py[i] - my;
+				sum2 += dx * dx + dy * dy;
+			}
+			cl.lantern = { x: mx, y: my, r: Math.max(0.008, Math.sqrt(sum2 / use.length)) };
+		}
+	}
+
+	// --- theme / colors ---
+
+	private readTheme(): void {
+		this.dark = !document.documentElement.classList.contains('theme-light');
+	}
+
+	private hueColors(step: number): HueColors {
+		const themeKey = this.dark ? 1 : 0;
+		const cacheKey = step * 2 + themeKey;
+		let c = this.hueCache.get(cacheKey);
+		if (!c) {
+			const h = step / HUE_STEPS;
+			const pal = this.dark ? TUNE.hueDark : TUNE.hueLight;
+			c = {
+				core: hslToRgb(h, pal.core[0], pal.core[1]),
+				mid: hslToRgb(h, pal.mid[0], pal.mid[1]),
+				edge: hslToRgb(h, pal.edge[0], pal.edge[1])
+			};
+			this.hueCache.set(cacheKey, c);
+		}
+		return c;
+	}
+
+	private themeKey(): string {
+		return this.dark ? 'dark' : 'light';
+	}
+
+	private invalidateSpritesIfThemed(): void {
+		const t = this.themeKey();
+		if (this.spriteTheme !== t) {
+			this.spriteTheme = t;
+			this.dotSprites.clear();
+			this.starSprites.clear();
+			this.haloSprites.clear();
+			this.hueCache.clear();
+		}
+	}
+
+	// --- sprites ---
+
+	private getDotSprite(step: number): HTMLCanvasElement {
+		let cv = this.dotSprites.get(step);
+		if (cv) return cv;
+		const c = this.hueColors(step);
+		const s = Math.max(4, Math.ceil(2.8 * this.dpr));
+		cv = document.createElement('canvas');
+		cv.width = s;
+		cv.height = s;
+		const g = cv.getContext('2d')!;
+		const half = s / 2;
+		const grad = g.createRadialGradient(half, half, 0, half, half, half);
+		const coreCol: [number, number, number] = this.dark
+			? [
+					Math.round(c.core[0] + (255 - c.core[0]) * 0.38),
+					Math.round(c.core[1] + (255 - c.core[1]) * 0.38),
+					Math.round(c.core[2] + (255 - c.core[2]) * 0.38)
+				]
+			: c.mid;
+		grad.addColorStop(0, rgba(coreCol, 1));
+		grad.addColorStop(0.4, rgba(c.mid, 0.5));
+		grad.addColorStop(1, rgba(c.mid, 0));
+		g.globalAlpha = 0.6;
+		g.fillStyle = grad;
+		g.beginPath();
+		g.arc(half, half, half, 0, Math.PI * 2);
+		g.fill();
+		this.dotSprites.set(step, cv);
+		return cv;
+	}
+
+	private getStarSprite(step: number, radius: number, hover: boolean): HTMLCanvasElement {
+		const r = Math.round(radius * 2) / 2;
+		const key = `${step}_${r}_${hover ? 1 : 0}`;
+		let cv = this.starSprites.get(key);
+		if (cv) return cv;
+		if (this.starSprites.size > 400) this.starSprites.clear();
+		const c = this.hueColors(step);
+		const rr = hover ? r * 1.35 : r;
+		const size = Math.ceil(rr * 3 * this.dpr) + 2;
+		cv = document.createElement('canvas');
+		cv.width = size;
+		cv.height = size;
+		const g = cv.getContext('2d')!;
+		const half = size / 2;
+		const R = rr * this.dpr;
+		const coreCol: [number, number, number] = this.dark
+			? [
+					Math.round(c.core[0] + (255 - c.core[0]) * 0.42),
+					Math.round(c.core[1] + (255 - c.core[1]) * 0.42),
+					Math.round(c.core[2] + (255 - c.core[2]) * 0.42)
+				]
+			: c.mid;
+		const sg = g.createRadialGradient(half, half, 0, half, half, R * 1.4);
+		sg.addColorStop(0, rgba(coreCol, 1));
+		sg.addColorStop(0.3, rgba(c.core, 0.5));
+		sg.addColorStop(1, rgba(c.core, 0));
+		g.globalAlpha = hover ? 0.95 : 0.78;
+		g.fillStyle = sg;
+		g.beginPath();
+		g.arc(half, half, R * 1.4, 0, Math.PI * 2);
+		g.fill();
+		this.starSprites.set(key, cv);
+		return cv;
+	}
+
+	private getHaloSprite(clusterId: number, radiusPx: number): { cv: HTMLCanvasElement; bucket: number } {
+		const buckets = [20, 50, 100, 200, 400];
+		let bucket = buckets[buckets.length - 1];
+		for (const b of buckets) {
+			if (radiusPx <= b) {
+				bucket = b;
+				break;
+			}
+		}
+		const step = Math.floor(hash01(clusterId) * HUE_STEPS) % HUE_STEPS;
+		const key = `${step}_${bucket}`;
+		let cv = this.haloSprites.get(key);
+		if (cv) return { cv, bucket };
+		const c = this.hueColors(step);
+		const size = bucket * 2 + 4;
+		cv = document.createElement('canvas');
+		cv.width = size;
+		cv.height = size;
+		const g = cv.getContext('2d')!;
+		const half = size / 2;
+		// gaussian-style falloff — the light just dissipates, hue drifting
+		// core -> mid -> edge as it fades
+		const K = 3.0;
+		const floor = Math.exp(-K);
+		const grad = g.createRadialGradient(half, half, 0, half, half, bucket);
+		for (let s = 0; s <= 10; s++) {
+			const t = s / 10;
+			const a = (Math.exp(-K * t * t) - floor) / (1 - floor);
+			const from = t < 0.5 ? c.core : c.mid;
+			const to = t < 0.5 ? c.mid : c.edge;
+			const f = t < 0.5 ? t * 2 : (t - 0.5) * 2;
+			grad.addColorStop(
+				t,
+				`rgba(${Math.round(from[0] + (to[0] - from[0]) * f)},${Math.round(
+					from[1] + (to[1] - from[1]) * f
+				)},${Math.round(from[2] + (to[2] - from[2]) * f)},${a.toFixed(4)})`
+			);
+		}
+		g.fillStyle = grad;
+		g.fillRect(0, 0, size, size);
+		this.haloSprites.set(key, cv);
+		return { cv, bucket };
+	}
+
+	// --- images ---
+
+	private loadCover(i: number): void {
+		if (!this.data) return;
+		if (this.coverImages.has(i) || this.coverFailed.has(i) || this.coverLoading.has(i)) return;
+		if (this.coverLoadCount >= 8) return;
+		const url = this.data.points[i].thumb;
+		if (!url) {
+			this.coverFailed.add(i);
+			return;
+		}
+		this.coverLoading.add(i);
+		this.coverLoadCount++;
+		const img = new Image();
+		img.onload = () => {
+			this.coverImages.set(i, img);
+			this.coverLoading.delete(i);
+			this.coverLoadCount--;
+			this.markDirty();
+		};
+		img.onerror = () => {
+			this.coverFailed.add(i);
+			this.coverLoading.delete(i);
+			this.coverLoadCount--;
+		};
+		img.src = url;
+	}
+
+	private loadAvatar(a: AtlasArtist): void {
+		if (this.avatarImages.has(a.did) || this.avatarFailed.has(a.did) || !a.avatar) return;
+		const img = new Image();
+		img.onload = () => {
+			this.avatarImages.set(a.did, img);
+			this.markDirty();
+		};
+		img.onerror = () => this.avatarFailed.add(a.did);
+		img.src = a.avatar;
+		// mark as pending so we don't create duplicate Image objects
+		this.avatarImages.set(a.did, img);
+	}
+
+	// --- transforms ---
+
+	private cacheTransform(): void {
+		this.scale = Math.min(this.W, this.H) * 0.42 * this.view.zoom;
+		this.cx = this.W / 2 + this.view.panX * this.scale;
+		this.cy = this.H / 2 + this.view.panY * this.scale;
+	}
+
+	private screenToData(sx: number, sy: number): [number, number] {
+		return [
+			(sx - this.W / 2) / this.scale - this.view.panX,
+			(sy - this.H / 2) / this.scale - this.view.panY
+		];
+	}
+
+	private findNearest(sx: number, sy: number, maxDistPx: number): number {
+		if (!this.data) return -1;
+		const [dx, dy] = this.screenToData(sx, sy);
+		const r = maxDistPx / this.scale;
+		const cs = this.cellSize;
+		let best = -1;
+		let bestD = r * r;
+		for (let gx = Math.floor((dx - r) / cs); gx <= Math.floor((dx + r) / cs); gx++) {
+			for (let gy = Math.floor((dy - r) / cs); gy <= Math.floor((dy + r) / cs); gy++) {
+				const cell = this.grid.get(`${gx},${gy}`);
+				if (!cell) continue;
+				for (const i of cell) {
+					const ddx = this.px[i] - dx;
+					const ddy = this.py[i] - dy;
+					const d2 = ddx * ddx + ddy * ddy;
+					if (d2 < bestD) {
+						bestD = d2;
+						best = i;
+					}
+				}
+			}
+		}
+		return best;
+	}
+
+	private artistRadiusPx(a: AtlasArtist): number {
+		return Math.min(26, Math.sqrt(a.count) * this.view.zoom * 0.9);
+	}
+
+	private findArtistAt(sx: number, sy: number): number {
+		if (!this.data) return -1;
+		for (let i = 0; i < this.data.artists.length; i++) {
+			const a = this.data.artists[i];
+			const pr = this.artistRadiusPx(a);
+			if (pr < 5) continue;
+			const ax = this.cx + a.cx * this.scale;
+			const ay = this.cy + a.cy * this.scale;
+			const dx = sx - ax;
+			const dy = sy - ay;
+			if (dx * dx + dy * dy <= pr * pr) return i;
+		}
+		return -1;
+	}
+
+	// --- frame scheduling ---
+
+	private markDirty(): void {
+		this.view.dirty = true;
+		this.scheduleFrame();
+	}
+
+	private scheduleFrame(): void {
+		if (this.frameRequested || this.destroyed) return;
+		this.frameRequested = true;
+		requestAnimationFrame(() => this.loop());
+	}
+
+	private loop(): void {
+		this.frameRequested = false;
+		if (this.destroyed) return;
+		if (this.animating) {
+			const t = Math.min(1, (performance.now() - this.animStart) / this.animMs);
+			const e = easeOutCubic(t);
+			this.view.zoom = this.animFrom.zoom + (this.animTo.zoom - this.animFrom.zoom) * e;
+			this.view.panX = this.animFrom.panX + (this.animTo.panX - this.animFrom.panX) * e;
+			this.view.panY = this.animFrom.panY + (this.animTo.panY - this.animFrom.panY) * e;
+			this.view.dirty = true;
+			if (t >= 1) this.animating = false;
+		}
+		this.render();
+		if (this.animating) this.scheduleFrame();
+	}
+
+	private resize(): void {
+		const rect = this.canvas.parentElement?.getBoundingClientRect();
+		this.W = rect?.width ?? window.innerWidth;
+		this.H = rect?.height ?? window.innerHeight;
+		this.canvas.width = this.W * this.dpr;
+		this.canvas.height = this.H * this.dpr;
+		this.canvas.style.width = `${this.W}px`;
+		this.canvas.style.height = `${this.H}px`;
+		this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
+		this.markDirty();
+	}
+
+	// --- render ---
+
+	private render(): void {
+		if (!this.data || !this.view.dirty) return;
+		this.view.dirty = false;
+		this.invalidateSpritesIfThemed();
+		this.cacheTransform();
+		const { ctx, W, H } = this;
+		const zoom = this.view.zoom;
+		const n = this.data.points.length;
+		const small = W < 600;
+
+		ctx.globalAlpha = 1;
+		ctx.fillStyle = this.dark ? '#0a0a0a' : '#fafafa';
+		ctx.fillRect(0, 0, W, H);
+
+		const tl = this.screenToData(0, 0);
+		const br = this.screenToData(W, H);
+		const pad = 0.05;
+		const xMin = tl[0] - pad;
+		const xMax = br[0] + pad;
+		const yMin = tl[1] - pad;
+		const yMax = br[1] + pad;
+
+		// --- coarse region nebulae (zoomed out) ---
+		const coarseAlphaNow =
+			(this.dark ? TUNE.coarse.alphaDark : TUNE.coarse.alphaLight) *
+			fadeOut(zoom, TUNE.coarse.outStart, TUNE.coarse.outRange);
+		if (coarseAlphaNow > 0.01) {
+			for (const cl of this.data.clusters.coarse) {
+				const r = (cl.radius ?? 0.05) * this.scale;
+				if (r < 2) continue;
+				const sx = this.cx + cl.cx * this.scale;
+				const sy = this.cy + cl.cy * this.scale;
+				if (sx + r < 0 || sx - r > W || sy + r < 0 || sy - r > H) continue;
+				const halo = this.getHaloSprite(cl.id + 1000, r);
+				const drawSize = halo.cv.width * (r / halo.bucket) * (small ? 0.7 : 1);
+				ctx.globalAlpha = coarseAlphaNow;
+				ctx.drawImage(halo.cv, sx - drawSize / 2, sy - drawSize / 2, drawSize, drawSize);
+			}
+			ctx.globalAlpha = 1;
+		}
+
+		// --- fine cluster lanterns (zoomed in) ---
+		const neb = TUNE.nebula;
+		const nebAlpha = fadeIn(zoom, neb.inStart, neb.inRange) * fadeOut(zoom, neb.outStart, neb.outRange);
+		if (nebAlpha > 0.01) {
+			for (const cl of this.data.clusters.fine) {
+				const L = cl.lantern;
+				if (!L) continue;
+				const rFloor = neb.minHaloPx * Math.sqrt(Math.max(1, zoom / neb.growRefZoom));
+				const rPx =
+					Math.min(neb.maxHaloPx, Math.max(rFloor, L.r * neb.spread * this.scale)) *
+					(small ? 0.85 : 1);
+				const sx = this.cx + L.x * this.scale;
+				const sy = this.cy + L.y * this.scale;
+				if (sx + rPx < 0 || sx - rPx > W || sy + rPx < 0 || sy - rPx > H) continue;
+				const halo = this.getHaloSprite(cl.id, rPx);
+				const drawSize = halo.cv.width * (rPx / halo.bucket);
+				const v = neb.varBase + hash01(cl.id) * neb.varRange;
+				ctx.globalAlpha = neb.alpha * v * nebAlpha;
+				ctx.drawImage(halo.cv, sx - drawSize / 2, sy - drawSize / 2, drawSize, drawSize);
+			}
+			ctx.globalAlpha = 1;
+		}
+
+		// --- points ---
+		const coverAlpha = fadeIn(zoom, TUNE.covers.start, TUNE.covers.range);
+		const useStar = zoom >= 2;
+		const pointR = Math.min(6, 1.0 + zoom * 0.18);
+		ctx.globalAlpha = 1;
+		for (let i = 0; i < n; i++) {
+			const x = this.px[i];
+			const y = this.py[i];
+			if (x < xMin || x > xMax || y < yMin || y > yMax) continue;
+			const sx = this.cx + x * this.scale;
+			const sy = this.cy + y * this.scale;
+			const spr = useStar
+				? this.getStarSprite(this.hueStep[i], pointR, i === this.hovered || i === this.selected)
+				: this.getDotSprite(this.hueStep[i]);
+			const w = spr.width / this.dpr;
+			ctx.drawImage(spr, sx - w / 2, sy - w / 2, w, w);
+		}
+
+		// --- cover art (high zoom): tracks resolve into their actual artwork ---
+		if (coverAlpha > 0.01) {
+			const budget = small ? TUNE.covers.budget.s : TUNE.covers.budget.l;
+			const cands: { i: number; sx: number; sy: number; d: number; size?: number }[] = [];
+			const vcx = W / 2;
+			const vcy = H / 2;
+			for (let i = 0; i < n; i++) {
+				const x = this.px[i];
+				const y = this.py[i];
+				if (x < xMin || x > xMax || y < yMin || y > yMax) continue;
+				const sx = this.cx + x * this.scale;
+				const sy = this.cy + y * this.scale;
+				const ddx = sx - vcx;
+				const ddy = sy - vcy;
+				cands.push({ i, sx, sy, d: ddx * ddx + ddy * ddy });
+			}
+			cands.sort((a, b) => a.d - b.d);
+			if (cands.length > budget) cands.length = budget;
+			// adaptive size: shrink to local spacing so dense clusters read as
+			// distinct covers instead of an overlapping pile
+			const maxPx = Math.min(TUNE.covers.maxPx, 10 + (zoom - TUNE.covers.start) * 2.2);
+			for (const c of cands) {
+				let best = Infinity;
+				for (const o of cands) {
+					if (o === c) continue;
+					const dx = c.sx - o.sx;
+					const dy = c.sy - o.sy;
+					const dd = dx * dx + dy * dy;
+					if (dd < best) best = dd;
+				}
+				c.size =
+					best === Infinity
+						? maxPx
+						: Math.max(TUNE.covers.minPx, Math.min(maxPx, Math.sqrt(best) * 0.9));
+			}
+			for (const c of cands) {
+				this.loadCover(c.i);
+				const img = this.coverImages.get(c.i);
+				const size = c.size ?? maxPx;
+				const half = size / 2;
+				const focus = c.i === this.hovered || c.i === this.selected;
+				if (img) {
+					ctx.globalAlpha = coverAlpha;
+					ctx.save();
+					ctx.beginPath();
+					ctx.roundRect(c.sx - half, c.sy - half, size, size, Math.max(2, size * 0.08));
+					ctx.clip();
+					ctx.drawImage(img, c.sx - half, c.sy - half, size, size);
+					ctx.restore();
+					if (focus) {
+						ctx.globalAlpha = coverAlpha;
+						ctx.strokeStyle = this.dark ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.8)';
+						ctx.lineWidth = 2;
+						ctx.beginPath();
+						ctx.roundRect(c.sx - half, c.sy - half, size, size, Math.max(2, size * 0.08));
+						ctx.stroke();
+					}
+				}
+			}
+			ctx.globalAlpha = 1;
+		}
+
+		// --- artist circles ---
+		const artistCands: { name: string; x: number; y: number }[] = [];
+		if (zoom >= 2.5) {
+			let avatarBudget = small ? 8 : 20;
+			for (const a of this.data.artists) {
+				const pr = this.artistRadiusPx(a);
+				if (pr < 5) continue;
+				const ax = this.cx + a.cx * this.scale;
+				const ay = this.cy + a.cy * this.scale;
+				if (ax < -40 || ax > W + 40 || ay < -40 || ay > H + 40) continue;
+				const wantAvatar = pr >= 10 && avatarBudget > 0;
+				if (wantAvatar) {
+					this.loadAvatar(a);
+					avatarBudget--;
+				}
+				const img = wantAvatar ? this.avatarImages.get(a.did) : undefined;
+				const loaded = img && img.complete && img.naturalWidth > 0;
+				if (loaded) {
+					ctx.save();
+					ctx.globalAlpha = 0.9;
+					ctx.beginPath();
+					ctx.arc(ax, ay, pr, 0, Math.PI * 2);
+					ctx.clip();
+					ctx.drawImage(img, ax - pr, ay - pr, pr * 2, pr * 2);
+					ctx.restore();
+				} else {
+					ctx.globalAlpha = 0.55;
+					ctx.beginPath();
+					ctx.arc(ax, ay, pr, 0, Math.PI * 2);
+					ctx.fillStyle = this.dark ? '#1a1a1a' : '#e8e8e8';
+					ctx.fill();
+					if (pr >= 12) {
+						ctx.font = `bold ${Math.max(8, Math.round(pr * 0.8))}px monospace`;
+						ctx.textAlign = 'center';
+						ctx.textBaseline = 'middle';
+						ctx.fillStyle = this.dark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.6)';
+						ctx.globalAlpha = 0.9;
+						ctx.fillText((a.name || '?').charAt(0).toLowerCase(), ax, ay);
+					}
+				}
+				ctx.globalAlpha = 0.25 + Math.min(0.35, pr / 40);
+				ctx.beginPath();
+				ctx.arc(ax, ay, pr, 0, Math.PI * 2);
+				ctx.strokeStyle = this.dark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.4)';
+				ctx.lineWidth = 1.5;
+				ctx.stroke();
+				if (zoom >= 3.5 && pr >= 9 && artistCands.length < 30) {
+					artistCands.push({ name: a.handle, x: ax, y: ay + pr + 9 });
+				}
+			}
+			ctx.globalAlpha = 1;
+		}
+
+		// --- label economy: one collision pass, priority order ---
+		const placed: { x: number; y: number; hw: number; hh: number }[] = [];
+		const PAD = small ? 2 : 4;
+		const MARGIN = small ? 8 : 12;
+		const canPlace = (lx: number, ly: number, tw: number, th: number): boolean => {
+			const hw = tw / 2 + PAD;
+			const hh = th / 2 + PAD;
+			for (const p of placed) {
+				if (Math.abs(lx - p.x) < hw + p.hw && Math.abs(ly - p.y) < hh + p.hh) return false;
+			}
+			placed.push({ x: lx, y: ly, hw, hh });
+			return true;
+		};
+		// labels stay anchored over their subject: cull at the viewport edge
+		// rather than shifting inward (a shifted label points at nothing)
+		const fitsHoriz = (lx: number, halfW: number): boolean =>
+			lx - halfW >= MARGIN && lx + halfW <= W - MARGIN;
+
+		ctx.textAlign = 'center';
+		ctx.textBaseline = 'middle';
+		const drawLabel = (text: string, x: number, y: number): void => {
+			ctx.strokeStyle = this.dark ? 'rgba(0,0,0,0.88)' : 'rgba(255,255,255,0.88)';
+			ctx.lineWidth = 4;
+			ctx.lineJoin = 'round';
+			ctx.strokeText(text, x, y);
+			ctx.fillText(text, x, y);
+		};
+
+		const coarseLabelAlpha = fadeOut(zoom, 1.7, 0.6);
+		if (coarseLabelAlpha > 0.01) {
+			const fontSize = small ? 10 : 13;
+			ctx.font = `${fontSize}px monospace`;
+			ctx.globalAlpha = 0.95 * coarseLabelAlpha;
+			ctx.fillStyle = this.dark ? 'rgba(255,255,255,0.95)' : 'rgba(0,0,0,0.88)';
+			const max = small ? TUNE.labels.coarse.s : TUNE.labels.coarse.l;
+			let shown = 0;
+			const sorted = [...this.data.clusters.coarse].sort((a, b) => b.count - a.count);
+			for (const cl of sorted) {
+				if (shown >= max) break;
+				const sx = this.cx + cl.cx * this.scale;
+				const sy = this.cy + cl.cy * this.scale - Math.sqrt(cl.count) * 1.5;
+				if (sy < MARGIN || sy > H - 40) continue;
+				const tw = ctx.measureText(cl.label).width;
+				if (!fitsHoriz(sx, tw / 2)) continue;
+				if (canPlace(sx, sy, tw, fontSize)) {
+					drawLabel(cl.label, sx, sy);
+					shown++;
+				}
+			}
+		}
+
+		const fineLabelAlpha = fadeIn(zoom, 1.7, 0.6) * fadeOut(zoom, neb.outStart, neb.outRange);
+		if (fineLabelAlpha > 0.01) {
+			const fontSize = small ? 10 : 12;
+			ctx.font = `bold ${fontSize}px monospace`;
+			ctx.globalAlpha = 0.95 * fineLabelAlpha;
+			ctx.fillStyle = this.dark ? 'rgba(255,255,255,0.95)' : 'rgba(0,0,0,0.88)';
+			const max = small ? TUNE.labels.fine.s : TUNE.labels.fine.l;
+			let shown = 0;
+			const sorted = [...this.data.clusters.fine].sort((a, b) => b.count - a.count);
+			for (const cl of sorted) {
+				if (shown >= max) break;
+				if (cl.cx < xMin || cl.cx > xMax || cl.cy < yMin || cl.cy > yMax) continue;
+				const sx = this.cx + cl.cx * this.scale;
+				const sy = this.cy + cl.cy * this.scale - 14;
+				if (sy < MARGIN || sy > H - 40) continue;
+				const tw = ctx.measureText(cl.label).width;
+				if (!fitsHoriz(sx, tw / 2)) continue;
+				if (canPlace(sx, sy, tw, fontSize)) {
+					drawLabel(cl.label, sx, sy);
+					shown++;
+				}
+			}
+		}
+
+		const titleAlpha = fadeIn(zoom, 4.5, 1.0);
+		if (titleAlpha > 0.01) {
+			const fontSize = small ? 9 : 11;
+			ctx.font = `${fontSize}px monospace`;
+			ctx.globalAlpha = 0.9 * titleAlpha;
+			ctx.fillStyle = this.dark ? 'rgba(255,255,255,0.95)' : 'rgba(0,0,0,0.88)';
+			const max = small ? TUNE.labels.titles.s : TUNE.labels.titles.l;
+			const truncLen = small ? 22 : 40;
+			let shown = 0;
+			for (let oi = 0; oi < n && shown < max; oi++) {
+				const i = this.popOrder[oi];
+				const x = this.px[i];
+				const y = this.py[i];
+				if (x < xMin || x > xMax || y < yMin || y > yMax) continue;
+				let title = this.data.points[i].title;
+				if (!title) continue;
+				const sx = this.cx + x * this.scale;
+				const sy = this.cy + y * this.scale - (coverAlpha > 0.5 ? 30 : 10);
+				if (sy < MARGIN || sy > H - 40) continue;
+				if (title.length > truncLen) title = title.slice(0, truncLen - 1) + '…';
+				const tw = ctx.measureText(title).width;
+				if (!fitsHoriz(sx, tw / 2)) continue;
+				if (canPlace(sx, sy, tw, fontSize)) {
+					drawLabel(title, sx, sy);
+					shown++;
+				}
+			}
+		}
+
+		if (artistCands.length) {
+			const fontSize = small ? 8 : 10;
+			ctx.font = `${fontSize}px monospace`;
+			ctx.globalAlpha = Math.min(0.8, fadeIn(zoom, 3.5, 1.0));
+			ctx.fillStyle = this.dark ? 'rgba(255,255,255,0.85)' : 'rgba(0,0,0,0.75)';
+			const max = small ? TUNE.labels.artists.s : TUNE.labels.artists.l;
+			let shown = 0;
+			for (const cand of artistCands) {
+				if (shown >= max) break;
+				if (cand.y < MARGIN || cand.y > H - 40) continue;
+				const name = cand.name.length > 24 ? cand.name.slice(0, 22) + '…' : cand.name;
+				const tw = ctx.measureText(name).width;
+				if (!fitsHoriz(cand.x, tw / 2)) continue;
+				if (canPlace(cand.x, cand.y, tw, fontSize)) {
+					drawLabel(name, cand.x, cand.y);
+					shown++;
+				}
+			}
+		}
+
+		ctx.globalAlpha = 1;
+	}
+
+	// --- input ---
+
+	private bindInput(): void {
+		const canvas = this.canvas;
+
+		const onWheel = (e: WheelEvent): void => {
+			e.preventDefault();
+			const dy = e.deltaMode === 1 ? e.deltaY * 40 : e.deltaY;
+			const factor = Math.pow(0.995, dy);
+			const rect = canvas.getBoundingClientRect();
+			const mx = e.clientX - rect.left;
+			const my = e.clientY - rect.top;
+			const newZoom = Math.max(this.view.minZoom, Math.min(this.view.maxZoom, this.view.zoom * factor));
+			this.cacheTransform();
+			const d = this.screenToData(mx, my);
+			this.view.zoom = newZoom;
+			this.cacheTransform();
+			const d2 = this.screenToData(mx, my);
+			this.view.panX += d2[0] - d[0];
+			this.view.panY += d2[1] - d[1];
+			this.markDirty();
+		};
+
+		const onMouseDown = (e: MouseEvent): void => {
+			if (e.button !== 0) return;
+			this.dragging = true;
+			this.dragStartX = e.clientX;
+			this.dragStartY = e.clientY;
+			this.dragStartPanX = this.view.panX;
+			this.dragStartPanY = this.view.panY;
+		};
+
+		const onMouseMove = (e: MouseEvent): void => {
+			const rect = canvas.getBoundingClientRect();
+			const mx = e.clientX - rect.left;
+			const my = e.clientY - rect.top;
+			if (this.dragging) {
+				this.cacheTransform();
+				this.view.panX = this.dragStartPanX + (e.clientX - this.dragStartX) / this.scale;
+				this.view.panY = this.dragStartPanY + (e.clientY - this.dragStartY) / this.scale;
+				this.markDirty();
+				this.cb.onHover(null, 0, 0);
+				return;
+			}
+			this.cacheTransform();
+			const ai = this.findArtistAt(mx, my);
+			if (ai >= 0) {
+				if (this.hoveredArtist !== ai) {
+					this.hoveredArtist = ai;
+					this.hovered = -1;
+					this.cb.onHover(null, 0, 0);
+					this.cb.onHoverArtist(this.data!.artists[ai], mx, my);
+					this.markDirty();
+				}
+				canvas.style.cursor = 'pointer';
+				return;
+			}
+			if (this.hoveredArtist >= 0) {
+				this.hoveredArtist = -1;
+				this.cb.onHoverArtist(null, 0, 0);
+			}
+			const idx = this.findNearest(mx, my, this.hitRadius);
+			if (idx !== this.hovered) {
+				this.hovered = idx;
+				this.markDirty();
+				if (idx >= 0 && this.data) this.cb.onHover(this.data.points[idx], mx, my);
+				else this.cb.onHover(null, 0, 0);
+			}
+			canvas.style.cursor = idx >= 0 ? 'pointer' : 'grab';
+		};
+
+		const onMouseUp = (e: MouseEvent): void => {
+			if (!this.dragging) return;
+			this.dragging = false;
+			if (Math.abs(e.clientX - this.dragStartX) >= 4 || Math.abs(e.clientY - this.dragStartY) >= 4)
+				return;
+			if (this.hoveredArtist >= 0 && this.data) {
+				this.cb.onActivateArtist(this.data.artists[this.hoveredArtist]);
+			} else if (this.hovered >= 0 && this.data) {
+				this.cb.onActivate(this.data.points[this.hovered]);
+			}
+		};
+
+		const onTouchStart = (e: TouchEvent): void => {
+			e.preventDefault();
+			for (const t of Array.from(e.changedTouches)) {
+				this.touches.set(t.identifier, { x: t.clientX, y: t.clientY });
+			}
+			this.touchMoved = false;
+			if (this.touches.size === 1) {
+				const t = this.touches.values().next().value!;
+				this.dragging = true;
+				this.dragStartX = t.x;
+				this.dragStartY = t.y;
+				this.dragStartPanX = this.view.panX;
+				this.dragStartPanY = this.view.panY;
+			} else if (this.touches.size === 2) {
+				this.dragging = false;
+				const [a, b] = Array.from(this.touches.values());
+				this.pinchStartDist = Math.hypot(a.x - b.x, a.y - b.y);
+				this.pinchStartZoom = this.view.zoom;
+				this.pinchMidX = (a.x + b.x) / 2;
+				this.pinchMidY = (a.y + b.y) / 2;
+			}
+		};
+
+		const onTouchMove = (e: TouchEvent): void => {
+			e.preventDefault();
+			for (const t of Array.from(e.changedTouches)) {
+				this.touches.set(t.identifier, { x: t.clientX, y: t.clientY });
+			}
+			this.touchMoved = true;
+			if (this.touches.size === 1 && this.dragging) {
+				const t = this.touches.values().next().value!;
+				this.cacheTransform();
+				this.view.panX = this.dragStartPanX + (t.x - this.dragStartX) / this.scale;
+				this.view.panY = this.dragStartPanY + (t.y - this.dragStartY) / this.scale;
+				this.markDirty();
+				this.selected = -1;
+				this.cb.onHover(null, 0, 0);
+			} else if (this.touches.size === 2) {
+				const [a, b] = Array.from(this.touches.values());
+				const dist = Math.hypot(a.x - b.x, a.y - b.y);
+				const newZoom = Math.max(
+					this.view.minZoom,
+					Math.min(this.view.maxZoom, this.pinchStartZoom * (dist / this.pinchStartDist))
+				);
+				const rect = this.canvas.getBoundingClientRect();
+				const mx = this.pinchMidX - rect.left;
+				const my = this.pinchMidY - rect.top;
+				this.cacheTransform();
+				const d = this.screenToData(mx, my);
+				this.view.zoom = newZoom;
+				this.cacheTransform();
+				const d2 = this.screenToData(mx, my);
+				this.view.panX += d2[0] - d[0];
+				this.view.panY += d2[1] - d[1];
+				this.markDirty();
+			}
+		};
+
+		const onTouchEnd = (e: TouchEvent): void => {
+			const ended = Array.from(e.changedTouches);
+			for (const t of ended) this.touches.delete(t.identifier);
+			if (this.touches.size > 0) return;
+			this.dragging = false;
+			const first = ended[0];
+			if (!first) return;
+			const moved =
+				this.touchMoved &&
+				(Math.abs(first.clientX - this.dragStartX) >= 10 ||
+					Math.abs(first.clientY - this.dragStartY) >= 10);
+			if (moved || !this.data) return;
+			const rect = this.canvas.getBoundingClientRect();
+			const tx = first.clientX - rect.left;
+			const ty = first.clientY - rect.top;
+			this.cacheTransform();
+			const ai = this.findArtistAt(tx, ty);
+			if (ai >= 0) {
+				this.cb.onActivateArtist(this.data.artists[ai]);
+				return;
+			}
+			// first tap selects (tooltip), second tap on the same track plays
+			const idx = this.findNearest(tx, ty, this.hitRadius);
+			if (idx >= 0) {
+				if (idx === this.selected) {
+					this.cb.onActivate(this.data.points[idx]);
+					this.selected = -1;
+					this.cb.onHover(null, 0, 0);
+				} else {
+					this.selected = idx;
+					this.hovered = idx;
+					this.cb.onHover(this.data.points[idx], tx, ty);
+					this.markDirty();
+				}
+			} else {
+				this.selected = -1;
+				this.hovered = -1;
+				this.cb.onHover(null, 0, 0);
+				this.markDirty();
+			}
+		};
+
+		canvas.addEventListener('wheel', onWheel, { passive: false });
+		canvas.addEventListener('mousedown', onMouseDown);
+		window.addEventListener('mousemove', onMouseMove);
+		window.addEventListener('mouseup', onMouseUp);
+		canvas.addEventListener('touchstart', onTouchStart, { passive: false });
+		canvas.addEventListener('touchmove', onTouchMove, { passive: false });
+		canvas.addEventListener('touchend', onTouchEnd);
+
+		this.removeListeners = [
+			() => canvas.removeEventListener('wheel', onWheel),
+			() => canvas.removeEventListener('mousedown', onMouseDown),
+			() => window.removeEventListener('mousemove', onMouseMove),
+			() => window.removeEventListener('mouseup', onMouseUp),
+			() => canvas.removeEventListener('touchstart', onTouchStart),
+			() => canvas.removeEventListener('touchmove', onTouchMove),
+			() => canvas.removeEventListener('touchend', onTouchEnd)
+		];
+	}
+}

--- a/loq.toml
+++ b/loq.toml
@@ -43,7 +43,7 @@ max_lines = 1868
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 1257
+max_lines = 1262
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
@@ -360,3 +360,11 @@ max_lines = 634
 [[rules]]
 path = "frontend/src/routes/u/[[]handle[]]/+page.svelte"
 max_lines = 1444
+
+[[rules]]
+path = "scripts/build_atlas.py"
+max_lines = 582
+
+[[rules]]
+path = "frontend/src/routes/atlas/renderer.ts"
+max_lines = 1171

--- a/scripts/build_atlas.py
+++ b/scripts/build_atlas.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.12,<3.14"
+# # numpy<2.2 + python<3.14: umap-learn's transitive numba/llvmlite have no wheel
+# # outside that window, so an unpinned solve backtracks into source builds.
+# dependencies = [
+#     "httpx",
+#     "numpy<2.2",
+#     "psycopg[binary]",
+#     "scikit-learn",
+#     "umap-learn",
+#     "hdbscan",
+#     "pydantic-settings",
+#     "anthropic",
+#     "boto3",
+# ]
+# ///
+"""build atlas.json — a 2D semantic map of the public track catalog.
+
+exports CLAP embeddings from turbopuffer, projects to 2D via PCA+UMAP,
+clusters with HDBSCAN at two granularities in a separate 10D space, and
+labels clusters via c-TF-IDF over titles+tags with optional LLM refinement.
+the pipeline follows pub-search's build-atlas (see its docs/atlas.md for the
+rationale on 10D clustering and core-only label evidence), scaled down to a
+catalog of ~1k tracks.
+
+eligibility mirrors the radio corpus (backend/api/radio/corpus.py): public
+discovery visibility, ungated, active artist, and no adult-audio or
+copyright labels — the atlas is an anonymous chosen-for-you surface.
+
+the output uploads to the dedicated stats bucket (same pattern as
+scripts/costs/export_costs.py); the backend proxies it at /stats/atlas and
+the /atlas page fetches that. a daily GitHub Action keeps it fresh.
+
+usage:
+    export ATLAS_DATABASE_URL=postgresql://...
+    export TURBOPUFFER_API_KEY=...
+    export ANTHROPIC_API_KEY=...   # optional: LLM-refined cluster labels
+    uv run scripts/build_atlas.py -o atlas.json   # local build only
+    uv run scripts/build_atlas.py --upload        # build + upload to R2
+"""
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+import httpx
+import numpy as np
+import psycopg
+from pydantic import ValidationError
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from sklearn.decomposition import PCA
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+DEFAULT_OUTPUT = Path(__file__).resolve().parent.parent / "atlas.json"
+
+EXCLUDED_LABELS = ["sexual", "porn", "copyright-violation"]
+
+CORPUS_SQL = """
+select
+    t.id,
+    t.title,
+    t.thumbnail_url,
+    t.image_url,
+    t.play_count,
+    a.did as artist_did,
+    a.handle as artist_handle,
+    a.display_name as artist_name,
+    a.avatar_url as artist_avatar,
+    coalesce(
+        (select array_agg(tg.name order by tg.name)
+         from track_tags tt join tags tg on tg.id = tt.tag_id
+         where tt.track_id = t.id),
+        '{}'
+    ) as tags,
+    coalesce(
+        (select count(*) from track_likes tl where tl.track_id = t.id), 0
+    ) as like_count
+from tracks t
+join artists a on a.did = t.artist_did
+where t.visibility in ('public', 'supporters')
+  and t.support_gate is null
+  and a.deactivated = false
+  and not (t.self_labels ?| %(labels)s or t.operator_labels ?| %(labels)s)
+"""
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file="backend/.env", extra="ignore")
+
+    atlas_database_url: str = ""
+    turbopuffer_api_key: str
+    turbopuffer_region: str = "api"
+    turbopuffer_namespace: str = "plyr-tracks"
+    anthropic_api_key: str = ""
+
+    # r2 stats bucket (dedicated, shared across environments) — for --upload
+    aws_access_key_id: str = ""
+    aws_secret_access_key: str = ""
+    r2_endpoint_url: str = ""
+    r2_stats_bucket: str = "plyr-stats"
+
+
+def tpuf_export(settings: Settings) -> list[dict]:
+    """export all vectors from turbopuffer via paginated query."""
+    url = (
+        f"https://{settings.turbopuffer_region}.turbopuffer.com"
+        f"/v2/namespaces/{settings.turbopuffer_namespace}/query"
+    )
+    headers = {
+        "Authorization": f"Bearer {settings.turbopuffer_api_key}",
+        "Content-Type": "application/json",
+    }
+    rows: list[dict] = []
+    last_id = None
+    with httpx.Client(timeout=120) as client:
+        while True:
+            body: dict = {
+                "rank_by": ["id", "asc"],
+                "limit": 10000,
+                "include_attributes": ["vector"],
+            }
+            if last_id is not None:
+                body["filters"] = ["id", "Gt", last_id]
+            resp = client.post(url, headers=headers, json=body)
+            resp.raise_for_status()
+            page = resp.json().get("rows", [])
+            if not page:
+                break
+            rows.extend(page)
+            last_id = page[-1]["id"]
+            log(f"  fetched {len(rows)} vectors so far...")
+            if len(page) < 10000:
+                break
+    return rows
+
+
+def load_corpus(db_url: str) -> dict[int, dict]:
+    """load atlas-eligible tracks keyed by id."""
+    with psycopg.connect(db_url) as conn, conn.cursor() as cur:
+        cur.execute(CORPUS_SQL, {"labels": EXCLUDED_LABELS})
+        cols = [d.name for d in cur.description]
+        return {row[0]: dict(zip(cols, row, strict=True)) for row in cur.fetchall()}
+
+
+def extract_terms(text: str) -> str:
+    return " ".join(t for t in re.findall(r"[a-z0-9]+", text.lower()) if len(t) > 1)
+
+
+def cluster_tfidf_labels(
+    docs_per_cluster: dict[int, list[str]], n_terms: int = 3
+) -> dict[int, str]:
+    """c-TF-IDF keyword labels: one pseudo-document per cluster."""
+    cluster_ids = sorted(docs_per_cluster.keys())
+    if not cluster_ids:
+        return {}
+    docs = [" ".join(docs_per_cluster[cid]) for cid in cluster_ids]
+    vectorizer = TfidfVectorizer(
+        max_features=5000,
+        stop_words="english",
+        token_pattern=r"[a-z0-9]{2,}",
+        lowercase=True,
+    )
+    try:
+        tfidf = vectorizer.fit_transform(docs)
+    except ValueError:
+        return {cid: f"cluster {cid}" for cid in cluster_ids}
+    feature_names = vectorizer.get_feature_names_out()
+    labels = {}
+    for i, cid in enumerate(cluster_ids):
+        row = tfidf[i].toarray().flatten()
+        top_idx = row.argsort()[-n_terms:][::-1]
+        top_terms = [feature_names[j] for j in top_idx if row[j] > 0]
+        labels[cid] = " ".join(top_terms) if top_terms else f"cluster {cid}"
+    return labels
+
+
+def llm_refine_labels(
+    tfidf_labels: dict[int, str],
+    evidence_per_cluster: dict[int, list[str]],
+    cluster_counts: dict[int, int],
+    api_key: str,
+    tier: str,
+    batch_size: int = 15,
+) -> dict[int, str]:
+    """refine keyword labels into short region names with claude haiku."""
+    from anthropic import AsyncAnthropic
+
+    client = AsyncAnthropic(api_key=api_key)
+    rng = np.random.default_rng(42)
+    cluster_ids = sorted(tfidf_labels.keys())
+    batches = [
+        cluster_ids[i : i + batch_size] for i in range(0, len(cluster_ids), batch_size)
+    ]
+
+    system_instructions = (
+        "You are labeling clusters for a music atlas — a 2D map of a track catalog "
+        "where each cluster groups tracks that sound alike (clustered on audio "
+        "embeddings, not text).\n\n"
+        "For each cluster you receive its keyword seed plus sample track titles and "
+        "listener tags. Write a short evocative label (2-4 lowercase words) that names "
+        "the sonic territory, like a region on a map.\n\n"
+        'Good labels: "ambient drift", "bedroom pop", "heavy guitars", '
+        '"late night electronic", "acoustic folk", "glitch experiments"\n'
+        'Bad labels: "track song mix", "untitled demo 2", "cluster seven"\n\n'
+        "Respond with ONLY a JSON object mapping cluster ID (as string) to label. "
+        "No other text."
+    )
+
+    async def label_batch(batch: list[int]) -> dict[int, str]:
+        parts = []
+        for cid in batch:
+            evidence = evidence_per_cluster.get(cid, [])
+            sample = (
+                list(rng.choice(evidence, size=min(12, len(evidence)), replace=False))
+                if evidence
+                else []
+            )
+            parts.append(
+                f"Cluster {cid} ({cluster_counts.get(cid, 0)} tracks):\n"
+                f"  Keywords: {tfidf_labels[cid]}\n"
+                f"  Samples: {', '.join(repr(t) for t in sample)}"
+            )
+        resp = await client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=2048,
+            system=[
+                {
+                    "type": "text",
+                    "text": system_instructions,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            messages=[{"role": "user", "content": "\n\n".join(parts)}],
+        )
+        text = resp.content[0].text.strip()
+        if text.startswith("```"):
+            text = text.split("\n", 1)[1].rsplit("```", 1)[0].strip()
+        try:
+            parsed = json.loads(text)
+            return {int(k): str(v) for k, v in parsed.items()}
+        except (json.JSONDecodeError, ValueError):
+            log("  warning: failed to parse LLM response for a batch, keeping keywords")
+            return {}
+
+    async def run_all() -> dict[int, str]:
+        results = await asyncio.gather(*[label_batch(b) for b in batches])
+        merged: dict[int, str] = {}
+        for r in results:
+            merged.update(r)
+        return merged
+
+    log(
+        f"  refining {tier} labels with LLM ({len(batches)} batches, {len(cluster_ids)} clusters)..."
+    )
+    refined = asyncio.run(run_all())
+    log(f"  {tier}: {len(refined)}/{len(cluster_ids)} labels refined")
+    return {cid: refined.get(cid, tfidf_labels[cid]) for cid in cluster_ids}
+
+
+def assign_outliers(
+    coords: np.ndarray, labels: np.ndarray, centroids: dict[int, np.ndarray]
+) -> np.ndarray:
+    """snap outlier points (label == -1) to the nearest cluster centroid."""
+    result = labels.copy()
+    outlier_mask = result == -1
+    if not outlier_mask.any() or not centroids:
+        return result
+    centroid_ids = sorted(centroids.keys())
+    centroid_arr = np.array([centroids[c] for c in centroid_ids])
+    dists = np.linalg.norm(
+        coords[outlier_mask][:, None] - centroid_arr[None, :], axis=2
+    )
+    result[outlier_mask] = np.array(centroid_ids)[dists.argmin(axis=1)]
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="build atlas.json")
+    parser.add_argument("--output", "-o", default=str(DEFAULT_OUTPUT))
+    parser.add_argument(
+        "--upload", action="store_true", help="upload to the R2 stats bucket"
+    )
+    args = parser.parse_args()
+
+    try:
+        settings = Settings()  # type: ignore[call-arg]
+    except ValidationError as e:
+        # never print the exception itself: pydantic embeds input values,
+        # which here would mean leaking unrelated env secrets into logs.
+        fields = ", ".join(str(err["loc"][0]) for err in e.errors()) or "config"
+        print(f"error loading settings; missing/invalid: {fields}", file=sys.stderr)
+        sys.exit(1)
+    if not settings.atlas_database_url:
+        print("ATLAS_DATABASE_URL is required", file=sys.stderr)
+        sys.exit(1)
+
+    t_start = time.monotonic()
+
+    log("loading eligible tracks from postgres...")
+    corpus = load_corpus(settings.atlas_database_url)
+    log(f"  {len(corpus)} atlas-eligible tracks")
+
+    log("exporting vectors from turbopuffer...")
+    rows = tpuf_export(settings)
+    log(f"  {len(rows)} vectors in namespace")
+
+    # intersect: only eligible tracks that actually have embeddings
+    keyed = [
+        (int(r["id"]), r["vector"])
+        for r in rows
+        if r.get("vector") and int(r["id"]) in corpus
+    ]
+    skipped = len(corpus) - len(keyed)
+    if skipped:
+        log(f"  {skipped} eligible tracks have no embedding (not on the map)")
+    if len(keyed) < 30:
+        print("too few embedded tracks to build an atlas", file=sys.stderr)
+        sys.exit(1)
+
+    # float64: randomized SVD overflows in float32 on these magnitudes
+    X = np.empty((len(keyed), len(keyed[0][1])), dtype=np.float64)
+    meta: list[dict] = []
+    for i, (track_id, vec) in enumerate(keyed):
+        X[i] = vec
+        meta.append(corpus[track_id])
+    log(f"  {X.shape[0]} vectors, {X.shape[1]} dims")
+
+    log("PCA → 50...")
+    n_components = min(50, X.shape[0] - 1, X.shape[1])
+    pca = PCA(n_components=n_components, random_state=42)
+    X_pca = pca.fit_transform(X)
+    log(f"  variance explained: {pca.explained_variance_ratio_.sum():.2%}")
+
+    log("UMAP 50 → 2 (display)...")
+    import umap
+
+    X_2d = umap.UMAP(
+        n_components=2, metric="cosine", n_neighbors=15, min_dist=0.1, random_state=42
+    ).fit_transform(X_pca)
+    for dim in range(2):
+        lo, hi = X_2d[:, dim].min(), X_2d[:, dim].max()
+        if hi > lo:
+            X_2d[:, dim] = 2 * (X_2d[:, dim] - lo) / (hi - lo) - 1
+
+    # cluster in a dedicated 10D UMAP, not the 2D display coords — clustering
+    # the display projection turns its own artifacts into cluster boundaries
+    # (measured in pub-search: the fine tier scored worse than chance in 2D).
+    log("UMAP 50 → 10 (clustering space)...")
+    X_10d = umap.UMAP(
+        n_components=10, metric="cosine", n_neighbors=30, min_dist=0.0, random_state=42
+    ).fit_transform(X_pca)
+
+    import hdbscan
+
+    def cluster_tier(name: str, min_cluster_size: int, min_samples: int):
+        log(f"HDBSCAN {name} (min_cluster_size={min_cluster_size}) on 10D...")
+        raw = hdbscan.HDBSCAN(
+            min_cluster_size=min_cluster_size, min_samples=min_samples
+        ).fit_predict(X_10d)
+        n_clusters = len(set(raw)) - (1 if -1 in raw else 0)
+        n_out = int((raw == -1).sum())
+        log(f"  {n_clusters} clusters, {n_out} outliers ({n_out / len(raw):.1%})")
+        centroids_10d = {
+            cid: X_10d[raw == cid].mean(axis=0) for cid in set(raw) if cid != -1
+        }
+        labels = assign_outliers(X_10d, raw, centroids_10d)
+        centroids_2d = {cid: X_2d[labels == cid].mean(axis=0) for cid in set(labels)}
+        return labels, centroids_2d, raw != -1
+
+    # thresholds sized for a catalog of ~1k tracks (pub-search's 50/20 would
+    # collapse this corpus into a couple of blobs)
+    n = X.shape[0]
+    coarse_size = max(12, n // 60)
+    fine_size = max(5, n // 160)
+    labels_coarse, coarse_centroids, core_coarse = cluster_tier(
+        "coarse", coarse_size, 5
+    )
+    labels_fine, fine_centroids, core_fine = cluster_tier("fine", fine_size, 2)
+
+    # label evidence: titles + tags of CORE members only — points HDBSCAN
+    # actually assigned. snapped outliers blur the vocabulary a label draws on.
+    # a cluster whose core evidence is empty falls back to full membership.
+    log("computing cluster labels (c-TF-IDF on titles+tags)...")
+
+    def evidence_for(i: int) -> str:
+        m = meta[i]
+        parts = [m["title"] or ""]
+        parts.extend(m["tags"] or [])
+        return extract_terms(" ".join(parts))
+
+    def display_evidence(i: int) -> str:
+        m = meta[i]
+        tags = ", ".join(m["tags"] or [])
+        return f"{m['title']}" + (f" [{tags}]" if tags else "")
+
+    def collect(
+        labels: np.ndarray, core: np.ndarray, centroids: dict
+    ) -> tuple[dict, dict]:
+        docs: dict[int, list[str]] = {int(c): [] for c in centroids}
+        samples: dict[int, list[str]] = {int(c): [] for c in centroids}
+        docs_all: dict[int, list[str]] = {int(c): [] for c in centroids}
+        samples_all: dict[int, list[str]] = {int(c): [] for c in centroids}
+        for i in range(n):
+            ev = evidence_for(i)
+            if not ev:
+                continue
+            cid = int(labels[i])
+            docs_all[cid].append(ev)
+            samples_all[cid].append(display_evidence(i))
+            if core[i]:
+                docs[cid].append(ev)
+                samples[cid].append(display_evidence(i))
+        for cid in docs:
+            if not docs[cid]:
+                docs[cid] = docs_all[cid]
+                samples[cid] = samples_all[cid]
+        return docs, samples
+
+    coarse_docs, coarse_samples = collect(labels_coarse, core_coarse, coarse_centroids)
+    fine_docs, fine_samples = collect(labels_fine, core_fine, fine_centroids)
+    coarse_labels = cluster_tfidf_labels(coarse_docs)
+    fine_labels = cluster_tfidf_labels(fine_docs)
+
+    if settings.anthropic_api_key:
+        coarse_counts = {
+            int(c): int((labels_coarse == c).sum()) for c in set(labels_coarse)
+        }
+        fine_counts = {int(c): int((labels_fine == c).sum()) for c in set(labels_fine)}
+        try:
+            coarse_labels = llm_refine_labels(
+                coarse_labels,
+                coarse_samples,
+                coarse_counts,
+                settings.anthropic_api_key,
+                "coarse",
+            )
+            fine_labels = llm_refine_labels(
+                fine_labels,
+                fine_samples,
+                fine_counts,
+                settings.anthropic_api_key,
+                "fine",
+            )
+        except Exception as e:
+            log(f"  LLM labeling failed, keeping c-TF-IDF labels: {e}")
+    else:
+        log("  (no ANTHROPIC_API_KEY — c-TF-IDF labels only)")
+
+    fine_to_coarse = {}
+    for fine_id in set(labels_fine):
+        counts = Counter(labels_coarse[labels_fine == fine_id])
+        fine_to_coarse[int(fine_id)] = int(counts.most_common(1)[0][0])
+
+    # artist centroids (2+ mapped tracks) — the "publications" of this atlas
+    log("computing artist centroids...")
+    by_artist: dict[str, list[int]] = {}
+    for i, m in enumerate(meta):
+        by_artist.setdefault(m["artist_did"], []).append(i)
+    artists = []
+    for did, indices in by_artist.items():
+        if len(indices) < 2:
+            continue
+        centroid = X_2d[indices].mean(axis=0)
+        m = meta[indices[0]]
+        artists.append(
+            {
+                "did": did,
+                "handle": m["artist_handle"],
+                "name": m["artist_name"] or m["artist_handle"],
+                "avatar": m["artist_avatar"] or "",
+                "cx": round(float(centroid[0]), 4),
+                "cy": round(float(centroid[1]), 4),
+                "count": len(indices),
+            }
+        )
+    artists.sort(key=lambda a: a["count"], reverse=True)
+    log(f"  {len(artists)} artists with 2+ tracks on the map")
+
+    log("building output...")
+    points = []
+    for i, m in enumerate(meta):
+        points.append(
+            {
+                "x": round(float(X_2d[i, 0]), 4),
+                "y": round(float(X_2d[i, 1]), 4),
+                "id": m["id"],
+                "title": m["title"],
+                "artist": m["artist_name"] or m["artist_handle"],
+                "handle": m["artist_handle"],
+                "thumb": m["thumbnail_url"] or m["image_url"] or "",
+                "plays": m["play_count"],
+                "likes": m["like_count"],
+                "clusterCoarse": int(labels_coarse[i]),
+                "clusterFine": int(labels_fine[i]),
+                "core": bool(core_fine[i]),
+            }
+        )
+
+    def cluster_payload(
+        centroids: dict, counts_src: np.ndarray, labels: dict, extra=None
+    ):
+        out = []
+        for cid in sorted(centroids.keys()):
+            entry = {
+                "id": int(cid),
+                "label": labels.get(int(cid), f"cluster {cid}"),
+                "cx": round(float(centroids[cid][0]), 4),
+                "cy": round(float(centroids[cid][1]), 4),
+                "count": int((counts_src == cid).sum()),
+            }
+            if extra:
+                entry.update(extra(int(cid)))
+            out.append(entry)
+        return out
+
+    output = {
+        "points": points,
+        "clusters": {
+            "coarse": cluster_payload(coarse_centroids, labels_coarse, coarse_labels),
+            "fine": cluster_payload(
+                fine_centroids,
+                labels_fine,
+                fine_labels,
+                extra=lambda cid: {"parent": fine_to_coarse.get(cid, 0)},
+            ),
+        },
+        "artists": artists,
+        "meta": {
+            "generatedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "nTracks": len(points),
+        },
+    }
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(output, separators=(",", ":")))
+    size_kb = out_path.stat().st_size / 1024
+    log(f"\nwrote {out_path} ({size_kb:.0f} KB, {len(points)} points)")
+
+    if args.upload:
+        if not (
+            settings.aws_access_key_id
+            and settings.aws_secret_access_key
+            and settings.r2_endpoint_url
+        ):
+            print(
+                "--upload requires AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / R2_ENDPOINT_URL",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        import boto3
+
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=settings.r2_endpoint_url,
+            aws_access_key_id=settings.aws_access_key_id,
+            aws_secret_access_key=settings.aws_secret_access_key,
+        )
+        s3.put_object(
+            Bucket=settings.r2_stats_bucket,
+            Key="atlas.json",
+            Body=out_path.read_bytes(),
+            ContentType="application/json",
+            CacheControl="public, max-age=3600",
+        )
+        log(f"uploaded to r2://{settings.r2_stats_bucket}/atlas.json")
+
+    log(f"done in {time.monotonic() - t_start:.1f}s")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
an unlisted `/atlas` page: every public track is a point on a pan/zoom canvas, positioned by CLAP audio-embedding similarity — the catalog mapped by how it *sounds*, with haiku-named regions ("neo-classical ambient", "radiator drone studies"), cover art at high zoom, and click-to-play through the normal footer player.

adapted from pub-search's atlas (pub-search.waow.tech/atlas), which pioneered the pipeline and renderer this borrows.

## motivation

we already store a 512-dim CLAP embedding for every track in turbopuffer (mood search). that's exactly the input a semantic map needs; the rest is projection, clustering, and a renderer. discovery today is lists (feeds, tags, radio) — this adds a *spatial* surface where neighborhoods mean something sonically.

## design

**data pipeline** (`scripts/build_atlas.py`, standalone uv script):
- corpus eligibility mirrors the radio corpus (`backend/api/radio/corpus.py`): `visibility in (public, supporters)`, ungated, active artist, no adult-audio/copyright labels — the atlas is an anonymous chosen-for-you surface, so it follows radio's rules, replicated in raw SQL against the projected label columns
- vectors: paginated turbopuffer export, intersected with eligible track ids (921 of 946 eligible tracks have embeddings today)
- projection: PCA→50 (float64 — randomized SVD overflows in float32 on these magnitudes), UMAP→2D for display, and a **separate** UMAP→10D for HDBSCAN — clustering the display projection turns its artifacts into cluster boundaries (measured in pub-search: the fine tier scored worse than chance in 2D)
- two cluster tiers scaled to a ~1k corpus (17 coarse regions / 56 fine clusters); outliers snap to the nearest centroid for display but are excluded from label evidence
- labels: c-TF-IDF over titles+tags of **core members only**, refined into 2-4 word region names by claude haiku (keyword fallback without `ANTHROPIC_API_KEY`)

**freshness** (the pub-search lesson — a static map fossilizes):
- `--upload` puts `atlas.json` in the dedicated stats bucket, same pattern as `scripts/costs/export_costs.py`
- `.github/workflows/build-atlas.yml` rebuilds daily (secrets already in place; `TURBOPUFFER_API_KEY` added to the repo)
- new `GET /stats/atlas` proxies the bucket exactly like `/stats/costs` (CORS avoidance), `Cache-Control: max-age=900`

**frontend** (`/atlas`, unlisted, noindex):
- canvas 2D renderer adapted from pub-search: sprite-stamped points over a spatial grid index, gaussian "lantern" nebulae per cluster, and one shared label-collision economy placed in priority order (regions → fine clusters → track titles ranked by plays+likes → artist handles)
- every point takes its fine cluster's hue (24-step palette) — there is no platform dimension here, the cluster *is* the identity
- semantic zoom: regions → named clusters → titles → **actual cover art** (96px webp thumbnails, drawn plain — no overlays or effects on artwork, per the #1756 standing rule)
- artists with 2+ tracks render as avatar circles at their catalog centroid; click → profile
- click a track → fetch `/tracks/{id}` → `player.playTrack` — the map drives the normal footer player
- theme-aware (`theme-light` observer), touch (drag/pinch, tap-select then tap-play), fits the viewport minus header/player like `/radio`

## verification

- build ran against prod data: 921 points, zero non-finite coords, labels sane
- rendered locally via chrome-devtools at overview/mid/deep zoom, light+dark, 390×844 mobile viewport
- click-to-play verified by **measuring the audio element**: `readyState: 4`, `paused: false`, src on the audio CDN
- `just frontend check` clean; `just backend test` full suite green; ruff clean (the 9 `ty` warnings are pre-existing in unrelated test mocks)

<details>
<summary>deferred scope / intentional non-behaviors</summary>

- **no nav link**: the page is reachable only by URL, deliberately
- **no live layer yet**: the coral-style overlay (radio's on-air track as a moving lantern, plays pulsing regions) is the natural follow-on, not in this PR
- **no ATProto artifact**: publishing the atlas as a PDS blob (phi-style) is a separate decision
- **`/stats/atlas` 404s until the first workflow run** — I'll dispatch `build-atlas` right after merge; the page shows its error state until then. local dev falls back to a gitignored `frontend/static/atlas.json`
- **deep links** (`?track=`, `?x/y/z`) and search-on-map from pub-search: dropped from v1
- **cluster granularity drifts** as the catalog grows (thresholds are `n//60`, `n//160`); labels regenerate daily anyway
- the WebGL rotating-planet layer from pub-search was deliberately not ported — covers are the artist's presentation and want to be shown flat
- eslint config gained four browser globals (`Image`, `MutationObserver`, `requestAnimationFrame`, `performance`) the curated allowlist didn't have yet

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)