### PR TITLE
fix(auth): keep OAuth payload encrypted in the session cache

### DIFF
--- a/backend/src/backend/_internal/auth/session.py
+++ b/backend/src/backend/_internal/auth/session.py
@@ -1,5 +1,6 @@
 """Session dataclass, CRUD, token update, and teal check."""
 
+import hashlib
 import json
 import logging
 import secrets
@@ -25,8 +26,12 @@ SESSION_CACHE_TTL_SECONDS = 60
 
 
 def _session_cache_key(session_id: str) -> str:
-    """build Redis cache key for a session."""
-    return f"{SESSION_CACHE_PREFIX}{session_id}"
+    """build Redis cache key for a session.
+
+    the session id is a bearer credential, so it is hashed rather than used
+    directly: a `KEYS plyr:session:*` scan must not yield replayable tokens.
+    """
+    return f"{SESSION_CACHE_PREFIX}{hashlib.sha256(session_id.encode()).hexdigest()}"
 
 
 async def _invalidate_session_cache(session_id: str) -> None:
@@ -35,7 +40,7 @@ async def _invalidate_session_cache(session_id: str) -> None:
         redis = get_async_redis_client()
         await redis.delete(_session_cache_key(session_id))
     except Exception:
-        logger.debug("failed to invalidate session cache for %s", session_id)
+        logger.debug("failed to invalidate session cache for %s", session_id[:8])
 
 
 @dataclass
@@ -190,14 +195,18 @@ async def get_session(session_id: str) -> Session | None:
             ) and now > datetime.fromisoformat(rexp):
                 await redis.delete(cache_key)
                 return None
-            return Session(
-                session_id=data["session_id"],
-                did=data["did"],
-                handle=data["handle"],
-                oauth_session=data["oauth_session"],
-            )
+            if decrypted_cached := _decrypt_data(data["oauth_session"]):
+                return Session(
+                    session_id=session_id,
+                    did=data["did"],
+                    handle=data["handle"],
+                    oauth_session=json.loads(decrypted_cached),
+                )
+            # unreadable payload (key rotation, corruption, tampering): evict and
+            # fall through to the DB rather than treating it as "no session"
+            await redis.delete(cache_key)
     except Exception:
-        logger.debug("redis cache read failed for session %s", session_id)
+        logger.debug("redis cache read failed for session %s", session_id[:8])
 
     # cache miss — fall back to DB
     async with db_session() as db:
@@ -219,6 +228,7 @@ async def get_session(session_id: str) -> Session | None:
             return None
 
         oauth_session_data = json.loads(decrypted_data)
