### PR TITLE
fix(scripts): give the PDS mirror backfill a docket client, and ship scripts in the image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,6 +22,12 @@ COPY lexicons ./lexicons
 COPY backend/alembic.ini .
 COPY backend/alembic ./alembic
 
+# operator scripts (backfills, audits). they need the environment's database
+# and R2 credentials, which live on the machine and nowhere else, so this is
+# where they have to run from. only scripts importing `backend` alone work --
+# nothing installs their PEP 723 dependencies.
+COPY scripts ./scripts
+
 # install the project itself with bytecode compilation
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --compile-bytecode

--- a/backend/src/backend/_internal/tasks/pds_mirror.py
+++ b/backend/src/backend/_internal/tasks/pds_mirror.py
@@ -148,8 +148,13 @@ async def mirror_pds_blob(track_id: int) -> None:
 
     # now that the track has an audio object of ours, the hooks resolve to it
     # and the vendor-facing steps run against bytes we verified. followers were
-    # already notified on the first pass.
-    await run_post_track_create_hooks(track_id, skip_notification=True)
+    # already notified on the first pass, and staging does not spend AudD
+    # credits on ingested tracks -- both mirroring what `ingest` passes.
+    await run_post_track_create_hooks(
+        track_id,
+        skip_notification=True,
+        skip_copyright=settings.observability.environment == "staging",
+    )
 
 
 async def _fetch_blob(pds_url: str, did: str, cid: str) -> bytes | None:

--- a/backend/tests/_internal/test_pds_mirror.py
+++ b/backend/tests/_internal/test_pds_mirror.py
@@ -91,6 +91,53 @@ class TestMirrorPdsBlob:
         reentry.assert_awaited_once()
         assert reentry.await_args.kwargs["skip_notification"] is True
 
+    async def test_staging_does_not_spend_audd_credits(
+        self, db_session: AsyncSession
+    ) -> None:
+        """`ingest` skips copyright on staging; the mirror's re-entry must too."""
+        audio = b"staging audio"
+        track = await _track_on_pds(db_session, cid=cid_for_blob(audio))
+
+        storage_mock = AsyncMock()
+        storage_mock.save.return_value = "deadbeefdeadbeef"
+        storage_mock.get_url.return_value = "https://r2.example.com/audio/x.mp3"
+
+        with (
+            patch(MOCK_FETCH_PATH, AsyncMock(return_value=audio)),
+            patch(MOCK_STORAGE_PATH, storage_mock),
+            patch(
+                "backend._internal.tasks.pds_mirror.settings.observability.environment",
+                "staging",
+            ),
+            patch(MOCK_REENTRY_PATH, AsyncMock()) as reentry,
+        ):
+            await mirror_pds_blob(track.id)
+
+        assert reentry.await_args.kwargs["skip_copyright"] is True
+
+    async def test_production_does_scan_the_mirrored_copy(
+        self, db_session: AsyncSession
+    ) -> None:
+        audio = b"production audio"
+        track = await _track_on_pds(db_session, cid=cid_for_blob(audio))
+
+        storage_mock = AsyncMock()
+        storage_mock.save.return_value = "deadbeefdeadbeef"
+        storage_mock.get_url.return_value = "https://r2.example.com/audio/x.mp3"
+
+        with (
+            patch(MOCK_FETCH_PATH, AsyncMock(return_value=audio)),
+            patch(MOCK_STORAGE_PATH, storage_mock),
+            patch(
+                "backend._internal.tasks.pds_mirror.settings.observability.environment",
+                "production",
+            ),
+            patch(MOCK_REENTRY_PATH, AsyncMock()) as reentry,
+        ):
+            await mirror_pds_blob(track.id)
+
+        assert reentry.await_args.kwargs["skip_copyright"] is False
+
     async def test_rejects_bytes_that_do_not_match_the_cid(
         self, db_session: AsyncSession
     ) -> None:

