### PR TITLE
fix(comments): first click on a comment timestamp seeks the wrong source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 *   **Async Everywhere:** Never block the event loop. Use `anyio`/`aiofiles`.
 *   **Type Hints:** Required everywhere (Python & TypeScript).
 *   **Communication:** Use emojis sparingly and strictly for emphasis.
+*   **No paragraph comments in code.** Rationale and mechanism explanations live in STATUS.md, docs, commit messages, and PR bodies — never as multi-line comment blocks in the middle of code. A comment, when warranted at all, is one short line.
 *   **DO NOT UNNECESSARILY DEFER IMPORTS.** Put imports at the top of the file where they belong. Deferred imports inside functions are only acceptable for avoiding circular imports - not for "lazy loading" or other reasons.
 
 ## 🛠️ Stack & Tooling

--- a/frontend/src/lib/components/TrackComments.svelte
+++ b/frontend/src/lib/components/TrackComments.svelte
@@ -164,17 +164,16 @@
 	}
 
 	async function seekToTimestamp(ms: number) {
-		const doSeek = () => {
-			queue.seek(ms);
-		};
-
 		// if this track is already loaded, seek immediately
 		if (player.currentTrack?.id === track.id) {
-			doSeek();
+			queue.seek(ms);
 			return;
 		}
 
-		// otherwise start playing and wait for audio to be ready
+		// the element still holds the previous source; the loader applies this
+		// once the new track's audio attaches
+		player.pendingSeek = { trackId: track.id, ms };
+
 		// use playTrack for gated content checks
 		let played = false;
 		if (track.gated) {
@@ -184,18 +183,7 @@
 			played = true;
 		}
 
-		if (!played) return; // gated - can't seek
-
-		if (player.audioElement && player.audioElement.readyState >= 1) {
-			doSeek();
-		} else {
-			// wait for metadata to load before seeking
-			const onReady = () => {
-				doSeek();
-				player.audioElement?.removeEventListener('loadedmetadata', onReady);
-			};
-			player.audioElement?.addEventListener('loadedmetadata', onReady);
-		}
+		if (!played) player.pendingSeek = null; // gated - can't seek
 	}
 
 	function formatRelativeTime(isoString: string): string {

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -390,12 +390,23 @@
 				// after radio releases the player). always mark the attempt done —
 				// with nothing to restore there is still nothing pending, and
 				// progress persistence stays paused until this flips true.
-				if (!positionRestored && queue.progressMs > 0 && player.audioElement) {
+				const pendingSeek =
+					player.pendingSeek?.trackId === resolved.trackId ? player.pendingSeek : null;
+				if (
+					!pendingSeek &&
+					!positionRestored &&
+					queue.progressMs > 0 &&
+					player.audioElement
+				) {
 					const positionSec = queue.progressMs / 1000;
 					// don't restore if near the end (within 5s of duration)
 					if (player.duration === 0 || positionSec < player.duration - 5) {
 						player.audioElement.currentTime = positionSec;
 					}
+				}
+				if (pendingSeek && player.audioElement) {
+					player.audioElement.currentTime = pendingSeek.ms / 1000;
+					player.pendingSeek = null;
 				}
 				positionRestored = true;
 				isLoadingTrack = false;
@@ -496,6 +507,11 @@
 			previousTrackId = trackToLoad.id;
 			previousFileId = trackToLoad.file_id;
 			return;
+		}
+
+		// a seek requested for some other track must not fire on this one
+		if (player.pendingSeek && player.pendingSeek.trackId !== trackToLoad.id) {
+			player.pendingSeek = null;
 		}
 
 		// update tracking state

--- a/frontend/src/lib/player-comment-seek.test.ts
+++ b/frontend/src/lib/player-comment-seek.test.ts
@@ -1,0 +1,112 @@
+// comment-timestamp seek on a not-yet-loaded track must apply after the new
+// source attaches, never against the previous source ("first click goes to 0")
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import { player } from '$lib/player.svelte';
+import { queue } from '$lib/queue.svelte';
+import type { Track } from '$lib/types';
+
+vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
+vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+
+vi.stubGlobal(
+	'fetch',
+	vi.fn(() => Promise.resolve(new Response(JSON.stringify({}))))
+);
+
+function track(id: number): Track {
+	return {
+		id,
+		title: `track ${id}`,
+		artist: 'artist',
+		artist_handle: 'artist.test',
+		file_id: `file-${id}`,
+		file_type: 'mp3',
+		play_count: 0
+	};
+}
+
+let component: Record<string, unknown>;
+
+async function mountPlayer(): Promise<HTMLAudioElement> {
+	const Player = (await import('$lib/components/player/Player.svelte')).default;
+	component = mount(Player, { target: document.body });
+	flushSync();
+	const audio = player.audioElement;
+	if (!audio) throw new Error('player audio element did not mount');
+	return audio;
+}
+
+async function waitForAttach(audio: HTMLAudioElement, fileId: string): Promise<void> {
+	await vi.waitFor(() => {
+		if (!audio.src.includes(fileId)) throw new Error(`audio not attached to ${fileId}`);
+	});
+}
+
+beforeEach(() => {
+	queue.tracks = [track(1)];
+	queue.currentIndex = 0;
+	queue.progressMs = 0;
+	player.currentTrack = track(1);
+	player.radio = null;
+	player.paused = false;
+	player.pendingSeek = null;
+});
+
+afterEach(() => {
+	unmount(component);
+	document.body.innerHTML = '';
+});
+
+describe('pending comment-timestamp seek', () => {
+	it('applies the seek once the new track attaches, not against the old source', async () => {
+		const audio = await mountPlayer();
+		await waitForAttach(audio, 'file-1');
+		audio.dispatchEvent(new Event('loadeddata'));
+
+		// comment timestamp click on a different track
+		player.pendingSeek = { trackId: 2, ms: 43_000 };
+		queue.playNow(track(2));
+		player.currentTrack = track(2);
+		flushSync();
+
+		// the seek must not have touched the element before the new source loads
+		expect(audio.currentTime).toBe(0);
+
+		await waitForAttach(audio, 'file-2');
+		audio.dispatchEvent(new Event('loadeddata'));
+
+		expect(audio.currentTime).toBeCloseTo(43);
+		expect(player.pendingSeek).toBeNull();
+	});
+
+	it('wins over saved-progress restore on a fresh mount', async () => {
+		queue.progressMs = 99_000; // hydrated saved position for some prior session
+		player.pendingSeek = { trackId: 1, ms: 43_000 };
+		const audio = await mountPlayer();
+		await waitForAttach(audio, 'file-1');
+
+		audio.dispatchEvent(new Event('loadeddata'));
+
+		expect(audio.currentTime).toBeCloseTo(43);
+		expect(player.pendingSeek).toBeNull();
+	});
+
+	it('clears a pending seek that belongs to a different track', async () => {
+		const audio = await mountPlayer();
+		await waitForAttach(audio, 'file-1');
+		audio.dispatchEvent(new Event('loadeddata'));
+
+		player.pendingSeek = { trackId: 3, ms: 43_000 };
+		queue.playNow(track(2));
+		player.currentTrack = track(2);
+		flushSync();
+
+		await waitForAttach(audio, 'file-2');
+		audio.dispatchEvent(new Event('loadeddata'));
+
+		expect(audio.currentTime).toBe(0);
+		expect(player.pendingSeek).toBeNull();
+	});
+});

--- a/frontend/src/lib/player.svelte.ts
+++ b/frontend/src/lib/player.svelte.ts
@@ -56,6 +56,9 @@ class PlayerState {
 	private hlsLoad: Promise<HlsModule | null> | null = null;
 	paused = $state(true);
 
+	/** seek to apply once the named track's audio attaches (comment timestamps) */
+	pendingSeek = $state<{ trackId: number; ms: number } | null>(null);
+
 	currentTime = $state(0);
 	duration = $state(0);
 	volume = $state(0.7);

--- a/loq.toml
+++ b/loq.toml
@@ -123,7 +123,7 @@ max_lines = 622
 
 [[rules]]
 path = "frontend/src/lib/components/player/Player.svelte"
-max_lines = 999
+max_lines = 1009
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"


### PR DESCRIPTION
Clicking a comment timestamp on a track that isn't currently loaded now seeks to the right position on the first click. Previously the seek fired against the *previous* audio source, so the first click started the track at 0 and only a second click landed on the timestamp.

<details>
<summary>mechanism and design</summary>

**the bug**: `seekToTimestamp` in `TrackComments.svelte` called `queue.playNow(track)` and then checked `player.audioElement.readyState >= 1` to decide whether to seek immediately. But the player attaches the new track's `src` asynchronously (`resolveAudioSource` in `Player.svelte`), so at that moment `readyState` still described the old source. The seek executed against the old audio; the new load then reset playback to 0. On the second click the track was current, so the immediate-seek branch worked.

The fallback `loadedmetadata` path had a second hazard: the loader's own `loadeddata` handler restores saved progress *after* `loadedmetadata`, so even a correctly-timed seek could be overwritten by the progress restore.

**the fix**: a `player.pendingSeek = { trackId, ms }` request, set by the comment click before starting playback. The loader's `loadeddata` handler applies it once the *matching* track's audio is attached, taking precedence over the saved-progress restore. The load effect clears a pending seek whose trackId doesn't match the track being loaded, so it can never fire on the wrong track. A gated track that fails its playability check clears the request.

**intentional non-behaviors**:
- the already-loaded path (`player.currentTrack.id === track.id` → `queue.seek`) is unchanged, including its jam-bridge routing.
- no change to radio's separate `start_at` pending-seek machinery.

**regression tests** (`player-comment-seek.test.ts`, mounted `Player.svelte` like the existing player tests): seek applies only after the new source attaches; it wins over saved-progress restore on a fresh mount; a mismatched pending seek is cleared. All three fail with the loader half of the fix reverted.

`Player.svelte` crossed its loq limit by 10 lines; relaxed via `just loq-relax`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)