### PR TITLE
feat(scripts): publish community.lexicon.app.profile for plyr.fm

### DIFF
--- a/scripts/publish_app_profile.py
+++ b/scripts/publish_app_profile.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+"""publish the community.lexicon.app.profile record for plyr.fm.
+
+this is the community lexicon's app record: a self-published description of the
+app (name, icon, links, which lexicons it produces and consumes) that app
+directories and stores read. it is keyed `self` in our own repo.
+
+the icon is uploaded as an atproto blob so the record does not depend on a URL
+we might later reshuffle.
+
+usage:
+    uv run --project backend scripts/publish_app_profile.py --dry-run
+    uv run --project backend scripts/publish_app_profile.py
+
+verify afterwards:
+    https://brand.waow.tech/xrpc/tech.waow.brand.getBrand?namespace=fm.plyr.track
+"""
+
+import argparse
+import asyncio
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from atproto import AsyncClient
+from atproto_client.exceptions import BadRequestError
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+ROOT = Path(__file__).parent.parent
+ICON = ROOT / "frontend" / "static" / "icons" / "icon-512.png"
+COLLECTION = "community.lexicon.app.profile"
+DEFS = "community.lexicon.app.defs"
+MAX_IMAGE_BYTES = 2_000_000
+
+PRODUCES = (
+    "fm.plyr.track",
+    "fm.plyr.like",
+    "fm.plyr.list",
+    "fm.plyr.comment",
+    "fm.plyr.actor.profile",
+    "fm.teal.alpha.feed.play",
+    "fm.teal.alpha.actor.status",
+)
+CONSUMES = ("app.bsky.actor.profile",)
+
+LINKS = (
+    ("https://plyr.fm", "linkRoleWebsite", "Website"),
+    ("https://docs.plyr.fm", "linkRoleDocs", "Docs"),
+    ("https://github.com/zzstoatzz/plyr.fm", "linkRoleSourceCode", "Source"),
+    ("https://plyr.fm/manifest.webmanifest", "linkRoleWebManifest", "Web manifest"),
+    ("https://plyr.fm/privacy", "linkRolePrivacyPolicy", "Privacy"),
+    ("https://plyr.fm/terms", "linkRoleTermsOfService", "Terms"),
+)
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=str(ROOT / ".env"), extra="ignore")
+
+    plyrfm_handle: str = Field(default="plyr.fm", validation_alias="PLYRFM_HANDLE")
+    plyrfm_password: str = Field(validation_alias="PLYRFM_PASSWORD")
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def build_record(icon: dict[str, Any], created_at: str) -> dict[str, Any]:
+    return {
+        "$type": COLLECTION,
+        "name": "plyr.fm",
+        "description": "audio on atproto — your music lives in your PDS, playable by any client.",
+        "status": f"{DEFS}#released",
+        "tags": ["music", "audio", "streaming", "radio"],
+        "platforms": [f"{DEFS}#platformWeb"],
+        "links": [
+            {"uri": uri, "role": f"{DEFS}#{role}", "label": label}
+            for uri, role, label in LINKS
+        ],
+        "images": [
+            {
+                "alt": "the plyr.fm app icon",
+                "purpose": f"{DEFS}#purposeIcon",
+                "image": icon,
+            }
+        ],
+        "lexicons": {"produces": list(PRODUCES), "consumes": list(CONSUMES)},
+        "accountIndicators": [{"collection": "fm.plyr.actor.profile", "rkey": "self"}],
+        "createdAt": created_at,
+    }
+
+
+async def existing_created_at(client: AsyncClient) -> str | None:
+    """reuse the createdAt of an already-published record so reruns are stable."""
+    try:
+        record = await client.com.atproto.repo.get_record(
+            {"repo": client.me.did, "collection": COLLECTION, "rkey": "self"}
+        )
+    except BadRequestError:
+        return None
+    return getattr(record.value, "created_at", None)
+
+
+async def main(dry_run: bool) -> None:
+    settings = Settings()
+
+    data = ICON.read_bytes()
+    if len(data) > MAX_IMAGE_BYTES:
+        raise SystemExit(
+            f"{ICON.name} is {len(data)}b, over the {MAX_IMAGE_BYTES}b lexicon cap"
+        )
+
+    client = AsyncClient()
+    await client.login(settings.plyrfm_handle, settings.plyrfm_password)
+    print(f"authenticated as {settings.plyrfm_handle} ({client.me.did})")
+
+    created_at = await existing_created_at(client)
+    print(f"createdAt: {created_at or 'new record, stamping now'}")
+
+    if dry_run:
+        placeholder = {
+            "$type": "blob",
+            "ref": {"$link": "<uploaded on publish>"},
+            "mimeType": "image/png",
+            "size": len(data),
+        }
+        print(json.dumps(build_record(placeholder, created_at or "<now>"), indent=2))
+        return
+
+    uploaded = (await client.com.atproto.repo.upload_blob(data)).blob
+    icon = {
+        "$type": "blob",
+        "ref": {"$link": uploaded.ref.link},
+        "mimeType": uploaded.mime_type,
+        "size": uploaded.size,
+    }
+    print(
+        f"uploaded icon blob {uploaded.ref.link} ({uploaded.size}b, {uploaded.mime_type})"
+    )
+
+    result = await client.com.atproto.repo.put_record(
+        {
+            "repo": client.me.did,
+            "collection": COLLECTION,
+            "rkey": "self",
+            "record": build_record(icon, created_at or _now_iso()),
+        }
+    )
+    print(f"published {COLLECTION}: {result.uri} (cid {result.cid})")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run", action="store_true", help="print the record without writing"
+    )
+    asyncio.run(main(parser.parse_args().dry_run))


