### PR TITLE
fix(track-page): say 'sign in' once in the like nudge

### DIFF
--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -108,7 +108,7 @@
 	function nudgeSignIn() {
 		heartShake = true;
 		setTimeout(() => (heartShake = false), 500);
-		toast.info('sign in to like tracks', 3000, { label: 'sign in', href: loginHref() });
+		toast.info('', 3000, { label: 'sign in to like tracks', href: loginHref() });
 	}
 
 	// likers tooltip state


### PR DESCRIPTION
the signed-out heart's toast rendered its message and its action label side by side — 'sign in to like tracks' followed by a 'sign in' link. the full sentence is now the action link itself, so it reads once and the whole thing is clickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)