### PR TITLE
fix(subsonic): only developer tokens authenticate /rest

### DIFF
--- a/backend/src/backend/api/subsonic/auth.py
+++ b/backend/src/backend/api/subsonic/auth.py
@@ -27,7 +27,7 @@ async def authenticate(params: Mapping[str, str]) -> Session:
     """resolve subsonic credential params to a plyr.fm session or raise SubsonicError."""
 
     if password := params.get("p"):
-        if session := await get_session(_decode_password(password)):
+        if session := await _developer_session(_decode_password(password)):
             return session
         raise SubsonicError(ERROR_WRONG_CREDENTIALS, "wrong username or password")
 
@@ -46,6 +46,21 @@ async def authenticate(params: Mapping[str, str]) -> Session:
     raise SubsonicError(
         ERROR_MISSING_PARAMETER, "required parameter is missing: p or u+t+s"
     )
+
+
+async def _developer_session(session_id: str) -> Session | None:
+    """resolve a session id, but only if it belongs to a developer token.
+
+    a browser cookie session and a developer token are the same opaque string;
+    only the latter is a credential the user meant to hand to a subsonic client.
+    """
+    async with db_session() as db:
+        is_developer_token = await db.scalar(
+            select(UserSession.is_developer_token).where(
+                UserSession.session_id == session_id
+            )
+        )
+    return await get_session(session_id) if is_developer_token else None
 
 
 def _decode_password(password: str) -> str:

--- a/backend/tests/api/test_subsonic.py
+++ b/backend/tests/api/test_subsonic.py
@@ -100,6 +100,12 @@ async def dev_token(db_session: AsyncSession) -> str:
 
 
 @pytest.fixture
+async def browser_session_id(db_session: AsyncSession) -> str:
+    """an ordinary cookie session — the same opaque string, not a developer token."""
+    return await create_session(DID, HANDLE, dict(OAUTH_SESSION))
+
+
+@pytest.fixture
 async def library(db_session: AsyncSession, audio_origin: str) -> dict[str, object]:
     """an artist with two tracks and a private playlist ordering them [2, 1]."""
     artist = Artist(did=DID, handle=HANDLE, display_name="Subsonic Tester")
@@ -169,6 +175,23 @@ async def test_ping_rejects_bad_token(live_server: str, dev_token: str) -> None:
     conn = _connection(live_server, "not-a-real-token")
     with pytest.raises(CredentialError):
         await asyncio.to_thread(conn.ping)
+
+
+async def test_browser_session_is_not_a_subsonic_credential(
+    live_server: str, browser_session_id: str
+) -> None:
+    """#1779: only developer tokens authenticate /rest, never a cookie session.
+
+    the legacy `p=` scheme resolved any session id, so a leaked browser cookie
+    worked here even though it was never meant to leave the browser.
+    """
+    conn = _connection(live_server, browser_session_id, legacyAuth=True)
+    with pytest.raises(CredentialError):
+        await asyncio.to_thread(conn.ping)
+
+    token_scheme = _connection(live_server, browser_session_id)
+    with pytest.raises(CredentialError):
+        await asyncio.to_thread(token_scheme.ping)
 
 
 async def test_get_playlists(


### PR DESCRIPTION
the subsonic legacy `p=` auth path resolved its credential with a bare `get_session()`, so **any** valid session id authenticated the whole `/rest` surface — including an ordinary browser cookie session that was never meant to leave the browser. the sibling `u+t+s` path already filtered on `is_developer_token`; this brings the two into line.

closes #1779.

## what changed

both auth schemes now go through one helper that resolves a session id *only* when it belongs to a developer token:

```python
async def _developer_session(session_id: str) -> Session | None:
    async with db_session() as db:
        is_developer_token = await db.scalar(
            select(UserSession.is_developer_token).where(
                UserSession.session_id == session_id
            )
        )
    return await get_session(session_id) if is_developer_token else None
```

the asymmetry was easy to miss because a browser session and a developer token are the same opaque string — `user_sessions.session_id` — distinguished only by a column. one path checked the column and the other didn't.

## why it mattered

developer tokens exist so a user can hand a named, separately revocable credential to a third-party client. resolving any session id erased that: a browser `session_id` that leaked through a log, a shared HAR, or the `/auth/exchange` JSON body became a working subsonic credential with no additional step. `/rest` also bypasses `require_auth`, so such a session skipped the scope-coverage gate in `_internal/auth/dependencies.py` that would have rejected it everywhere else.

scope of the exposure was bounded — `/rest` is read-only plus scrobble, `stream` already refuses private and gated tracks, and `scrobble` re-checks the teal scope itself — so this was a credential-scoping break rather than an authorization break on protected content.

<details>
<summary>tests</summary>

`test_browser_session_is_not_a_subsonic_credential` creates a real non-developer session and asserts both schemes reject it. it drives the live uvicorn server through `libsonic`, the same off-the-shelf client the rest of this file uses, so it exercises the actual wire path rather than calling `authenticate()` directly.

**verified failing pre-fix** on the `p=` scheme specifically (the `u+t+s` half already passed, which is the point — the test pins both so they can't drift apart again). full backend suite green.

</details>

## not in this PR

- `hashed == digest` in the token scheme is a non-constant-time comparison. it compares md5 digests of a 256-bit random token, so it isn't practically exploitable, and folding it in would muddy a security fix with an unrelated one.
- `/rest` still bypasses the scope-upgrade gate that `require_auth` applies elsewhere. worth its own issue — it needs a decision about what scope changes should mean for an already-issued developer token, rather than a quick patch here.
