### PR TITLE
feat(spaces): members of an artist's private-media space can see and play their private tracks

### DIFF
--- a/backend/alembic/versions/2026_08_22_000000_f3a9c1d27b4e_private_media_members.py
+++ b/backend/alembic/versions/2026_08_22_000000_f3a9c1d27b4e_private_media_members.py
@@ -1,0 +1,46 @@
+"""private media members
+
+plyr.fm's mirror of each artist's simplespace member list, so visibility
+checks can answer in SQL. the PDS list is the source of truth.
+
+Revision ID: f3a9c1d27b4e
+Revises: e7a4d1b93fc5
+Create Date: 2026-08-22 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f3a9c1d27b4e"
+down_revision: str | Sequence[str] | None = "e7a4d1b93fc5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "private_media_members",
+        sa.Column("artist_did", sa.String(), nullable=False),
+        sa.Column("member_did", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("artist_did", "member_did"),
+    )
+    op.create_index(
+        "ix_private_media_members_member_did",
+        "private_media_members",
+        ["member_did"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        "ix_private_media_members_member_did", table_name="private_media_members"
+    )
+    op.drop_table("private_media_members")

--- a/backend/src/backend/_internal/track_visibility.py
+++ b/backend/src/backend/_internal/track_visibility.py
@@ -1,7 +1,8 @@
 """private (permissioned-space) track visibility — one place, applied everywhere.
 
 a private track (`Track.is_private`) lives in the artist's permissioned space and
-must be invisible and inert to everyone except its owner: no metadata reads, no
+is visible to its owner and to the DIDs on the artist's private-media member
+list, and invisible and inert to everyone else: no metadata reads, no
 listing/counting, no likes/comments/shares/embeds. public, unlisted, and gated
 tracks are unaffected (unlisted is still searchable/listable by design).
 
@@ -15,9 +16,10 @@ two shapes:
 from typing import Protocol, runtime_checkable
 
 from fastapi import HTTPException
-from sqlalchemy import ColumnElement, or_
+from sqlalchemy import ColumnElement, exists, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from backend.models import Track
+from backend.models import PrivateMediaMember, Track
 
 
 @runtime_checkable
@@ -27,26 +29,55 @@ class _HasDid(Protocol):
     did: str
 
 
+def _membership(artist_did, viewer_did: str) -> ColumnElement[bool]:
+    return exists(
+        select(PrivateMediaMember.member_did).where(
+            PrivateMediaMember.artist_did == artist_did,
+            PrivateMediaMember.member_did == viewer_did,
+        )
+    )
+
+
 def track_visible_filter(viewer_did: str | None) -> ColumnElement[bool]:
-    """SQL condition: non-private tracks, plus the viewer's own private tracks."""
+    """SQL condition: non-private tracks, plus private tracks the viewer owns or
+    is a member of."""
     not_private = Track.visibility != "private"
     if viewer_did is None:
         return not_private
-    return or_(not_private, Track.artist_did == viewer_did)
+    return or_(
+        not_private,
+        Track.artist_did == viewer_did,
+        _membership(Track.artist_did, viewer_did),
+    )
 
 
-def can_view_track(viewer_did: str | None, track: Track) -> bool:
-    """whether `viewer_did` may see/interact with `track` (owner-only when private)."""
-    return not track.is_private or viewer_did == track.artist_did
+async def is_private_media_member(
+    db: AsyncSession, artist_did: str, viewer_did: str | None
+) -> bool:
+    """whether ``viewer_did`` is on ``artist_did``'s private-media member list."""
+    if viewer_did is None:
+        return False
+    return bool(await db.scalar(select(_membership(artist_did, viewer_did))))
 
 
-def ensure_track_visible(track: Track, viewer_did: str | None) -> None:
-    """404 when a private track is accessed by anyone but its owner.
+async def can_view_track(
+    db: AsyncSession, viewer_did: str | None, track: Track
+) -> bool:
+    """whether `viewer_did` may see/interact with `track`."""
+    if not track.is_private or viewer_did == track.artist_did:
+        return True
+    return await is_private_media_member(db, track.artist_did, viewer_did)
+
+
+async def ensure_track_visible(
+    db: AsyncSession, track: Track, viewer_did: str | None
+) -> None:
+    """404 when a private track is accessed by anyone but its owner or a member.
 
     404 (not 403) so a private track is indistinguishable from a missing one —
