### PR TITLE
fix(record): private memos never reached consent; e2e the /record flow in a real browser

### DIFF
--- a/.github/workflows/e2e-private-media.yml
+++ b/.github/workflows/e2e-private-media.yml
@@ -18,6 +18,10 @@ on:
       - "frontend/src/**"
       - ".github/workflows/e2e-private-media.yml"
       - "frontend/e2e/**"
+  pull_request:
+    paths:
+      - ".github/workflows/e2e-private-media.yml"
+      - "frontend/e2e/**"
   workflow_dispatch:
 
 concurrency:
@@ -52,12 +56,20 @@ jobs:
           echo "staging never became healthy" >&2
           exit 1
 
-      - name: run the flow
+      - name: private upload
         working-directory: frontend
         env:
           ZAT_TEST_HANDLE: ${{ secrets.ZAT_TEST_HANDLE }}
           ZAT_TEST_PASSWORD: ${{ secrets.ZAT_TEST_PASSWORD }}
         run: node e2e/private-media.mjs
+
+      - name: private voice memo from /record
+        if: success() || failure()
+        working-directory: frontend
+        env:
+          ZAT_TEST_HANDLE: ${{ secrets.ZAT_TEST_HANDLE }}
+          ZAT_TEST_PASSWORD: ${{ secrets.ZAT_TEST_PASSWORD }}
+        run: node e2e/record-private.mjs
 
       - name: keep screenshots from a failed run
         if: failure()

