### PR TITLE
fix: embeds die in sandboxed iframes — safe storage access + Origin: null CORS

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -231,11 +231,15 @@ class FrontendSettings(AppSettingsSection):
         parsed = urlparse(self.url)
         hostname = parsed.hostname or "localhost"
 
+        # "null" is the literal Origin sent by sandboxed iframes (embeds inside
+        # documents sandboxed without allow-same-origin) — since any https
+        # origin is already allowed in prod/staging, permitting it loosens
+        # nothing, and local dev needs it to test embeds.
         if hostname in ("localhost", "127.0.0.1"):
-            return r"^http://localhost:\d+$"
+            return r"^(http://localhost:\d+|null)$"
         else:
             # production / staging: any HTTPS origin + localhost for dev
-            return r"^(https://.+|http://localhost:\d+)$"
+            return r"^(https://.+|http://localhost:\d+|null)$"
 
 
 def normalize_postgres_driver(url: str) -> str:

--- a/backend/tests/test_cors_origins.py
+++ b/backend/tests/test_cors_origins.py
@@ -41,6 +41,7 @@ class TestProductionCorsOrigins:
             "https://example.com",
             "http://localhost:5173",
             "http://localhost:3000",
+            "null",  # sandboxed iframes (embeds) send the literal Origin: null
         ],
     )
     def test_allowed(self, regex: str, origin: str) -> None:
@@ -71,6 +72,7 @@ class TestStagingCorsOrigins:
             "https://docs.stg.plyr.fm",
             "https://any-site.example.com",
             "http://localhost:5173",
+            "null",
         ],
     )
     def test_allowed(self, regex: str, origin: str) -> None:
@@ -101,3 +103,6 @@ class TestLocalDevCorsOrigins:
 
     def test_rejects_remote(self, regex: str) -> None:
         assert not _matches(regex, "https://plyr.fm")
+
+    def test_allows_null(self, regex: str) -> None:
+        assert _matches(regex, "null")

--- a/frontend/src/lib/ambient.svelte.ts
+++ b/frontend/src/lib/ambient.svelte.ts
@@ -1,5 +1,6 @@
 // ambient weather theme — location-aware atmospheric background + full tinting
 import { browser } from '$app/environment';
+import { safeLocalStorage } from './utils/safe-storage';
 
 type TemperatureUnit = 'fahrenheit' | 'celsius';
 
@@ -202,12 +203,12 @@ function blendColor(base: RGBA, tint: RGB, strength: number): string {
 }
 
 function cacheWeather(w: WeatherData): void {
-	try { localStorage.setItem('ambient_weather', JSON.stringify(w)); } catch { /* quota */ }
+	try { safeLocalStorage.setItem('ambient_weather', JSON.stringify(w)); } catch { /* quota */ }
 }
 
 function getCachedWeather(): WeatherData | null {
 	try {
-		const raw = localStorage.getItem('ambient_weather');
+		const raw = safeLocalStorage.getItem('ambient_weather');
 		return raw ? JSON.parse(raw) as WeatherData : null;
 	} catch { return null; }
 }
