### PR TITLE
fix(migrations): restore the applied revision the drop was chained past

### DIFF
--- a/backend/alembic/versions/2026_08_21_000000_d5f3c9a62eb2_add_spaces_unsupported_pds_to_artists.py
+++ b/backend/alembic/versions/2026_08_21_000000_d5f3c9a62eb2_add_spaces_unsupported_pds_to_artists.py
@@ -1,0 +1,31 @@
+"""add spaces_unsupported_pds to artists
+
+Revision ID: d5f3c9a62eb2
+Revises: c4e2b8f51da1
+Create Date: 2026-08-21 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d5f3c9a62eb2"
+down_revision: str | Sequence[str] | None = "c4e2b8f51da1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "artists", sa.Column("spaces_unsupported_pds", sa.String(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("artists", "spaces_unsupported_pds")

--- a/backend/alembic/versions/2026_08_21_120000_e7a4d1b93fc5_drop_spaces_unsupported_pds.py
+++ b/backend/alembic/versions/2026_08_21_120000_e7a4d1b93fc5_drop_spaces_unsupported_pds.py
@@ -4,7 +4,7 @@ Capability is read from the authorization server's advertised scopes, so there
 is no failed-upgrade result to remember.
 
 Revision ID: e7a4d1b93fc5
-Revises: c4e2b8f51da1
+Revises: d5f3c9a62eb2
 Create Date: 2026-08-21 12:00:00.000000
 
 """
@@ -17,7 +17,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "e7a4d1b93fc5"
-down_revision: str | Sequence[str] | None = "c4e2b8f51da1"
+down_revision: str | Sequence[str] | None = "d5f3c9a62eb2"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
Staging's release command failed on #1885: `Can't locate revision identified by 'd5f3c9a62eb2'`.

I deleted that migration file when replacing it with a drop — but it had already been applied to staging and production in the #1884 release, so both databases have it stamped in `alembic_version`. Deleting an applied migration orphans the pointer and no further migration can run.

The add migration is restored and the drop now descends from it: `c4e2b8f51da1 → d5f3c9a62eb2 (add) → e7a4d1b93fc5 (drop)`, one head. A deployed database moves straight from `d5f3c9a62eb2` to `e7a4d1b93fc5`.

Verified against a database stamped at `d5f3c9a62eb2` with an artist row present — the exact shape staging and prod are in:

```
Running upgrade d5f3c9a62eb2 -> e7a4d1b93fc5, drop spaces_unsupported_pds from artists
version_num: e7a4d1b93fc5
spaces_unsupported_pds columns: 0
artists rows: 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)