### PR TITLE
debug: any tap starts playback on the scrub bisect page

### DIFF
--- a/frontend/static/scrub-test.html
+++ b/frontend/static/scrub-test.html
@@ -83,6 +83,12 @@
     });
   }
 
+  // any click/tap on the page starts playback — lets automation (and thumbs)
+  // avoid hunting for the native control
+  document.addEventListener('pointerdown', (e) => {
+    if (audio.paused && !e.target.closest('a')) audio.play();
+  });
+
   const state = document.getElementById('state');
   setInterval(() => {
     const r = audio.seekable;


### PR DESCRIPTION
makes the bisect page play on any pointerdown (outside links) so simulator automation and thumbs don't have to hit the small native control. part of the temporary /scrub-test diagnostic; the whole surface gets removed once the scrubber bug is found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)