### PR TITLE
fix: drop image origin validation from the record write path

### DIFF
--- a/backend/src/backend/_internal/atproto/records/fm_plyr/track.py
+++ b/backend/src/backend/_internal/atproto/records/fm_plyr/track.py
@@ -86,8 +86,6 @@ async def build_track_record(
                 for p in profiles
             ]
     if image_url:
-        # validate image URL comes from allowed origin
-        settings.storage.validate_image_url(image_url)
         record["imageUrl"] = image_url
     if support_gate:
         record["supportGate"] = support_gate

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -210,8 +210,6 @@ class FrontendSettings(AppSettingsSection):
     @property
     def domain(self) -> str:
         """extract domain from frontend URL (e.g., 'plyr.fm', 'stg.plyr.fm')."""
-        from urllib.parse import urlparse
-
         parsed = urlparse(self.url)
         return parsed.netloc or "plyr.fm"
 
@@ -225,8 +223,6 @@ class FrontendSettings(AppSettingsSection):
         # the API is public — allow any HTTPS origin (plus localhost for dev).
         # auth uses HttpOnly cookies scoped to plyr.fm, so credentialed
         # cross-origin requests from third-party sites won't carry session cookies.
-
-        from urllib.parse import urlparse
 
         parsed = urlparse(self.url)
         hostname = parsed.hostname or "localhost"
@@ -374,41 +370,6 @@ class StorageSettings(AppSettingsSection):
         validation_alias="ATLAS_JSON_URL",
         description="URL for the /atlas semantic map JSON",
     )
-
-    @computed_field
-    @property
-    def allowed_image_origins(self) -> set[str]:
-        """Origins allowed for imageUrl validation."""
-        origins = set()
-        if self.r2_public_image_bucket_url:
-            parsed = urlparse(self.r2_public_image_bucket_url)
-            origins.add(f"{parsed.scheme}://{parsed.netloc}")
-        return origins
-
-    def validate_image_url(self, url: str | None) -> bool:
-        """Validate that imageUrl comes from allowed origin.
-
-        args:
-            url: image URL to validate
-
-        returns:
-            True if valid or None, raises ValueError if invalid
-
-        raises:
-            ValueError: if URL is from untrusted origin
-        """
-        if not url:
-            return True
-
-        parsed = urlparse(url)
-        origin = f"{parsed.scheme}://{parsed.netloc}"
-
-        if origin not in self.allowed_image_origins:
-            raise ValueError(
-                f"image must be hosted on allowed origins: {self.allowed_image_origins}"
-            )
-
-        return True
 
 
 class AtprotoSettings(AppSettingsSection):

--- a/backend/tests/test_origin_validation.py
+++ b/backend/tests/test_origin_validation.py
@@ -1,74 +1,30 @@
+"""record authorship must not constrain where a creator hosts their artwork.
+
+origin trust is an ingest/display concern (`_internal/tasks/origin_trust.py`),
+not a write-path one: what goes into a creator's own PDS record is their call.
+regression for the portal PDS save failing on tracks whose imageUrl predates
+the images.plyr.fm custom domain.
+"""
+
 import pytest
 
