### PR TITLE
feat(auth): request private media at sign-in; finish the save after a legacy consent

### DIFF
--- a/backend/src/backend/_internal/auth/oauth.py
+++ b/backend/src/backend/_internal/auth/oauth.py
@@ -270,10 +270,15 @@ async def start_oauth_flow(
     """start OAuth flow and return (auth_url, state).
 
     uses extended scope if user has enabled teal.fm scrobbling or has opted
-    into a copyright paradigm.
+    into a copyright paradigm. the private-media permission set is always
+    requested: a spaces PDS expands it into ``space:`` grants at consent, any
+    other PDS leaves it unexpanded, and an authserver that rejects it at PAR
+    gets the request again without it.
     """
     from backend._internal.atproto.handles import resolve_handle
 
+    wants_teal = False
+    wants_indiemusi = False
     try:
         # resolve handle to DID to check preferences
         resolved = await resolve_handle(handle)
@@ -281,21 +286,32 @@ async def start_oauth_flow(
             did = resolved["did"]
             wants_teal = await _check_teal_preference(did)
             wants_indiemusi = await _check_copyright_paradigm(did)
-            client = get_oauth_client(
-                include_teal=wants_teal, include_indiemusi=wants_indiemusi
-            )
             logger.info(
                 f"starting OAuth for {handle} (did={did}, "
                 f"teal={wants_teal}, indiemusi={wants_indiemusi})"
             )
         else:
-            # fallback to base client if resolution fails
-            # (OAuth flow will resolve handle again internally)
-            client = get_oauth_client()
+            # OAuth flow will resolve handle again internally
             logger.info(f"starting OAuth for {handle} (resolution failed, using base)")
 
-        auth_url, state = await _start_authorization_with_retry(client, handle, prompt)
-        return auth_url, state
+        client = get_oauth_client(
+            include_teal=wants_teal,
+            include_indiemusi=wants_indiemusi,
+            include_permissioned=True,
+        )
+        try:
+            return await _start_authorization_with_retry(client, handle, prompt)
+        except Exception as exc:
+            if "invalid_scope" not in str(exc):
+                raise
+            logger.info(
+                f"authserver for {handle} rejected the private-media permission "
+                "set; signing in without it"
+            )
+        client = get_oauth_client(
+            include_teal=wants_teal, include_indiemusi=wants_indiemusi
+        )
+        return await _start_authorization_with_retry(client, handle, prompt)
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/tests/_internal/test_permissioned_spaces.py
+++ b/backend/tests/_internal/test_permissioned_spaces.py
@@ -155,6 +155,73 @@ async def test_pds_supports_spaces_without_issuer_is_false():
     assert await cap.pds_supports_spaces(session) is False
 
 
+def _login_harness(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, bool]]:
+    from backend._internal.atproto import handles
+
+    monkeypatch.setattr(
+        handles, "resolve_handle", AsyncMock(return_value={"did": "did:plc:x"})
+    )
+    monkeypatch.setattr(
+        oauth_module, "_check_teal_preference", AsyncMock(return_value=False)
+    )
+    monkeypatch.setattr(
+        oauth_module, "_check_copyright_paradigm", AsyncMock(return_value=False)
+    )
+    clients: list[dict[str, bool]] = []
+
+    def fake_client(**kwargs):
+        clients.append(kwargs)
+        return SimpleNamespace(scope=str(kwargs))
+
+    monkeypatch.setattr(oauth_module, "get_oauth_client", fake_client)
+    return clients
+
+
+async def test_login_always_requests_the_private_media_permission_set(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clients = _login_harness(monkeypatch)
+    start = AsyncMock(return_value=("https://auth.example/authorize", "state"))
+    monkeypatch.setattr(oauth_module, "_start_authorization_with_retry", start)
+
+    assert await oauth_module.start_oauth_flow("someone.example") == (
+        "https://auth.example/authorize",
+        "state",
+    )
+    assert [c["include_permissioned"] for c in clients] == [True]
+    start.assert_awaited_once()
+
+
+async def test_login_retries_without_the_permission_set_when_par_rejects_it(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clients = _login_harness(monkeypatch)
+    start = AsyncMock(
+        side_effect=[
+            RuntimeError('PAR failed: 400 {"error":"invalid_scope"}'),
+            ("https://auth.example/authorize", "state"),
+        ]
+    )
+    monkeypatch.setattr(oauth_module, "_start_authorization_with_retry", start)
+
+    assert await oauth_module.start_oauth_flow("someone.example") == (
+        "https://auth.example/authorize",
+        "state",
+    )
+    assert [c.get("include_permissioned", False) for c in clients] == [True, False]
+
+
+async def test_login_surfaces_other_par_failures(monkeypatch: pytest.MonkeyPatch):
+    _login_harness(monkeypatch)
+    monkeypatch.setattr(
+        oauth_module,
+        "_start_authorization_with_retry",
+        AsyncMock(side_effect=RuntimeError("PAR failed: 500 boom")),
+    )
+    with pytest.raises(Exception, match="boom"):
+        await oauth_module.start_oauth_flow("someone.example")
+
+
 # --- OAuth scope composition --------------------------------------------------
 
 

--- a/docs/internal/architecture/permissioned-private-media.md
+++ b/docs/internal/architecture/permissioned-private-media.md
@@ -215,10 +215,18 @@ Rollout order matters:
    canonical URI;
 5. verify a non-supporting PDS continues to hide the private option.
 
-Publishing must precede deployment because a newly upgraded browser session requests
+Publishing must precede deployment because every browser sign-in requests
 `include:<namespace>.privateMediaAccess`; the PDS must be able to resolve that permission
-set during authorization. Existing sessions without the include will be sent through the
-normal one-time OAuth scope upgrade when they first choose private media.
+set during authorization. The grant is the capability signal, as in Bulletin: a spaces
+PDS expands the include into `space:` grants at consent (`granted: true`), any other PDS
+leaves it unexpanded and private media stays hidden, and an authserver that rejects the
+include at PAR with `invalid_scope` gets the sign-in again without it. `scopes_supported`
+cannot carry this — the reference oauth-provider only ever lists `atproto` and the
+`transition:*` hints ("other atproto scopes can't be enumerated as they are dynamic"), so
+the Bluesky-hosted alpha PDS (`spaces-alpha.host.bsky.network`) advertises nothing; zds is
+the one implementation that adds `space:*`. Sessions signed in before this (no include)
+take the one-time OAuth scope upgrade the first time they choose private; the upload or
+recording is held across that redirect and completes on return without another click.
 
 The smoke script covers space creation, record/blob writes, credential exchange, record
 reads, and ranged blob playback. Unit tests cover URI parsing, current config shape,

--- a/frontend/e2e/private-media.mjs
+++ b/frontend/e2e/private-media.mjs
@@ -47,7 +47,10 @@ try {
 	if (before?.permissioned_spaces?.supported !== true) {
 		fail(`spaces PDS not detected as supported: ${JSON.stringify(before?.permissioned_spaces)}`);
 	}
-	step('capability', `supported=true granted=${before.permissioned_spaces.granted}`);
+	if (before.permissioned_spaces.granted !== true) {
+		fail('sign-in on a spaces PDS did not carry the private-media grant');
+	}
+	step('capability', 'supported=true granted=true straight from sign-in');
 
 	await page.goto(`${APP}/upload`, { waitUntil: 'networkidle' });
 	await page.waitForTimeout(1500);
@@ -77,12 +80,7 @@ try {
 		if (after?.permissioned_spaces?.granted !== true) {
 			fail(`grant absent after consent: ${JSON.stringify(after?.permissioned_spaces)}`);
 		}
-		step('granted', 'token carries the space grant');
-		if (!page.url().includes('/upload')) await page.goto(`${APP}/upload`, { waitUntil: 'networkidle' });
-		await page.waitForTimeout(2000);
-		// the stash restores text + visibility; the file must be re-attached
-		await fillForm();
-		await page.locator('button[type="submit"]').last().click();
+		step('granted', 'token carries the space grant; the upload resumes by itself');
 	}
 
 	step('uploading', 'waiting for the track to exist');

--- a/frontend/e2e/record-private.mjs
+++ b/frontend/e2e/record-private.mjs
@@ -35,11 +35,12 @@ let dump = null;
 
 const privateRadio = (page) => page.locator('input[type="radio"][value="private"]');
 
-async function choosePrivateAndSave(page) {
+async function choosePrivateAndSave(page, granted) {
 	await page.locator('#record-title').fill(title);
 	await page.locator('label:has(input[type="radio"][value="private"])').click();
-	const save = page.getByRole('button', { name: 'save privately' });
-	if (!(await save.count())) fail('choosing private did not relabel the button "save privately"');
+	const expected = granted ? 'save privately' : 'approve private media';
+	const save = page.getByRole('button', { name: expected });
+	if (!(await save.count())) fail(`choosing private did not relabel the button "${expected}"`);
 	await save.click();
 }
 
@@ -57,7 +58,10 @@ try {
 	if (before?.permissioned_spaces?.supported !== true) {
 		fail(`spaces PDS not detected as supported: ${JSON.stringify(before?.permissioned_spaces)}`);
 	}
-	step('capability', `supported=true granted=${before.permissioned_spaces.granted}`);
+	if (before.permissioned_spaces.granted !== true) {
+		fail('sign-in on a spaces PDS did not carry the private-media grant');
+	}
+	step('capability', 'supported=true granted=true straight from sign-in');
 
 	await page.goto(`${APP}/record`, { waitUntil: 'networkidle' });
 	step('record', 'three seconds from the fake microphone');
@@ -73,7 +77,7 @@ try {
 	step('preview', mime);
 	if ((await privateRadio(page).count()) !== 1) fail('private option not offered on /record');
 
-	await choosePrivateAndSave(page);
+	await choosePrivateAndSave(page, before.permissioned_spaces.granted);
 
 	if (!before.permissioned_spaces.granted) {
 		step('consent', 'expecting the one-time private-media approval');
@@ -89,9 +93,7 @@ try {
 		await page.locator('#record-title').waitFor({ timeout: 15000 });
 		const restored = await page.locator('#record-title').inputValue();
 		if (restored !== title) fail(`restored title is "${restored}", expected "${title}"`);
-		if (!(await privateRadio(page).isChecked())) fail('visibility fell back from private after consent');
-		step('restored', 'recording, title and private visibility survived the round trip');
-		await page.getByRole('button', { name: 'save privately' }).click();
+		step('restored', 'recording and title survived the round trip; the save resumes by itself');
 	}
 
 	step('uploading', 'waiting for the track to exist');

--- a/frontend/src/lib/record-stash.ts
+++ b/frontend/src/lib/record-stash.ts
@@ -10,6 +10,13 @@
 const DB_NAME = 'plyr-record';
 const STORE = 'pending';
 const KEY = 'recording';
+const UPLOAD_KEY = 'upload-files';
+
+/** the audio + cover files of an /upload draft, kept across the consent redirect. */
+export interface StashedUploadFiles {
+	file: File;
+	imageFile: File | null;
+}
 
 export interface StashedRecording {
 	blob: Blob;
@@ -70,5 +77,34 @@ export async function clearStashedRecording(): Promise<void> {
 		await tx('readwrite', (store) => store.delete(KEY));
 	} catch (e) {
 		console.error('could not clear the stashed recording:', e);
+	}
+}
+
+export async function stashUploadFiles(files: StashedUploadFiles): Promise<boolean> {
+	try {
+		await tx('readwrite', (store) => store.put(files, UPLOAD_KEY));
+		return true;
+	} catch (e) {
+		console.error('could not stash the upload files:', e);
+		return false;
+	}
+}
+
+export async function takeUploadFiles(): Promise<StashedUploadFiles | null> {
+	try {
+		const stashed = await tx<StashedUploadFiles | undefined>('readonly', (store) => store.get(UPLOAD_KEY));
+		await clearUploadFiles();
+		return stashed?.file ? stashed : null;
+	} catch (e) {
+		console.error('could not read the stashed upload files:', e);
+		return null;
+	}
+}
+
+export async function clearUploadFiles(): Promise<void> {
+	try {
+		await tx('readwrite', (store) => store.delete(UPLOAD_KEY));
+	} catch (e) {
+		console.error('could not clear the stashed upload files:', e);
 	}
 }

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -44,8 +44,8 @@ const MOBILE_LARGE_FILE_THRESHOLD_MB = 50;
  * (private media) scope, then redirect to the authorization URL. After the user
  * returns, they retry the upload with the scope granted.
  */
-async function startPermissionedScopeUpgrade(): Promise<void> {
-	toast.info('one-time approval needed to store private media on your PDS...', 6000);
+export async function startPermissionedScopeUpgrade(): Promise<void> {
+	toast.info('approving private media — your draft is saved', 6000);
 	try {
 		const res = await fetch(`${API_URL}/auth/scope-upgrade/start`, {
 			method: 'POST',

--- a/frontend/src/routes/record/+page.svelte
+++ b/frontend/src/routes/record/+page.svelte
@@ -291,14 +291,15 @@
 		previewUrl = URL.createObjectURL(stashed.blob);
 		title = stashed.title;
 		tags = stashed.tags;
-		if (stashed.visibility === 'private') visibility = 'private';
 		capturedDuration = stashed.capturedDuration;
 		uiState = 'preview';
-		if (permissionedGranted) {
-			toast.success('approved — upload when ready', 6000);
-		} else {
-			toast.error("private media wasn't approved", 6000);
+		if (!permissionedGranted) {
+			toast.error("not approved — your recording is still here", 6000);
+			return;
 		}
+		visibility = 'private';
+		toast.success('approved — saving your recording', 4000);
+		await handleUpload();
 	}
 
 	onMount(async () => {
@@ -469,7 +470,11 @@
 						<polyline points="17 8 12 3 7 8" />
 						<line x1="12" y1="3" x2="12" y2="15" />
 					</svg>
-					{visibility === 'private' ? 'save privately' : 'publish'}
+					{visibility !== 'private'
+						? 'publish'
+						: permissionedGranted
+							? 'save privately'
+							: 'approve private media'}
 				</button>
 			</div>
 		</div>

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -25,6 +25,8 @@
 		clearTrackFormStash,
 		preflightAuth,
 	} from "$lib/upload-form-stash";
+	import { stashUploadFiles, takeUploadFiles } from "$lib/record-stash";
+	import { startPermissionedScopeUpgrade } from "$lib/uploader.svelte";
 
 	const AUDIO_EXTENSIONS = [".mp3", ".wav", ".m4a", ".aiff", ".aif", ".flac"];
 	const AUDIO_MIME_TYPES = [
@@ -79,6 +81,9 @@
 	const permissionedSupported = $derived(
 		auth.user?.permissioned_spaces?.supported ?? false
 	);
+	const permissionedGranted = $derived(
+		auth.user?.permissioned_spaces?.granted ?? false
+	);
 	// copyright rights metadata — orthogonal, rides on public/unlisted tracks.
 	// when enabled, audio is uploaded to private storage and the backend writes
 	// indiemusi song + recording records after the track is published.
@@ -117,10 +122,22 @@
 			sensitiveAudio = stashed.sensitiveAudio ?? false;
 			visibility = (stashed.visibility ?? 'public') as typeof visibility;
 			clearTrackFormStash();
-			toast.info(
-				"your draft was restored — please reattach your audio file",
-				7000,
-			);
+			const files = await takeUploadFiles();
+			if (files) {
+				file = files.file;
+				imageFile = files.imageFile;
+			}
+			if (visibility === "private" && !permissionedGranted) {
+				toast.error("not approved — your draft is still here", 6000);
+			} else if (files && visibility === "private") {
+				toast.success("approved — uploading your track", 4000);
+				await submitUpload();
+			} else if (!files) {
+				toast.info(
+					"your draft was restored — please reattach your audio file",
+					7000,
+				);
+			}
 		}
 
 		await Promise.all([loadMyAlbums(), loadArtistProfile()]);
@@ -175,6 +192,10 @@
 
 	async function handleUpload(e: SubmitEvent) {
 		e.preventDefault();
+		await submitUpload();
+	}
+
+	async function submitUpload() {
 		if (!file) return;
 
 		// private media has no transcode step (audio is stored as-is as a PDS
@@ -258,6 +279,15 @@
 		// terminal error (the scope-upgrade path returns without firing onError).
 		if (uploadVisibility === "private") {
 			stashTrackForm(currentFormStash());
+			if (!permissionedGranted) {
+				if (!(await stashUploadFiles({ file: uploadFile, imageFile: uploadImage }))) {
+					clearTrackFormStash();
+					toast.error("couldn't save your draft — try again");
+					return;
+				}
+				await startPermissionedScopeUpgrade();
+				return;
+			}
 		}
 
 		uploader.upload(
@@ -520,7 +550,7 @@
 				supportUrl={artistProfile?.support_url}
 				showPrivate={permissionedSupported}
 				restrictedToPublic={copyrightEnabled}
-				privateGranted={auth.user?.permissioned_spaces?.granted ?? false}
+				privateGranted={permissionedGranted}
 			/>
 
 			<div class="form-group attestation">
@@ -562,7 +592,11 @@
 						? "please confirm you have distribution rights"
 						: ""}
 			>
-				<span>upload track</span>
+				<span
+					>{visibility === "private" && !permissionedGranted
+						? "approve private media"
+						: "upload track"}</span
+				>
 			</button>
 
 		</form>

--- a/loq.toml
+++ b/loq.toml
@@ -175,7 +175,7 @@ max_lines = 1299
 
 [[rules]]
 path = "frontend/src/routes/upload/+page.svelte"
-max_lines = 893
+max_lines = 927
 
 [[rules]]
 path = "services/moderation/src/admin.rs"
@@ -243,7 +243,7 @@ max_lines = 600
 
 [[rules]]
 path = "frontend/src/routes/record/+page.svelte"
-max_lines = 794
+max_lines = 798
 
 [[rules]]
 path = "backend/src/backend/api/albums/mutations.py"
@@ -287,7 +287,7 @@ max_lines = 921
 
 [[rules]]
 path = "backend/src/backend/_internal/auth/oauth.py"
-max_lines = 642
+max_lines = 657
 
 [[rules]]
 path = "frontend/src/lib/components/CopyrightSection.svelte"
@@ -355,7 +355,7 @@ max_lines = 689
 
 [[rules]]
 path = "backend/tests/_internal/test_permissioned_spaces.py"
-max_lines = 664
+max_lines = 712
 
 [[rules]]
 path = "frontend/src/routes/u/[[]handle[]]/+page.svelte"


### PR DESCRIPTION
Private media is now requested at sign-in, and the grant is the capability — the pattern Bulletin uses. The on-demand consent round trip remains only for sessions created before this, and it no longer bounces you to an auth page from a button that said "save": the button says "approve private media", and the upload or recording completes by itself when you're back.

<details>
<summary>why the sign-in change — #1885 hides private media from the official alpha PDS</summary>

#1885 decided "can this PDS do spaces" from `scopes_supported` in the authserver metadata. The reference `oauth-provider` (`packages/oauth/oauth-provider/src/metadata/build-metadata.ts`, identical on `main` and `permissioned-data`) only ever lists `atproto` + the `transition:*` hints — *"Other atproto scopes can't be enumerated as they are dynamic."* Live:

| host | implementation | `space:` advertised |
|---|---|---|
| `spaces-alpha.host.bsky.network` (Bluesky-hosted alpha, `{"version":"permissioned-data"}`) | official | **no** |
| `bsky.social` | official | no |
| `pds.cauda.cloud` (0.4.5027) | official | no |
| `pds.zat.dev` (zds 0.3.0) | zds | yes |
| `pi.chadtmiller.com` (zds 0.2.0) | zds | yes |

So `/auth/me` reports `supported: false` for everyone on the Bluesky alpha PDS. zds is the only implementation that advertises, and that's zat's addition.

Bulletin (`lib/config.ts`, `lib/auth/bulletin-capabilities.ts`) requests `include:<set>` at login unconditionally and derives capability from the expanded grant via `ScopePermissions.allowsSpace`. This PR does the same: `start_oauth_flow` always includes the permission set; on a PAR `invalid_scope` it signs in again without it. `/auth/me.supported` is unchanged (`granted or advertises`) — the advertised branch only keeps pre-existing zds sessions offered private until they re-sign-in.

This is #1559's design; #1560 reverted it because "scope granted ≠ PDS implements spaces". With expansion (#1881) that's answered: a non-spaces PDS may resolve the include but cannot expand it, so `granted` stays false and private stays hidden.
</details>

<details>
<summary>what I verified on each PDS</summary>

PAR with a loopback public client, `atproto repo:fm.plyr.track` with and without `include:fm.plyr.privateMediaAccess` (the published prod set), then the resulting `/authorize` rendered in Chromium:

- alpha, bsky.social, pds.cauda.cloud: **201** both ways; `/authorize` renders the normal sign-in page.
- pds.zat.dev, pi.chadtmiller.com: zds rejects loopback clients (`invalid_client`), so the evidence for zds is plyr's real client sending the same include-PAR in the scope-upgrade path, which the staging e2e exercises on every merge.

Not verified by me: the token exchange on a non-spaces official PDS with the include present. #1560 observed it complete on a standard PDS with no expansion. Staging-first; please sign in at stg.plyr.fm with `nate.spaces-alpha.bsky.network` after merge — `/auth/me` should show `granted: true` with no consent round trip.
</details>

<details>
<summary>the legacy consent UX</summary>

- `/record`: primary button reads `approve private media` when private is chosen without the grant; after consent the page restores the recording and calls the save itself (`approved — saving your recording`). Not approved → `not approved — your recording is still here`.
- `/upload`: same label; the draft's audio + cover files go to IndexedDB (`stashUploadFiles`/`takeUploadFiles` beside the recording stash) so the redirect doesn't lose them; on return with the grant the upload submits itself. The pre-existing "reattach your audio file" toast only fires when no files were stashed (the expired-session path). The uploader's 403 `permissioned_scope_required` fallback stays as defense.
- `startPermissionedScopeUpgrade` is exported so `/upload` escalates *before* uploading instead of after a 403.
</details>

<details>
<summary>tests</summary>

- backend: login always includes the set; falls back to base on `invalid_scope`; other PAR failures surface. 48 pass in the two touched suites.
- e2e (both flows): **fail unless `granted: true` comes straight from sign-in** on the spaces PDS — the regression test for the at-login design; the consent branches no longer re-fill or re-click. The PR-triggered run targets current staging and will show the old behavior; the run after merge is the real one.
- 139 frontend unit tests, svelte-check, eslint, ruff, ty clean.
</details>

<details>
<summary>docs</summary>

`docs/internal/architecture/permissioned-private-media.md` rewrites the "publishing must precede deployment" paragraph to state the contract: the grant is the signal; `scopes_supported` cannot carry it.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
