### PR TITLE
fix(comments): the emission surfaces below the utilities row, not over the stats

### DIFF
--- a/frontend/src/lib/components/TrackComments.svelte
+++ b/frontend/src/lib/components/TrackComments.svelte
@@ -284,7 +284,7 @@
 	{#if emission}
 		<button
 			class="comment-emission"
-			transition:fly={{ y: 10, duration: reduceMotionComments ? 0 : 300 }}
+			transition:fly={{ y: -8, duration: reduceMotionComments ? 0 : 300 }}
 			onclick={() => {
 				emission = null;
 				commentsOpen = true;
@@ -456,10 +456,11 @@
 		display: inline-flex;
 	}
 
-	/* the emission: a passing comment surfaces briefly above the trigger */
+	/* the emission: a passing comment surfaces briefly in the open space
+	   below the utilities row — never over the stats line above */
 	.comment-emission {
 		position: absolute;
-		bottom: calc(100% + 0.5rem);
+		top: calc(100% + 0.5rem);
 		left: 50%;
 		translate: -50% 0;
 		display: flex;

--- a/loq.toml
+++ b/loq.toml
@@ -379,4 +379,4 @@ max_lines = 524
 
 [[rules]]
 path = "frontend/src/lib/components/TrackComments.svelte"
-max_lines = 1090
+max_lines = 1091


### PR DESCRIPTION
nate's screenshot: the emission bubble anchored above the 💬 trigger, landing on the listens/ⓘ line — while the space *below* the utilities row is genuinely empty on every viewport now that the composition is centered. the bubble now drifts down out of the trigger into that open space. verified at 390px by measurement: 2px below the row, zero stats overlap, in-viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)