@@ -249,17 +250,17 @@ class AmbientManager {
 
 		try {
 			// check device-global location cache first
-			let locStr = localStorage.getItem('ambient_location');
+			let locStr = safeLocalStorage.getItem('ambient_location');
 
 			// migrate from old DID-scoped keys if needed
 			if (!locStr) {
-				for (let i = 0; i < localStorage.length; i++) {
-					const k = localStorage.key(i);
+				for (let i = 0; i < safeLocalStorage.length; i++) {
+					const k = safeLocalStorage.key(i);
 					if (k && k.startsWith('ambient_location:')) {
-						locStr = localStorage.getItem(k);
+						locStr = safeLocalStorage.getItem(k);
 						if (locStr) {
-							localStorage.setItem('ambient_location', locStr);
-							localStorage.removeItem(k);
+							safeLocalStorage.setItem('ambient_location', locStr);
+							safeLocalStorage.removeItem(k);
 						}
 						break;
 					}
@@ -278,7 +279,7 @@ class AmbientManager {
 			if (!this.location) {
 				const coords = await this.requestLocation();
 				this.location = coords;
-				localStorage.setItem('ambient_location', JSON.stringify(coords));
+				safeLocalStorage.setItem('ambient_location', JSON.stringify(coords));
 			}
 
 			// restore cached weather for instant gradient, then refresh in background
@@ -322,10 +323,10 @@ class AmbientManager {
 		this.clearFromDOM();
 
 		// clean up old DID-scoped enabled keys
-		for (let i = localStorage.length - 1; i >= 0; i--) {
-			const k = localStorage.key(i);
+		for (let i = safeLocalStorage.length - 1; i >= 0; i--) {
+			const k = safeLocalStorage.key(i);
 			if (k && k.startsWith('ambient_enabled')) {
-				localStorage.removeItem(k);
+				safeLocalStorage.removeItem(k);
 			}
 		}
 	}

--- a/frontend/src/lib/for-you.svelte.ts
+++ b/frontend/src/lib/for-you.svelte.ts
@@ -1,3 +1,4 @@
+import { safeLocalStorage } from './utils/safe-storage';
 import { API_URL } from './config';
 import type { Track } from './types';
 
@@ -11,7 +12,7 @@ interface ForYouApiResponse {
 function loadSavedTags(): string[] {
 	if (typeof window === 'undefined') return [];
 	try {
-		const saved = localStorage.getItem('active_tags');
+		const saved = safeLocalStorage.getItem('active_tags');
 		return saved ? JSON.parse(saved) : [];
 	} catch {
 		return [];

--- a/frontend/src/lib/jam.svelte.ts
+++ b/frontend/src/lib/jam.svelte.ts
@@ -1,3 +1,4 @@
+import { safeSessionStorage } from './utils/safe-storage';
 import { browser } from '$app/environment';
 import { API_URL } from './config';
 import { auth } from '$lib/auth.svelte';
@@ -35,8 +36,8 @@ class JamState {
 	constructor() {
 		if (browser) {
 			this.clientId =
-				sessionStorage.getItem('jam_client_id') ?? crypto.randomUUID();
-			sessionStorage.setItem('jam_client_id', this.clientId);
+				safeSessionStorage.getItem('jam_client_id') ?? crypto.randomUUID();
+			safeSessionStorage.setItem('jam_client_id', this.clientId);
 		}
 	}
 

--- a/frontend/src/lib/moderation.svelte.ts
+++ b/frontend/src/lib/moderation.svelte.ts
@@ -1,5 +1,6 @@
 // content moderation state - tracks sensitive images
 import { browser } from '$app/environment';
+import { safeLocalStorage } from './utils/safe-storage';
 import { API_URL } from '$lib/config';
 
 const STORAGE_KEY = 'plyr:sensitive-images';
@@ -78,7 +79,7 @@ class ModerationManager {
 	 */
 	private loadFromStorage(): void {
 		try {
-			const stored = localStorage.getItem(STORAGE_KEY);
+			const stored = safeLocalStorage.getItem(STORAGE_KEY);
 			if (stored) {
 				const parsed: SensitiveImagesData = JSON.parse(stored);
 				this.data = {
@@ -96,7 +97,7 @@ class ModerationManager {
 	 */
 	private saveToStorage(data: SensitiveImagesData): void {
 		try {
-			localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+			safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 		} catch {
 			// ignore storage errors (quota exceeded, etc)
 		}

--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -1,5 +1,6 @@
 // user preferences state management
 import { browser } from '$app/environment';
+import { safeLocalStorage } from './utils/safe-storage';
 import { API_URL, getServerConfig } from '$lib/config';
 import { auth } from '$lib/auth.svelte';
 import { ambient } from '$lib/ambient.svelte';
@@ -185,7 +186,7 @@ class PreferencesManager {
 
 	setAutoDownloadLiked(enabled: boolean): void {
 		if (browser) {
-			localStorage.setItem('autoDownloadLiked', enabled ? '1' : '0');
+			safeLocalStorage.setItem('autoDownloadLiked', enabled ? '1' : '0');
 		}
 		if (this.data) {
 			this.data = { ...this.data, auto_download_liked: enabled };
@@ -198,7 +199,7 @@ class PreferencesManager {
 				// attempt activation — revert to dark if geolocation denied
 				const ok = await ambient.activate();
 				if (!ok) {
-					localStorage.setItem('theme', 'dark');
+					safeLocalStorage.setItem('theme', 'dark');
 					this.applyTheme('dark');
 					this.update({ theme: 'dark' });
 					return;
@@ -206,7 +207,7 @@ class PreferencesManager {
 			} else {
 				ambient.deactivate();
 			}
-			localStorage.setItem('theme', theme);
+			safeLocalStorage.setItem('theme', theme);
 			this.applyTheme(theme);
 		}
 		this.update({ theme });
@@ -266,7 +267,7 @@ class PreferencesManager {
 				const data = await response.json();
 				// theme comes from server (per-account), localStorage is just a flash-prevention cache
 				const serverTheme = (data.theme as Theme) ?? DEFAULT_PREFERENCES.theme;
-				const storedAutoDownload = localStorage.getItem('autoDownloadLiked') === '1';
+				const storedAutoDownload = safeLocalStorage.getItem('autoDownloadLiked') === '1';
 				this.data = {
 					accent_color: data.accent_color ?? null,
 					auto_advance: data.auto_advance ?? DEFAULT_PREFERENCES.auto_advance,
@@ -285,19 +286,19 @@ class PreferencesManager {
 				};
 			} else {
 				// server error — fall back to localStorage cache
-				const storedTheme = localStorage.getItem('theme') as Theme | null;
-				const storedAutoDownload = localStorage.getItem('autoDownloadLiked') === '1';
+				const storedTheme = safeLocalStorage.getItem('theme') as Theme | null;
+				const storedAutoDownload = safeLocalStorage.getItem('autoDownloadLiked') === '1';
 				this.data = { ...DEFAULT_PREFERENCES, theme: storedTheme ?? DEFAULT_PREFERENCES.theme, auto_download_liked: storedAutoDownload };
 			}
 			// sync localStorage cache and apply
 			if (browser) {
-				localStorage.setItem('theme', this.data.theme);
+				safeLocalStorage.setItem('theme', this.data.theme);
 				if (this.data.accent_color) {
-					localStorage.setItem('accentColor', this.data.accent_color);
+					safeLocalStorage.setItem('accentColor', this.data.accent_color);
 					this.applyAccentColor(this.data.accent_color);
 				}
 				const font = this.data.ui_settings?.font_family ?? DEFAULT_FONT;
-				localStorage.setItem('fontFamily', font);
+				safeLocalStorage.setItem('fontFamily', font);
 				this.applyFont(font);
 				this.applyTheme(this.data.theme);
 				if (this.data.theme === 'live') {
@@ -309,7 +310,7 @@ class PreferencesManager {
 		} catch (error) {
 			console.error('failed to fetch preferences:', error);
 			// network error — fall back to localStorage cache
-			const storedTheme = localStorage.getItem('theme') as Theme | null;
+			const storedTheme = safeLocalStorage.getItem('theme') as Theme | null;
 			this.data = { ...DEFAULT_PREFERENCES, theme: storedTheme ?? DEFAULT_PREFERENCES.theme };
 		} finally {
 			this.loading = false;

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -1,3 +1,4 @@
+import { safeSessionStorage } from './utils/safe-storage';
 import { browser } from '$app/environment';
 import type { QueueResponse, QueueState, RepeatMode, Track } from './types';
 import { API_URL } from './config';
@@ -145,12 +146,12 @@ class Queue {
 		if (!browser || this.initialized) return;
 		this.initialized = true;
 
-		const storedTabId = sessionStorage.getItem('queue_tab_id');
+		const storedTabId = safeSessionStorage.getItem('queue_tab_id');
 		if (storedTabId) {
 			this.tabId = storedTabId;
 		} else {
 			this.tabId = this.createTabId();
-			sessionStorage.setItem('queue_tab_id', this.tabId);
+			safeSessionStorage.setItem('queue_tab_id', this.tabId);
 		}
 
 		// set up cross-tab synchronization
@@ -472,7 +473,7 @@ class Queue {
 			const sourceTabId = this.tabId ?? this.createTabId();
 			this.tabId = sourceTabId;
 			try {
-				sessionStorage.setItem('queue_tab_id', sourceTabId);
+				safeSessionStorage.setItem('queue_tab_id', sourceTabId);
 			} catch (error) {
 				console.warn('failed to persist queue tab id', error);
 			}

--- a/frontend/src/lib/radio.svelte.ts
+++ b/frontend/src/lib/radio.svelte.ts
@@ -4,6 +4,7 @@
 // single source of truth.
 import { API_URL } from './config';
 import { player, type RadioNowPlaying } from './player.svelte';
+import { safeLocalStorage } from './utils/safe-storage';
 import type { Track } from './types';
 
 export interface RadioTrack {
@@ -107,7 +108,7 @@ class Radio {
 
 	/** the last station the listener picked, if any (drives bare /radio) */
 	private remembered(): string | null {
-		return typeof localStorage !== 'undefined' ? localStorage.getItem(STATION_STORAGE_KEY) : null;
+		return typeof window !== 'undefined' ? safeLocalStorage.getItem(STATION_STORAGE_KEY) : null;
 	}
 
 	/** slug of the next/previous station in the lineup (wraps); null if <2 stations.
@@ -130,8 +131,8 @@ class Radio {
 		// fall through, or it never matches station_slug and reloads endlessly.
 		if (this.state && (target === null || target === this.state.station_slug)) return;
 		this.station = target;
-		if (slug && typeof localStorage !== 'undefined') {
-			localStorage.setItem(STATION_STORAGE_KEY, slug);
+		if (slug && typeof window !== 'undefined') {
+			safeLocalStorage.setItem(STATION_STORAGE_KEY, slug);
 		}
 		this.switching = true;
 		try {
@@ -143,8 +144,8 @@ class Radio {
 			// and being shown another would be worse than being told it is off air.
 			if (slug === null && target !== null && !this.hasSomethingOnAir) {
 				this.station = null;
-				if (typeof localStorage !== 'undefined') {
-					localStorage.removeItem(STATION_STORAGE_KEY);
+				if (typeof window !== 'undefined') {
+					safeLocalStorage.removeItem(STATION_STORAGE_KEY);
 				}
 				await this.loadState();
 			}
@@ -225,7 +226,7 @@ class Radio {
 				// a persisted station slug no longer exists (e.g. renamed) — drop it
 				// and fall back to the server default rather than going "off air".
 				this.station = null;
-				if (typeof localStorage !== 'undefined') localStorage.removeItem(STATION_STORAGE_KEY);
+				if (typeof window !== 'undefined') safeLocalStorage.removeItem(STATION_STORAGE_KEY);
 				return this.loadState();
 			}
 			if (!response.ok) throw new Error(`radio returned ${response.status}`);

--- a/frontend/src/lib/tracks.svelte.ts
+++ b/frontend/src/lib/tracks.svelte.ts
@@ -1,3 +1,4 @@
+import { safeLocalStorage } from './utils/safe-storage';
 import { API_URL } from './config';
 import type { Track } from './types';
 import { preferences } from './preferences.svelte';
@@ -22,12 +23,12 @@ function loadCachedTracks(): CachedTracksData {
 		return { tracks: [], nextCursor: null, hasMore: true };
 	}
 	try {
-		const cached = localStorage.getItem('tracks_cache');
+		const cached = safeLocalStorage.getItem('tracks_cache');
 		if (cached) {
 			const data = JSON.parse(cached);
 			// check if cache has the new is_liked field, if not invalidate
 			if (data.tracks && data.tracks.length > 0 && !('is_liked' in data.tracks[0])) {
-				localStorage.removeItem('tracks_cache');
+				safeLocalStorage.removeItem('tracks_cache');
 				return { tracks: [], nextCursor: null, hasMore: true };
 			}
 			return {
@@ -45,7 +46,7 @@ function loadCachedTracks(): CachedTracksData {
 function loadSavedTags(): string[] {
 	if (typeof window === 'undefined') return [];
 	try {
-		const saved = localStorage.getItem('active_tags');
+		const saved = safeLocalStorage.getItem('active_tags');
 		return saved ? JSON.parse(saved) : [];
 	} catch {
 		return [];
@@ -64,7 +65,7 @@ class TracksCache {
 	private persistToStorage(): void {
 		if (typeof window !== 'undefined' && this.activeTags.length === 0) {
 			try {
-				localStorage.setItem(
+				safeLocalStorage.setItem(
 					'tracks_cache',
 					JSON.stringify({
 						tracks: this.tracks,
@@ -143,7 +144,7 @@ class TracksCache {
 	invalidate(): void {
 		// clear cache and reset pagination state - next fetch will get fresh data
 		if (typeof window !== 'undefined') {
-			localStorage.removeItem('tracks_cache');
+			safeLocalStorage.removeItem('tracks_cache');
 		}
 		this.nextCursor = null;
 		this.hasMore = true;
@@ -155,9 +156,9 @@ class TracksCache {
 		this.hasMore = true;
 		if (typeof window !== 'undefined') {
 			if (tags.length > 0) {
-				localStorage.setItem('active_tags', JSON.stringify(tags));
+				safeLocalStorage.setItem('active_tags', JSON.stringify(tags));
 			} else {
-				localStorage.removeItem('active_tags');
+				safeLocalStorage.removeItem('active_tags');
 			}
 		}
 		this.fetch(true);

--- a/frontend/src/lib/utils/safe-storage.test.ts
+++ b/frontend/src/lib/utils/safe-storage.test.ts
@@ -1,0 +1,59 @@
+// regression test for sandboxed embeds (leaflet et al): in an iframe without
+// allow-same-origin, *accessing* window.localStorage throws a SecurityError.
+// the safe wrappers must degrade to no-ops instead of throwing, or the embed
+// bundle dies at import time and hydration never happens.
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { safeLocalStorage, safeSessionStorage } from './safe-storage';
+
+const original = Object.getOwnPropertyDescriptor(window, 'localStorage');
+
+function makeStorageThrow(): void {
+	Object.defineProperty(window, 'localStorage', {
+		configurable: true,
+		get() {
+			throw new DOMException('access denied', 'SecurityError');
+		}
+	});
+}
+
+afterEach(() => {
+	if (original) {
+		Object.defineProperty(window, 'localStorage', original);
+	}
+});
+
+describe('safeLocalStorage with working storage', () => {
+	it('round-trips values', () => {
+		safeLocalStorage.setItem('safe-storage-test', 'hi');
+		expect(safeLocalStorage.getItem('safe-storage-test')).toBe('hi');
+		safeLocalStorage.removeItem('safe-storage-test');
+		expect(safeLocalStorage.getItem('safe-storage-test')).toBeNull();
+	});
+
+	it('exposes length and key', () => {
+		safeLocalStorage.setItem('safe-storage-test', 'hi');
+		expect(safeLocalStorage.length).toBeGreaterThan(0);
+		expect(typeof safeLocalStorage.key(0)).toBe('string');
+		safeLocalStorage.removeItem('safe-storage-test');
+	});
+});
+
+describe('safeLocalStorage when storage access throws', () => {
+	it('degrades to a no-op instead of throwing', () => {
+		makeStorageThrow();
+		expect(() => safeLocalStorage.setItem('k', 'v')).not.toThrow();
+		expect(safeLocalStorage.getItem('k')).toBeNull();
+		expect(() => safeLocalStorage.removeItem('k')).not.toThrow();
+		expect(safeLocalStorage.key(0)).toBeNull();
+		expect(safeLocalStorage.length).toBe(0);
+	});
+});
+
+describe('safeSessionStorage', () => {
+	it('round-trips values', () => {
+		safeSessionStorage.setItem('safe-storage-test', 'hi');
+		expect(safeSessionStorage.getItem('safe-storage-test')).toBe('hi');
+		safeSessionStorage.removeItem('safe-storage-test');
+	});
+});

--- a/frontend/src/lib/utils/safe-storage.ts
+++ b/frontend/src/lib/utils/safe-storage.ts
@@ -1,0 +1,58 @@
+// storage wrappers that survive sandboxed iframes.
+//
+// in an iframe sandboxed without allow-same-origin (e.g. embeds inside
+// Leaflet documents), the document has an opaque origin and *accessing*
+// window.localStorage/sessionStorage throws a SecurityError — `typeof`
+// and `browser` guards don't catch it. every access goes through try/catch
+// so embeds degrade to no persistence instead of failing to hydrate.
+
+export interface SafeStorage {
+	getItem(key: string): string | null;
+	setItem(key: string, value: string): void;
+	removeItem(key: string): void;
+	key(index: number): string | null;
+	readonly length: number;
+}
+
+function wrap(getStorage: () => Storage): SafeStorage {
+	return {
+		getItem(key) {
+			try {
+				return getStorage().getItem(key);
+			} catch {
+				return null;
+			}
+		},
+		setItem(key, value) {
+			try {
+				getStorage().setItem(key, value);
+			} catch {
+				// unavailable (sandboxed/opaque origin) or quota exceeded
+			}
+		},
+		removeItem(key) {
+			try {
+				getStorage().removeItem(key);
+			} catch {
+				// unavailable
+			}
+		},
+		key(index) {
+			try {
+				return getStorage().key(index);
+			} catch {
+				return null;
+			}
+		},
+		get length() {
+			try {
+				return getStorage().length;
+			} catch {
+				return 0;
+			}
+		}
+	};
+}
+
+export const safeLocalStorage: SafeStorage = wrap(() => window.localStorage);
+export const safeSessionStorage: SafeStorage = wrap(() => window.sessionStorage);

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -18,6 +18,7 @@
 	import { afterNavigate, goto } from '$app/navigation';
 	import { auth } from '$lib/auth.svelte';
 	import { preferences, getContrastColor } from '$lib/preferences.svelte';
+	import { safeLocalStorage } from '$lib/utils/safe-storage';
 	import { ambient } from '$lib/ambient.svelte';
 	import { moderation } from '$lib/moderation.svelte';
 	import { player } from '$lib/player.svelte';
@@ -101,7 +102,7 @@
 			untrack(() => {
 				if (!showQueue) {
 					showQueue = true;
-					localStorage.setItem('showQueue', 'true');
+					safeLocalStorage.setItem('showQueue', 'true');
 				}
 			});
 		}
@@ -373,7 +374,7 @@
 
 	onMount(() => {
 		// apply saved accent color from localStorage
-		const savedAccent = localStorage.getItem('accentColor');
+		const savedAccent = safeLocalStorage.getItem('accentColor');
 		if (savedAccent) {
 			document.documentElement.style.setProperty('--accent', savedAccent);
 			document.documentElement.style.setProperty('--accent-hover', getHoverColor(savedAccent));
@@ -381,7 +382,7 @@
 		}
 
 		// apply saved theme from localStorage
-		const savedTheme = localStorage.getItem('theme') as 'dark' | 'light' | 'system' | 'live' | null;
+		const savedTheme = safeLocalStorage.getItem('theme') as 'dark' | 'light' | 'system' | 'live' | null;
 		if (savedTheme) {
 			preferences.applyTheme(savedTheme);
 		} else {
@@ -390,7 +391,7 @@
 		}
 
 		// restore queue visibility preference
-		const savedQueueVisibility = localStorage.getItem('showQueue');
+		const savedQueueVisibility = safeLocalStorage.getItem('showQueue');
 		if (savedQueueVisibility !== null) {
 			showQueue = savedQueueVisibility === 'true';
 		}
@@ -401,7 +402,7 @@
 		// listen for system theme changes
 		const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 		const handleSystemThemeChange = () => {
-			const currentTheme = localStorage.getItem('theme');
+			const currentTheme = safeLocalStorage.getItem('theme');
 			if (currentTheme === 'system') {
 				preferences.applyTheme('system');
 			}
@@ -430,7 +431,7 @@
 
 	function toggleQueue() {
 		showQueue = !showQueue;
-		localStorage.setItem('showQueue', showQueue.toString());
+		safeLocalStorage.setItem('showQueue', showQueue.toString());
 	}
 </script>
 
@@ -476,13 +477,22 @@
 	{/if}
 
 	<script>
-		// prevent flash by applying saved settings immediately
+		// prevent flash by applying saved settings immediately.
+		// inline script — can't import the safe-storage helper, so read via a
+		// local shim (localStorage access throws in sandboxed embeds).
 		if (typeof window !== 'undefined') {
 			(function() {
 				const root = document.documentElement;
+				const getItem = (key) => {
+					try {
+						return localStorage.getItem(key);
+					} catch {
+						return null;
+					}
+				};
 
 				// apply accent color
-				const savedAccent = localStorage.getItem('accentColor');
+				const savedAccent = getItem('accentColor');
 				if (savedAccent) {
 					root.style.setProperty('--accent', savedAccent);
 					// simple lightening for hover state
@@ -494,7 +504,7 @@
 				}
 
 				// apply font
-				const savedFont = localStorage.getItem('fontFamily');
+				const savedFont = getItem('fontFamily');
 				if (savedFont) {
 					const fonts = {
 						'mono': "'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', 'Consolas', monospace",
@@ -508,7 +518,7 @@
 				}
 
 				// apply theme
-				const savedTheme = localStorage.getItem('theme') || 'dark';
+				const savedTheme = getItem('theme') || 'dark';
 				let effectiveTheme = savedTheme;
 				if (savedTheme === 'live') {
 					effectiveTheme = 'dark';

--- a/loq.toml
+++ b/loq.toml
@@ -43,7 +43,7 @@ max_lines = 1868
 
 [[rules]]
 path = "backend/src/backend/config.py"
-max_lines = 1262
+max_lines = 1266
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
@@ -131,7 +131,7 @@ max_lines = 955
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"
-max_lines = 846
+max_lines = 856
 
 [[rules]]
 path = "frontend/src/routes/costs/+page.svelte"


### PR DESCRIPTION
embeds inside sandboxed iframes (e.g. a plyr.fm radio embed nested in a Leaflet document) never hydrated — stuck on their SSR'd "tuning…" state. this makes storage access sandbox-safe and lets the backend accept the `Origin: null` those iframes send.

## why it broke

an iframe sandboxed without `allow-same-origin` gets an opaque origin, and *accessing* `window.localStorage`/`sessionStorage` there throws a `SecurityError` — `typeof localStorage !== 'undefined'` and `browser` guards do not catch it. `jam.svelte.ts` touched `sessionStorage` in its module-level singleton constructor, so the whole bundle threw at import time; hydration never ran, and the embed sat on its initial `loading && !radioState` branch forever.

## what changed

- **`frontend/src/lib/utils/safe-storage.ts`** — `safeLocalStorage` / `safeSessionStorage` wrappers with every access (including the property access itself) in try/catch. this is the MDN-documented idiom for the problem; adopting something like `svelte-persisted-store` would mean restructuring every `$state` manager, deliberately out of scope.
- swapped all storage call sites in the root layout and the state modules it imports (`jam`, `queue`, `preferences`, `radio`, `tracks`, `moderation`, `ambient`, `for-you`). the inline flash-prevention script in `<svelte:head>` can't import, so it gets a local try/catch shim.
- **backend CORS** — sandboxed iframes send the literal `Origin: null`, which `^(https://.+|http://localhost:\d+)$` rejects, so the embed would hydrate but its fetches would be blocked. added `null` to the regex. prod/staging already allow *any* https origin (session cookies are HttpOnly and scoped to plyr.fm), so this loosens nothing; local dev gets it too so embeds are testable there.

## verification

- new `safe-storage.test.ts` covers the throwing-storage path (SecurityError on property access) plus normal round-trips; CORS tests extended for `null` in all three environments
- rendered the embed in a `sandbox="allow-scripts"` iframe against a local wrangler pages build: it hydrates and reaches its styled error branch (was: unstyled, frozen on "tuning…"). the fetch half completes once the backend CORS change deploys
- full backend suite (1438 passed), frontend vitest (132), svelte-check, eslint, ruff, ty all green

<details>
<summary>intentional non-behaviors / deferred</summary>

- no persistence fallback (in-memory shim) for sandboxed contexts — embeds just don't persist preferences, which is correct for them
- playback inside a sandboxed embed still requires a user gesture (autoplay policy); unrelated to this fix
- `__cf_bm` cookie warnings in embedding pages' consoles are Cloudflare failing to set cookies for opaque origins — harmless, unaffected
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)