### PR TITLE
fix(tests): make parallel test-database bootstrap timeout-proof

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -35,6 +35,27 @@ from backend.utilities.redis import clear_client_cache
 settings.atproto.app_namespace = "fm.plyr"
 
 
+def _bootstrap_template_database_from_controller(config: pytest.Config) -> None:
+    """bootstrap the template database in the xdist controller.
+
+    the template build used to happen lazily in each worker's session fixture,
+    which runs inside the first test's pytest-timeout budget (10s). on a cold
+    postgres the creator's schema setup plus the advisory-lock queue routinely
+    blew that budget: waiters timed out (poisoning their whole worker session),
+    and a creator killed mid-bootstrap left a schemaless template that every
+    other worker cloned — the "relation artists does not exist" cascades.
+
+    the controller runs before any worker and outside any test timeout, so the
+    build happens exactly once here; workers then only take the fast
+    already-finalized path and clone.
+    """
+    if os.environ.get("PYTEST_XDIST_WORKER"):
+        return  # worker process — the controller already did this
+    if not getattr(config.option, "numprocesses", None):
+        return  # single-process run uses the base database directly
+    asyncio.run(_ensure_template_database(settings.database.url))
+
+
 class MockStorage(R2Storage):
     """Mock storage for tests - no R2 credentials needed."""
 
@@ -79,12 +100,14 @@ class MockStorage(R2Storage):
         return "mock_gated_file_id_456"
 
 
-def pytest_configure(config):
+def pytest_configure(config: pytest.Config) -> None:
     """Set mock storage before any test modules are imported."""
     import backend.storage
 
     # set _storage directly to prevent R2Storage initialization
     backend.storage._storage = MockStorage()
+
+    _bootstrap_template_database_from_controller(config)
 
 
 def _database_from_url(url: str) -> str:
@@ -204,9 +227,16 @@ async def _setup_template_database(template_url: str) -> None:
 
 
 async def _ensure_template_database(base_url: str) -> str:
-    """ensure template database exists and is migrated.
+    """ensure template database exists, is migrated, and is FINALIZED.
 
