### PR TITLE
feat(spaces): member-list wrappers, and a two-account membership leg in the smoke script

### DIFF
--- a/backend/src/backend/_internal/atproto/spaces/client.py
+++ b/backend/src/backend/_internal/atproto/spaces/client.py
@@ -159,6 +159,47 @@ async def ensure_personal_space(
     return space_uri
 
 
+async def add_space_member(auth_session: AuthSession, *, space: str, did: str) -> None:
+    """put ``did`` on the space's member list. Authority-only on the space host."""
+    await make_pds_request(
+        auth_session,
+        "POST",
+        "com.atproto.simplespace.addMember",
+        payload={"space": space, "did": did},
+    )
+
+
+async def remove_space_member(
+    auth_session: AuthSession, *, space: str, did: str
+) -> None:
+    """take ``did`` off the member list and forget any credential plyr minted
+    for it. The PDS stops issuing new credentials at once; one already issued
+    keeps working until it expires, which the protocol leaves at two hours."""
+    await make_pds_request(
+        auth_session,
+        "POST",
+        "com.atproto.simplespace.removeMember",
+        payload={"space": space, "did": did},
+    )
+    forget_credential(did, space)
+
+
+async def list_space_members(
+    auth_session: AuthSession, *, space: str, cursor: str | None = None
+) -> tuple[list[str], str | None]:
+    """one page of the member list (zds caps a page at 100). Authority-only."""
+    params: dict[str, Any] = {"space": space, "limit": 100}
+    if cursor:
+        params["cursor"] = cursor
+    result = await make_pds_request(
+        auth_session,
+        "GET",
+        "com.atproto.simplespace.listMembers",
+        params=params,
+    )
+    return [m["did"] for m in result.get("members", [])], result.get("cursor")
+
+
 async def create_space_record(
     auth_session: AuthSession,
     *,
@@ -218,6 +259,11 @@ class SpaceCredential:
 # useful without the other. Include the requesting user so an authorization
 # decision made for one account is never reused for another.
 _credential_cache: dict[tuple[str, str], SpaceCredential] = {}
+
+
+def forget_credential(did: str, space: str) -> None:
+    """drop the cached credential plyr holds for ``did`` on ``space``, if any."""
+    _credential_cache.pop((did, space), None)
 
 
 async def _mint_credential(auth_session: AuthSession, space: str) -> SpaceCredential:

--- a/backend/tests/_internal/test_permissioned_spaces.py
+++ b/backend/tests/_internal/test_permissioned_spaces.py
@@ -279,6 +279,72 @@ async def test_ensure_personal_space_uses_simplespace_shape(
     assert "config" not in payload
 
 
+def _owner_session() -> Session:
+    return Session(
+        session_id="s",
+        did="did:plc:x",
+        handle="x.test",
+        oauth_session={"pds_url": "https://x"},
+    )
+
+
+async def test_add_and_remove_member_use_simplespace_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = AsyncMock(return_value={})
+    monkeypatch.setattr(space_client, "make_pds_request", request)
+    session = _owner_session()
+    space = "at://did:plc:x/space/fm.plyr.privateMedia/self"
+
+    await space_client.add_space_member(session, space=space, did="did:plc:friend")
+    request.assert_awaited_with(
+        session,
+        "POST",
+        "com.atproto.simplespace.addMember",
+        payload={"space": space, "did": "did:plc:friend"},
+    )
+
+    space_client._credential_cache[("did:plc:friend", space)] = (
+        space_client.SpaceCredential(
+            token="t", dpop_key=ec.generate_private_key(ec.SECP256R1()), expires_at=1e12
+        )
+    )
+    await space_client.remove_space_member(session, space=space, did="did:plc:friend")
+    request.assert_awaited_with(
+        session,
+        "POST",
+        "com.atproto.simplespace.removeMember",
+        payload={"space": space, "did": "did:plc:friend"},
+    )
+    # plyr forgets the credential it minted for the removed member
+    assert ("did:plc:friend", space) not in space_client._credential_cache
+
+
+async def test_list_members_pages_by_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    request = AsyncMock(
+        side_effect=[
+            {"members": [{"did": "did:plc:a"}, {"did": "did:plc:b"}], "cursor": "c1"},
+            {"members": [{"did": "did:plc:c"}]},
+        ]
+    )
+    monkeypatch.setattr(space_client, "make_pds_request", request)
+    session = _owner_session()
+    space = "at://did:plc:x/space/fm.plyr.privateMedia/self"
+
+    first, cursor = await space_client.list_space_members(session, space=space)
+    assert (first, cursor) == (["did:plc:a", "did:plc:b"], "c1")
+    second, end = await space_client.list_space_members(
+        session, space=space, cursor="c1"
+    )
+    assert (second, end) == (["did:plc:c"], None)
+    assert request.await_args_list[0].kwargs["params"] == {"space": space, "limit": 100}
+    assert request.await_args_list[1].kwargs["params"] == {
+        "space": space,
+        "limit": 100,
+        "cursor": "c1",
+    }
+
+
 async def test_mint_credential_uses_delegation_token_flow(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/loq.toml
+++ b/loq.toml
@@ -355,7 +355,7 @@ max_lines = 689
 
 [[rules]]
 path = "backend/tests/_internal/test_permissioned_spaces.py"
-max_lines = 712
+max_lines = 778
 
 [[rules]]
 path = "frontend/src/routes/u/[[]handle[]]/+page.svelte"

--- a/scripts/permissioned_smoke.py
+++ b/scripts/permissioned_smoke.py
@@ -15,6 +15,10 @@ operations, then exercises the proposal's separate ephemeral DPoP key for space
 credential issuance and credential-gated reads.
 
 run: uv run scripts/permissioned_smoke.py
+optional membership leg: ZAT_MEMBER_PDS / ZAT_MEMBER_HANDLE / ZAT_MEMBER_PASSWORD — a
+second account on a spaces PDS, added to the first account's member list and read
+through its own delegation token.
+
 needs ZAT_TEST_HANDLE / ZAT_TEST_PASSWORD / ZAT_TEST_PDS in .env (a test account on a
 ZDS_PERMISSIONED_DATA=true instance).
 """
@@ -31,6 +35,9 @@ load_dotenv()
 PDS = os.environ["ZAT_TEST_PDS"].rstrip("/")
 HANDLE = os.environ["ZAT_TEST_HANDLE"]
 PASSWORD = os.environ["ZAT_TEST_PASSWORD"]
+MEMBER_PDS = os.environ.get("ZAT_MEMBER_PDS", "").rstrip("/")
+MEMBER_HANDLE = os.environ.get("ZAT_MEMBER_HANDLE", "")
+MEMBER_PASSWORD = os.environ.get("ZAT_MEMBER_PASSWORD", "")
 
 # dev namespace — mirrors ATPROTO_APP_NAMESPACE=fm.plyr.dev locally
 SPACE_TYPE = "fm.plyr.dev.privateMedia"
@@ -46,6 +53,111 @@ def xrpc(
     if method == "GET":
         return client.get(url, headers=headers, params=kw.get("params"))
     return client.post(url, headers=headers, json=kw.get("json"))
+
+
+def member_reads(
+    c: httpx.Client, member_token: str, space_uri: str, owner_did: str, blob_cid: str
+) -> int:
+    """mint a credential for the member and range-read the owner's blob; return status."""
+    delegation = c.get(
+        f"{MEMBER_PDS}/xrpc/com.atproto.space.getDelegationToken",
+        headers={"authorization": f"Bearer {member_token}"},
+        params={"space": space_uri},
+    )
+    if delegation.status_code != 200:
+        return delegation.status_code
+    credential_url = f"{PDS}/xrpc/com.atproto.space.getSpaceCredential"
+    key = DPoPManager.generate_keypair()
+    cred = c.post(
+        credential_url,
+        headers={
+            "authorization": f"Bearer {delegation.json()['token']}",
+            "dpop": DPoPManager.create_proof(
+                method="POST", url=credential_url, private_key=key
+            ),
+        },
+        json={"space": space_uri},
+    )
+    if cred.status_code != 200:
+        return cred.status_code
+    blob_url = f"{PDS}/xrpc/com.atproto.space.getBlob"
+    got = c.get(
+        blob_url,
+        headers={
+            "authorization": f"DPoP {cred.json()['credential']}",
+            "dpop": DPoPManager.create_proof(
+                method="GET",
+                url=blob_url,
+                private_key=key,
+                access_token=cred.json()["credential"],
+            ),
+            "range": "bytes=0-3",
+        },
+        params={"space": space_uri, "repo": owner_did, "cid": blob_cid},
+    )
+    return got.status_code
+
+
+def membership_leg(
+    c: httpx.Client, owner_token: str, owner_did: str, space_uri: str, blob_cid: str
+) -> None:
+    """a second account on a spaces PDS: refused, added, reads, removed, refused."""
+    session = c.post(
+        f"{MEMBER_PDS}/xrpc/com.atproto.server.createSession",
+        json={"identifier": MEMBER_HANDLE, "password": MEMBER_PASSWORD},
+    )
+    session.raise_for_status()
+    member_did = session.json()["did"]
+    member_token = session.json()["accessJwt"]
+    print(f"✓ member session  did={member_did}")
+
+    xrpc(
+        c,
+        "POST",
+        "com.atproto.simplespace.removeMember",
+        token=owner_token,
+        json={"space": space_uri, "did": member_did},
+    )
+    before = member_reads(c, member_token, space_uri, owner_did, blob_cid)
+    assert before == 403, f"non-member read should be refused, got {before}"
+    print("✓ non-member refused (403)")
+
+    added = xrpc(
+        c,
+        "POST",
+        "com.atproto.simplespace.addMember",
+        token=owner_token,
+        json={"space": space_uri, "did": member_did},
+    )
+    added.raise_for_status()
+    members = xrpc(
+        c,
+        "GET",
+        "com.atproto.simplespace.listMembers",
+        token=owner_token,
+        params={"space": space_uri, "limit": 100},
+    )
+    members.raise_for_status()
+    assert member_did in members.text, members.text
+    print("✓ addMember + listMembers")
+
+    during = member_reads(c, member_token, space_uri, owner_did, blob_cid)
+    assert during == 206, f"member read should succeed, got {during}"
+    print("✓ member reads the owner's blob via its own delegation token (206)")
+
+    removed = xrpc(
+        c,
+        "POST",
+        "com.atproto.simplespace.removeMember",
+        token=owner_token,
+        json={"space": space_uri, "did": member_did},
+    )
+    removed.raise_for_status()
+    after = member_reads(c, member_token, space_uri, owner_did, blob_cid)
+    assert after == 403, (
+        f"removed member should be refused a new credential, got {after}"
+    )
+    print("✓ removed member refused a fresh credential (403)")
 
 
 def main() -> int:
@@ -213,6 +325,11 @@ def main() -> int:
     )
     assert len(blob_get.content) == 4, blob_get.content
     print(f"✓ getBlob via space credential (206, {len(blob_get.content)} bytes)")
+
+    if MEMBER_PDS and MEMBER_HANDLE and MEMBER_PASSWORD:
+        membership_leg(c, token, did, space_uri, blob_cid)
+    else:
+        print("· membership leg skipped (set ZAT_MEMBER_PDS/HANDLE/PASSWORD)")
 
     print(
         "\nPASS — private media stored and read back through the permissioned-space path"


### PR DESCRIPTION
PR 2 of the access-list arc (#1897). The spaces client learns the `simplespace` member list — `add_space_member`, `remove_space_member`, `list_space_members` — and the smoke script proves cross-account reads against a real zds.

<details>
<summary>details</summary>

- Wrappers call `com.atproto.simplespace.{addMember,removeMember,listMembers}` on the authority's PDS with the owner's session; zds requires the authority plus `manage=update`, which the owner grant carries. `listMembers` pages by cursor (zds caps at 100).
- `remove_space_member` also calls `forget_credential(did, space)`: the PDS refuses new credentials immediately, but a space credential is valid for 2h with no revocation (0016 §Space credential; zds `exp = iat + 7200`), so plyr must at least drop the one it cached for the removed DID rather than outlive the PDS's answer.
- Tests pin the exact payloads and the cache drop; cursor paging is table-tested.
- `scripts/permissioned_smoke.py`: optional `ZAT_MEMBER_PDS/HANDLE/PASSWORD` leg — non-member refused (403), `addMember` + `listMembers`, member range-reads the owner's blob via **its own PDS's** `getDelegationToken` (206), `removeMember`, fresh credential refused (403). This is the cross-host proof: the member's delegation token comes from the member's PDS, the credential from the owner's space host.

No product behavior changes; nothing calls the wrappers yet (PR 3 wires membership into visibility and audio).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)