### PR TITLE
fix(redis): require a password on plyr-redis

### DIFF
--- a/infrastructure/redis/README.md
+++ b/infrastructure/redis/README.md
@@ -1,6 +1,10 @@
 # plyr-redis
 
-self-hosted Redis on Fly.io for docket background tasks.
+self-hosted Redis on Fly.io. backs docket background tasks, the session cache,
+rate-limit counters, and the discovery cache.
+
+two apps, one per environment — `plyr-redis` (prod, used by `relay-api`) and
+`plyr-redis-stg` (staging, used by `relay-api-staging`). they are not shared.
 
 ## deployment
 
@@ -9,30 +13,49 @@ self-hosted Redis on Fly.io for docket background tasks.
 fly apps create plyr-redis
 fly volumes create redis_data --region iad --size 1 -a plyr-redis
 
-# deploy
+# deploy (staging: -c fly.staging.toml -a plyr-redis-stg)
 fly deploy -a plyr-redis
 ```
 
+## authentication
+
+Redis requires a password. it is read from the `REDIS_PASSWORD` secret and
+applied via `--requirepass` in `[processes]`, which is why the command is
+wrapped in `sh -c` — Fly exec's the process args rather than running them
+through a shell, so an unwrapped `$REDIS_PASSWORD` would be taken literally.
+
+neither app has a public IP (`fly ips list` is empty), so this is defense in
+depth against anything that reaches the org's private network — see #1782.
+
 ## connecting from other fly apps
 
-Redis is accessible via Fly's private network:
+the password belongs in the connection string:
 
 ```
-redis://plyr-redis.internal:6379
+redis://:<REDIS_PASSWORD>@plyr-redis.internal:6379
 ```
-
-Update `DOCKET_URL` secret on backend apps:
 
 ```bash
-fly secrets set DOCKET_URL=redis://plyr-redis.internal:6379 -a relay-api
-fly secrets set DOCKET_URL=redis://plyr-redis.internal:6379 -a relay-api-staging
+fly secrets set DOCKET_URL='redis://:<pw>@plyr-redis.internal:6379' -a relay-api
+fly secrets set DOCKET_URL='redis://:<pw>@plyr-redis-stg.internal:6379' -a relay-api-staging
 ```
+
+**the password and the connection string must change together.** Redis rejects
+`AUTH` when no password is set, and rejects unauthenticated clients once one is,
+so whichever side moves first, the other is broken until it catches up. plan for
+a brief window: the session cache degrades gracefully (every Redis call falls
+through to Postgres), but in-flight docket tasks can fail.
+
+> verifying with `redis-cli`? use `-a <pw>`, not `-u redis://:<pw>@host` — the
+> URL form sends an empty ACL username and fails with `WRONGPASS` even when the
+> password is right. the Python client parses the same URL correctly.
 
 ## configuration
 
 - **persistence**: AOF (append-only file) enabled for durability
 - **memory**: 200MB max with LRU eviction
 - **storage**: 1GB volume mounted at /data
+- **auth**: `--requirepass` from the `REDIS_PASSWORD` secret
 
 ## cost
 

--- a/infrastructure/redis/fly.staging.toml
+++ b/infrastructure/redis/fly.staging.toml
@@ -12,7 +12,10 @@ primary_region = "iad"
   # redis config via command line args in [processes]
 
 [processes]
-  app = "--appendonly yes --maxmemory 200mb --maxmemory-policy allkeys-lru"
+  # wrapped in `sh -c` so $REDIS_PASSWORD expands — [processes] args are exec'd,
+  # not shell-interpreted, so `--requirepass $REDIS_PASSWORD` would set the
+  # password to the literal string
+  app = "sh -c 'redis-server --appendonly yes --maxmemory 200mb --maxmemory-policy allkeys-lru --requirepass \"$REDIS_PASSWORD\"'"
 
 [[services]]
   protocol = "tcp"

