### PR TITLE
fix(player): stop resetting Now Playing position state every frame

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -247,18 +247,37 @@
 		navigator.mediaSession.playbackState = player.paused ? 'paused' : 'playing';
 	});
 
-	// keep position state current so the lock-screen timeline tracks the
-	// element; guards keep Infinity/NaN durations (streams, sources mid-swap)
-	// from making setPositionState throw
+	// push position state only when the timeline actually changes — new track
+	// (duration), a seek (position deviating from extrapolation), or a
+	// pause/resume boundary. The OS extrapolates position from playbackRate
+	// between pushes; re-pushing every frame (currentTime is bound per-frame)
+	// resets the Now Playing timeline ~60×/s, which makes the iOS lock-screen
+	// scrubber render but ignore drags. Finite-duration guard keeps
+	// Infinity/NaN (streams, sources mid-swap) from making the call throw.
+	let pushedPosition = -1;
+	let pushedDuration = -1;
+	let pushedPaused = false;
+	let pushedAt = 0;
 	$effect(() => {
 		if (!('mediaSession' in navigator) || !Number.isFinite(player.duration) || player.duration <= 0)
 			return;
+		const duration = player.duration;
+		const position = Math.min(player.currentTime, duration);
+		const rate = player.audioElement?.playbackRate || 1;
+		const extrapolated =
+			pushedPosition + ((Date.now() - pushedAt) / 1000) * (pushedPaused ? 0 : rate);
+		if (
+			duration === pushedDuration &&
+			player.paused === pushedPaused &&
+			Math.abs(position - extrapolated) < 2
+		)
+			return;
 		try {
-			navigator.mediaSession.setPositionState({
-				duration: player.duration,
-				playbackRate: player.audioElement?.playbackRate || 1,
-				position: Math.min(player.currentTime, player.duration)
-			});
+			navigator.mediaSession.setPositionState({ duration, playbackRate: rate, position });
+			pushedPosition = position;
+			pushedDuration = duration;
+			pushedPaused = player.paused;
+			pushedAt = Date.now();
 		} catch {
 			// invalid transient position state
 		}

--- a/loq.toml
+++ b/loq.toml
@@ -123,7 +123,7 @@ max_lines = 622
 
 [[rules]]
 path = "frontend/src/lib/components/player/Player.svelte"
-max_lines = 999
+max_lines = 1017
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"


### PR DESCRIPTION
instrumenting `navigator.mediaSession` on the staging app showed `setPositionState` being called **1,283 times in 15 seconds** (~every animation frame) — the effect is keyed on `player.currentTime`, which is `bind:`-ed to the audio element and updates per-frame. the isolated bisect recipe (#1865's basis) pushed at ~4Hz off `timeupdate` and scrubbed fine on the iOS simulator; the real app's 60Hz cadence resets the Now Playing timeline continuously, so the lock-screen scrubber renders but stomps any drag the moment it starts — the exact on-device symptom, invisible in the cold bisect.

the OS extrapolates position from `playbackRate` between pushes, so continuous updates are unnecessary as well as harmful. the effect now pushes only when the timeline materially changes: new duration (track change), pause/resume boundary, or the position deviating >2s from extrapolation (a seek). handlers and metadata were verified to fire exactly once per track — this was the only churn.

verification: same instrumentation re-run against staging after deploy should show a handful of calls per track instead of ~85/s; final confirmation is on-device scrubbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)