### PR TITLE
fix(spaces): send the spaces-alpha createSpace body; page listRepos/listRepoOps by cursor

### DIFF
--- a/backend/src/backend/_internal/atproto/spaces/client.py
+++ b/backend/src/backend/_internal/atproto/spaces/client.py
@@ -149,8 +149,10 @@ async def ensure_personal_space(
 ) -> str:
     """create (or find) the caller's artist-owned personal space; return its URI.
 
-    The required ``simplespace`` management layer uses a member-list policy for
-    this owner-only MVP. App access stays open so local/public OAuth clients can
+    The space is anchored on the authenticated DID. The ``simplespace``
+    management layer uses ``memberListPolicy`` for this owner-only MVP; the
+    authority is authorized on its own member-list space without an explicit
+    ``addMember``. App access stays open so local/public OAuth clients can
     exercise the experimental feature without a confidential-client key.
     """
     space_type = settings.atproto.private_media_space_type
@@ -161,13 +163,10 @@ async def ensure_personal_space(
             "POST",
             "com.atproto.simplespace.createSpace",
             payload={
-                "did": auth_session.did,
                 "type": space_type,
                 "skey": skey,
-                "config": {
-                    "policy": "member-list",
-                    "appAccess": {"$type": "com.atproto.simplespace.defs#open"},
-                },
+                "policy": {"$type": "com.atproto.simplespace.defs#memberListPolicy"},
+                "appAccess": {"$type": "com.atproto.simplespace.defs#open"},
             },
         )
     except Exception as exc:
@@ -414,14 +413,21 @@ async def list_space_repos(
     space: str,
     *,
     limit: int = 50,
+    cursor: str | None = None,
 ) -> dict[str, Any]:
-    """Discover the writer set for a space from its authority host."""
+    """Discover the writer set for a space from its authority host.
+
+    A full page carries ``cursor``; the final page omits it.
+    """
+    params: dict[str, Any] = {"space": space, "limit": limit}
+    if cursor:
+        params["cursor"] = cursor
     return await _credential_read(
         auth_session,
         host_url=await _space_host_url(space),
         endpoint="com.atproto.space.listRepos",
         space=space,
-        params={"space": space, "limit": limit},
+        params=params,
     )
 
 
@@ -457,19 +463,25 @@ async def list_space_repo_ops(
     *,
     space: str,
     repo: str,
-    since: str,
+    since: str | None = None,
     limit: int = 500,
+    cursor: str | None = None,
 ) -> dict[str, Any]:
-    """Pull incremental operations directly from a writer's repo host."""
+    """Pull incremental operations directly from a writer's repo host.
+
+    A full page carries ``cursor`` and no ``commit``; the page that reaches the
+    head of the oplog carries the signed ``commit`` and no ``cursor``. ``cursor``
+    takes precedence over ``since`` when both are sent.
+    """
+    params: dict[str, Any] = {"space": space, "repo": repo, "limit": limit}
+    if since:
+        params["since"] = since
+    if cursor:
+        params["cursor"] = cursor
     return await _credential_read(
         auth_session,
         host_url=await _repo_host_url(repo),
         endpoint="com.atproto.space.listRepoOps",
         space=space,
-        params={
-            "space": space,
-            "repo": repo,
-            "since": since,
-            "limit": limit,
-        },
+        params=params,
     )