--- a/infrastructure/redis/fly.toml
+++ b/infrastructure/redis/fly.toml
@@ -12,7 +12,10 @@ primary_region = "iad"
   # redis config via command line args in [processes]
 
 [processes]
-  app = "--appendonly yes --maxmemory 200mb --maxmemory-policy allkeys-lru"
+  # wrapped in `sh -c` so $REDIS_PASSWORD expands — [processes] args are exec'd,
+  # not shell-interpreted, so `--requirepass $REDIS_PASSWORD` would set the
+  # password to the literal string
+  app = "sh -c 'redis-server --appendonly yes --maxmemory 200mb --maxmemory-policy allkeys-lru --requirepass \"$REDIS_PASSWORD\"'"
 
 [[services]]
   protocol = "tcp"


### PR DESCRIPTION
`plyr-redis` accepted connections with no authentication. Neither app has a public IP, so this is defense in depth rather than an open door — but it was the payoff step in the chain from #1782, and it stays valuable for every future foothold.

refs #1782 (the caching half shipped in #1783)

## what changed

`--requirepass` from a `REDIS_PASSWORD` secret, on both `plyr-redis` and `plyr-redis-stg`.

The command is wrapped in `sh -c` because Fly **exec's** `[processes]` args rather than running them through a shell — an unwrapped `--requirepass $REDIS_PASSWORD` would have set the password to that literal 16-character string, which fails closed in the worst way: it looks like it worked. Verified locally against `redis:7-alpine` before deploying.

The README also told you to point *both* environments at production Redis, which is wrong — they are separate apps — and said nothing about the cutover ordering.

## staging: deployed and verified

Rolled out to `plyr-redis-stg` + `relay-api-staging`, then asserted against the live instance over `fly proxy`:

| check | result |
|---|---|
| unauthenticated `PING` | refused — `AuthenticationError` |
| unauthenticated keyspace scan | refused |
| authenticated connection | works, `dbsize=63` (AOF data survived) |
| wrong password | refused |

Application side: `/auth/me` returns 200 with cache hits, 44 docket task-worker keys registered, jetstream cursor present.

<details>
<summary>the cutover window, measured</summary>

51 seconds end to end; ~25 seconds of client disruption (04:56:24–04:56:49), self-healed by retries. The telemetry shows the expected sequence exactly: `ConnectionError` while Redis restarted → `AuthenticationError` once it came up with a password but before `DOCKET_URL` propagated → recovery.

There is no way to avoid a window. Redis rejects `AUTH` when no password is set and rejects unauthenticated clients once one is, so whichever side moves first, the other is briefly broken.

</details>

## ✅ blocker cleared — the rate-limiter fix shipped in #1787

> Verified on staging after #1787 deployed: `plyr-redis-stg` was restarted while polling
> the API, and **150/150 requests returned 200**. Redis came back with auth still enforced,
> 44 docket workers re-registered, and telemetry shows zero 5xx and zero `AttributeError`
> across 552 records. The production cutover is safe to run.

<details>
<summary>original blocker (kept for the record)</summary>


Staging surfaced something that changes the prod plan. During the window, **every request returned 500 — including `/health`**.

`slowapi`'s middleware uses Redis for rate-limit storage. When that storage raises, it hands the exception to its rate-limit handler, which does `exc.detail`:

```
AttributeError: 'ConnectionError' object has no attribute 'detail'
```

So a Redis blip does not degrade rate limiting — it takes the whole API down, and fails the Fly health check while doing it, which on production could get machines killed and turn 25 seconds into something much longer.

My earlier prediction that this "degrades gracefully" was wrong. The *session cache* does — every call is wrapped and falls through to Postgres. The rate limiter does not, and it sits in middleware in front of everything.

`Limiter(...)` in `utilities/rate_limit.py` is built without `swallow_errors` or `in_memory_fallback_enabled`. Fixing that is a separate PR; this one should not go to production before it does.

</details>
