### PR TITLE
fix(spaces): bind credentials to DPoP

### DIFF
--- a/backend/src/backend/_internal/atproto/spaces/client.py
+++ b/backend/src/backend/_internal/atproto/spaces/client.py
@@ -1,27 +1,29 @@
 """Client for the Proposal-0016 permissioned-data surfaces.
 
-owner/author writes go through the DPoP-protected OAuth path
-([make_pds_request][backend._internal.atproto.client.make_pds_request]); the
-credential exchange and credential-gated reads use plain Bearer tokens
-(delegation tokens and space credentials are JWTs, not DPoP-bound), so those go
-through a small raw-bearer helper.
+Owner/author writes go through the DPoP-protected OAuth path
+([make_pds_request][backend._internal.atproto.client.make_pds_request]). Space
+credentials use a separate ephemeral DPoP key generated during credential
+exchange and retained with the credential for subsequent reads.
 
 Read path:
 
     user OAuth -> getDelegationToken (requester PDS, DPoP) -> getSpaceCredential
-    (space authority, delegation token + optional client attestation) -> reads
-    (plain Bearer credential)
+    (space authority, delegation token + DPoP proof + optional client
+    attestation) -> reads (DPoP-bound space credential)
 """
 
 import logging
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import Any
 
 import httpx
 from atproto_identity.did.resolver import AsyncDidResolver
+from atproto_oauth.dpop import DPoPManager
 from atproto_oauth.security import is_safe_url
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
 
 from backend._internal import Session as AuthSession
 from backend._internal.atproto.client import make_pds_request
@@ -74,27 +76,67 @@ async def _repo_host_url(repo: str) -> str:
     return await _resolve_did_service(repo, "#atproto_pds")
 
 