-    sequential ids must not let a non-owner probe for private uploads.
+    sequential ids must not let a non-member probe for private uploads.
     """
-    if not can_view_track(viewer_did, track):
+    if not await can_view_track(db, viewer_did, track):
         raise HTTPException(status_code=404, detail="track not found")
 
 

--- a/backend/src/backend/api/artists.py
+++ b/backend/src/backend/api/artists.py
@@ -5,10 +5,10 @@ import logging
 from datetime import UTC, datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel, ConfigDict, field_validator
 from redis.exceptions import RedisError
-from sqlalchemy import func, select, text
+from sqlalchemy import delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, get_optional_session, require_auth
@@ -17,8 +17,23 @@ from backend._internal.atproto import (
     normalize_avatar_url,
     upsert_profile_record,
 )
+from backend._internal.atproto.handles import resolve_handle
+from backend._internal.atproto.profiles import resolve_dids
+from backend._internal.atproto.spaces.client import (
+    add_space_member,
+    ensure_personal_space,
+    list_space_members,
+    remove_space_member,
+)
 from backend._internal.track_visibility import track_visible_filter, viewer_did
-from backend.models import Artist, Track, TrackLike, UserPreferences, get_db
+from backend.models import (
+    Artist,
+    PrivateMediaMember,
+    Track,
+    TrackLike,
+    UserPreferences,
+    get_db,
+)
 from backend.utilities.aggregations import get_top_artists_by_plays
 from backend.utilities.redis import get_async_redis_client
 
@@ -445,3 +460,138 @@ async def refresh_artist_avatar(
         logger.info(f"refreshed avatar for {did}: {fresh_avatar}")
 
     return RefreshAvatarResponse(avatar_url=fresh_avatar)
+
+
+# --- private media members ----------------------------------------------------
+
+
+class PrivateMediaMemberResponse(BaseModel):
+    did: str
+    handle: str
+    display_name: str
+    avatar_url: str | None
+
+
+class AddPrivateMediaMemberRequest(BaseModel):
+    """a handle or DID to add to the caller's private-media member list."""
+
+    actor: str
+
+
+async def _mirror(db: AsyncSession, artist_did: str) -> list[str]:
+    result = await db.execute(
+        select(PrivateMediaMember.member_did)
+        .where(PrivateMediaMember.artist_did == artist_did)
+        .order_by(PrivateMediaMember.created_at)
+    )
+    return list(result.scalars().all())
+
+
+async def _members_response(dids: list[str]) -> list[PrivateMediaMemberResponse]:
+    return [
+        PrivateMediaMemberResponse(
+            did=p.did,
+            handle=p.handle,
+            display_name=p.display_name,
+            avatar_url=p.avatar_url,
+        )
+        for p in await resolve_dids(dids)
+    ]
+
+
+async def _reconcile_from_pds(
+    db: AsyncSession, auth_session: Session, space: str
+) -> list[str] | None:
+    """replace the mirror with the PDS's member list; None when the PDS can't answer."""
+    members: list[str] = []
+    cursor: str | None = None
+    try:
+        while True:
+            page, cursor = await list_space_members(
+                auth_session, space=space, cursor=cursor
+            )
+            members.extend(did for did in page if did != auth_session.did)
+            if not cursor:
+                break
+    except Exception as exc:
+        logger.warning(f"could not read the member list for {auth_session.did}: {exc}")
+        return None
+    await db.execute(
+        delete(PrivateMediaMember).where(
+            PrivateMediaMember.artist_did == auth_session.did,
+            PrivateMediaMember.member_did.not_in(members),
+        )
+    )
+    known = set(await _mirror(db, auth_session.did))
+    for did in members:
+        if did not in known:
+            db.add(PrivateMediaMember(artist_did=auth_session.did, member_did=did))
+    await db.commit()
+    return members
+
+
+@router.get("/me/private-media/members")
+async def list_private_media_members(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    auth_session: Session = Depends(require_auth),
+) -> list[PrivateMediaMemberResponse]:
+    """the DIDs allowed to hear the caller's private tracks.
+
+    the PDS member list is the source of truth; plyr.fm's mirror is refreshed
+    from it here and served as a fallback when the PDS cannot answer.
+    """
+    space = await ensure_personal_space(auth_session)
+    members = await _reconcile_from_pds(db, auth_session, space)
+    if members is None:
+        members = await _mirror(db, auth_session.did)
+    return await _members_response(members)
+
+
+@router.post("/me/private-media/members", status_code=201)
+async def add_private_media_member(
+    body: AddPrivateMediaMemberRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    auth_session: Session = Depends(require_auth),
+) -> PrivateMediaMemberResponse:
+    """let one more account hear the caller's private tracks."""
+    actor = body.actor.strip().lstrip("@")
+    if actor.startswith("did:"):
+        did = actor
+    else:
+        resolved = await resolve_handle(actor)
+        if not resolved:
+            raise HTTPException(status_code=404, detail="account not found")
+        did = resolved["did"]
+    if did == auth_session.did:
+        raise HTTPException(status_code=400, detail="you already hear your own tracks")
+
+    space = await ensure_personal_space(auth_session)
+    await add_space_member(auth_session, space=space, did=did)
+    if did not in await _mirror(db, auth_session.did):
+        db.add(PrivateMediaMember(artist_did=auth_session.did, member_did=did))
+        await db.commit()
+    (member,) = await _members_response([did])
+    return member
+
+
+@router.delete("/me/private-media/members/{did}", status_code=204)
+async def remove_private_media_member(
+    did: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    auth_session: Session = Depends(require_auth),
+) -> Response:
+    """stop an account from hearing the caller's private tracks.
+
+    the PDS refuses them a new credential at once; one already issued keeps
+    working until it expires, which the protocol leaves at two hours.
+    """
+    space = await ensure_personal_space(auth_session)
+    await remove_space_member(auth_session, space=space, did=did)
+    await db.execute(
+        delete(PrivateMediaMember).where(
+            PrivateMediaMember.artist_did == auth_session.did,
+            PrivateMediaMember.member_did == did,
+        )
+    )
+    await db.commit()
+    return Response(status_code=204)

