### PR TITLE
fix(player): restore seekto + position state — required for lock-screen scrubbing

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -70,12 +70,20 @@
 			queue.pause();
 		});
 
-		// deliberately NO seekbackward/seekforward (iOS replaces the ⏮/⏭ track
-		// buttons with 10s-skip buttons when those handlers exist) and NO
-		// seekto/setPositionState: iOS drives the lock-screen scrubber natively
-		// from the audio element's seekable state, and supplying an explicit
-		// position state replaces that with an emulated one the lock screen
-		// won't let you drag. SoundCloud's working web player registers neither.
+		// seekto is REQUIRED for lock-screen scrubbing: once any action handler
+		// is registered, WebKit stops advertising the element's native
+		// seekability and only declares the commands the page registered —
+		// without seekto the scrubber renders but ignores drags (bisected on
+		// the iOS 26.5 simulator: bare element scrubs, +play/pause kills it,
+		// +seekto restores it)
+		navigator.mediaSession.setActionHandler('seekto', (details) => {
+			if (details.seekTime !== undefined) {
+				queue.seek(details.seekTime * 1000);
+			}
+		});
+
+		// deliberately NO seekbackward/seekforward: iOS replaces the ⏮/⏭ track
+		// buttons with 10s-skip buttons when those handlers exist
 	}
 
 	// check if we're on the current track's detail page
@@ -237,6 +245,23 @@
 	$effect(() => {
 		if (!('mediaSession' in navigator)) return;
 		navigator.mediaSession.playbackState = player.paused ? 'paused' : 'playing';
+	});
+
+	// keep position state current so the lock-screen timeline tracks the
+	// element; guards keep Infinity/NaN durations (streams, sources mid-swap)
+	// from making setPositionState throw
+	$effect(() => {
+		if (!('mediaSession' in navigator) || !Number.isFinite(player.duration) || player.duration <= 0)
+			return;
+		try {
+			navigator.mediaSession.setPositionState({
+				duration: player.duration,
+				playbackRate: player.audioElement?.playbackRate || 1,
+				position: Math.min(player.currentTime, player.duration)
+			});
+		} catch {
+			// invalid transient position state
+		}
 	});
 
 	// report now-playing state for external integrations (teal.fm/Piper)


### PR DESCRIPTION
#1861 (dropping seekto/setPositionState to \"let iOS drive the scrubber natively\") made lock-screen scrubbing structurally impossible. bisected on the iOS 26.5 simulator with a staging test page that layers media-session ingredients one at a time:

| mode | ingredients | lock-screen scrub |
|---|---|---|
| A | bare `<audio>` | ✅ |
| B | + MediaMetadata | ✅ |
| C | + play/pause/prev/next handlers | ❌ (= staging after #1861) |
| D | + seekto + setPositionState | ✅ |

mechanism: once a page registers ANY media-session action handler, WebKit stops advertising the element's native seekability and only declares the registered commands — without `seekto` the lock-screen bar renders but ignores drags. (SoundCloud survives without `seekto` because it registers `seekforward`/`seekbackward`, which iOS also accepts as seek support — at the cost of the ⏮/⏭ arrows.)

this restores the `seekto` handler and the guarded `setPositionState` effect, keeping #1860's improvements (no skip handlers so the arrows stay, reactive prev/next registration, radio metadata, finite-duration guard).

<details><summary>remaining known issue (separate)</summary>

during the bisect a second failure mode reproduced: when a track ends or changes identity under a live Now Playing session, the widget can freeze on a stale timeline (matches the production screenshots taken before #1861, which ran the D-equivalent recipe). that's a metadata/track-churn issue, to be reproduced against the real app next — this PR restores the structurally-required baseline first.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)