--- a/frontend/e2e/lib.mjs
+++ b/frontend/e2e/lib.mjs
@@ -1,0 +1,158 @@
+/** shared plumbing for the browser e2e flows against staging. */
+
+import { mkdirSync } from 'node:fs';
+
+export const APP = process.env.PLYR_APP_URL ?? 'https://stg.plyr.fm';
+export const API = process.env.PLYR_API_URL ?? 'https://api-stg.plyr.fm';
+export const HANDLE = required('ZAT_TEST_HANDLE');
+export const PASSWORD = required('ZAT_TEST_PASSWORD');
+
+function required(name) {
+	const value = process.env[name]?.trim();
+	if (!value) {
+		console.error(`missing ${name}`);
+		process.exit(2);
+	}
+	return value;
+}
+
+let stage = 'start';
+export const currentStage = () => stage;
+export const step = (name, detail = '') => {
+	stage = name;
+	console.log(`[${name}] ${detail}`);
+};
+export const fail = (detail) => {
+	console.error(`FAILED at [${stage}]: ${detail}`);
+	process.exitCode = 1;
+	throw new Error(detail);
+};
+
+export const ARTIFACTS = process.env.E2E_ARTIFACT_DIR ?? 'e2e-artifacts';
+mkdirSync(ARTIFACTS, { recursive: true });
+
+/** every API request and console error a page makes, so a failure can say
+ * what the browser actually did instead of just where it stopped. */
+export function observe(page, label) {
+	const seen = [];
+	page.on('request', (r) => {
+		if (r.url().startsWith(API)) seen.push(`${r.method()} ${new URL(r.url()).pathname}`);
+	});
+	page.on('response', (r) => {
+		if (r.url().startsWith(API) && r.status() >= 400) seen.push(`  -> ${r.status()} ${new URL(r.url()).pathname}`);
+	});
+	page.on('console', (m) => {
+		if (m.type() === 'error') seen.push(`console.error: ${m.text().slice(0, 200)}`);
+	});
+	page.on('pageerror', (e) => seen.push(`pageerror: ${String(e).slice(0, 200)}`));
+	return async () => {
+		console.error(`--- ${label}: url=${page.url()}`);
+		console.error(`--- ${label}: requests\n${seen.map((l) => '    ' + l).join('\n')}`);
+		const text = await page
+			.locator('body')
+			.innerText()
+			.then((t) => t.replace(/\s+/g, ' ').slice(0, 600))
+			.catch(() => '(no body)');
+		console.error(`--- ${label}: text: ${text}`);
+		await page.screenshot({ path: `${ARTIFACTS}/${label}.png`, fullPage: true }).catch(() => undefined);
+	};
+}
+
+/** 0.2s of 8kHz mono sine — small but decodable, and unique per run so the
+ * content-hash dedupe never mistakes two test runs for the same track. */
+export const seed = Date.now() % 997;
+export function wavBuffer() {
+	const frames = 1600;
+	const data = frames * 2;
+	const b = Buffer.alloc(44 + data);
+	b.write('RIFF');
+	b.writeUInt32LE(36 + data, 4);
+	b.write('WAVE', 8);
+	b.write('fmt ', 12);
+	b.writeUInt32LE(16, 16);
+	b.writeUInt16LE(1, 20);
+	b.writeUInt16LE(1, 22);
+	b.writeUInt32LE(8000, 24);
+	b.writeUInt32LE(16000, 28);
+	b.writeUInt16LE(2, 32);
+	b.writeUInt16LE(16, 34);
+	b.write('data', 36);
+	b.writeUInt32LE(data, 40);
+	for (let i = 0; i < frames; i++) {
+		b.writeInt16LE(Math.floor(3000 * Math.sin(i / (10 + seed / 100))), 44 + i * 2);
+	}
+	return b;
+}
+
+/** the zds consent page: expand the password form and authorize. */
+export async function authorizeOnPds(page) {
+	await page.waitForTimeout(800);
+	const usePassword = page.getByText('use password instead');
+	if (await usePassword.count()) await usePassword.click().catch(() => undefined);
+	await page.locator('input[name="username"]').fill(HANDLE);
+	await page.locator('input[name="password"]').fill(PASSWORD);
+	await page.getByRole('button', { name: 'authorize' }).click();
+	await page.waitForURL((u) => u.href.startsWith(APP), { timeout: 30000 });
+}
+
+export async function signIn(page) {
+	await page.goto(`${APP}/login`, { waitUntil: 'networkidle' });
+	const handle = page.getByPlaceholder('you.example.com');
+	await handle.waitFor({ timeout: 15000 });
+	await handle.fill(HANDLE);
+	await handle.press('Enter');
+	await page.waitForURL(/oauth\/authorize/, { timeout: 30000 });
+	await authorizeOnPds(page);
+	await page.waitForTimeout(2500);
+	const terms = page.locator('.terms-overlay');
+	if (await terms.count()) {
+		await terms.getByRole('button', { name: /accept/i }).click();
+		await page.waitForTimeout(1500);
+	}
+}
+
+export const me = (page) =>
+	page.evaluate(async (api) => (await (await fetch(`${api}/auth/me`, { credentials: 'include' })).json()), API);
+
+
+/** the id of the signed-in artist's track with this exact title, or null. */
+export const findTrackByTitle = (page, wanted) =>
+	page.evaluate(
+		async ([api, title]) => {
+			const r = await fetch(`${api}/auth/me`, { credentials: 'include' });
+			if (!r.ok) return null;
+			const who = await r.json();
+			const tr = await fetch(`${api}/tracks/?artist_did=${who.did}&limit=50`, { credentials: 'include' });
+			if (!tr.ok) return null;
+			const data = await tr.json();
+			const list = data.tracks ?? data;
+			return list.find((t) => t.title === title)?.id ?? null;
+		},
+		[API, wanted]
+	);
+
+/** poll until the track exists (the upload finishes asynchronously). */
+export async function waitForTrack(page, title, attempts = 30) {
+	for (let i = 0; i < attempts; i++) {
+		await page.waitForTimeout(2000);
+		const id = await findTrackByTitle(page, title);
+		if (id) return id;
+	}
+	return null;
+}
+
+/** leave the fixture account the way we found it. */
+export async function deleteTrack(context, id) {
+	const cleanup = await context.newPage();
+	const deleted = await cleanup
+		.goto(`${APP}/portal`, { waitUntil: 'domcontentloaded' })
+		.then(() =>
+			cleanup.evaluate(
+				async ([api, trackId]) =>
+					(await fetch(`${api}/tracks/${trackId}`, { method: 'DELETE', credentials: 'include' })).status,
+				[API, id]
+			)
+		)
+		.catch((e) => `cleanup error: ${e}`);
+	console.log(`[cleanup] DELETE /tracks/${id} -> ${deleted}`);
+}

