### PR TITLE
revert: don't ship scripts/ in the backend image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,12 +22,6 @@ COPY lexicons ./lexicons
 COPY backend/alembic.ini .
 COPY backend/alembic ./alembic
 
-# operator scripts (backfills, audits). they need the environment's database
-# and R2 credentials, which live on the machine and nowhere else, so this is
-# where they have to run from. only scripts importing `backend` alone work --
-# nothing installs their PEP 723 dependencies.
-COPY scripts ./scripts
-
 # install the project itself with bytecode compilation
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --compile-bytecode


### PR DESCRIPTION
Reverts the `COPY scripts ./scripts` layer added in #1791. The docket-client fix from that PR stands — that bug was real and the staging rehearsal proved it.

I justified shipping `scripts/` by claiming the environment's R2 credentials live only on the deployed machine, so the backfill had nowhere else to run. That was wrong. The Cloudflare API is reachable directly (R2 buckets enumerate fine), and the root `.env` holds a token that can mint scoped R2 credentials. I had printed that `.env`'s variable list earlier in the same session and read past it.

A structural change to every deployed image should not rest on an unchecked assumption about access, and the lighter path — get credentials, run the script locally — was available the whole time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)