### PR TITLE
fix(security): stop treating an uploader-controlled endpoint as our own storage (#1778)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "sqlalchemy>=2.0.36",
     "alembic>=1.14.0",
     "asyncpg>=0.30.0",
-    "atproto @ git+https://github.com/zzstoatzz/atproto@4577e6532bb540a64d5037fde26d7921416a7058",
+    "atproto @ git+https://github.com/zzstoatzz/atproto@1ad4f176292d688005c6247f1e65f2d2c1057b89",
     "boto3>=1.37.0",
     "python-multipart>=0.0.20",
     "python-jose[cryptography]>=3.3.0",

--- a/backend/src/backend/_internal/slingshot.py
+++ b/backend/src/backend/_internal/slingshot.py
@@ -13,11 +13,16 @@ import logging
 from typing import TypedDict
 
 import httpx
+from atproto_oauth.security import is_safe_url
 
 logger = logging.getLogger(__name__)
 
 SLINGSHOT_URL = "https://slingshot.microcosm.blue"
 USER_AGENT = "plyr.fm (zzstoatzz.io)"
+
+
+class UnsafePdsEndpoint(ValueError):
+    """raised when a resolved miniDoc names a PDS we will not talk to."""
 
 
 class MiniDoc(TypedDict):
@@ -33,14 +38,23 @@ async def resolve_mini_doc(did: str) -> MiniDoc:
     """resolve a DID to its current verified handle, PDS, and signing key.
 
     the miniDoc is bidirectionally verified by slingshot, so the handle is
-    confirmed to resolve back to the DID.
+    confirmed to resolve back to the DID. that verification says the DID owns
+    the document, not that the document names a reasonable PDS: for `did:web`
+    the document is served from the subject's own domain, so `serviceEndpoint`
+    is whatever they say it is. the endpoint is `is_safe_url`-checked here,
+    at the boundary where it enters, because everything downstream treats
+    `Artist.pds_url` as a host we chose to trust.
+
+    a miniDoc is accepted or rejected whole — a hostile PDS also blocks the
+    handle update it arrived with, rather than half-trusting the document.
 
     args:
         did: the DID to resolve (also accepts a handle as the identifier).
 
     raises:
         httpx.HTTPError on transport/status failure; KeyError if the response
-        is missing required fields.
+        is missing required fields; UnsafePdsEndpoint if the PDS is not a
+        URL we will talk to.
     """
     async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}) as client:
         resp = await client.get(
@@ -50,6 +64,8 @@ async def resolve_mini_doc(did: str) -> MiniDoc:
         )
         resp.raise_for_status()
         data = resp.json()