--- a/scripts/backfill_pds_blob_mirror.py
+++ b/scripts/backfill_pds_blob_mirror.py
@@ -39,6 +39,7 @@ from atproto_oauth.security import get_hardened_async_client, is_safe_url
 from sqlalchemy import select
 
 from backend._internal.atproto.client import pds_blob_url
+from backend._internal.background import docket_client_lifespan
 from backend._internal.tasks.pds_mirror import BlobVerificationError, mirror_pds_blob
 from backend.models import Artist, Track
 from backend.utilities.database import db_session
@@ -110,12 +111,22 @@ async def main() -> None:
     if not candidates:
         return
 
-    mirrored = skipped = failed = 0
-    for track_id, title, cid, did, pds in candidates:
-        if args.dry_run:
+    if args.dry_run:
+        for track_id, title, cid, did, pds in candidates:
             await _report(track_id, title, cid, did, pds)
-            continue
+        return
 
+    # a successful mirror re-enters the post-create hooks to schedule the scans
+    # against the copy we now hold, and those enqueue onto docket. without a
+    # client the mirror stores the bytes and then raises, leaving the track
+    # mirrored but never scanned.
+    async with docket_client_lifespan():
+        await _mirror_all(candidates)
+
+
+async def _mirror_all(candidates: list[tuple[int, str, str, str, str]]) -> None:
+    mirrored = skipped = failed = 0
+    for track_id, title, _cid, _did, _pds in candidates:
         try:
             await mirror_pds_blob(track_id)
         except BlobVerificationError as exc:
@@ -139,10 +150,7 @@ async def main() -> None:
             logger.warning("track %s (%r): not mirrored", track_id, title)
             skipped += 1
 
-    if not args.dry_run:
-        logger.info(
-            "done: %d mirrored, %d skipped, %d failed", mirrored, skipped, failed
-        )
+    logger.info("done: %d mirrored, %d skipped, %d failed", mirrored, skipped, failed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Rehearsing the #1778 backfill on staging surfaced two problems. One is a bug, the other is that the script had nowhere it could actually run.

**The bug.** A successful mirror re-enters `run_post_track_create_hooks` so the copyright/CLAP/genre steps run against the verified copy. Those enqueue onto docket. Run standalone there is no docket client, so `get_docket()` raised *after* the bytes were already stored — leaving the track mirrored but permanently unscanned, since the task returns early once `r2_url` is set.

Staging track 1128 hit exactly this: mirrored to R2 correctly, then `RuntimeError: docket not initialized`.

**Where it runs.** The script needs the environment's database and R2 credentials. Those live on the deployed machine and nowhere else — locally `STORAGE_BACKEND=filesystem` with no R2 keys, so pointing `DATABASE_URL` at prod would download blobs to a laptop and write local paths into `r2_url`. `scripts/` now ships in the image so the backfill can run where the credentials are.

<details>
<summary>staging rehearsal results</summary>

5 candidates, and the non-mirroring outcomes were all correct:

| track | outcome |
|---|---|
| 1128 `a minor drone` | mirrored — and the R2 copy hashes to exactly the record's CID |
| 1129, 6271 | PDS returned non-200 for the blob (test tracks, blobs gone) — skipped, nothing stored |
| 3784, 3887 | artist has no `pds_url` — skipped before any fetch |

The verification that matters: the stored object at `audio-stg.plyr.fm/audio/961905495becbcf8.mp3` is 241205 bytes and hashes to `bafkreiewdecusw7mxt4ex464xym4be4dyz2lt4wgu5y4fwr55xmntkln5u`, which is the CID its PDS record commits to.

</details>

<details>
<summary>known limitation</summary>

If the re-entry fails for some *other* reason (a Redis outage mid-run), the track stays mirrored-but-unscanned and re-running won't fix it — `mirror_pds_blob` returns early once `r2_url` exists. The script reports those as failures so they're visible rather than silent.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)