### PR TITLE
feat(spaces): a reader permission in the private-media set, so members can play what artists share

### DIFF
--- a/backend/src/backend/_internal/atproto/spaces/__init__.py
+++ b/backend/src/backend/_internal/atproto/spaces/__init__.py
@@ -7,6 +7,7 @@ read from the token's expanded ``space:`` grant — see
 
 from backend._internal.atproto.spaces.capability import (
     pds_supports_spaces,
+    session_can_read_shared_private_media,
     session_has_private_media_access,
 )
 from backend._internal.atproto.spaces.uris import (
@@ -22,5 +23,6 @@ __all__ = [
     "parse_space_record_uri",
     "parse_space_uri",
     "pds_supports_spaces",
+    "session_can_read_shared_private_media",
     "session_has_private_media_access",
 ]

--- a/backend/src/backend/_internal/atproto/spaces/capability.py
+++ b/backend/src/backend/_internal/atproto/spaces/capability.py
@@ -22,7 +22,10 @@ from atproto_oauth.security import is_safe_url
 from redis.exceptions import RedisError
 
 from backend._internal.auth.session import Session as AuthSession
-from backend._internal.auth.space_scope import private_media_grant_present
+from backend._internal.auth.space_scope import (
+    private_media_grant_present,
+    private_media_reader_grant_present,
+)
 from backend.utilities.redis import get_async_redis_client
 
 logger = logging.getLogger(__name__)
@@ -37,6 +40,14 @@ def session_has_private_media_access(auth_session: AuthSession) -> bool:
     if data.get("auth_type") == "app_password":
         return True
     return private_media_grant_present(data.get("scope", ""), auth_session.did)
+
+
+def session_can_read_shared_private_media(auth_session: AuthSession) -> bool:
+    """whether this session may read private-media spaces artists shared with it."""
+    data = auth_session.oauth_session or {}
+    if data.get("auth_type") == "app_password":
+        return True
+    return private_media_reader_grant_present(data.get("scope", ""))
 
 
 def advertises_spaces(metadata: dict) -> bool:

--- a/backend/src/backend/_internal/auth/space_scope.py
+++ b/backend/src/backend/_internal/auth/space_scope.py
@@ -227,6 +227,19 @@ def private_media_grant_present(scope: str, did: str) -> bool:
     )
 
 
+def private_media_reader_grant_present(scope: str) -> bool:
+    """whether ``scope`` lets this session read private-media spaces of *other*
+    authorities — the grant a member needs to play what an artist shared."""
+    space_type = settings.atproto.private_media_space_type
+    return any(
+        grant.type in ("*", space_type)
+        and grant.authority == "*"
+        and grant.skey in ("*", "self")
+        and "read" in grant.action
+        for grant in space_grants(scope)
+    )
+
+
 def permissioned_scope_requested(scope: str) -> bool:
     """whether a scope string asks for (``include:``) or carries (``space:``) private media."""
     if ScopesSet.from_string(scope).has(settings.atproto.private_media_include_scope):

--- a/backend/src/backend/api/auth.py
+++ b/backend/src/backend/api/auth.py
@@ -42,6 +42,7 @@ from backend._internal import (
 )
 from backend._internal.atproto.spaces import (
     pds_supports_spaces,
+    session_can_read_shared_private_media,
     session_has_private_media_access,
 )
 from backend._internal.auth import get_refresh_token_lifetime_days
@@ -78,10 +79,13 @@ class PermissionedSpacesStatus(BaseModel):
 
     ``granted``: the token carries the expanded space grant. ``supported``:
     offer the option — true unless an upgrade on this PDS came back without it.
