### PR TITLE
fix(artist): the owner's private tracks were missing from their own page, and counted for everyone

### DIFF
--- a/backend/src/backend/api/artists.py
+++ b/backend/src/backend/api/artists.py
@@ -11,12 +11,13 @@ from redis.exceptions import RedisError
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from backend._internal import Session, require_auth
+from backend._internal import Session, get_optional_session, require_auth
 from backend._internal.atproto import (
     fetch_user_avatar,
     normalize_avatar_url,
     upsert_profile_record,
 )
+from backend._internal.track_visibility import track_visible_filter, viewer_did
 from backend.models import Artist, Track, TrackLike, UserPreferences, get_db
 from backend.utilities.aggregations import get_top_artists_by_plays
 from backend.utilities.redis import get_async_redis_client
@@ -326,18 +327,23 @@ async def _get_artist_rank(db: AsyncSession, artist_did: str) -> int | None:
 async def get_artist_analytics(
     artist_did: str,
     db: Annotated[AsyncSession, Depends(get_db)],
+    session: Annotated[Session | None, Depends(get_optional_session)] = None,
 ) -> AnalyticsResponse:
     """get public analytics for any artist by DID.
 
-    returns zeros if artist has no tracks.
+    returns zeros if artist has no tracks. private tracks count only for
+    their owner.
     """
+    visible = track_visible_filter(viewer_did(session))
     # get total plays, item count, and duration in one query
     result = await db.execute(
         select(
             func.sum(Track.play_count),
             func.count(Track.id),
             func.coalesce(func.sum(text("(extra->>'duration')::int")), 0),
-        ).where(Track.artist_did == artist_did)
+        )
+        .where(Track.artist_did == artist_did)
+        .where(visible)
     )
     total_plays, total_items, total_duration = result.one()
     total_plays = total_plays or 0  # handle None when no tracks
