### PR TITLE
fix(portal): banner CTA opens the PDS picker

### DIFF
--- a/frontend/src/lib/components/PdsSaveBanner.svelte
+++ b/frontend/src/lib/components/PdsSaveBanner.svelte
@@ -36,7 +36,7 @@
 			<span>save the audio to your PDS so your work lives on your own server</span>
 		</div>
 		<div class="banner-actions">
-			<a href="/portal/manage" class="banner-cta">move it to your PDS</a>
+			<a href="/portal/manage?save=pds" class="banner-cta">move it to your PDS</a>
 			<button class="banner-dismiss" onclick={dismiss} disabled={dismissing} title="don't show this again">
 				dismiss
 			</button>

--- a/frontend/src/lib/components/PdsSaveControl.svelte
+++ b/frontend/src/lib/components/PdsSaveControl.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
+	import { replaceState } from '$app/navigation';
 	import PdsSaveModal from './PdsSaveModal.svelte';
 	import { API_URL } from '$lib/config';
 	import { toast } from '$lib/toast.svelte';
 	import type { Track } from '$lib/types';
 	import { isOptimizing } from '$lib/utils/track-audio';
+
+	// `?save=pds` opens the picker straight away — the control sits below the
+	// profile, rights, and sharing sections, so landing at the top of /manage
+	// leaves the caller scrolling for the thing they just asked for.
+	const DEEP_LINK_PARAM = 'save';
+	const DEEP_LINK_VALUE = 'pds';
 
 	let {
 		tracks,
@@ -15,6 +24,7 @@
 
 	let showModal = $state(false);
 	let saving = $state(false);
+	let controlEl = $state<HTMLDivElement | null>(null);
 
 	let savableTrackCount = $derived(
 		tracks.filter(
@@ -28,6 +38,21 @@
 		tracks.filter((track) => ['both', 'pds'].includes(track.audio_storage ?? 'r2')).length
 	);
 	let gatedTrackCount = $derived(tracks.filter((track) => track.support_gate).length);
+
+	onMount(() => {
+		if ($page.url.searchParams.get(DEEP_LINK_PARAM) !== DEEP_LINK_VALUE) return;
+
+		// the parent resolves the full catalog before rendering this control, so
+		// the count is final here. nothing savable => the all-caught-up card is
+		// showing and an empty picker would be a dead end.
+		if (savableTrackCount > 0) showModal = true;
+		controlEl?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+
+		// drop the param so a refresh or back-navigation doesn't reopen it
+		const url = new URL($page.url);
+		url.searchParams.delete(DEEP_LINK_PARAM);
+		replaceState(url.pathname + url.search, {});
+	});
 
 	async function handleSave(trackIds: number[]) {
 		saving = true;
@@ -107,7 +132,7 @@
 </script>
 
 {#if savableTrackCount > 0}
-	<div class="data-control">
+	<div class="data-control" bind:this={controlEl}>
 		<div class="control-info">
 			<h3>save audio to your PDS</h3>
 			<p class="control-description">
@@ -125,7 +150,7 @@
 		</button>
 	</div>
 {:else if savedTrackCount > 0}
-	<div class="data-control all-saved">
+	<div class="data-control all-saved" bind:this={controlEl}>
 		<div class="control-info">
 			<h3>
 				<svg

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -249,7 +249,7 @@ class UploaderState {
 
 							const warnings: string[] = update.warnings ?? [];
 							const warningAction = update.pds_blob_failed
-								? { label: 'save to your PDS', href: '/portal/manage' }
+								? { label: 'save to your PDS', href: '/portal/manage?save=pds' }
 								: undefined;
 							for (const w of warnings) {
 								toast.warning(w, 0, warningAction);


### PR DESCRIPTION
the #1808 banner linked to `/portal/manage`, which drops you at the top of a page whose "save audio to your PDS" control lives *below* the profile, rights, and sharing sections — so the CTA appeared to do nothing but navigate. it now opens the picker directly.

## what changed

- the banner CTA and the #1806 upload-failure toast both link to `/portal/manage?save=pds`.
- `PdsSaveControl` opens the modal on mount when that param is present, scrolls itself into view, and strips the param via `replaceState` so a refresh or back-navigation doesn't reopen it. same `?autoplay=1` shape `/radio` already uses.
- guard: if nothing is savable by the time you arrive (e.g. you saved from another device), no modal opens — the all-caught-up card is showing and an empty picker would be a dead end. the scroll still happens, so you land on the answer.

the count is final at mount: `/portal/manage` pages through the entire catalog before rendering `DataSection`.

## verification

`just frontend check` clean. the authenticated flow needs a staging click-through — that's the review this PR is asking for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)