### PR TITLE
feat(albums): download an album as a cached zip

### DIFF
--- a/backend/src/backend/_internal/export_tasks.py
+++ b/backend/src/backend/_internal/export_tasks.py
@@ -14,6 +14,7 @@ import aioboto3
 import aiofiles
 import logfire
 from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 
 from backend._internal.background import get_docket
 from backend._internal.jobs import job_service
@@ -24,6 +25,8 @@ from backend.storage import storage
 from backend.storage.keys import AudioKey, InvalidMediaExtension
 from backend.storage.r2 import UploadProgressTracker
 from backend.utilities.database import db_session
+from backend.utilities.downloads import download_filename as track_entry_name
+from backend.utilities.downloads import download_key
 from backend.utilities.progress import R2ProgressTracker
 
 logger = logging.getLogger(__name__)
@@ -326,6 +329,192 @@ async def process_export(export_id: str, artist_did: str) -> None:
             "export failed",
             error=f"unexpected error: {e!s}",
         )
+
+
+async def process_album_download(
+    job_id: str, track_ids: list[int], r2_key: str, zip_filename: str
+) -> None:
+    """build a public album zip and cache it in R2 under a content-digest key.
+
+    sibling of `process_export` with two deliberate differences: entries are
+    ZIP_STORED (audio is already compressed — deflate burns worker CPU for
+    nothing), and the destination key encodes a digest of the member tracks,
+    so an edited album naturally builds a fresh object while the old one is
+    swept below. eligibility (no gated/labeled/opted-out tracks) is enforced
+    by the API endpoint before this job is ever enqueued.
+    """
+    try:
+        await job_service.update_progress(
+            job_id, JobStatus.PROCESSING, "fetching album..."
+        )
+
+        async with db_session() as db:
+            stmt = (
+                select(Track)
+                .options(selectinload(Track.artist))
+                .where(Track.id.in_(track_ids))
+            )
+            by_id = {t.id: t for t in (await db.execute(stmt)).scalars().all()}
+            # the endpoint owns ordering (the ATProto list record); preserve it
+            tracks = [by_id[tid] for tid in track_ids if tid in by_id]
+
+        entries = []
+        for position, track in enumerate(tracks, start=1):
+            key = download_key(
+                file_id=track.file_id,
+                file_type=track.file_type,
+                original_file_id=track.original_file_id,
+                original_file_type=track.original_file_type,
+                r2_url=track.r2_url,
+                audio_storage=track.audio_storage,
+            )
+            if key is None:
+                continue
+            entries.append(
+                {
+                    "track": track,
+                    "key": key.key,
+                    "filename": f"{position:02d} "
+                    + track_entry_name(
+                        track.artist.display_name, track.title, key.extension
+                    ),
+                }
+            )
+
+        if not entries:
+            await job_service.update_progress(
+                job_id,
+                JobStatus.FAILED,
+                "album download failed",
+                error="no downloadable tracks",
+            )
+            return
+
+        async_session = aioboto3.Session()
+        total = len(entries)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            zip_path = temp_path / "album.zip"
+            for info in entries:
+                info["temp_path"] = temp_path / info["filename"]
+
+            downloaded = 0
+            download_lock = asyncio.Lock()
+            semaphore = asyncio.Semaphore(4)
+
+            async def download_one(info: dict, s3_client) -> dict | None:
+                nonlocal downloaded
+                async with semaphore:
+                    try:
+                        response = await s3_client.get_object(
+                            Bucket=storage.audio_bucket_name, Key=info["key"]
+                        )
+                        async with aiofiles.open(info["temp_path"], "wb") as f:
+                            async for chunk in response["Body"].iter_chunks():
+                                await f.write(chunk)
+                        async with download_lock:
+                            downloaded += 1
+                            await job_service.update_progress(
+                                job_id,
+                                JobStatus.PROCESSING,
+                                f"gathering tracks ({downloaded}/{total})...",
+                                progress_pct=(downloaded / total) * 90,
+                            )
+                        return info
+                    except Exception as e:
+                        logfire.error(
+                            "album download: failed to fetch track",
+                            track_id=info["track"].id,
+                            key=info["key"],
+                            error=str(e),
+                        )
+                        return None
+
+            async with async_session.client(
+                "s3",
+                endpoint_url=settings.storage.r2_endpoint_url,
+                aws_access_key_id=settings.storage.aws_access_key_id,
+                aws_secret_access_key=settings.storage.aws_secret_access_key,
+            ) as s3_client:
+                results = await asyncio.gather(
+                    *[download_one(info, s3_client) for info in entries]
+                )
+
+            fetched = [r for r in results if r is not None]
+            if len(fetched) != total:
+                # a partial album zip is a corrupt product — fail loudly
+                await job_service.update_progress(
+                    job_id,
+                    JobStatus.FAILED,
+                    "album download failed",
+                    error=f"only {len(fetched)}/{total} tracks were fetchable",
+                )
+                return
+
+            await job_service.update_progress(
+                job_id, JobStatus.PROCESSING, "packaging...", progress_pct=92.0
+            )
+            with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_STORED) as zf:
+                for info in fetched:
+                    zf.write(info["temp_path"], arcname=info["filename"])
+                    os.unlink(info["temp_path"])
+
+            async with async_session.client(
+                "s3",
+                endpoint_url=settings.storage.r2_endpoint_url,
+                aws_access_key_id=settings.storage.aws_access_key_id,
+                aws_secret_access_key=settings.storage.aws_secret_access_key,
+            ) as upload_client:
+                with open(zip_path, "rb") as zip_file_obj:
+                    await upload_client.upload_fileobj(
+                        zip_file_obj,
+                        storage.audio_bucket_name,
+                        r2_key,
+                        ExtraArgs={
+                            "ContentType": "application/zip",
+                            "ContentDisposition": (
+                                f'attachment; filename="{zip_filename}"'
+                            ),
+                        },
+                    )
+
+                # sweep stale digests for this album so edits don't accrete zips
+                prefix = r2_key.rsplit("-", 1)[0] + "-"
+                listing = await upload_client.list_objects_v2(
+                    Bucket=storage.audio_bucket_name, Prefix=prefix
+                )
+                for obj in listing.get("Contents", []):
+                    if obj["Key"] != r2_key:
+                        await upload_client.delete_object(
+                            Bucket=storage.audio_bucket_name, Key=obj["Key"]
+                        )
+                        logfire.info("swept stale album zip", key=obj["Key"])
+
+        download_url = f"{storage.public_audio_bucket_url}/{r2_key}"
+        await job_service.update_progress(
+            job_id,
+            JobStatus.COMPLETED,
+            "album ready",
+            result={"download_url": download_url, "total_count": total},
+        )
+
+    except Exception as e:
+        logfire.exception("album download failed", job_id=job_id)
+        await job_service.update_progress(
+            job_id,
+            JobStatus.FAILED,
+            "album download failed",
+            error=f"unexpected error: {e!s}",
+        )
+
+
+async def schedule_album_download(
+    job_id: str, track_ids: list[int], r2_key: str, zip_filename: str
+) -> None:
+    """schedule an album zip build via docket."""
+    docket = get_docket()
+    await docket.add(process_album_download)(job_id, track_ids, r2_key, zip_filename)
+    logfire.info("scheduled album download", job_id=job_id, r2_key=r2_key)
 
 
 async def schedule_export(export_id: str, artist_did: str) -> None:

--- a/backend/src/backend/_internal/tasks/__init__.py
+++ b/backend/src/backend/_internal/tasks/__init__.py
@@ -6,7 +6,7 @@ they should be self-contained and handle their own database sessions.
 requires DOCKET_URL to be set (Redis is always available).
 """
 
-from backend._internal.export_tasks import process_export
+from backend._internal.export_tasks import process_album_download, process_export
 from backend._internal.pds_save_tasks import save_tracks_to_pds
 from backend._internal.tasks.copyright import (
     scan_copyright,
@@ -108,6 +108,7 @@ def _build_background_tasks() -> list:
         sync_operator_labels,
         publish_moderation_decisions,
         process_export,
+        process_album_download,
         sync_atproto,
         scrobble_to_teal,
         sync_album_list,

--- a/backend/src/backend/api/albums/__init__.py
+++ b/backend/src/backend/api/albums/__init__.py
@@ -21,6 +21,7 @@ from . import listing as _listing  # /, /{handle}, /{handle}/{slug}
 from . import (
     mutations as _mutations,
 )  # POST /, /{id}/cover, /{id}/finalize, PATCH, DELETE
+from . import downloads as _downloads  # /{handle}/{slug}/download
 
 __all__ = [
     "ALBUM_CACHE_PREFIX",

--- a/backend/src/backend/api/albums/downloads.py
+++ b/backend/src/backend/api/albums/downloads.py
@@ -1,0 +1,133 @@
+"""album download — a cached zip of an all-downloadable album.
+
+GET /albums/{handle}/{slug}/download either redirects to the cached zip in
+R2 (bytes served by the CDN, never proxied through the app) or enqueues a
+worker build and returns 202 with a job id the client can follow on the
+exports SSE endpoint. the cache key encodes a digest of the ordered member
+tracks, so editing the album naturally invalidates; the worker sweeps stale
+digests when it publishes a fresh one.
+"""
+
+import hashlib
+import logging
+from typing import Annotated
+
+from fastapi import Depends, HTTPException
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from backend._internal.export_tasks import schedule_album_download
+from backend._internal.jobs import job_service
+from backend._internal.track_visibility import track_visible_filter
+from backend.models import Album, Artist, Track, get_db
+from backend.models.job import JobType
+from backend.storage import storage
+from backend.utilities.downloads import (
+    download_filename,
+    download_key,
+    download_refusal,
+)
+
+from .listing import order_album_tracks
+from .router import router
+
+logger = logging.getLogger(__name__)
+
+
+class AlbumDownloadPending(BaseModel):
+    """the zip is being built; follow /exports/{job_id}/progress."""
+
+    job_id: str
+    status: str = "preparing"
+
+
+@router.get("/{handle}/{slug}/download", response_model=None)
+async def download_album(
+    handle: str,
+    slug: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> RedirectResponse | AlbumDownloadPending:
+    """download an album as a zip, if every member track is downloadable.
+
+    anonymous by design, like the track download endpoint: eligibility is
+    the same shared policy (no gated, copyright-labeled, or artist-opted-out
+    tracks, and we must actually hold every object).
+    """
+    row = (
+        await db.execute(
+            select(Album, Artist)
+            .join(Artist, Album.artist_did == Artist.did)
+            .where(Artist.handle == handle, Album.slug == slug)
+        )
+    ).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="album not found")
+    album, artist = row
+
+    tracks = list(
+        (
+            await db.execute(
+                select(Track)
+                .options(selectinload(Track.artist))
+                .where(Track.album_id == album.id)
+                # anonymous viewer: public tracks only
+                .where(track_visible_filter(None))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not tracks:
+        raise HTTPException(status_code=404, detail="no downloadable tracks")
+
+    ordered = await order_album_tracks(album, artist, tracks)
+
+    entries: list[tuple[int, str, str]] = []  # (track_id, key, entry name)
+    for position, track in enumerate(ordered, start=1):
+        prefs = track.artist.preferences
+        refusal = download_refusal(
+            is_private=track.is_private,
+            support_gate=track.support_gate,
+            labels=set(track.self_labels or []) | set(track.operator_labels or []),
+            moderation_override=track.moderation_override,
+            allow_downloads=prefs.allow_downloads if prefs else None,
+        )
+        if refusal is not None:
+            raise HTTPException(
+                status_code=403,
+                detail="this album is not available for download",
+            )
+        key = download_key(
+            file_id=track.file_id,
+            file_type=track.file_type,
+            original_file_id=track.original_file_id,
+            original_file_type=track.original_file_type,
+            r2_url=track.r2_url,
+            audio_storage=track.audio_storage,
+        )
+        if key is None:
+            raise HTTPException(status_code=404, detail="no downloadable file")
+        entry = f"{position:02d} " + download_filename(
+            track.artist.display_name, track.title, key.extension
+        )
+        entries.append((track.id, key.key, entry))
+
+    digest = hashlib.sha256(
+        "\n".join(f"{key}|{entry}" for _, key, entry in entries).encode()
+    ).hexdigest()[:16]
+    r2_key = f"exports/albums/{album.id}-{digest}.zip"
+
+    if await storage.object_exists(r2_key):
+        return RedirectResponse(url=f"{storage.public_audio_bucket_url}/{r2_key}")
+
+    zip_filename = download_filename(artist.display_name, album.title, "zip")
+    job_id = await job_service.create_job(
+        JobType.EXPORT, album.artist_did, "album download queued"
+    )
+    await schedule_album_download(
+        job_id, [track_id for track_id, _, _ in entries], r2_key, zip_filename
+    )
+    return AlbumDownloadPending(job_id=job_id)

--- a/backend/src/backend/api/albums/listing.py
+++ b/backend/src/backend/api/albums/listing.py
@@ -137,6 +137,37 @@ async def list_artist_albums(
     return {"albums": album_items}
 
 
+async def order_album_tracks(
+    album: Album, artist: Artist, all_tracks: list[Track]
+) -> list[Track]:
+    """order an album's tracks by its ATProto list record, created_at fallback.
+
+    the list record is the source of truth for curated order; tracks missing
+    from it (or the whole fetch failing) fall back to upload order.
+    """
+    if not album.atproto_record_uri:
+        return sorted(all_tracks, key=lambda t: t.created_at)
+    try:
+        track_uris = await fetch_list_item_uris(
+            album.atproto_record_uri, artist.pds_url
+        )
+        track_by_uri = {t.atproto_record_uri: t for t in all_tracks}
+        ordered: list[Track] = []
+        seen_ids = set()
+        for uri in track_uris:
+            if uri in track_by_uri:
+                track = track_by_uri[uri]
+                ordered.append(track)
+                seen_ids.add(track.id)
+        for track in sorted(all_tracks, key=lambda t: t.created_at):
+            if track.id not in seen_ids:
+                ordered.append(track)
+        return ordered
+    except Exception as e:
+        logger.warning(f"failed to fetch ATProto list for album ordering: {e}")
+        return sorted(all_tracks, key=lambda t: t.created_at)
+
+
 @router.get("/{handle}/{slug}")
 async def get_album(
     handle: str,
@@ -180,36 +211,7 @@ async def get_album(
     all_tracks = list(track_result.scalars().all())
 
     # determine track order: use ATProto list record if available
-    ordered_tracks: list[Track] = []
-    if album.atproto_record_uri:
-        try:
-            track_uris = await fetch_list_item_uris(
-                album.atproto_record_uri, artist.pds_url
-            )
-
-            # build uri -> track map
-            track_by_uri = {t.atproto_record_uri: t for t in all_tracks}
-
-            # order tracks by ATProto list, append any not in list at end
-            seen_ids = set()
-            for uri in track_uris:
-                if uri in track_by_uri:
-                    track = track_by_uri[uri]
-                    ordered_tracks.append(track)
-                    seen_ids.add(track.id)
-
-            # append any tracks not in the ATProto list (fallback)
-            for track in sorted(all_tracks, key=lambda t: t.created_at):
-                if track.id not in seen_ids:
-                    ordered_tracks.append(track)
-
-        except Exception as e:
-            logger.warning(f"failed to fetch ATProto list for album ordering: {e}")
-            # fallback to created_at order
-            ordered_tracks = sorted(all_tracks, key=lambda t: t.created_at)
-    else:
-        # no ATProto record - order by created_at
-        ordered_tracks = sorted(all_tracks, key=lambda t: t.created_at)
+    ordered_tracks = await order_album_tracks(album, artist, all_tracks)
 
     # an album someone opened is a destination, not a surface we chose
     tracks, labels_by_id = await filter_sensitive_audio_tracks(

--- a/backend/src/backend/storage/protocol.py
+++ b/backend/src/backend/storage/protocol.py
@@ -89,6 +89,10 @@ class StorageProtocol(Protocol):
         expires_in: int | None = None,
     ) -> str: ...
 
+    async def object_exists(self, key: str) -> bool:
+        """whether an audio-bucket object exists at this raw key."""
+        ...
+
     async def generate_download_url(
         self,
         *,

--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -893,6 +893,15 @@ class R2Storage:
                 )
                 return url
 
+    async def object_exists(self, key: str) -> bool:
+        """HEAD an audio-bucket object by raw key (cache checks, not media reads)."""
+        async with self._s3_client() as client:
+            try:
+                await client.head_object(Bucket=self.audio_bucket_name, Key=key)
+                return True
+            except ClientError:
+                return False
+
     async def generate_download_url(
         self,
         *,

--- a/backend/tests/api/test_album_download.py
+++ b/backend/tests/api/test_album_download.py
@@ -1,0 +1,147 @@
+"""tests for the album download endpoint."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.main import app
+from backend.models import Album, Artist, Track, UserPreferences
+
+
+@pytest.fixture
+def test_app() -> FastAPI:
+    return app
+
+
+async def _make_album(
+    db_session: AsyncSession,
+    *,
+    n_tracks: int = 2,
+    track_overrides: dict | None = None,
+) -> tuple[Album, list[Track]]:
+    artist = Artist(
+        did="did:plc:albumartist",
+        handle="albumartist.bsky.social",
+        display_name="Album Artist",
+    )
+    db_session.add(artist)
+    await db_session.flush()
+
+    album = Album(
+        artist_did=artist.did,
+        slug="test-album",
+        title="Test Album",
+    )
+    db_session.add(album)
+    await db_session.flush()
+
+    tracks = []
+    for i in range(n_tracks):
+        fields = {
+            "title": f"Song {i + 1}",
+            "artist_did": artist.did,
+            "album_id": album.id,
+            "file_id": f"aabbccddeeff{i:04x}",
+            "file_type": "mp3",
+        } | (track_overrides or {})
+        track = Track(**fields)
+        db_session.add(track)
+        tracks.append(track)
+    await db_session.commit()
+    for t in tracks:
+        await db_session.refresh(t)
+    return album, tracks
+
+
+async def _download(test_app: FastAPI, handle: str = "albumartist.bsky.social"):
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        return await client.get(
+            f"/albums/{handle}/test-album/download", follow_redirects=False
+        )
+
+
+async def test_album_download_enqueues_build_when_uncached(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    await _make_album(db_session)
+
+    mock_storage = MagicMock()
+    mock_storage.object_exists = AsyncMock(return_value=False)
+    with (
+        patch("backend.api.albums.downloads.storage", mock_storage),
+        patch(
+            "backend.api.albums.downloads.schedule_album_download",
+            new_callable=AsyncMock,
+        ) as schedule,
+    ):
+        response = await _download(test_app)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "preparing"
+    assert body["job_id"]
+    schedule.assert_awaited_once()
+    # ordered track ids travel to the worker; digest-keyed destination
+    _, track_ids, r2_key, zip_filename = schedule.await_args.args
+    assert len(track_ids) == 2
+    assert r2_key.startswith("exports/albums/")
+    assert zip_filename == "Album Artist - Test Album.zip"
+
+
+async def test_album_download_redirects_when_cached(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    await _make_album(db_session)
+
+    mock_storage = MagicMock()
+    mock_storage.object_exists = AsyncMock(return_value=True)
+    mock_storage.public_audio_bucket_url = "https://audio.example.com"
+    with patch("backend.api.albums.downloads.storage", mock_storage):
+        response = await _download(test_app)
+
+    assert response.status_code == 307
+    assert response.headers["location"].startswith(
+        "https://audio.example.com/exports/albums/"
+    )
+
+
+async def test_album_download_refuses_if_any_track_gated(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    await _make_album(db_session, track_overrides={"support_gate": {"type": "any"}})
+    response = await _download(test_app)
+    assert response.status_code == 403
+
+
+async def test_album_download_refuses_if_artist_opted_out(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    album, _ = await _make_album(db_session)
+    db_session.add(UserPreferences(did=album.artist_did, allow_downloads=False))
+    await db_session.commit()
+
+    response = await _download(test_app)
+    assert response.status_code == 403
+
+
+async def test_album_download_404_when_a_file_is_not_ours(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    # rkey-shaped file_id with no r2_url: nothing we can serve
+    await _make_album(
+        db_session, n_tracks=1, track_overrides={"file_id": "3jzfcijpj2z2a"}
+    )
+    response = await _download(test_app)
+    assert response.status_code == 404
+
+
+async def test_album_download_404_unknown_album(
+    test_app: FastAPI, db_session: AsyncSession
+):
+    response = await _download(test_app, handle="nobody.bsky.social")
+    assert response.status_code == 404

--- a/frontend/src/lib/components/DownloadButton.svelte
+++ b/frontend/src/lib/components/DownloadButton.svelte
@@ -2,14 +2,23 @@
 	import { downloadTrack } from '$lib/downloads';
 
 	interface Props {
-		fileId: string;
+		fileId?: string;
+		onDownload?: () => void;
 		title?: string;
 	}
 
-	let { fileId, title = 'download audio file' }: Props = $props();
+	let { fileId, onDownload, title = 'download audio file' }: Props = $props();
+
+	function handleClick() {
+		if (onDownload) {
+			onDownload();
+		} else if (fileId) {
+			downloadTrack(fileId);
+		}
+	}
 </script>
 
-<button class="download-btn" onclick={() => downloadTrack(fileId)} {title}>
+<button class="download-btn" onclick={handleClick} {title}>
 	<!-- 15px: the download glyph fills its viewBox denser than share's corner
 	     circles do, so equal nominal sizes read unequal. -->
 	<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/frontend/src/lib/downloads.ts
+++ b/frontend/src/lib/downloads.ts
@@ -21,3 +21,49 @@ export async function downloadTrack(fileId: string): Promise<void> {
 		toast.error('download failed');
 	}
 }
+
+/**
+ * download an album zip. a cached zip redirects immediately; otherwise the
+ * backend builds it on the worker and we follow the job's SSE progress
+ * until the download URL is ready.
+ */
+export async function downloadAlbum(handle: string, slug: string): Promise<void> {
+	const url = `${API_URL}/albums/${encodeURIComponent(handle)}/${encodeURIComponent(slug)}/download`;
+	try {
+		const res = await fetch(url, { credentials: 'include', redirect: 'manual' });
+		if (res.type === 'opaqueredirect') {
+			window.location.assign(url);
+			return;
+		}
+		if (res.ok) {
+			const data = await res.json();
+			if (data.job_id) {
+				toast.info('preparing album download...');
+				const es = new EventSource(`${API_URL}/exports/${data.job_id}/progress`);
+				es.onmessage = (event) => {
+					const progress = JSON.parse(event.data);
+					if (progress.status === 'completed') {
+						es.close();
+						if (progress.download_url) {
+							window.location.assign(progress.download_url);
+						} else {
+							toast.error('album download failed');
+						}
+					} else if (progress.status === 'failed') {
+						es.close();
+						toast.error(progress.error || 'album download failed');
+					}
+				};
+				es.onerror = () => {
+					es.close();
+					toast.error('album download failed');
+				};
+				return;
+			}
+		}
+		const data = await res.json().catch(() => ({}));
+		toast.error(data.detail || 'download unavailable');
+	} catch {
+		toast.error('download failed');
+	}
+}

--- a/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/album/[slug]/+page.svelte
@@ -4,6 +4,8 @@
 	import Header from '$lib/components/Header.svelte';
 	import TrackItem from '$lib/components/TrackItem.svelte';
 	import ShareButton from '$lib/components/ShareButton.svelte';
+	import DownloadButton from '$lib/components/DownloadButton.svelte';
+	import { downloadAlbum } from '$lib/downloads';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
 	import { moderation } from '$lib/moderation.svelte';
 	import { player } from '$lib/player.svelte';
@@ -32,6 +34,7 @@
 
 	// local mutable copy of tracks for reordering
 	let tracks = $state<Track[]>([...data.album.tracks]);
+	let albumDownloadable = $derived(tracks.length > 0 && tracks.every((t) => t.downloadable));
 
 	// check if current user owns this album
 	const isOwner = $derived(auth.user?.did === albumMetadata.artist_did);
@@ -356,6 +359,12 @@
 
 				<div class="side-buttons">
 					<ShareButton url={shareUrl} title="share album" />
+					{#if albumDownloadable}
+						<DownloadButton
+							onDownload={() => downloadAlbum(albumMetadata.artist_handle, albumMetadata.slug)}
+							title="download album"
+						/>
+					{/if}
 					{#if isOwner}
 						<button
 							class="icon-btn"
@@ -430,6 +439,12 @@
 			</button>
 			<div class="mobile-buttons">
 				<ShareButton url={shareUrl} title="share album" />
+				{#if albumDownloadable}
+					<DownloadButton
+							onDownload={() => downloadAlbum(albumMetadata.artist_handle, albumMetadata.slug)}
+							title="download album"
+						/>
+				{/if}
 				{#if isOwner}
 					<button
 						class="icon-btn"

--- a/loq.toml
+++ b/loq.toml
@@ -47,7 +47,7 @@ max_lines = 1266
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
-max_lines = 1016
+max_lines = 1025
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"
@@ -372,3 +372,7 @@ max_lines = 1178
 [[rules]]
 path = "backend/src/backend/api/audio.py"
 max_lines = 510
+
+[[rules]]
+path = "backend/src/backend/_internal/export_tasks.py"
+max_lines = 524


### PR DESCRIPTION
per nate's call on mechanism (option 3): worker-built zip cached in R2, served by redirect — the repo's existing export pattern, chosen so album bytes never transit the 1GB app VM we hardened today.

## design

- **`GET /albums/{handle}/{slug}/download`** (anonymous, like track downloads): resolves the album, applies the *same shared policy* per member track (`download_refusal` + `download_key` — one policy, now three consumers), and refuses the whole album if any track is gated/labeled/opted-out (403) or has no servable object (404).
- **cache**: destination key `exports/albums/{album_id}-{digest}.zip` where the digest covers the ordered member keys + entry names — an edited album naturally misses the cache, and the worker sweeps stale digests for that album when it publishes a fresh one. cache hit → 307 to the R2 URL (attachment disposition baked at upload, CDN carries the bytes). miss → job + 202 `{job_id}`; the client follows the existing `/exports/{id}/progress` SSE.
- **the worker task** is a sibling of `process_export`: semaphore(4) downloads to a tempdir, then a **ZIP_STORED** archive (audio is already compressed — deflate would burn worker CPU for nothing), entries `NN artist - title.ext` in the album's ATProto-list order (ordering logic extracted from `get_album` into `order_album_tracks`, shared). a partial fetch fails the job rather than shipping a corrupt album.
- **frontend**: download icon beside share on the album page (desktop + mobile layouts), shown only when `tracks.every(t => t.downloadable)` — server-computed fields, no client policy. `DownloadButton` gains an `onDownload` callback variant.

## known accepted gaps

- two concurrent first-clicks can enqueue duplicate builds; the writes are idempotent (same key) so the cost is wasted worker time, not corruption.
- no zip for albums with any non-downloadable track — no partial albums by design.

## verification

- 6 new endpoint tests (enqueue path incl. schedule args + digest key + zip filename, cache-hit redirect, gated/opt-out 403s, unservable 404, unknown album); full suite green (1514).
- rendered against prod data: the button appears on darkhart's event album (7/7 downloadable) and nowhere ineligible.
- end-to-end zip build to be exercised on staging post-merge before any prod release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)