### PR TITLE
chore(spaces): remove the pre-DPoP Bearer fallback

### DIFF
--- a/backend/src/backend/_internal/atproto/spaces/client.py
+++ b/backend/src/backend/_internal/atproto/spaces/client.py
@@ -105,7 +105,6 @@ async def _space_token_request(
     dpop_key: EllipticCurvePrivateKey,
     *,
     issuance: bool = False,
-    legacy_bearer: bool = False,
     json: dict[str, Any] | None = None,
     params: dict[str, Any] | None = None,
 ) -> httpx.Response:
@@ -113,11 +112,7 @@ async def _space_token_request(
     url = f"{service_url}/xrpc/{endpoint}"
     if not is_safe_url(url):
         raise ValueError(f"unsafe service URL: {url}")
-    headers = (
-        {"authorization": f"Bearer {token}"}
-        if legacy_bearer
-        else _space_dpop_headers(method, url, token, dpop_key, issuance=issuance)
-    )
+    headers = _space_dpop_headers(method, url, token, dpop_key, issuance=issuance)
     async with httpx.AsyncClient(timeout=30) as http:
         return await http.request(
             method,
@@ -126,17 +121,6 @@ async def _space_token_request(
             json=json,
             params=params,
         )
-
-
-def _is_pre_dpop_rejection(response: httpx.Response) -> bool:
-    """Identify the old space server that only recognizes Bearer credentials."""
-    if response.status_code != 401:
-        return False
-    try:
-        body = response.json()
-    except ValueError:
-        return False
-    return isinstance(body, dict) and body.get("error") == "AuthenticationRequired"
 
 
 # --- space lifecycle + record writes (owner/author, DPoP OAuth) ---------------
@@ -330,15 +314,6 @@ async def open_space_blob(
                 headers["range"] = range_header
             req = http.build_request("GET", url, headers=headers, params=params)
             resp = await http.send(req, stream=True)
-            if _is_pre_dpop_rejection(resp):
-                await resp.aclose()
-                fallback_headers = {"authorization": f"Bearer {credential.token}"}
-                if range_header:
-                    fallback_headers["range"] = range_header
-                req = http.build_request(
-                    "GET", url, headers=fallback_headers, params=params
-                )
-                resp = await http.send(req, stream=True)
             if resp.status_code == 401 and attempt == 0:
                 await resp.aclose()
                 continue  # stale credential — renew and retry once
@@ -388,16 +363,6 @@ async def _credential_read(
             credential.dpop_key,
             params=params,
         )
-        if _is_pre_dpop_rejection(response):
-            response = await _space_token_request(
-                host_url,
-                "GET",
-                endpoint,
-                credential.token,
-                credential.dpop_key,
-                legacy_bearer=True,
-                params=params,
-            )
         if response.status_code == 401 and attempt == 0:
             continue
         if response.status_code != 200:

--- a/backend/tests/_internal/test_permissioned_space_dpop.py
+++ b/backend/tests/_internal/test_permissioned_space_dpop.py
@@ -44,38 +44,23 @@ def test_space_dpop_headers_bind_the_correct_operation(
         assert claims["ath"] == expected_ath
 
 
-@pytest.mark.parametrize(
-    ("status", "body", "expected"),
-    [
-        (401, {"error": "AuthenticationRequired"}, True),
-        (401, {"error": "InvalidDpopProof"}, False),
-        (403, {"error": "AuthenticationRequired"}, False),
-    ],
-)
-def test_pre_dpop_rejection_is_narrow(
-    status: int, body: dict[str, str], expected: bool
-) -> None:
-    response = httpx.Response(status, json=body)
-    assert space_client._is_pre_dpop_rejection(response) is expected
-
-
-async def test_credential_read_bridges_only_a_pre_dpop_server(
+async def test_credential_read_renews_on_401_and_never_downgrades_to_bearer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    credential = space_client.SpaceCredential(
-        token="space-credential",
-        dpop_key=space_client.DPoPManager.generate_keypair(),
-        expires_at=time.monotonic() + 300,
-    )
     token_request = AsyncMock(
         side_effect=[
             httpx.Response(401, json={"error": "AuthenticationRequired"}),
             httpx.Response(200, json={"records": []}),
         ]
     )
-    monkeypatch.setattr(
-        space_client, "get_space_credential", AsyncMock(return_value=credential)
+    mint = AsyncMock(
+        side_effect=lambda *_, **__: space_client.SpaceCredential(
+            token="space-credential",
+            dpop_key=space_client.DPoPManager.generate_keypair(),
+            expires_at=time.monotonic() + 300,
+        )
     )
+    monkeypatch.setattr(space_client, "get_space_credential", mint)
     monkeypatch.setattr(space_client, "_space_token_request", token_request)
     session = Session(
         session_id="s",
@@ -93,8 +78,8 @@ async def test_credential_read_bridges_only_a_pre_dpop_server(
     )
 
     assert result == {"records": []}
-    assert token_request.await_args_list[0].kwargs.get("legacy_bearer") is None
-    assert token_request.await_args_list[1].kwargs["legacy_bearer"] is True
+    assert [c.kwargs["force_refresh"] for c in mint.await_args_list] == [False, True]
+    assert all("legacy_bearer" not in c.kwargs for c in token_request.await_args_list)
 
 
 async def test_space_credential_cache_and_force_refresh(

--- a/backend/tests/_internal/test_permissioned_space_dpop.py
+++ b/backend/tests/_internal/test_permissioned_space_dpop.py
@@ -53,13 +53,12 @@ async def test_credential_read_renews_on_401_and_never_downgrades_to_bearer(
             httpx.Response(200, json={"records": []}),
         ]
     )
-    mint = AsyncMock(
-        side_effect=lambda *_, **__: space_client.SpaceCredential(
-            token="space-credential",
-            dpop_key=space_client.DPoPManager.generate_keypair(),
-            expires_at=time.monotonic() + 300,
-        )
+    credential = space_client.SpaceCredential(
+        token="space-credential",
+        dpop_key=space_client.DPoPManager.generate_keypair(),
+        expires_at=time.monotonic() + 300,
     )
+    mint = AsyncMock(return_value=credential)
     monkeypatch.setattr(space_client, "get_space_credential", mint)
     monkeypatch.setattr(space_client, "_space_token_request", token_request)
     session = Session(


### PR DESCRIPTION
zds has served DPoP-bound space credentials since it moved to the spaces-alpha surface, so the `401 AuthenticationRequired` → Bearer retry added in #1856 as a rollout bridge is dead code. this deletes it; a 401 on a space read now only renews the credential and retries with DPoP.

<details>
<summary>what changed</summary>

- `_space_token_request` loses `legacy_bearer`; `_is_pre_dpop_rejection` and both fallback branches (`open_space_blob`, `_credential_read`) are gone.
- the two bridge tests are replaced by one asserting a 401 triggers `force_refresh=True` renewal and that no call ever passes a Bearer downgrade.
- no behavior change for any current server. the PR CI's live private-media integration (upload → proxy playback → delete against pds.zat.dev) is the proof.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)