--- a/backend/src/backend/api/audio.py
+++ b/backend/src/backend/api/audio.py
@@ -5,10 +5,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal import Session, get_optional_session, validate_supporter
 from backend._internal.atproto.client import pds_blob_url
 from backend._internal.atproto.spaces.client import SpaceAccessError, open_space_blob
+from backend._internal.track_visibility import is_private_media_member
 from backend.config import settings
 from backend.models import Artist, Track, UserPreferences
 from backend.storage import storage
@@ -107,12 +109,14 @@ async def stream_audio(
             is_private,
             space_uri,
         ) = track_data
+        can_read_private = await _can_read_private(db, session, artist_did)
 
     # private media lives in a permissioned space — proxy the bytes through the
-    # owner's space credential (can't redirect: the browser has no credential).
+    # reader's space credential (can't redirect: the browser has no credential).
     if is_private:
         return await _handle_private_audio(
             session=session,
+            allowed=can_read_private,
             artist_did=artist_did,
             space_uri=space_uri,
             pds_blob_cid=pds_blob_cid,
@@ -406,12 +410,13 @@ async def get_audio_url(
             is_private,
             _space_uri,
         ) = track_data
+        can_read_private = await _can_read_private(db, session, artist_did)
 
     # private media is proxied through the permissioned-space credential path,
     # so the cacheable "url" is this backend's own stream endpoint (which holds
     # the credential), not a presigned/CDN URL the client could fetch directly.
     if is_private:
-        if session is None or session.did != artist_did:
+        if not can_read_private:
             raise HTTPException(status_code=404, detail="audio file not found")
         backend_url = settings.atproto.redirect_uri.rsplit("/", 2)[0]
         return AudioUrlResponse(
@@ -484,9 +489,20 @@ def _relay_headers(resp) -> dict[str, str]:
     return {k: resp.headers[k] for k in _PROXY_HEADERS if k in resp.headers}
 
 
+async def _can_read_private(
+    db: AsyncSession, session: Session | None, artist_did: str
+) -> bool:
+    if session is None:
+        return False
+    return session.did == artist_did or await is_private_media_member(
+        db, artist_did, session.did
+    )
+
+
 async def _handle_private_audio(
     *,
     session: Session | None,
+    allowed: bool,
     artist_did: str,
     space_uri: str | None,
     pds_blob_cid: str | None,
@@ -495,15 +511,13 @@ async def _handle_private_audio(
 ) -> Response:
     """proxy a private track's audio through the permissioned-space credential path.
 
-    access is owner-only at two layers: plyr.fm rejects non-owners here, while the
-    ``simplespace`` created for this MVP uses its explicit ``memberListPolicy``.
-    Core permissioned spaces do not enumerate readers, but ``simplespace`` is the
-    required PDS management layer above that core protocol and may maintain members.
-    A non-owner (or anonymous) request gets a 404 — the same as a missing file — so
-    private tracks do not leak their existence. Range is passed through so the
-    206/seek semantics survive the proxy.
+    the owner and the artist's private-media members pass; anyone else gets a
+    404 — the same as a missing file — so private tracks do not leak their
+    existence. the credential is minted from the requesting session, so a
+    member streams through their own PDS's delegation token. Range is passed
+    through so the 206/seek semantics survive the proxy.
     """
-    if session is None or session.did != artist_did:
+    if session is None or not allowed:
         raise HTTPException(status_code=404, detail="audio file not found")
     if not (space_uri and pds_blob_cid):
         raise HTTPException(status_code=404, detail="audio file not found")

--- a/backend/src/backend/api/oembed.py
+++ b/backend/src/backend/api/oembed.py
@@ -82,7 +82,7 @@ async def _build_track_oembed(
     if not (track := result.scalar_one_or_none()):
         raise HTTPException(status_code=404, detail="track not found")
     # oEmbed is an unauthenticated public-embed surface — private media never embeds
-    ensure_track_visible(track, None)
+    await ensure_track_visible(db, track, None)
 
     return OEmbedResponse(
         title=f"{track.title} - {track.artist.display_name}",

--- a/backend/src/backend/api/tracks/comments.py
+++ b/backend/src/backend/api/tracks/comments.py
@@ -79,7 +79,7 @@ async def get_track_comments(
 
     if not track:
         raise HTTPException(status_code=404, detail="track not found")
-    ensure_track_visible(track, viewer_did(session))
+    await ensure_track_visible(db, track, viewer_did(session))
 
     # check if artist allows comments
     prefs_result = await db.execute(
@@ -139,7 +139,7 @@ async def create_comment(
 
     if not track:
         raise HTTPException(status_code=404, detail="track not found")
-    ensure_track_visible(track, auth_session.did)
+    await ensure_track_visible(db, track, auth_session.did)
 
     if not track.atproto_record_uri or not track.atproto_record_cid:
         raise HTTPException(

--- a/backend/src/backend/api/tracks/likes.py
+++ b/backend/src/backend/api/tracks/likes.py
@@ -116,7 +116,7 @@ async def like_track(
 
     if not track:
         raise HTTPException(status_code=404, detail="track not found")
-    ensure_track_visible(track, auth_session.did)
+    await ensure_track_visible(db, track, auth_session.did)
 
     if not track.atproto_record_uri or not track.atproto_record_cid:
         raise HTTPException(

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -22,6 +22,7 @@ from backend._internal.content_labels import (
     get_track_label_values,
     label_visible_clause,
 )
+from backend._internal.track_visibility import track_visible_filter
 from backend.config import settings
 from backend.models import (
     Artist,
@@ -143,10 +144,7 @@ async def list_tracks(
     # filter by artist if provided
     if artist_did:
         stmt = stmt.where(Track.artist_did == artist_did)
-        # private (permissioned-space) media is visible only to its owner — an
-        # artist page viewed by anyone else (or logged out) must not list it
-        if not (session and session.did == artist_did):
-            stmt = stmt.where(Track.visibility != "private")
+        stmt = stmt.where(track_visible_filter(session.did if session else None))
     else:
         # discovery feed: only listed visibilities (public + supporters); excludes
         # unlisted and private. plus tracks from deactivated accounts drop out.

--- a/backend/src/backend/api/tracks/playback.py
+++ b/backend/src/backend/api/tracks/playback.py
@@ -145,7 +145,7 @@ async def get_track_by_uri(
     )
     if not (track := result.scalar_one_or_none()):
         raise HTTPException(status_code=404, detail="track not found")
-    ensure_track_visible(track, viewer_did(session))
+    await ensure_track_visible(db, track, viewer_did(session))
 
     return await _resolve_track(db, track, session)
 
@@ -165,7 +165,7 @@ async def get_track(
     )
     if not (track := result.scalar_one_or_none()):
         raise HTTPException(status_code=404, detail="track not found")
-    ensure_track_visible(track, viewer_did(session))
+    await ensure_track_visible(db, track, viewer_did(session))
 
     return await _resolve_track(db, track, session)
 
@@ -199,7 +199,7 @@ async def increment_play_count(
 
     if not (track := result.scalar_one_or_none()):
         raise HTTPException(status_code=404, detail="track not found")
-    ensure_track_visible(track, viewer_did(session))
+    await ensure_track_visible(db, track, viewer_did(session))
 
     ttl = max(
         _PLAY_DEDUP_MIN_TTL_S,

--- a/backend/src/backend/api/tracks/shares.py
+++ b/backend/src/backend/api/tracks/shares.py
@@ -87,7 +87,7 @@ async def create_share_link(
     track = await db.scalar(select(Track).where(Track.id == track_id))
     if not track:
         raise HTTPException(status_code=404, detail="track not found")
-    ensure_track_visible(track, auth_session.did)  # non-owner → 404
+    await ensure_track_visible(db, track, auth_session.did)  # non-owner → 404
     if track.is_private:
         raise HTTPException(status_code=409, detail="private tracks can't be shared")
 

--- a/backend/src/backend/api/tracks/tags.py
+++ b/backend/src/backend/api/tracks/tags.py
@@ -205,7 +205,7 @@ async def get_recommended_tags(
     track = result.scalar_one_or_none()
     if not track:
         raise HTTPException(status_code=404, detail="track not found")
-    ensure_track_visible(track, viewer_did(session))
+    await ensure_track_visible(db, track, viewer_did(session))
 
     # check for stored predictions (invalidate if audio file changed)
     extra = track.extra or {}

--- a/backend/src/backend/models/__init__.py
+++ b/backend/src/backend/models/__init__.py
@@ -16,6 +16,7 @@ from backend.models.pending_dev_token import PendingDevToken
 from backend.models.pending_scope_upgrade import PendingScopeUpgrade
 from backend.models.playlist import Playlist
 from backend.models.preferences import UserPreferences
+from backend.models.private_media_member import PrivateMediaMember
 from backend.models.queue import QueueState
 from backend.models.session import UserSession
 from backend.models.share_link import ShareLink, ShareLinkEvent
@@ -44,6 +45,7 @@ __all__ = [
     "PendingDevToken",
     "PendingScopeUpgrade",
     "Playlist",
+    "PrivateMediaMember",
     "QueueState",
     "SensitiveImage",
     "ShareLink",

--- a/backend/src/backend/models/private_media_member.py
+++ b/backend/src/backend/models/private_media_member.py
@@ -1,0 +1,30 @@
+"""plyr.fm's mirror of an artist's private-media member list."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, Index, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.models.database import Base
+
+
+class PrivateMediaMember(Base):
+    """one DID an artist lets hear their private tracks.
+
+    the source of truth is the ``simplespace`` member list on the artist's PDS,
+    consulted at credential-mint time; this row exists so listings and
+    visibility checks can answer in SQL. it is written through on every
+    add/remove plyr.fm performs and reconciled from ``listMembers``.
+    """
+
+    __tablename__ = "private_media_members"
+
+    artist_did: Mapped[str] = mapped_column(String, primary_key=True)
+    member_did: Mapped[str] = mapped_column(String, primary_key=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+
+    __table_args__ = (Index("ix_private_media_members_member_did", "member_did"),)

--- a/backend/tests/api/test_private_media_members.py
+++ b/backend/tests/api/test_private_media_members.py
@@ -1,0 +1,200 @@
+"""the artist's private-media member list: PDS is the source of truth, plyr mirrors."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import Session, require_auth
+from backend._internal.atproto.profiles import ResolvedProfile
+from backend.main import app
+from backend.models import Artist, PrivateMediaMember
+
+_ARTIST = "did:test:pmm-artist"
+_SPACE = f"at://{_ARTIST}/space/fm.plyr.privateMedia/self"
+
+
+def _owner() -> Session:
+    s = Session.__new__(Session)
+    s.did = _ARTIST
+    s.handle = "pmm.test"
+    s.session_id = "sess"
+    s.oauth_session = {"did": _ARTIST, "pds_url": "https://test.pds"}
+    return s
+
+
+@pytest.fixture
+async def artist(db_session: AsyncSession) -> Artist:
+    a = Artist(did=_ARTIST, handle="pmm.test", display_name="PMM")
+    db_session.add(a)
+    await db_session.commit()
+    return a
+
+
+@pytest.fixture
+def as_owner():
+    async def _auth() -> Session:
+        return _owner()
+
+    app.dependency_overrides[require_auth] = _auth
+    yield
+    app.dependency_overrides.clear()
+
+
+def _profiles(dids):
+    return [
+        ResolvedProfile(
+            did=d, handle=f"{d[-4:]}.test", display_name=d[-4:], avatar_url=None
+        )
+        for d in dids
+    ]
+
+
+async def _mirror(db: AsyncSession) -> list[str]:
+    rows = await db.execute(
+        select(PrivateMediaMember.member_did).where(
+            PrivateMediaMember.artist_did == _ARTIST
+        )
+    )
+    return sorted(rows.scalars().all())
+
+
+async def test_add_writes_pds_then_mirror(
+    db_session: AsyncSession, artist: Artist, as_owner
+):
+    with (
+        patch(
+            "backend.api.artists.ensure_personal_space", AsyncMock(return_value=_SPACE)
+        ),
+        patch("backend.api.artists.add_space_member", AsyncMock()) as add,
+        patch(
+            "backend.api.artists.resolve_handle",
+            AsyncMock(return_value={"did": "did:test:friend"}),
+        ),
+        patch(
+            "backend.api.artists.resolve_dids",
+            AsyncMock(side_effect=lambda d: _profiles(d)),
+        ),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            r = await c.post(
+                "/artists/me/private-media/members", json={"actor": "@friend.test"}
+            )
+    assert r.status_code == 201, r.text
+    assert r.json()["did"] == "did:test:friend"
+    add.assert_awaited_once_with(_owner_like(add), space=_SPACE, did="did:test:friend")
+    assert await _mirror(db_session) == ["did:test:friend"]
+
+
+def _owner_like(mock):
+    return mock.await_args.args[0]
+
+
+async def test_add_rejects_self_and_unknown(
+    db_session: AsyncSession, artist: Artist, as_owner
+):
+    with (
+        patch(
+            "backend.api.artists.ensure_personal_space", AsyncMock(return_value=_SPACE)
+        ),
+        patch("backend.api.artists.add_space_member", AsyncMock()) as add,
+        patch("backend.api.artists.resolve_handle", AsyncMock(return_value=None)),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            me = await c.post(
+                "/artists/me/private-media/members", json={"actor": _ARTIST}
+            )
+            nobody = await c.post(
+                "/artists/me/private-media/members", json={"actor": "nobody.test"}
+            )
+    assert me.status_code == 400
+    assert nobody.status_code == 404
+    add.assert_not_awaited()
+    assert await _mirror(db_session) == []
+
+
+async def test_remove_clears_pds_and_mirror(
+    db_session: AsyncSession, artist: Artist, as_owner
+):
+    db_session.add(PrivateMediaMember(artist_did=_ARTIST, member_did="did:test:friend"))
+    await db_session.commit()
+    with (
+        patch(
+            "backend.api.artists.ensure_personal_space", AsyncMock(return_value=_SPACE)
+        ),
+        patch("backend.api.artists.remove_space_member", AsyncMock()) as remove,
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            r = await c.delete("/artists/me/private-media/members/did:test:friend")
+    assert r.status_code == 204
+    remove.assert_awaited_once()
+    assert remove.await_args.kwargs == {"space": _SPACE, "did": "did:test:friend"}
+    assert await _mirror(db_session) == []
+
+
+async def test_list_reconciles_mirror_from_pds(
+    db_session: AsyncSession, artist: Artist, as_owner
+):
+    # plyr thinks `stale` is a member; the PDS says `a` and `b` (and the authority itself)
+    db_session.add(PrivateMediaMember(artist_did=_ARTIST, member_did="did:test:stale"))
+    await db_session.commit()
+    pages = [(["did:test:a", _ARTIST], "c1"), (["did:test:b"], None)]
+    with (
+        patch(
+            "backend.api.artists.ensure_personal_space", AsyncMock(return_value=_SPACE)
+        ),
+        patch("backend.api.artists.list_space_members", AsyncMock(side_effect=pages)),
+        patch(
+            "backend.api.artists.resolve_dids",
+            AsyncMock(side_effect=lambda d: _profiles(d)),
+        ),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            r = await c.get("/artists/me/private-media/members")
+    assert r.status_code == 200
+    assert [m["did"] for m in r.json()] == ["did:test:a", "did:test:b"]
+    assert await _mirror(db_session) == ["did:test:a", "did:test:b"]
+
+
+async def test_list_falls_back_to_mirror_when_pds_cannot_answer(
+    db_session: AsyncSession, artist: Artist, as_owner
+):
+    db_session.add(PrivateMediaMember(artist_did=_ARTIST, member_did="did:test:kept"))
+    await db_session.commit()
+    with (
+        patch(
+            "backend.api.artists.ensure_personal_space", AsyncMock(return_value=_SPACE)
+        ),
+        patch(
+            "backend.api.artists.list_space_members",
+            AsyncMock(side_effect=RuntimeError("down")),
+        ),
+        patch(
+            "backend.api.artists.resolve_dids",
+            AsyncMock(side_effect=lambda d: _profiles(d)),
+        ),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            r = await c.get("/artists/me/private-media/members")
+    assert r.status_code == 200
+    assert [m["did"] for m in r.json()] == ["did:test:kept"]
+    assert await _mirror(db_session) == ["did:test:kept"]
+
+
+async def test_members_require_auth():
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        assert (await c.get("/artists/me/private-media/members")).status_code == 401

--- a/backend/tests/api/test_private_media_visibility.py
+++ b/backend/tests/api/test_private_media_visibility.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import selectinload
 from backend._internal import Session
 from backend.api.search import _search_tracks
 from backend.api.tracks.listing import list_tracks
-from backend.models import Artist, Track
+from backend.models import Artist, PrivateMediaMember, Track
 from backend.schemas import TrackResponse
 
 _DID = "did:test:private-vis"
@@ -130,33 +130,49 @@ async def test_adult_track_serializes_through_policy_endpoint(
 # --- centralized helper (the chokepoint every endpoint routes through) --------
 
 
-def test_visibility_helper_rules():
+async def test_visibility_helper_rules(db_session: AsyncSession, artist: Artist):
     from fastapi import HTTPException
 
     from backend._internal.track_visibility import can_view_track, ensure_track_visible
 
-    public = Track(title="p", artist_did=_DID, file_id="h_pub", file_type="mp3")
-    private = Track(
-        title="x",
-        artist_did=_DID,
-        file_id="h_priv",
-        file_type="mp3",
-        visibility="private",
-    )
+    public = await _make_track(db_session, title="p", fid="h_pub", private=False)
+    private = await _make_track(db_session, title="x", fid="h_priv", private=True)
+    db_session.add(PrivateMediaMember(artist_did=_DID, member_did="did:test:member"))
+    await db_session.commit()
 
     # public: anyone
-    assert can_view_track(None, public)
-    assert can_view_track("did:test:other", public)
-    # private: owner only
-    assert can_view_track(_DID, private)
-    assert not can_view_track(None, private)
-    assert not can_view_track("did:test:other", private)
+    assert await can_view_track(db_session, None, public)
+    assert await can_view_track(db_session, "did:test:other", public)
+    # private: owner and members
+    assert await can_view_track(db_session, _DID, private)
+    assert await can_view_track(db_session, "did:test:member", private)
+    assert not await can_view_track(db_session, None, private)
+    assert not await can_view_track(db_session, "did:test:other", private)
 
-    ensure_track_visible(private, _DID)  # owner: no raise
+    await ensure_track_visible(db_session, private, _DID)
+    await ensure_track_visible(db_session, private, "did:test:member")
     for did in (None, "did:test:other"):
         with pytest.raises(HTTPException) as exc:
-            ensure_track_visible(private, did)
+            await ensure_track_visible(db_session, private, did)
         assert exc.value.status_code == 404
+
+
+async def test_member_sees_private_in_artist_listing(
+    db_session: AsyncSession, artist: Artist
+):
+    await _make_track(db_session, title="for members", fid="m_priv", private=True)
+    db_session.add(PrivateMediaMember(artist_did=_DID, member_did="did:test:member"))
+    await db_session.commit()
+
+    async def titles(session: Session | None) -> list[str]:
+        page = await list_tracks(
+            db=db_session, session=session, artist_did=_DID, limit=50
+        )
+        return [t.title for t in page.tracks]
+
+    assert "for members" in await titles(_session("did:test:member"))
+    assert "for members" not in await titles(_session("did:test:other"))
+    assert "for members" not in await titles(None)
 
 
 # --- endpoint proof: GET /tracks/{id} is the headline leak --------------------
@@ -185,5 +201,54 @@ async def test_track_detail_endpoint_owner_only_for_private(
         app.dependency_overrides[get_optional_session] = _owner
         with TestClient(app) as client:
             assert client.get(f"/tracks/{track.id}").status_code == 200
+
+        db_session.add(
+            PrivateMediaMember(artist_did=_DID, member_did="did:test:member")
+        )
+        await db_session.commit()
+
+        async def _member() -> Session | None:
+            return _session("did:test:member")
+
+        async def _stranger() -> Session | None:
+            return _session("did:test:other")
+
+        app.dependency_overrides[get_optional_session] = _member
+        with TestClient(app) as client:
+            assert client.get(f"/tracks/{track.id}").status_code == 200
+        app.dependency_overrides[get_optional_session] = _stranger
+        with TestClient(app) as client:
+            assert client.get(f"/tracks/{track.id}").status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_audio_url_for_private_track_owner_and_members_only(
+    db_session: AsyncSession, artist: Artist
+):
+    """/audio/{id}/url is the cacheable handle the player asks for first; it must
+    answer the owner and members with the proxy URL and everyone else with 404."""
+    from fastapi.testclient import TestClient
+
+    from backend._internal import get_optional_session
+    from backend.main import app
+
+    track = await _make_track(db_session, title="hear", fid="aud_priv", private=True)
+    db_session.add(PrivateMediaMember(artist_did=_DID, member_did="did:test:member"))
+    await db_session.commit()
+
+    async def statuses(session: Session | None) -> int:
+        async def dep() -> Session | None:
+            return session
+
+        app.dependency_overrides[get_optional_session] = dep
+        with TestClient(app) as client:
+            return client.get(f"/audio/{track.file_id}/url").status_code
+
+    try:
+        assert await statuses(_session(_DID)) == 200
+        assert await statuses(_session("did:test:member")) == 200
+        assert await statuses(_session("did:test:other")) == 404
+        assert await statuses(None) == 404
     finally:
         app.dependency_overrides.clear()

--- a/loq.toml
+++ b/loq.toml
@@ -371,7 +371,7 @@ max_lines = 1178
 
 [[rules]]
 path = "backend/src/backend/api/audio.py"
-max_lines = 538
+max_lines = 552
 
 [[rules]]
 path = "backend/src/backend/_internal/export_tasks.py"
@@ -380,3 +380,7 @@ max_lines = 524
 [[rules]]
 path = "frontend/src/lib/components/TrackComments.svelte"
 max_lines = 1091
+
+[[rules]]
+path = "backend/src/backend/api/artists.py"
+max_lines = 597


### PR DESCRIPTION
PR 3 of the access-list arc (#1897). An artist's private tracks become visible and playable to the DIDs on their private-media member list; everyone else still gets 404.

<details>
<summary>source of truth and the mirror</summary>

The `simplespace` member list on the artist's PDS decides who gets a credential — plyr cannot override it. A new `private_media_members (artist_did, member_did)` table mirrors it so `track_visible_filter` can express membership in SQL. It is written through on every add/remove plyr performs and **reconciled from `listMembers`** whenever the owner reads the list (rows the PDS no longer lists are dropped; the authority itself is never stored — it's implicitly a member). If the PDS can't answer, the mirror is served as a fallback. The asymmetry is safe by construction: the mirror can only over-*show* metadata for a moment; bytes always go through `open_space_blob` with a credential the PDS minted for that session.

</details>

<details>
<summary>what changed where</summary>

- `track_visibility.py`: `track_visible_filter` gains an `EXISTS` on the mirror; `can_view_track` / `ensure_track_visible` become `async` and take `db` (9 call sites updated); new `is_private_media_member`.
- `tracks/listing.py`: the artist-page private filter now uses the shared `track_visible_filter` instead of a bare owner compare.
- `audio.py`: both private paths (`/audio/{id}` proxy and `/audio/{id}/url`) accept the owner or a member. The credential is minted from the **requesting** session, so a member streams through their own PDS's delegation token — the cross-host path the smoke script proves (#1899).
- `artists.py`: `GET /artists/me/private-media/members` (reconcile + hydrate via `resolve_dids`), `POST` `{actor: handle|did}` (resolves, `ensure_personal_space`, `addMember`, mirror), `DELETE /{did}` (`removeMember`, which also forgets plyr's cached credential for that DID, then mirror).
- migration `f3a9c1d27b4e` (single head).

</details>

<details>
<summary>tests</summary>

- visibility rules with a member: listing, detail `200`/`404`, `/audio/{id}/url` owner/member `200`, stranger/anon `404`.
- member endpoints: add writes PDS then mirror; self and unknown rejected without touching the PDS; remove clears both; list reconciles (drops a stale row, adds PDS rows, skips the authority, pages by cursor) and falls back to the mirror when the PDS errors; auth required.
- full backend suite: 1573 passed.

</details>

<details>
<summary>deliberately not in this PR</summary>

- No portal UI yet (PR 4) — the endpoints are the surface for it.
- Downloads of private tracks stay refused for everyone; `download_refusal` is untouched.
- No "shared with you" surface for members; a member finds the track only via a link today.
- Membership is not supporter standing anywhere (`viewer_is_supporter` untouched).

</details>

Needs #1898 (the reader permission) published and re-consented for a member to actually mint a credential; without it the PDS refuses at `getDelegationToken` and the proxy answers 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)