+    ``reader``: the token also carries the any-authority read grant, so this
+    session can play private tracks other artists share with it.
     """
 
     supported: bool = False
     granted: bool = False
+    reader: bool = False
 
 
 class CurrentUserResponse(BaseModel):
@@ -552,7 +556,9 @@ async def get_current_user(
         ],
         enabled_flags=current_user_flags,
         permissioned_spaces=PermissionedSpacesStatus(
-            supported=spaces_supported, granted=granted
+            supported=spaces_supported,
+            granted=granted,
+            reader=session_can_read_shared_private_media(session),
         ),
     )
 

--- a/backend/tests/_internal/test_permissioned_spaces.py
+++ b/backend/tests/_internal/test_permissioned_spaces.py
@@ -109,6 +109,47 @@ def test_grant_present_requires_manage_and_collection_write(prod_namespace):
     )
 
 
+_READER_GRANT = (
+    "space:fm.plyr.privateMedia?authority=*&skey=self"
+    "&collection=fm.plyr.track&action=read"
+)
+
+
+def test_reader_grant_is_the_any_authority_read(prod_namespace):
+    assert space_scope.private_media_reader_grant_present(
+        f"atproto {_GRANT} {_READER_GRANT}"
+    )
+    # the owner grant alone names one authority — it cannot read anyone else's space
+    assert not space_scope.private_media_reader_grant_present(_GRANT)
+    # unexpanded include, or a different space type, is not a reader grant
+    assert not space_scope.private_media_reader_grant_present(
+        "atproto include:fm.plyr.privateMediaAccess"
+    )
+    assert not space_scope.private_media_reader_grant_present(
+        "space:fm.other.space?authority=*&skey=self&action=read"
+    )
+    # a wildcard type with read covers it
+    assert space_scope.private_media_reader_grant_present(
+        "space:*?authority=*&skey=*&action=read"
+    )
+    # the reader grant never makes someone an owner
+    assert not space_scope.private_media_grant_present(_READER_GRANT, "did:plc:x")
+
+
+def test_published_permission_set_declares_owner_and_reader():
+    import json
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[3]
+    doc = json.loads((root / "lexicons" / "privateMediaAccess.json").read_text())
+    perms = doc["defs"]["main"]["permissions"]
+    by_authority = {p["authority"]: p for p in perms}
+    assert set(by_authority) == {"self", "*"}
+    assert by_authority["*"]["action"] == ["read"]
+    assert "manage" not in by_authority["*"]
+    assert by_authority["*"]["skey"] == "self"
+
+
 def test_permissioned_scope_requested_matches_include_or_grant(prod_namespace):
     assert space_scope.permissioned_scope_requested(
         "atproto include:fm.plyr.privateMediaAccess"

--- a/backend/tests/api/test_scope_upgrade.py
+++ b/backend/tests/api/test_scope_upgrade.py
@@ -376,7 +376,7 @@ async def test_auth_me_hides_private_media_when_the_authserver_lacks_space_scope
             response = await client.get("/auth/me")
     assert response.status_code == 200
     spaces = response.json()["permissioned_spaces"]
-    assert spaces == {"supported": False, "granted": False}
+    assert spaces == {"supported": False, "granted": False, "reader": False}
 
     with patch(
         "backend.api.auth.pds_supports_spaces",

--- a/docs/internal/architecture/permissioned-private-media.md
+++ b/docs/internal/architecture/permissioned-private-media.md
@@ -215,6 +215,17 @@ Rollout order matters:
    canonical URI;
 5. verify a non-supporting PDS continues to hide the private option.
 
+The permission set `fm.plyr.privateMediaAccess` carries two permissions on the
+`fm.plyr.privateMedia` space type: the owner permission (`authority: self`, all
+actions, `manage`) and, since the access-list work, a reader permission
+(`authority: "*"`, `action: ["read"]`). The reader permission is what lets a
+member's own PDS issue a delegation token for *another* artist's space; zds
+passes `*` through at token issuance, so the expanded grant reads
+`space:fm.plyr.privateMedia?authority=*&skey=self&collection=fm.plyr.track&action=read`.
+`/auth/me` reports it as `permissioned_spaces.reader`. It never makes anyone an
+owner: `private_media_grant_present` still requires the `self`-resolved
+authority plus `manage=create`.
+
 Publishing must precede deployment because every browser sign-in requests
 `include:<namespace>.privateMediaAccess`; the PDS must be able to resolve that permission
 set during authorization. The grant is the capability signal, as in Bulletin: a spaces

--- a/frontend/e2e/private-media.mjs
+++ b/frontend/e2e/private-media.mjs
@@ -50,7 +50,10 @@ try {
 	if (before.permissioned_spaces.granted !== true) {
 		fail('sign-in on a spaces PDS did not carry the private-media grant');
 	}
-	step('capability', 'supported=true granted=true straight from sign-in');
+	if (before.permissioned_spaces.reader !== true) {
+		fail('sign-in did not carry the any-authority read grant (is the revised permission set published?)');
+	}
+	step('capability', 'supported=true granted=true reader=true straight from sign-in');
 
 	await page.goto(`${APP}/upload`, { waitUntil: 'networkidle' });
 	await page.waitForTimeout(1500);

--- a/frontend/e2e/record-private.mjs
+++ b/frontend/e2e/record-private.mjs
@@ -61,7 +61,10 @@ try {
 	if (before.permissioned_spaces.granted !== true) {
 		fail('sign-in on a spaces PDS did not carry the private-media grant');
 	}
-	step('capability', 'supported=true granted=true straight from sign-in');
+	if (before.permissioned_spaces.reader !== true) {
+		fail('sign-in did not carry the any-authority read grant (is the revised permission set published?)');
+	}
+	step('capability', 'supported=true granted=true reader=true straight from sign-in');
 
 	await page.goto(`${APP}/record`, { waitUntil: 'networkidle' });
 	step('record', 'three seconds from the fake microphone');

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -90,7 +90,7 @@ export interface User {
 	// private media on ATProto permissioned spaces. `granted` = this session's
 	// token carries the expanded space grant; `supported` = still worth offering
 	// (false once an upgrade on this PDS came back without one).
-	permissioned_spaces?: { supported: boolean; granted?: boolean };
+	permissioned_spaces?: { supported: boolean; granted?: boolean; reader?: boolean };
 }
 
 export interface Artist {

--- a/lexicons/privateMediaAccess.json
+++ b/lexicons/privateMediaAccess.json
@@ -5,7 +5,7 @@
     "main": {
       "type": "permission-set",
       "title": "plyr.fm Private Media",
-      "detail": "Create and manage your private-media space and read or update the track records and audio it contains.",
+      "detail": "Create and manage your private-media space, read or update the track records and audio it contains, and play private tracks other artists have shared with you.",
       "permissions": [
         {
           "type": "permission",
@@ -13,9 +13,33 @@
           "spaceType": "fm.plyr.privateMedia",
           "authority": "self",
           "skey": "self",
-          "collection": ["fm.plyr.track"],
-          "action": ["read", "create", "update", "delete"],
-          "manage": ["create", "update", "delete"]
+          "collection": [
+            "fm.plyr.track"
+          ],
+          "action": [
+            "read",
+            "create",
+            "update",
+            "delete"
+          ],
+          "manage": [
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        {
+          "type": "permission",
+          "resource": "space",
+          "spaceType": "fm.plyr.privateMedia",
+          "authority": "*",
+          "skey": "self",
+          "collection": [
+            "fm.plyr.track"
+          ],
+          "action": [
+            "read"
+          ]
         }
       ]
     }

--- a/loq.toml
+++ b/loq.toml
@@ -355,7 +355,7 @@ max_lines = 689
 
 [[rules]]
 path = "backend/tests/_internal/test_permissioned_spaces.py"
-max_lines = 712
+max_lines = 753
 
 [[rules]]
 path = "frontend/src/routes/u/[[]handle[]]/+page.svelte"


### PR DESCRIPTION
PR 1 of the access-list arc (#1897). Revises `fm.plyr.privateMediaAccess` **in place**: next to the owner permission (`authority: self`, all actions + `manage`) it now carries a reader permission — `authority: "*"`, `action: ["read"]`, same space type and `skey: self`. Without it a member's own PDS can never issue a delegation token for another artist's space, whatever the member list says; Bulletin grants `authority: "*"` for exactly this reason.

<details>
<summary>what zds does with it (verified in source)</summary>

`permission_sets.zig` `writeResolvedScope` substitutes the user DID for `self` and passes `*` through literally, so the token carries `space:fm.plyr.privateMedia?authority=*&skey=self&collection=fm.plyr.track&action=read`. `getDelegationToken` then requires a grant covering the *target* space's authority — `authority=self` hard-fails for anyone else's space, `authority=*` matches any — and signs with the requester's own key, never checking the authority is local. So cross-host reads work once this grant exists. Delegation tokens live 60s single-use; space credentials 2h with no revocation.

</details>

<details>
<summary>what's in the PR</summary>

- `lexicons/privateMediaAccess.json`: the reader permission; detail copy mentions playing what other artists shared.
- `space_scope.private_media_reader_grant_present(scope)`: any-authority read on the space type. The owner check is unchanged and a reader grant never satisfies it.
- `/auth/me` → `permissioned_spaces.reader` (app-password sessions: true, like `granted`).
- tests: reader-grant detection matrix; the published set declares exactly `{self, *}` with `*` read-only and no `manage`; `/auth/me` exact-shape test updated.
- both e2e flows now require `reader: true` straight from sign-in.
- architecture doc: the two-permission contract and the expanded shape.

</details>

<details>
<summary>before this merges — a publish step only nate can run</summary>

The set must be republished to staging from this branch so new sign-ins expand the reader grant; the PR's e2e run fails at `[sign-in]` until then:

```
NAMESPACE=fm.plyr.stg uv run --project backend scripts/publish_permission_set.py privateMediaAccess
```

Existing staging sessions keep their old grant (no `reader`) until they sign in again; the scope-upgrade path covers them too. Production publish happens with the eventual `just release` of the arc, never before.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)