-async def _raw_bearer_request(
-    pds_url: str,
+def _space_dpop_headers(
+    method: str,
+    url: str,
+    token: str,
+    dpop_key: EllipticCurvePrivateKey,
+    *,
+    issuance: bool = False,
+) -> dict[str, str]:
+    proof = DPoPManager.create_proof(
+        method=method,
+        url=url,
+        private_key=dpop_key,
+        access_token=None if issuance else token,
+    )
+    scheme = "Bearer" if issuance else "DPoP"
+    return {
+        "authorization": f"{scheme} {token}",
+        "dpop": proof,
+    }
+
+
+async def _space_token_request(
+    service_url: str,
     method: str,
     endpoint: str,
-    bearer: str,
+    token: str,
+    dpop_key: EllipticCurvePrivateKey,
     *,
+    issuance: bool = False,
+    legacy_bearer: bool = False,
     json: dict[str, Any] | None = None,
     params: dict[str, Any] | None = None,
 ) -> httpx.Response:
-    """call XRPC with a plain Bearer token (delegation token / space credential)."""
-    url = f"{pds_url}/xrpc/{endpoint}"
+    """Call a permissioned XRPC with its operation-specific DPoP proof."""
+    url = f"{service_url}/xrpc/{endpoint}"
     if not is_safe_url(url):
-        raise ValueError(f"unsafe PDS URL: {url}")
+        raise ValueError(f"unsafe service URL: {url}")
+    headers = (
+        {"authorization": f"Bearer {token}"}
+        if legacy_bearer
+        else _space_dpop_headers(method, url, token, dpop_key, issuance=issuance)
+    )
     async with httpx.AsyncClient(timeout=30) as http:
         return await http.request(
             method,
             url,
-            headers={"authorization": f"Bearer {bearer}"},
+            headers=headers,
             json=json,
             params=params,
         )
+
+
+def _is_pre_dpop_rejection(response: httpx.Response) -> bool:
+    """Identify the old space server that only recognizes Bearer credentials."""
+    if response.status_code != 401:
+        return False
+    try:
+        body = response.json()
+    except ValueError:
+        return False
+    return isinstance(body, dict) and body.get("error") == "AuthenticationRequired"
 
 
 # --- space lifecycle + record writes (owner/author, DPoP OAuth) ---------------
@@ -181,12 +223,21 @@ async def delete_space_record(auth_session: AuthSession, record_uri: str) -> Non
 
 # --- credential exchange ------------------------------------------------------
 
-# per-process cache: space credentials are owner-signed and client-id-bound, so
-# they're reusable across reads of the same space until they expire.
-_credential_cache: dict[str, tuple[str, float]] = {}
+
+@dataclass(frozen=True)
+class SpaceCredential:
+    token: str
+    dpop_key: EllipticCurvePrivateKey
+    expires_at: float
 
 
-async def _mint_credential(auth_session: AuthSession, space: str) -> str:
+# Per-process cache. Keep the proof key and credential together: neither is
+# useful without the other. Include the requesting user so an authorization
+# decision made for one account is never reused for another.
+_credential_cache: dict[tuple[str, str], SpaceCredential] = {}
+
+
+async def _mint_credential(auth_session: AuthSession, space: str) -> SpaceCredential:
     delegation_resp = await make_pds_request(
         auth_session,
         "GET",
@@ -203,11 +254,14 @@ async def _mint_credential(auth_session: AuthSession, space: str) -> str:
 
     # Credential issuance happens on the resolved space host, which may differ
     # from both the user's PDS and each writer's repo host.
-    cred_resp = await _raw_bearer_request(
+    dpop_key = DPoPManager.generate_keypair()
+    cred_resp = await _space_token_request(
         await _space_host_url(space),
         "POST",
         "com.atproto.space.getSpaceCredential",
         delegation_token,
+        dpop_key,
+        issuance=True,
         json=payload,
     )
     if cred_resp.status_code != 200:
@@ -224,20 +278,24 @@ async def _mint_credential(auth_session: AuthSession, space: str) -> str:
         if any(error in body for error in refused_errors):
             raise SpaceAccessError(f"space authority refused credential: {body}")
         raise Exception(f"getSpaceCredential failed: {cred_resp.status_code} {body}")
-    return cred_resp.json()["credential"]
+    return SpaceCredential(
+        token=cred_resp.json()["credential"],
+        dpop_key=dpop_key,
+        expires_at=time.monotonic() + _CREDENTIAL_TTL_SECONDS,
+    )
 
 
 async def get_space_credential(
     auth_session: AuthSession, space: str, *, force_refresh: bool = False
-) -> str:
+) -> SpaceCredential:
     """obtain a space credential for `space`, minting+caching or renewing as needed."""
     now = time.monotonic()
-    if not force_refresh and (cached := _credential_cache.get(space)):
-        credential, expires_at = cached
-        if expires_at > now:
-            return credential
+    cache_key = (auth_session.did, space)
+    if not force_refresh and (cached := _credential_cache.get(cache_key)):
+        if cached.expires_at > now:
+            return cached
     credential = await _mint_credential(auth_session, space)
-    _credential_cache[space] = (credential, now + _CREDENTIAL_TTL_SECONDS)
+    _credential_cache[cache_key] = credential
     return credential
 
 
@@ -266,11 +324,22 @@ async def open_space_blob(
             credential = await get_space_credential(
                 auth_session, space, force_refresh=attempt > 0
             )
-            headers = {"authorization": f"Bearer {credential}"}
+            headers = _space_dpop_headers(
+                "GET", url, credential.token, credential.dpop_key
+            )
             if range_header:
                 headers["range"] = range_header
             req = http.build_request("GET", url, headers=headers, params=params)
             resp = await http.send(req, stream=True)
+            if _is_pre_dpop_rejection(resp):
+                await resp.aclose()
+                fallback_headers = {"authorization": f"Bearer {credential.token}"}
+                if range_header:
+                    fallback_headers["range"] = range_header
+                req = http.build_request(
+                    "GET", url, headers=fallback_headers, params=params
+                )
+                resp = await http.send(req, stream=True)
             if resp.status_code == 401 and attempt == 0:
                 await resp.aclose()
                 continue  # stale credential — renew and retry once
@@ -312,13 +381,24 @@ async def _credential_read(
         credential = await get_space_credential(
             auth_session, space, force_refresh=attempt > 0
         )
-        response = await _raw_bearer_request(
+        response = await _space_token_request(
             host_url,
             "GET",
             endpoint,
-            credential,
+            credential.token,
+            credential.dpop_key,
             params=params,
         )
+        if _is_pre_dpop_rejection(response):
+            response = await _space_token_request(
+                host_url,
+                "GET",
+                endpoint,
+                credential.token,
+                credential.dpop_key,
+                legacy_bearer=True,
+                params=params,
+            )
         if response.status_code == 401 and attempt == 0:
             continue
         if response.status_code != 200:

--- a/backend/tests/_internal/test_permissioned_space_dpop.py
+++ b/backend/tests/_internal/test_permissioned_space_dpop.py
@@ -1,0 +1,133 @@
+"""DPoP binding and rollout behavior for permissioned-space credentials."""
+
+import base64
+import hashlib
+import time
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from jose import jwt
+
+from backend._internal import Session
+from backend._internal.atproto.spaces import client as space_client
+
+
+@pytest.mark.parametrize(
+    ("issuance", "scheme", "has_ath"),
+    [(True, "Bearer", False), (False, "DPoP", True)],
+)
+def test_space_dpop_headers_bind_the_correct_operation(
+    issuance: bool, scheme: str, has_ath: bool
+) -> None:
+    token = "permissioned-token"
+    headers = space_client._space_dpop_headers(
+        "GET",
+        "https://space.test/xrpc/com.atproto.space.listRecords?space=ignored",
+        token,
+        space_client.DPoPManager.generate_keypair(),
+        issuance=issuance,
+    )
+
+    claims = jwt.get_unverified_claims(headers["dpop"])
+    assert headers["authorization"] == f"{scheme} {token}"
+    assert jwt.get_unverified_header(headers["dpop"])["typ"] == "dpop+jwt"
+    assert claims["htm"] == "GET"
+    assert claims["htu"] == "https://space.test/xrpc/com.atproto.space.listRecords"
+    assert ("ath" in claims) is has_ath
+    if has_ath:
+        expected_ath = (
+            base64.urlsafe_b64encode(hashlib.sha256(token.encode()).digest())
+            .rstrip(b"=")
+            .decode()
+        )
+        assert claims["ath"] == expected_ath
+
+
+@pytest.mark.parametrize(
+    ("status", "body", "expected"),
+    [
+        (401, {"error": "AuthenticationRequired"}, True),
+        (401, {"error": "InvalidDpopProof"}, False),
+        (403, {"error": "AuthenticationRequired"}, False),
+    ],
+)
+def test_pre_dpop_rejection_is_narrow(
+    status: int, body: dict[str, str], expected: bool
+) -> None:
+    response = httpx.Response(status, json=body)
+    assert space_client._is_pre_dpop_rejection(response) is expected
+
+
+async def test_credential_read_bridges_only_a_pre_dpop_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    credential = space_client.SpaceCredential(
+        token="space-credential",
+        dpop_key=space_client.DPoPManager.generate_keypair(),
+        expires_at=time.monotonic() + 300,
+    )
+    token_request = AsyncMock(
+        side_effect=[
+            httpx.Response(401, json={"error": "AuthenticationRequired"}),
+            httpx.Response(200, json={"records": []}),
+        ]
+    )
+    monkeypatch.setattr(
+        space_client, "get_space_credential", AsyncMock(return_value=credential)
+    )
+    monkeypatch.setattr(space_client, "_space_token_request", token_request)
+    session = Session(
+        session_id="s",
+        did="did:plc:user",
+        handle="user.test",
+        oauth_session={},
+    )
+
+    result = await space_client._credential_read(
+        session,
+        host_url="https://repo.test",
+        endpoint="com.atproto.space.listRecords",
+        space="at://did:plc:authority/space/fm.example.catalog/main",
+        params={"repo": "did:plc:user"},
+    )
+
+    assert result == {"records": []}
+    assert token_request.await_args_list[0].kwargs.get("legacy_bearer") is None
+    assert token_request.await_args_list[1].kwargs["legacy_bearer"] is True
+
+
+async def test_space_credential_cache_and_force_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    space_client._credential_cache.clear()
+    calls = {"n": 0}
+
+    async def fake_mint(auth_session, space):
+        calls["n"] += 1
+        return space_client.SpaceCredential(
+            token=f"cred-{calls['n']}",
+            dpop_key=space_client.DPoPManager.generate_keypair(),
+            expires_at=time.monotonic() + 300,
+        )
+
+    monkeypatch.setattr(space_client, "_mint_credential", fake_mint)
+    session = Session(
+        session_id="s",
+        did="did:plc:x",
+        handle="x.test",
+        oauth_session={"pds_url": "https://x"},
+    )
+    space = "at://did:plc:x/space/fm.plyr.privateMedia/self"
+
+    first = await space_client.get_space_credential(session, space)
+    cached = await space_client.get_space_credential(session, space)
+    assert first is cached
+    assert first.token == "cred-1"
+    assert calls["n"] == 1
+
+    renewed = await space_client.get_space_credential(
+        session, space, force_refresh=True
+    )
+    assert renewed.token == "cred-2"
+    assert calls["n"] == 2

--- a/backend/tests/_internal/test_permissioned_spaces.py
+++ b/backend/tests/_internal/test_permissioned_spaces.py
@@ -6,7 +6,7 @@ full data path is exercised against a live ZDS by scripts/permissioned_smoke.py.
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock
 
 import httpx
 import pytest
@@ -234,11 +234,11 @@ async def test_mint_credential_uses_delegation_token_flow(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     pds_request = AsyncMock(return_value={"token": "delegation-token"})
-    bearer_request = AsyncMock(
+    token_request = AsyncMock(
         return_value=httpx.Response(200, json={"credential": "space-credential"})
     )
     monkeypatch.setattr(space_client, "make_pds_request", pds_request)
-    monkeypatch.setattr(space_client, "_raw_bearer_request", bearer_request)
+    monkeypatch.setattr(space_client, "_space_token_request", token_request)
     monkeypatch.setattr(
         space_client,
         "_space_host_url",
@@ -257,18 +257,20 @@ async def test_mint_credential_uses_delegation_token_flow(
 
     credential = await space_client._mint_credential(session, space)
 
-    assert credential == "space-credential"
+    assert credential.token == "space-credential"
     pds_request.assert_awaited_once_with(
         session,
         "GET",
         "com.atproto.space.getDelegationToken",
         params={"space": space},
     )
-    bearer_request.assert_awaited_once_with(
+    token_request.assert_awaited_once_with(
         "https://space-host.test",
         "POST",
         "com.atproto.space.getSpaceCredential",
         "delegation-token",
+        ANY,
+        issuance=True,
         json={"space": space},
     )
 
@@ -276,7 +278,7 @@ async def test_mint_credential_uses_delegation_token_flow(
 async def test_mint_credential_sends_separate_client_attestation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    bearer_request = AsyncMock(
+    token_request = AsyncMock(
         return_value=httpx.Response(200, json={"credential": "space-credential"})
     )
     monkeypatch.setattr(
@@ -284,7 +286,7 @@ async def test_mint_credential_sends_separate_client_attestation(
         "make_pds_request",
         AsyncMock(return_value={"token": "delegation-token"}),
     )
-    monkeypatch.setattr(space_client, "_raw_bearer_request", bearer_request)
+    monkeypatch.setattr(space_client, "_space_token_request", token_request)
     monkeypatch.setattr(
         space_client,
         "_space_host_url",
@@ -305,11 +307,13 @@ async def test_mint_credential_sends_separate_client_attestation(
 
     await space_client._mint_credential(session, space)
 
-    bearer_request.assert_awaited_once_with(
+    token_request.assert_awaited_once_with(
         "https://space-host.test",
         "POST",
         "com.atproto.space.getSpaceCredential",
         "delegation-token",
+        ANY,
+        issuance=True,
         json={
             "space": space,
             "clientAttestation": (
@@ -403,7 +407,7 @@ async def test_mint_credential_maps_zds_access_refusal(
     )
     monkeypatch.setattr(
         space_client,
-        "_raw_bearer_request",
+        "_space_token_request",
         AsyncMock(
             return_value=httpx.Response(
                 403,
@@ -461,35 +465,6 @@ async def test_delete_space_record_uses_record_uri_shape(
         },
         success_codes=(200, 201, 204),
     )
-
-
-async def test_space_credential_cache_and_force_refresh(monkeypatch):
-    space_client._credential_cache.clear()
-    calls = {"n": 0}
-
-    async def fake_mint(auth_session, space):
-        calls["n"] += 1
-        return f"cred-{calls['n']}"
-
-    monkeypatch.setattr(space_client, "_mint_credential", fake_mint)
-    session = Session(
-        session_id="s",
-        did="did:plc:x",
-        handle="x.test",
-        oauth_session={"pds_url": "https://x"},
-    )
-    space = "at://did:plc:x/space/fm.plyr.privateMedia/self"
-
-    first = await space_client.get_space_credential(session, space)
-    cached = await space_client.get_space_credential(session, space)
-    assert first == cached == "cred-1"
-    assert calls["n"] == 1  # second call served from cache
-
-    renewed = await space_client.get_space_credential(
-        session, space, force_refresh=True
-    )
-    assert renewed == "cred-2"
-    assert calls["n"] == 2
 
 
 # --- discovery and sync routing ----------------------------------------------

--- a/docs/internal/architecture/permissioned-private-media.md
+++ b/docs/internal/architecture/permissioned-private-media.md
@@ -199,8 +199,9 @@ reads, and ranged blob playback. Unit tests cover URI parsing, current config sh
 scope composition, attestation inclusion, host routing, credential renewal, and the public
 record URL boundary.
 
-The smoke script currently authenticates with an app password. It proves the aligned ZDS
-data path, but not the browser OAuth scope-upgrade or confidential-client attestation path.
+The smoke script authenticates resident operations with an app password, then proves the
+DPoP-bound credential exchange and ranged read path using a separate ephemeral key. It
+does not prove the browser OAuth scope-upgrade or confidential-client attestation path.
 That browser-level interoperability proof remains in #1684.
 
 ## remaining product work

--- a/scripts/permissioned_smoke.py
+++ b/scripts/permissioned_smoke.py
@@ -1,14 +1,18 @@
 # /// script
 # requires-python = ">=3.12"
-# dependencies = ["httpx", "python-dotenv"]
+# dependencies = [
+#   "httpx",
+#   "python-dotenv",
+#   "atproto @ git+https://github.com/zzstoatzz/atproto@1ad4f176292d688005c6247f1e65f2d2c1057b89",
+# ]
 # ///
 """end-to-end smoke for the permissioned-spaces private-media flow against a live PDS.
 
 exercises the exact com.atproto.space.* request/response shapes the plyr.fm space
 client uses, proving private records + blobs actually store and read back through the
-permissioned-space access path. uses a plain createSession bearer (scope
-com.atproto.access bypasses ZDS granular space-scope checks) so it can run without the
-full OAuth/DPoP plumbing.
+permissioned-space access path. Uses a plain createSession bearer for resident
+operations, then exercises the proposal's separate ephemeral DPoP key for space
+credential issuance and credential-gated reads.
 
 run: uv run scripts/permissioned_smoke.py
 needs ZAT_TEST_HANDLE / ZAT_TEST_PASSWORD / ZAT_TEST_PDS in .env (a test account on a
@@ -19,6 +23,7 @@ import os
 import sys
 
 import httpx
+from atproto_oauth.dpop import DPoPManager
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -170,9 +175,19 @@ def main() -> int:
     delegation_token = delegation_resp.json()["token"]
     print("✓ getDelegationToken")
 
+    credential_url = f"{PDS}/xrpc/com.atproto.space.getSpaceCredential"
+    credential_key = DPoPManager.generate_keypair()
+    issuance_proof = DPoPManager.create_proof(
+        method="POST",
+        url=credential_url,
+        private_key=credential_key,
+    )
     cred_resp = c.post(
-        f"{PDS}/xrpc/com.atproto.space.getSpaceCredential",
-        headers={"authorization": f"Bearer {delegation_token}"},
+        credential_url,
+        headers={
+            "authorization": f"Bearer {delegation_token}",
+            "dpop": issuance_proof,
+        },
         json={"space": space_uri},
     )
     cred_resp.raise_for_status()
@@ -180,9 +195,20 @@ def main() -> int:
     print("✓ getSpaceCredential")
 
     # read the blob THROUGH the permissioned path using the space credential + Range
+    blob_url = f"{PDS}/xrpc/com.atproto.space.getBlob"
+    read_proof = DPoPManager.create_proof(
+        method="GET",
+        url=blob_url,
+        private_key=credential_key,
+        access_token=credential,
+    )
     blob_get = c.get(
-        f"{PDS}/xrpc/com.atproto.space.getBlob",
-        headers={"authorization": f"Bearer {credential}", "range": "bytes=0-3"},
+        blob_url,
+        headers={
+            "authorization": f"DPoP {credential}",
+            "dpop": read_proof,
+            "range": "bytes=0-3",
+        },
         params={"space": space_uri, "repo": did, "cid": blob_cid},
     )
     assert blob_get.status_code == 206, (


### PR DESCRIPTION
## Summary

- bind permissioned-space credentials to an independent ephemeral DPoP key
- send operation-specific DPoP proofs for credential reads, including ranged blob playback
- key the credential cache by resident DID and space
- retain a narrow rollout bridge for the current pre-DPoP ZDS response; it only retries exact `401 AuthenticationRequired` responses and does not downgrade proof or policy errors
- update the permissioned smoke and architecture notes to cover the DPoP credential path

## Verification

- `just backend lint`
- `uvx loq check`
- 43 focused permissioned-space tests
- full backend suite: 1523 passed, 25 skipped
- live private-media integration against current ZDS: passed
