### PR TITLE
feat(observability): jetstream write-echo signal — the quiet-immune ingest-blackout detector

### DIFF
--- a/backend/src/backend/_internal/atproto/client.py
+++ b/backend/src/backend/_internal/atproto/client.py
@@ -10,6 +10,7 @@ from typing import Any, BinaryIO
 
 import httpcore
 import httpx
+import logfire
 from atproto import AtUri
 from atproto_oauth.models import OAuthSession
 from atproto_oauth.security import is_safe_url
@@ -22,6 +23,7 @@ from backend._internal.auth import (
     get_client_auth_method,
     get_refresh_token_lifetime_days,
 )
+from backend.config import settings
 from backend.utilities.redis import get_async_redis_client
 
 # factory that produces a fresh async iterator over the request body. used
@@ -523,6 +525,34 @@ async def _app_password_upload_blob(
     )
 
 
+_RECORD_WRITE_OPERATIONS = {
+    "com.atproto.repo.createRecord": "create",
+    "com.atproto.repo.putRecord": "put",
+    "com.atproto.repo.deleteRecord": "delete",
+}
+
+
+def _log_own_record_write(endpoint: str, payload: dict[str, Any] | None) -> None:
+    """emit the write half of the jetstream echo signal.
+
+    every record plyr writes to a PDS in its own namespace must come back
+    through the jetstream consumer as a `jetstream dispatched` log. alerting
+    on "writes happened but zero dispatches" is the only quiet-immune way to
+    detect an ingest blackout: fm.plyr.* traffic is user writes, so a silent
+    window alone cannot distinguish an outage from a quiet night (#1739).
+    """
+    operation = _RECORD_WRITE_OPERATIONS.get(endpoint)
+    collection = (payload or {}).get("collection", "")
+    if operation is None or not collection.startswith(settings.atproto.app_namespace):
+        return
+    logfire.info(
+        "pds record write {collection}.{operation}",
+        collection=collection,
+        operation=operation,
+        repo=(payload or {}).get("repo"),
+    )
+
+
 async def make_pds_request(
     auth_session: AuthSession,
     method: str,
@@ -558,7 +588,7 @@ async def make_pds_request(
         )
 
     if oauth_data.get("auth_type") == "app_password":
-        return await _app_password_request(
+        result = await _app_password_request(
             auth_session,
             method,
             endpoint,
@@ -567,6 +597,8 @@ async def make_pds_request(
             success_codes,
             parse_response,
         )
+        _log_own_record_write(endpoint, payload)
+        return result
 
     oauth_session = reconstruct_oauth_session(oauth_data)
     url = f"{oauth_data['pds_url']}/xrpc/{endpoint}"
@@ -602,6 +634,7 @@ async def make_pds_request(
             ) from e
 
         if response.status_code in success_codes:
+            _log_own_record_write(endpoint, payload)
             if response.status_code == 204 or not parse_response:
                 return {}
             return response.json()

--- a/backend/src/backend/_internal/jetstream.py
+++ b/backend/src/backend/_internal/jetstream.py
@@ -176,7 +176,10 @@ class JetstreamConsumer:
                     await self._maybe_refresh_dids()
 
                     if self._is_blind():
-                        logfire.warn(
+                        # info, not warn: this fires on every quiet fm.plyr
+                        # window (see _is_blind), so it is a breadcrumb for
+                        # rotation history, not a failure signal.
+                        logfire.info(
                             "jetstream host is serving other collections but "
                             "none of ours, rotating",
                             endpoint=self._current_endpoint(),
@@ -381,9 +384,15 @@ class JetstreamConsumer:
 
         the failure this catches never disconnects: jetstream2 kept serving
         `app.bsky.actor.profile` for 10h on 2026-07-30 while dropping every
-        `fm.plyr.*` event. requiring recent *other* traffic is what separates a
-        blind host from a quiet network — on a genuinely quiet stream both go
-        silent together and we stay put.
+        `fm.plyr.*` event. requiring recent *other* traffic separates a blind
+        host from a fully quiet stream — but NOT from an organically quiet
+        fm.plyr window, because the profile mirror flows constantly and keeps
+        `_last_any_event` fresh. so on any night with no fm.plyr writes this
+        trips on every host, one rotation per timeout, by design: rotating is
+        cheap and the false positive costs a reconnect. it does mean a
+        rotation is not evidence of a broken host — the trustworthy outage
+        signal is the write echo ("pds record write" with no matching
+        "jetstream dispatched"), which is quiet-immune.
         """
         timeout = settings.jetstream.blind_host_timeout_seconds
         if timeout <= 0 or not self._last_own_event or not self._last_any_event:

--- a/backend/tests/_internal/test_record_write_echo_log.py
+++ b/backend/tests/_internal/test_record_write_echo_log.py
@@ -1,0 +1,60 @@
+"""the write half of the jetstream echo signal.
+
+every record plyr writes in its own namespace must emit a "pds record write"
+log, because the ingest-blackout alert is defined as "writes happened but zero
+`jetstream dispatched` logs followed" (#1739). if the write log disappears or
+stops matching plyr's namespace, the alert goes permanently silent.
+"""
+
+from unittest.mock import patch
+
+from backend._internal.atproto.client import _log_own_record_write
+from backend.config import settings
+
+
+def _own(collection_suffix: str) -> str:
+    return f"{settings.atproto.app_namespace}.{collection_suffix}"
+
+
+def test_own_namespace_create_emits() -> None:
+    with patch("backend._internal.atproto.client.logfire.info") as info:
+        _log_own_record_write(
+            "com.atproto.repo.createRecord",
+            {"collection": _own("track"), "repo": "did:plc:abc"},
+        )
+    info.assert_called_once()
+    assert info.call_args.kwargs["collection"] == _own("track")
+    assert info.call_args.kwargs["operation"] == "create"
+
+
+def test_own_namespace_delete_emits() -> None:
+    with patch("backend._internal.atproto.client.logfire.info") as info:
+        _log_own_record_write(
+            "com.atproto.repo.deleteRecord",
+            {"collection": _own("like"), "repo": "did:plc:abc"},
+        )
+    assert info.call_args.kwargs["operation"] == "delete"
+
+
+def test_foreign_namespace_is_silent() -> None:
+    with patch("backend._internal.atproto.client.logfire.info") as info:
+        _log_own_record_write(
+            "com.atproto.repo.createRecord",
+            {"collection": "app.bsky.feed.post", "repo": "did:plc:abc"},
+        )
+    info.assert_not_called()
+
+
+def test_non_write_endpoint_is_silent() -> None:
+    with patch("backend._internal.atproto.client.logfire.info") as info:
+        _log_own_record_write(
+            "com.atproto.repo.getRecord",
+            {"collection": _own("track")},
+        )
+    info.assert_not_called()
+
+
+def test_missing_payload_is_silent() -> None:
+    with patch("backend._internal.atproto.client.logfire.info") as info:
+        _log_own_record_write("com.atproto.repo.createRecord", None)
+    info.assert_not_called()

--- a/loq.toml
+++ b/loq.toml
@@ -283,7 +283,7 @@ max_lines = 2589
 
 [[rules]]
 path = "backend/src/backend/_internal/atproto/client.py"
-max_lines = 888
+max_lines = 921
 
 [[rules]]
 path = "backend/src/backend/_internal/auth/oauth.py"


### PR DESCRIPTION
tonight's "jetstream hosts look blind" alert firing (4 rotations in 2h) was investigated and found to be the detector, not the hosts: this PR adds the signal that can actually distinguish an ingest blackout from a quiet night, so alerting can move onto it.

## why the current signals can't work

- **counting `fm.plyr.*` dispatches**: they are user writes — legitimately zero for hours overnight. silence proves nothing.
- **counting #1740 blind-host rotations**: `_is_blind()` requires "no own event for 30m while other traffic flows", but the subscription includes the `app.bsky.actor.profile` mirror, which flows constantly (~1–2/min) and keeps `_last_any_event` permanently fresh. the docstring's "on a genuinely quiet stream both go silent together and we stay put" describes a state that cannot occur. every quiet fm.plyr window therefore trips the detector on **every** host, one rotation per 1800s timeout, like clockwork — which is exactly the observed firing (`silent_seconds: 1801`, 4/2h). rotation is cheap by design, so the behavior is harmless; but rotation count measures user activity, not host health.

## the echo signal

every record plyr writes to a PDS in its own namespace comes back through jetstream (we ingest our own writes since #1068). so "we wrote N records AND zero `jetstream dispatched` logs followed" is a quiet-immune outage signal: no writes → no fire; any real user action → blackout detected within the alert window.

<details>
<summary>changes</summary>

- `_log_own_record_write()` in `atproto/client.py`: emits `pds record write {collection}.{operation}` on successful `createRecord`/`putRecord`/`deleteRecord` where the collection is under `settings.atproto.app_namespace`. hooked into `make_pds_request` on both the oauth and app-password success paths — the single funnel every scattered write site (track/like/comment/list/profile) goes through. `fm.teal.*` and bsky writes deliberately don't match.
- `_is_blind()` docstring corrected to describe the real behavior (fires on every quiet fm.plyr window; a rotation is not evidence of a broken host).
- rotation log demoted warn → info: it fires ~20×/night in normal operation; it is rotation-history breadcrumb, not a failure signal.
- tests pin the echo contract: own-namespace writes emit (create + delete), foreign namespaces and non-write/read endpoints stay silent. if the log stops matching plyr's namespace, the downstream alert goes permanently silent — that's the regression these guard.

</details>

<details>
<summary>intentional non-behaviors / deferred</summary>

- the #1740 rotation behavior itself is unchanged — rotating on a false positive costs one reconnect with a rewound cursor and is fine.
- the logfire alert changes (delete the rotation-count alert, create the write-echo differential alert) are operational config, done outside this PR once this reaches production.
- no alert can be built purely on dispatch-counting; this PR exists precisely because both existing signals are activity-confounded.

</details>

refs #1739, #1740

🤖 Generated with [Claude Code](https://claude.com/claude-code)
