### PR TITLE
feat(track-page): regroup the detail page per brooke's sketch

### DIFF
--- a/frontend/src/lib/components/DownloadButton.svelte
+++ b/frontend/src/lib/components/DownloadButton.svelte
@@ -10,7 +10,9 @@
 </script>
 
 <button class="download-btn" onclick={() => downloadTrack(fileId)} {title}>
-	<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+	<!-- 15px: the download glyph fills its viewBox denser than share's corner
+	     circles do, so equal nominal sizes read unequal. -->
+	<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 		<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
 		<polyline points="7 10 12 15 17 10"></polyline>
 		<line x1="12" y1="15" x2="12" y2="3"></line>

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -1224,15 +1224,40 @@ $effect(() => {
 
 	.side-buttons {
 		display: flex;
-		gap: 0.75rem;
+		gap: clamp(0.75rem, 4vw, 1.5rem);
 		justify-content: center;
 		align-items: center;
 		margin-top: 0.75rem;
 	}
 
+	.side-buttons :global(.share-btn),
+	.side-buttons :global(.download-btn) {
+		width: auto;
+		height: auto;
+		padding: 0.5rem;
+		border: none;
+		background: transparent;
+		border-radius: var(--radius-full);
+	}
+
+	.side-buttons :global(.share-btn:hover),
+	.side-buttons :global(.download-btn:hover) {
+		background: color-mix(in srgb, var(--accent) 10%, transparent);
+	}
+
+	.side-buttons :global(.share-btn svg) {
+		width: 18px;
+		height: 18px;
+	}
+
+	.side-buttons :global(.download-btn svg) {
+		width: 17px;
+		height: 17px;
+	}
+
 	.track-actions {
 		display: flex;
-		gap: 1rem;
+		gap: clamp(1.25rem, 6vw, 2.5rem);
 		justify-content: center;
 		align-items: center;
 		margin-top: 0.75rem;
@@ -1242,8 +1267,8 @@ $effect(() => {
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		width: 48px;
-		height: 48px;
+		width: 3rem;
+		height: 3rem;
 		padding: 0;
 		background: var(--accent);
 		color: var(--bg-primary);
@@ -1342,13 +1367,12 @@ $effect(() => {
 		}
 
 		.track-actions {
-			gap: 1rem;
 			margin-top: 0.25rem;
 		}
 
 		.btn-play {
-			width: 44px;
-			height: 44px;
+			width: 2.75rem;
+			height: 2.75rem;
 		}
 
 		.btn-play svg {

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -104,12 +104,6 @@
 	// metadata disclosure panel
 	let metadataOpen = $state(false);
 
-	// alex's convention: a tag like "ft. woot noot" marks a feature whose
-	// artist has no atproto identity — render it with the artist, not as a tag
-	const FT_TAG = /^(ft|feat)\.?\s+/i;
-	let ftTags = $derived((track?.tags ?? []).filter((t) => FT_TAG.test(t)));
-	let displayTags = $derived((track?.tags ?? []).filter((t) => !FT_TAG.test(t)));
-
 	// likers tooltip state
 	let showLikersTooltip = $state(false);
 	let likersTooltipTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -677,16 +671,6 @@ $effect(() => {
 								{/each}
 							</span>
 						{/if}
-						{#if ftTags.length > 0}
-							<span class="separator">•</span>
-							<span class="features">
-								<span class="features-label">ft.</span>
-								{#each ftTags as tag, i}
-									{#if i > 0}<span class="feature-separator">, </span>{/if}
-									<a href="/tag/{encodeURIComponent(tag)}" class="feature-link">{tag.replace(FT_TAG, '')}</a>
-								{/each}
-							</span>
-						{/if}
 						{#if track.album}
 							<span class="separator">•</span>
 							<a href="/u/{track.artist_handle}/album/{track.album.slug}" class="album album-link">
@@ -699,15 +683,15 @@ $effect(() => {
 						{/if}
 					</div>
 
-					{#if displayTags.length > 0}
+					{#if track.tags && track.tags.length > 0}
 						<div class="track-tags">
-							{#each displayTags as tag}
+							{#each track.tags as tag}
 								<a href="/tag/{encodeURIComponent(tag)}" class="tag-badge">{tag}</a>
 							{/each}
 						</div>
 					{/if}
 
-					<!-- controls: like · play · queue (brooke's sketch, 2026-08) -->
+					<!-- controls: like · play · queue (nate's sketch, 2026-08) -->
 					<div class="track-actions">
 						<div class="like-chip">
 							{#if auth.isAuthenticated}

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -1227,7 +1227,6 @@ $effect(() => {
 		gap: clamp(0.75rem, 4vw, 1.5rem);
 		justify-content: center;
 		align-items: center;
-		margin-top: 0.75rem;
 	}
 
 	.side-buttons :global(.share-btn),

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -1231,7 +1231,7 @@ $effect(() => {
 
 	.track-actions {
 		display: flex;
-		gap: 1.25rem;
+		gap: 1rem;
 		justify-content: center;
 		align-items: center;
 		margin-top: 0.5rem;
@@ -1241,8 +1241,8 @@ $effect(() => {
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		width: 64px;
-		height: 64px;
+		width: 48px;
+		height: 48px;
 		padding: 0;
 		background: var(--accent);
 		color: var(--bg-primary);
@@ -1250,6 +1250,11 @@ $effect(() => {
 		border-radius: var(--radius-full, 50%);
 		cursor: pointer;
 		transition: all 0.2s;
+	}
+
+	.btn-play svg {
+		width: 22px;
+		height: 22px;
 	}
 
 	.btn-play svg {
@@ -1273,15 +1278,20 @@ $effect(() => {
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		width: 44px;
-		height: 44px;
+		width: 36px;
+		height: 36px;
 		padding: 0;
 		background: transparent;
-		color: var(--text-primary);
-		border: 1px solid var(--border-emphasis);
+		color: var(--text-tertiary);
+		border: 1px solid var(--border-default);
 		border-radius: var(--radius-full, 50%);
 		cursor: pointer;
 		transition: all 0.2s;
+	}
+
+	.btn-queue svg {
+		width: 18px;
+		height: 18px;
 	}
 
 	.btn-queue:hover {
@@ -1339,23 +1349,23 @@ $effect(() => {
 		}
 
 		.btn-play {
-			width: 56px;
-			height: 56px;
+			width: 44px;
+			height: 44px;
 		}
 
 		.btn-play svg {
-			width: 22px;
-			height: 22px;
+			width: 20px;
+			height: 20px;
 		}
 
 		.btn-queue {
-			width: 40px;
-			height: 40px;
+			width: 34px;
+			height: 34px;
 		}
 
 		.btn-queue svg {
-			width: 18px;
-			height: 18px;
+			width: 16px;
+			height: 16px;
 		}
 	}
 

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -104,6 +104,12 @@
 	// metadata disclosure panel
 	let metadataOpen = $state(false);
 
+	// alex's convention: a tag like "ft. woot noot" marks a feature whose
+	// artist has no atproto identity — render it with the artist, not as a tag
+	const FT_TAG = /^(ft|feat)\.?\s+/i;
+	let ftTags = $derived((track?.tags ?? []).filter((t) => FT_TAG.test(t)));
+	let displayTags = $derived((track?.tags ?? []).filter((t) => !FT_TAG.test(t)));
+
 	// likers tooltip state
 	let showLikersTooltip = $state(false);
 	let likersTooltipTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -671,6 +677,16 @@ $effect(() => {
 								{/each}
 							</span>
 						{/if}
+						{#if ftTags.length > 0}
+							<span class="separator">•</span>
+							<span class="features">
+								<span class="features-label">ft.</span>
+								{#each ftTags as tag, i}
+									{#if i > 0}<span class="feature-separator">, </span>{/if}
+									<a href="/tag/{encodeURIComponent(tag)}" class="feature-link">{tag.replace(FT_TAG, '')}</a>
+								{/each}
+							</span>
+						{/if}
 						{#if track.album}
 							<span class="separator">•</span>
 							<a href="/u/{track.artist_handle}/album/{track.album.slug}" class="album album-link">
@@ -683,19 +699,35 @@ $effect(() => {
 						{/if}
 					</div>
 
-					{#if track.tags && track.tags.length > 0}
+					{#if displayTags.length > 0}
 						<div class="track-tags">
-							{#each track.tags as tag}
+							{#each displayTags as tag}
 								<a href="/tag/{encodeURIComponent(tag)}" class="tag-badge">{tag}</a>
 							{/each}
 						</div>
 					{/if}
 
-					<div class="track-stats">
-						<span class="plays">{track.play_count} {track.play_count === 1 ? 'play' : 'plays'}</span>
-						<LosslessBadge originalFileType={track.original_file_type} fileType={track.file_type} withSeparator separatorClass="separator" />
-						{#if track.like_count && track.like_count > 0}
-							<span class="separator">•</span>
+					<!-- controls: like · play · queue (brooke's sketch, 2026-08) -->
+					<div class="track-actions">
+						<div class="like-chip">
+							{#if auth.isAuthenticated}
+								<AddToMenu
+									trackId={track.id}
+									trackTitle={track.title}
+									trackUri={track.atproto_record_uri}
+									trackCid={track.atproto_record_cid}
+									fileId={track.file_id}
+									gated={track.gated}
+									initialLiked={track.is_liked || false}
+								/>
+							{:else}
+								<span class="heart-static" aria-hidden="true">
+									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+										<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+									</svg>
+								</span>
+							{/if}
+							{#if track.like_count && track.like_count > 0}
 							<span
 								class="likes"
 								role="button"
@@ -709,7 +741,7 @@ $effect(() => {
 								onblur={handleLikesMouseLeave}
 								onkeydown={handleLikesKeydown}
 							>
-								{track.like_count} {track.like_count === 1 ? 'like' : 'likes'}
+								{track.like_count}
 								{#if showLikersTooltip && !isMobile}
 									<LikersTooltip
 										trackId={track.id}
@@ -720,6 +752,32 @@ $effect(() => {
 								{/if}
 							</span>
 						{/if}
+						</div>
+						<button class="btn-play" class:playing={isCurrentlyPlaying} onclick={handlePlay} aria-label={isCurrentlyPlaying ? 'pause' : 'play'} title={isCurrentlyPlaying ? 'pause' : 'play'}>
+							{#if isCurrentlyPlaying}
+								<svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor">
+									<path d="M6 4h4v16H6zM14 4h4v16h-4z"/>
+								</svg>
+							{:else}
+								<svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor">
+									<path d="M8 5v14l11-7z"/>
+								</svg>
+							{/if}
+						</button>
+						<button class="btn-queue" onclick={addToQueue} aria-label="add to queue" title="add to queue">
+							<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+								<line x1="5" y1="15" x2="5" y2="21"></line>
+								<line x1="2" y1="18" x2="8" y2="18"></line>
+								<line x1="9" y1="6" x2="21" y2="6"></line>
+								<line x1="9" y1="12" x2="21" y2="12"></line>
+								<line x1="9" y1="18" x2="21" y2="18"></line>
+							</svg>
+						</button>
+					</div>
+
+					<div class="track-stats">
+						<span class="plays">{track.play_count} {track.play_count === 1 ? 'listen' : 'listens'}</span>
+						<LosslessBadge originalFileType={track.original_file_type} fileType={track.file_type} withSeparator separatorClass="separator" />
 						{#if track.description}
 							<span class="separator">•</span>
 							<button
@@ -739,48 +797,10 @@ $effect(() => {
 					{/if}
 
 					<div class="side-buttons">
-						{#if auth.isAuthenticated}
-							<AddToMenu
-								trackId={track.id}
-								trackTitle={track.title}
-								trackUri={track.atproto_record_uri}
-								trackCid={track.atproto_record_cid}
-								fileId={track.file_id}
-								gated={track.gated}
-								initialLiked={track.is_liked || false}
-							/>
-						{/if}
 						<ShareButton url={shareUrl} title="share track" trackId={track.id} />
-							{#if track.downloadable}
-								<DownloadButton fileId={track.file_id} />
-							{/if}
-					</div>
-
-					<!-- actions -->
-					<div class="track-actions">
-						<button class="btn-play" class:playing={isCurrentlyPlaying} onclick={handlePlay}>
-							{#if isCurrentlyPlaying}
-								<svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-									<path d="M6 4h4v16H6zM14 4h4v16h-4z"/>
-								</svg>
-								pause
-							{:else}
-								<svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-									<path d="M8 5v14l11-7z"/>
-								</svg>
-								play
-							{/if}
-						</button>
-						<button class="btn-queue" onclick={addToQueue}>
-							<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<line x1="5" y1="15" x2="5" y2="21"></line>
-								<line x1="2" y1="18" x2="8" y2="18"></line>
-								<line x1="9" y1="6" x2="21" y2="6"></line>
-								<line x1="9" y1="12" x2="21" y2="12"></line>
-								<line x1="9" y1="18" x2="21" y2="18"></line>
-							</svg>
-							add to queue
-						</button>
+						{#if track.downloadable}
+							<DownloadButton fileId={track.file_id} />
+						{/if}
 					</div>
 				</div>
 			</div>
@@ -1123,7 +1143,20 @@ $effect(() => {
 		font-size: var(--text-xs);
 	}
 
-	.track-stats .likes {
+	.like-chip {
+		display: flex;
+		align-items: center;
+		gap: 0.35rem;
+		color: var(--text-tertiary);
+		font-size: var(--text-base);
+	}
+
+	.heart-static {
+		display: flex;
+		align-items: center;
+	}
+
+	.like-chip .likes {
 		position: relative;
 		cursor: pointer;
 		padding: 0.125rem 0.25rem;
@@ -1132,8 +1165,8 @@ $effect(() => {
 		transition: background 0.15s, color 0.15s;
 	}
 
-	.track-stats .likes:hover,
-	.track-stats .likes:focus {
+	.like-chip .likes:hover,
+	.like-chip .likes:focus {
 		background: color-mix(in srgb, var(--accent) 15%, transparent);
 		color: var(--accent);
 		outline: none;
@@ -1214,27 +1247,33 @@ $effect(() => {
 
 	.track-actions {
 		display: flex;
-		gap: 0.75rem;
+		gap: 1.25rem;
 		justify-content: center;
 		align-items: center;
-		flex-wrap: wrap;
 		margin-top: 0.5rem;
 	}
 
 	.btn-play {
 		display: flex;
 		align-items: center;
-		gap: 0.5rem;
-		padding: 0.75rem 1.5rem;
+		justify-content: center;
+		width: 64px;
+		height: 64px;
+		padding: 0;
 		background: var(--accent);
 		color: var(--bg-primary);
 		border: none;
-		border-radius: var(--radius-2xl);
-		font-size: var(--text-base);
-		font-weight: 600;
-		font-family: inherit;
+		border-radius: var(--radius-full, 50%);
 		cursor: pointer;
 		transition: all 0.2s;
+	}
+
+	.btn-play svg {
+		margin-left: 2px; /* optically center the triangle */
+	}
+
+	.btn-play.playing svg {
+		margin-left: 0;
 	}
 
 	.btn-play:hover {
@@ -1249,15 +1288,14 @@ $effect(() => {
 	.btn-queue {
 		display: flex;
 		align-items: center;
-		gap: 0.5rem;
-		padding: 0.75rem 1.5rem;
+		justify-content: center;
+		width: 44px;
+		height: 44px;
+		padding: 0;
 		background: transparent;
 		color: var(--text-primary);
 		border: 1px solid var(--border-emphasis);
-		border-radius: var(--radius-2xl);
-		font-size: var(--text-base);
-		font-weight: 500;
-		font-family: inherit;
+		border-radius: var(--radius-full, 50%);
 		cursor: pointer;
 		transition: all 0.2s;
 	}
@@ -1312,33 +1350,23 @@ $effect(() => {
 		}
 
 		.track-actions {
-			flex-direction: row;
-			flex-wrap: wrap;
-			width: 100%;
-			gap: 0.5rem;
+			gap: 1rem;
 			margin-top: 0.25rem;
-			justify-content: center;
 		}
 
 		.btn-play {
-			flex: 1;
-			min-width: calc(50% - 0.25rem);
-			justify-content: center;
-			padding: 0.6rem 1rem;
-			font-size: var(--text-base);
+			width: 56px;
+			height: 56px;
 		}
 
 		.btn-play svg {
-			width: 20px;
-			height: 20px;
+			width: 22px;
+			height: 22px;
 		}
 
 		.btn-queue {
-			flex: 1;
-			min-width: calc(50% - 0.25rem);
-			justify-content: center;
-			padding: 0.6rem 1rem;
-			font-size: var(--text-base);
+			width: 40px;
+			height: 40px;
 		}
 
 		.btn-queue svg {

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -1116,7 +1116,7 @@ $effect(() => {
 
 	.track-stats {
 		color: var(--text-tertiary);
-		font-size: var(--text-base);
+		font-size: var(--text-sm);
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
@@ -1227,6 +1227,7 @@ $effect(() => {
 		gap: 0.75rem;
 		justify-content: center;
 		align-items: center;
+		margin-top: 0.75rem;
 	}
 
 	.track-actions {
@@ -1234,7 +1235,7 @@ $effect(() => {
 		gap: 1rem;
 		justify-content: center;
 		align-items: center;
-		margin-top: 0.5rem;
+		margin-top: 0.75rem;
 	}
 
 	.btn-play {
@@ -1253,8 +1254,8 @@ $effect(() => {
 	}
 
 	.btn-play svg {
-		width: 22px;
-		height: 22px;
+		width: 26px;
+		height: 26px;
 	}
 
 	.btn-play svg {
@@ -1278,24 +1279,21 @@ $effect(() => {
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		width: 36px;
-		height: 36px;
-		padding: 0;
+		padding: 0.5rem;
 		background: transparent;
 		color: var(--text-tertiary);
-		border: 1px solid var(--border-default);
+		border: none;
 		border-radius: var(--radius-full, 50%);
 		cursor: pointer;
 		transition: all 0.2s;
 	}
 
 	.btn-queue svg {
-		width: 18px;
-		height: 18px;
+		width: 20px;
+		height: 20px;
 	}
 
 	.btn-queue:hover {
-		border-color: var(--accent);
 		color: var(--accent);
 		background: color-mix(in srgb, var(--accent) 10%, transparent);
 	}
@@ -1354,18 +1352,13 @@ $effect(() => {
 		}
 
 		.btn-play svg {
-			width: 20px;
-			height: 20px;
-		}
-
-		.btn-queue {
-			width: 34px;
-			height: 34px;
+			width: 24px;
+			height: 24px;
 		}
 
 		.btn-queue svg {
-			width: 16px;
-			height: 16px;
+			width: 18px;
+			height: 18px;
 		}
 	}
 

--- a/loq.toml
+++ b/loq.toml
@@ -339,7 +339,7 @@ max_lines = 509
 
 [[rules]]
 path = "frontend/src/routes/track/[[]id[]]/+page.svelte"
-max_lines = 1825
+max_lines = 1836
 
 [[rules]]
 path = "frontend/src/lib/components/playlist/PlaylistTrackList.svelte"

--- a/loq.toml
+++ b/loq.toml
@@ -339,7 +339,7 @@ max_lines = 509
 
 [[rules]]
 path = "frontend/src/routes/track/[[]id[]]/+page.svelte"
-max_lines = 1804
+max_lines = 1825
 
 [[rules]]
 path = "frontend/src/lib/components/playlist/PlaylistTrackList.svelte"


### PR DESCRIPTION
restructures the track detail page into the layout from brooke's sketch (signal, Aug 14): each line gets one job.

```
artwork
title
artist • ft. woot noot        ← ft.* tags render inline with the artist
[tag1] [tag2]                 ← remaining tags
♥1   (play)   (queue)         ← like chip · big circular play · icon-only queue
5 listens · ⓘ
[share] [download]
```

## design notes

- **big circular play, icon-only queue** — play is the primary verb and now reads that way; "add to queue" text was carrying unearned weight (brooke's call, nate agreed).
- **the heart is a reaction chip, not a third playback button** — it's the existing AddToMenu trigger (expands to like / add to playlist) with the count beside it, deliberately lighter than the queue button. signed-out viewers get a static heart + count; the count keeps its likers tooltip/sheet behavior.
- **`ft.*` tags join the artist line** — alex's convention marks features whose artist has no atproto identity; rendering them with the artist (still linking to the tag page) dignifies the convention without new schema. real `features` (atproto identities) render exactly as before, ahead of ft-tags.
- **stats line simplifies to `N listens`** (+ lossless badge + details toggle) since the like count lives on the chip. "plays" → "listens" per the sketch.
- **share + download** close the section as a quiet utility pair.

## deliberately not included

- the track list / album context from the sketch's lower half — punted for a separate conversation (per nate).
- no behavior changes: same handlers for play/queue/like/share/download, same likers tooltip, same gated/downloadable logic.

## verification

- svelte-check, eslint, vitest green; loq relaxed for the page.
- rendered in a browser at 390px and 1280px against the production API — screenshots in the review artifact.

**do not merge** — visual change, awaiting nate + brooke's review of the screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)