-from backend.config import StorageSettings
+from backend._internal.atproto.records.fm_plyr.track import build_track_record
 
 
-@pytest.fixture
-def storage_settings(monkeypatch: pytest.MonkeyPatch) -> StorageSettings:
-    """fixture for storage settings with R2 image bucket configured."""
-    monkeypatch.setenv(
-        "R2_PUBLIC_IMAGE_BUCKET_URL", "https://images.example.com/bucket"
+@pytest.mark.parametrize(
+    "image_url",
+    [
+        "https://pub-308b393655d9474fa790a0ff4200a3ca.r2.dev/legacy.png",
+        "https://images.plyr.fm/images/current.jpeg",
+        "https://my-own-server.example.com/art.png",
+    ],
+)
+async def test_build_track_record_accepts_any_image_origin(image_url: str) -> None:
+    record = await build_track_record(
+        title="test",
+        artist="tester",
+        file_type="m4a",
+        audio_url="https://audio.plyr.fm/audio/abc.m4a",
+        image_url=image_url,
     )
-    return StorageSettings()
-
-
-def test_validate_image_url_allows_none(storage_settings: StorageSettings) -> None:
-    """validate that None/empty imageUrl is allowed."""
-    assert storage_settings.validate_image_url(None) is True
-    assert storage_settings.validate_image_url("") is True
-
-
-def test_validate_image_url_allows_trusted_origin(
-    storage_settings: StorageSettings,
-) -> None:
-    """validate that imageUrl from allowed origin passes."""
-    url = "https://images.example.com/bucket/track123.jpg"
-    assert storage_settings.validate_image_url(url) is True
-
-
-def test_validate_image_url_rejects_external_origin(
-    storage_settings: StorageSettings,
-) -> None:
-    """validate that imageUrl from external origin is rejected."""
-    url = "https://malicious.com/bad-image.jpg"
-
-    with pytest.raises(ValueError, match="image must be hosted on allowed origins"):
-        storage_settings.validate_image_url(url)
-
-
-def test_validate_image_url_rejects_subdomain_mismatch(
-    storage_settings: StorageSettings,
-) -> None:
-    """validate that subdomains are not automatically trusted."""
-    url = "https://evil.images.example.com/fake.jpg"
-
-    with pytest.raises(ValueError, match="image must be hosted on allowed origins"):
-        storage_settings.validate_image_url(url)
-
-
-def test_validate_image_url_respects_scheme(storage_settings: StorageSettings) -> None:
-    """validate that scheme (http vs https) is enforced."""
-    url = "http://images.example.com/bucket/track123.jpg"
-
-    with pytest.raises(ValueError, match="image must be hosted on allowed origins"):
-        storage_settings.validate_image_url(url)
-
-
-def test_allowed_image_origins_empty_when_no_bucket_configured(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """validate that allowed_image_origins is empty without R2 config."""
-    monkeypatch.setenv("R2_PUBLIC_IMAGE_BUCKET_URL", "")
-    settings = StorageSettings()
-    assert settings.allowed_image_origins == set()
-
-
-def test_allowed_image_origins_extracts_origin(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """validate that allowed_image_origins correctly extracts scheme+netloc."""
-    monkeypatch.setenv(
-        "R2_PUBLIC_IMAGE_BUCKET_URL", "https://cdn.example.com/my-bucket/path"
-    )
-    settings = StorageSettings()
-    assert settings.allowed_image_origins == {"https://cdn.example.com"}
+    assert record["imageUrl"] == image_url


### PR DESCRIPTION
removes the `validate_image_url` origin allowlist from `build_track_record`, so authoring a track record no longer requires the cover art to live on plyr's image CDN. record authorship is the creator's call; origin trust remains an ingest/display concern.

## motivation

the portal "save audio to your PDS" batch failed deterministically for 4 tracks with `image must be hosted on allowed origins: {'https://images.plyr.fm'}`. those tracks are Nov 2025 uploads whose `image_url` still points at the pre-custom-domain `pub-…r2.dev` origin — plyr's *own* bucket, just its old public hostname. the allowlist is computed from the *current* `R2_PUBLIC_IMAGE_BUCKET_URL`, so every domain move silently invalidates plyr's own history.

more fundamentally, the check was conceived as ingest defense (4172a82b, PR #168 / #166: tampered records pointing at hostile images) but was placed on the write path, where it constrains what a creator may put in their **own** PDS record — a centralization of a concern that isn't plyr's to enforce there.

## design

- the write path (`build_track_record`) now passes `imageUrl` through untouched.
- the actual defense stays where it belongs and is unchanged: jetstream ingest strips/declines untrusted image origins via `_internal/tasks/origin_trust.py` (`ingest_track_create` nulls them; `ingest_track_update` keeps the existing DB value). hostile record edits still never reach plyr's UI.
- `allowed_image_origins` / `validate_image_url` had no other callers and are deleted; the two redundant function-local `urlparse` imports in `config.py` fold into the existing top-level import.
- regression test: `build_track_record` accepts legacy r2.dev, current images.plyr.fm, and arbitrary self-hosted origins.

## intentional non-behaviors

- ingest-side trust policy is untouched. externally-hosted artwork saved to a record will survive on the PDS but is still stripped at ingest — extending trust to creator-registered origins (BYOS) is the deliberate next conversation, not smuggled in here.
- the 5 stale `pub-…r2.dev` image_url rows in prod are left as-is; after this deploys, the 4 pending tracks save to the PDS without any data rewrite.

## deferred scope

- surfacing PDS-save/upload blob failures via an actionable toast + a logfire alert (separate PR / ops change, in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)