### PR TITLE
fix(pds-save): locate audio by its real storage key, and explain every failure

### DIFF
--- a/backend/src/backend/_internal/export_tasks.py
+++ b/backend/src/backend/_internal/export_tasks.py
@@ -81,13 +81,18 @@ async def process_export(export_id: str, artist_did: str) -> None:
                     )
                     continue
 
-                # prefer original file for export (lossless if available)
+                # prefer original file for export (lossless if available).
+                # `original_file_id` is only ever written by our own upload
+                # pipeline, so it always addresses storage directly; the
+                # playable pointer does not, on rows that came from ingest.
+                export_from_url: str | None = None
                 if track.original_file_id and track.original_file_type:
                     export_file_id = track.original_file_id
                     export_file_type = track.original_file_type
                 else:
                     export_file_id = track.file_id
                     export_file_type = track.file_type
+                    export_from_url = track.r2_url
 
                 # create safe filename with duplicate handling
                 base_filename = f"{track.title}.{export_file_type}"
@@ -108,7 +113,11 @@ async def process_export(export_id: str, artist_did: str) -> None:
                 # route through the typed-key path: same R2 key derivation
                 # as every other read/write site. see backend/storage/keys.py.
                 try:
-                    audio_key = AudioKey.for_file(export_file_id, export_file_type)
+                    audio_key = AudioKey.for_track(
+                        file_id=export_file_id,
+                        file_type=export_file_type,
+                        r2_url=export_from_url,
+                    )
                 except InvalidMediaExtension:
                     logfire.warn(
                         "skipping track: unsupported file_type for export",

--- a/backend/src/backend/_internal/pds_save_tasks.py
+++ b/backend/src/backend/_internal/pds_save_tasks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections import Counter
 from collections.abc import AsyncIterable
 
 import logfire
@@ -84,6 +85,9 @@ async def save_tracks_to_pds(
     failed_count = 0
     processed_count = 0
     errors: list[str] = []
+    # failures grouped by cause — a batch usually fails for one reason across
+    # many tracks, and "6 tracks: <reason>" beats six near-identical toasts
+    reason_counts: Counter[str] = Counter()
     last_processed_track_id: int | None = None
     last_status: str | None = None
     progress_lock = asyncio.Lock()
@@ -116,6 +120,27 @@ async def save_tracks_to_pds(
         async with semaphore:
             track_data: dict | None = None
             one_status = "skipped"
+
+            def fail(reason: str, title: str | None = None) -> None:
+                """record a failure together with WHY.
+
+                every failure path goes through here. a bare `failed_count += 1`
+                leaves the caller with a number and no explanation — that is how
+                a save reported "6 failed" with an empty error list and nothing
+                in telemetry to reconstruct it from.
+                """
+                nonlocal failed_count, one_status
+                failed_count += 1
+                one_status = "failed"
+                reason_counts[reason] += 1
+                errors.append(f"{title or f'track {track_id}'}: {reason}")
+                logfire.warn(
+                    "pds save failed for track",
+                    track_id=track_id,
+                    reason=reason,
+                    did=auth_session.did,
+                )
+
             try:
                 async with db_session() as db:
                     result = await db.execute(
@@ -142,7 +167,7 @@ async def save_tracks_to_pds(
                         return
 
                     if not track.file_id or not track.file_type:
-                        failed_count += 1
+                        fail("track has no stored audio file", track.title)
                         return
 
                     track_data = {
@@ -169,7 +194,10 @@ async def save_tracks_to_pds(
 
                 audio_format = AudioFormat.from_extension(track_data["file_type"])
                 if not audio_format:
-                    failed_count += 1
+                    fail(
+                        f"unsupported audio format ({track_data['file_type']})",
+                        track_data["title"],
+                    )
                     return
 
                 audio_url = track_data["r2_url"]
@@ -180,7 +208,7 @@ async def save_tracks_to_pds(
                         extension=track_data["file_type"],
                     )
                 if not audio_url:
-                    failed_count += 1
+                    fail("no audio URL to copy from", track_data["title"])
                     return
 
                 content_length = await storage.head_file(
@@ -188,7 +216,13 @@ async def save_tracks_to_pds(
                     track_data["file_type"],
                 )
                 if content_length is None:
-                    failed_count += 1
+                    # the row references audio this deployment can't read — most
+                    # often a track ingested from the firehose, whose bytes live
+                    # wherever it was uploaded, not in this environment's bucket.
+                    fail(
+                        "audio isn't in plyr.fm storage, so there's nothing to copy",
+                        track_data["title"],
+                    )
                     return
 
                 track_file_id = track_data["file_id"]
@@ -239,7 +273,7 @@ async def save_tracks_to_pds(
                     result = await db.execute(select(Track).where(Track.id == track_id))
                     track = result.scalar_one_or_none()
                     if not track:
-                        failed_count += 1
+                        fail("track disappeared mid-save", track_data["title"])
                         return
 
                     track.audio_storage = "both"
@@ -262,10 +296,7 @@ async def save_tracks_to_pds(
                     e,
                     exc_info=True,
                 )
-                failed_count += 1
-                one_status = "failed"
-                title = track_data["title"] if track_data else f"track {track_id}"
-                errors.append(f"{title}: {str(e)[:200]}")
+                fail(str(e)[:200], track_data["title"] if track_data else None)
             finally:
                 async with progress_lock:
                     processed_count += 1
@@ -274,6 +305,11 @@ async def save_tracks_to_pds(
                     await update_progress(f"saved {saved_count}/{total_count} tracks")
 
     await asyncio.gather(*(save_one(track_id) for track_id in track_ids))
+
+    failure_summary = [
+        f"{n} track{'s' if n != 1 else ''}: {reason}"
+        for reason, n in reason_counts.most_common()
+    ]
 
     if saved_count == 0 and failed_count > 0 and skipped_count == 0:
         await job_service.update_progress(
@@ -287,6 +323,7 @@ async def save_tracks_to_pds(
                 "skipped_count": skipped_count,
                 "failed_count": failed_count,
                 "errors": errors[:5],
+                "failure_summary": failure_summary,
             },
         )
         return
@@ -307,6 +344,7 @@ async def save_tracks_to_pds(
             "skipped_count": skipped_count,
             "failed_count": failed_count,
             "errors": errors[:5],
+            "failure_summary": failure_summary,
         },
     )
 

--- a/backend/src/backend/_internal/pds_save_tasks.py
+++ b/backend/src/backend/_internal/pds_save_tasks.py
@@ -20,7 +20,7 @@ from backend.config import settings
 from backend.models import Track
 from backend.models.job import JobStatus
 from backend.storage import storage
-from backend.utilities.audio_formats import AudioFormat
+from backend.storage.keys import AudioKey, InvalidMediaExtension
 from backend.utilities.database import db_session
 
 logger = logging.getLogger(__name__)
@@ -192,8 +192,16 @@ async def save_tracks_to_pds(
                     skipped_count += 1
                     return
 
-                audio_format = AudioFormat.from_extension(track_data["file_type"])
-                if not audio_format:
+                # `file_id` addresses storage only for uploads that went through
+                # us; an ingested row carries the record's `fileId`/rkey, and its
+                # `r2_url` is what actually points at the bytes.
+                try:
+                    audio_key = AudioKey.for_track(
+                        file_id=track_data["file_id"],
+                        file_type=track_data["file_type"],
+                        r2_url=track_data["r2_url"],
+                    )
+                except InvalidMediaExtension:
                     fail(
                         f"unsupported audio format ({track_data['file_type']})",
                         track_data["title"],
@@ -203,17 +211,17 @@ async def save_tracks_to_pds(
                 audio_url = track_data["r2_url"]
                 if not audio_url:
                     audio_url = await storage.get_url(
-                        track_data["file_id"],
+                        audio_key.file_id,
                         file_type="audio",
-                        extension=track_data["file_type"],
+                        extension=audio_key.extension,
                     )
                 if not audio_url:
                     fail("no audio URL to copy from", track_data["title"])
                     return
 
                 content_length = await storage.head_file(
-                    track_data["file_id"],
-                    track_data["file_type"],
+                    audio_key.file_id,
+                    audio_key.extension,
                 )
                 if content_length is None:
                     # the row references audio this deployment can't read — most
@@ -225,17 +233,18 @@ async def save_tracks_to_pds(
                     )
                     return
 
-                track_file_id = track_data["file_id"]
-                track_file_type = track_data["file_type"]
+                stream_key = audio_key
 
                 def body_factory() -> AsyncIterable[bytes]:
-                    return storage.stream_file_data(track_file_id, track_file_type)
+                    return storage.stream_file_data(
+                        stream_key.file_id, stream_key.extension
+                    )
 
                 blob_ref = await upload_blob(
                     auth_session,
                     body_factory=body_factory,
                     content_length=content_length,
-                    content_type=audio_format.media_type,
+                    content_type=audio_key.format.media_type,
                 )
                 blob_cid = blob_ref.get("ref", {}).get("$link")
                 blob_size = blob_ref.get("size")

--- a/backend/src/backend/_internal/track_revisions.py
+++ b/backend/src/backend/_internal/track_revisions.py
@@ -19,6 +19,7 @@ from sqlalchemy import select
 
 from backend.models import MAX_REVISIONS_PER_TRACK, Track, TrackRevision
 from backend.storage import storage
+from backend.storage.keys import AudioKey
 from backend.utilities.database import db_session
 
 logger = logging.getLogger(__name__)
@@ -111,11 +112,19 @@ async def _maybe_delete_blob(
     if revision.audio_storage == "pds":
         return  # not ours to delete
 
-    # primary playable file: routed to gated bucket if it was gated at the time
+    # primary playable file: routed to gated bucket if it was gated at the time.
+    # the key comes from the snapshot's `audio_url` when present — a revision of
+    # an ingested track carries that track's rkey in `file_id`, which addresses
+    # no object of ours (see AudioKey.for_track).
     if revision.file_id and revision.file_id not in in_use_file_ids:
         delete_fn = storage.delete_gated if revision.was_gated else storage.delete
         try:
-            await delete_fn(revision.file_id, revision.file_type)
+            key = AudioKey.for_track(
+                file_id=revision.file_id,
+                file_type=revision.file_type,
+                r2_url=revision.audio_url,
+            )
+            await delete_fn(key.file_id, key.extension)
         except Exception:
             logger.exception(
                 "failed to delete pruned revision blob (file_id=%s, gated=%s)",

--- a/backend/src/backend/api/account.py
+++ b/backend/src/backend/api/account.py
@@ -24,6 +24,7 @@ from backend.models import (
     get_db,
 )
 from backend.storage import storage
+from backend.storage.keys import AudioKey, InvalidMediaExtension
 from backend.utilities.tags import DEFAULT_HIDDEN_TAGS
 
 logger = logging.getLogger(__name__)
@@ -113,12 +114,22 @@ async def delete_account(
 
     # track audio and images
     tracks_result = await db.execute(
-        select(Track.file_id, Track.file_type, Track.image_id).where(
+        select(Track.file_id, Track.file_type, Track.r2_url, Track.image_id).where(
             Track.artist_did == session.did
         )
     )
-    for file_id, file_type, image_id in tracks_result.fetchall():
-        r2_audio_files.append((file_id, file_type))
+    for file_id, file_type, r2_url, image_id in tracks_result.fetchall():
+        # an ingested row's `file_id` is the record's `fileId`/rkey and names no
+        # object of ours; `r2_url` holds the real key. deleting by `file_id`
+        # there leaves the audio behind after the account is gone.
+        try:
+            key = AudioKey.for_track(
+                file_id=file_id, file_type=file_type, r2_url=r2_url
+            )
+        except InvalidMediaExtension:
+            logger.warning("skipping unstorable audio key for %s", file_id)
+        else:
+            r2_audio_files.append((key.file_id, key.extension))
         if image_id:
             r2_image_ids.append(image_id)
 

--- a/backend/src/backend/api/pds_save.py
+++ b/backend/src/backend/api/pds_save.py
@@ -124,6 +124,9 @@ async def save_progress(save_id: str) -> StreamingResponse:
                     if job.result
                     else None,
                     "errors": job.result.get("errors") if job.result else None,
+                    "failure_summary": job.result.get("failure_summary")
+                    if job.result
+                    else None,
                 }
 
                 yield f"data: {json.dumps(payload)}\n\n"

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -34,6 +34,7 @@ from backend.models import (
 )
 from backend.schemas import TrackResponse
 from backend.storage import storage
+from backend.storage.keys import AudioKey, InvalidMediaExtension
 from backend.utilities.aggregations import (
     get_comment_counts,
     get_copyright_info,
@@ -617,7 +618,7 @@ async def get_my_file_sizes(
     auth_session: AuthSession = Depends(require_auth),
 ) -> FileSizesResponse:
     """Get file sizes for the authenticated user's tracks via R2 HEAD requests."""
-    stmt = select(Track.id, Track.file_id, Track.file_type).where(
+    stmt = select(Track.id, Track.file_id, Track.file_type, Track.r2_url).where(
         Track.artist_did == auth_session.did,
         Track.file_id.isnot(None),
     )
@@ -630,19 +631,28 @@ async def get_my_file_sizes(
     semaphore = asyncio.Semaphore(10)
     sizes: dict[int, int] = {}
 
-    async def get_size(track_id: int, file_id: str, file_type: str) -> None:
-        # routes through the typed-key path: head_file builds the R2 key via
-        # AudioKey.for_file(file_id, file_type), so this endpoint can't drift
-        # from how save() wrote the object. see backend/storage/keys.py.
+    async def get_size(
+        track_id: int, file_id: str, file_type: str, r2_url: str | None
+    ) -> None:
+        # routes through the typed-key path so this endpoint can't drift from
+        # how save() wrote the object; `for_track` additionally resolves the key
+        # from `r2_url` for ingested rows, whose `file_id` is the record's
+        # rkey and addresses nothing. see backend/storage/keys.py.
+        try:
+            key = AudioKey.for_track(
+                file_id=file_id, file_type=file_type, r2_url=r2_url
+            )
+        except InvalidMediaExtension:
+            return
         async with semaphore:
-            size = await storage.head_file(file_id, file_type)
+            size = await storage.head_file(key.file_id, key.extension)
         if size is not None:
             sizes[track_id] = size
 
     await asyncio.gather(
         *(
-            get_size(track_id, file_id, file_type)
-            for track_id, file_id, file_type in tracks
+            get_size(track_id, file_id, file_type, r2_url)
+            for track_id, file_id, file_type, r2_url in tracks
         )
     )
 

--- a/backend/src/backend/api/tracks/mutations.py
+++ b/backend/src/backend/api/tracks/mutations.py
@@ -44,7 +44,7 @@ from backend.config import settings
 from backend.models import Artist, Track, TrackTag, get_db
 from backend.schemas import MessageResponse, TrackResponse
 from backend.storage import storage
-from backend.utilities.audio_formats import AudioFormat
+from backend.storage.keys import AudioKey, InvalidMediaExtension
 from backend.utilities.tags import get_or_create_tag, parse_tags_json
 
 from .metadata_service import apply_album_update
@@ -107,10 +107,17 @@ async def delete_track(
                     detail=f"failed to delete ATProto record: {e}",
                 ) from e
 
-    # delete audio file from storage
+    # delete audio file from storage. the key comes from `r2_url` when the row
+    # was ingested — deleting by `file_id` there addresses nothing and silently
+    # orphans the real object.
     if not track.is_private:
         try:
-            await storage.delete(track.file_id, track.file_type)
+            delete_key = AudioKey.for_track(
+                file_id=track.file_id,
+                file_type=track.file_type,
+                r2_url=track.r2_url,
+            )
+            await storage.delete(delete_key.file_id, delete_key.extension)
         except Exception as e:
             # log but don't fail - maybe file was already deleted
             logger.warning(f"failed to delete file {track.file_id}: {e}", exc_info=True)
@@ -673,19 +680,24 @@ async def migrate_track_to_pds(
             detail="supporter-gated tracks cannot be migrated to PDS",
         )
 
-    # determine content type from file type
-    audio_format = AudioFormat.from_extension(track.file_type)
-    if not audio_format:
+    # `file_id` addresses storage only for uploads that came through us — an
+    # ingested row carries the record's `fileId`/rkey, and `r2_url` is what
+    # points at the bytes (see AudioKey.for_track).
+    try:
+        audio_key = AudioKey.for_track(
+            file_id=track.file_id, file_type=track.file_type, r2_url=track.r2_url
+        )
+    except InvalidMediaExtension as e:
         raise HTTPException(
             status_code=400,
             detail=f"unsupported audio format: {track.file_type}",
-        )
-    content_type = audio_format.media_type
+        ) from e
+    content_type = audio_key.format.media_type
 
     # confirm the audio object exists and capture its size for Content-Length;
     # the body itself is streamed from R2 to the PDS, never buffered here.
     try:
-        content_length = await storage.head_file(track.file_id, track.file_type)
+        content_length = await storage.head_file(audio_key.file_id, audio_key.extension)
     except Exception as e:
         logger.error(f"failed to head audio for track {track_id}: {e}", exc_info=True)
         raise HTTPException(
@@ -698,11 +710,10 @@ async def migrate_track_to_pds(
             detail="audio file not found in storage",
         )
 
-    file_id = track.file_id
-    file_type = track.file_type
+    stream_key = audio_key
 
     def body_factory() -> AsyncIterable[bytes]:
-        return storage.stream_file_data(file_id, file_type)
+        return storage.stream_file_data(stream_key.file_id, stream_key.extension)
 
     # upload blob to PDS
     try:

--- a/backend/src/backend/api/tracks/revisions.py
+++ b/backend/src/backend/api/tracks/revisions.py
@@ -36,6 +36,7 @@ from backend.api.albums import invalidate_album_cache_by_id
 from backend.config import settings
 from backend.models import Track, TrackRevision
 from backend.storage import storage
+from backend.storage.keys import AudioKey
 from backend.utilities.audio_formats import AudioFormat
 from backend.utilities.database import db_session
 
@@ -259,16 +260,19 @@ async def restore_track_revision(
             )
             reupload_blob_ref: dict | None = None
             try:
+                revision_key = AudioKey.for_track(
+                    file_id=revision.file_id,
+                    file_type=revision.file_type,
+                    r2_url=revision.audio_url,
+                )
                 content_length = await storage.head_file(
-                    revision.file_id, revision.file_type
+                    revision_key.file_id, revision_key.extension
                 )
                 if content_length is not None:
-                    revision_file_id = revision.file_id
-                    revision_file_type = revision.file_type
 
                     def body_factory() -> AsyncIterable[bytes]:
                         return storage.stream_file_data(
-                            revision_file_id, revision_file_type
+                            revision_key.file_id, revision_key.extension
                         )
 
                     reupload_blob_ref = await upload_blob(

--- a/backend/src/backend/storage/keys.py
+++ b/backend/src/backend/storage/keys.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import PurePosixPath
+from urllib.parse import urlsplit
 
 from backend._internal.image import ImageFormat
 from backend.utilities.audio_formats import AudioFormat
@@ -61,8 +62,57 @@ class AudioKey:
 
     @classmethod
     def for_file(cls, file_id: str, file_type: str) -> AudioKey:
-        """build from `(file_id, file_type)` as stored in the tracks table."""
+        """build from `(file_id, file_type)` as stored in the tracks table.
+
+        NOTE: `Track.file_id` is only a storage key for audio *we* stored. on
+        the jetstream ingest path it is `record["fileId"]` falling back to the
+        rkey — a value the record's author chose, which generally addresses
+        nothing in our bucket. for a row that carries an `r2_url`, that URL is
+        the authoritative pointer: use `from_url` (see `for_track`).
+        """
         return cls(file_id=file_id, extension=_strip_ext(file_type))
+
+    @classmethod
+    def from_url(cls, url: str) -> AudioKey | None:
+        """recover the key from one of *our own* public audio URLs.
+
+        the origin must match this deployment's configured audio bucket. a
+        record's `audioUrl` is written by whoever authored the record, and a
+        path lifted from a foreign origin would name one of our objects while
+        claiming to describe someone else's bytes (#1778: never treat an
+        uploader-controlled endpoint as our storage). returns None for a
+        foreign origin, another environment's bucket, or a shape we don't
+        store — callers decide whether that's a fallback or a failure.
+        """
+        from backend.config import settings
+
+        bucket_url = settings.storage.r2_public_bucket_url
+        if not bucket_url:
+            return None
+        parsed = urlsplit(url)
+        ours = urlsplit(bucket_url)
+        if (parsed.scheme, parsed.netloc) != (ours.scheme, ours.netloc):
+            return None
+
+        path = PurePosixPath(parsed.path)
+        if path.parent.name != "audio" or not path.stem:
+            return None
+        try:
+            return cls(file_id=path.stem, extension=_strip_ext(path.suffix))
+        except InvalidMediaExtension:
+            return None
+
+    @classmethod
+    def for_track(cls, *, file_id: str, file_type: str, r2_url: str | None) -> AudioKey:
+        """the key that actually locates a track's audio.
+
+        prefers the key encoded in `r2_url` — set by whoever stored the bytes —
+        over `(file_id, file_type)`, which only addresses storage for uploads
+        that went through us.
+        """
+        if r2_url and (from_url := cls.from_url(r2_url)):
+            return from_url
+        return cls.for_file(file_id, file_type)
 
     @property
     def key(self) -> str:

--- a/backend/tests/_internal/test_pds_save_failure_reporting.py
+++ b/backend/tests/_internal/test_pds_save_failure_reporting.py
@@ -37,7 +37,7 @@ async def track(db_session: AsyncSession) -> Track:
         file_id="3mskqx26ked22",
         file_type="webm",
         artist_did=_DID,
-        r2_url="https://audio.plyr.fm/audio/3mskqx26ked22.webm",
+        r2_url="https://audio.plyr.fm/audio/3mskqx26ked22_hashed.webm",
         atproto_record_uri=f"at://{_DID}/fm.plyr.track/3mskqx26ked22",
     )
     db_session.add(track)
@@ -45,7 +45,7 @@ async def track(db_session: AsyncSession) -> Track:
     return track
 
 
-async def _run_save(track_id: int) -> dict:
+async def _run_save(track_id: int, head_file: AsyncMock | None = None) -> dict:
     """run a save whose audio is absent from storage; return the job result."""
     captured: dict = {}
 
@@ -60,7 +60,7 @@ async def _run_save(track_id: int) -> dict:
         ),
         patch(
             "backend._internal.pds_save_tasks.storage.head_file",
-            new=AsyncMock(return_value=None),
+            new=head_file or AsyncMock(return_value=None),
         ),
         patch(
             "backend._internal.pds_save_tasks.job_service.update_progress",
@@ -96,3 +96,23 @@ async def test_no_failure_is_counted_without_an_explanation(track: Track) -> Non
         int(entry.split(" ", 1)[0]) for entry in result["failure_summary"]
     )
     assert counted_in_summary == result["failed_count"]
+
+
+async def test_ingested_track_is_looked_up_by_its_real_storage_key(
+    track: Track, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """the save must ask storage for the key in `r2_url`, not the record rkey.
+
+    this is the bug behind the "6 failed" batch: the bytes were in the bucket
+    under their content hash the whole time, and we asked for `audio/<rkey>`.
+    """
+    from backend.config import settings
+
+    monkeypatch.setattr(
+        settings.storage, "r2_public_bucket_url", "https://audio.plyr.fm"
+    )
+    head_file = AsyncMock(return_value=None)
+
+    await _run_save(track.id, head_file=head_file)
+
+    head_file.assert_awaited_once_with("3mskqx26ked22_hashed", "webm")

--- a/backend/tests/_internal/test_pds_save_failure_reporting.py
+++ b/backend/tests/_internal/test_pds_save_failure_reporting.py
@@ -1,0 +1,98 @@
+"""a failed PDS save must always say why.
+
+regression: a batch of 18 reported "11 saved, 1 skipped, 6 failed" with an
+empty error list and nothing in telemetry. the six had been ingested from the
+firehose, so their audio was never in this deployment's bucket and
+`storage.head_file` returned None — one of four early returns that bumped
+`failed_count` and returned without recording a reason or logging.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal.pds_save_tasks import save_tracks_to_pds
+from backend.models import Artist, Track
+
+_DID = "did:plc:pds_save_reporting"
+_SESSION_ID = "session-under-test"
+
+
+class _Session:
+    did = _DID
+    session_id = _SESSION_ID
+    handle = "saver.test"
+
+
+@pytest.fixture
+async def track(db_session: AsyncSession) -> Track:
+    db_session.add(Artist(did=_DID, handle="saver.test", display_name="Saver"))
+    await db_session.commit()
+
+    track = Track(
+        title="ingested from elsewhere",
+        # firehose-ingested rows carry the record rkey, not an upload hash —
+        # nothing under that key exists in this environment's bucket
+        file_id="3mskqx26ked22",
+        file_type="webm",
+        artist_did=_DID,
+        r2_url="https://audio.plyr.fm/audio/3mskqx26ked22.webm",
+        atproto_record_uri=f"at://{_DID}/fm.plyr.track/3mskqx26ked22",
+    )
+    db_session.add(track)
+    await db_session.commit()
+    return track
+
+
+async def _run_save(track_id: int) -> dict:
+    """run a save whose audio is absent from storage; return the job result."""
+    captured: dict = {}
+
+    async def _capture(save_id, status, message, **kwargs):
+        if result := kwargs.get("result"):
+            captured.update(result)
+
+    with (
+        patch(
+            "backend._internal.pds_save_tasks.get_session",
+            new=AsyncMock(return_value=_Session()),
+        ),
+        patch(
+            "backend._internal.pds_save_tasks.storage.head_file",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "backend._internal.pds_save_tasks.job_service.update_progress",
+            new=AsyncMock(side_effect=_capture),
+        ),
+    ):
+        await save_tracks_to_pds("save-1", _SESSION_ID, [track_id])
+
+    return captured
+
+
+async def test_missing_audio_failure_reports_a_reason(track: Track) -> None:
+    result = await _run_save(track.id)
+
+    assert result["failed_count"] == 1
+    assert result["saved_count"] == 0
+
+    # the whole point: a counted failure carries an explanation
+    assert result["errors"], "a failure was counted with no error recorded"
+    assert "ingested from elsewhere" in result["errors"][0]
+    assert "plyr.fm storage" in result["errors"][0]
+
+    assert result["failure_summary"] == [
+        "1 track: audio isn't in plyr.fm storage, so there's nothing to copy"
+    ]
+
+
+async def test_no_failure_is_counted_without_an_explanation(track: Track) -> None:
+    """the invariant, stated directly: failed_count and the reasons agree."""
+    result = await _run_save(track.id)
+
+    counted_in_summary = sum(
+        int(entry.split(" ", 1)[0]) for entry in result["failure_summary"]
+    )
+    assert counted_in_summary == result["failed_count"]

--- a/backend/tests/test_audio_key_for_track.py
+++ b/backend/tests/test_audio_key_for_track.py
@@ -1,0 +1,66 @@
+"""a track's audio key comes from its r2_url, not blindly from file_id.
+
+regression: a portal PDS save reported "6 failed" on tracks whose audio was
+sitting in the bucket the whole time. those rows came from jetstream ingest,
+where `file_id` is `record["fileId"]` falling back to the rkey — so the save
+asked storage for `audio/<rkey>.<ext>` while the bytes lived under the content
+hash in `r2_url`. playback never noticed because it redirects to `r2_url`.
+"""
+
+import pytest
+
+from backend.config import settings
+from backend.storage.keys import AudioKey
+
+_BUCKET = "https://audio-stg.plyr.fm"
+
+
+@pytest.fixture(autouse=True)
+def _bucket(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings.storage, "r2_public_bucket_url", _BUCKET)
+
+
+def test_ingested_row_resolves_to_the_key_in_its_url() -> None:
+    """the rkey in file_id addresses nothing; the URL holds the real key."""
+    key = AudioKey.for_track(
+        file_id="3mskqx26ked22",
+        file_type="webm",
+        r2_url=f"{_BUCKET}/audio/53d0e394cf033b02.webm",
+    )
+    assert key.key == "audio/53d0e394cf033b02.webm"
+
+
+def test_uploaded_row_without_a_url_falls_back_to_file_id() -> None:
+    key = AudioKey.for_track(file_id="5e1db6607b79ec7f", file_type="wav", r2_url=None)
+    assert key.key == "audio/5e1db6607b79ec7f.wav"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://evil.example.com/audio/5e1db6607b79ec7f.wav",  # foreign origin
+        "https://audio.plyr.fm/audio/5e1db6607b79ec7f.wav",  # another environment
+        "http://audio-stg.plyr.fm/audio/5e1db6607b79ec7f.wav",  # scheme mismatch
+    ],
+)
+def test_foreign_urls_never_become_our_storage_key(url: str) -> None:
+    """a path lifted off someone else's origin would name OUR object while
+    claiming to describe their bytes (#1778)."""
+    assert AudioKey.from_url(url) is None
+    assert (
+        AudioKey.for_track(file_id="fallback", file_type="mp3", r2_url=url).key
+        == "audio/fallback.mp3"
+    )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        f"{_BUCKET}/images/abc.jpeg",  # not an audio object
+        f"{_BUCKET}/audio/abc.txt",  # extension we don't store
+        f"{_BUCKET}/audio/",  # no object
+        "not a url",
+    ],
+)
+def test_unusable_urls_return_none(url: str) -> None:
+    assert AudioKey.from_url(url) is None

--- a/backend/tests/test_audio_key_for_track.py
+++ b/backend/tests/test_audio_key_for_track.py
@@ -64,3 +64,31 @@ def test_foreign_urls_never_become_our_storage_key(url: str) -> None:
 )
 def test_unusable_urls_return_none(url: str) -> None:
     assert AudioKey.from_url(url) is None
+
+
+def test_no_storage_call_is_keyed_by_a_track_row_file_id() -> None:
+    """the invariant behind the audit, enforced on the source.
+
+    `Track.file_id` is a storage key only for uploads that came through us; on
+    the ingest path it is the record's `fileId`/rkey. handing it straight to a
+    storage call addresses nothing for those rows — the "6 failed" PDS save,
+    audio orphaned on delete, tracks silently missing from exports. every such
+    call must go through `AudioKey.for_track`, which prefers `r2_url`.
+    """
+    import re
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parents[1] / "src" / "backend"
+    ops = "head_file|stream_file_data|delete|get_url"
+    holders = r"track\.file_id|track_data\[.file_id.\]|revision\.file_id"
+    offenders = []
+
+    for path in src.rglob("*.py"):
+        # collapse wrapped calls so multi-line arguments are still matched
+        flat = re.sub(r"\s+", " ", path.read_text())
+        for match in re.finditer(rf"storage\.({ops})\( *({holders})", flat):
+            offenders.append(f"{path.relative_to(src)}: {match.group(0).strip()}")
+
+    assert not offenders, "storage calls keyed by a track row file_id: " + "; ".join(
+        offenders
+    )

--- a/backend/tests/test_background_tasks.py
+++ b/backend/tests/test_background_tasks.py
@@ -146,6 +146,10 @@ async def test_process_export_downloads_concurrently() -> None:
         track.file_type = "mp3"
         track.original_file_id = None
         track.original_file_type = None
+        # likewise null the cached public URL: with none set, the key comes
+        # from file_id/file_type (an ingested row would resolve it from the
+        # URL instead — see AudioKey.for_track)
+        track.r2_url = None
         mock_tracks.append(track)
 
     # mock database query

--- a/frontend/src/lib/components/PdsSaveControl.svelte
+++ b/frontend/src/lib/components/PdsSaveControl.svelte
@@ -104,8 +104,10 @@
 					if (data.skipped_count) parts.push(`${data.skipped_count} skipped`);
 					if (data.failed_count) parts.push(`${data.failed_count} failed`);
 					toast.success(parts.join(', ') || 'saved to your PDS');
-					for (const err of data.errors ?? []) {
-						toast.warning(err, 0);
+					// grouped by cause: a batch usually fails for one reason, and
+					// one line per reason beats one per track
+					for (const reason of data.failure_summary ?? data.errors ?? []) {
+						toast.warning(reason, 0);
 					}
 					onComplete?.();
 				}
@@ -114,8 +116,10 @@
 					eventSource.close();
 					saving = false;
 					toast.dismiss(toastId);
-					const firstError: string | undefined = (data.errors ?? [])[0];
-					toast.error(firstError || data.error || 'save failed', 0);
+					const firstReason: string | undefined = (data.failure_summary ??
+						data.errors ??
+						[])[0];
+					toast.error(firstReason || data.error || 'save failed', 0);
 				}
 			} catch {
 				/* ignore parse errors */

--- a/loq.toml
+++ b/loq.toml
@@ -31,7 +31,7 @@ max_lines = 923
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
-max_lines = 653
+max_lines = 659
 
 [[rules]]
 path = "backend/src/backend/api/tracks/mutations.py"


### PR DESCRIPTION
a save of 18 tracks reported **"11 saved, 1 skipped, 6 failed"** with `errors: []` and nothing in telemetry — while the audio sat in the bucket the whole time. Two defects, plus the audit of every other site that shares the first one.

## defect 1 — a track row's `file_id` is not a storage key

`Track.file_id` addresses storage only for uploads that came through us. On the jetstream ingest path it is `record["fileId"]` falling back to the **rkey** — #1778's own commit message says it: *"the record's `fileId`, which is attacker-supplied on the ingest path."* The real pointer for those rows is `r2_url`, whose stem is the content hash `storage.save` computed.

The PDS save mixed the two conventions: URL from `r2_url` (correct), storage key from `file_id` (wrong). It asked for `audio/3mskqx26ked22.webm` while the object lived at `audio/53d0e394cf033b02.webm`. Verified on staging: all six "missing" objects return **206** at the key in their `r2_url` and 404 at the key from `file_id`. Playback never noticed because it redirects to `r2_url` and never derives a key.

**Fix:** `AudioKey.for_track(file_id, file_type, r2_url)` prefers the key encoded in `r2_url`, falling back to `(file_id, file_type)`. `AudioKey.from_url` requires the origin to match *this deployment's* bucket — a path lifted off a foreign origin (or another environment's) would name one of **our** objects while claiming to describe someone else's bytes, exactly the #1778 hazard. It lives in `storage/keys.py`, whose premise is that typing the key makes this family of bug unrepresentable; these were the sites that never got typed.

### every site fixed

| site | what was broken |
|---|---|
| `_internal/pds_save_tasks.py` | the reported bug — batch PDS save |
| `api/tracks/mutations.py` (migrate) | single-track PDS migrate, same bug |
| `api/tracks/mutations.py` (delete) | deleted nothing; **orphaned the real object** |
| `api/account.py` | same, for every track on account deletion |
| `_internal/export_tasks.py` | ingested tracks **silently omitted** from the export zip |
| `api/tracks/listing.py` | file sizes missing for ingested tracks |
| `api/tracks/revisions.py` | restore couldn't re-upload bytes after PDS lost a blob |
| `_internal/track_revisions.py` | pruning left the real blob behind |

`TrackRevision` already stores `audio_url`, so no migration was needed. `api/audio.py`'s `get_url` fallback is left alone deliberately: it is guarded by the `r2_url` redirect and the PDS-blob redirect above it, and is only reachable for `original_file_*` keys, which only our upload pipeline writes.

**The invariant is now pinned in source**: a test scans `src/backend` for any `storage.{head_file,stream_file_data,delete,get_url}` call keyed by `track.file_id` / `track_data["file_id"]` / `revision.file_id` and fails with the offending file and line. It caught `revisions.py` while I was writing this, which is how the last two rows in that table got fixed.

## defect 2 — failures didn't say why

`save_one` had four early returns doing `failed_count += 1; return` with no log and no recorded reason. #1806 only captured the `except Exception` branch, so these produced a number and nothing else — including in Logfire, which is why querying `pds save failed for track` returned zero rows for a batch that had just failed six times. They also left `last_status` reading "skipped" on a failure.

Every failure now routes through one `fail(reason, title)` helper; a bare `failed_count += 1` no longer exists in the module. Reasons are grouped by cause into `failure_summary` (`"6 tracks: <reason>"`) so a batch yields one line, not six near-identical sticky toasts.

## verification

- `AudioKey` unit tests: ingested row resolves to the URL's key; upload without `r2_url` falls back; foreign origin / other environment / scheme mismatch never become our key.
- save-path test asserts `head_file` is awaited with the **hash-derived** key — confirmed failing against the old code.
- failure-reporting test asserts every counted failure carries an explanation and that `failure_summary` totals equal `failed_count` — also confirmed failing before the fix.
- source-invariant test verified to fail when any individual site is reverted.
- full suite **1484 passed**; lint and `just frontend check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)