@@ -350,6 +356,7 @@ async def get_artist_analytics(
         result = await db.execute(
             select(Track.id, Track.title, Track.play_count)
             .where(Track.artist_did == artist_did)
+            .where(visible)
             .order_by(Track.play_count.desc())
             .limit(1)
         )
@@ -368,6 +375,7 @@ async def get_artist_analytics(
             select(Track.id, Track.title, func.count(TrackLike.id).label("like_count"))
             .join(TrackLike, TrackLike.track_id == Track.id)
             .where(Track.artist_did == artist_did)
+            .where(visible)
             .group_by(Track.id, Track.title)
             .order_by(func.count(TrackLike.id).desc())
             .limit(1)

--- a/backend/tests/api/test_analytics.py
+++ b/backend/tests/api/test_analytics.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from backend._internal import Session, require_auth
+from backend._internal import Session, get_optional_session, require_auth
 from backend.main import app
 from backend.models import Artist, Track, TrackLike
 
@@ -276,3 +276,76 @@ async def test_get_artist_analytics_with_duration(
     assert data["total_items"] == 3
     # duration should sum only tracks that have it: 180 + 3600 = 3780
     assert data["total_duration_seconds"] == 3780
+
+
+@pytest.fixture
+async def artist_with_private_track(db_session: AsyncSession) -> Artist:
+    """one public track (10 plays) and one private track (99 plays)."""
+    artist = Artist(
+        did="did:plc:spaces", handle="spaces.example", display_name="Spaces"
+    )
+    db_session.add(artist)
+    await db_session.flush()
+    db_session.add(
+        Track(
+            title="public one",
+            artist_did=artist.did,
+            file_id="pub",
+            file_type="mp3",
+            play_count=10,
+            atproto_record_uri="at://did:plc:spaces/fm.plyr.track/pub",
+            atproto_record_cid="cid_pub",
+        )
+    )
+    db_session.add(
+        Track(
+            title="private memo",
+            artist_did=artist.did,
+            file_id="priv",
+            file_type="wav",
+            play_count=99,
+            visibility="private",
+            atproto_record_uri="at://did:plc:spaces/fm.plyr.track/priv",
+            atproto_record_cid="cid_priv",
+        )
+    )
+    await db_session.commit()
+    return artist
+
+
+async def test_analytics_hide_private_tracks_from_everyone_else(
+    artist_with_private_track: Artist,
+):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            f"/artists/{artist_with_private_track.did}/analytics"
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_items"] == 1
+    assert data["total_plays"] == 10
+    assert data["top_item"]["title"] == "public one"
+
+
+async def test_analytics_count_private_tracks_for_their_owner(
+    artist_with_private_track: Artist,
+):
+    async def owner() -> Session:
+        return MockSession(did=artist_with_private_track.did)
+
+    app.dependency_overrides[get_optional_session] = owner
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get(
+                f"/artists/{artist_with_private_track.did}/analytics"
+            )
+    finally:
+        app.dependency_overrides.clear()
+    data = response.json()
+    assert data["total_items"] == 2
+    assert data["total_plays"] == 109
+    assert data["top_item"]["title"] == "private memo"

--- a/frontend/e2e/private-media.mjs
+++ b/frontend/e2e/private-media.mjs
@@ -88,6 +88,29 @@ try {
 	if (!createdTrackId) fail('uploaded track never appeared');
 	step('created', `track ${createdTrackId}`);
 
+	// --- the artist page: listed for the owner, absent for everyone else
+	await page.goto(`${APP}/u/${before.handle}`, { waitUntil: 'networkidle' });
+	await page.getByText(title, { exact: true }).first().waitFor({ timeout: 15000 });
+	const ownerCount = await page.evaluate(
+		async ([api, did]) => (await (await fetch(`${api}/artists/${did}/analytics`, { credentials: 'include' })).json()).total_items,
+		[API, before.did]
+	);
+	step('artist-page', `owner sees "${title}" listed; analytics total_items=${ownerCount}`);
+	const stranger = await (await browser.newContext()).newPage();
+	await stranger.goto(`${APP}/u/${before.handle}`, { waitUntil: 'networkidle' });
+	await stranger.waitForTimeout(2000);
+	const strangerSees = await stranger.getByText(title, { exact: true }).count();
+	const strangerCount = await stranger.evaluate(
+		async ([api, did]) => (await (await fetch(`${api}/artists/${did}/analytics`)).json()).total_items,
+		[API, before.did]
+	);
+	await stranger.context().close();
+	if (strangerSees) fail('a signed-out visitor can see the private track on the artist page');
+	if (strangerCount !== ownerCount - 1) {
+		fail(`analytics leak: stranger total_items=${strangerCount}, owner=${ownerCount}`);
+	}
+	step('artist-page-anon', `hidden from a signed-out visitor; total_items=${strangerCount}`);
+
 	// --- session 2: a fresh sign-in (base scope, no grant) must still play it
 	const freshContext = await browser.newContext({ viewport: { width: 1000, height: 2000 } });
 	const fresh = await freshContext.newPage();

--- a/frontend/src/routes/u/[handle]/+page.svelte
+++ b/frontend/src/routes/u/[handle]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { API_URL, getAtprotofansSupportUrl } from '$lib/config';
 	import { browser } from '$app/environment';
@@ -298,6 +299,39 @@ $effect(() => {
 			console.error('failed to load more tracks:', _e);
 		} finally {
 			loadingMoreTracks = false;
+		}
+	}
+
+	/**
+	 * The server render is anonymous, so an owner's private tracks are missing
+	 * from it; once auth settles on the owner, reload the first page with their
+	 * session. Keyed on auth readiness because the layout's initialize() races
+	 * this page's first hydration pass.
+	 */
+	let ownerReloadedFor = $state<string | null>(null);
+	$effect(() => {
+		const did = data.artist?.did;
+		const viewer = auth.user?.did;
+		if (!browser || auth.loading || !did || viewer !== did) return;
+		if (untrack(() => ownerReloadedFor) === did) return;
+		ownerReloadedFor = did;
+		void untrack(() => reloadTracksAsOwner(did));
+	});
+
+	async function reloadTracksAsOwner(did: string) {
+		try {
+			const response = await fetch(`${API_URL}/tracks/?artist_did=${did}&limit=5`, {
+				credentials: 'include'
+			});
+			if (!response.ok) return;
+			const data = await response.json();
+			tracks = data.tracks ?? [];
+			hasMoreTracks = data.has_more ?? false;
+			nextCursor = data.next_cursor ?? null;
+			const likedTracks = await fetchLikedTracks();
+			applyLikedFlags(new Set(likedTracks.map((track) => track.id)));
+		} catch (_e) {
+			console.error('failed to reload tracks as owner:', _e);
 		}
 	}
 

--- a/loq.toml
+++ b/loq.toml
@@ -359,7 +359,7 @@ max_lines = 712
 
 [[rules]]
 path = "frontend/src/routes/u/[[]handle[]]/+page.svelte"
-max_lines = 1444
+max_lines = 1478
 
 [[rules]]
 path = "scripts/build_atlas.py"


### PR DESCRIPTION
nate uploaded a private track from bufo.uk (zds) in prod: analytics said **2 tracks**, the list showed **1**. Two bugs, opposite directions.

<details>
<summary>the list (frontend)</summary>

`/u/[handle]/+page.server.ts` fetches the track list server-side, and SSR has no session cookie (its own comment says so — #284), so the list is always the anonymous view and the owner's private tracks never appear. Nothing refetched after hydration. Now an `$effect` keyed on auth readiness (the layout's `auth.initialize()` races the page's first hydration pass) reloads the first page with the owner's session when the viewer is the artist, then re-applies like flags. Non-owners are untouched.
</details>

<details>
<summary>the count (backend)</summary>

`GET /artists/{did}/analytics` had no visibility filter: private tracks were counted in `total_items`/`total_plays`/duration and could surface as `top_item` **by title** to any visitor. It now takes the optional session and applies `track_visible_filter`, like every other listing. Regression tests: anonymous → 1 track / public title; owner → 2 tracks / private title. The anonymous test fails `assert 2 == 1` on the pre-fix code.
</details>

<details>
<summary>e2e</summary>

After the private upload, the flow renders `/u/<handle>` as the owner and waits for the private title in the DOM, then opens it signed-out and asserts the title is absent and `total_items` is one less. This PR's own e2e run targets current staging and will fail at `[artist-page]` until merged + deployed; the post-merge run is the real one.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)