### PR TITLE
feat: track downloads for public, ungated, unflagged tracks

### DIFF
--- a/backend/alembic/versions/2026_08_13_000000_b3d1a7e42c90_add_allow_downloads_to_user_preferences.py
+++ b/backend/alembic/versions/2026_08_13_000000_b3d1a7e42c90_add_allow_downloads_to_user_preferences.py
@@ -1,0 +1,37 @@
+"""add allow_downloads to user_preferences
+
+Revision ID: b3d1a7e42c90
+Revises: 4aaed6c819f1
+Create Date: 2026-08-13 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b3d1a7e42c90"
+down_revision: str | Sequence[str] | None = "4aaed6c819f1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "user_preferences",
+        sa.Column(
+            "allow_downloads",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("user_preferences", "allow_downloads")

--- a/backend/src/backend/api/audio.py
+++ b/backend/src/backend/api/audio.py
@@ -9,10 +9,14 @@ from sqlalchemy import or_, select
 from backend._internal import Session, get_optional_session, validate_supporter
 from backend._internal.atproto.client import pds_blob_url
 from backend._internal.atproto.spaces.client import SpaceAccessError, open_space_blob
+from backend._internal.content_labels import has_copyright_label
 from backend.config import settings
-from backend.models import Artist, Track
+from backend.models import Artist, Track, UserPreferences
+from backend.models.copyright_scan import CopyrightScan
 from backend.storage import storage
+from backend.storage.keys import AudioKey
 from backend.utilities.database import db_session
+from backend.utilities.downloads import download_filename
 
 # headers worth relaying from the upstream getBlob response so range/seek works
 _PROXY_HEADERS = ("content-type", "content-length", "content-range", "accept-ranges")
@@ -240,6 +244,87 @@ async def _handle_gated_audio(
 
     # R2-backed gated tracks: presigned URL for private bucket
     url = await storage.generate_presigned_url(file_id=file_id, extension=file_type)
+    return RedirectResponse(url=url)
+
+
+@router.get("/{file_id}/download")
+async def download_audio(file_id: str) -> RedirectResponse:
+    """download a track's audio as an attachment named `artist - title.ext`.
+
+    downloads are offered only where the bytes are already publicly
+    reachable (the artist's PDS serves them to anyone): public and unlisted
+    tracks that are not supporter-gated, not copyright-flagged, and whose
+    artist has not switched downloads off. prefers the preserved lossless
+    original over the streaming rendition.
+    """
+    async with db_session() as db:
+        result = await db.execute(
+            select(
+                Track.id,
+                Track.title,
+                Track.file_id,
+                Track.file_type,
+                Track.original_file_id,
+                Track.original_file_type,
+                Track.r2_url,
+                Track.support_gate,
+                Track.is_private,
+                Track.self_labels,
+                Track.operator_labels,
+                Track.moderation_override,
+                Artist.display_name,
+                UserPreferences.allow_downloads,
+            )
+            .join(Artist, Artist.did == Track.artist_did)
+            .outerjoin(UserPreferences, UserPreferences.did == Track.artist_did)
+            .where(or_(Track.file_id == file_id, Track.original_file_id == file_id))
+            .order_by(Track.r2_url.is_not(None).desc(), Track.created_at.desc())
+            .limit(1)
+        )
+        row = result.first()
+
+        if not row:
+            raise HTTPException(status_code=404, detail="audio file not found")
+
+        if row.is_private:
+            raise HTTPException(status_code=404, detail="audio file not found")
+
+        if row.support_gate is not None:
+            raise HTTPException(
+                status_code=403, detail="gated tracks cannot be downloaded"
+            )
+
+        labels = set(row.self_labels or []) | set(row.operator_labels or [])
+        if has_copyright_label(labels) and row.moderation_override != "allow":
+            raise HTTPException(
+                status_code=403, detail="this track is not available for download"
+            )
+
+        flagged = await db.scalar(
+            select(CopyrightScan.is_flagged).where(CopyrightScan.track_id == row.id)
+        )
+        if flagged and row.moderation_override != "allow":
+            raise HTTPException(
+                status_code=403, detail="this track is not available for download"
+            )
+
+        # no preferences row means the artist never changed the default (on)
+        if row.allow_downloads is False:
+            raise HTTPException(
+                status_code=403, detail="the artist has disabled downloads"
+            )
+
+    # prefer the lossless original; its key never comes from r2_url, which
+    # encodes the streaming rendition
+    if row.original_file_id and row.original_file_type:
+        key = AudioKey.for_file(row.original_file_id, row.original_file_type)
+    else:
+        key = AudioKey.for_track(
+            file_id=row.file_id, file_type=row.file_type, r2_url=row.r2_url
+        )
+
+    filename = download_filename(row.display_name, row.title, key.extension)
+    url = await storage.generate_download_url(key=key.key, filename=filename)
     return RedirectResponse(url=url)
 
 

--- a/backend/src/backend/api/audio.py
+++ b/backend/src/backend/api/audio.py
@@ -9,14 +9,15 @@ from sqlalchemy import or_, select
 from backend._internal import Session, get_optional_session, validate_supporter
 from backend._internal.atproto.client import pds_blob_url
 from backend._internal.atproto.spaces.client import SpaceAccessError, open_space_blob
-from backend._internal.content_labels import has_copyright_label
 from backend.config import settings
 from backend.models import Artist, Track, UserPreferences
-from backend.models.copyright_scan import CopyrightScan
 from backend.storage import storage
-from backend.storage.keys import AudioKey
 from backend.utilities.database import db_session
-from backend.utilities.downloads import download_filename
+from backend.utilities.downloads import (
+    download_filename,
+    download_key,
+    download_refusal,
+)
 
 # headers worth relaying from the upstream getBlob response so range/seek works
 _PROXY_HEADERS = ("content-type", "content-length", "content-range", "accept-ranges")
@@ -269,6 +270,7 @@ async def download_audio(file_id: str) -> RedirectResponse:
                 Track.r2_url,
                 Track.support_gate,
                 Track.is_private,
+                Track.audio_storage,
                 Track.self_labels,
                 Track.operator_labels,
                 Track.moderation_override,
@@ -286,42 +288,41 @@ async def download_audio(file_id: str) -> RedirectResponse:
         if not row:
             raise HTTPException(status_code=404, detail="audio file not found")
 
-        if row.is_private:
+    refusal = download_refusal(
+        is_private=row.is_private,
+        support_gate=row.support_gate,
+        labels=set(row.self_labels or []) | set(row.operator_labels or []),
+        moderation_override=row.moderation_override,
+        allow_downloads=row.allow_downloads,
+    )
+    match refusal:
+        case "private":
+            # same shape as a missing file, so private tracks don't leak
             raise HTTPException(status_code=404, detail="audio file not found")
-
-        if row.support_gate is not None:
+        case "gated":
             raise HTTPException(
                 status_code=403, detail="gated tracks cannot be downloaded"
             )
-
-        labels = set(row.self_labels or []) | set(row.operator_labels or [])
-        if has_copyright_label(labels) and row.moderation_override != "allow":
+        case "copyright":
             raise HTTPException(
                 status_code=403, detail="this track is not available for download"
             )
-
-        flagged = await db.scalar(
-            select(CopyrightScan.is_flagged).where(CopyrightScan.track_id == row.id)
-        )
-        if flagged and row.moderation_override != "allow":
-            raise HTTPException(
-                status_code=403, detail="this track is not available for download"
-            )
-
-        # no preferences row means the artist never changed the default (on)
-        if row.allow_downloads is False:
+        case "artist_opt_out":
             raise HTTPException(
                 status_code=403, detail="the artist has disabled downloads"
             )
 
-    # prefer the lossless original; its key never comes from r2_url, which
-    # encodes the streaming rendition
-    if row.original_file_id and row.original_file_type:
-        key = AudioKey.for_file(row.original_file_id, row.original_file_type)
-    else:
-        key = AudioKey.for_track(
-            file_id=row.file_id, file_type=row.file_type, r2_url=row.r2_url
-        )
+    key = download_key(
+        file_id=row.file_id,
+        file_type=row.file_type,
+        original_file_id=row.original_file_id,
+        original_file_type=row.original_file_type,
+        r2_url=row.r2_url,
+        audio_storage=row.audio_storage,
+    )
+    if key is None:
+        # we hold no object to serve as a file (PDS-only or unmirrored ingest)
+        raise HTTPException(status_code=404, detail="no downloadable file")
 
     filename = download_filename(row.display_name, row.title, key.extension)
     url = await storage.generate_download_url(key=key.key, filename=filename)

--- a/backend/src/backend/api/preferences.py
+++ b/backend/src/backend/api/preferences.py
@@ -27,6 +27,7 @@ class PreferencesResponse(BaseModel):
     accent_color: str
     auto_advance: bool
     allow_comments: bool
+    allow_downloads: bool
     hidden_tags: list[str]
     enable_teal_scrobbling: bool
     # indicates if user needs to re-login to activate teal scrobbling
@@ -47,6 +48,7 @@ class PreferencesUpdate(BaseModel):
     accent_color: str | None = None
     auto_advance: bool | None = None
     allow_comments: bool | None = None
+    allow_downloads: bool | None = None
     hidden_tags: list[str] | None = None
     enable_teal_scrobbling: bool | None = None
     show_sensitive_artwork: bool | None = None
@@ -111,6 +113,7 @@ async def get_preferences(
         accent_color=prefs.accent_color,
         auto_advance=prefs.auto_advance,
         allow_comments=prefs.allow_comments,
+        allow_downloads=prefs.allow_downloads,
         hidden_tags=prefs.hidden_tags or [],
         enable_teal_scrobbling=prefs.enable_teal_scrobbling,
         teal_needs_reauth=teal_needs_reauth,
@@ -147,6 +150,9 @@ async def update_preferences(
             allow_comments=update.allow_comments
             if update.allow_comments is not None
             else False,
+            allow_downloads=update.allow_downloads
+            if update.allow_downloads is not None
+            else True,
             hidden_tags=update.hidden_tags
             if update.hidden_tags is not None
             else list(DEFAULT_HIDDEN_TAGS),
@@ -176,6 +182,8 @@ async def update_preferences(
             prefs.auto_advance = update.auto_advance
         if update.allow_comments is not None:
             prefs.allow_comments = update.allow_comments
+        if update.allow_downloads is not None:
+            prefs.allow_downloads = update.allow_downloads
         if update.hidden_tags is not None:
             prefs.hidden_tags = update.hidden_tags
         if update.enable_teal_scrobbling is not None:
@@ -205,6 +213,7 @@ async def update_preferences(
         accent_color=prefs.accent_color,
         auto_advance=prefs.auto_advance,
         allow_comments=prefs.allow_comments,
+        allow_downloads=prefs.allow_downloads,
         hidden_tags=prefs.hidden_tags or [],
         enable_teal_scrobbling=prefs.enable_teal_scrobbling,
         teal_needs_reauth=teal_needs_reauth,

--- a/backend/src/backend/models/artist.py
+++ b/backend/src/backend/models/artist.py
@@ -11,6 +11,7 @@ from backend.models.database import Base
 if TYPE_CHECKING:
     from backend.models.album import Album
     from backend.models.playlist import Playlist
+    from backend.models.preferences import UserPreferences
     from backend.models.track import Track
 
 
@@ -58,6 +59,17 @@ class Artist(Base):
 
     # relationships
     tracks: Mapped[list["Track"]] = relationship("Track", back_populates="artist")
+    # one-to-one with UserPreferences, which shares the DID as its primary key
+    # but declares no FK column — hence the explicit join. selectin-loaded so
+    # any query that loads an Artist (eagerly or not) can read policy flags
+    # like allow_downloads without a per-row query.
+    preferences: Mapped["UserPreferences | None"] = relationship(
+        "UserPreferences",
+        primaryjoin="Artist.did == foreign(UserPreferences.did)",
+        uselist=False,
+        viewonly=True,
+        lazy="selectin",
+    )
     albums: Mapped[list["Album"]] = relationship("Album", back_populates="artist")
     playlists: Mapped[list["Playlist"]] = relationship(
         "Playlist", back_populates="owner"

--- a/backend/src/backend/models/preferences.py
+++ b/backend/src/backend/models/preferences.py
@@ -32,6 +32,13 @@ class UserPreferences(Base):
         Boolean, nullable=False, default=False, server_default=text("false")
     )
 
+    # when enabled (the default), listeners may download this artist's public,
+    # ungated, unflagged tracks. the bytes are already publicly reachable via
+    # the artist's PDS, so this is a courtesy switch, not an access control.
+    allow_downloads: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=text("true")
+    )
+
     # tag filtering preferences
     # stores a list of tag names that should be hidden from track listings
     # defaults to ["ai"] to hide AI-generated content by default

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -5,10 +5,10 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from backend._internal.atproto.client import parse_at_uri
-from backend._internal.content_labels import has_copyright_label
 from backend.config import settings
 from backend.models import Album, Track
 from backend.utilities.aggregations import CopyrightInfo
+from backend.utilities.downloads import download_key, download_refusal
 
 # --- common simple response types ---
 
@@ -276,17 +276,28 @@ class TrackResponse(BaseModel):
                 f"{settings.atproto.base_url.rstrip('/')}/audio/{track.file_id}"
             )
 
-        # mirror the download endpoint's policy so the UI only offers what the
-        # endpoint would serve (the artist relationship selectin-loads prefs)
+        # the download endpoint derives from the same policy function, so the
+        # UI only offers what the endpoint would serve (the artist relationship
+        # selectin-loads prefs)
         artist_prefs = track.artist.preferences
-        copyright_blocked = (
-            has_copyright_label(labels) or bool(copyright_flagged)
-        ) and track.moderation_override != "allow"
         downloadable = (
-            not track.is_private
-            and track.support_gate is None
-            and not copyright_blocked
-            and (artist_prefs is None or artist_prefs.allow_downloads)
+            download_refusal(
+                is_private=track.is_private,
+                support_gate=track.support_gate,
+                labels=labels,
+                moderation_override=track.moderation_override,
+                allow_downloads=artist_prefs.allow_downloads if artist_prefs else None,
+            )
+            is None
+            and download_key(
+                file_id=track.file_id,
+                file_type=track.file_type,
+                original_file_id=track.original_file_id,
+                original_file_type=track.original_file_type,
+                r2_url=track.r2_url,
+                audio_storage=track.audio_storage,
+            )
+            is not None
         )
 
         return cls(

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from backend._internal.atproto.client import parse_at_uri
+from backend._internal.content_labels import has_copyright_label
 from backend.config import settings
 from backend.models import Album, Track
 from backend.utilities.aggregations import CopyrightInfo
@@ -144,6 +145,9 @@ class TrackResponse(BaseModel):
     copyright_match: str | None = None  # "Title by Artist" of primary match
     support_gate: dict[str, Any] | None = None  # supporter gating config
     gated: bool = False  # true if track is gated AND viewer lacks access
+    # true when the download endpoint would hand this track out: public,
+    # ungated, not copyright-blocked, and the artist hasn't disabled downloads
+    downloadable: bool = False
     # indiemusi rights record pointers (set when this track has copyright metadata)
     copyright_song_uri: str | None = None
     copyright_recording_uri: str | None = None
@@ -272,6 +276,19 @@ class TrackResponse(BaseModel):
                 f"{settings.atproto.base_url.rstrip('/')}/audio/{track.file_id}"
             )
 
+        # mirror the download endpoint's policy so the UI only offers what the
+        # endpoint would serve (the artist relationship selectin-loads prefs)
+        artist_prefs = track.artist.preferences
+        copyright_blocked = (
+            has_copyright_label(labels) or bool(copyright_flagged)
+        ) and track.moderation_override != "allow"
+        downloadable = (
+            not track.is_private
+            and track.support_gate is None
+            and not copyright_blocked
+            and (artist_prefs is None or artist_prefs.allow_downloads)
+        )
+
         return cls(
             id=track.id,
             title=track.title,
@@ -299,6 +316,7 @@ class TrackResponse(BaseModel):
             copyright_match=copyright_match,
             support_gate=track.support_gate,
             gated=gated,
+            downloadable=downloadable,
             description=track.description,
             original_file_id=track.original_file_id,
             original_file_type=track.original_file_type,

--- a/backend/src/backend/storage/protocol.py
+++ b/backend/src/backend/storage/protocol.py
@@ -89,6 +89,21 @@ class StorageProtocol(Protocol):
         expires_in: int | None = None,
     ) -> str: ...
 
+    async def generate_download_url(
+        self,
+        *,
+        key: str,
+        filename: str,
+        expires_in: int | None = None,
+    ) -> str:
+        """presigned public-bucket URL that downloads as ``filename``.
+
+        the attachment disposition is carried by the signed
+        ``response-content-disposition`` param, so the object itself and its
+        streaming (inline) URL are untouched.
+        """
+        ...
+
     async def move_audio(
         self,
         file_id: str,

--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -23,6 +23,7 @@ from backend.models.track import Track
 from backend.storage.keys import AudioKey, ImageKey, InvalidMediaExtension
 from backend.utilities.audio_formats import AudioFormat
 from backend.utilities.database import db_session
+from backend.utilities.downloads import content_disposition
 from backend.utilities.hashing import hash_file_chunked
 
 # default chunk size for streaming reads. 1MB matches aiobotocore's default
@@ -856,6 +857,34 @@ class R2Storage:
                     expires_in=expiry,
                 )
                 return url
+
+    async def generate_download_url(
+        self,
+        *,
+        key: str,
+        filename: str,
+        expires_in: int | None = None,
+    ) -> str:
+        """presigned public-bucket URL that downloads as ``filename``.
+
+        the object is publicly readable anyway; presigning exists only to carry
+        a signed ``response-content-disposition`` so the browser saves the file
+        under a human filename instead of the content-hash key.
+        """
+        expiry = expires_in or self.presigned_url_expiry
+        with logfire.span("R2 generate_download_url", key=key, expires_in=expiry):
+            async with self._s3_client(
+                config=Config(signature_version="s3v4"),
+            ) as client:
+                return await client.generate_presigned_url(
+                    "get_object",
+                    Params={
+                        "Bucket": self.audio_bucket_name,
+                        "Key": key,
+                        "ResponseContentDisposition": content_disposition(filename),
+                    },
+                    ExpiresIn=expiry,
+                )
 
     def build_image_url(self, image_id: str, ext: str) -> str:
         """construct public image URL without HEAD checks."""

--- a/backend/src/backend/utilities/downloads.py
+++ b/backend/src/backend/utilities/downloads.py
@@ -1,6 +1,79 @@
 """helpers for user-facing file downloads."""
 
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any, Literal, TypeAlias
 from urllib.parse import quote
+
+from backend._internal.content_labels import has_copyright_label
+from backend.storage.keys import AudioKey, InvalidMediaExtension
+
+DownloadRefusal: TypeAlias = Literal["private", "gated", "copyright", "artist_opt_out"]
+
+# a file_id minted by our upload path: sha256 truncated to 16 hex chars.
+# anything else (e.g. a record rkey) came from the firehose and names nothing
+# in our bucket — see _internal/CLAUDE.md and #1811.
+_UPLOAD_FILE_ID = re.compile(r"[0-9a-f]{16}")
+
+
+def download_key(
+    *,
+    file_id: str,
+    file_type: str | None,
+    original_file_id: str | None,
+    original_file_type: str | None,
+    r2_url: str | None,
+    audio_storage: str,
+) -> AudioKey | None:
+    """the public-bucket key a download would serve, or None if we hold none.
+
+    None for PDS-only rows (the R2 copy is gone or never existed — a PDS
+    getBlob URL can't carry a filename disposition) and for firehose-ingested
+    rows that were never mirrored (their `file_id` is an author-supplied rkey
+    and their `r2_url` names someone else's origin). presigning without this
+    check "succeeds" and hands the listener a NoSuchKey error body.
+    """
+    if audio_storage == "pds":
+        return None
+    try:
+        if original_file_id and original_file_type:
+            return AudioKey.for_file(original_file_id, original_file_type)
+        if r2_url and (from_url := AudioKey.from_url(r2_url)):
+            return from_url
+        if file_type and _UPLOAD_FILE_ID.fullmatch(file_id):
+            return AudioKey.for_file(file_id, file_type)
+    except InvalidMediaExtension:
+        return None
+    return None
+
+
+def download_refusal(
+    *,
+    is_private: bool,
+    support_gate: Mapping[str, Any] | None,
+    labels: Iterable[str],
+    moderation_override: str | None,
+    allow_downloads: bool | None,
+) -> DownloadRefusal | None:
+    """single source of the download policy; None means downloadable.
+
+    both the download endpoint and TrackResponse.downloadable derive from this,
+    so the UI never offers what the endpoint would refuse. keyed on the
+    copyright *label* — the decided moderation state that discovery, radio,
+    and streaming already filter on — never raw scan flags, which mark a
+    pending review, not a finding. `allow_downloads=None` means the artist has
+    no preferences row, i.e. the default (on).
+    """
+    if is_private:
+        return "private"
+    if support_gate is not None:
+        return "gated"
+    if has_copyright_label(labels) and moderation_override != "allow":
+        return "copyright"
+    if allow_downloads is False:
+        return "artist_opt_out"
+    return None
+
 
 # characters that break filesystems or the quoted-string header grammar
 _UNSAFE = set('\\/:*?"<>|')

--- a/backend/src/backend/utilities/downloads.py
+++ b/backend/src/backend/utilities/downloads.py
@@ -1,0 +1,25 @@
+"""helpers for user-facing file downloads."""
+
+from urllib.parse import quote
+
+# characters that break filesystems or the quoted-string header grammar
+_UNSAFE = set('\\/:*?"<>|')
+
+
+def download_filename(artist: str, title: str, extension: str) -> str:
+    """build `artist - title.ext`, safe for filesystems."""
+    stem = f"{artist} - {title}" if artist else title
+    cleaned = "".join(c for c in stem if c not in _UNSAFE and c.isprintable())
+    cleaned = " ".join(cleaned.split()).strip(". ") or "track"
+    return f"{cleaned}.{extension}"
+
+
+def content_disposition(filename: str) -> str:
+    """RFC 6266 attachment disposition with a unicode-capable filename*.
+
+    the plain `filename` parameter is ascii-only for old clients; `filename*`
+    carries the real name percent-encoded as UTF-8 and wins where supported.
+    """
+    ascii_name = filename.encode("ascii", "replace").decode("ascii")
+    utf8_name = quote(filename, safe="")
+    return f"attachment; filename=\"{ascii_name}\"; filename*=UTF-8''{utf8_name}"

--- a/backend/tests/api/test_audio_download.py
+++ b/backend/tests/api/test_audio_download.py
@@ -32,9 +32,8 @@ async def _make_track(db_session: AsyncSession, **overrides) -> Track:
     fields = {
         "title": "My Song",
         "artist_did": artist.did,
-        "file_id": "dl1234",
+        "file_id": "aabbccddeeff0011",
         "file_type": "mp3",
-        "r2_url": "https://cdn.example.com/audio/dl1234.mp3",
     } | overrides
     track = Track(**fields)
     db_session.add(track)
@@ -66,7 +65,7 @@ async def test_download_public_track_redirects_with_filename(
     assert response.status_code == 307
     assert response.headers["location"] == "https://r2.example.com/signed"
     mock_storage.generate_download_url.assert_awaited_once_with(
-        key="audio/dl1234.mp3", filename="Download Artist - My Song.mp3"
+        key="audio/aabbccddeeff0011.mp3", filename="Download Artist - My Song.mp3"
     )
 
 
@@ -75,7 +74,7 @@ async def test_download_prefers_lossless_original(
 ):
     track = await _make_track(
         db_session,
-        original_file_id="orig9999",
+        original_file_id="ccddeeff00112233",
         original_file_type="flac",
     )
 
@@ -87,7 +86,7 @@ async def test_download_prefers_lossless_original(
 
     assert response.status_code == 307
     mock_storage.generate_download_url.assert_awaited_once_with(
-        key="audio/orig9999.flac", filename="Download Artist - My Song.flac"
+        key="audio/ccddeeff00112233.flac", filename="Download Artist - My Song.flac"
     )
 
 
@@ -125,15 +124,23 @@ async def test_download_allows_copyright_label_with_allow_override(
     assert response.status_code == 307
 
 
-async def test_download_refuses_scan_flagged_track(
+async def test_scan_flag_alone_does_not_block_downloads(
     test_app: FastAPI, db_session: AsyncSession
 ):
+    """a fingerprint match is a pending review, not a finding — policy keys on
+    the copyright label, matching discovery/radio/streaming (#1697)."""
     track = await _make_track(db_session)
     db_session.add(CopyrightScan(track_id=track.id, is_flagged=True))
     await db_session.commit()
 
-    response = await _download(test_app, track.file_id)
-    assert response.status_code == 403
+    mock_storage = MagicMock()
+    mock_storage.generate_download_url = AsyncMock(return_value="https://signed")
+
+    with patch("backend.api.audio.storage", mock_storage):
+        response = await _download(test_app, track.file_id)
+
+    assert response.status_code == 307
+    assert (await _response_for(db_session, track.id)).downloadable is True
 
 
 async def test_download_refuses_when_artist_disabled_downloads(
@@ -154,7 +161,6 @@ async def test_download_refuses_private_track(
     track = await _make_track(
         db_session,
         visibility="private",
-        r2_url=None,
         space_uri="at://did:plc:dlartist/space/media/abc",
     )
     response = await _download(test_app, track.file_id)
@@ -215,11 +221,36 @@ async def test_track_response_not_downloadable_when_gated_or_labeled(
     labeled = await _make_track(
         db_session,
         artist_did="did:plc:dlartist2",
-        file_id="dl5678",
-        r2_url="https://cdn.example.com/audio/dl5678.mp3",
+        file_id="aabbccddeeff0022",
         operator_labels=["copyright-violation"],
     )
     gated_id, labeled_id = gated.id, labeled.id
 
     assert (await _response_for(db_session, gated_id)).downloadable is False
     assert (await _response_for(db_session, labeled_id)).downloadable is False
+
+
+async def test_download_refuses_when_no_object_is_ours_to_serve(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    """pds-only rows and unmirrored ingested rows must 404, not 307 to a
+    presigned URL for a key that names nothing (NoSuchKey error body)."""
+    pds_only = await _make_track(
+        db_session,
+        audio_storage="pds",
+        pds_blob_cid="bafyfake",
+    )
+    ingested = await _make_track(
+        db_session,
+        artist_did="did:plc:dlartist3",
+        file_id="3jzfcijpj2z2a",  # a record rkey, not our content hash
+        r2_url="https://someone-elses.example.com/audio/whatever.mp3",
+    )
+    pds_only_id, ingested_id = pds_only.id, ingested.id
+
+    for track in (pds_only, ingested):
+        response = await _download(test_app, track.file_id)
+        assert response.status_code == 404
+
+    assert (await _response_for(db_session, pds_only_id)).downloadable is False
+    assert (await _response_for(db_session, ingested_id)).downloadable is False

--- a/backend/tests/api/test_audio_download.py
+++ b/backend/tests/api/test_audio_download.py
@@ -5,10 +5,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from backend.main import app
 from backend.models import Artist, CopyrightScan, Track, UserPreferences
+from backend.schemas import TrackResponse
 from backend.utilities.downloads import content_disposition, download_filename
 
 
@@ -173,3 +176,50 @@ def test_content_disposition_carries_unicode():
     value = content_disposition("héllo.mp3")
     assert value.startswith('attachment; filename="h?llo.mp3"')
     assert "filename*=UTF-8''h%C3%A9llo.mp3" in value
+
+
+async def _response_for(db_session: AsyncSession, track_id: int) -> TrackResponse:
+    """rebuild the track through a fresh ORM query, the way endpoints do."""
+    db_session.expire_all()
+    result = await db_session.execute(
+        select(Track)
+        .where(Track.id == track_id)
+        .options(selectinload(Track.artist), selectinload(Track.album_rel))
+    )
+    return await TrackResponse.from_track(result.scalar_one())
+
+
+async def test_track_response_downloadable_by_default(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    track = await _make_track(db_session)
+    response = await _response_for(db_session, track.id)
+    assert response.downloadable is True
+
+
+async def test_track_response_not_downloadable_when_artist_opted_out(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    track = await _make_track(db_session)
+    db_session.add(UserPreferences(did=track.artist_did, allow_downloads=False))
+    await db_session.commit()
+
+    response = await _response_for(db_session, track.id)
+    assert response.downloadable is False
+
+
+async def test_track_response_not_downloadable_when_gated_or_labeled(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    gated = await _make_track(db_session, support_gate={"type": "any"})
+    labeled = await _make_track(
+        db_session,
+        artist_did="did:plc:dlartist2",
+        file_id="dl5678",
+        r2_url="https://cdn.example.com/audio/dl5678.mp3",
+        operator_labels=["copyright-violation"],
+    )
+    gated_id, labeled_id = gated.id, labeled.id
+
+    assert (await _response_for(db_session, gated_id)).downloadable is False
+    assert (await _response_for(db_session, labeled_id)).downloadable is False

--- a/backend/tests/api/test_audio_download.py
+++ b/backend/tests/api/test_audio_download.py
@@ -1,0 +1,175 @@
+"""tests for the audio download endpoint."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.main import app
+from backend.models import Artist, CopyrightScan, Track, UserPreferences
+from backend.utilities.downloads import content_disposition, download_filename
+
+
+@pytest.fixture
+def test_app() -> FastAPI:
+    return app
+
+
+async def _make_track(db_session: AsyncSession, **overrides) -> Track:
+    artist = Artist(
+        did=overrides.pop("artist_did", "did:plc:dlartist"),
+        handle="dlartist.bsky.social",
+        display_name="Download Artist",
+    )
+    db_session.add(artist)
+    await db_session.flush()
+
+    fields = {
+        "title": "My Song",
+        "artist_did": artist.did,
+        "file_id": "dl1234",
+        "file_type": "mp3",
+        "r2_url": "https://cdn.example.com/audio/dl1234.mp3",
+    } | overrides
+    track = Track(**fields)
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+    return track
+
+
+async def _download(test_app: FastAPI, file_id: str):
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        return await client.get(f"/audio/{file_id}/download", follow_redirects=False)
+
+
+async def test_download_public_track_redirects_with_filename(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    track = await _make_track(db_session)
+
+    mock_storage = MagicMock()
+    mock_storage.generate_download_url = AsyncMock(
+        return_value="https://r2.example.com/signed"
+    )
+
+    with patch("backend.api.audio.storage", mock_storage):
+        response = await _download(test_app, track.file_id)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "https://r2.example.com/signed"
+    mock_storage.generate_download_url.assert_awaited_once_with(
+        key="audio/dl1234.mp3", filename="Download Artist - My Song.mp3"
+    )
+
+
+async def test_download_prefers_lossless_original(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    track = await _make_track(
+        db_session,
+        original_file_id="orig9999",
+        original_file_type="flac",
+    )
+
+    mock_storage = MagicMock()
+    mock_storage.generate_download_url = AsyncMock(return_value="https://signed")
+
+    with patch("backend.api.audio.storage", mock_storage):
+        response = await _download(test_app, track.file_id)
+
+    assert response.status_code == 307
+    mock_storage.generate_download_url.assert_awaited_once_with(
+        key="audio/orig9999.flac", filename="Download Artist - My Song.flac"
+    )
+
+
+async def test_download_refuses_gated_track(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    track = await _make_track(db_session, support_gate={"type": "any"})
+    response = await _download(test_app, track.file_id)
+    assert response.status_code == 403
+
+
+async def test_download_refuses_copyright_labeled_track(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    track = await _make_track(db_session, operator_labels=["copyright-violation"])
+    response = await _download(test_app, track.file_id)
+    assert response.status_code == 403
+
+
+async def test_download_allows_copyright_label_with_allow_override(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    track = await _make_track(
+        db_session,
+        operator_labels=["copyright-violation"],
+        moderation_override="allow",
+    )
+
+    mock_storage = MagicMock()
+    mock_storage.generate_download_url = AsyncMock(return_value="https://signed")
+
+    with patch("backend.api.audio.storage", mock_storage):
+        response = await _download(test_app, track.file_id)
+
+    assert response.status_code == 307
+
+
+async def test_download_refuses_scan_flagged_track(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    track = await _make_track(db_session)
+    db_session.add(CopyrightScan(track_id=track.id, is_flagged=True))
+    await db_session.commit()
+
+    response = await _download(test_app, track.file_id)
+    assert response.status_code == 403
+
+
+async def test_download_refuses_when_artist_disabled_downloads(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    track = await _make_track(db_session)
+    db_session.add(UserPreferences(did=track.artist_did, allow_downloads=False))
+    await db_session.commit()
+
+    response = await _download(test_app, track.file_id)
+    assert response.status_code == 403
+    assert "disabled downloads" in response.json()["detail"]
+
+
+async def test_download_refuses_private_track(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    track = await _make_track(
+        db_session,
+        visibility="private",
+        r2_url=None,
+        space_uri="at://did:plc:dlartist/space/media/abc",
+    )
+    response = await _download(test_app, track.file_id)
+    assert response.status_code == 404
+
+
+async def test_download_unknown_file_404(test_app: FastAPI, db_session: AsyncSession):
+    response = await _download(test_app, "nope-not-real")
+    assert response.status_code == 404
+
+
+def test_download_filename_sanitizes():
+    assert download_filename("A/B", 'so:ng "quoted"', "mp3") == "AB - song quoted.mp3"
+    assert download_filename("", "solo", "flac") == "solo.flac"
+    assert download_filename("x", "...", "mp3") == "x -.mp3"
+
+
+def test_content_disposition_carries_unicode():
+    value = content_disposition("héllo.mp3")
+    assert value.startswith('attachment; filename="h?llo.mp3"')
+    assert "filename*=UTF-8''h%C3%A9llo.mp3" in value

--- a/frontend/src/lib/components/DownloadButton.svelte
+++ b/frontend/src/lib/components/DownloadButton.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import { downloadTrack } from '$lib/downloads';
+
+	interface Props {
+		fileId: string;
+		title?: string;
+	}
+
+	let { fileId, title = 'download audio file' }: Props = $props();
+</script>
+
+<button class="download-btn" onclick={() => downloadTrack(fileId)} {title}>
+	<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+		<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+		<polyline points="7 10 12 15 17 10"></polyline>
+		<line x1="12" y1="15" x2="12" y2="3"></line>
+	</svg>
+</button>
+
+<style>
+	.download-btn {
+		background: var(--glass-btn-bg, transparent);
+		border: 1px solid var(--glass-btn-border, var(--border-default));
+		border-radius: var(--radius-base);
+		width: 32px;
+		height: 32px;
+		padding: 0;
+		color: var(--text-tertiary);
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		transition: all 0.2s;
+	}
+
+	.download-btn:hover {
+		background: var(--glass-btn-bg-hover, transparent);
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+</style>

--- a/frontend/src/lib/components/TrackActionsMenu.svelte
+++ b/frontend/src/lib/components/TrackActionsMenu.svelte
@@ -2,6 +2,7 @@
 	import { likeTrack, unlikeTrack } from '$lib/tracks.svelte';
 	import { toast } from '$lib/toast.svelte';
 	import { API_URL } from '$lib/config';
+	import { downloadTrack } from '$lib/downloads';
 	import type { Playlist } from '$lib/types';
 
 	interface Props {
@@ -11,6 +12,7 @@
 		trackCid?: string;
 		fileId?: string;
 		gated?: boolean;
+		downloadable?: boolean;
 		initialLiked: boolean;
 		shareUrl: string;
 		onQueue: () => void;
@@ -26,6 +28,7 @@
 		trackCid,
 		fileId,
 		gated,
+		downloadable = false,
 		initialLiked,
 		shareUrl,
 		onQueue,
@@ -202,6 +205,13 @@
 		}
 	}
 
+	async function handleDownload(e: Event) {
+		e.stopPropagation();
+		if (!fileId) return;
+		await downloadTrack(fileId);
+		closeMenu();
+	}
+
 	function goBack(e: Event) {
 		e.stopPropagation();
 		if (showCreateForm) {
@@ -321,6 +331,16 @@
 					</svg>
 					<span>share</span>
 				</button>
+				{#if downloadable && fileId}
+					<button class="menu-item" onclick={handleDownload}>
+						<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+							<polyline points="7 10 12 15 17 10"></polyline>
+							<line x1="12" y1="15" x2="12" y2="3"></line>
+						</svg>
+						<span>download</span>
+					</button>
+				{/if}
 			{:else}
 				<div class="playlist-picker">
 					<button class="back-button" onclick={goBack}>

--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -440,6 +440,7 @@
 				trackCid={track.atproto_record_cid}
 				fileId={track.file_id}
 				gated={track.gated}
+				downloadable={!track.gated && !track.copyright_flagged}
 				initialLiked={track.is_liked || false}
 				shareUrl={shareUrl}
 				onQueue={handleQueue}

--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -440,7 +440,7 @@
 				trackCid={track.atproto_record_cid}
 				fileId={track.file_id}
 				gated={track.gated}
-				downloadable={!track.gated && !track.copyright_flagged}
+				downloadable={track.downloadable ?? false}
 				initialLiked={track.is_liked || false}
 				shareUrl={shareUrl}
 				onQueue={handleQueue}

--- a/frontend/src/lib/downloads.ts
+++ b/frontend/src/lib/downloads.ts
@@ -1,0 +1,23 @@
+import { API_URL } from '$lib/config';
+import { toast } from '$lib/toast.svelte';
+
+/**
+ * trigger a file download of a track's audio via the backend download
+ * endpoint, which redirects to a presigned URL with an attachment
+ * disposition. probes first (without following the redirect) so a refusal
+ * surfaces as a toast instead of navigating to a JSON error body.
+ */
+export async function downloadTrack(fileId: string): Promise<void> {
+	const url = `${API_URL}/audio/${fileId}/download`;
+	try {
+		const probe = await fetch(url, { credentials: 'include', redirect: 'manual' });
+		if (probe.type === 'opaqueredirect' || probe.ok) {
+			window.location.assign(url);
+			return;
+		}
+		const data = await probe.json().catch(() => ({}));
+		toast.error(data.detail || 'download unavailable');
+	} catch {
+		toast.error('download failed');
+	}
+}

--- a/frontend/src/lib/preferences.svelte.ts
+++ b/frontend/src/lib/preferences.svelte.ts
@@ -52,6 +52,7 @@ export interface Preferences {
 	accent_color: string | null;
 	auto_advance: boolean;
 	allow_comments: boolean;
+	allow_downloads: boolean;
 	hidden_tags: string[];
 	theme: Theme;
 	enable_teal_scrobbling: boolean;
@@ -69,6 +70,7 @@ const DEFAULT_PREFERENCES: Preferences = {
 	accent_color: null,
 	auto_advance: true,
 	allow_comments: true,
+	allow_downloads: true,
 	hidden_tags: ['ai', 'ai-slop', 'suno'],
 	theme: 'dark',
 	enable_teal_scrobbling: false,
@@ -113,6 +115,10 @@ class PreferencesManager {
 
 	get allowComments(): boolean {
 		return this.data?.allow_comments ?? DEFAULT_PREFERENCES.allow_comments;
+	}
+
+	get allowDownloads(): boolean {
+		return this.data?.allow_downloads ?? DEFAULT_PREFERENCES.allow_downloads;
 	}
 
 	get theme(): Theme {
@@ -273,6 +279,7 @@ class PreferencesManager {
 					accent_color: data.accent_color ?? null,
 					auto_advance: data.auto_advance ?? DEFAULT_PREFERENCES.auto_advance,
 					allow_comments: data.allow_comments ?? DEFAULT_PREFERENCES.allow_comments,
+				allow_downloads: data.allow_downloads ?? DEFAULT_PREFERENCES.allow_downloads,
 					hidden_tags: data.hidden_tags ?? DEFAULT_PREFERENCES.hidden_tags,
 					theme: serverTheme,
 					enable_teal_scrobbling: data.enable_teal_scrobbling ?? DEFAULT_PREFERENCES.enable_teal_scrobbling,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -56,6 +56,7 @@ export interface Track {
 	thumbnail_url?: string;
 	is_liked?: boolean;
 	copyright_flagged?: boolean | null; // null = not scanned, false = clear, true = flagged
+	downloadable?: boolean; // server-computed: the download endpoint would serve this track
 	copyright_match?: string | null; // "Title by Artist" of primary match
 	labels?: string[]; // active ATProto moderation labels on the track record
 	self_labels?: string[]; // creator-published ATProto content warnings

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -18,6 +18,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 
 	// derive from preferences store
 	let allowComments = $derived(preferences.allowComments);
+	let allowDownloads = $derived(preferences.allowDownloads);
 	let enableTealScrobbling = $derived(preferences.enableTealScrobbling);
 	let tealNeedsReauth = $derived(preferences.tealNeedsReauth);
 	let showSensitiveArtwork = $derived(preferences.showSensitiveArtwork);
@@ -281,6 +282,16 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		try {
 			await preferences.update({ allow_comments: enabled });
 			toast.success(enabled ? 'comments enabled on your tracks' : 'comments disabled');
+		} catch (_e) {
+			console.error('failed to save preference:', _e);
+			toast.error('failed to update preference');
+		}
+	}
+
+	async function saveAllowDownloads(enabled: boolean) {
+		try {
+			await preferences.update({ allow_downloads: enabled });
+			toast.success(enabled ? 'downloads enabled on your tracks' : 'downloads disabled');
 		} catch (_e) {
 			console.error('failed to save preference:', _e);
 			toast.error('failed to update preference');
@@ -754,6 +765,21 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 							type="checkbox"
 							checked={allowComments}
 							onchange={(e) => saveAllowComments((e.target as HTMLInputElement).checked)}
+						/>
+						<span class="toggle-slider"></span>
+					</label>
+				</div>
+
+				<div class="setting-row">
+					<div class="setting-info">
+						<h3>downloads</h3>
+						<p>let listeners download your public, ungated tracks as files</p>
+					</div>
+					<label class="toggle-switch">
+						<input
+							type="checkbox"
+							checked={allowDownloads}
+							onchange={(e) => saveAllowDownloads((e.target as HTMLInputElement).checked)}
 						/>
 						<span class="toggle-slider"></span>
 					</label>

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -15,6 +15,7 @@
 	import LosslessBadge from '$lib/components/LosslessBadge.svelte';
 	import RichText from '$lib/components/RichText.svelte';
 	import ShareButton from '$lib/components/ShareButton.svelte';
+	import { downloadTrack } from '$lib/downloads';
 	import { moderation } from '$lib/moderation.svelte';
 	import { player } from '$lib/player.svelte';
 	import { queue } from '$lib/queue.svelte';
@@ -777,6 +778,16 @@ $effect(() => {
 							</svg>
 							add to queue
 						</button>
+						{#if !track.gated && !track.copyright_flagged}
+							<button class="btn-queue" onclick={() => track && downloadTrack(track.file_id)} title="download audio file">
+								<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+									<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+									<polyline points="7 10 12 15 17 10"></polyline>
+									<line x1="12" y1="15" x2="12" y2="3"></line>
+								</svg>
+								download
+							</button>
+						{/if}
 					</div>
 				</div>
 			</div>

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -15,7 +15,7 @@
 	import LosslessBadge from '$lib/components/LosslessBadge.svelte';
 	import RichText from '$lib/components/RichText.svelte';
 	import ShareButton from '$lib/components/ShareButton.svelte';
-	import { downloadTrack } from '$lib/downloads';
+	import DownloadButton from '$lib/components/DownloadButton.svelte';
 	import { moderation } from '$lib/moderation.svelte';
 	import { player } from '$lib/player.svelte';
 	import { queue } from '$lib/queue.svelte';
@@ -751,6 +751,9 @@ $effect(() => {
 							/>
 						{/if}
 						<ShareButton url={shareUrl} title="share track" trackId={track.id} />
+							{#if track.downloadable}
+								<DownloadButton fileId={track.file_id} />
+							{/if}
 					</div>
 
 					<!-- actions -->
@@ -778,16 +781,6 @@ $effect(() => {
 							</svg>
 							add to queue
 						</button>
-						{#if track.downloadable}
-							<button class="btn-queue" onclick={() => track && downloadTrack(track.file_id)} title="download audio file">
-								<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-									<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-									<polyline points="7 10 12 15 17 10"></polyline>
-									<line x1="12" y1="15" x2="12" y2="3"></line>
-								</svg>
-								download
-							</button>
-						{/if}
 					</div>
 				</div>
 			</div>

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -778,7 +778,7 @@ $effect(() => {
 							</svg>
 							add to queue
 						</button>
-						{#if !track.gated && !track.copyright_flagged}
+						{#if track.downloadable}
 							<button class="btn-queue" onclick={() => track && downloadTrack(track.file_id)} title="download audio file">
 								<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 									<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>

--- a/loq.toml
+++ b/loq.toml
@@ -47,7 +47,7 @@ max_lines = 1266
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
-max_lines = 952
+max_lines = 981
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"
@@ -111,7 +111,7 @@ max_lines = 627
 
 [[rules]]
 path = "frontend/src/lib/components/TrackActionsMenu.svelte"
-max_lines = 777
+max_lines = 797
 
 [[rules]]
 path = "frontend/src/lib/components/TrackItem.svelte"
@@ -159,7 +159,7 @@ max_lines = 3961
 
 [[rules]]
 path = "frontend/src/routes/settings/+page.svelte"
-max_lines = 1788
+max_lines = 1814
 
 [[rules]]
 path = "frontend/src/routes/track/\\[id\\]/+page.svelte"
@@ -339,7 +339,7 @@ max_lines = 509
 
 [[rules]]
 path = "frontend/src/routes/track/[[]id[]]/+page.svelte"
-max_lines = 1793
+max_lines = 1804
 
 [[rules]]
 path = "frontend/src/lib/components/playlist/PlaylistTrackList.svelte"
@@ -368,3 +368,7 @@ max_lines = 586
 [[rules]]
 path = "frontend/src/routes/atlas/renderer.ts"
 max_lines = 1178
+
+[[rules]]
+path = "backend/src/backend/api/audio.py"
+max_lines = 509

--- a/loq.toml
+++ b/loq.toml
@@ -371,4 +371,4 @@ max_lines = 1178
 
 [[rules]]
 path = "backend/src/backend/api/audio.py"
-max_lines = 509
+max_lines = 510


### PR DESCRIPTION
listeners can now download a track's audio file — anything public, ungated, and un-flagged — with an artist opt-out toggle that defaults to on, since the same bytes are already served unauthenticated by the artist's own PDS.

## motivation

a community member asked for downloads to support a community event (signal thread, Aug 13). the agreed shape: downloadable by default for anything that isn't gated or copyrighted, with an optional artist toggle.

## design

- **one policy, two consumers**: `utilities/downloads.py` owns `download_refusal()` (private / gated / copyright / artist opt-out) and `download_key()` (which public-bucket object, if any, we actually hold). the endpoint and `TrackResponse.downloadable` both derive from these, so the UI can never offer what the endpoint would refuse — no drift by construction.
- **`GET /audio/{file_id}/download`** looks the track up by `file_id` *or* `original_file_id` (same query shape as `stream_audio`), maps a refusal to 403/404, then 307s to a presigned public-bucket URL carrying a signed `response-content-disposition: attachment; filename="artist - title.ext"` (RFC 6266, with UTF-8 `filename*`). the object and its normal streaming URL are untouched.
- **prefers the preserved lossless original** when one exists. `download_key` refuses (404, button hidden) when we hold nothing to serve: PDS-only rows and unmirrored firehose-ingested rows (author-supplied rkey `file_id`, foreign `r2_url` — the #1811 family) would otherwise get a presigned URL to a nonexistent key.
- **copyright policy keys on the label, not scan flags**: the label is the decided moderation state that discovery, radio, and streaming already filter on (#1697); a fingerprint match is a pending review, not a finding. `moderation_override == "allow"` is honored. this is deliberately consistent with every other surface — a scan-flagged-but-undecided track streams today and downloads today.
- **`allow_downloads`** is a real boolean column on `user_preferences` (a policy, like `allow_comments`), `server_default true`; read via a selectin-loaded one-to-one `Artist.preferences` relationship — one batched query per artist-load operation, not per row.
- **frontend**: track-page button, mobile `TrackActionsMenu` item, and settings toggle, all rendered from the server-computed `track.downloadable` alone. the endpoint's refusals remain as enforcement for stale clients.

## deferred scope / intentional non-behaviors

- **gated tracks never download**, even for the artist or validated supporters — "pay to download" is a later, deliberate extension per the signal thread.
- no per-track toggle — the artist switch is account-wide.
- no download counts/telemetry beyond the normal request span.
- PDS-only tracks 404 rather than redirecting to `getBlob` — a PDS URL can't carry a filename disposition, and those bytes are reachable there anyway.

## verification

- 15 backend tests (`tests/api/test_audio_download.py`): redirect + exact presign args, lossless preference, every refusal path, override-allow, the scan-flag-does-not-block invariant, dead-key 404s for PDS-only/ingested rows, filename sanitization, RFC 6266 encoding, and `TrackResponse.downloadable` parity. **full parallel suite green (1507 passed).**
- adversarially reviewed (high effort): the dead-presigned-URL finding and a scan-row ordering bug were found and fixed by consolidating into the shared policy module; svelte-check, eslint, vitest, ty, ruff all green.
- UI verified in a browser (desktop track page, mobile actions menu, settings toggle).

**do not merge yet** — awaiting @zzstoatzz sign-off on the mockup (merge deploys staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)