### PR TITLE
fix(uploads): cap the io_queue — the real memory bomb was the reader, not the uploaders

### DIFF
--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -1696,8 +1696,11 @@ async def upload_track(
             # permissioned media: audio lives ON THE PDS, never R2. upload the
             # blob straight to the user's PDS blobstore here (we hold the bytes +
             # the auth session); the worker only writes the permissioned record.
-            with open(file_path, "rb") as f:
-                audio_file_id = hash_file_chunked(f)[:16]
+            def _hash_tmp() -> str:
+                with open(file_path, "rb") as f:
+                    return hash_file_chunked(f)
+
+            audio_file_id = (await anyio.to_thread.run_sync(_hash_tmp))[:16]
 
             # stream the temp file (don't buffer audio in memory); the factory is
             # re-invoked per upload attempt, so it must yield a fresh iterator.

--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -53,13 +53,17 @@ def content_disposition(filename: str) -> str:
 # content-hashed files never change — cache forever
 IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
 
-# bounds the memory an upload may hold in flight. boto's defaults are 10
-# concurrent 8MB parts — 80MB per upload, which with 3 concurrent uploads
-# starved the 1GB app VM into a wedge on 2026-08-14 (an album batch of WAVs).
-# 2 x 8MB caps each upload at ~16MB of part buffers.
+# bounds the memory an upload may hold in flight. two independent knobs both
+# default dangerously high in aioboto3's upload_fileobj: uploader concurrency
+# (10 x 8MB parts) and — far worse — the reader-side io_queue, which eagerly
+# buffers up to 100 full 8MB parts (~800MB) ahead of the uploaders. a single
+# large WAV could therefore hold most of the file in memory, which is what
+# wedged the 1GB app VM on 2026-08-14 during an album batch. 2 queued + 2 in
+# flight caps each upload at ~32MB.
 UPLOAD_TRANSFER_CONFIG = TransferConfig(
     multipart_chunksize=8 * 1024 * 1024,
     max_concurrency=2,
+    max_io_queue=2,
 )
 
 # every column that can name a stored object. `_reference_count` walks all of

--- a/loq.toml
+++ b/loq.toml
@@ -39,7 +39,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1880
+max_lines = 1883
 
 [[rules]]
 path = "backend/src/backend/config.py"
@@ -47,7 +47,7 @@ max_lines = 1266
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
-max_lines = 1012
+max_lines = 1016
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"


### PR DESCRIPTION
careful re-review of #1831 (prompted by nate) found the merged fix insufficient.

reading aioboto3's `upload_fileobj` source: a reader task assembles full `multipart_chunksize` parts and eagerly `put`s them into `asyncio.Queue(maxsize=Config.max_io_queue_size)` ahead of the uploaders. boto3's `TransferConfig` defaults `max_io_queue` to **100**, so the queue alone can hold **100 × 8MB = 800MB per upload** — independent of `max_concurrency`, which #1831 capped. disk reads always outrun network uploads, so the queue fills toward its max on any sufficiently large file: **a single big WAV could hold most of itself in memory**, which is a cleaner explanation of the 2026-08-14 wedge than the uploader-side arithmetic.

- `max_io_queue=2` joins the config: per-upload memory ≈ (2 queued + 2 in flight) × 8MB ≈ **32MB**, ~96MB across the 3-per-artist gate.
- the private/PDS branch's `hash_file_chunked` moves to a worker thread — the one sync scan #1831 missed.

verified against the installed libraries, not docs: `aioboto3.s3.inject.upload_fileobj` reads `Config.max_io_queue_size` / `Config.max_request_concurrency` (boto3's kwargs alias to both), and queue entries carry full-part `Body` payloads.

full suite green (1508). same deliberate exclusions as #1831 (VM sizing, machine-level health alerting) — plus one newly quantified exposure for the record: with `max_upload_size_mb=1536`, each upload transiently costs up to 2× file size in /tmp (starlette spool + our tempfile) on a 7.8GB rootfs; 3 concurrent worst-case uploads could exhaust disk. separate issue, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)