### PR TITLE
fix(record): drop the PDS capability note from the idle screen

### DIFF
--- a/frontend/src/routes/record/+page.svelte
+++ b/frontend/src/routes/record/+page.svelte
@@ -354,11 +354,6 @@
 				</button>
 			</div>
 			<p class="hint">tap the mic to start</p>
-			{#if permissionedSupported}
-				<p class="capability-note">
-					your PDS supports private media — you can keep a recording to yourself
-				</p>
-			{/if}
 		</div>
 	{:else if uiState === 'recording'}
 		<div class="stage">
@@ -612,13 +607,6 @@
 		color: var(--text-muted);
 	}
 
-	.capability-note {
-		margin: 0;
-		font-size: var(--text-xs);
-		color: var(--text-tertiary);
-		text-align: center;
-		max-width: 34ch;
-	}
 
 	.preview-card {
 		background: color-mix(in srgb, var(--track-bg, var(--bg-primary)) 70%, transparent);

--- a/loq.toml
+++ b/loq.toml
@@ -243,7 +243,7 @@ max_lines = 600
 
 [[rules]]
 path = "frontend/src/routes/record/+page.svelte"
-max_lines = 795
+max_lines = 783
 
 [[rules]]
 path = "backend/src/backend/api/albums/mutations.py"


### PR DESCRIPTION
Removes the line I added under "tap the mic to start":

> your PDS supports private media — you can keep a recording to yourself

It announced infrastructure before the user had done anything, and the visibility card already offers private at the moment the choice actually matters — with a better explanation. `loq` limit lowered 795 → 783 to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)