### PR TITLE
fix(mobile): media session arrows/scrubber, settings reachability, fold + button-size polish

### DIFF
--- a/frontend/src/lib/components/DownloadButton.svelte
+++ b/frontend/src/lib/components/DownloadButton.svelte
@@ -49,4 +49,16 @@
 		border-color: var(--accent);
 		color: var(--accent);
 	}
+
+	@media (max-width: 768px) {
+		.download-btn {
+			width: 28px;
+			height: 28px;
+		}
+
+		.download-btn svg {
+			width: 13px;
+			height: 13px;
+		}
+	}
 </style>

--- a/frontend/src/lib/components/ProfileMenu.svelte
+++ b/frontend/src/lib/components/ProfileMenu.svelte
@@ -1080,9 +1080,12 @@
 
 	.all-settings-link {
 		display: block;
+		position: sticky;
+		bottom: 0;
+		background: var(--bg-secondary);
 		text-align: center;
 		padding: 1rem;
-		margin-top: 0.5rem;
+		margin: 0.5rem -1.25rem -1.25rem;
 		border-top: 1px solid var(--border-subtle);
 		color: var(--text-secondary);
 		text-decoration: none;

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -70,39 +70,15 @@
 			queue.pause();
 		});
 
-		navigator.mediaSession.setActionHandler('previoustrack', () => {
-			if (queue.hasPrevious) {
-				queue.previous();
-			}
-		});
-
-		navigator.mediaSession.setActionHandler('nexttrack', () => {
-			if (queue.hasNext) {
-				queue.next();
-			}
-		});
-
 		navigator.mediaSession.setActionHandler('seekto', (details) => {
 			if (details.seekTime !== undefined) {
 				queue.seek(details.seekTime * 1000);
 			}
 		});
 
-		navigator.mediaSession.setActionHandler('seekbackward', (details) => {
-			if (player.audioElement) {
-				const skipTime = details.seekOffset ?? 10;
-				const newTime = Math.max(0, player.audioElement.currentTime - skipTime);
-				queue.seek(newTime * 1000);
-			}
-		});
-
-		navigator.mediaSession.setActionHandler('seekforward', (details) => {
-			if (player.audioElement) {
-				const skipTime = details.seekOffset ?? 10;
-				const newTime = Math.min(player.duration, player.audioElement.currentTime + skipTime);
-				queue.seek(newTime * 1000);
-			}
-		});
+		// deliberately NO seekbackward/seekforward: iOS replaces the ⏮/⏭ track
+		// buttons with 10s-skip buttons when those handlers exist, and seekto +
+		// the lock-screen scrubber already cover in-track seeking
 	}
 
 	// check if we're on the current track's detail page
@@ -238,11 +214,26 @@
 		localStorage.setItem('player_volume', player.volume.toString());
 	});
 
-	// update media session metadata when track changes
+	// update media session metadata when track changes (queue OR radio)
 	$effect(() => {
-		if (player.currentTrack) {
-			updateMediaSessionMetadata(player.currentTrack);
+		if (nowPlayingTrack) {
+			updateMediaSessionMetadata(nowPlayingTrack);
 		}
+	});
+
+	// (de)register prev/next reactively: the OS only shows ⏮/⏭ for commands it
+	// believes are live, so availability must be signaled by registration, not
+	// by a no-op inside the callback. radio has no queue navigation.
+	$effect(() => {
+		if (!('mediaSession' in navigator)) return;
+		navigator.mediaSession.setActionHandler(
+			'previoustrack',
+			!player.radio && queue.hasPrevious ? () => queue.previous() : null
+		);
+		navigator.mediaSession.setActionHandler(
+			'nexttrack',
+			!player.radio && queue.hasNext ? () => queue.next() : null
+		);
 	});
 
 	// update media session playback state when paused changes
@@ -253,11 +244,14 @@
 
 	// update media session position state when time/duration changes
 	$effect(() => {
-		if (!('mediaSession' in navigator) || !player.duration || player.duration <= 0) return;
+		// Infinity/NaN durations (streams, sources mid-swap) make
+		// setPositionState throw, which leaves iOS with no scrubber
+		if (!('mediaSession' in navigator) || !Number.isFinite(player.duration) || player.duration <= 0)
+			return;
 		try {
 			navigator.mediaSession.setPositionState({
 				duration: player.duration,
-				playbackRate: 1,
+				playbackRate: player.audioElement?.playbackRate || 1,
 				position: Math.min(player.currentTime, player.duration)
 			});
 		} catch {

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -1119,8 +1119,10 @@ $effect(() => {
 			max-width: 100%;
 		}
 
+		/* height-aware like desktop: the artwork gives way before the
+		   share/download row falls past the fold */
 		.cover-art-container {
-			max-width: 60%;
+			max-width: min(60%, 22dvh);
 			margin: 0 auto;
 		}
 

--- a/loq.toml
+++ b/loq.toml
@@ -99,7 +99,7 @@ max_lines = 805
 
 [[rules]]
 path = "frontend/src/lib/components/ProfileMenu.svelte"
-max_lines = 1193
+max_lines = 1196
 
 [[rules]]
 path = "frontend/src/lib/components/Queue.svelte"


### PR DESCRIPTION
four mobile polish fixes from a single review pass — the common thread is fixes that had landed at the page level instead of the root cause, and mobile styles that forked from desktop and drifted.

## media session (iOS lock screen / control center)

- **⏮/⏭ arrows were missing** because we registered `seekbackward`/`seekforward` handlers; iOS replaces the track-skip buttons with 10s-skip buttons when those exist. removed — `seekto` + the scrubber cover in-track seeking.
- **prev/next were registered once at mount** with the `hasPrevious`/`hasNext` check *inside* the callback, so the OS could never tell whether the command was live. now (de)registered reactively via `setActionHandler(..., fn | null)` keyed on queue state (and off in radio mode).
- **scrubber**: `setPositionState` bailed on falsy duration but not `Infinity`/`NaN` (streams, sources mid-swap on iOS Safari), where it throws and leaves stale/no position state. guarded with `Number.isFinite`; `playbackRate` now read from the element.
- **radio mode** never fed metadata to the media session (effect keyed on `player.currentTrack` only); now keyed on `nowPlayingTrack`.

<details><summary>intentional non-behaviors</summary>

- the embed's `media-session.ts` (#1340) still registers seekbackward/seekforward; embeds are a separate surface and out of scope here.
- prev/next availability remains queue-index-based — no "restart current track" fallback semantics were added.
</details>

## settings popover: "all settings" was below the fold

the link exists but was the last child of the scrollable settings stack (theme/accent/font/playback above it), so on phones it was never visible. it's now `position: sticky; bottom: 0` with an opaque full-bleed background, pinned at the bottom of the popover scrollport.

## track page: share/download below the fold on mobile

13f9157a made the desktop artwork height-aware (`clamp(260px, 38dvh, 480px)`) but the mobile block still overrode it with `max-width: 60%` — width-based, so height-unbounded on tall-stacked phones. mobile is now `min(60%, 22dvh)` so the artwork gives way before the share/download row falls past the fold.

## album page: share vs download button size mismatch

root cause was in the shared components: `ShareButton` shrinks to 28px at ≤768px, `DownloadButton` had no mobile block and stayed 32px. the track page had papered over this with per-page `:global` overrides that the album page never got. `DownloadButton` now mirrors ShareButton's mobile block (keeping the deliberate 1px-smaller glyph), which fixes the album page — and every other surface using the pair — without page-level CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)