### PR TITLE
fix(moderation): exclude is curation, not removal — never empty a destination

### DIFF
--- a/backend/src/backend/_internal/content_labels.py
+++ b/backend/src/backend/_internal/content_labels.py
@@ -113,29 +113,36 @@ def label_visible_clause(
     whole predicate for viewers who opted into sensitive audio, which would
     have leaked copyright-labeled tracks to exactly those viewers.
 
-    `exclude` hides a track with no label needed. `allow` surfaces one whose
-    copyright label we reviewed and decided not to act on — a cover, say —
-    without negating the label and thereby claiming the match never happened.
-    `allow` deliberately does not lift the adult half: that is a listener
-    preference, and an operator deciding what someone else may be *shown* is a
-    different power from deciding what we *host*.
+    `exclude` is a curation decision, not a removal: it keeps a track out of
+    the surfaces where we choose what to put in front of someone (feeds,
+    search, radio), and nothing else. An artist's own catalogue is theirs —
+    hiding part of it would misrepresent what is there, the same principle
+    that keeps labels from gutting destinations (#1709). Only `takedown`
+    removes a track outright. `allow` surfaces one whose copyright label we
+    reviewed and decided not to act on — a cover, say — without negating the
+    label and thereby claiming the match never happened. `allow` deliberately
+    does not lift the adult half: that is a listener preference, and an
+    operator deciding what someone else may be *shown* is a different power
+    from deciding what we *host*.
     """
     # NULL-safe: the column is null for almost every track, and `NOT (NULL =
     # 'exclude')` is NULL, which a WHERE clause drops. That would have hidden
     # the entire catalogue.
     allowed = Track.moderation_override.is_not_distinct_from("allow")
-    not_excluded = Track.moderation_override.is_distinct_from("exclude")
 
     # copyright is a hosting obligation, so it applies in every context and
     # only an explicit operator decision lifts it
     visible = allowed | copyright_visible_clause()
 
-    # adult labels are a rendering default, so they apply only where we are
-    # choosing what to surface
-    if context is LabelContext.LIST and not shows_sensitive_audio:
-        visible = visible & sensitive_audio_visible_clause(viewer_did)
+    if context is LabelContext.LIST:
+        # adult labels are a rendering default, so they apply only where we
+        # are choosing what to surface
+        if not shows_sensitive_audio:
+            visible = visible & sensitive_audio_visible_clause(viewer_did)
+        # `exclude` is likewise a choosing-time decision only
+        visible = visible & Track.moderation_override.is_distinct_from("exclude")
 
-    return not_excluded & visible
+    return visible
 
 
 async def get_operator_label_values(
@@ -231,7 +238,9 @@ async def filter_sensitive_audio_tracks_for_viewer(
     for track in track_list:
         labels = labels_by_id.get(track.id, set())
         override = track.moderation_override
-        if override == "exclude":
+        # exclude is a curation decision: it empties our chosen surfaces,
+        # never a page someone navigated to (see label_visible_clause)
+        if override == "exclude" and context is LabelContext.LIST:
             continue
         # copyright applies to everyone; no preference and no owner exemption,
         # unless an operator reviewed it and decided to surface it anyway

--- a/backend/src/backend/api/albums/listing.py
+++ b/backend/src/backend/api/albums/listing.py
@@ -59,10 +59,12 @@ async def list_albums(
         )
         .join(Artist, Album.artist_did == Artist.did)
         # count only tracks the album view will actually show. Private uploads
-        # drop out via the having clause; copyright-labeled and
-        # override-excluded tracks are counted out too, because a card
-        # promising three tracks over a page that lists two is the mismatch
-        # that made the artist page unreadable (#1709).
+        # drop out via the having clause; copyright-labeled tracks are counted
+        # out too, because a card promising three tracks over a page that
+        # lists two is the mismatch that made the artist page unreadable
+        # (#1709). Override-excluded tracks stay counted: exclude is a
+        # curation decision that never touches destination pages, and the
+        # album view shows them.
         #
         # Deliberately viewer-independent: adult labels are a preference, and
         # a per-viewer count could not be cached or agreed on. In a VIEW
@@ -73,7 +75,6 @@ async def list_albums(
                 Track.album_id == Album.id,
                 Track.visibility != "private",
                 copyright_visible_clause(),
-                Track.moderation_override.is_distinct_from("exclude"),
             ),
         )
         .group_by(Album.id, Artist.did)

--- a/backend/src/backend/models/track.py
+++ b/backend/src/backend/models/track.py
@@ -98,8 +98,9 @@ class Track(Base):
     )
     # Standing operator decision projected from the moderation event log:
     # "allow" surfaces the track despite a copyright label, "exclude" keeps it
-    # off shared surfaces regardless of labels. Distinct from negating a label,
-    # which claims the assertion itself was wrong.
+    # out of chosen surfaces (feeds, search, radio) regardless of labels —
+    # never out of destinations like the artist's own page. Distinct from
+    # negating a label, which claims the assertion itself was wrong.
     moderation_override: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # PDS blob storage (for audio stored on user's PDS)

--- a/backend/tests/test_content_label_policy.py
+++ b/backend/tests/test_content_label_policy.py
@@ -176,13 +176,13 @@ async def test_override_allow_surfaces_a_copyright_labeled_track(
 async def test_override_exclude_hides_an_unlabeled_track(
     db_session: AsyncSession,
 ) -> None:
-    """The other direction: keep something off shared surfaces with no label."""
+    """The other direction: keep something off chosen surfaces with no label."""
     track = await _track(db_session, file_id="ov2")
     track.moderation_override = "exclude"
     await db_session.commit()
 
     visible, _ = await filter_sensitive_audio_tracks_for_viewer(
-        db_session, [track], OWNER
+        db_session, [track], OWNER, context=LabelContext.LIST
     )
     assert visible == []
 
@@ -248,18 +248,48 @@ async def test_copyright_hides_in_every_context(db_session: AsyncSession) -> Non
         }, context
 
 
-async def test_exclude_override_hides_in_every_context(
+async def test_exclude_override_is_curation_not_removal(
     db_session: AsyncSession,
 ) -> None:
+    """`exclude` empties chosen surfaces, never a page someone navigated to.
+
+    Regression: exclude once applied in every context, so excluding an
+    artist's tracks from radio also blanked their public profile ("no
+    tracks") — a curation decision presented as a takedown. Removal outright
+    is `takedown`'s job.
+    """
     hidden = await _track(db_session, file_id="dest7")
     hidden.moderation_override = "exclude"
     plain = await _track(db_session, file_id="dest8")
     await db_session.commit()
 
-    for context in (LabelContext.LIST, LabelContext.VIEW):
-        assert await _visible(db_session, context, shows_sensitive=True) == {
-            plain.id
-        }, context
+    assert await _visible(db_session, LabelContext.LIST, shows_sensitive=True) == {
+        plain.id
+    }
+    assert await _visible(db_session, LabelContext.VIEW, shows_sensitive=True) == {
+        hidden.id,
+        plain.id,
+    }
+
+
+async def test_app_side_filter_agrees_exclude_is_list_only(
+    db_session: AsyncSession,
+) -> None:
+    """The Python filter and the SQL clause must agree on exclude's reach."""
+    hidden = await _track(db_session, file_id="dest9")
+    hidden.moderation_override = "exclude"
+    plain = await _track(db_session, file_id="dest10")
+    await db_session.commit()
+
+    shown, _ = await filter_sensitive_audio_tracks_for_viewer(
+        db_session, [hidden, plain], VIEWER, context=LabelContext.VIEW
+    )
+    assert {t.id for t in shown} == {hidden.id, plain.id}
+
+    listed, _ = await filter_sensitive_audio_tracks_for_viewer(
+        db_session, [hidden, plain], VIEWER, context=LabelContext.LIST
+    )
+    assert {t.id for t in listed} == {plain.id}
 
 
 async def test_app_side_filter_honours_view_context(db_session: AsyncSession) -> None:
@@ -305,8 +335,8 @@ async def test_album_card_count_matches_what_the_album_will_show(
     """A card promising more tracks than the page lists is the reported bug.
 
     The count is viewer-independent on purpose, so it excludes only what no
-    viewer can see: copyright labels and exclude overrides. Adult-labeled
-    tracks stay counted because a VIEW context shows them.
+    viewer can see: copyright labels. Adult-labeled and override-excluded
+    tracks stay counted because a VIEW context shows both.
     """
     from backend.models import Album
 
@@ -331,7 +361,6 @@ async def test_album_card_count_matches_what_the_album_will_show(
                 Track.album_id == album.id,
                 Track.visibility != "private",
                 copyright_visible_clause(),
-                Track.moderation_override.is_distinct_from("exclude"),
             )
         )
     ).scalar_one()
@@ -342,7 +371,7 @@ async def test_album_card_count_matches_what_the_album_will_show(
         None,
         context=LabelContext.VIEW,
     )
-    assert counted == len(shown) == 2
+    assert counted == len(shown) == 3
 
 
 async def test_owner_sees_their_own_adult_track_but_not_their_own_copyright_one(

--- a/docs/internal/moderation/event-log.md
+++ b/docs/internal/moderation/event-log.md
@@ -66,7 +66,11 @@ track has a higher id than the acknowledgement, so it surfaces again.
 
 **overrides** — the latest `override_*` per subject wins. Projected onto
 `tracks.moderation_override` by `sync_operator_labels` and read by
-`discovery_visible_clause`.
+`label_visible_clause` / `filter_tracks_for_viewer` and the radio corpus.
+`exclude` applies only in LIST contexts — feeds, search, radio, the atlas —
+never on destinations (an artist's own page, an album, a permalink). Hiding
+a navigated-to catalogue would misrepresent what is there; removal outright
+is `takedown`'s job, not `exclude`'s.
 
 ## attribution is not authentication
 


### PR DESCRIPTION
`override_exclude` applied in every `LabelContext`, so excluding six tracks from radio also blanked the artist's public profile to "no tracks" — a curation decision presented as a takedown. `exclude` now applies only in LIST contexts (feeds, search, radio, atlas); destinations — an artist's page, an album, a permalink — always show the full catalogue.

<details>
<summary>details</summary>

## motivation

Applying the exclude runbook to a user report (non-music recordings on radio) revealed that the override reached far past its intent: the artist's own page rendered empty. This is the same principle #1709 established for adult labels — a page someone navigated to shows what is on it; hiding part of it misrepresents what is there. Removal outright is `takedown`'s job.

## changes

- `label_visible_clause`: the `exclude` predicate moved inside the `LIST` branch, next to the adult-preference clause it behaves like.
- `filter_tracks_for_viewer` (the app-side twin): same, so SQL-assembled and Python-assembled surfaces agree.
- album card count: no longer counts out excluded tracks, since the album VIEW now shows them — the count keeps mirroring the page (#1709's invariant).
- `test_exclude_override_hides_in_every_context` pinned the old semantics and is rewritten as `test_exclude_override_is_curation_not_removal`, plus an app-side agreement test; docs (`event-log.md`, model comment) updated to state exclude's reach precisely.

## intentional non-behaviors

- copyright labels still hide in every context — a hosting obligation is not a curation choice.
- radio corpus and atlas eligibility keep their direct `exclude` filters (both are chosen-for-you surfaces; #1797).
- the transparency headline "removed a track from discovery and radio" remains accurate.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)