--- a/frontend/e2e/private-media.mjs
+++ b/frontend/e2e/private-media.mjs
@@ -11,119 +11,22 @@
  *   ZAT_TEST_HANDLE=... ZAT_TEST_PASSWORD=... node e2e/private-media.mjs
  */
 
-import { mkdirSync } from 'node:fs';
 import { chromium } from 'playwright';
-
-const APP = process.env.PLYR_APP_URL ?? 'https://stg.plyr.fm';
-const API = process.env.PLYR_API_URL ?? 'https://api-stg.plyr.fm';
-const HANDLE = required('ZAT_TEST_HANDLE');
-const PASSWORD = required('ZAT_TEST_PASSWORD');
-
-function required(name) {
-	const value = process.env[name]?.trim();
-	if (!value) {
-		console.error(`missing ${name}`);
-		process.exit(2);
-	}
-	return value;
-}
-
-let stage = 'start';
-const step = (name, detail = '') => {
-	stage = name;
-	console.log(`[${name}] ${detail}`);
-};
-const fail = (detail) => {
-	console.error(`FAILED at [${stage}]: ${detail}`);
-	process.exitCode = 1;
-	throw new Error(detail);
-};
-
-const ARTIFACTS = process.env.E2E_ARTIFACT_DIR ?? 'e2e-artifacts';
-mkdirSync(ARTIFACTS, { recursive: true });
-
-/** every API request and console error a page makes, so a failure can say
- * what the browser actually did instead of just where it stopped. */
-function observe(page, label) {
-	const seen = [];
-	page.on('request', (r) => {
-		if (r.url().startsWith(API)) seen.push(`${r.method()} ${new URL(r.url()).pathname}`);
-	});
-	page.on('response', (r) => {
-		if (r.url().startsWith(API) && r.status() >= 400) seen.push(`  -> ${r.status()} ${new URL(r.url()).pathname}`);
-	});
-	page.on('console', (m) => {
-		if (m.type() === 'error') seen.push(`console.error: ${m.text().slice(0, 200)}`);
-	});
-	page.on('pageerror', (e) => seen.push(`pageerror: ${String(e).slice(0, 200)}`));
-	return async () => {
-		console.error(`--- ${label}: url=${page.url()}`);
-		console.error(`--- ${label}: requests\n${seen.map((l) => '    ' + l).join('\n')}`);
-		const text = await page
-			.locator('body')
-			.innerText()
-			.then((t) => t.replace(/\s+/g, ' ').slice(0, 600))
-			.catch(() => '(no body)');
-		console.error(`--- ${label}: text: ${text}`);
-		await page.screenshot({ path: `${ARTIFACTS}/${label}.png`, fullPage: true }).catch(() => undefined);
-	};
-}
-
-/** 0.2s of 8kHz mono sine — small but decodable, and unique per run so the
- * content-hash dedupe never mistakes two test runs for the same track. */
-const seed = Date.now() % 997;
-function wavBuffer() {
-	const frames = 1600;
-	const data = frames * 2;
-	const b = Buffer.alloc(44 + data);
-	b.write('RIFF');
-	b.writeUInt32LE(36 + data, 4);
-	b.write('WAVE', 8);
-	b.write('fmt ', 12);
-	b.writeUInt32LE(16, 16);
-	b.writeUInt16LE(1, 20);
-	b.writeUInt16LE(1, 22);
-	b.writeUInt32LE(8000, 24);
-	b.writeUInt32LE(16000, 28);
-	b.writeUInt16LE(2, 32);
-	b.writeUInt16LE(16, 34);
-	b.write('data', 36);
-	b.writeUInt32LE(data, 40);
-	for (let i = 0; i < frames; i++) {
-		b.writeInt16LE(Math.floor(3000 * Math.sin(i / (10 + seed / 100))), 44 + i * 2);
-	}
-	return b;
-}
-
-/** the zds consent page: expand the password form and authorize. */
-async function authorizeOnPds(page) {
-	await page.waitForTimeout(800);
-	const usePassword = page.getByText('use password instead');
-	if (await usePassword.count()) await usePassword.click().catch(() => undefined);
-	await page.locator('input[name="username"]').fill(HANDLE);
-	await page.locator('input[name="password"]').fill(PASSWORD);
-	await page.getByRole('button', { name: 'authorize' }).click();
-	await page.waitForURL((u) => u.href.startsWith(APP), { timeout: 30000 });
-}
-
-async function signIn(page) {
-	await page.goto(`${APP}/login`, { waitUntil: 'networkidle' });
-	const handle = page.getByPlaceholder('you.example.com');
-	await handle.waitFor({ timeout: 15000 });
-	await handle.fill(HANDLE);
-	await handle.press('Enter');
-	await page.waitForURL(/oauth\/authorize/, { timeout: 30000 });
-	await authorizeOnPds(page);
-	await page.waitForTimeout(2500);
-	const terms = page.locator('.terms-overlay');
-	if (await terms.count()) {
-		await terms.getByRole('button', { name: /accept/i }).click();
-		await page.waitForTimeout(1500);
-	}
-}
-
-const me = (page) =>
-	page.evaluate(async (api) => (await (await fetch(`${api}/auth/me`, { credentials: 'include' })).json()), API);
+import {
+	API,
+	APP,
+	HANDLE,
+	authorizeOnPds,
+	currentStage,
+	deleteTrack,
+	fail,
+	me,
+	observe,
+	signIn,
+	step,
+	waitForTrack,
+	wavBuffer
+} from './lib.mjs';
 
 const browser = await chromium.launch();
 const title = `e2e private ${Date.now()}`;
