### PR TITLE
feat(r2): CORS policy for the public media buckets

### DIFF
--- a/infrastructure/r2/README.md
+++ b/infrastructure/r2/README.md
@@ -1,0 +1,45 @@
+# R2 bucket CORS
+
+`cors.json` is the CORS policy for the **public** media buckets. Without it,
+browser JS on another origin can play a track through `<audio src>` but cannot
+read the bytes — so `fetch()` → `arrayBuffer()` → `decodeAudioData()` and
+`crossorigin="anonymous"` + `createMediaElementSource()` both fail. That rules
+out third-party decks, waveforms, and analysers.
+
+Apply it with:
+
+```sh
+export CLOUDFLARE_ACCOUNT_ID=...   # personal account; see docs/internal/tools/agent-access.md
+bunx wrangler r2 bucket cors set audio-staging  --file infrastructure/r2/cors.json
+bunx wrangler r2 bucket cors set images-staging --file infrastructure/r2/cors.json
+bunx wrangler r2 bucket cors set audio-prod     --file infrastructure/r2/cors.json
+bunx wrangler r2 bucket cors set images-prod    --file infrastructure/r2/cors.json
+```
+
+## which buckets
+
+Only the four buckets above — the ones already public via a custom domain and
+an enabled `r2.dev` URL. `*` there grants reads to origins that could already
+read the object with `curl`; CORS is a browser policy, not authentication.
+
+**Never apply this to `audio-private-{staging,prod}`.** Those hold gated audio,
+have no custom domain, have `r2.dev` public access disabled, and are reachable
+only by presigned URL. `*` there would be an actual access-control change.
+
+## after applying
+
+Two things lag:
+
+- the policy takes up to a minute to reach every colo, so the first curl after
+  `cors set` can still show no `access-control-allow-origin`
+- the media domains carry a 1yr edge TTL ("Cache R2 media assets"). Objects
+  already cached keep serving their header-less variant, and `Vary: Origin`
+  does not rescue them — those keys need an explicit cache purge
+
+Verify against a *cached* object, not a cache-busted one, since the cached path
+is what listeners and third-party apps actually hit:
+
+```sh
+curl -sI -H 'Origin: https://example.com' https://audio.plyr.fm/audio/<key>
+# want: access-control-allow-origin: *   alongside cf-cache-status: HIT
+```

--- a/infrastructure/r2/cors.json
+++ b/infrastructure/r2/cors.json
@@ -1,0 +1,13 @@
+{
+  "rules": [
+    {
+      "allowed": {
+        "origins": ["*"],
+        "methods": ["GET", "HEAD"],
+        "headers": ["range"]
+      },
+      "exposeHeaders": ["Content-Length", "Content-Range", "Content-Type", "Accept-Ranges", "ETag"],
+      "maxAgeSeconds": 86400
+    }
+  ]
+}


### PR DESCRIPTION
`audio.plyr.fm` and `images.plyr.fm` had **no** bucket CORS policy, so third-party browser apps could play a track but never read its bytes — no `decodeAudioData`, no analyser, no waveform. This commits the policy that fixes that (already applied to staging and prod) and documents which buckets it must never touch.

Prompted by [@chris.pardy.family asking for raw ArrayBuffer access to build a web DJ deck](https://bsky.app/profile/chris.pardy.family).

<details>
<summary>why it was broken when the API's CORS is wide open</summary>

The API has allowed any https origin since #1106, and `Origin: null` since #1770 — but audio bytes never come from the API. `r2_url` points at an R2 custom domain, and R2 bucket CORS is configured per-bucket, entirely separately from the FastAPI middleware.

Before, on prod:

```
$ curl -sI -X OPTIONS -H 'Origin: https://example.com' \
    -H 'Access-Control-Request-Method: GET' https://audio.plyr.fm/audio/<key>
HTTP/2 403

$ curl -s -D- -H 'Origin: https://example.com' -r 0-10 https://audio.plyr.fm/audio/<key>
HTTP/2 206
content-range: bytes 0-10/24343244      <- bytes fine, no access-control-allow-origin
```

`wrangler r2 bucket cors list` returned *"The CORS configuration does not exist. [code: 10059]"* for all four public buckets.
</details>

<details>
<summary>security review — why `*` is not an access-control change</summary>

CORS is a browser policy about whether *JS on another origin* may read a response, not authentication. What was verified rather than assumed:

- **the buckets are already fully public, two ways.** `audio-prod` / `images-prod` each have an active custom domain *and* an enabled `pub-*.r2.dev` URL, neither authenticated. The "before" curl above returned real audio bytes — any server-side script could already fetch and redistribute them.
- **private audio is excluded.** `audio-private-{staging,prod}`: no custom domain, `r2.dev` public access disabled, presigned-URL only (`r2.py:660`). `*` there *would* be material; the README says so explicitly.
- **no credential surface.** R2 returns literal `*`, so browsers hard-refuse credentialed cross-origin requests. Independently, no `set_cookie` in the backend passes `domain=`, so `session_id` is host-only and never sent to the media hosts.
- **no enumeration.** `/`, `/audio/`, and `?list-type=2` all 404 on the custom domain. Keys are content hashes; you still need the key.

Real deltas, stated plainly: grabbing audio programmatically gets easier (it was already trivial via curl), and whole-file `arrayBuffer` fetches cost more egress than streamed range requests. Narrowing `origins` later is a config edit, not a redesign.
</details>

<details>
<summary>deferred / not in this PR</summary>

- **cache purge.** The media domains carry a 1yr edge TTL, so already-cached objects keep serving their header-less variant and `Vary: Origin` does not rescue them. Fresh fetches carry `access-control-allow-origin: *` on both prod buckets; cached `HIT`s do not yet. Needs an explicit purge, which I don't hold the credential for.
- **the mirror-consent question.** `pds_mirror.py` re-hosts firehose-ingested audio on our CDN because a record was published, not because the artist asked. Those blobs are already public and unauthenticated at the source PDS, so CORS changes nothing about it — flagged here only so it isn't mistaken for something this PR introduced.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)