### PR TITLE
feat(spaces): read private-media capability from the token's expanded scope

### DIFF
--- a/backend/alembic/versions/2026_08_21_000000_d5f3c9a62eb2_add_spaces_unsupported_pds_to_artists.py
+++ b/backend/alembic/versions/2026_08_21_000000_d5f3c9a62eb2_add_spaces_unsupported_pds_to_artists.py
@@ -1,0 +1,31 @@
+"""add spaces_unsupported_pds to artists
+
+Revision ID: d5f3c9a62eb2
+Revises: c4e2b8f51da1
+Create Date: 2026-08-21 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d5f3c9a62eb2"
+down_revision: str | Sequence[str] | None = "c4e2b8f51da1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "artists", sa.Column("spaces_unsupported_pds", sa.String(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("artists", "spaces_unsupported_pds")

--- a/backend/src/backend/_internal/atproto/spaces/__init__.py
+++ b/backend/src/backend/_internal/atproto/spaces/__init__.py
@@ -1,12 +1,16 @@
 """permissioned-data spaces (com.atproto.space.*).
 
-experimental ATProto permissioned-data surface. all of this engages only for
-sessions whose PDS actually implements the space methods — see
-[capability.detect_permissioned_capability][backend._internal.atproto.spaces.capability.detect_permissioned_capability].
+experimental ATProto permissioned-data surface. whether a session can use it is
+read from the token's expanded ``space:`` grant — see
+[capability][backend._internal.atproto.spaces.capability].
 """
 
 from backend._internal.atproto.spaces.capability import (
-    detect_permissioned_capability,
+    permissioned_scope_requested,
+    private_media_grant_present,
+    session_has_private_media_access,
+    set_spaces_unsupported,
+    spaces_unsupported_here,
 )
 from backend._internal.atproto.spaces.uris import (
     build_record_uri,
@@ -18,7 +22,11 @@ from backend._internal.atproto.spaces.uris import (
 __all__ = [
     "build_record_uri",
     "build_space_uri",
-    "detect_permissioned_capability",
     "parse_space_record_uri",
     "parse_space_uri",
+    "permissioned_scope_requested",
+    "private_media_grant_present",
+    "session_has_private_media_access",
+    "set_spaces_unsupported",
+    "spaces_unsupported_here",
 ]

--- a/backend/src/backend/_internal/atproto/spaces/__init__.py
+++ b/backend/src/backend/_internal/atproto/spaces/__init__.py
@@ -6,8 +6,6 @@ read from the token's expanded ``space:`` grant — see
 """
 
 from backend._internal.atproto.spaces.capability import (
-    permissioned_scope_requested,
-    private_media_grant_present,
     session_has_private_media_access,
     set_spaces_unsupported,
     spaces_unsupported_here,
@@ -24,8 +22,6 @@ __all__ = [
     "build_space_uri",
     "parse_space_record_uri",
     "parse_space_uri",
-    "permissioned_scope_requested",
-    "private_media_grant_present",
     "session_has_private_media_access",
     "set_spaces_unsupported",
     "spaces_unsupported_here",

--- a/backend/src/backend/_internal/atproto/spaces/capability.py
+++ b/backend/src/backend/_internal/atproto/spaces/capability.py
@@ -12,20 +12,9 @@ the option is not offered again until the user retries explicitly.
 from sqlalchemy import select
 
 from backend._internal.auth.session import Session as AuthSession
-from backend._internal.auth.space_scope import (
-    permissioned_scope_requested,
-    private_media_grant_present,
-)
+from backend._internal.auth.space_scope import private_media_grant_present
 from backend.models import Artist
 from backend.utilities.database import db_session
-
-__all__ = [
-    "permissioned_scope_requested",
-    "private_media_grant_present",
-    "session_has_private_media_access",
-    "set_spaces_unsupported",
-    "spaces_unsupported_here",
-]
 
 
 def session_has_private_media_access(auth_session: AuthSession) -> bool:

--- a/backend/src/backend/_internal/atproto/spaces/capability.py
+++ b/backend/src/backend/_internal/atproto/spaces/capability.py
@@ -1,108 +1,51 @@
-"""detect whether a PDS implements the permissioned-data space surface.
+"""whether a session can use permissioned spaces (private media).
 
-no PDS advertises this declaratively (not describeServer, not .well-known, not
-OAuth metadata; ZDS's openapi.json is vendor-specific). so we **probe**: call a
-`com.atproto.space.*` method with the user's auth and branch on the response.
-
-    supported   -> the method dispatches for real (2xx, or a genuine
-                   InvalidRequest / InsufficientScope / auth error proving the
-                   route exists and ran)
-    unsupported -> HTTP 404/501 or an error in {MethodNotImplemented,
-                   UnknownMethod, XRPCNotSupported} (identical across a
-                   ZDS with the flag off and a vanilla PDS like bsky/tranquil)
-
-ambiguous results (transient 5xx, network) fail **closed** and are not cached, so a
-blip never pins a capable PDS to "unsupported" for the cache lifetime.
-
-the probe is authenticated: an unauthenticated call can't distinguish a supporting
-PDS from a vanilla one, because PDS auth middleware returns 401 before method routing.
+No PDS advertises the space surface declaratively, and probing a
+``com.atproto.space.*`` route is a guess about the host. The honest signal is
+the token: a spaces-capable PDS expands ``include:<permission set>`` into
+concrete ``space:`` grants, and one that is not either rejects the scope or
+returns a token without them. Capability is therefore read from the granted
+scope, and a grant that came back empty is remembered per (account, PDS) so
+the option is not offered again until the user retries explicitly.
 """
 
-import logging
-import re
+from sqlalchemy import select
 
-from redis.exceptions import RedisError
+from backend._internal.auth.session import Session as AuthSession
+from backend._internal.auth.space_scope import (
+    permissioned_scope_requested,
+    private_media_grant_present,
+)
+from backend.models import Artist
+from backend.utilities.database import db_session
 
-from backend._internal import Session as AuthSession
-from backend._internal.atproto.client import make_pds_request
-from backend.config import settings
-from backend.utilities.redis import get_async_redis_client
-
-logger = logging.getLogger(__name__)
-
-# bumped to v2 when the classifier flipped to fail-closed — invalidates any stale
-# (overly-permissive) cached results from the prior heuristic.
-_CACHE_PREFIX = "permissioned_capability:v2:"
-_CACHE_TTL_SECONDS = 6 * 60 * 60
-
-_STATUS_RE = re.compile(r"PDS request failed:\s*(\d{3})")
+__all__ = [
+    "permissioned_scope_requested",
+    "private_media_grant_present",
+    "session_has_private_media_access",
+    "set_spaces_unsupported",
+    "spaces_unsupported_here",
+]
 
 
-def _classify_failure(message: str) -> bool | None:
-    """interpret a FAILED listSpaces probe — fail closed.
-
-    a PDS is treated as supporting permissioned spaces ONLY on an unambiguous
-    positive signal (handled in `_probe`: HTTP 200, or 403 InsufficientScope —
-    ZDS's space-scope check, which proves the route is implemented). every other
-    failure is unsupported; a non-supporting PDS returns auth/method-not-found
-    errors that must NOT be read as "route exists."
-
-    returns True (supported), False (unsupported, cacheable), or None (transient
-    — don't cache, fail closed for this call only).
-    """
-    # the space-scope check ran → the route is implemented → supported
-    if "InsufficientScope" in message:
+def session_has_private_media_access(auth_session: AuthSession) -> bool:
+    """whether this session may write to the user's private-media space."""
+    data = auth_session.oauth_session or {}
+    if data.get("auth_type") == "app_password":
         return True
-    if match := _STATUS_RE.search(message):
-        status = int(match.group(1))
-        if status == 501:
-            return False  # not implemented
-        if 500 <= status < 600:
-            return None  # transient upstream failure (500/502/503/504)
-        return False  # 401/400/404/405/other 4xx → not a supporting PDS
-    return None  # opaque / network error
+    return private_media_grant_present(data.get("scope", ""), auth_session.did)
 
 
-async def _probe(auth_session: AuthSession) -> bool | None:
-    """probe listSpaces. True/False = definitive; None = ambiguous (don't cache)."""
-    try:
-        await make_pds_request(
-            auth_session,
-            "GET",
-            "com.atproto.space.listSpaces",
-            params={
-                "did": auth_session.did,
-                "type": settings.atproto.private_media_space_type,
-            },
-        )
-        return True
-    except Exception as exc:  # make_pds_request raises a bare Exception on non-2xx
-        return _classify_failure(str(exc))
-
-
-async def detect_permissioned_capability(auth_session: AuthSession) -> bool:
-    """whether the session's PDS implements permissioned spaces (cached per PDS)."""
+def spaces_unsupported_here(artist: Artist | None, auth_session: AuthSession) -> bool:
+    """whether a previous upgrade on this session's PDS came back without the grant."""
     pds_url = (auth_session.oauth_session or {}).get("pds_url")
-    cache_key = f"{_CACHE_PREFIX}{pds_url}" if pds_url else None
+    return bool(artist and pds_url and artist.spaces_unsupported_pds == pds_url)
 
-    redis = None
-    if cache_key:
-        try:
-            redis = get_async_redis_client()
-            if (cached := await redis.get(cache_key)) is not None:
-                return cached == "1"
-        except RedisError as exc:
-            logger.debug("permissioned capability cache read failed: %s", exc)
-            redis = None
 
-    result = await _probe(auth_session)
-    if result is None:
-        return False  # ambiguous: fail closed, do not cache
-
-    if redis is not None and cache_key:
-        try:
-            await redis.set(cache_key, "1" if result else "0", ex=_CACHE_TTL_SECONDS)
-        except RedisError as exc:
-            logger.debug("permissioned capability cache write failed: %s", exc)
-
-    return result
+async def set_spaces_unsupported(did: str, pds_url: str | None) -> None:
+    """record (or, with ``None``, clear) the PDS that returned no private-media grant."""
+    async with db_session() as db:
+        result = await db.execute(select(Artist).where(Artist.did == did))
+        if artist := result.scalar_one_or_none():
+            artist.spaces_unsupported_pds = pds_url
+            await db.commit()

--- a/backend/src/backend/_internal/auth/oauth.py
+++ b/backend/src/backend/_internal/auth/oauth.py
@@ -31,6 +31,7 @@ from backend._internal.auth.session import (
     get_client_auth_method,
     get_refresh_token_lifetime_days,
 )
+from backend._internal.auth.space_scope import permissioned_scope_requested
 from backend._internal.oauth_stores import PostgresStateStore
 from backend.config import settings
 from backend.models import Artist
@@ -173,9 +174,7 @@ def get_oauth_client_for_scope(scope: str) -> OAuthClient:
     include_indiemusi = scopes.matches(
         "repo", collection=settings.indiemusi.song_collection, action="create"
     )
-    # match on the private-media NSID — present whether the scope is the requested
-    # `include:<nsid>` form or the granted, expanded `space:<nsid>?...` form
-    include_permissioned = settings.atproto.private_media_space_type in scope
+    include_permissioned = permissioned_scope_requested(scope)
     return get_oauth_client(
         include_teal=include_teal,
         include_indiemusi=include_indiemusi,

--- a/backend/src/backend/_internal/auth/space_scope.py
+++ b/backend/src/backend/_internal/auth/space_scope.py
@@ -1,0 +1,235 @@
+"""``space:`` OAuth scope parsing and matching.
+
+Mirrors ``SpacePermission`` from ``@atproto/oauth-scopes`` on the
+``permissioned-data`` branch; ``atproto_oauth.scopes`` does not know this
+resource yet.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+from atproto_core.nsid import validate_nsid
+from atproto_oauth.scopes._parser import ParamSchema, Parser
+from atproto_oauth.scopes._syntax import ScopeStringSyntax
+from atproto_oauth.scopes.scopes_set import ScopesSet
+
+from backend.config import settings
+
+SPACE_ACTIONS = ("read_self", "read", "create", "update", "delete")
+SPACE_DEFAULT_ACTIONS = ("read", "create", "update", "delete")
+SPACE_MANAGE_OPS = ("create", "update", "delete")
+
+SpaceAction = Literal["read_self", "read", "create", "update", "delete"]
+SpaceManageOp = Literal["create", "update", "delete"]
+
+_DID_RE = re.compile(r"^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._%-]$")
+_RKEY_RE = re.compile(r"^[a-zA-Z0-9._:~-]{1,512}$")
+_EMPTY_PARAM_RE = re.compile(r"[?&][a-z]+=(?:&|$)")
+
+
+def _is_nsid(value: str) -> bool:
+    return validate_nsid(value, soft_fail=True)
+
+
+def _is_nsid_or_wildcard(value: str) -> bool:
+    return value == "*" or _is_nsid(value)
+
+
+def _is_authority(value: str) -> bool:
+    return value in ("*", "self") or bool(_DID_RE.match(value))
+
+
+def _is_record_key(value: str) -> bool:
+    return value not in (".", "..") and bool(_RKEY_RE.match(value))
+
+
+def _is_skey(value: str) -> bool:
+    return value == "*" or _is_record_key(value)
+
+
+def _normalize_collections(value: list[str]) -> list[str]:
+    if len(value) > 1:
+        return ["*"] if "*" in value else sorted(set(value))
+    return value
+
+
+_space_parser = Parser(
+    "space",
+    {
+        "type": ParamSchema(
+            multiple=False, required=True, validate=_is_nsid_or_wildcard
+        ),
+        "authority": ParamSchema(
+            multiple=False, required=False, validate=_is_authority, default="self"
+        ),
+        "skey": ParamSchema(
+            multiple=False, required=False, validate=_is_skey, default="*"
+        ),
+        "collection": ParamSchema(
+            multiple=True,
+            required=False,
+            validate=_is_nsid_or_wildcard,
+            default=[],
+            normalize=_normalize_collections,
+        ),
+        "action": ParamSchema(
+            multiple=True,
+            required=False,
+            validate=lambda v: v in SPACE_ACTIONS,
+            default=list(SPACE_DEFAULT_ACTIONS),
+            normalize=lambda value: [a for a in SPACE_ACTIONS if a in value],
+        ),
+        "manage": ParamSchema(
+            multiple=True,
+            required=False,
+            validate=lambda v: v in SPACE_MANAGE_OPS,
+            default=[],
+            normalize=lambda value: [m for m in SPACE_MANAGE_OPS if m in value],
+        ),
+    },
+    positional_name="type",
+)
+
+
+@dataclass(frozen=True)
+class SpacePermission:
+    """One granted ``space:`` scope."""
+
+    type: str
+    authority: str
+    skey: str
+    collection: tuple[str, ...]
+    action: tuple[str, ...]
+    manage: tuple[str, ...]
+
+    @classmethod
+    def from_string(cls, scope: str) -> "SpacePermission | None":
+        if scope != "space" and not scope.startswith(("space:", "space?")):
+            return None
+        if _EMPTY_PARAM_RE.search(scope):
+            return None
+        parsed = _space_parser.parse(ScopeStringSyntax.from_string(scope))
+        if parsed is None:
+            return None
+        return cls(
+            type=parsed["type"],
+            authority=parsed["authority"],
+            skey=parsed["skey"],
+            collection=tuple(parsed["collection"]),
+            action=tuple(parsed["action"]),
+            manage=tuple(parsed["manage"]),
+        )
+
+    def __str__(self) -> str:
+        return _space_parser.format(
+            {
+                "type": self.type,
+                "authority": self.authority,
+                "skey": self.skey,
+                "collection": list(self.collection),
+                "action": list(self.action),
+                "manage": list(self.manage),
+            }
+        )
+
+    @property
+    def is_self_authority(self) -> bool:
+        return self.authority == "self"
+
+    def with_resolved_authority(self, user_did: str) -> "SpacePermission":
+        if not self.is_self_authority:
+            return self
+        return SpacePermission(
+            self.type, user_did, self.skey, self.collection, self.action, self.manage
+        )
+
+    def matches(
+        self,
+        *,
+        type: str,
+        authority: str,
+        skey: str,
+        action: SpaceAction | None = None,
+        collection: str | None = None,
+        manage: SpaceManageOp | None = None,
+    ) -> bool:
+        """Whether this grant covers one concrete operation.
+
+        An unresolved ``self`` authority matches nothing: ``authority`` is
+        always a concrete DID. Reads are collection-independent and ``read``
+        implies ``read_self``; writes need the action and the collection.
+        """
+        if self.type != "*" and self.type != type:
+            return False
+        if self.authority != "*" and self.authority != authority:
+            return False
+        if self.skey != "*" and self.skey != skey:
+            return False
+        if action is None:
+            return manage is not None and manage in self.manage
+        if action == "read":
+            return "read" in self.action
+        if action == "read_self":
+            return "read" in self.action or "read_self" in self.action
+        if collection is None:
+            return False
+        return action in self.action and (
+            "*" in self.collection or collection in self.collection
+        )
+
+
+def space_grants(scope: str) -> list[SpacePermission]:
+    """Every parseable ``space:`` grant in a granted scope string."""
+    return [
+        grant
+        for token in ScopesSet.from_string(scope)
+        if (grant := SpacePermission.from_string(token)) is not None
+    ]
+
+
+def allows_space(
+    scope: str,
+    *,
+    type: str,
+    authority: str,
+    skey: str,
+    action: SpaceAction | None = None,
+    collection: str | None = None,
+    manage: SpaceManageOp | None = None,
+) -> bool:
+    """Whether any grant in ``scope`` covers the operation."""
+    return any(
+        grant.matches(
+            type=type,
+            authority=authority,
+            skey=skey,
+            action=action,
+            collection=collection,
+            manage=manage,
+        )
+        for grant in space_grants(scope)
+    )
+
+
+def private_media_grant_present(scope: str, did: str) -> bool:
+    """whether ``scope`` carries the expanded private-media grant for ``did``."""
+    space_type = settings.atproto.private_media_space_type
+    return allows_space(
+        scope, type=space_type, authority=did, skey="self", manage="create"
+    ) and allows_space(
+        scope,
+        type=space_type,
+        authority=did,
+        skey="self",
+        action="create",
+        collection=settings.atproto.track_collection,
+    )
+
+
+def permissioned_scope_requested(scope: str) -> bool:
+    """whether a scope string asks for (``include:``) or carries (``space:``) private media."""
+    if ScopesSet.from_string(scope).has(settings.atproto.private_media_include_scope):
+        return True
+    space_type = settings.atproto.private_media_space_type
+    return any(grant.type == space_type for grant in space_grants(scope))

--- a/backend/src/backend/api/auth.py
+++ b/backend/src/backend/api/auth.py
@@ -773,12 +773,23 @@ async def start_scope_upgrade_flow(
     if body.include_permissioned:
         await set_spaces_unsupported(session.did, None)
 
-    auth_url, state = await start_oauth_flow_with_scopes(
-        session.handle,
-        include_teal=include_teal,
-        include_indiemusi=include_indiemusi,
-        include_permissioned=include_permissioned,
-    )
+    try:
+        auth_url, state = await start_oauth_flow_with_scopes(
+            session.handle,
+            include_teal=include_teal,
+            include_indiemusi=include_indiemusi,
+            include_permissioned=include_permissioned,
+        )
+    except HTTPException as exc:
+        # a PDS without spaces refuses the permission set at PAR, before the
+        # user ever sees a consent screen — the same answer the callback path
+        # handles, arriving earlier.
+        if not (body.include_permissioned and "invalid_scope" in str(exc.detail)):
+            raise
+        pds_url = (session.oauth_session or {}).get("pds_url")
+        await set_spaces_unsupported(session.did, pds_url)
+        logger.info("PDS %s refused the private-media permission set", pds_url)
+        raise HTTPException(status_code=400, detail="incompatible_pds") from exc
 
     # build the requested scopes string for logging/tracking
     requested_scopes = (

--- a/backend/src/backend/api/auth.py
+++ b/backend/src/backend/api/auth.py
@@ -40,7 +40,13 @@ from backend._internal import (
     start_oauth_flow_with_scopes,
     switch_active_account,
 )
-from backend._internal.atproto.spaces import detect_permissioned_capability
+from backend._internal.atproto.spaces import (
+    permissioned_scope_requested,
+    private_media_grant_present,
+    session_has_private_media_access,
+    set_spaces_unsupported,
+    spaces_unsupported_here,
+)
 from backend._internal.auth import get_refresh_token_lifetime_days
 from backend._internal.auth.app_password import (
     AppPasswordAuthError,
@@ -67,9 +73,14 @@ class LinkedAccountResponse(BaseModel):
 
 
 class PermissionedSpacesStatus(BaseModel):
-    """whether the user's PDS implements the experimental permissioned-space surface."""
+    """private-media availability for this session.
+
+    ``granted``: the token carries the expanded space grant. ``supported``:
+    offer the option — true unless an upgrade on this PDS came back without it.
+    """
 
     supported: bool = False
+    granted: bool = False
 
 
 class CurrentUserResponse(BaseModel):
@@ -186,9 +197,11 @@ async def start_login(
 
 @router.get("/callback")
 async def oauth_callback(
-    code: Annotated[str, Query()],
     state: Annotated[str, Query()],
-    iss: Annotated[str, Query()],
+    code: Annotated[str | None, Query()] = None,
+    iss: Annotated[str | None, Query()] = None,
+    error: Annotated[str | None, Query()] = None,
+    error_description: Annotated[str | None, Query()] = None,
 ) -> RedirectResponse:
     """handle OAuth callback and create session.
 
@@ -200,7 +213,32 @@ async def oauth_callback(
     2. scope upgrade flow - replaces old session with new one, redirects to settings
     3. add account flow - creates session in existing group, redirects to portal
     4. regular login flow - creates session, redirects to portal or profile setup
+
+    an authorization-server refusal arrives as ``error=`` with no ``code``. an
+    ``invalid_scope`` refusal of a private-media upgrade means the PDS does not
+    do permissioned spaces: remember that for the account and keep the old
+    session, which the upgrade never replaced.
     """
+    if error or not code or not iss:
+        pending = await get_pending_scope_upgrade(state)
+        if pending and pending.requested_scopes == "permissioned":
+            await delete_pending_scope_upgrade(state)
+            if error == "invalid_scope":
+                old = await get_session(pending.old_session_id)
+                pds_url = (old.oauth_session or {}).get("pds_url") if old else None
+                await set_spaces_unsupported(pending.did, pds_url)
+                return RedirectResponse(
+                    url=f"{settings.frontend.url}/settings?scope_upgrade_error=incompatible_pds",
+                    status_code=303,
+                )
+        logger.warning(
+            "OAuth callback refused (error=%s): %s", error, error_description
+        )
+        return RedirectResponse(
+            url=f"{settings.frontend.url}/?auth_error={error or 'failed'}",
+            status_code=303,
+        )
+
     try:
         did, handle, oauth_session = await handle_oauth_callback(code, state, iss)
     except HTTPException as e:
@@ -291,8 +329,16 @@ async def oauth_callback(
         await schedule_atproto_sync(session_id, did)
 
         redirect_path = pending_scope_upgrade.redirect_to or "/settings"
+        outcome = "scope_upgraded=true"
+        if pending_scope_upgrade.requested_scopes == "permissioned":
+            granted = private_media_grant_present(oauth_session.get("scope", ""), did)
+            await set_spaces_unsupported(
+                did, None if granted else oauth_session.get("pds_url")
+            )
+            if not granted:
+                outcome = "scope_upgrade_error=incompatible_pds"
         return RedirectResponse(
-            url=f"{settings.frontend.url}{redirect_path}?exchange_token={exchange_token}&scope_upgraded=true",
+            url=f"{settings.frontend.url}{redirect_path}?exchange_token={exchange_token}&{outcome}",
             status_code=303,
         )
 
@@ -488,22 +534,19 @@ async def get_current_user(
     # look up artist profiles to get fresh avatars
     dids = [account.did for account in linked]
     avatar_map: dict[str, str | None] = {}
+    current_artist: Artist | None = None
     if dids:
         result = await db.execute(select(Artist).where(Artist.did.in_(dids)))
         for artist in result.scalars().all():
             avatar_map[artist.did] = artist.avatar_url
+            if artist.did == session.did:
+                current_artist = artist
 
     # get feature flags for current user from dedicated table
     current_user_flags = await get_user_flags(db, session.did)
 
-    # permissioned-spaces capability is the gate for the private-media feature;
-    # cached per-PDS in redis so this probe is cheap after the first call. never
-    # let it break /auth/me.
-    try:
-        spaces_supported = await detect_permissioned_capability(session)
-    except Exception as exc:
-        logger.debug(f"permissioned capability probe failed: {exc}")
-        spaces_supported = False
+    granted = session_has_private_media_access(session)
+    spaces_supported = granted or not spaces_unsupported_here(current_artist, session)
 
     return CurrentUserResponse(
         did=session.did,
@@ -517,7 +560,9 @@ async def get_current_user(
             for account in linked
         ],
         enabled_flags=current_user_flags,
-        permissioned_spaces=PermissionedSpacesStatus(supported=spaces_supported),
+        permissioned_spaces=PermissionedSpacesStatus(
+            supported=spaces_supported, granted=granted
+        ),
     )
 
 
@@ -722,9 +767,11 @@ async def start_scope_upgrade_flow(
         f"repo:{settings.teal.play_collection}" in current_scope
     )
     include_indiemusi = settings.indiemusi.song_collection in current_scope
-    include_permissioned = body.include_permissioned or (
-        settings.atproto.private_media_space_type in current_scope
+    include_permissioned = body.include_permissioned or permissioned_scope_requested(
+        current_scope
     )
+    if body.include_permissioned:
+        await set_spaces_unsupported(session.did, None)
 
     auth_url, state = await start_oauth_flow_with_scopes(
         session.handle,

--- a/backend/src/backend/api/auth.py
+++ b/backend/src/backend/api/auth.py
@@ -41,8 +41,6 @@ from backend._internal import (
     switch_active_account,
 )
 from backend._internal.atproto.spaces import (
-    permissioned_scope_requested,
-    private_media_grant_present,
     session_has_private_media_access,
     set_spaces_unsupported,
     spaces_unsupported_here,
@@ -52,6 +50,10 @@ from backend._internal.auth.app_password import (
     AppPasswordAuthError,
     create_app_password_session,
     resolve_pds,
+)
+from backend._internal.auth.space_scope import (
+    permissioned_scope_requested,
+    private_media_grant_present,
 )
 from backend._internal.copyright import complete_indiemusi_setup
 from backend._internal.tasks import schedule_atproto_sync
@@ -781,9 +783,7 @@ async def start_scope_upgrade_flow(
             include_permissioned=include_permissioned,
         )
     except HTTPException as exc:
-        # a PDS without spaces refuses the permission set at PAR, before the
-        # user ever sees a consent screen — the same answer the callback path
-        # handles, arriving earlier.
+        # a PDS without spaces refuses at PAR, before any consent screen
         if not (body.include_permissioned and "invalid_scope" in str(exc.detail)):
             raise
         pds_url = (session.oauth_session or {}).get("pds_url")

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -1602,11 +1602,8 @@ async def upload_track(
             f"supported: {AudioFormat.supported_extensions_str()}",
         )
 
-    # private media: audio + record live in the artist's ATProto permissioned
-    # space. the token must carry the expanded space grant; absent → the
-    # frontend runs the opt-in scope upgrade and the PDS answers whether it
-    # can. web-playable sources only (the blob is written at publish time; the
-    # deferred transcode path still targets the public repo).
+    # web-playable only: the blob is written at publish time, and the deferred
+    # transcode path still targets the public repo.
     if is_private:
         if not session_has_private_media_access(auth_session):
             raise HTTPException(status_code=403, detail="permissioned_scope_required")

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -45,7 +45,7 @@ from backend._internal.atproto.records.fm_plyr.track import build_track_record
 from backend._internal.atproto.self_labels import parse_self_label_values_json
 from backend._internal.atproto.spaces import (
     build_record_uri,
-    detect_permissioned_capability,
+    session_has_private_media_access,
 )
 from backend._internal.atproto.spaces.client import (
     create_space_record,
@@ -1603,24 +1603,12 @@ async def upload_track(
         )
 
     # private media: audio + record live in the artist's ATProto permissioned
-    # space. only available on a PDS that supports com.atproto.space.*, and only
-    # for web-playable sources (the blob is written at publish time; the deferred
-    # transcode path still targets the public repo — see the design note).
+    # space. the token must carry the expanded space grant; absent → the
+    # frontend runs the opt-in scope upgrade and the PDS answers whether it
+    # can. web-playable sources only (the blob is written at publish time; the
+    # deferred transcode path still targets the public repo).
     if is_private:
-        if not await detect_permissioned_capability(auth_session):
-            raise HTTPException(
-                status_code=400,
-                detail="your PDS does not support permissioned spaces (private media)",
-            )
-        # writing to a space needs the granted space scope (the capability probe
-        # passes without it). the granted token carries the expanded
-        # `space:<nsid>?...` scopes, so match on the NSID. absent → tell the
-        # frontend to run the opt-in scope upgrade (which requests include:<nsid>).
-        auth_data = auth_session.oauth_session or {}
-        has_space_access = auth_data.get("auth_type") == "app_password" or (
-            settings.atproto.private_media_space_type in auth_data.get("scope", "")
-        )
-        if not has_space_access:
+        if not session_has_private_media_access(auth_session):
             raise HTTPException(status_code=403, detail="permissioned_scope_required")
         if not audio_format.is_web_playable:
             raise HTTPException(

--- a/backend/src/backend/models/artist.py
+++ b/backend/src/backend/models/artist.py
@@ -44,6 +44,10 @@ class Artist(Base):
     # kept so the flag above can be explained rather than just believed.
     account_status: Mapped[str | None] = mapped_column(String, nullable=True)
 
+    # the PDS whose private-media scope upgrade came back without a space grant;
+    # NULL until that happens, and cleared on an explicit retry or a host change.
+    spaces_unsupported_pds: Mapped[str | None] = mapped_column(String, nullable=True)
+
     # metadata
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/backend/tests/_internal/test_permissioned_spaces.py
+++ b/backend/tests/_internal/test_permissioned_spaces.py
@@ -23,6 +23,7 @@ from backend._internal.atproto.spaces.uris import (
     parse_space_uri,
 )
 from backend._internal.auth import oauth as oauth_module
+from backend._internal.auth import space_scope
 from backend.config import settings
 from backend.models import Artist
 
@@ -91,29 +92,31 @@ def prod_namespace(monkeypatch):
 
 
 def test_grant_present_requires_manage_and_collection_write(prod_namespace):
-    assert cap.private_media_grant_present(f"atproto blob:*/* {_GRANT}", "did:plc:x")
+    assert space_scope.private_media_grant_present(
+        f"atproto blob:*/* {_GRANT}", "did:plc:x"
+    )
     # the include: came back unexpanded — a PDS without spaces
-    assert not cap.private_media_grant_present(
+    assert not space_scope.private_media_grant_present(
         "atproto blob:*/* include:fm.plyr.privateMediaAccess", "did:plc:x"
     )
     # granted to someone else's authority
-    assert not cap.private_media_grant_present(_GRANT, "did:plc:other")
+    assert not space_scope.private_media_grant_present(_GRANT, "did:plc:other")
     # record writes without manage=create cannot create the space
     no_manage = _GRANT.split("&manage=")[0]
-    assert not cap.private_media_grant_present(no_manage, "did:plc:x")
+    assert not space_scope.private_media_grant_present(no_manage, "did:plc:x")
     # the pre-alpha `did=*` shape is not a grant
-    assert not cap.private_media_grant_present(
+    assert not space_scope.private_media_grant_present(
         "space:fm.plyr.privateMedia?action=create&did=*&skey=self", "did:plc:x"
     )
 
 
 def test_permissioned_scope_requested_matches_include_or_grant(prod_namespace):
-    assert cap.permissioned_scope_requested(
+    assert space_scope.permissioned_scope_requested(
         "atproto include:fm.plyr.privateMediaAccess"
     )
-    assert cap.permissioned_scope_requested(_GRANT)
-    assert not cap.permissioned_scope_requested("atproto repo:fm.plyr.track")
-    assert not cap.permissioned_scope_requested("atproto space:fm.other.space")
+    assert space_scope.permissioned_scope_requested(_GRANT)
+    assert not space_scope.permissioned_scope_requested("atproto repo:fm.plyr.track")
+    assert not space_scope.permissioned_scope_requested("atproto space:fm.other.space")
 
 
 def test_session_access_and_unsupported_marker(prod_namespace):

--- a/backend/tests/_internal/test_permissioned_spaces.py
+++ b/backend/tests/_internal/test_permissioned_spaces.py
@@ -1,6 +1,6 @@
 """unit tests for the permissioned-data spaces foundation (#1528).
 
-pure-logic + mocked-PDS-boundary tests for capability detection, canonical URI
+pure-logic + mocked-PDS-boundary tests for scope-derived capability, canonical URI
 helpers, the OAuth scope composition, and space-credential caching/renewal. the
 full data path is exercised against a live ZDS by scripts/permissioned_smoke.py.
 """
@@ -24,6 +24,7 @@ from backend._internal.atproto.spaces.uris import (
 )
 from backend._internal.auth import oauth as oauth_module
 from backend.config import settings
+from backend.models import Artist
 
 # --- canonical permissioned at:// URI helpers --------------------------------
 
@@ -74,104 +75,73 @@ def test_parse_space_record_uri_rejects_malformed(bad: str) -> None:
         parse_space_record_uri(bad)
 
 
-# --- capability probe interpretation -----------------------------------------
+# --- capability from the expanded scope ----------------------------------------
 
 
-@pytest.mark.parametrize(
-    "message,expected",
-    [
-        # the ONLY supported signal from a failure: ZDS's space-scope check ran
-        ("PDS request failed: 403 InsufficientScope", True),
-        # not-a-supporting-PDS responses — all unsupported (fail closed)
-        ("PDS request failed: 401 AuthMissing", False),  # regression: bsky 401 leak
-        ("PDS request failed: 400 InvalidRequest: bad", False),
-        ("PDS request failed: 404 UnknownMethod", False),
-        ("PDS request failed: 405 MethodNotAllowed", False),
-        ("PDS request failed: 501 MethodNotImplemented", False),
-        # genuinely transient → don't cache, fail closed for this call
-        ("PDS request failed: 503 upstream", None),
-        ("PDS request failed: 502 bad gateway", None),
-        ("totally opaque error", None),
-    ],
+_GRANT = (
+    "space:fm.plyr.privateMedia?authority=did:plc:x&skey=self"
+    "&collection=fm.plyr.track&action=read&action=create&action=update"
+    "&action=delete&manage=create&manage=update&manage=delete"
 )
-def test_classify_failure(message, expected):
-    assert cap._classify_failure(message) is expected
 
 
-async def test_detect_capability_insufficient_scope_is_supported(monkeypatch):
-    # a capable PDS that hasn't been granted the space scope yet returns 403
-    # InsufficientScope from the space route — that proves the route exists.
-    async def fake_request(*args, **kwargs):
-        raise Exception("PDS request failed: 403 InsufficientScope")
+@pytest.fixture
+def prod_namespace(monkeypatch):
+    monkeypatch.setattr(settings.atproto, "app_namespace", "fm.plyr")
 
-    monkeypatch.setattr(cap, "make_pds_request", fake_request)
+
+def test_grant_present_requires_manage_and_collection_write(prod_namespace):
+    assert cap.private_media_grant_present(f"atproto blob:*/* {_GRANT}", "did:plc:x")
+    # the include: came back unexpanded — a PDS without spaces
+    assert not cap.private_media_grant_present(
+        "atproto blob:*/* include:fm.plyr.privateMediaAccess", "did:plc:x"
+    )
+    # granted to someone else's authority
+    assert not cap.private_media_grant_present(_GRANT, "did:plc:other")
+    # record writes without manage=create cannot create the space
+    no_manage = _GRANT.split("&manage=")[0]
+    assert not cap.private_media_grant_present(no_manage, "did:plc:x")
+    # the pre-alpha `did=*` shape is not a grant
+    assert not cap.private_media_grant_present(
+        "space:fm.plyr.privateMedia?action=create&did=*&skey=self", "did:plc:x"
+    )
+
+
+def test_permissioned_scope_requested_matches_include_or_grant(prod_namespace):
+    assert cap.permissioned_scope_requested(
+        "atproto include:fm.plyr.privateMediaAccess"
+    )
+    assert cap.permissioned_scope_requested(_GRANT)
+    assert not cap.permissioned_scope_requested("atproto repo:fm.plyr.track")
+    assert not cap.permissioned_scope_requested("atproto space:fm.other.space")
+
+
+def test_session_access_and_unsupported_marker(prod_namespace):
     session = Session(
+        session_id="s", did="did:plc:x", handle="x", oauth_session={"scope": _GRANT}
+    )
+    assert cap.session_has_private_media_access(session)
+    app_pw = Session(
         session_id="s",
         did="did:plc:x",
-        handle="x.test",
-        oauth_session={"pds_url": "https://probe-insufficient.test"},
+        handle="x",
+        oauth_session={"auth_type": "app_password", "scope": ""},
     )
-    assert await cap.detect_permissioned_capability(session) is True
+    assert cap.session_has_private_media_access(app_pw)
 
-
-async def test_detect_capability_401_is_unsupported(monkeypatch):
-    # regression: a non-supporting PDS (e.g. bsky) must NOT be read as supported
-    async def fake_request(*args, **kwargs):
-        raise Exception("PDS request failed: 401 AuthMissing")
-
-    monkeypatch.setattr(cap, "make_pds_request", fake_request)
-    session = Session(
+    here = Session(
         session_id="s",
         did="did:plc:x",
-        handle="x.test",
-        oauth_session={"pds_url": "https://probe-bsky.test"},
+        handle="x",
+        oauth_session={"pds_url": "https://pds.example", "scope": ""},
     )
-    assert await cap.detect_permissioned_capability(session) is False
-
-
-async def test_detect_capability_supported(monkeypatch):
-    async def fake_request(*args, **kwargs):
-        return {"spaces": []}
-
-    monkeypatch.setattr(cap, "make_pds_request", fake_request)
-
-    session = Session(
-        session_id="s",
-        did="did:plc:x",
-        handle="x.test",
-        oauth_session={"pds_url": "https://probe-supported.test"},
-    )
-    assert await cap.detect_permissioned_capability(session) is True
-
-
-async def test_detect_capability_unsupported(monkeypatch):
-    async def fake_request(*args, **kwargs):
-        raise Exception("PDS request failed: 501 MethodNotImplemented")
-
-    monkeypatch.setattr(cap, "make_pds_request", fake_request)
-
-    session = Session(
-        session_id="s",
-        did="did:plc:x",
-        handle="x.test",
-        oauth_session={"pds_url": "https://probe-unsupported.test"},
-    )
-    assert await cap.detect_permissioned_capability(session) is False
-
-
-async def test_detect_capability_transient_fails_closed(monkeypatch):
-    async def fake_request(*args, **kwargs):
-        raise Exception("PDS request failed: 503 upstream")
-
-    monkeypatch.setattr(cap, "make_pds_request", fake_request)
-
-    session = Session(
-        session_id="s",
-        did="did:plc:x",
-        handle="x.test",
-        oauth_session={"pds_url": "https://probe-transient.test"},
-    )
-    assert await cap.detect_permissioned_capability(session) is False
+    marked = Artist(did="did:plc:x", handle="x", display_name="x")
+    marked.spaces_unsupported_pds = "https://pds.example"
+    moved = Artist(did="did:plc:x", handle="x", display_name="x")
+    moved.spaces_unsupported_pds = "https://old.example"
+    assert cap.spaces_unsupported_here(marked, here)
+    assert not cap.spaces_unsupported_here(moved, here)
+    assert not cap.spaces_unsupported_here(None, here)
 
 
 # --- OAuth scope composition --------------------------------------------------

--- a/backend/tests/_internal/test_space_scope.py
+++ b/backend/tests/_internal/test_space_scope.py
@@ -1,0 +1,224 @@
+"""``space:`` scope parsing and matching, against the oauth-scopes test vectors."""
+
+import pytest
+
+from backend._internal.auth.space_scope import (
+    SPACE_DEFAULT_ACTIONS,
+    SpaceAction,
+    SpaceManageOp,
+    SpacePermission,
+    allows_space,
+    space_grants,
+)
+
+TYPE = "com.atmoboards.forum"
+AUTHORITY = "did:plc:abc"
+SKEY = "default"
+
+
+def covers(
+    scope: SpacePermission,
+    *,
+    type: str = TYPE,
+    authority: str = AUTHORITY,
+    skey: str = SKEY,
+    action: SpaceAction | None = None,
+    collection: str | None = None,
+    manage: SpaceManageOp | None = None,
+) -> bool:
+    return scope.matches(
+        type=type,
+        authority=authority,
+        skey=skey,
+        action=action,
+        collection=collection,
+        manage=manage,
+    )
+
+
+def parse(scope: str) -> SpacePermission:
+    parsed = SpacePermission.from_string(scope)
+    assert parsed is not None, scope
+    return parsed
+
+
+def any_authority(rest: str = "") -> SpacePermission:
+    return parse(f"space:com.atmoboards.forum?authority=*{rest}")
+
+
+def test_positional_type_with_all_defaults() -> None:
+    scope = parse("space:com.atmoboards.forum")
+    assert scope.type == "com.atmoboards.forum"
+    assert scope.authority == "self"
+    assert scope.skey == "*"
+    assert scope.collection == ()
+    assert scope.action == SPACE_DEFAULT_ACTIONS
+    assert scope.manage == ()
+
+
+def test_fully_specified_scope() -> None:
+    scope = parse(
+        "space:com.atmoboards.forum?authority=did:plc:abc123xyz&skey=default"
+        "&collection=com.atmoboards.thread&action=create&action=update"
+    )
+    assert scope.authority == "did:plc:abc123xyz"
+    assert scope.skey == "default"
+    assert scope.collection == ("com.atmoboards.thread",)
+    assert scope.action == ("create", "update")
+
+
+def test_wildcards_and_manage_verbs() -> None:
+    assert parse("space:*?authority=did:plc:abc123xyz").type == "*"
+    assert parse("space:com.atmoboards.forum?authority=*").authority == "*"
+    assert parse("space:com.atmoboards.forum?manage=update&manage=delete").manage == (
+        "update",
+        "delete",
+    )
+    assert parse("space:com.atmoboards.forum?action=read_self&collection=*").action == (
+        "read_self",
+    )
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        "space:foo bar",
+        "space:short",
+        "space:*?authority=not-a-did",
+        "space:*?authority=did:",
+        "space:com.example.x?action=bogus",
+        "space:com.example.x?manage=bogus",
+        "space:com.example.x?collection=not_an_nsid",
+        "space:com.example.x?skey=",
+        "space:com.example.x?skey=hello%20world",
+        "space:com.example.x?skey=.",
+        "space:com.example.x?skey=..",
+        "space:com.example.x?skey=a%2Fb",
+        "space:com.example.x?skey=" + "x" * 513,
+        "repo:com.example.x",
+        "whatever",
+    ],
+)
+def test_rejects_invalid_scopes(scope: str) -> None:
+    assert SpacePermission.from_string(scope) is None
+
+
+@pytest.mark.parametrize("skey", ["self", "3jui7kd54zh2y", "a.b-c_d~e:f", "x" * 512])
+def test_accepts_rkey_shaped_skeys(skey: str) -> None:
+    assert parse(f"space:com.example.x?skey={skey}").skey == skey
+
+
+def test_read_and_write_matching() -> None:
+    assert covers(any_authority(), action="read")
+    assert not covers(any_authority("&action=create"), action="read")
+    assert not covers(
+        any_authority("&action=read"),
+        action="create",
+        collection="com.atmoboards.thread",
+    )
+    assert not covers(
+        any_authority(), action="create", collection="com.atmoboards.thread"
+    )
+    assert covers(
+        any_authority("&collection=*"), action="update", collection="another.one.here"
+    )
+    limited = any_authority("&collection=com.atmoboards.thread&action=create")
+    assert covers(limited, action="create", collection="com.atmoboards.thread")
+    assert not covers(limited, action="create", collection="com.atmoboards.reply")
+
+
+def test_manage_is_independent_of_collection() -> None:
+    scope = any_authority("&action=read&manage=update")
+    assert covers(scope, manage="update")
+    assert not covers(scope, manage="delete")
+    assert not covers(any_authority("&action=read"), manage="update")
+    assert not covers(any_authority(), manage="update")
+
+
+def test_read_self_semantics() -> None:
+    assert covers(any_authority("&action=read"), action="read_self")
+    read_self = any_authority("&action=read_self")
+    assert covers(read_self, action="read_self")
+    assert not covers(read_self, action="read")
+    assert covers(
+        any_authority("&action=read_self&collection=com.atmoboards.thread"),
+        action="read_self",
+    )
+
+
+def test_tuple_matching_and_self_authority() -> None:
+    assert covers(
+        parse("space:*?authority=did:plc:abc"),
+        type="com.example.different",
+        action="read",
+    )
+    concrete = parse("space:com.atmoboards.forum?authority=did:plc:abc&skey=default")
+    assert covers(concrete, action="read")
+    assert not covers(concrete, authority="did:plc:other", action="read")
+    assert not covers(concrete, skey="other", action="read")
+
+    unresolved = parse("space:com.atmoboards.forum")
+    assert unresolved.is_self_authority
+    assert not covers(unresolved, action="read")
+    resolved = unresolved.with_resolved_authority("did:plc:abc")
+    assert covers(resolved, action="read")
+    assert not covers(resolved, authority="did:plc:other", action="read")
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        "space:com.atmoboards.forum",
+        "space:com.atmoboards.forum?authority=did:plc:abc123xyz&skey=default"
+        "&collection=com.atmoboards.thread&action=create",
+    ],
+)
+def test_round_trips(scope: str) -> None:
+    assert str(parse(scope)) == scope
+
+
+def test_allows_space_over_a_granted_scope_string() -> None:
+    granted = (
+        "atproto blob:*/* repo:fm.plyr.track "
+        "space:fm.plyr.privateMedia?authority=did:plc:abc&skey=self"
+        "&collection=fm.plyr.track&action=read&action=create&action=update"
+        "&action=delete&manage=create&manage=update&manage=delete"
+    )
+    assert len(space_grants(granted)) == 1
+    assert allows_space(
+        granted,
+        type="fm.plyr.privateMedia",
+        authority="did:plc:abc",
+        skey="self",
+        manage="create",
+    )
+    assert allows_space(
+        granted,
+        type="fm.plyr.privateMedia",
+        authority="did:plc:abc",
+        skey="self",
+        action="create",
+        collection="fm.plyr.track",
+    )
+    assert not allows_space(
+        granted,
+        type="fm.plyr.privateMedia",
+        authority="did:plc:abc",
+        skey="self",
+        action="create",
+        collection="fm.plyr.like",
+    )
+    assert not allows_space(
+        granted,
+        type="fm.plyr.privateMedia",
+        authority="did:plc:other",
+        skey="self",
+        action="read",
+    )
+    assert not allows_space(
+        "atproto include:fm.plyr.privateMediaAccess",
+        type="fm.plyr.privateMedia",
+        authority="did:plc:abc",
+        skey="self",
+        action="read",
+    )

--- a/backend/tests/api/test_private_media_upload.py
+++ b/backend/tests/api/test_private_media_upload.py
@@ -19,10 +19,14 @@ from backend.config import settings
 from backend.main import app
 from backend.utilities.audio_formats import AudioFormat
 
-# the granted token carries the expanded space scope (what the preflight checks for),
-# not the requested `include:` form
+# the granted token carries the expanded space grant (what the preflight checks
+# for), not the requested `include:` form
 _TYPE = settings.atproto.private_media_space_type
-PERM_SCOPE = f"space:{_TYPE}?action=create&did=*&skey=self&collection={_TYPE}"
+PERM_SCOPE = (
+    f"space:{_TYPE}?authority=did:test:artist&skey=self"
+    f"&collection={settings.atproto.track_collection}"
+    "&action=read&action=create&action=update&action=delete&manage=create"
+)
 
 
 class _MockSession(Session):
@@ -81,27 +85,8 @@ def _post(client: TestClient, *, filename: str = "t.wav", data: dict) -> httpx.R
     )
 
 
-def test_private_requires_pds_capability(app_no_scope: FastAPI):
-    with (
-        patch(
-            "backend.api.tracks.uploads.detect_permissioned_capability",
-            return_value=False,
-        ),
-        TestClient(app_no_scope) as client,
-    ):
-        resp = _post(client, data={"visibility": "private"})
-    assert resp.status_code == 400
-    assert "permissioned spaces" in resp.json()["detail"]
-
-
-def test_private_capable_but_scope_missing_requests_upgrade(app_no_scope: FastAPI):
-    with (
-        patch(
-            "backend.api.tracks.uploads.detect_permissioned_capability",
-            return_value=True,
-        ),
-        TestClient(app_no_scope) as client,
-    ):
+def test_private_without_grant_requests_upgrade(app_no_scope: FastAPI):
+    with TestClient(app_no_scope) as client:
         resp = _post(client, data={"visibility": "private"})
     assert resp.status_code == 403
     assert resp.json()["detail"] == "permissioned_scope_required"
@@ -122,10 +107,6 @@ def test_private_app_password_session_bypasses_oauth_scope_gate(
     }
 
     with (
-        patch(
-            "backend.api.tracks.uploads.detect_permissioned_capability",
-            return_value=True,
-        ),
         patch("backend.api.tracks.uploads.upload_blob", return_value=fake_blob),
         patch("backend.api.tracks.uploads.schedule_track_upload"),
         TestClient(app_no_scope) as client,
@@ -137,10 +118,6 @@ def test_private_app_password_session_bypasses_oauth_scope_gate(
 
 def test_private_rejects_non_web_playable(app_with_scope: FastAPI):
     with (
-        patch(
-            "backend.api.tracks.uploads.detect_permissioned_capability",
-            return_value=True,
-        ),
         TestClient(app_with_scope) as client,
     ):
         resp = client.post(
@@ -187,10 +164,6 @@ def test_private_upload_goes_to_pds_not_r2(app_with_scope: FastAPI):
         raise AssertionError("private upload must not stage audio to R2")
 
     with (
-        patch(
-            "backend.api.tracks.uploads.detect_permissioned_capability",
-            return_value=True,
-        ),
         patch("backend.api.tracks.uploads.upload_blob", _fake_upload_blob),
         patch("backend.api.tracks.uploads.stage_audio_to_storage", _no_stage),
         patch("backend.api.tracks.uploads.schedule_track_upload", _fake_schedule),
@@ -303,10 +276,6 @@ def test_private_upload_dead_session_returns_401_not_500(app_with_scope: FastAPI
         )
 
     with (
-        patch(
-            "backend.api.tracks.uploads.detect_permissioned_capability",
-            return_value=True,
-        ),
         patch("backend.api.tracks.uploads.upload_blob", _dead_session),
         TestClient(app_with_scope) as client,
     ):

--- a/backend/tests/api/test_scope_upgrade.py
+++ b/backend/tests/api/test_scope_upgrade.py
@@ -4,7 +4,7 @@ from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -337,4 +337,52 @@ async def test_permissioned_upgrade_start_clears_marker(
                 json={"include_teal": False, "include_permissioned": True},
             )
     assert response.status_code == 200
+    assert await _marker(db_session) is None
+
+
+async def test_permissioned_start_marks_pds_when_par_refuses_the_scope(
+    test_app: FastAPI, db_session: AsyncSession, upgrade_artist: Artist
+):
+    """a PDS without spaces refuses at PAR, before any consent screen."""
+    with patch(
+        "backend.api.auth.start_oauth_flow_with_scopes",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(
+            status_code=400,
+            detail=(
+                "failed to start OAuth flow: invalid_scope: Permissioned data "
+                "(spaces) is not enabled on this server"
+            ),
+        ),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/auth/scope-upgrade/start",
+                json={"include_teal": False, "include_permissioned": True},
+            )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "incompatible_pds"
+    assert await _marker(db_session) == "https://test.pds"
+
+
+async def test_non_permissioned_start_failure_is_not_swallowed(
+    test_app: FastAPI, db_session: AsyncSession, upgrade_artist: Artist
+):
+    with patch(
+        "backend.api.auth.start_oauth_flow_with_scopes",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(status_code=400, detail="invalid_scope: teal"),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/auth/scope-upgrade/start", json={"include_teal": True}
+            )
+
+    assert response.status_code == 400
+    assert "invalid_scope" in response.json()["detail"]
     assert await _marker(db_session) is None

--- a/backend/tests/api/test_scope_upgrade.py
+++ b/backend/tests/api/test_scope_upgrade.py
@@ -9,7 +9,9 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, require_auth
+from backend.config import settings
 from backend.main import app
+from backend.models import Artist
 
 
 class MockSession(Session):
@@ -149,3 +151,190 @@ async def test_scope_upgrade_saves_pending_record(
         assert pending.did == "did:test:user123"
         assert pending.old_session_id == "test_session_id_for_upgrade"
         assert pending.requested_scopes == "teal"
+
+
+# --- private-media upgrade callback: the PDS answers through the grant ---------
+
+_GRANTED_SCOPE = (
+    "atproto blob:*/* space:fm.plyr.dev.privateMedia?authority=did:test:user123"
+    "&skey=self&collection=fm.plyr.dev.track&action=read&action=create"
+    "&action=update&action=delete&manage=create&manage=update&manage=delete"
+)
+_UNEXPANDED_SCOPE = "atproto blob:*/* include:fm.plyr.dev.privateMediaAccess"
+
+
+def _oauth_session(scope: str) -> dict:
+    return {
+        "did": "did:test:user123",
+        "handle": "testuser.bsky.social",
+        "pds_url": "https://test.pds",
+        "authserver_iss": "https://auth.test",
+        "scope": scope,
+        "access_token": "t",
+        "refresh_token": "r",
+        "dpop_private_key_pem": "fake_key",
+        "dpop_authserver_nonce": "",
+        "dpop_pds_nonce": "",
+    }
+
+
+@pytest.fixture
+async def upgrade_artist(db_session: AsyncSession) -> Artist:
+    artist = Artist(
+        did="did:test:user123", handle="testuser.bsky.social", display_name="t"
+    )
+    db_session.add(artist)
+    await db_session.commit()
+    return artist
+
+
+async def _run_permissioned_callback(
+    test_app: FastAPI, scope: str, monkeypatch: pytest.MonkeyPatch
+) -> str:
+    from backend._internal import save_pending_scope_upgrade
+
+    monkeypatch.setattr(settings.atproto, "app_namespace", "fm.plyr.dev")
+    await save_pending_scope_upgrade(
+        state="perm_state",
+        did="did:test:user123",
+        old_session_id="old_session",
+        requested_scopes="permissioned",
+    )
+    with (
+        patch(
+            "backend.api.auth.handle_oauth_callback",
+            new_callable=AsyncMock,
+            return_value=(
+                "did:test:user123",
+                "testuser.bsky.social",
+                _oauth_session(scope),
+            ),
+        ),
+        patch(
+            "backend.api.auth.get_pending_dev_token",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "backend.api.auth.ensure_artist_exists",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch("backend.api.auth.delete_session", new_callable=AsyncMock),
+        patch(
+            "backend.api.auth.create_session",
+            new_callable=AsyncMock,
+            return_value="new_session",
+        ),
+        patch(
+            "backend.api.auth.create_exchange_token",
+            new_callable=AsyncMock,
+            return_value="xt",
+        ),
+        patch("backend.api.auth.schedule_atproto_sync", new_callable=AsyncMock),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.get(
+                "/auth/callback",
+                params={"code": "c", "state": "perm_state", "iss": "https://auth.test"},
+            )
+    assert response.status_code == 303
+    return response.headers["location"]
+
+
+async def _marker(db_session: AsyncSession) -> str | None:
+    db_session.expire_all()
+    artist = await db_session.get(Artist, "did:test:user123")
+    assert artist is not None
+    return artist.spaces_unsupported_pds
+
+
+async def test_permissioned_callback_with_expanded_grant_succeeds(
+    test_app: FastAPI,
+    db_session: AsyncSession,
+    upgrade_artist: Artist,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    location = await _run_permissioned_callback(test_app, _GRANTED_SCOPE, monkeypatch)
+    assert location.endswith("/settings?exchange_token=xt&scope_upgraded=true")
+    assert await _marker(db_session) is None
+
+
+async def test_permissioned_callback_with_unexpanded_scope_marks_pds(
+    test_app: FastAPI,
+    db_session: AsyncSession,
+    upgrade_artist: Artist,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    location = await _run_permissioned_callback(
+        test_app, _UNEXPANDED_SCOPE, monkeypatch
+    )
+    assert location.endswith(
+        "/settings?exchange_token=xt&scope_upgrade_error=incompatible_pds"
+    )
+    assert await _marker(db_session) == "https://test.pds"
+
+
+async def test_permissioned_callback_invalid_scope_keeps_old_session(
+    test_app: FastAPI,
+    db_session: AsyncSession,
+    upgrade_artist: Artist,
+):
+    from backend._internal import get_pending_scope_upgrade, save_pending_scope_upgrade
+
+    await save_pending_scope_upgrade(
+        state="perm_state",
+        did="did:test:user123",
+        old_session_id="old_session",
+        requested_scopes="permissioned",
+    )
+    with (
+        patch(
+            "backend.api.auth.get_session",
+            new_callable=AsyncMock,
+            return_value=MockSession(),
+        ),
+        patch("backend.api.auth.delete_session", new_callable=AsyncMock) as delete,
+        patch("backend.api.auth.handle_oauth_callback", new_callable=AsyncMock) as cb,
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.get(
+                "/auth/callback",
+                params={
+                    "state": "perm_state",
+                    "error": "invalid_scope",
+                    "error_description": "unknown scope",
+                },
+            )
+    assert response.status_code == 303
+    assert response.headers["location"].endswith(
+        "/settings?scope_upgrade_error=incompatible_pds"
+    )
+    assert await _marker(db_session) == "https://test.pds"
+    delete.assert_not_awaited()
+    cb.assert_not_awaited()
+    assert await get_pending_scope_upgrade("perm_state") is None
+
+
+async def test_permissioned_upgrade_start_clears_marker(
+    test_app: FastAPI, db_session: AsyncSession, upgrade_artist: Artist
+):
+    upgrade_artist.spaces_unsupported_pds = "https://test.pds"
+    await db_session.commit()
+    with patch(
+        "backend.api.auth.start_oauth_flow_with_scopes", new_callable=AsyncMock
+    ) as mock_oauth:
+        mock_oauth.return_value = ("https://auth.example.com/authorize", "retry_state")
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/auth/scope-upgrade/start",
+                json={"include_teal": False, "include_permissioned": True},
+            )
+    assert response.status_code == 200
+    assert await _marker(db_session) is None

--- a/docs/internal/architecture/permissioned-private-media.md
+++ b/docs/internal/architecture/permissioned-private-media.md
@@ -72,12 +72,26 @@ check is no longer sufficient.
 
 ## capability and OAuth upgrade
 
-No stable declarative PDS capability exists yet. An authenticated
-`com.atproto.space.listSpaces` probe remains the isolation point:
+No stable declarative PDS capability exists, and probing a `com.atproto.space.*`
+route only ever guessed at the host. The signal is the **token**: a
+spaces-capable PDS expands `include:fm.plyr.privateMediaAccess` into concrete
+`space:` grants, and one without spaces either rejects the scope
+(`invalid_scope`) or returns a token with the include silently unexpanded — the
+reference PDS's `IncludeScope.buildPermissions` skips resource types it does not
+know. Capability is therefore *presence of the parsed grant*, per session:
 
-- a real response or route-level `InsufficientScope` proves support;
-- `UnknownMethod`, `MethodNotImplemented`, `404`, or `501` means unsupported;
-- ambiguous/transient failures fail closed and are not treated as support.
+- `private_media_grant_present()` requires `manage=create` on
+  `space:<type>?authority=<user did>&skey=self` **and** `action=create` on the
+  track collection — the two operations a first private upload performs;
+- absent after an upgrade → record the PDS in `artists.spaces_unsupported_pds`
+  and stop offering the option, cleared on an explicit retry or a host change;
+- `invalid_scope` at the callback is the same answer arriving faster, and never
+  replaces the old session.
+
+`space:` scopes are parsed by `_internal/auth/space_scope.py`, a port of
+`SpacePermission` from `@atproto/oauth-scopes` (`permissioned-data` branch),
+which `atproto_oauth.scopes` does not yet implement. Bulletin and its fork
+secretsky read capability the same way.
 
 The result is cached per PDS and surfaced by `/auth/me`. Private-media OAuth permission is
 requested only through the explicit scope-upgrade flow for a capable PDS, never during the

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -87,8 +87,10 @@ export interface User {
 	handle: string;
 	linked_accounts: LinkedAccount[];
 	enabled_flags: string[];
-	// whether the user's PDS supports ATProto permissioned spaces (private media)
-	permissioned_spaces?: { supported: boolean };
+	// private media on ATProto permissioned spaces. `granted` = this session's
+	// token carries the expanded space grant; `supported` = still worth offering
+	// (false once an upgrade on this PDS came back without one).
+	permissioned_spaces?: { supported: boolean; granted?: boolean };
 }
 
 export interface Artist {

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -1,5 +1,6 @@
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
+import { auth } from './auth.svelte';
 import { API_URL } from './config';
 import { toast } from './toast.svelte';
 import { tracksCache } from './tracks.svelte';
@@ -54,7 +55,17 @@ async function startPermissionedScopeUpgrade(): Promise<void> {
 			// current session and only ADDS permissioned (doesn't force teal on).
 			body: JSON.stringify({ include_teal: false, include_permissioned: true })
 		});
-		if (!res.ok) throw new Error(`scope upgrade failed (${res.status})`);
+		if (!res.ok) {
+			// the PDS refused the permission set at PAR — it doesn't do spaces.
+			// the backend has recorded that, so refreshing auth stops offering it.
+			const detail = await res.json().catch(() => null);
+			if (detail?.detail === 'incompatible_pds') {
+				toast.error("your PDS doesn't support private media yet", 8000);
+				await auth.refresh();
+				return;
+			}
+			throw new Error(`scope upgrade failed (${res.status})`);
+		}
 		const data = await res.json();
 		// preserve intent across the consent redirect via the same plyr_return_to
 		// cookie jams/login use — the scope-upgrade lands on /settings, which

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -128,6 +128,7 @@
 				scope_mismatch:
 					'sign-in failed — your PDS did not grant the permissions plyr.fm needs. it may not support permission sets yet.',
 				expired: 'sign-in expired — please try again.',
+				access_denied: 'sign-in cancelled.',
 				failed: 'sign-in failed — please try again.'
 			};
 			toast.error(messages[authError] ?? messages.failed, authError === 'scope_mismatch' ? 8000 : 5000);

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -98,6 +98,15 @@ import WaveLoading from '$lib/components/WaveLoading.svelte';
 		const exchangeToken = params.get('exchange_token');
 		const isDevToken = params.get('dev_token') === 'true';
 		const isScopeUpgrade = params.get('scope_upgraded') === 'true';
+		if (params.get('scope_upgrade_error') === 'incompatible_pds') {
+			clearReturnUrl();
+			toast.error(
+				"your PDS doesn't support private media yet — it didn't grant permissioned-space access",
+				8000
+			);
+			await auth.refresh();
+			window.history.replaceState({}, '', '/settings');
+		}
 
 		if (exchangeToken) {
 			try {

--- a/loq.toml
+++ b/loq.toml
@@ -27,7 +27,7 @@ max_lines = 904
 
 [[rules]]
 path = "backend/src/backend/api/auth.py"
-max_lines = 970
+max_lines = 981
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"
@@ -335,7 +335,7 @@ max_lines = 1424
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"
-max_lines = 509
+max_lines = 520
 
 [[rules]]
 path = "frontend/src/routes/track/[[]id[]]/+page.svelte"

--- a/loq.toml
+++ b/loq.toml
@@ -27,7 +27,7 @@ max_lines = 904
 
 [[rules]]
 path = "backend/src/backend/api/auth.py"
-max_lines = 923
+max_lines = 970
 
 [[rules]]
 path = "backend/src/backend/api/tracks/listing.py"


### PR DESCRIPTION
plyr.fm decided whether a PDS did permissioned spaces by probing `com.atproto.space.listSpaces` and classifying the failure string, cached 6h per PDS. The alpha makes the **token** authoritative: a spaces-capable PDS expands `include:fm.plyr.privateMediaAccess` into concrete `space:` grants, so capability is simply *did the grant come back*. Closes #1880.

<details>
<summary>why the probe had to go, not just get demoted</summary>

The zds session checked both sides for me:

- **zds with `ZDS_PERMISSIONED_DATA=false`** expands `include:` regardless of the flag (the flag only gates the XRPC handlers) — so the probe's "route answers" test and the expansion disagree. They're fixing zds to answer `invalid_scope`; either way the old probe was capable of a false positive.
- **the reference PDS** (`IncludeScope.buildPermissions`) only knows `repo` and `rpc` resources and silently skips anything else, so `include:` with a `space` permission resolves fine and expands to **nothing** — no `invalid_scope`, just a token with no grant.

So neither error strings nor `invalid_scope` is the reliable signal — presence of the parsed grant is, which is exactly what Bulletin and secretsky check. `invalid_scope` is handled as a fast path when it does arrive.
</details>

<details>
<summary>what changed</summary>

- **`_internal/auth/space_scope.py`** — a port of `SpacePermission` from `@atproto/oauth-scopes` on `permissioned-data` (python's `atproto_oauth.scopes` has repo/blob/rpc/account/identity/include but no `space`). Defaults (`authority=self`, `skey=*`, empty `collection`, the four-action default, empty `manage`), `read` ⇒ `read_self`, unresolved `self` matches nothing. `tests/_internal/test_space_scope.py` ports the upstream vectors, including the invalid-scope and rkey-shape tables.
- **capability** is now `private_media_grant_present()`: `manage=create` on the user's own `space:<type>?authority=<did>&skey=self` **and** `action=create` on the track collection — the two operations a first private upload performs. The `listSpaces` probe, its error-string classifier, and the redis cache are deleted.
- **the substring matches are parsed checks**: `oauth.py:178` (`private_media_space_type in scope`, which picked the OAuth client) and the upload gate in `uploads.py` both go through `space_scope`. The upload preflight collapses from two gates to one — the capability check was never the thing that authorized the write.
- **`invalid_scope` at the callback** is handled explicitly: `code`/`iss` are now optional, an error return for a pending *permissioned* upgrade marks the PDS and redirects `scope_upgrade_error=incompatible_pds`, and the old session is left alone (the upgrade never replaced it).
- **remembering the answer**: new nullable `artists.spaces_unsupported_pds` (migration `d5f3c9a62eb2`) records the PDS whose upgrade came back grantless. Keyed with the host so an account migration resets it, and cleared whenever the user explicitly retries the upgrade — PDSes will be turning spaces on over the coming months.
- **`/auth/me`** gains `permissioned_spaces.granted` (this token holds the grant) alongside `supported` (still worth offering). The upload page's existing `supported` check keeps working unchanged.
- frontend: the type, and a settings toast + auth refresh on `scope_upgrade_error=incompatible_pds`.
</details>

<details>
<summary>behavior change worth naming</summary>

A user on a PDS without spaces now sees the "private" option and pays one OAuth round trip to find out, instead of being silently filtered by a probe. That is the same round trip any scope upgrade costs, and after one refusal the option is hidden for that PDS. The alternative — keeping the probe as a hint — preserves a signal that can now be wrong in both directions.
</details>

<details>
<summary>verification</summary>

- full backend suite: 1548 passed, 25 skipped. ruff clean; ty diagnostics back at the 13 baseline; `svelte-check` 0 errors.
- new tests: expanded grant → success; unexpanded `include:` → marks the PDS and redirects incompatible; `invalid_scope` → same, without touching the old session or calling the callback handler; retry clears the marker.
- not covered here: a live upgrade against pds.zat.dev (needs a browser OAuth round trip). The PR's live private-media integration still exercises the write path.
- `loq` relaxed for `api/auth.py` (970 > 923) — the callback grew an error branch.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)