@@ -183,22 +86,7 @@ try {
 	}
 
 	step('uploading', 'waiting for the track to exist');
-	for (let i = 0; i < 30 && !createdTrackId; i++) {
-		await page.waitForTimeout(2000);
-		createdTrackId = await page.evaluate(
-			async ([api, wanted]) => {
-				const r = await fetch(`${api}/auth/me`, { credentials: 'include' });
-				if (!r.ok) return null;
-				const who = await r.json();
-				const tr = await fetch(`${api}/tracks/?artist_did=${who.did}&limit=50`, { credentials: 'include' });
-				if (!tr.ok) return null;
-				const data = await tr.json();
-				const list = data.tracks ?? data;
-				return list.find((t) => t.title === wanted)?.id ?? null;
-			},
-			[API, title]
-		);
-	}
+	createdTrackId = await waitForTrack(page, title);
 	if (!createdTrackId) fail('uploaded track never appeared');
 	step('created', `track ${createdTrackId}`);
 
@@ -234,26 +122,12 @@ try {
 	console.log('PASS — private media works end to end');
 } catch (e) {
 	if (process.exitCode !== 1) {
-		console.error(`FAILED at [${stage}]: ${String(e).slice(0, 400)}`);
+		console.error(`FAILED at [${currentStage()}]: ${String(e).slice(0, 400)}`);
 		process.exitCode = 1;
 	}
 	if (dumpFresh) await dumpFresh();
 	if (dumpOwner) await dumpOwner();
 } finally {
-	// leave the fixture account the way we found it
-	if (createdTrackId && ownerContext) {
-		const cleanup = await ownerContext.newPage();
-		const deleted = await cleanup
-			.goto(`${APP}/portal`, { waitUntil: 'domcontentloaded' })
-			.then(() =>
-				cleanup.evaluate(
-					async ([api, id]) =>
-						(await fetch(`${api}/tracks/${id}`, { method: 'DELETE', credentials: 'include' })).status,
-					[API, createdTrackId]
-				)
-			)
-			.catch((e) => `cleanup error: ${e}`);
-		console.log(`[cleanup] DELETE /tracks/${createdTrackId} -> ${deleted}`);
-	}
+	if (createdTrackId && ownerContext) await deleteTrack(ownerContext, createdTrackId);
 	await browser.close();
 }

