### PR TITLE
fix(player): let iOS drive the lock-screen scrubber natively

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -70,15 +70,12 @@
 			queue.pause();
 		});
 
-		navigator.mediaSession.setActionHandler('seekto', (details) => {
-			if (details.seekTime !== undefined) {
-				queue.seek(details.seekTime * 1000);
-			}
-		});
-
-		// deliberately NO seekbackward/seekforward: iOS replaces the ⏮/⏭ track
-		// buttons with 10s-skip buttons when those handlers exist, and seekto +
-		// the lock-screen scrubber already cover in-track seeking
+		// deliberately NO seekbackward/seekforward (iOS replaces the ⏮/⏭ track
+		// buttons with 10s-skip buttons when those handlers exist) and NO
+		// seekto/setPositionState: iOS drives the lock-screen scrubber natively
+		// from the audio element's seekable state, and supplying an explicit
+		// position state replaces that with an emulated one the lock screen
+		// won't let you drag. SoundCloud's working web player registers neither.
 	}
 
 	// check if we're on the current track's detail page
@@ -240,23 +237,6 @@
 	$effect(() => {
 		if (!('mediaSession' in navigator)) return;
 		navigator.mediaSession.playbackState = player.paused ? 'paused' : 'playing';
-	});
-
-	// update media session position state when time/duration changes
-	$effect(() => {
-		// Infinity/NaN durations (streams, sources mid-swap) make
-		// setPositionState throw, which leaves iOS with no scrubber
-		if (!('mediaSession' in navigator) || !Number.isFinite(player.duration) || player.duration <= 0)
-			return;
-		try {
-			navigator.mediaSession.setPositionState({
-				duration: player.duration,
-				playbackRate: player.audioElement?.playbackRate || 1,
-				position: Math.min(player.currentTime, player.duration)
-			});
-		} catch {
-			// ignore errors from invalid position state
-		}
 	});
 
 	// report now-playing state for external integrations (teal.fm/Piper)


### PR DESCRIPTION
the lock screen showed correct times but the scrubber could not be grabbed at all (iOS Safari, non-PWA). differential test: SoundCloud's web player scrubs fine on the same phone/browser — so it's achievable and was our bug.

instrumenting `navigator.mediaSession` on SoundCloud's player showed their working recipe registers `play`/`pause`/`previoustrack`/`nexttrack`/`seekforward`/`seekbackward` and **never registers `seekto` nor calls `setPositionState`**. conclusion: iOS wires the Now Playing scrubber natively to the audio element's seekable state; supplying an explicit position state replaces that with an emulated position the lock screen displays but won't let you drag.

this PR drops the `seekto` handler and the `setPositionState` effect from Player.svelte, matching the empirically working recipe. `playbackState`, metadata, and the reactive prev/next registration from #1860 are unchanged.

<details><summary>verification & deferred scope</summary>

- verification is device-only: to be confirmed on staging on a physical iPhone (arrows from #1860 already confirmed working there).
- prod audio serves ranged GETs (`206` + `Content-Range`), so the element's seekable state is well-formed — the native path has what it needs.
- the embed's `media-session.ts` still uses seekto/positionState; left untouched until this recipe is confirmed on the main player.
- if scrubbing still fails on staging, next step is Safari Web Inspector attached to the device, not another blind iteration.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)