### PR TITLE
fix(copy): say what private means, not where the bytes live

### DIFF
--- a/frontend/src/lib/components/VisibilityPicker.svelte
+++ b/frontend/src/lib/components/VisibilityPicker.svelte
@@ -34,8 +34,8 @@
 
 	const defaultPrivateNote = $derived(
 		privateGranted
-			? 'stored in a permissioned space on your PDS — no public copy, hidden from feeds, playable only by you.'
-			: "stored in a permissioned space on your PDS — no public copy, hidden from feeds, playable only by you. you'll be asked once to approve access."
+			? 'only you can play it. nothing public, nothing in feeds.'
+			: "only you can play it. nothing public, nothing in feeds. you'll be asked once to allow it."
 	);
 </script>
 


### PR DESCRIPTION
The private row of the visibility picker (shared by `/upload` and `/record`) read protocol vocabulary — *"stored in a permissioned space on your PDS…"*. Now: **only you can play it. nothing public, nothing in feeds.** with *"you'll be asked once to allow it."* appended while the grant is missing. Same voice as the public/unlisted rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)