### PR TITLE
fix: use production Teal lexicon defaults

### DIFF
--- a/backend/src/backend/_internal/atproto/records/fm_teal/play.py
+++ b/backend/src/backend/_internal/atproto/records/fm_teal/play.py
@@ -44,7 +44,7 @@ def build_teal_play_record(
         "$type": settings.teal.play_collection,
         "trackName": track_name,
         "artists": [{"artistName": artist_name}],
-        "musicServiceBaseDomain": "plyr.fm",
+        "musicServiceUri": "https://plyr.fm",
         "submissionClientAgent": "plyr.fm/1.0",
         "playedTime": played_time.isoformat().replace("+00:00", "Z"),
     }
@@ -54,7 +54,7 @@ def build_teal_play_record(
     if album_name:
         record["releaseName"] = album_name
     if origin_url:
-        record["originUrl"] = origin_url
+        record["originUri"] = origin_url
 
     return record
 

--- a/backend/src/backend/_internal/atproto/records/fm_teal/status.py
+++ b/backend/src/backend/_internal/atproto/records/fm_teal/status.py
@@ -35,7 +35,7 @@ def build_teal_status_record(
     item: dict[str, Any] = {
         "trackName": track_name,
         "artists": [{"artistName": artist_name}],
-        "musicServiceBaseDomain": "plyr.fm",
+        "musicServiceUri": "https://plyr.fm",
         "submissionClientAgent": "plyr.fm/1.0",
         "playedTime": now.isoformat().replace("+00:00", "Z"),
     }
@@ -45,7 +45,7 @@ def build_teal_status_record(
     if album_name:
         item["releaseName"] = album_name
     if origin_url:
-        item["originUrl"] = origin_url
+        item["originUri"] = origin_url
 
     record: dict[str, Any] = {
         "$type": settings.teal.status_collection,

--- a/backend/src/backend/api/auth.py
+++ b/backend/src/backend/api/auth.py
@@ -711,7 +711,7 @@ async def start_scope_upgrade_flow(
     will be replaced with a new session that has the requested scopes.
 
     use this when a user enables a feature that requires additional OAuth scopes
-    (e.g., enabling teal.fm scrobbling which needs fm.teal.alpha.* scopes).
+    (e.g., enabling teal.fm scrobbling which needs fm.teal.* scopes).
 
     returns the authorization URL that the frontend should redirect to.
     """

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -533,8 +533,8 @@ class AtprotoSettings(AppSettingsSection):
         """OAuth scope including teal.fm scrobbling permissions.
 
         args:
-            teal_play: teal.fm play collection NSID (e.g., fm.teal.alpha.feed.play)
-            teal_status: teal.fm status collection NSID (e.g., fm.teal.alpha.actor.status)
+            teal_play: teal.fm play collection NSID (e.g., fm.teal.feed.play)
+            teal_status: teal.fm status collection NSID (e.g., fm.teal.actor.status)
         """
         base = self.resolved_scope
         teal_scopes = [f"repo:{teal_play}", f"repo:{teal_status}"]
@@ -592,11 +592,11 @@ class TealSettings(AppSettingsSection):
         description="Enable teal.fm scrobbling feature. When False, the toggle is hidden and no scrobbles are sent.",
     )
     play_collection: str = Field(
-        default="fm.teal.alpha.feed.play",
+        default="fm.teal.feed.play",
         description="Lexicon NSID for teal.fm play records (scrobbles)",
     )
     status_collection: str = Field(
-        default="fm.teal.alpha.actor.status",
+        default="fm.teal.actor.status",
         description="Lexicon NSID for teal.fm actor status (now playing)",
     )
 

--- a/backend/src/backend/models/preferences.py
+++ b/backend/src/backend/models/preferences.py
@@ -43,7 +43,7 @@ class UserPreferences(Base):
     )
 
     # teal.fm scrobbling integration
-    # when enabled, plays are written to user's PDS as fm.teal.alpha.feed.play records
+    # when enabled, plays are written to user's PDS as fm.teal.feed.play records
     # requires re-login to grant teal scopes after enabling
     enable_teal_scrobbling: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=text("false")

--- a/backend/tests/test_teal_scrobbling.py
+++ b/backend/tests/test_teal_scrobbling.py
@@ -27,7 +27,7 @@ class TestBuildTealPlayRecord:
         assert record["$type"] == settings.teal.play_collection
         assert record["trackName"] == "Test Track"
         assert record["artists"] == [{"artistName": "Test Artist"}]
-        assert record["musicServiceBaseDomain"] == "plyr.fm"
+        assert record["musicServiceUri"] == "https://plyr.fm"
         assert record["submissionClientAgent"] == "plyr.fm/1.0"
         assert "playedTime" in record
 
@@ -43,7 +43,7 @@ class TestBuildTealPlayRecord:
 
         assert record["duration"] == 180
         assert record["releaseName"] == "Test Album"
-        assert record["originUrl"] == "https://plyr.fm/track/123"
+        assert record["originUri"] == "https://plyr.fm/track/123"
 
     def test_uses_provided_played_time(self) -> None:
         """should use provided played_time instead of now."""
@@ -112,11 +112,11 @@ class TestTealSettings:
 
     def test_default_play_collection(self):
         """should have correct default teal play collection."""
-        assert settings.teal.play_collection == "fm.teal.alpha.feed.play"
+        assert settings.teal.play_collection == "fm.teal.feed.play"
 
     def test_default_status_collection(self):
         """should have correct default teal status collection."""
-        assert settings.teal.status_collection == "fm.teal.alpha.actor.status"
+        assert settings.teal.status_collection == "fm.teal.actor.status"
 
     def test_default_enabled(self):
         """should be enabled by default."""
@@ -128,8 +128,8 @@ class TestTealSettings:
             settings.teal.play_collection, settings.teal.status_collection
         )
 
-        assert "fm.teal.alpha.feed.play" in scope
-        assert "fm.teal.alpha.actor.status" in scope
+        assert "fm.teal.feed.play" in scope
+        assert "fm.teal.actor.status" in scope
         # should also include base scopes
         assert settings.atproto.track_collection in scope
 

--- a/docs/public/developers/api-reference/auth.md
+++ b/docs/public/developers/api-reference/auth.md
@@ -149,7 +149,7 @@ the user will be redirected to authorize, and on callback the old session
 will be replaced with a new session that has the requested scopes.
 
 use this when a user enables a feature that requires additional OAuth scopes
-(e.g., enabling teal.fm scrobbling which needs fm.teal.alpha.* scopes).
+(e.g., enabling teal.fm scrobbling which needs fm.teal.* scopes).
 
 returns the authorization URL that the frontend should redirect to.
 
@@ -305,4 +305,3 @@ request model for switching to a different account.
 
 
 response model after switching accounts.
-

--- a/docs/public/developers/auth.md
+++ b/docs/public/developers/auth.md
@@ -91,7 +91,7 @@ plyr.fm requests the following OAuth scopes:
 | `repo:fm.plyr.comment` | timed comments |
 | `repo:fm.plyr.list` | playlists, albums, liked lists |
 | `repo:fm.plyr.actor.profile` | artist profile |
-| `repo:fm.teal.alpha.feed.play` | scrobbles to [teal.fm](https://teal.fm) |
+| `repo:fm.teal.feed.play` | scrobbles to [teal.fm](https://teal.fm) |
 | `blob:*/*` | upload audio and images |
 
 if your session is missing a required scope (e.g. new features were added since you authenticated), the API returns `403` with `"detail": "scope_upgrade_required"`. re-authenticate via `/auth/scope-upgrade/start` to grant the new scopes.

--- a/docs/public/lexicons/overview.md
+++ b/docs/public/lexicons/overview.md
@@ -279,8 +279,8 @@ when you sign in to plyr.fm, the app requests OAuth scopes for the collections i
 | `repo:fm.plyr.feed.comment` | timed comments |
 | `repo:fm.plyr.graph.list` | playlists, albums, liked lists |
 | `repo:fm.plyr.actor.profile` | artist profile |
-| `repo:fm.teal.alpha.feed.play` | scrobbles to [teal.fm](https://teal.fm) |
-| `repo:fm.teal.alpha.actor.status` | now-playing status |
+| `repo:fm.teal.feed.play` | scrobbles to [teal.fm](https://teal.fm) |
+| `repo:fm.teal.actor.status` | now-playing status |
 | `blob:*/*` | upload audio and images |
 
 scopes are requested at authorization time so your PDS knows exactly what plyr.fm is allowed to do.

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -784,7 +784,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 					<div class="setting-info">
 						<h3>teal.fm scrobbling</h3>
 						<p>
-							track your listens as <a href="https://pdsls.dev/at://{auth.user?.did}/fm.teal.alpha.feed.play" target="_blank" rel="noopener">fm.teal.alpha.feed.play</a> records
+							track your listens as <a href="https://pdsls.dev/at://{auth.user?.did}/fm.teal.feed.play" target="_blank" rel="noopener">fm.teal.feed.play</a> records
 						</p>
 					</div>
 					<label class="toggle-switch">


### PR DESCRIPTION
Coauthored by GPT 5.6 Luna

## Summary

- Switch plyr.fm's Teal scrobbling defaults and OAuth scopes to `fm.teal.feed.play` and `fm.teal.actor.status`.
- Emit the canonical URI field names from the production Teal lexicons.
- Update user-facing documentation and regression expectations.

## Behavior and compatibility

plyr.fm is a scrobbling producer, so new writes use the production lexicons. Existing alpha records are not rewritten. Collection names remain configurable through the existing `TEAL_*` environment variables.

## Validation

- Python syntax checks passed for the changed backend modules and tests.
- `git diff --check` passed.
- The repository's contribution guide routes code PRs through the GitHub mirror; this PR targets `zzstoatzz/plyr.fm` accordingly.
- Full pytest/lint could not run because this checkout does not have `pytest` or `uv` installed.

Canonical source: `teal-fm/teal` main after PR #110.
