### PR TITLE
fix(e2e): lint the node script, and say what the browser did when a stage fails

### DIFF
--- a/.github/workflows/e2e-private-media.yml
+++ b/.github/workflows/e2e-private-media.yml
@@ -58,3 +58,11 @@ jobs:
           ZAT_TEST_HANDLE: ${{ secrets.ZAT_TEST_HANDLE }}
           ZAT_TEST_PASSWORD: ${{ secrets.ZAT_TEST_PASSWORD }}
         run: node e2e/private-media.mjs
+
+      - name: keep screenshots from a failed run
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-private-media
+          path: frontend/e2e-artifacts
+          if-no-files-found: ignore

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -24,3 +24,4 @@ vite.config.ts.timestamp-*
 
 *storybook.log
 storybook-static
+e2e-artifacts

--- a/frontend/e2e/private-media.mjs
+++ b/frontend/e2e/private-media.mjs
@@ -11,6 +11,7 @@
  *   ZAT_TEST_HANDLE=... ZAT_TEST_PASSWORD=... node e2e/private-media.mjs
  */
 
+import { mkdirSync } from 'node:fs';
 import { chromium } from 'playwright';
 
 const APP = process.env.PLYR_APP_URL ?? 'https://stg.plyr.fm';
@@ -37,6 +38,36 @@ const fail = (detail) => {
 	process.exitCode = 1;
 	throw new Error(detail);
 };
+
+const ARTIFACTS = process.env.E2E_ARTIFACT_DIR ?? 'e2e-artifacts';
+mkdirSync(ARTIFACTS, { recursive: true });
+
+/** every API request and console error a page makes, so a failure can say
+ * what the browser actually did instead of just where it stopped. */
+function observe(page, label) {
+	const seen = [];
+	page.on('request', (r) => {
+		if (r.url().startsWith(API)) seen.push(`${r.method()} ${new URL(r.url()).pathname}`);
+	});
+	page.on('response', (r) => {
+		if (r.url().startsWith(API) && r.status() >= 400) seen.push(`  -> ${r.status()} ${new URL(r.url()).pathname}`);
+	});
+	page.on('console', (m) => {
+		if (m.type() === 'error') seen.push(`console.error: ${m.text().slice(0, 200)}`);
+	});
+	page.on('pageerror', (e) => seen.push(`pageerror: ${String(e).slice(0, 200)}`));
+	return async () => {
+		console.error(`--- ${label}: url=${page.url()}`);
+		console.error(`--- ${label}: requests\n${seen.map((l) => '    ' + l).join('\n')}`);
+		const text = await page
+			.locator('body')
+			.innerText()
+			.then((t) => t.replace(/\s+/g, ' ').slice(0, 600))
+			.catch(() => '(no body)');
+		console.error(`--- ${label}: text: ${text}`);
+		await page.screenshot({ path: `${ARTIFACTS}/${label}.png`, fullPage: true }).catch(() => undefined);
+	};
+}
 
 /** 0.2s of 8kHz mono sine — small but decodable, and unique per run so the
  * content-hash dedupe never mistakes two test runs for the same track. */
@@ -77,8 +108,10 @@ async function authorizeOnPds(page) {
 
 async function signIn(page) {
 	await page.goto(`${APP}/login`, { waitUntil: 'networkidle' });
-	await page.locator('input').first().fill(HANDLE);
-	await page.keyboard.press('Enter');
+	const handle = page.getByPlaceholder('you.example.com');
+	await handle.waitFor({ timeout: 15000 });
+	await handle.fill(HANDLE);
+	await handle.press('Enter');
 	await page.waitForURL(/oauth\/authorize/, { timeout: 30000 });
 	await authorizeOnPds(page);
 	await page.waitForTimeout(2500);
@@ -96,11 +129,14 @@ const browser = await chromium.launch();
 const title = `e2e private ${Date.now()}`;
 let createdTrackId = null;
 let ownerContext = null;
+let dumpOwner = null;
+let dumpFresh = null;
 
 try {
 	// --- session 1: sign in, upload privately through the consent round trip
 	ownerContext = await browser.newContext({ viewport: { width: 1000, height: 2600 } });
 	const page = await ownerContext.newPage();
+	dumpOwner = observe(page, 'owner');
 
 	step('sign-in', HANDLE);
 	await signIn(page);
@@ -169,6 +205,7 @@ try {
 	// --- session 2: a fresh sign-in (base scope, no grant) must still play it
 	const freshContext = await browser.newContext({ viewport: { width: 1000, height: 2000 } });
 	const fresh = await freshContext.newPage();
+	dumpFresh = observe(fresh, 'fresh');
 	step('fresh-session', 'signing in again without the grant');
 	await signIn(fresh);
 	const freshMe = await me(fresh);
@@ -200,6 +237,8 @@ try {
 		console.error(`FAILED at [${stage}]: ${String(e).slice(0, 400)}`);
 		process.exitCode = 1;
 	}
+	if (dumpFresh) await dumpFresh();
+	if (dumpOwner) await dumpOwner();
 } finally {
 	// leave the fixture account the way we found it
 	if (createdTrackId && ownerContext) {

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -21,6 +21,20 @@ export default [
 	},
 	js.configs.recommended,
 	{
+		files: ['e2e/**/*.mjs'],
+		languageOptions: {
+			globals: {
+				process: 'readonly',
+				console: 'readonly',
+				fetch: 'readonly',
+				Buffer: 'readonly',
+				URL: 'readonly',
+				setTimeout: 'readonly',
+				clearTimeout: 'readonly'
+			}
+		}
+	},
+	{
 		files: ['**/*.ts', '**/*.svelte'],
 		languageOptions: {
 			parser: tsParser,


### PR DESCRIPTION
main has been red since #1887 merged: pre-commit failed on \`frontend/e2e/private-media.mjs\` (20 \`no-undef\` — \`fetch\`/\`console\`/\`process\`), and the new e2e workflow timed out at its second sign-in with nothing to diagnose from.

<details>
<summary>what's in here</summary>

- **eslint**: a globals block for \`e2e/**/*.mjs\` so node scripts lint.
- **sign-in** targets the handle field by placeholder (\`you.example.com\`) rather than \`input.first()\`.
- **diagnostics**: each page records its API requests, error responses, console errors and page errors. On failure the script prints them alongside the final URL and page text, and writes full-page screenshots to \`e2e-artifacts/\`, which the workflow uploads on failure.

</details>

<details>
<summary>what I know about the fresh-session failure</summary>

Staging's telemetry (Logfire, 19:01:20–19:06 UTC) shows **zero** requests from the fresh context — not \`/auth/pds-options\`, not \`/auth/me\`, not \`/auth/start\` — while the cleanup's \`/auth/me\` at 19:01:52 arrived fine. A credential-free reproduction from my machine (two fresh contexts, \`/login\` → Enter) hits \`/auth/start\` both times. So the cause isn't visible from outside CI; this PR makes the next CI run tell us. I'll dispatch the workflow once this merges.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)