### PR TITLE
fix(uploads): bound in-flight upload memory, keep scans off the event loop

### DIFF
--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Annotated, Any, BinaryIO
 
 import aiofiles
+import anyio.to_thread
 import logfire
 from docket import ConcurrencyLimit
 from fastapi import (
@@ -1672,16 +1673,24 @@ async def upload_track(
 
         # extract duration once, while the bytes are still local — saves
         # the worker an extra storage round-trip just to read length metadata.
-        with open(file_path, "rb") as f:
-            duration = extract_duration(f)
+        # off the event loop: these scans read the whole temp file.
+        def _scan_duration() -> int | None:
+            with open(file_path, "rb") as f:
+                return extract_duration(f)
+
+        duration = await anyio.to_thread.run_sync(_scan_duration)
 
         # an .m4a extension is treated as web-playable, but ALAC-in-m4a has no
         # browser decoder; detect it from the bytes here so the worker schedules
         # a streaming-rendition transcode instead of serving the raw file.
         needs_transcode = False
         if audio_format is AudioFormat.M4A:
-            with open(file_path, "rb") as f:
-                needs_transcode = is_alac(f)
+
+            def _scan_alac() -> bool:
+                with open(file_path, "rb") as f:
+                    return is_alac(f)
+
+            needs_transcode = await anyio.to_thread.run_sync(_scan_alac)
 
         if is_private:
             # permissioned media: audio lives ON THE PDS, never R2. upload the

--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -10,8 +10,10 @@ from typing import BinaryIO
 from urllib.parse import quote
 
 import aioboto3
+import anyio.to_thread
 import boto3
 import logfire
+from boto3.s3.transfer import TransferConfig
 from botocore.config import Config
 from botocore.exceptions import ClientError
 from sqlalchemy import func, or_, select
@@ -50,6 +52,15 @@ def content_disposition(filename: str) -> str:
 
 # content-hashed files never change — cache forever
 IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
+
+# bounds the memory an upload may hold in flight. boto's defaults are 10
+# concurrent 8MB parts — 80MB per upload, which with 3 concurrent uploads
+# starved the 1GB app VM into a wedge on 2026-08-14 (an album batch of WAVs).
+# 2 x 8MB caps each upload at ~16MB of part buffers.
+UPLOAD_TRANSFER_CONFIG = TransferConfig(
+    multipart_chunksize=8 * 1024 * 1024,
+    max_concurrency=2,
+)
 
 # every column that can name a stored object. `_reference_count` walks all of
 # them, because a content hash makes "these bytes" and "this row's media"
@@ -183,8 +194,9 @@ class R2Storage:
         save and read can't disagree about the extension.
         """
         with logfire.span("R2 save", filename=filename):
-            # compute hash in chunks (constant memory)
-            file_id = hash_file_chunked(file)[:16]
+            # chunked (constant memory), and off the event loop — sha256 of a
+            # multi-hundred-MB WAV is real CPU time
+            file_id = (await anyio.to_thread.run_sync(hash_file_chunked, file))[:16]
             logfire.info("computed file hash", file_id=file_id)
 
             # determine file extension and type via the typed key constructors
@@ -227,6 +239,7 @@ class R2Storage:
                         "Fileobj": file,
                         "Bucket": bucket,
                         "Key": key,
+                        "Config": UPLOAD_TRANSFER_CONFIG,
                         "ExtraArgs": {
                             "ContentType": media_type,
                             "CacheControl": IMMUTABLE_CACHE_CONTROL,
@@ -680,8 +693,8 @@ class R2Storage:
             raise ValueError("R2_PRIVATE_BUCKET not configured")
 
         with logfire.span("R2 save_gated", filename=filename):
-            # compute hash in chunks (constant memory)
-            file_id = hash_file_chunked(file)[:16]
+            # chunked (constant memory), and off the event loop
+            file_id = (await anyio.to_thread.run_sync(hash_file_chunked, file))[:16]
             logfire.info("computed file hash for gated content", file_id=file_id)
 
             # only audio is supported for gated content
@@ -715,6 +728,7 @@ class R2Storage:
                         "Fileobj": file,
                         "Bucket": self.private_audio_bucket_name,
                         "Key": key,
+                        "Config": UPLOAD_TRANSFER_CONFIG,
                         "ExtraArgs": {
                             "ContentType": media_type,
                             "CacheControl": IMMUTABLE_CACHE_CONTROL,

--- a/loq.toml
+++ b/loq.toml
@@ -39,7 +39,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1871
+max_lines = 1880
 
 [[rules]]
 path = "backend/src/backend/config.py"
@@ -47,7 +47,7 @@ max_lines = 1266
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
-max_lines = 998
+max_lines = 1012
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"


### PR DESCRIPTION
postmortem fix for the 2026-08-14 02:02 UTC production wedge.

## what happened

@darkhart.whereditgo.diamonds batch-uploaded an album of WAVs. the primary app machine stopped answering entirely — last log at 02:02:04 mid-`POST /tracks/`, health check failing with "context deadline exceeded" 15s later, no further logs, SSH exec unschedulable. fly-proxy autostarted the standby app machine at 02:02:39; clients recovered at 02:03 (93-request burst). every upload in the batch except one showed "upload timed out (stopped at 100%)" — the client had sent all bytes and the server never answered. no 5xx anywhere in Logfire, because failing requests never reached the app. the wedged machine stayed critical until a manual `fly machine restart` ~15 minutes later.

## root cause

the streaming upload path from #1389 held — spool → tmpfile → chunked hash → streaming R2 upload, no whole-file buffering regression. but `upload_fileobj` ran with boto's **default `TransferConfig`: 10 concurrent 8MB parts ≈ 80MB of in-flight buffers per upload**. the route's `ConcurrencyLimit("artist_did", max_concurrent=3)` allows 3 simultaneous uploads, so an album batch could hold ~240MB of part buffers on a **1GB VM that idles with ~330MB available** — memory starvation and page-cache thrash, which presents exactly as observed: process alive, nothing schedulable, no clean OOM kill.

compounding: `hash_file_chunked` (sha256 of the full file), `extract_duration`, and `is_alac` all ran their sync loops on the event loop, so under pressure the loop also couldn't answer `/health`.

## the fix

- both `storage.save` and `storage.save_gated` pass an explicit `TransferConfig(multipart_chunksize=8MB, max_concurrency=2)` — ~16MB of part buffers per upload, ~48MB worst-case across the artist gate.
- the three whole-file sync scans move to `anyio.to_thread.run_sync`, keeping the loop responsive during them.

## deliberately not in this PR

- **VM sizing**: 1GB for the app group is tight regardless; bumping it is an operator/cost call (flagged to nate).
- the `fly worker tcp health check (running-but-stuck symptom detector)` backlog item — this incident is the app-group version of that symptom; an alert on machine-level health-check criticality would have paged before a user report did.

## verification

- full suite green (1508 passed) the CI way; lint/ty clean.
- the transfer-config change is exercised by every existing save/save_gated test; memory behavior itself is validated by the arithmetic above, and will be watched on the next album batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)