-    uses advisory lock to coordinate between xdist workers.
+    uses an advisory lock to coordinate concurrent callers, and postgres's
+    `datistemplate` flag as a bootstrap-complete marker: the flag is set only
+    after the schema and helper procedure are in place, so a bootstrap killed
+    partway (e.g. by a test timeout) leaves the flag unset and the next caller
+    drops the partial database and rebuilds instead of cloning a schemaless
+    template — the failure mode behind whole-worker "relation does not exist"
+    cascades.
+
     returns the template database name.
     """
     base_db_name = _database_from_url(base_url)
@@ -217,25 +247,37 @@ async def _ensure_template_database(base_url: str) -> str:
     try:
         # advisory lock prevents race condition between workers
         await conn.execute("SELECT pg_advisory_lock(hashtext($1))", template_db_name)
-
-        # check if template exists
-        exists = await conn.fetchval(
-            "SELECT 1 FROM pg_database WHERE datname = $1", template_db_name
-        )
-
-        if not exists:
-            # create template database
-            await conn.execute(f'CREATE DATABASE "{template_db_name}"')
-
-            # build URL for template and set it up
-            scheme, netloc, _, query, fragment = urlsplit(base_url)
-            template_url = urlunsplit(
-                (scheme, netloc, f"/{template_db_name}", query, fragment)
+        try:
+            finalized = await conn.fetchval(
+                "SELECT datistemplate FROM pg_database WHERE datname = $1",
+                template_db_name,
             )
-            await _setup_template_database(template_url)
 
-        # release lock (other workers waiting will see template exists)
-        await conn.execute("SELECT pg_advisory_unlock(hashtext($1))", template_db_name)
+            if finalized is False:
+                # exists but never finalized — a previous bootstrap was
+                # interrupted between CREATE DATABASE and schema setup
+                await conn.execute(f'DROP DATABASE IF EXISTS "{template_db_name}"')
+                finalized = None
+
+            if finalized is None:
+                await conn.execute(f'CREATE DATABASE "{template_db_name}"')
+
+                # build URL for template and set it up
+                scheme, netloc, _, query, fragment = urlsplit(base_url)
+                template_url = urlunsplit(
+                    (scheme, netloc, f"/{template_db_name}", query, fragment)
+                )
+                await _setup_template_database(template_url)
+
+                await conn.execute(
+                    f'ALTER DATABASE "{template_db_name}" IS_TEMPLATE true'
+                )
+        finally:
+            # release even on failure so other workers aren't stuck waiting
+            # for this connection to close
+            await conn.execute(
+                "SELECT pg_advisory_unlock(hashtext($1))", template_db_name
+            )
 
         return template_db_name
     finally:

--- a/backend/tests/docker-compose.yml
+++ b/backend/tests/docker-compose.yml
@@ -18,4 +18,8 @@ services:
     image: redis:7-alpine
     ports:
       - "6380:6379"
-    command: redis-server --appendonly no --save ""
+    # --databases: each xdist worker claims db (1 + gwN) for isolation; the
+    # redis default of 16 breaks past gw14 ("DB index is out of range") on
+    # many-core machines. CI's redis service container keeps the default but
+    # its 4-core runners stay far below the limit.
+    command: redis-server --appendonly no --save "" --databases 128

--- a/loq.toml
+++ b/loq.toml
@@ -259,7 +259,7 @@ max_lines = 840
 
 [[rules]]
 path = "backend/tests/conftest.py"
-max_lines = 518
+max_lines = 560
 
 [[rules]]
 path = "backend/tests/api/track_audio_replace/test_pipeline.py"


### PR DESCRIPTION
`pytest -n auto` (CI's invocation) had two real defects that presented as "flaky CI". neither is a flake; on a many-core machine the suite failed **5 out of 5 runs** with 124–218 errors. with this PR: **5/5 green**.

## defect 1: session DB bootstrap runs inside per-test timeout budgets (the CI failure)

the template-database build happened lazily in each worker's session fixture, inside the first test's `timeout = 10` budget. on a cold postgres, the creator's `create_all` plus the advisory-lock queue routinely blew it:

- waiters died in `pg_advisory_lock` with `Failed: Timeout (>10.0s)` (verbatim in the failed run on PR #1808 — 1456 timeout hits across all four workers), poisoning their entire worker session;
- worse, a creator killed between `CREATE DATABASE` and `create_all` left a permanently schemaless template — every worker clones it and drowns in `relation "artists" does not exist`.

**fix:** build the template in `pytest_configure` on the xdist controller — before any worker or test timeout exists — and mark bootstrap completion with postgres's `datistemplate` flag: `_ensure_template_database` now treats exists-but-unfinalized as an interrupted build and rebuilds instead of cloning garbage. (folded into the existing `pytest_configure`; a second hook definition would silently shadow the first.)

## defect 2: redis DB allocation caps at 16 workers (the local failure)

each worker claims redis db `1 + gwN`; redis defaults to 16 databases, so gw15+ dies with `DB index is out of range`. invisible on 4-core CI runners, guaranteed on a many-core mac — this was why local `-n auto` runs failed even after defect 1 was fixed. the local test redis now runs `--databases 128` (CI's service container keeps the default; its runners stay far below it).

## why this never showed locally before

`just backend test` runs pytest **without `-n`** — single "master" worker, `_setup_database_direct`, no template, no lock, no per-worker redis pressure. the entire parallel bootstrap path only ever executed in CI. worth considering aligning the just recipe with CI (`-n auto`) as a follow-up so the paths can't drift again.

## verification

- before: 5/5 `-n auto` runs failed (124–218 errors). after: 5/5 pass, plus a clean run on this branch.
- single-worker path untouched (`just backend test` unaffected).
- the finalization marker alone was tested in isolation and does NOT fix the cascade (still 144 errors) — the controller bootstrap is load-bearing; the marker is the crash-safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)