### PR TITLE
feat(portal): all-caught-up PDS state + calmer share links

### DIFF
--- a/frontend/src/lib/components/PdsSaveControl.svelte
+++ b/frontend/src/lib/components/PdsSaveControl.svelte
@@ -24,6 +24,10 @@
 				!isOptimizing(track)
 		).length
 	);
+	let savedTrackCount = $derived(
+		tracks.filter((track) => ['both', 'pds'].includes(track.audio_storage ?? 'r2')).length
+	);
+	let gatedTrackCount = $derived(tracks.filter((track) => track.support_gate).length);
 
 	async function handleSave(trackIds: number[]) {
 		saving = true;
@@ -116,6 +120,34 @@
 			{saving ? 'saving...' : 'choose tracks'}
 		</button>
 	</div>
+{:else if savedTrackCount > 0}
+	<div class="data-control all-saved">
+		<div class="control-info">
+			<h3>
+				<svg
+					width="16"
+					height="16"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2.5"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<polyline points="20 6 9 17 4 12"></polyline>
+				</svg>
+				all your audio is on your PDS
+			</h3>
+			<p class="control-description">
+				{savedTrackCount === 1
+					? 'your track'
+					: `all ${savedTrackCount} tracks`} live on your personal data server, with the CDN as fallback{gatedTrackCount >
+				0
+					? ` (${gatedTrackCount} gated ${gatedTrackCount === 1 ? 'track streams' : 'tracks stream'} through plyr.fm and ${gatedTrackCount === 1 ? "isn't" : "aren't"} mirrored)`
+					: ''}
+			</p>
+		</div>
+	</div>
 {/if}
 
 {#if showModal}
@@ -156,6 +188,21 @@
 		font-size: var(--text-xs);
 		color: var(--text-tertiary);
 		margin: 0;
+	}
+
+	.all-saved {
+		border-color: color-mix(in srgb, var(--success) 25%, transparent);
+	}
+
+	.all-saved h3 {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.all-saved h3 svg {
+		color: var(--success);
+		flex-shrink: 0;
 	}
 
 	.save-trigger-btn {

--- a/frontend/src/lib/components/portal/SharesSection.svelte
+++ b/frontend/src/lib/components/portal/SharesSection.svelte
@@ -39,8 +39,10 @@
 			loadingShares = true;
 		}
 		try {
+			// keep the first page short — old links shouldn't dominate the portal
+			const limit = append ? 20 : 5;
 			const offset = append ? shares.length : 0;
-			const response = await fetch(`${API_URL}/tracks/me/shares?limit=20&offset=${offset}`, {
+			const response = await fetch(`${API_URL}/tracks/me/shares?limit=${limit}&offset=${offset}`, {
 				credentials: 'include'
 			});
 			if (response.ok) {
@@ -227,7 +229,9 @@
 				onclick={() => loadShares(true)}
 				disabled={loadingMoreShares}
 			>
-				{loadingMoreShares ? 'loading...' : 'load more'}
+				{loadingMoreShares
+					? 'loading...'
+					: `load more (${sharesTotal - shares.length} older)`}
 			</button>
 		{/if}
 	{/if}

--- a/loq.toml
+++ b/loq.toml
@@ -315,7 +315,7 @@ max_lines = 1879
 
 [[rules]]
 path = "frontend/src/lib/components/portal/SharesSection.svelte"
-max_lines = 585
+max_lines = 589
 
 [[rules]]
 path = "frontend/src/lib/components/portal/ProfileSection.svelte"


### PR DESCRIPTION
two aesthetic fixes for `/portal/manage`, prompted by the state where everything is already mirrored: the page previously gave no signal that there was nothing to do.

## what changed

- **PDS save control**: when no tracks are savable but saved tracks exist, the control renders an affirmative empty state — a success-colored check and "all your audio is on your PDS" with the mirrored count — instead of a "choose tracks" button whose modal contains only reference rows. gated tracks, which intentionally never mirror, are called out in the description when present so the copy stays honest. when nothing is saved and nothing is savable (no tracks), it renders nothing, as before.
- **share links**: first page shows 5 links (newest first, matching the API's `created_at desc` ordering) instead of 20; the load-more button now says how many older links remain (`load more (12 older)`).

## deferred scope

- PDS storage-usage inspection ("how much space is your audio occupying on your PDS") — interesting, needs a `com.atproto`-side capability survey first.
- the save modal itself (typography/badge treatment) untouched.

UI change — for staging review before any prod release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)