### PR TITLE
fix: circular import crashed the staging app at boot

### DIFF
--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -7,6 +7,7 @@ from functools import reduce
 from io import BytesIO
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO
+from urllib.parse import quote
 
 import aioboto3
 import boto3
@@ -23,13 +24,29 @@ from backend.models.track import Track
 from backend.storage.keys import AudioKey, ImageKey, InvalidMediaExtension
 from backend.utilities.audio_formats import AudioFormat
 from backend.utilities.database import db_session
-from backend.utilities.downloads import content_disposition
 from backend.utilities.hashing import hash_file_chunked
 
 # default chunk size for streaming reads. 1MB matches aiobotocore's default
 # part size and keeps per-chunk python overhead negligible against a multi-MB
 # file. callers that want different granularity can override.
 STREAM_CHUNK_SIZE = 1024 * 1024
+
+
+def content_disposition(filename: str) -> str:
+    """RFC 6266 attachment disposition with a unicode-capable filename*.
+
+    lives here rather than utilities/downloads.py because this module is on
+    the import path of `backend.storage` itself — importing policy helpers
+    from there re-enters the package mid-initialization (the circular import
+    that crashed staging on 2026-08-13).
+
+    the plain `filename` parameter is ascii-only for old clients; `filename*`
+    carries the real name percent-encoded as UTF-8 and wins where supported.
+    """
+    ascii_name = filename.encode("ascii", "replace").decode("ascii")
+    utf8_name = quote(filename, safe="")
+    return f"attachment; filename=\"{ascii_name}\"; filename*=UTF-8''{utf8_name}"
+
 
 # content-hashed files never change — cache forever
 IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"

--- a/backend/src/backend/utilities/downloads.py
+++ b/backend/src/backend/utilities/downloads.py
@@ -3,7 +3,6 @@
 import re
 from collections.abc import Iterable, Mapping
 from typing import Any, Literal, TypeAlias
-from urllib.parse import quote
 
 from backend._internal.content_labels import has_copyright_label
 from backend.storage.keys import AudioKey, InvalidMediaExtension
@@ -85,14 +84,3 @@ def download_filename(artist: str, title: str, extension: str) -> str:
     cleaned = "".join(c for c in stem if c not in _UNSAFE and c.isprintable())
     cleaned = " ".join(cleaned.split()).strip(". ") or "track"
     return f"{cleaned}.{extension}"
-
-
-def content_disposition(filename: str) -> str:
-    """RFC 6266 attachment disposition with a unicode-capable filename*.
-
-    the plain `filename` parameter is ascii-only for old clients; `filename*`
-    carries the real name percent-encoded as UTF-8 and wins where supported.
-    """
-    ascii_name = filename.encode("ascii", "replace").decode("ascii")
-    utf8_name = quote(filename, safe="")
-    return f"attachment; filename=\"{ascii_name}\"; filename*=UTF-8''{utf8_name}"

--- a/backend/tests/api/test_audio_download.py
+++ b/backend/tests/api/test_audio_download.py
@@ -1,5 +1,7 @@
 """tests for the audio download endpoint."""
 
+import subprocess
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -12,7 +14,8 @@ from sqlalchemy.orm import selectinload
 from backend.main import app
 from backend.models import Artist, CopyrightScan, Track, UserPreferences
 from backend.schemas import TrackResponse
-from backend.utilities.downloads import content_disposition, download_filename
+from backend.storage.r2 import content_disposition
+from backend.utilities.downloads import download_filename
 
 
 @pytest.fixture
@@ -254,3 +257,20 @@ async def test_download_refuses_when_no_object_is_ours_to_serve(
 
     assert (await _response_for(db_session, pds_only_id)).downloadable is False
     assert (await _response_for(db_session, ingested_id)).downloadable is False
+
+
+def test_app_imports_in_production_order():
+    """main.py's import order must not hit a circular import.
+
+    the 2026-08-13 staging outage: schemas -> utilities.downloads ->
+    storage.keys triggers storage/__init__ -> r2, which re-entered the
+    partially initialized downloads module. only reproducible in a fresh
+    interpreter that imports backend.main first, the way uvicorn does.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", "import backend.main"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr

--- a/loq.toml
+++ b/loq.toml
@@ -47,7 +47,7 @@ max_lines = 1266
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
-max_lines = 981
+max_lines = 998
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"


### PR DESCRIPTION
#1824's staging deploy failed: the app process group crash-looped on `ImportError: cannot import name 'content_disposition' from partially initialized module 'backend.utilities.downloads'` while the worker/jetstream groups (different entrypoints, different import order) came up fine.

the cycle: `main.py → schemas → utilities.downloads → storage.keys` — importing `storage.keys` runs `storage/__init__`, which imports `r2.py`, which imported `content_disposition` back out of the still-initializing `downloads` module. only uvicorn's entrypoint order hits it; the test suite (and my pre-merge import check) touched `backend.storage` first, fully initializing it and masking the cycle.

fix: `content_disposition` moves into `storage/r2.py`, its only consumer — the back-edge is gone rather than deferred. a regression test now imports `backend.main` in a fresh interpreter, exactly the way uvicorn does, so any future cycle on the production import path fails CI instead of staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)