### PR DESCRIPTION
Publishes the community lexicon's app record for plyr.fm, so `fm.plyr.*` namespaces resolve to our actual name and icon instead of a borrowed Bluesky avatar. **The record is already live** — this PR is the reproducible script that wrote it.

`community.lexicon.app.profile` is a community standard that app directories and stores read; it is keyed `self` in our own repo and defines no new record type of ours. We publish it for the ecosystem — the brand.waow.tech service that prompted this just happens to consume it.

<details>
<summary>why the sample record in the proposal needed correcting</summary>

- **`https://plyr.fm/icon.png` is a 404.** It returns the SvelteKit SPA shell with `content-type: text/html`, so the record would have advertised an HTML page as a PNG. Our real icons are at `/icons/icon-512.png`.
- **`lexicons.produces` was a subset.** The sample listed two collections; we actually write seven. Since the whole point of that field is tracing a namespace back to its app, a partial list is worse than the domain-mirror heuristic it is meant to improve on.
- **`fm.plyr.song` isn't ours** — the track record is `fm.plyr.track`. Only the `fm.plyr` prefix match was carrying the proposal's example URL.
</details>

<details>
<summary>design notes</summary>

- **blob, not URI.** The lexicon accepts either; a blob is self-contained and immutable, which matters for a record meant to be read by directories we don't control. A URI would break if we ever reshuffle `frontend/static/icons/`. Icon is 6291b against the lexicon's 2MB cap, which the script asserts.
- **`createdAt` is preserved across reruns.** The script reads the existing record first, so republishing (to update links or add a lexicon) doesn't restamp the creation date. Ingest elsewhere rejects future timestamps, so a stable real value matters.
- **dev/staging namespaces deliberately omitted.** `fm.plyr.dev.*` and `fm.plyr.stg.*` are environment-aware variants, not a published surface.
- **every claim verified against source, not assumed.** `produces` was enumerated from the code (including the two `fm.teal.alpha.*` scrobble records), `consumes` from actual Bluesky reads, and all six link URLs return 200.
- `--dry-run` prints the exact record with a placeholder blob ref.
</details>

Authority chain was verified before writing: `_lexicon.plyr.fm` and `_atproto.plyr.fm` both resolve to `did:plc:vs3hnzq2daqbszxlysywzy54`.

**Verified live.** brand now returns `source: "declared"` with our own blob for all five real NSIDs:

```
icon → getBlob?did=did:plc:vs3hnzq2daqbszxlysywzy54
            &cid=bafkreifns6uiep4xvm3cpu5yajyet7y3pg25ol6y7tddxovj3x7xd4wnpq
getIcon → 200  image/png  6291b
```

The CID matches what we published byte-for-byte, and `getIcon` went from `image/webp 16674b` (the borrowed Bluesky avatar) to `image/png 6291b` (`icon-512.png`). The initial `borrowed` reading was a stale negative cache entry upstream, since flushed — not a problem with this record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
