### PR TITLE
fix(atlas): strip sqlalchemy driver suffix from CI database URL

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -363,7 +363,7 @@ max_lines = 1444
 
 [[rules]]
 path = "scripts/build_atlas.py"
-max_lines = 582
+max_lines = 584
 
 [[rules]]
 path = "frontend/src/routes/atlas/renderer.ts"

--- a/scripts/build_atlas.py
+++ b/scripts/build_atlas.py
@@ -146,6 +146,8 @@ def tpuf_export(settings: Settings) -> list[dict]:
 
 def load_corpus(db_url: str) -> dict[int, dict]:
     """load atlas-eligible tracks keyed by id."""
+    # the CI secret carries a sqlalchemy driver suffix psycopg can't parse
+    db_url = re.sub(r"postgresql\+\w+://", "postgresql://", db_url)
     with psycopg.connect(db_url) as conn, conn.cursor() as cur:
         cur.execute(CORPUS_SQL, {"labels": EXCLUDED_LABELS})
         cols = [d.name for d in cur.description]


### PR DESCRIPTION
the `NEON_DATABASE_URL_PRD` secret is in sqlalchemy form (`postgresql+asyncpg://`); psycopg rejects it. normalize the same way `export_costs.py` does. the first `build-atlas` dispatch failed on exactly this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)