### PR TITLE
fix(radio): honor the moderation exclude override in the corpus and atlas

### DIFF
--- a/backend/src/backend/api/radio/corpus.py
+++ b/backend/src/backend/api/radio/corpus.py
@@ -27,6 +27,10 @@ async def load_corpus(db: AsyncSession) -> list[Track]:
         .where(
             Track.in_discovery,
             Track.support_gate.is_(None),
+            # a standing operator `exclude` keeps a track off shared surfaces
+            # with no label needed; NULL-safe because the column is null for
+            # almost every track (see label_visible_clause).
+            Track.moderation_override.is_distinct_from("exclude"),
             Artist.deactivated == False,  # noqa: E712
         )
         .order_by(Track.created_at.desc(), Track.id.desc())

--- a/backend/tests/api/test_radio.py
+++ b/backend/tests/api/test_radio.py
@@ -583,6 +583,42 @@ async def test_radio_excludes_deactivated_artists(
     assert gone_track.id not in ids
 
 
+async def test_radio_excludes_moderation_override_exclude(
+    radio_app: FastAPI,
+    db_session: AsyncSession,
+    radio_artist: Artist,
+) -> None:
+    """a standing `exclude` override keeps a track off radio, no label needed.
+
+    regression: load_corpus filtered on labels only, so an operator exclude
+    (user report: prayer recordings airing on radio) removed a track from
+    discovery feeds but radio kept broadcasting it.
+    """
+    now = datetime.now(UTC) + TEST_TIME_OFFSET
+    airing = await _create_track(
+        db_session, radio_artist, title="Airing", file_id="airing", created_at=now
+    )
+    excluded = await _create_track(
+        db_session,
+        radio_artist,
+        title="Excluded",
+        file_id="excluded",
+        created_at=now - timedelta(minutes=1),
+    )
+    excluded.moderation_override = "exclude"
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=radio_app),
+        base_url="https://radio.plyr.fm",
+    ) as client:
+        response = await client.get("/radio/state.json")
+
+    ids = {t["id"] for t in response.json()["rotation"]}
+    assert airing.id in ids
+    assert excluded.id not in ids
+
+
 async def test_radio_state_includes_tags_and_up_next(
     radio_app: FastAPI,
     db_session: AsyncSession,

--- a/loq.toml
+++ b/loq.toml
@@ -331,7 +331,7 @@ max_lines = 1284
 
 [[rules]]
 path = "backend/tests/api/test_radio.py"
-max_lines = 1388
+max_lines = 1424
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"
@@ -363,7 +363,7 @@ max_lines = 1444
 
 [[rules]]
 path = "scripts/build_atlas.py"
-max_lines = 584
+max_lines = 586
 
 [[rules]]
 path = "frontend/src/routes/atlas/renderer.ts"

--- a/scripts/build_atlas.py
+++ b/scripts/build_atlas.py
@@ -25,8 +25,9 @@ rationale on 10D clustering and core-only label evidence), scaled down to a
 catalog of ~1k tracks.
 
 eligibility mirrors the radio corpus (backend/api/radio/corpus.py): public
-discovery visibility, ungated, active artist, and no adult-audio or
-copyright labels — the atlas is an anonymous chosen-for-you surface.
+discovery visibility, ungated, active artist, no adult-audio or
+copyright labels, and no standing `exclude` override — the atlas is an
+anonymous chosen-for-you surface.
 
 the output uploads to the dedicated stats bucket (same pattern as
 scripts/costs/export_costs.py); the backend proxies it at /stats/atlas and
@@ -87,6 +88,7 @@ where t.visibility in ('public', 'supporters')
   and t.support_gate is null
   and a.deactivated = false
   and not (t.self_labels ?| %(labels)s or t.operator_labels ?| %(labels)s)
+  and t.moderation_override is distinct from 'exclude'
 """
 
 


### PR DESCRIPTION
A standing `override_exclude` decision is supposed to keep a track off shared surfaces — the transparency headline literally says "removed a track from discovery and radio" — but radio's `load_corpus` filtered on labels only, so an excluded track kept airing. The atlas eligibility SQL replicated the same gap.

<details>
<summary>details</summary>

## motivation

A user report (via @vicwalker.dev.br, 2026-08-08) flagged non-music recordings airing on radio. The intended remedy is the `override_exclude` paradigm from #1699/#1700: record a decision in the moderation event log, project it onto `tracks.moderation_override`, and shared surfaces stop showing the track — no label asserted, reversible via `override_clear`. Checking before applying it showed radio never honored the projection: `radio/corpus.py` predates the override work (#1525 vs #1700) and filters only adult/copyright labels. `docs/internal/moderation/overview.md` already states the policy ("always exclude both from shared radio"); this makes the code match it.

## changes

- `load_corpus` adds `Track.moderation_override.is_distinct_from("exclude")` — NULL-safe (`is_distinct_from`, matching `label_visible_clause`'s note: the column is null for almost every track, and `NOT (NULL = 'exclude')` is NULL, which a WHERE drops).
- `scripts/build_atlas.py` adds the same predicate to its raw-SQL eligibility, which mirrors the radio corpus by design.
- regression test `test_radio_excludes_moderation_override_exclude`, verified failing before the corpus change and passing after.

## intentional non-behaviors

- `override_allow` is untouched: it lifts copyright labels on destination surfaces; radio's corpus continues to exclude copyright-labeled tracks outright regardless of `allow`, per the existing comment (radio is us actively broadcasting).
- no change to station-level filters (`_exclude_slop` etc.) — the override is a corpus-level gate.
- transparency-post batching for grouped exclude decisions is a separate PR.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)