### PR TITLE
feat: surface PDS blob failures to the user

### DIFF
--- a/backend/src/backend/_internal/pds_save_tasks.py
+++ b/backend/src/backend/_internal/pds_save_tasks.py
@@ -83,6 +83,7 @@ async def save_tracks_to_pds(
     skipped_count = 0
     failed_count = 0
     processed_count = 0
+    errors: list[str] = []
     last_processed_track_id: int | None = None
     last_status: str | None = None
     progress_lock = asyncio.Lock()
@@ -263,6 +264,8 @@ async def save_tracks_to_pds(
                 )
                 failed_count += 1
                 one_status = "failed"
+                title = track_data["title"] if track_data else f"track {track_id}"
+                errors.append(f"{title}: {str(e)[:200]}")
             finally:
                 async with progress_lock:
                     processed_count += 1
@@ -283,6 +286,7 @@ async def save_tracks_to_pds(
                 "saved_count": saved_count,
                 "skipped_count": skipped_count,
                 "failed_count": failed_count,
+                "errors": errors[:5],
             },
         )
         return
@@ -302,6 +306,7 @@ async def save_tracks_to_pds(
             "saved_count": saved_count,
             "skipped_count": skipped_count,
             "failed_count": failed_count,
+            "errors": errors[:5],
         },
     )
 

--- a/backend/src/backend/api/pds_save.py
+++ b/backend/src/backend/api/pds_save.py
@@ -123,6 +123,7 @@ async def save_progress(save_id: str) -> StreamingResponse:
                     "last_status": job.result.get("last_status")
                     if job.result
                     else None,
+                    "errors": job.result.get("errors") if job.result else None,
                 }
 
                 yield f"data: {json.dumps(payload)}\n\n"

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -1297,6 +1297,7 @@ async def _process_upload_background(ctx: UploadContext) -> None:
             }
             if pds_result and pds_result.warning:
                 result["warnings"] = [pds_result.warning]