--- a/backend/src/backend/api/audio.py
+++ b/backend/src/backend/api/audio.py
@@ -496,7 +496,7 @@ async def _handle_private_audio(
     """proxy a private track's audio through the permissioned-space credential path.
 
     access is owner-only at two layers: plyr.fm rejects non-owners here, while the
-    ``simplespace`` created for this MVP uses its explicit ``member-list`` policy.
+    ``simplespace`` created for this MVP uses its explicit ``memberListPolicy``.
     Core permissioned spaces do not enumerate readers, but ``simplespace`` is the
     required PDS management layer above that core protocol and may maintain members.
     A non-owner (or anonymous) request gets a 404 — the same as a missing file — so

--- a/backend/tests/_internal/test_permissioned_spaces.py
+++ b/backend/tests/_internal/test_permissioned_spaces.py
@@ -219,15 +219,16 @@ async def test_ensure_personal_space_uses_simplespace_shape(
         "POST",
         "com.atproto.simplespace.createSpace",
         payload={
-            "did": "did:plc:x",
             "type": "fm.plyr.privateMedia",
             "skey": "self",
-            "config": {
-                "policy": "member-list",
-                "appAccess": {"$type": "com.atproto.simplespace.defs#open"},
-            },
+            "policy": {"$type": "com.atproto.simplespace.defs#memberListPolicy"},
+            "appAccess": {"$type": "com.atproto.simplespace.defs#open"},
         },
     )
+    assert request.await_args is not None
+    payload = request.await_args.kwargs["payload"]
+    assert "did" not in payload
+    assert "config" not in payload
 
 
 async def test_mint_credential_uses_delegation_token_flow(
@@ -529,6 +530,27 @@ async def test_list_space_repos_routes_to_authority_host(
     )
 
 
+async def test_list_space_repos_forwards_cursor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    read = AsyncMock(return_value={"repos": []})
+    monkeypatch.setattr(space_client, "_credential_read", read)
+    monkeypatch.setattr(
+        space_client, "_space_host_url", AsyncMock(return_value="https://a.example")
+    )
+    session = Session(session_id="s", did="did:plc:user", handle="u", oauth_session={})
+    space = "at://did:plc:authority/space/fm.example.catalog/main"
+
+    await space_client.list_space_repos(session, space, limit=20, cursor="page-2")
+
+    assert read.await_args is not None
+    assert read.await_args.kwargs["params"] == {
+        "space": space,
+        "limit": 20,
+        "cursor": "page-2",
+    }
+
+
 async def test_list_space_records_routes_to_writer_repo_host(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -607,3 +629,36 @@ async def test_list_space_repo_ops_routes_to_writer_repo_host(
             "limit": 250,
         },
     )
+
+
+async def test_list_space_repo_ops_pages_by_cursor_and_tolerates_missing_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    full_page = {"ops": [{"rev": "3mabd"}], "cursor": "page-2"}
+    head_page = {"ops": [], "commit": {"rev": "3mabd"}}
+    read = AsyncMock(side_effect=[full_page, head_page])
+    monkeypatch.setattr(space_client, "_credential_read", read)
+    monkeypatch.setattr(
+        space_client, "_repo_host_url", AsyncMock(return_value="https://w.example")
+    )
+    session = Session(session_id="s", did="did:plc:user", handle="u", oauth_session={})
+    space = "at://did:plc:authority/space/fm.example.catalog/main"
+
+    first = await space_client.list_space_repo_ops(
+        session, space=space, repo="did:plc:writer", since="3mabc"
+    )
+    assert first == full_page
+    assert "commit" not in first
+
+    second = await space_client.list_space_repo_ops(
+        session, space=space, repo="did:plc:writer", cursor=first["cursor"]
+    )
+    assert second == head_page
+    assert "cursor" not in second
+    assert read.await_args is not None
+    assert read.await_args.kwargs["params"] == {
+        "space": space,
+        "repo": "did:plc:writer",
+        "limit": 500,
+        "cursor": "page-2",
+    }

--- a/docs/internal/architecture/permissioned-private-media.md
+++ b/docs/internal/architecture/permissioned-private-media.md
@@ -6,6 +6,13 @@ and [Permissioned Data Diary 7](https://dholms.leaflet.pub/3mqtqvjidqs2p).
 The proposal is not a final specification, so this integration remains capability-gated
 and intentionally isolated under `backend/_internal/atproto/spaces/`.
 
+The wire contract is the **spaces-alpha lexicons** at the tip of the `permissioned-data`
+branch of [bluesky-social/atproto](https://github.com/bluesky-social/atproto/tree/permissioned-data/lexicons/com/atproto)
+(`lexicons/com/atproto/{space,simplespace}`) — not the proposal prose, which lags them.
+[Bulletin](https://github.com/bluesky-social/bulletin) is the alpha's reference client;
+when a request shape is in doubt, match what its `lib/atproto/` does. ZDS tracks the same
+branch, and has rejected stale bodies twice (#1656, #1876).
+
 ## what exists today
 
 The shipped product is the smallest personal-space case:
@@ -78,23 +85,23 @@ base login.
 
 ## space creation and policy
 
-`com.atproto.simplespace.createSpace` receives the current proposal shape:
+`com.atproto.simplespace.createSpace` receives the alpha body. The space is anchored on
+the authenticated DID (no `did` field), and `policy` / `appAccess` are `$type` unions:
 
 ```json
 {
-  "did": "did:plc:artist",
   "type": "fm.plyr.privateMedia",
   "skey": "self",
-  "config": {
-    "policy": "member-list",
-    "appAccess": {"$type": "com.atproto.simplespace.defs#open"}
-  }
+  "policy": {"$type": "com.atproto.simplespace.defs#memberListPolicy"},
+  "appAccess": {"$type": "com.atproto.simplespace.defs#open"}
 }
 ```
 
-The required `simplespace` management layer has a member list even though the core sync
-protocol does not enumerate readers. The authority is added by default and plyr.fm adds
-nobody else, yielding owner-only access.
+The `simplespace` management layer has a member list even though the core sync protocol
+does not enumerate readers. The authority is authorized on its own member-list space
+without an explicit `addMember`, and plyr.fm adds nobody else, yielding owner-only access.
+`getSpace` returns `{uri, policy, appAccess}` with the same unions; `updateSpace` takes
+`{space, policy?, appAccess?}`.
 
 App access is open for this personal experiment so local/public OAuth clients can use it
 without a confidential-client signing key. This is separate from user eligibility. A
@@ -125,6 +132,11 @@ The generic client exposes:
 - `list_space_repos` on the authority host;
 - `list_space_records` and `list_space_repo_ops` on each writer's repo host;
 - ranged `open_space_blob` reads on the writer's repo host.
+
+`listRepos` and `listRepoOps` page by `cursor` (default 100, max 1000): a full page
+carries `cursor`, the final page omits it. `listRepoOps` additionally returns the signed
+`commit` only on the page that reaches the head of the oplog, so a consumer must not
+expect `commit` on every page. Both client functions accept `cursor`.
 
 Proposal 0016 also defines full CAR recovery (`getRepo`), deniable LtHash commits, and
 best-effort notifications (`registerNotify`/`notifyWrite`). plyr.fm does not yet keep a

--- a/docs/internal/backend/audio-streaming.md
+++ b/docs/internal/backend/audio-streaming.md
@@ -40,7 +40,7 @@ never R2. the browser has no space credential, so we cannot redirect — we
 **proxy** the bytes through the owner's credential (`open_space_blob` →
 `getDelegationToken` → `getSpaceCredential` → ranged `getBlob`). access is
 owner-only at two layers: plyr rejects non-owners, and the required
-`com.atproto.simplespace` management layer uses an explicit `member-list`
+`com.atproto.simplespace` management layer uses an explicit `memberListPolicy`
 policy for this MVP. The core permissioned-data protocol does not enumerate
 readers; `simplespace` sits above that core and may maintain members. A
 non-owner or anonymous request gets a `404`, identical to a missing file, so

--- a/loq.toml
+++ b/loq.toml
@@ -355,7 +355,7 @@ max_lines = 689
 
 [[rules]]
 path = "backend/tests/_internal/test_permissioned_spaces.py"
-max_lines = 634
+max_lines = 664
 
 [[rules]]
 path = "frontend/src/routes/u/[[]handle[]]/+page.svelte"

--- a/scripts/permissioned_smoke.py
+++ b/scripts/permissioned_smoke.py
@@ -94,13 +94,10 @@ def main() -> int:
         "com.atproto.simplespace.createSpace",
         token=token,
         json={
-            "did": did,
             "type": SPACE_TYPE,
             "skey": SKEY,
-            "config": {
-                "policy": "member-list",
-                "appAccess": {"$type": "com.atproto.simplespace.defs#open"},
-            },
+            "policy": {"$type": "com.atproto.simplespace.defs#memberListPolicy"},
+            "appAccess": {"$type": "com.atproto.simplespace.defs#open"},
         },
     )
     if created.status_code == 400 and "SpaceAlreadyExists" in created.text:


### PR DESCRIPTION
zds now speaks the spaces-alpha lexicons and rejects the pre-alpha `createSpace` body plyr.fm was still sending, so every first private upload on pds.zat.dev failed at space creation. this sends the alpha body and makes the two paged space reads actually pageable. closes #1876.

<details>
<summary>what changed</summary>

- `ensure_personal_space` sends `{type, skey, policy: {$type: …#memberListPolicy}, appAccess: {$type: …#open}}` — anchored on the authenticated DID, no `did`, no `config` wrapper. the unit test asserts the exact payload and the absence of `did`/`config`.
- `list_space_repos` / `list_space_repo_ops` accept `cursor`; `since` is now optional (the lexicon makes it so, and `cursor` takes precedence anyway). a new test pages a full page (`cursor`, no `commit`) into a head page (`commit`, no `cursor`). neither function ever assumed `commit`, but neither could page before.
- `scripts/permissioned_smoke.py` sends the same alpha body.
- `docs/internal/architecture/permissioned-private-media.md`: the createSpace body, the `getSpace`/`updateSpace` shapes, the cursor/commit paging contract, and a note that the contract is the `permissioned-data` branch-tip lexicons with Bulletin as the reference client. `member-list` wording → `memberListPolicy` in the audio-streaming doc and `audio.py` docstring.
</details>

<details>
<summary>verification</summary>

- lexicons read from `origin/permissioned-data` tip of bluesky-social/atproto (`createSpace.json`, `defs.json`, `listRepoOps.json`, `listRepos.json`) and Bulletin's `createBoard` — body matches.
- live against pds.zat.dev on the test account, fresh skey `smoke-1876`: old body → `400 InvalidRequest "Missing policy"`; new body → `200 {uri}`; `getSpace` returns `{uri, policy, appAccess}` with the unions.
- `uv run scripts/permissioned_smoke.py` → PASS (createSpace idempotent on `self`, createRecord, getRecord, listRecords, getDelegationToken, getSpaceCredential, ranged getBlob 206).
- `tests/_internal/test_permissioned_spaces.py`: 38 passed; ruff clean; ty diagnostic count unchanged (13).
</details>

<details>
<summary>not done here</summary>

- acceptance item "a fresh account's first private upload works end to end in staging; an existing migrated private track still plays" — needs staging after merge; will verify then.
- the `smoke-1876` space left on the zat test account is harmless; delete it if you'd rather it not exist.
- no caller pages yet (plyr.fm keeps no durable replica); the client just stops being unable to.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