+        if not is_safe_url(pds := data["pds"]):
+            raise UnsafePdsEndpoint(f"refusing PDS endpoint {pds!r} for {did}")
         return MiniDoc(
             did=data["did"],
             handle=data["handle"],

--- a/backend/src/backend/_internal/tasks/__init__.py
+++ b/backend/src/backend/_internal/tasks/__init__.py
@@ -25,6 +25,10 @@ from backend._internal.tasks.hooks import (
     run_post_track_create_hooks,
 )
 from backend._internal.tasks.labels import sync_operator_labels
+from backend._internal.tasks.pds_mirror import (
+    mirror_pds_blob,
+    schedule_pds_blob_mirror,
+)
 from backend._internal.tasks.transparency import publish_moderation_decisions
 from backend._internal.tasks.moderation import (
     scan_image_moderation,
@@ -98,6 +102,7 @@ def _build_background_tasks() -> list:
     from backend.api.tracks.uploads import run_track_upload
 
     return [
+        mirror_pds_blob,
         scan_copyright,
         sync_copyright_resolutions,
         sync_operator_labels,
@@ -175,6 +180,7 @@ __all__ = [
     "ingest_track_delete",
     "ingest_track_update",
     "invalidate_tracks_discovery_cache",
+    "mirror_pds_blob",
     "move_track_audio",
     "pds_create_comment",
     "pds_create_like",
@@ -195,6 +201,7 @@ __all__ = [
     "schedule_genre_classification",
     "schedule_image_moderation_scan",
     "schedule_move_track_audio",
+    "schedule_pds_blob_mirror",
     "schedule_pds_create_comment",
     "schedule_pds_create_like",
     "schedule_pds_delete_comment",

--- a/backend/src/backend/_internal/tasks/hooks.py
+++ b/backend/src/backend/_internal/tasks/hooks.py
@@ -7,6 +7,7 @@ both the API upload path and Jetstream ingest call run_post_track_create_hooks()
 import logging
 
 import logfire
+from atproto_oauth.security import is_safe_url
 from redis.exceptions import RedisError
 from sqlalchemy import delete, select
 from sqlalchemy.orm import joinedload
@@ -63,7 +64,10 @@ async def resolve_audio_url(track_id: int) -> str | None:
                 select(Artist.pds_url).where(Artist.did == artist_did).limit(1)
             )
             artist_pds_url = artist_result.scalar_one_or_none()
-            if artist_pds_url:
+            # rows written before the resolution-time check (#1778) can still
+            # hold an unsafe endpoint, and this URL is handed to third-party
+            # fetchers, so re-check what we stored rather than trusting it
+            if artist_pds_url and is_safe_url(artist_pds_url):
                 return pds_blob_url(artist_pds_url, artist_did, pds_blob_cid)
 
         return None

--- a/backend/src/backend/_internal/tasks/hooks.py
+++ b/backend/src/backend/_internal/tasks/hooks.py
@@ -18,6 +18,7 @@ from backend._internal.tasks.ml import (
     schedule_embedding_generation,
     schedule_genre_classification,
 )
+from backend._internal.tasks.pds_mirror import schedule_pds_blob_mirror
 from backend.config import settings
 from backend.models import Artist, CopyrightScan, Track
 from backend.utilities.database import db_session
@@ -73,6 +74,12 @@ async def resolve_audio_url(track_id: int) -> str | None:
         return None
 
 
+async def _has_own_audio_object(track_id: int) -> bool:
+    """whether the track's audio is stored by us rather than only on a PDS."""
+    async with db_session() as db:
+        return bool(await db.scalar(select(Track.r2_url).where(Track.id == track_id)))
+
+
 async def run_post_track_create_hooks(
     track_id: int,
     *,
@@ -106,6 +113,15 @@ async def run_post_track_create_hooks(
         await _mark_notification_sent(track_id)
     else:
         await _send_track_notification(track_id)
+
+    # 1b. audio that lives only on the artist's PDS is mirrored and verified
+    # against its CID before any vendor sees it — a PDS serves its blobs fresh
+    # per request, so scanning that URL scans whatever it feels like returning
+    # at that moment (#1778). the mirror re-enters here once we hold a copy.
+    if audio_url and not await _has_own_audio_object(track_id):
+        await schedule_pds_blob_mirror(track_id)
+        await invalidate_tracks_discovery_cache()
+        return
 
     # 2. copyright scan
     if audio_url and not skip_copyright:

--- a/backend/src/backend/_internal/tasks/ingest.py
+++ b/backend/src/backend/_internal/tasks/ingest.py
@@ -13,6 +13,7 @@ from pathlib import PurePosixPath
 from urllib.parse import urlparse
 
 import logfire
+from atproto_oauth.security import is_safe_url
 from docket import ConcurrencyLimit, ExponentialRetry
 from sqlalchemy import delete, select, update
 from sqlalchemy.exc import IntegrityError, OperationalError
@@ -219,6 +220,7 @@ async def ingest_track_create(
                     not resolved_audio_url
                     and existing_track.pds_blob_cid
                     and artist.pds_url
+                    and is_safe_url(artist.pds_url)
                 ):
                     resolved_audio_url = pds_blob_url(
                         artist.pds_url, did, existing_track.pds_blob_cid
@@ -352,7 +354,12 @@ async def ingest_track_create(
             return
 
         resolved_audio_url = track.r2_url
-        if not resolved_audio_url and pds_blob_cid and artist.pds_url:
+        if (
+            not resolved_audio_url
+            and pds_blob_cid
+            and artist.pds_url
+            and is_safe_url(artist.pds_url)
+        ):
             resolved_audio_url = pds_blob_url(artist.pds_url, did, pds_blob_cid)
 
         logfire.info(

--- a/backend/src/backend/_internal/tasks/pds_mirror.py
+++ b/backend/src/backend/_internal/tasks/pds_mirror.py
@@ -1,0 +1,194 @@
+"""mirror PDS-hosted audio into R2 after verifying it against its CID.
+
+a track ingested from the firehose may have no R2 object of our own: the
+audio lives as a blob on the artist's PDS and `resolve_audio_url` builds a
+`com.atproto.sync.getBlob` URL for it. handing that URL to AudD, Modal, and
+Replicate treats an endpoint the uploader operates as if it were our own
+immutable storage — the bytes are served fresh on every request, so the
+copyright scanner can be shown one thing and listeners another, and the
+fetch doubles as a callback oracle telling the uploader exactly when each
+vendor processed their track (#1778).
+
+so we fetch the blob once, check that it hashes to the `pds_blob_cid` the
+record committed to, and store our verified copy. scans then run against
+bytes we can vouch for. this is the same trade an index makes everywhere:
+hold a copy, and earn the right to by verifying it.
+
+the CID is what makes the copy legitimate rather than presumptuous, and it
+is self-securing: the fetch targets the PDS that slingshot resolved for the
+DID, so a record naming bytes that PDS does not serve simply fails to
+mirror. an unverified event can cause a failed mirror, never a wrong one.
+"""
+
+import base64
+import hashlib
+import logging
+from io import BytesIO
+
+import logfire
+from atproto_oauth.security import get_hardened_async_client, is_safe_url
+from sqlalchemy import select
+
+from backend._internal.atproto.client import pds_blob_url
+from backend._internal.background import get_docket
+from backend.config import settings
+from backend.models import Artist, Track
+from backend.storage import storage
+from backend.storage.keys import AudioKey, InvalidMediaExtension
+from backend.utilities.database import db_session
+
+logger = logging.getLogger(__name__)
+
+# CIDv1, raw codec, sha256, 32 bytes — the multihash prefix atproto blob refs
+# use. verified against a live blob rather than inferred from the spec.
+_CIDV1_RAW_SHA256_PREFIX = bytes([0x01, 0x55, 0x12, 0x20])
+
+
+class BlobVerificationError(Exception):
+    """the fetched bytes are not the bytes the record committed to."""
+
+
+def cid_for_blob(data: bytes) -> str:
+    """the CIDv1 an atproto PDS would advertise for these bytes."""
+    multihash = _CIDV1_RAW_SHA256_PREFIX + hashlib.sha256(data).digest()
+    return "b" + base64.b32encode(multihash).decode().lower().rstrip("=")
+
+
+async def mirror_pds_blob(track_id: int) -> None:
+    """fetch, verify, and store a track's PDS blob as our own R2 object.
+
+    idempotent: a track that already has an R2 object is left alone, and a
+    re-run after a partial failure re-fetches and re-verifies from scratch.
+    """
+    async with db_session() as db:
+        row = (
+            await db.execute(
+                select(
+                    Track.r2_url,
+                    Track.pds_blob_cid,
+                    Track.file_type,
+                    Track.artist_did,
+                    Artist.pds_url,
+                )
+                .join(Artist, Artist.did == Track.artist_did)
+                .where(Track.id == track_id)
+                .limit(1)
+            )
+        ).first()
+
+    if not row:
+        logger.debug("mirror_pds_blob: unknown track %s", track_id)
+        return
+
+    r2_url, blob_cid, file_type, artist_did, artist_pds_url = row
+
+    if r2_url:
+        return
+    if not (blob_cid and artist_pds_url and is_safe_url(artist_pds_url)):
+        logfire.info(
+            "mirror_pds_blob: nothing safe to mirror",
+            track_id=track_id,
+            has_cid=blob_cid is not None,
+        )
+        return
+
+    try:
+        # the extension is validated before the fetch so an unstorable file
+        # type fails without spending the bandwidth
+        AudioKey.for_file("verify", file_type)
+    except InvalidMediaExtension:
+        logfire.warn(
+            "mirror_pds_blob: unsupported file type",
+            track_id=track_id,
+            file_type=file_type,
+        )
+        return
+
+    data = await _fetch_blob(artist_pds_url, artist_did, blob_cid)
+    if data is None:
+        return
+
+    if (actual := cid_for_blob(data)) != blob_cid:
+        # the PDS served bytes the record does not commit to. this is the
+        # case the whole task exists to catch, so it is loud.
+        logfire.error(
+            "mirror_pds_blob: blob does not match its CID",
+            track_id=track_id,
+            expected_cid=blob_cid,
+            actual_cid=actual,
+            byte_count=len(data),
+        )
+        raise BlobVerificationError(
+            f"track {track_id}: PDS served {actual}, record commits to {blob_cid}"
+        )
+
+    file_id = await storage.save(BytesIO(data), f"blob.{file_type}")
+    stored_url = await storage.get_url(file_id, file_type=file_type)
+    if not stored_url:
+        logfire.error("mirror_pds_blob: stored blob has no URL", track_id=track_id)
+        return
+
+    async with db_session() as db:
+        if track := await db.get(Track, track_id):
+            track.r2_url = stored_url
+            track.file_id = file_id
+            track.audio_storage = "both"
+            await db.commit()
+
+    logfire.info(
+        "mirror_pds_blob: verified and stored",
+        track_id=track_id,
+        cid=blob_cid,
+        file_id=file_id,
+        byte_count=len(data),
+    )
+
+    # hooks imports this module, so the re-entry import is deferred
+    from backend._internal.tasks.hooks import run_post_track_create_hooks
+
+    # now that the track has an audio object of ours, the hooks resolve to it
+    # and the vendor-facing steps run against bytes we verified. followers were
+    # already notified on the first pass.
+    await run_post_track_create_hooks(track_id, skip_notification=True)
+
+
+async def _fetch_blob(pds_url: str, did: str, cid: str) -> bytes | None:
+    """download a blob, refusing anything larger than an upload would be."""
+    max_bytes = settings.storage.max_upload_size_mb * 1024 * 1024
+    url = pds_blob_url(pds_url, did, cid)
+
+    async with (
+        get_hardened_async_client() as client,
+        client.stream("GET", url) as response,
+    ):
+        if response.status_code != 200:
+            logfire.warn(
+                "mirror_pds_blob: PDS returned {status}",
+                status=response.status_code,
+                cid=cid,
+            )
+            return None
+
+        chunks: list[bytes] = []
+        total = 0
+        async for chunk in response.aiter_bytes():
+            total += len(chunk)
+            if total > max_bytes:
+                # a PDS can advertise any length, or none, so the cap is
+                # enforced on what actually arrives
+                logfire.warn(
+                    "mirror_pds_blob: blob exceeds the upload ceiling",
+                    cid=cid,
+                    max_bytes=max_bytes,
+                )
+                return None
+            chunks.append(chunk)
+
+    return b"".join(chunks)
+
+
+async def schedule_pds_blob_mirror(track_id: int) -> None:
+    """schedule a verified mirror via docket."""
+    docket = get_docket()
+    await docket.add(mirror_pds_blob)(track_id)
+    logfire.info("scheduled pds blob mirror", track_id=track_id)

--- a/backend/tests/_internal/test_pds_mirror.py
+++ b/backend/tests/_internal/test_pds_mirror.py
@@ -1,0 +1,154 @@
+"""tests for the verified PDS blob mirror (#1778)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal.tasks.pds_mirror import (
+    BlobVerificationError,
+    cid_for_blob,
+    mirror_pds_blob,
+)
+from backend.models import Artist, Track
+
+MOCK_FETCH_PATH = "backend._internal.tasks.pds_mirror._fetch_blob"
+MOCK_STORAGE_PATH = "backend._internal.tasks.pds_mirror.storage"
+MOCK_REENTRY_PATH = "backend._internal.tasks.hooks.run_post_track_create_hooks"
+
+# pinned CIDv1 / raw / sha256 vectors, reproducible by any implementation.
+# the encoding was additionally checked end-to-end against a live PDS: the
+# 783487-byte blob at pds.zzstoatzz.io for
+# bafkreig2lezdhb6ctnljhennnqfy3x66vvdndjjo7nerqji7n3sypm5mca hashed to
+# exactly that CID. it is not inlined here for obvious reasons.
+_CID_OF_EMPTY = "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"
+_CID_OF_HELLO_WORLD = "bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e"
+
+
+async def _track_on_pds(
+    db: AsyncSession,
+    *,
+    cid: str,
+    pds_url: str = "https://pds.example.com",
+) -> Track:
+    artist = Artist(
+        did="did:plc:mirror_test",
+        handle="mirror.test.social",
+        display_name="Mirror Artist",
+        pds_url=pds_url,
+    )
+    db.add(artist)
+    await db.commit()
+
+    track = Track(
+        title="mirrored",
+        file_id="notahash",
+        file_type="mp3",
+        artist_did=artist.did,
+        r2_url=None,
+        audio_storage="pds",
+        pds_blob_cid=cid,
+        publish_state="published",
+    )
+    db.add(track)
+    await db.commit()
+    return track
+
+
+class TestCidForBlob:
+    def test_matches_known_cid_vectors(self) -> None:
+        """the whole guarantee rests on this encoding being the PDS's."""
+        assert cid_for_blob(b"") == _CID_OF_EMPTY
+        assert cid_for_blob(b"hello world") == _CID_OF_HELLO_WORLD
+
+    def test_distinct_bytes_give_distinct_cids(self) -> None:
+        assert cid_for_blob(b"one") != cid_for_blob(b"two")
+
+
+class TestMirrorPdsBlob:
+    async def test_stores_verified_blob_and_flips_storage(
+        self, db_session: AsyncSession
+    ) -> None:
+        audio = b"real audio bytes"
+        track = await _track_on_pds(db_session, cid=cid_for_blob(audio))
+
+        storage_mock = AsyncMock()
+        storage_mock.save.return_value = "deadbeefdeadbeef"
+        storage_mock.get_url.return_value = "https://r2.example.com/audio/x.mp3"
+
+        with (
+            patch(MOCK_FETCH_PATH, AsyncMock(return_value=audio)),
+            patch(MOCK_STORAGE_PATH, storage_mock),
+            patch(MOCK_REENTRY_PATH, AsyncMock()) as reentry,
+        ):
+            await mirror_pds_blob(track.id)
+
+        await db_session.refresh(track)
+        assert track.r2_url == "https://r2.example.com/audio/x.mp3"
+        assert track.file_id == "deadbeefdeadbeef"
+        assert track.audio_storage == "both"
+        # the scans re-run against our copy, without re-notifying followers
+        reentry.assert_awaited_once()
+        assert reentry.await_args.kwargs["skip_notification"] is True
+
+    async def test_rejects_bytes_that_do_not_match_the_cid(
+        self, db_session: AsyncSession
+    ) -> None:
+        """the case the task exists for: a PDS serving something else.
+
+        the blob URL is fetched fresh on every request, so without this check
+        a scanner can be shown clean audio and listeners something else.
+        """
+        track = await _track_on_pds(db_session, cid=cid_for_blob(b"what was published"))
+
+        storage_mock = AsyncMock()
+        with (
+            patch(MOCK_FETCH_PATH, AsyncMock(return_value=b"something else entirely")),
+            patch(MOCK_STORAGE_PATH, storage_mock),
+            pytest.raises(BlobVerificationError),
+        ):
+            await mirror_pds_blob(track.id)
+
+        storage_mock.save.assert_not_awaited()
+        await db_session.refresh(track)
+        assert track.r2_url is None
+        assert track.audio_storage == "pds"
+
+    async def test_refuses_unsafe_pds_url(self, db_session: AsyncSession) -> None:
+        track = await _track_on_pds(
+            db_session, cid=cid_for_blob(b"x"), pds_url="http://169.254.169.254"
+        )
+
+        with patch(MOCK_FETCH_PATH, AsyncMock()) as fetch:
+            await mirror_pds_blob(track.id)
+
+        fetch.assert_not_awaited()
+
+    async def test_skips_track_that_already_has_an_r2_object(
+        self, db_session: AsyncSession
+    ) -> None:
+        track = await _track_on_pds(db_session, cid=cid_for_blob(b"x"))
+        track.r2_url = "https://r2.example.com/audio/existing.mp3"
+        await db_session.commit()
+
+        with patch(MOCK_FETCH_PATH, AsyncMock()) as fetch:
+            await mirror_pds_blob(track.id)
+
+        fetch.assert_not_awaited()
+
+    async def test_unfetchable_blob_leaves_the_track_alone(
+        self, db_session: AsyncSession
+    ) -> None:
+        """a fabricated record names a CID the real PDS will not serve."""
+        track = await _track_on_pds(db_session, cid=cid_for_blob(b"x"))
+
+        storage_mock = AsyncMock()
+        with (
+            patch(MOCK_FETCH_PATH, AsyncMock(return_value=None)),
+            patch(MOCK_STORAGE_PATH, storage_mock),
+        ):
+            await mirror_pds_blob(track.id)
+
+        storage_mock.save.assert_not_awaited()
+        await db_session.refresh(track)
+        assert track.r2_url is None

--- a/backend/tests/test_post_create_hooks.py
+++ b/backend/tests/test_post_create_hooks.py
@@ -90,6 +90,24 @@ class TestResolveAudioUrl:
         expected = pds_blob_url("https://pds.example.com", artist.did, "bafyblob")
         assert url == expected
 
+    async def test_none_for_unsafe_stored_pds_url(
+        self, db_session: AsyncSession
+    ) -> None:
+        """rows predating the resolution-time check can hold a hostile endpoint.
+
+        this URL is handed to AudD, Modal, and Replicate, so a stored value is
+        re-checked rather than trusted (#1778).
+        """
+        artist = await _create_artist(db_session, pds_url="http://169.254.169.254")
+        track = await _create_track(
+            db_session,
+            artist,
+            r2_url=None,
+            audio_storage="pds",
+            pds_blob_cid="bafyblob",
+        )
+        assert await resolve_audio_url(track.id) is None
+
     async def test_none_when_no_audio(self, db_session: AsyncSession) -> None:
         artist = await _create_artist(db_session)
         track = await _create_track(

--- a/backend/tests/test_slingshot.py
+++ b/backend/tests/test_slingshot.py
@@ -4,7 +4,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend._internal.slingshot import resolve_mini_doc, resolve_mini_doc_safe
+from backend._internal.slingshot import (
+    UnsafePdsEndpoint,
+    resolve_mini_doc,
+    resolve_mini_doc_safe,
+)
 
 # a real resolveMiniDoc response shape (verified against the live service).
 _MINI_DOC = {
@@ -50,6 +54,42 @@ class TestResolveMiniDoc:
             "/xrpc/com.bad-example.identity.resolveMiniDoc"
         )
         assert kwargs["params"] == {"identifier": _MINI_DOC["did"]}
+
+    @pytest.mark.parametrize(
+        "pds",
+        [
+            "http://169.254.169.254",
+            "http://10.0.0.1",
+            "https://192.168.1.1",
+            "file:///etc/passwd",
+        ],
+    )
+    async def test_rejects_unsafe_pds_endpoint(self, pds: str) -> None:
+        """a did:web subject serves their own DID document, so `pds` is theirs
+        to choose. we hand URLs built from it to third-party fetchers (#1778).
+        """
+        mock_response = MagicMock()
+        mock_response.json.return_value = {**_MINI_DOC, "pds": pds}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("backend._internal.slingshot.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            with pytest.raises(UnsafePdsEndpoint):
+                await resolve_mini_doc("did:web:evil.example")
+
+    async def test_unsafe_pds_rejects_the_whole_minidoc(self) -> None:
+        """the handle in a document naming a hostile PDS is not adopted either."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {**_MINI_DOC, "pds": "http://10.0.0.1"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("backend._internal.slingshot.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            assert await resolve_mini_doc_safe("did:web:evil.example") is None
 
     async def test_raises_on_http_error(self) -> None:
         mock_response = MagicMock()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -302,8 +302,8 @@ wheels = [
 
 [[package]]
 name = "atproto"
-version = "0.0.2.dev5"
-source = { git = "https://github.com/zzstoatzz/atproto?rev=4577e6532bb540a64d5037fde26d7921416a7058#4577e6532bb540a64d5037fde26d7921416a7058" }
+version = "0.0.2.dev6"
+source = { git = "https://github.com/zzstoatzz/atproto?rev=1ad4f176292d688005c6247f1e65f2d2c1057b89#1ad4f176292d688005c6247f1e65f2d2c1057b89" }
 dependencies = [
     { name = "click" },
     { name = "cryptography" },
@@ -382,7 +382,7 @@ requires-dist = [
     { name = "aioboto3", specifier = ">=15.5.0" },
     { name = "alembic", specifier = ">=1.14.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
-    { name = "atproto", git = "https://github.com/zzstoatzz/atproto?rev=4577e6532bb540a64d5037fde26d7921416a7058" },
+    { name = "atproto", git = "https://github.com/zzstoatzz/atproto?rev=1ad4f176292d688005c6247f1e65f2d2c1057b89" },
     { name = "beartype", specifier = ">=0.22.8" },
     { name = "boto3", specifier = ">=1.37.0" },
     { name = "cachetools", specifier = ">=6.2.1" },

--- a/loq.toml
+++ b/loq.toml
@@ -211,7 +211,7 @@ max_lines = 544
 
 [[rules]]
 path = "backend/src/backend/_internal/tasks/ingest.py"
-max_lines = 1092
+max_lines = 1099
 
 [[rules]]
 path = "backend/tests/test_jetstream.py"
@@ -303,7 +303,7 @@ max_lines = 649
 
 [[rules]]
 path = "backend/tests/test_post_create_hooks.py"
-max_lines = 505
+max_lines = 523
 
 [[rules]]
 path = "backend/tests/api/test_audio_optimize.py"

--- a/scripts/backfill_pds_blob_mirror.py
+++ b/scripts/backfill_pds_blob_mirror.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env -S uv run --script --quiet
+"""backfill verified R2 copies for tracks whose audio lives only on a PDS.
+
+## Context
+
+Tracks ingested from the firehose can have no audio object of ours: the bytes
+are a blob on the artist's PDS, and `resolve_audio_url` built a `getBlob` URL
+that we handed to AudD, Modal, and Replicate. A PDS serves its blobs fresh on
+every request, so scanning that URL scanned whatever the operator felt like
+returning at that moment (#1778).
+
+`mirror_pds_blob` fixes this going forward, but it only runs from the
+post-create hooks — a track ingested months ago never fires those again. This
+walks the existing rows.
+
+Each track is fetched once, checked against the `pds_blob_cid` its record
+commits to, and stored only if the bytes match. A mismatch is reported and
+skipped, never stored.
+
+## Usage
+
+```bash
+# what would be mirrored, including a HEAD-only reachability check
+uv run --project backend scripts/backfill_pds_blob_mirror.py --dry-run
+
+# mirror a single track first
+uv run --project backend scripts/backfill_pds_blob_mirror.py --limit 1
+
+# the rest
+uv run --project backend scripts/backfill_pds_blob_mirror.py
+```
+"""
+
+import argparse
+import asyncio
+import logging
+
+from atproto_oauth.security import get_hardened_async_client, is_safe_url
+from sqlalchemy import select
+
+from backend._internal.atproto.client import pds_blob_url
+from backend._internal.tasks.pds_mirror import BlobVerificationError, mirror_pds_blob
+from backend.models import Artist, Track
+from backend.utilities.database import db_session
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+async def _candidates(limit: int | None) -> list[tuple[int, str, str, str, str]]:
+    """tracks with a PDS blob and no audio object of ours."""
+    async with db_session() as db:
+        query = (
+            select(
+                Track.id,
+                Track.title,
+                Track.pds_blob_cid,
+                Track.artist_did,
+                Artist.pds_url,
+            )
+            .join(Artist, Artist.did == Track.artist_did)
+            .where(
+                Track.r2_url.is_(None),
+                Track.pds_blob_cid.isnot(None),
+            )
+            .order_by(Track.id)
+        )
+        if limit:
+            query = query.limit(limit)
+        return list((await db.execute(query)).all())
+
+
+async def _report(track_id: int, title: str, cid: str, did: str, pds: str) -> None:
+    """describe one candidate without fetching its bytes."""
+    if not pds:
+        logger.warning("track %s (%r): artist has no pds_url", track_id, title)
+        return
+    if not is_safe_url(pds):
+        logger.warning("track %s (%r): unsafe pds_url %s", track_id, title, pds)
+        return
+
+    url = pds_blob_url(pds, did, cid)
+    try:
+        async with get_hardened_async_client() as client:
+            response = await client.head(url)
+        size = response.headers.get("content-length", "unknown")
+        logger.info(
+            "track %s (%r): %s -> HTTP %s, %s bytes",
+            track_id,
+            title,
+            pds,
+            response.status_code,
+            size,
+        )
+    except Exception as exc:
+        logger.warning("track %s (%r): HEAD failed: %s", track_id, title, exc)
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="report only")
+    parser.add_argument("--limit", type=int, help="process at most N tracks")
+    args = parser.parse_args()
+
+    candidates = await _candidates(args.limit)
+    logger.info("found %d track(s) with PDS-only audio", len(candidates))
+    if not candidates:
+        return
+
+    mirrored = skipped = failed = 0
+    for track_id, title, cid, did, pds in candidates:
+        if args.dry_run:
+            await _report(track_id, title, cid, did, pds)
+            continue
+
+        try:
+            await mirror_pds_blob(track_id)
+        except BlobVerificationError as exc:
+            # the PDS served bytes its own record does not commit to
+            logger.error("track %s (%r): VERIFICATION FAILED: %s", track_id, title, exc)
+            failed += 1
+            continue
+        except Exception as exc:
+            logger.error("track %s (%r): %s", track_id, title, exc)
+            failed += 1
+            continue
+
+        async with db_session() as db:
+            stored = await db.scalar(select(Track.r2_url).where(Track.id == track_id))
+        if stored:
+            logger.info("track %s (%r): mirrored -> %s", track_id, title, stored)
+            mirrored += 1
+        else:
+            # unreachable blob, oversized blob, or unsupported file type --
+            # mirror_pds_blob logs the specific reason
+            logger.warning("track %s (%r): not mirrored", track_id, title)
+            skipped += 1
+
+    if not args.dry_run:
+        logger.info(
+            "done: %d mirrored, %d skipped, %d failed", mirrored, skipped, failed
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
`Artist.pds_url` comes from a DID document, and for `did:web` that document is served from the subject's own domain. We interpolated it into a `getBlob` URL and handed it to AudD, Modal, and Replicate — each of which fetches it server-side. Worse, a PDS serves its blobs *fresh on every request*, so "scan the track" meant "scan whatever that host feels like returning at that moment."

Two commits: validate the endpoint, then stop pointing vendors at it at all.

<details>
<summary>1. validate the PDS endpoint (1143d943)</summary>

`is_safe_url` at `slingshot.resolve_mini_doc`, where an untrusted endpoint enters the system. Slingshot's bidirectional verification confirms the DID owns the document; it says nothing about whether the document names a reasonable host. A miniDoc is now accepted or rejected whole, so a hostile PDS also blocks the handle update it arrived with.

Also at the two `pds_blob_url` construction sites, because rows written before this change can still hold a hostile endpoint and nothing backfills them.

The regression test fails on `main` with exactly the vulnerability:

```
AssertionError: assert 'http://169.254.169.254/xrpc/com.atproto.sync.getBlob?did=...&cid=bafyblob' is None
```

That is the cloud metadata endpoint, built from a stored `pds_url`, on its way to three third-party fetchers.

</details>

<details>
<summary>2. mirror the blob, verified against its CID (1d729c9c)</summary>

Validation alone leaves the harder half: the source is mutable. Verifying the CID and then still handing over the PDS URL fixes nothing, since the vendor fetches independently afterward — same TOCTOU, plus a reassuring log line.

So `mirror_pds_blob` fetches the blob once through the hardened client with a size cap, checks it hashes to the `pds_blob_cid` the record commits to, and stores our verified copy. The hooks then re-enter and the vendor-facing steps run against bytes we can vouch for.

**Why this is legitimate rather than presumptuous:** it's the trade an index always makes — hold a copy, and earn the right to by verifying it. pub-search does the same with document content, verifying commits via zat. The CID is what does that work here.

**Keying:** the object is keyed by the content hash `storage.save` computes, *not* by the record's `fileId`, which on the ingest path is `record.get("fileId", rkey)` — attacker-supplied. Given `content_hash_ownership` has caused three incidents already, that surface doesn't get a user-controlled string.

**The verification is self-securing.** The fetch targets the PDS slingshot resolved for the DID, so a record naming bytes that PDS won't serve simply fails to mirror. An unverified jetstream event can cause a *failed* mirror, never a wrong one — which is why this doesn't depend on commit verification.

</details>

<details>
<summary>verification</summary>

Full suite: 1461 passed, 25 skipped. Lint clean.

CID encoding is pinned to known CIDv1/raw/sha256 vectors in the tests, and was checked end-to-end against a live PDS: the 783487-byte blob behind `bafkreig2lezdhb6ctnljhennnqfy3x66vvdndjjo7nerqji7n3sypm5mca` hashes to exactly that CID.

The mutation test — a PDS serving bytes other than what the record commits to — asserts we raise and store nothing.

</details>

<details>
<summary>scope, and why now</summary>

1001 prod tracks; 2 have `audio_storage='pds'` with no R2 copy. Both are `did:plc` artists on ordinary PDSes, and both arrived via jetstream ingest — plyr as pure index over someone else's PDS.

That population is the one that grows: 75% of August uploads carry a PDS blob, up from 3% in December. This closes the path before it matters rather than after.

</details>

<details>
<summary>deferred</summary>

- **backfilling the 2 existing tracks** — they'll mirror on their next hook run; a one-shot script may be worth it.
- **`is_safe_url` is weak** — string-prefix hostname matching, no DNS resolution, so a hostname resolving to a private address passes. It lives in the `atproto` fork; worth hardening there.
- **Two commits in one PR.** These were planned as separate PRs. They share one code path and the second is meaningless without the first, and stacking them would have made the squash-merge messy, so they're stacked as commits instead.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)