--- a/frontend/e2e/record-private.mjs
+++ b/frontend/e2e/record-private.mjs
@@ -1,0 +1,131 @@
+/**
+ * End-to-end: a private voice memo from /record, on a real spaces PDS.
+ *
+ * Chromium's fake microphone stands in for a person: sign in, record a few
+ * seconds, choose "private", approve the one-time private-media consent the
+ * page stashes the recording across, save, and confirm the track exists as
+ * private with audio streaming through the space-credential proxy.
+ *
+ *   ZAT_TEST_HANDLE=... ZAT_TEST_PASSWORD=... node e2e/record-private.mjs
+ */
+
+import { chromium } from 'playwright';
+import {
+	API,
+	APP,
+	HANDLE,
+	authorizeOnPds,
+	currentStage,
+	deleteTrack,
+	fail,
+	me,
+	observe,
+	signIn,
+	step,
+	waitForTrack
+} from './lib.mjs';
+
+const browser = await chromium.launch({
+	args: ['--use-fake-device-for-media-stream', '--use-fake-ui-for-media-stream']
+});
+const title = `e2e memo ${Date.now()}`;
+let createdTrackId = null;
+let context = null;
+let dump = null;
+
+const privateRadio = (page) => page.locator('input[type="radio"][value="private"]');
+
+async function choosePrivateAndSave(page) {
+	await page.locator('#record-title').fill(title);
+	await page.locator('label:has(input[type="radio"][value="private"])').click();
+	const save = page.getByRole('button', { name: 'save privately' });
+	if (!(await save.count())) fail('choosing private did not relabel the button "save privately"');
+	await save.click();
+}
+
+try {
+	context = await browser.newContext({
+		viewport: { width: 1000, height: 2000 },
+		permissions: ['microphone']
+	});
+	const page = await context.newPage();
+	dump = observe(page, 'record');
+
+	step('sign-in', HANDLE);
+	await signIn(page);
+	const before = await me(page);
+	if (before?.permissioned_spaces?.supported !== true) {
+		fail(`spaces PDS not detected as supported: ${JSON.stringify(before?.permissioned_spaces)}`);
+	}
+	step('capability', `supported=true granted=${before.permissioned_spaces.granted}`);
+
+	await page.goto(`${APP}/record`, { waitUntil: 'networkidle' });
+	step('record', 'three seconds from the fake microphone');
+	await page.getByRole('button', { name: 'start recording' }).click();
+	await page.getByRole('button', { name: 'stop recording' }).waitFor({ timeout: 10000 });
+	await page.waitForTimeout(3000);
+	await page.getByRole('button', { name: 'stop recording' }).click();
+	await page.locator('#record-title').waitFor({ timeout: 15000 });
+	const mime = await page.evaluate(() => {
+		const el = document.querySelector('audio');
+		return el?.src?.startsWith('blob:') ? 'blob attached' : 'no preview blob';
+	});
+	step('preview', mime);
+	if ((await privateRadio(page).count()) !== 1) fail('private option not offered on /record');
+
+	await choosePrivateAndSave(page);
+
+	if (!before.permissioned_spaces.granted) {
+		step('consent', 'expecting the one-time private-media approval');
+		await page.waitForURL(/oauth\/authorize/, { timeout: 30000 });
+		await authorizeOnPds(page);
+		await page.waitForTimeout(3000);
+		const after = await me(page);
+		if (after?.permissioned_spaces?.granted !== true) {
+			fail(`grant absent after consent: ${JSON.stringify(after?.permissioned_spaces)}`);
+		}
+		step('granted', `back on ${new URL(page.url()).pathname}`);
+		if (!page.url().includes('/record')) fail(`consent returned to ${page.url()}, not /record`);
+		await page.locator('#record-title').waitFor({ timeout: 15000 });
+		const restored = await page.locator('#record-title').inputValue();
+		if (restored !== title) fail(`restored title is "${restored}", expected "${title}"`);
+		if (!(await privateRadio(page).isChecked())) fail('visibility fell back from private after consent');
+		step('restored', 'recording, title and private visibility survived the round trip');
+		await page.getByRole('button', { name: 'save privately' }).click();
+	}
+
+	step('uploading', 'waiting for the track to exist');
+	createdTrackId = await waitForTrack(page, title);
+	if (!createdTrackId) fail('recorded track never appeared');
+	step('created', `track ${createdTrackId}`);
+
+	const playback = await page.evaluate(
+		async ([api, id]) => {
+			const d = await fetch(`${api}/tracks/${id}`, { credentials: 'include' });
+			if (!d.ok) return { detailStatus: d.status };
+			const t = await d.json();
+			const a = await fetch(`${api}/audio/${t.file_id}?track_id=${id}`, {
+				credentials: 'include',
+				headers: { Range: 'bytes=0-99' }
+			});
+			return { detailStatus: d.status, visibility: t.visibility, extension: t.extension, audioStatus: a.status };
+		},
+		[API, createdTrackId]
+	);
+	if (playback.visibility !== 'private') fail(`visibility is ${playback.visibility}, not private`);
+	if (playback.audioStatus !== 206 && playback.audioStatus !== 200) {
+		fail(`private audio did not stream: ${JSON.stringify(playback)}`);
+	}
+	step('playback', JSON.stringify(playback));
+
+	console.log('PASS — a private voice memo from /record works end to end');
+} catch (e) {
+	if (process.exitCode !== 1) {
+		console.error(`FAILED at [${currentStage()}]: ${String(e).slice(0, 400)}`);
+		process.exitCode = 1;
+	}
+	if (dump) await dump();
+} finally {
+	if (createdTrackId && context) await deleteTrack(context, createdTrackId);
+	await browser.close();
+}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -29,6 +29,7 @@ export default [
 				fetch: 'readonly',
 				Buffer: 'readonly',
 				URL: 'readonly',
+				document: 'readonly',
 				setTimeout: 'readonly',
 				clearTimeout: 'readonly'
 			}

