### PR TITLE
debug: serve the scrub bisect via a route

### DIFF
--- a/frontend/src/routes/scrub-test/+server.ts
+++ b/frontend/src/routes/scrub-test/+server.ts
@@ -1,0 +1,7 @@
+import page from '../../../static/scrub-test.html?raw';
+import type { RequestHandler } from './$types';
+
+// served as a raw route (not a +page) so the root layout's Player — and its
+// media-session registrations — never mount and contaminate the bisect
+export const GET: RequestHandler = () =>
+	new Response(page, { headers: { 'content-type': 'text/html; charset=utf-8' } });


### PR DESCRIPTION
follow-up to #1862: the static file built fine and `_routes.json` excluded `/scrub-test.html`, but Cloudflare Pages' always-on clean-URL redirect 308s it to `/scrub-test`, which is not excluded — so it fell through to the SvelteKit worker and the SPA 404'd. static `.html` files are effectively unreachable on this setup.

this serves the same file through a `+server.ts` GET (raw-imported), deliberately not a `+page` so the root layout's Player — and its media-session registrations — never mount and contaminate the bisect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)