+                result["pds_blob_failed"] = True
 
             await job_service.update_progress(
                 ctx.upload_id,
@@ -1837,6 +1838,8 @@ async def upload_progress(upload_id: str) -> StreamingResponse:
                     payload["track_id"] = job.result["track_id"]
                 if job.result and "warnings" in job.result:
                     payload["warnings"] = job.result["warnings"]
+                if job.result and "pds_blob_failed" in job.result:
+                    payload["pds_blob_failed"] = job.result["pds_blob_failed"]
                 # surface the PDS strongRef so album upload callers can build
                 # items[] arrays without a follow-up DB query (see #1260).
                 # background writes these to job.result in _process_upload_background;

--- a/backend/tests/api/test_upload_progress_sse.py
+++ b/backend/tests/api/test_upload_progress_sse.py
@@ -25,6 +25,7 @@ def _make_completed_job(
     atproto_uri: str | None = "at://did:plc:test/fm.plyr.track/abc",
     atproto_cid: str | None = "bafyTestCid",
     warnings: list[str] | None = None,
+    pds_blob_failed: bool = False,
 ) -> Job:
     """build a Job row with a completed upload and an arbitrary result dict."""
     now = datetime.now(UTC)
@@ -35,6 +36,8 @@ def _make_completed_job(
         result["atproto_cid"] = atproto_cid
     if warnings:
         result["warnings"] = warnings
+    if pds_blob_failed:
+        result["pds_blob_failed"] = True
 
     job = Job(
         id=job_id,
@@ -133,3 +136,26 @@ async def test_sse_payload_preserves_warnings_alongside_strongref(
     assert payload["atproto_uri"] == "at://did:plc:test/fm.plyr.track/abc"
     assert payload["atproto_cid"] == "bafyTestCid"
     assert payload["warnings"] == ["pds blob upload timed out, used r2"]
+
+
+async def test_sse_payload_surfaces_pds_blob_failed_flag(progress_app: FastAPI):
+    """the structured pds_blob_failed flag must reach the SSE payload so the
+    frontend can attach a portal deep-link to the failure toast, and must
+    stay absent when the blob uploaded fine."""
+    failed = _make_completed_job(
+        warnings=["couldn't upload to your PDS"], pds_blob_failed=True
+    )
+    with patch(
+        "backend.api.tracks.uploads.job_service.get_job",
+        new=AsyncMock(return_value=failed),
+    ):
+        payload = await _read_first_completed_event(progress_app, failed.id)
+    assert payload["pds_blob_failed"] is True
+
+    ok = _make_completed_job()
+    with patch(
+        "backend.api.tracks.uploads.job_service.get_job",
+        new=AsyncMock(return_value=ok),
+    ):
+        payload = await _read_first_completed_event(progress_app, ok.id)
+    assert "pds_blob_failed" not in payload

--- a/frontend/src/lib/components/PdsSaveControl.svelte
+++ b/frontend/src/lib/components/PdsSaveControl.svelte
@@ -75,6 +75,9 @@
 					if (data.skipped_count) parts.push(`${data.skipped_count} skipped`);
 					if (data.failed_count) parts.push(`${data.failed_count} failed`);
 					toast.success(parts.join(', ') || 'saved to your PDS');
+					for (const err of data.errors ?? []) {
+						toast.warning(err, 0);
+					}
 					onComplete?.();
 				}
 
@@ -82,7 +85,8 @@
 					eventSource.close();
 					saving = false;
 					toast.dismiss(toastId);
-					toast.error(data.error || 'save failed');
+					const firstError: string | undefined = (data.errors ?? [])[0];
+					toast.error(firstError || data.error || 'save failed', 0);
 				}
 			} catch {
 				/* ignore parse errors */

--- a/frontend/src/lib/toast.svelte.ts
+++ b/frontend/src/lib/toast.svelte.ts
@@ -65,8 +65,8 @@ class ToastState {
 		return this.add(message, 'info', duration, action);
 	}
 
-	warning(message: string, duration = 4000): string {
-		return this.add(message, 'warning', duration);
+	warning(message: string, duration = 4000, action?: ToastAction): string {
+		return this.add(message, 'warning', duration, action);
 	}
 }
 

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -248,8 +248,11 @@ class UploaderState {
 							} : undefined);
 
 							const warnings: string[] = update.warnings ?? [];
+							const warningAction = update.pds_blob_failed
+								? { label: 'save to your PDS', href: '/portal/manage' }
+								: undefined;
 							for (const w of warnings) {
-								toast.warning(w, 8000);
+								toast.warning(w, 0, warningAction);
 							}
 
 							tracksCache.invalidate();

--- a/loq.toml
+++ b/loq.toml
@@ -39,7 +39,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1868
+max_lines = 1871
 
 [[rules]]
 path = "backend/src/backend/config.py"
@@ -335,7 +335,7 @@ max_lines = 1424
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"
-max_lines = 506
+max_lines = 509
 
 [[rules]]
 path = "frontend/src/routes/track/[[]id[]]/+page.svelte"


### PR DESCRIPTION
PDS blob failures were silent: the upload path degraded to R2-only with only a server-side log, and the portal batch save reported a bare "save failed" with the reason visible only in logfire. now both surfaces tell the user what happened and where to go.

## motivation

10 tracks silently lost their PDS mirror over months (the #1565 token herd plus one unattributable one-off) and the owner only found out by asking. separately, a portal batch save failing on origin validation (#1805) showed only "save failed" — the actual reason had to be dug out of logfire, whose retention had already dropped the older incidents.

## design

- **upload path**: `_process_upload_background` writes a structured `pds_blob_failed: true` into the job result next to the existing `warnings`; the SSE whitelist forwards it. the frontend turns the warning toast sticky (duration 0) and attaches a `save to your PDS → /portal/manage` action, using the toast component's existing action-link support. structured flag rather than string-matching the warning text.
- **portal save path**: `pds_save_tasks` collects per-track failure reasons (`title: error`, capped at 5, each truncated to 200 chars) into the job result; the SSE payload and `PdsSaveControl` surface them — first error as the sticky failure toast when everything failed, sticky per-error warnings after partial completions.
- `toast.warning` gains the optional `action` param the other variants already had.

## intentional non-behaviors

- the deferred-optimize path (`audio_optimize.py`) still can't toast — its PDS write happens after the upload SSE stream closes. operator-side visibility for it lands via the logfire alert on the shared `pds blob upload failed` log line (ops change, alongside this PR).
- no retry machinery; the portal save remains the recovery path.

## verification

- regression test extends `test_upload_progress_sse.py`: flag present when set, absent otherwise.
- `just backend test` (1474 passed), `just backend lint`, `just frontend check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)