--- a/frontend/src/routes/record/+page.svelte
+++ b/frontend/src/routes/record/+page.svelte
@@ -200,7 +200,7 @@
 		const stashed = await stashRecording({
 			blob,
 			title,
-			tags,
+			tags: $state.snapshot(tags),
 			visibility: 'private',
 			capturedDuration
 		});
@@ -291,6 +291,7 @@
 		previewUrl = URL.createObjectURL(stashed.blob);
 		title = stashed.title;
 		tags = stashed.tags;
+		if (stashed.visibility === 'private') visibility = 'private';
 		capturedDuration = stashed.capturedDuration;
 		uiState = 'preview';
 		if (permissionedGranted) {


### PR DESCRIPTION
Every first-time private save from `/record` dead-ended before the consent redirect: `stashRecording()` handed IndexedDB the `$state` proxy behind `tags`, structured clone refused it (`DataCloneError: [object Array] could not be cloned`), and the page fell back to the preview with "couldn't save your recording". Found by the browser flow this PR adds, on its first run (#1889's first CI run, `record.png` artifact).

<details>
<summary>the fix</summary>

- `upgradeForPrivate` stashes `$state.snapshot(tags)`.
- `restoreStashedRecording` keeps the private visibility the person chose; before, the picker fell back to public after the consent round trip (the button read "publish", so a person would have had to re-pick private).

No unit test: jsdom has no IndexedDB and a fake wouldn't reproduce the structured-clone rejection. The browser flow below is the regression test and exercised the real path.

</details>

<details>
<summary>the e2e flow</summary>

`frontend/e2e/record-private.mjs`: Chromium's fake microphone records on `/record` at staging with the zat test account, the run picks **private**, approves the one-time consent that the page stashes the recording across, asserts the title and private visibility survived the round trip, saves, and checks the track is private with audio streaming through the space-credential proxy. Shared sign-in / PDS consent / track polling / cleanup plumbing moves to `e2e/lib.mjs`; `private-media.mjs` imports it. The workflow runs it as a second step and now also triggers on pull requests touching `frontend/e2e/**`.

**This PR's own e2e check stays red**: the flow runs against staging, which serves `main`'s frontend, so it hits the very bug being fixed until this merges and Pages deploys. The private-upload step passes; the record step fails at `[consent]` exactly as on the first run. I'll dispatch the workflow after the staging deploy and report the result.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)