+        encrypted_oauth = user_session.oauth_session_data
 
         refresh_expires_at = _get_refresh_token_expires_at(
             user_session, oauth_session_data
@@ -241,10 +251,9 @@ async def get_session(session_id: str) -> Session | None:
             cache_key,
             json.dumps(
                 {
-                    "session_id": session.session_id,
                     "did": session.did,
                     "handle": session.handle,
-                    "oauth_session": session.oauth_session,
+                    "oauth_session": encrypted_oauth,
                     "expires_at": user_session.expires_at.isoformat()
                     if user_session.expires_at
                     else None,
@@ -256,7 +265,7 @@ async def get_session(session_id: str) -> Session | None:
             ex=SESSION_CACHE_TTL_SECONDS,
         )
     except Exception:
-        logger.debug("redis cache write failed for session %s", session_id)
+        logger.debug("redis cache write failed for session %s", session_id[:8])
 
     return session
 

--- a/backend/tests/_internal/test_auth_modules.py
+++ b/backend/tests/_internal/test_auth_modules.py
@@ -1,5 +1,7 @@
 """stateless smoke tests for auth package modules."""
 
+import hashlib
+
 from backend._internal.auth.encryption import _decrypt_data, _encrypt_data
 from backend._internal.auth.exchange import (
     consume_exchange_token,
@@ -65,10 +67,13 @@ def test_exchange_token_functions_exist():
 
 
 def test_session_cache_key_format():
-    """cache key uses plyr:session: prefix."""
+    """cache key is the prefix plus a hash of the session id, never the id itself."""
     key = _session_cache_key("abc-123")
-    assert key == "plyr:session:abc-123"
     assert key.startswith(SESSION_CACHE_PREFIX)
+    assert "abc-123" not in key
+    assert key == SESSION_CACHE_PREFIX + hashlib.sha256(b"abc-123").hexdigest()
+    # stable across calls, or cache reads would never hit
+    assert key == _session_cache_key("abc-123")
 
 
 def test_session_cache_constants():

--- a/backend/tests/_internal/test_session_cache.py
+++ b/backend/tests/_internal/test_session_cache.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from backend._internal.auth.session import (
+    SESSION_CACHE_PREFIX,
     SESSION_CACHE_TTL_SECONDS,
     _session_cache_key,
     create_session,
@@ -54,7 +55,6 @@ async def test_cache_miss_then_hit(session_id: str) -> None:
     assert cached_raw is not None
     cached = json.loads(cached_raw)
     assert cached["did"] == "did:plc:testcache"
-    assert cached["session_id"] == session_id
 
     # second call — should come from cache (we verify by checking TTL exists)
     session2 = await get_session(session_id)
@@ -62,6 +62,67 @@ async def test_cache_miss_then_hit(session_id: str) -> None:
     assert session2.did == session.did
     ttl = await redis.ttl(cache_key)
     assert 0 < ttl <= SESSION_CACHE_TTL_SECONDS
+
+
+async def test_cache_holds_no_replayable_credentials(
+    session_id: str, oauth_data: dict
+) -> None:
+    """#1782: Redis must hold neither the bearer session id nor OAuth tokens.
+
+    plyr-redis is reachable without authentication from the private network, so
+    anything cached here is readable by any workload that lands there. the key is
+    hashed and the OAuth payload stays Fernet-encrypted end to end.
+    """
+    redis = get_async_redis_client()
+    cache_key = _session_cache_key(session_id)
+
+    session = await get_session(session_id)
+    assert session is not None
+
+    assert session_id not in cache_key
+
+    cached_raw = await redis.get(cache_key)
+    assert cached_raw is not None
+    blob = cached_raw if isinstance(cached_raw, str) else cached_raw.decode()
+
+    assert session_id not in blob
+    assert oauth_data["access_token"] not in blob
+    assert oauth_data["refresh_token"] not in blob
+    assert oauth_data["session_id"] not in blob
+
+    # a scan of the whole keyspace must not surface the credential either
+    keys = [
+        k if isinstance(k, str) else k.decode()
+        for k in await redis.keys(f"{SESSION_CACHE_PREFIX}*")
+    ]
+    assert all(session_id not in k for k in keys)
+
+    # and the round trip still returns usable tokens from cache
+    from_cache = await get_session(session_id)
+    assert from_cache is not None
+    assert from_cache.session_id == session_id
+    assert from_cache.oauth_session["access_token"] == oauth_data["access_token"]
+    assert from_cache.oauth_session["refresh_token"] == oauth_data["refresh_token"]
+
+
+async def test_cache_entry_with_undecryptable_payload_is_dropped(
+    session_id: str,
+) -> None:
+    """a cache entry we cannot decrypt is evicted rather than trusted."""
+    redis = get_async_redis_client()
+    cache_key = _session_cache_key(session_id)
+
+    await get_session(session_id)
+    cached_raw = await redis.get(cache_key)
+    assert cached_raw is not None
+    data = json.loads(cached_raw)
+    data["oauth_session"] = "not-a-valid-fernet-token"
+    await redis.set(cache_key, json.dumps(data), ex=SESSION_CACHE_TTL_SECONDS)
+
+    # falls through to the DB rather than returning a broken session
+    session = await get_session(session_id)
+    assert session is not None
+    assert session.oauth_session["access_token"] == "at_test"
 
 
 async def test_delete_session_invalidates_cache(session_id: str) -> None:


### PR DESCRIPTION
the session cache wrote the **decrypted** OAuth payload — access token and refresh token — plus the raw bearer session id into Redis as plain JSON. `plyr-redis` accepts connections with no authentication, so any workload that reaches the Fly private network could harvest live PDS write credentials for every user active in the last 60 seconds, without the Fernet key and without touching Postgres. this keeps the encryption boundary intact end to end.

closes #1782 (the caching half — Redis `--requirepass` follows separately), closes #1781.

## what changed

**the OAuth payload stays encrypted in the cache.** we already hold the Fernet ciphertext at cache-write time (`user_session.oauth_session_data`), so it goes into Redis as-is and is decrypted on read. Postgres and Redis now hold the same ciphertext, and the plaintext exists only in process memory.

**the cache key is hashed.** `plyr:session:<sha256(session_id)>` rather than `plyr:session:<session_id>`. a `KEYS plyr:session:*` scan previously enumerated replayable bearer tokens on its own, before you read a single value.

**the raw session id is out of the cached value.** it was stored as a field and used to rebuild the `Session`; the id is already known from the lookup argument, so it's simply no longer written.

**three debug logs stop printing the full credential** (#1781) — `session_id[:8]`, matching the convention already used in `_internal/tasks/pds.py`. these are the same read/write paths this PR touches, which is why they ride along here instead of a separate PR that would conflict with itself.

## a bug the regression test caught

first cut returned `None` when a cached payload wouldn't decrypt. that's wrong twice over: an OAuth key rotation would log out every active user, and anyone able to write to the unauthenticated Redis could force-logout arbitrary users by corrupting their entry. an unreadable cache entry is now evicted and the request falls through to Postgres, which is what "cache" should mean.

<details>
<summary>tests</summary>

- `test_cache_holds_no_replayable_credentials` — asserts the session id appears in neither the key nor the value, that the access and refresh tokens are absent from the raw blob, that a `KEYS` scan surfaces nothing replayable, and that the cached round trip still returns usable tokens. **verified failing on the pre-fix implementation** and passing after.
- `test_cache_entry_with_undecryptable_payload_is_dropped` — pins the fall-through-to-DB behavior above.
- `test_cache_miss_then_hit` lost its `cached["session_id"] == session_id` assertion, which encoded exactly the behavior being removed.

full backend suite green; `ruff` clean; the 9 `ty` diagnostics are pre-existing on `main` and none are in these files.

</details>

## deliberately not in this PR

- **`--requirepass` on `plyr-redis` / `plyr-redis-stg`.** the remaining half of #1782 and a coordinated secret rotation across `relay-api`; it lands separately so a config mistake there can't take this fix down with it.
- **hashing `user_sessions.session_id` at rest.** would defang the whole leak class, but the subsonic `md5(token + salt)` scheme needs the plaintext, so it's a design change rather than a hardening one.
## rollout

the key format changed, so entries written by the old code live at a key the new code never reads. they are not migrated and not evicted — they simply expire on their existing 60s TTL. during a rolling deploy the two formats coexist without colliding, since old and new pods address different keys for the same session; the worst case is one extra Postgres read per session per pod. no cache flush, no coordination, and nothing to roll back beyond the deploy itself.
