### PR TITLE
docs: downloads reach the settings copy and the public docs

### DIFF
--- a/docs/public/artists.md
+++ b/docs/public/artists.md
@@ -237,6 +237,12 @@ standard ATProto self-label and immediately participates in plyr.fm's
 default-hide policy. It remains separate from any independent moderator label.
 See [sensitive content](/sensitive-content/) for the listener behavior.
 
+## downloads
+
+listeners can download your public audio — single tracks, and whole albums as a zip — with files named after you and your titles, preferring lossless originals. this is **on by default**: the same bytes are already publicly served by your PDS to anyone, so the toggle is a courtesy, not an access control. switch it off any time in [settings](https://plyr.fm/settings) under *downloads*.
+
+supporter-gated tracks, tracks under a copyright notice, and private tracks are never downloadable, and an album containing any of them doesn't offer a zip.
+
 ## your data
 
 ![the artist portal — manage your profile, tracks, and albums](/screenshots/portal-dashboard.png)

--- a/docs/public/listeners.md
+++ b/docs/public/listeners.md
@@ -72,8 +72,15 @@ links, radio, and playback behave.
 - **like, comment, and build playlists** — public (visible to other atproto apps) or private
 - **timed comments** — leave a reaction at a specific moment in a track
 - **jams** — shared listening rooms, in real time with friends
+- **downloads** — save a track, or a whole album as a zip, when the artist allows it
 
 your records — likes, playlists, comments — are stored on your [PDS](/glossary/#pds), the same place a Bluesky post lives. they belong to your atmosphere account, not to plyr.fm.
+
+## downloads
+
+most public audio can be downloaded — look for the download icon next to share on track and album pages. files come named (`artist - title.ext`) and prefer the lossless original when one exists; albums arrive as a numbered zip in the artist's track order. the first album download takes a minute to prepare — it's safe to leave, it stays ready once built.
+
+if there's no download icon, the artist has switched downloads off, or the audio is supporter-gated or under a copyright notice.
 
 ## keyboard shortcuts
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -291,7 +291,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 	async function saveAllowDownloads(enabled: boolean) {
 		try {
 			await preferences.update({ allow_downloads: enabled });
-			toast.success(enabled ? 'downloads enabled on your tracks' : 'downloads disabled');
+			toast.success(enabled ? 'downloads on' : 'downloads off');
 		} catch (_e) {
 			console.error('failed to save preference:', _e);
 			toast.error('failed to update preference');
@@ -773,7 +773,7 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 				<div class="setting-row">
 					<div class="setting-info">
 						<h3>downloads</h3>
-						<p>let listeners download your public, ungated tracks as files</p>
+						<p>let listeners download your public, ungated audio — single tracks and whole albums</p>
 					</div>
 					<label class="toggle-switch">
 						<input


### PR DESCRIPTION
nate: the settings copy was still pinned to tracks-only downloads, and docs.plyr.fm never learned the feature exists.

- **settings**: the toggle description now covers albums ("let listeners download your public, ungated audio — single tracks and whole albums"), and its toasts follow the new toast-copy skill: `downloads on` / `downloads off`.
- **docs.plyr.fm/listeners**: a downloads section — where the icon lives, file naming, album zips in track order, the cold-build wait (safe to leave), and why an icon might be absent.
- **docs.plyr.fm/artists**: a downloads section — on by default with the honest rationale (the PDS already serves the bytes publicly; the toggle is a courtesy, not an access control), what's never downloadable, and where the toggle is. bulk export stays its own distinct section.

not touched: the generated API reference (#1680 tracks making regeneration reproducible — hand-editing it would drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)