### PR TITLE
fix(rate-limit): survive a redis outage instead of 500ing the API

### DIFF
--- a/backend/src/backend/utilities/rate_limit.py
+++ b/backend/src/backend/utilities/rate_limit.py
@@ -68,4 +68,12 @@ limiter = Limiter(
     enabled=settings.rate_limit.enabled,
     default_limits=[settings.rate_limit.default_limit],
     storage_uri=settings.docket.url or "memory://",
+    # a Redis outage must not take the API down with it. slowapi hands any
+    # storage exception to its rate-limit handler, which reads `exc.detail` --
+    # absent on redis errors -- so an unreachable Redis 500s every request,
+    # including /health, which then fails the platform health check.
+    # the fallback keeps limits enforced per-process and probes for recovery;
+    # swallow_errors is the backstop for paths the fallback does not cover.
+    in_memory_fallback_enabled=True,
+    swallow_errors=True,
 )

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+from fastapi.testclient import TestClient
+
 from backend.config import settings
 
 
@@ -33,3 +35,51 @@ def test_limiter_falls_back_to_memory_when_no_docket_url() -> None:
         assert rl_module.limiter._storage_uri == "memory://"
 
     importlib.reload(rl_module)
+
+
+def test_api_survives_rate_limit_storage_outage(client: TestClient) -> None:
+    """#1782: an unreachable Redis must not 500 the API.
+
+    slowapi hands any storage exception to its rate-limit handler, which reads
+    `exc.detail`. redis errors have no such attribute, so before the fallback was
+    enabled every request -- including /health -- died with
+
+        AttributeError: 'ConnectionError' object has no attribute 'detail'
+
+    that failed the platform health check during a Redis restart, which turns a
+    brief blip into machines being cycled.
+    """
+    from backend.utilities.rate_limit import limiter
+
+    was_dead = limiter._storage_dead
+    try:
+        with patch.object(
+            limiter.limiter,
+            "hit",
+            side_effect=ConnectionError("redis down"),
+        ):
+            response = client.get("/health")
+
+        assert response.status_code == 200, (
+            f"expected the request to survive a storage outage, got "
+            f"{response.status_code}: {response.text[:200]}"
+        )
+    finally:
+        limiter._storage_dead = was_dead
+
+
+def test_rate_limiting_recovers_after_storage_returns(client: TestClient) -> None:
+    """the in-memory fallback is not a one-way door -- storage is probed again."""
+    from backend.utilities.rate_limit import limiter
+
+    was_dead = limiter._storage_dead
+    try:
+        with patch.object(
+            limiter.limiter, "hit", side_effect=ConnectionError("redis down")
+        ):
+            assert client.get("/health").status_code == 200
+
+        limiter._storage_dead = False
+        assert client.get("/health").status_code == 200
+    finally:
+        limiter._storage_dead = was_dead


### PR DESCRIPTION
A Redis outage currently takes the **entire API** down, not just rate limiting — and it fails `/health` while doing it, so the platform starts cycling machines and a brief blip becomes a real outage.

Found on staging during the #1782 `requirepass` cutover. Blocks the production half of that change.

## the mechanism

`slowapi`'s `_check_limits` catches *any* exception from the limit check, then looks up a handler by exception type and falls back to `_rate_limit_exceeded_handler`. That handler assumes it received a `RateLimitExceeded` and reads `exc.detail`:

```
AttributeError: 'ConnectionError' object has no attribute 'detail'
```

`redis.exceptions.ConnectionError` has no `.detail`, so the handler itself explodes and the request 500s. The middleware sits in front of everything, so this is every route, `/health` included.

Observed on staging: ~25 seconds of 500s across the whole API while Redis restarted — first `ConnectionError`, then `AuthenticationError` once Redis came back with a password but before `DOCKET_URL` propagated. Both hit the same broken path.

## the fix

```python
in_memory_fallback_enabled=True,
swallow_errors=True,
```

Reading `_check_request_limit`, the `except` branch retries the check against in-memory limits when the fallback is enabled, marks storage dead, and probes for recovery via `self._storage.check()` on later requests. So this is not "turn rate limiting off" — **limits stay enforced per-process**, and enforcement returns to shared Redis counters automatically once it is reachable.

`swallow_errors` is the backstop: `_inject_headers` has its own failure path that the fallback does not cover, and there a raise would still surface as a 500.

The trade-off during an outage is per-process rather than global counters, which means N processes × the limit. That is strictly better than the current behavior of serving nothing at all.

<details>
<summary>tests</summary>

`test_api_survives_rate_limit_storage_outage` drives the real app through `TestClient` with the limiter's storage raising `ConnectionError`, and asserts `/health` returns 200. **Verified failing pre-fix with the exact production traceback** — `AttributeError: 'ConnectionError' object has no attribute 'detail'` at `slowapi/extension.py:82` — so it reproduces the staging incident rather than approximating it.

`test_rate_limiting_recovers_after_storage_returns` pins that the fallback is not a one-way door.

Full suite: 1448 passed, 25 skipped. Lint clean.

</details>

## why this is separate from #1786

#1786 is the Redis config change. This is a standalone resilience bug that exists regardless — *any* Redis restart, eviction, or network blip 500s the API today. It should merge and deploy first, then the production `requirepass` cutover can proceed safely.