### PR TITLE
fix(track-page): center the composition; artwork absorbs spare height

### DIFF
--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -631,9 +631,12 @@ $effect(() => {
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		justify-content: flex-start;
+		/* the page is a single composition now (comments live in the panel):
+		   center it in the available height rather than top-anchoring it over
+		   a void — the apple now-playing posture */
+		justify-content: center;
 		padding: 2rem;
-		padding-bottom: 8rem;
+		padding-bottom: calc(var(--player-height, 0px) + 2rem);
 		width: 100%;
 	}
 
@@ -648,7 +651,9 @@ $effect(() => {
 
 	.cover-art-container {
 		width: 100%;
-		max-width: 300px;
+		/* spare vertical room becomes artwork, not void: scale with viewport
+		   height, bounded for short windows and very large screens */
+		max-width: clamp(260px, 38dvh, 480px);
 		aspect-ratio: 1;
 		border-radius: var(--radius-md);
 		overflow: hidden;


### PR DESCRIPTION
nate's annotated screenshots: the page top-anchored its content over a dead bottom 40% — a leftover posture from when comments lived in the page flow. the composition now centers in the available height (apple now-playing posture) and the artwork scales with viewport height (`clamp(260px, 38dvh, 480px)`), so spare room becomes art instead of void. bottom padding respects `--player-height` so the player doesn't eat the centered stack. verified at 1240×1150 (his geometry): centered, artwork ~437px, no void; mobile keeps its existing 60% artwork rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)