### PR TITLE
feat(portal): people who can hear your private tracks

### DIFF
--- a/.github/workflows/e2e-private-media.yml
+++ b/.github/workflows/e2e-private-media.yml
@@ -61,6 +61,8 @@ jobs:
         env:
           ZAT_TEST_HANDLE: ${{ secrets.ZAT_TEST_HANDLE }}
           ZAT_TEST_PASSWORD: ${{ secrets.ZAT_TEST_PASSWORD }}
+          ALPHA_TEST_HANDLE: ${{ secrets.ALPHA_TEST_HANDLE }}
+          ALPHA_TEST_PASSWORD: ${{ secrets.ALPHA_TEST_PASSWORD }}
         run: node e2e/private-media.mjs
 
       - name: private voice memo from /record

--- a/frontend/e2e/lib.mjs
+++ b/frontend/e2e/lib.mjs
@@ -6,6 +6,8 @@ export const APP = process.env.PLYR_APP_URL ?? 'https://stg.plyr.fm';
 export const API = process.env.PLYR_API_URL ?? 'https://api-stg.plyr.fm';
 export const HANDLE = required('ZAT_TEST_HANDLE');
 export const PASSWORD = required('ZAT_TEST_PASSWORD');
+export const MEMBER_HANDLE = process.env.ALPHA_TEST_HANDLE?.trim() || null;
+export const MEMBER_PASSWORD = process.env.ALPHA_TEST_PASSWORD?.trim() || null;
 
 function required(name) {
 	const value = process.env[name]?.trim();
@@ -85,24 +87,24 @@ export function wavBuffer() {
 }
 
 /** the zds consent page: expand the password form and authorize. */
-export async function authorizeOnPds(page) {
+export async function authorizeOnPds(page, who = HANDLE, secret = PASSWORD) {
 	await page.waitForTimeout(800);
 	const usePassword = page.getByText('use password instead');
 	if (await usePassword.count()) await usePassword.click().catch(() => undefined);
-	await page.locator('input[name="username"]').fill(HANDLE);
-	await page.locator('input[name="password"]').fill(PASSWORD);
+	await page.locator('input[name="username"]').fill(who);
+	await page.locator('input[name="password"]').fill(secret);
 	await page.getByRole('button', { name: 'authorize' }).click();
 	await page.waitForURL((u) => u.href.startsWith(APP), { timeout: 30000 });
 }
 
-export async function signIn(page) {
+export async function signIn(page, who = HANDLE, secret = PASSWORD) {
 	await page.goto(`${APP}/login`, { waitUntil: 'networkidle' });
 	const handle = page.getByPlaceholder('you.example.com');
 	await handle.waitFor({ timeout: 15000 });
-	await handle.fill(HANDLE);
+	await handle.fill(who);
 	await handle.press('Enter');
 	await page.waitForURL(/oauth\/authorize/, { timeout: 30000 });
-	await authorizeOnPds(page);
+	await authorizeOnPds(page, who, secret);
 	await page.waitForTimeout(2500);
 	const terms = page.locator('.terms-overlay');
 	if (await terms.count()) {

--- a/frontend/e2e/private-media.mjs
+++ b/frontend/e2e/private-media.mjs
@@ -16,6 +16,8 @@ import {
 	API,
 	APP,
 	HANDLE,
+	MEMBER_HANDLE,
+	MEMBER_PASSWORD,
 	authorizeOnPds,
 	currentStage,
 	deleteTrack,
@@ -34,6 +36,7 @@ let createdTrackId = null;
 let ownerContext = null;
 let dumpOwner = null;
 let dumpFresh = null;
+let dumpMember = null;
 
 try {
 	// --- session 1: sign in, upload privately through the consent round trip
@@ -112,6 +115,59 @@ try {
 	}
 	step('artist-page-anon', `hidden from a signed-out visitor; total_items=${strangerCount}`);
 
+	// --- a second account on a spaces PDS: refused, then added, then plays it
+	if (MEMBER_HANDLE && MEMBER_PASSWORD) {
+		const memberContext = await browser.newContext({ viewport: { width: 1000, height: 2000 } });
+		const member = await memberContext.newPage();
+		dumpMember = observe(member, 'member');
+		step('member-sign-in', MEMBER_HANDLE);
+		await signIn(member, MEMBER_HANDLE, MEMBER_PASSWORD);
+		const memberMe = await me(member);
+		if (memberMe?.permissioned_spaces?.reader !== true) {
+			fail(`member session lacks the reader grant: ${JSON.stringify(memberMe?.permissioned_spaces)}`);
+		}
+		const probe = (p) =>
+			p.evaluate(
+				async ([api, id]) => (await fetch(`${api}/tracks/${id}`, { credentials: 'include' })).status,
+				[API, createdTrackId]
+			);
+		if ((await probe(member)) !== 404) fail('a non-member could read the private track');
+		step('member-before', 'not a member yet → 404');
+
+		await page.goto(`${APP}/portal/manage`, { waitUntil: 'networkidle' });
+		const search = page.locator('.private-media-section input.search-input');
+		await search.waitFor({ timeout: 15000 });
+		await search.fill(MEMBER_HANDLE);
+		await page.locator('.private-media-section .search-result-item').first().click({ timeout: 20000 });
+		await page.getByText(`@${MEMBER_HANDLE} can hear your private tracks`).waitFor({ timeout: 15000 });
+		step('member-added', `owner added ${MEMBER_HANDLE} in the portal`);
+
+		if ((await probe(member)) !== 200) fail('the member still cannot read the private track');
+		const memberPlayback = await member.evaluate(
+			async ([api, id]) => {
+				const t = await (await fetch(`${api}/tracks/${id}`, { credentials: 'include' })).json();
+				const a = await fetch(`${api}/audio/${t.file_id}?track_id=${id}`, {
+					credentials: 'include',
+					headers: { Range: 'bytes=0-99' }
+				});
+				return a.status;
+			},
+			[API, createdTrackId]
+		);
+		if (memberPlayback !== 206 && memberPlayback !== 200) {
+			fail(`member audio did not stream through their own PDS: ${memberPlayback}`);
+		}
+		step('member-plays', `audio ${memberPlayback} via the member's own delegation token`);
+
+		await page.locator('.private-media-section .selected-artist-chip button').first().click();
+		await page.getByText(/removed @/).waitFor({ timeout: 15000 });
+		if ((await probe(member)) !== 404) fail('a removed member can still read the private track');
+		step('member-removed', 'removed → 404 again');
+		await memberContext.close();
+	} else {
+		step('member', 'skipped — set ALPHA_TEST_HANDLE/ALPHA_TEST_PASSWORD for the cross-account leg');
+	}
+
 	// --- session 2: a fresh sign-in (base scope, no grant) must still play it
 	const freshContext = await browser.newContext({ viewport: { width: 1000, height: 2000 } });
 	const fresh = await freshContext.newPage();
@@ -147,6 +203,7 @@ try {
 		console.error(`FAILED at [${currentStage()}]: ${String(e).slice(0, 400)}`);
 		process.exitCode = 1;
 	}
+	if (dumpMember) await dumpMember();
 	if (dumpFresh) await dumpFresh();
 	if (dumpOwner) await dumpOwner();
 } finally {

--- a/frontend/src/lib/components/VisibilityPicker.svelte
+++ b/frontend/src/lib/components/VisibilityPicker.svelte
@@ -34,7 +34,7 @@
 
 	const defaultPrivateNote = $derived(
 		privateGranted
-			? 'only you can play it. nothing public, nothing in feeds.'
+			? 'only you, and anyone you add under private tracks in your portal, can play it. nothing public, nothing in feeds.'
 			: "only you can play it. nothing public, nothing in feeds. you'll be asked once to allow it."
 	);
 </script>

--- a/frontend/src/lib/components/portal/PrivateMediaSection.svelte
+++ b/frontend/src/lib/components/portal/PrivateMediaSection.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import HandleSearch from '$lib/components/HandleSearch.svelte';
+	import WaveLoading from '$lib/components/WaveLoading.svelte';
+	import type { FeaturedArtist } from '$lib/types';
+	import { API_URL } from '$lib/config';
+	import { auth } from '$lib/auth.svelte';
+	import { toast } from '$lib/toast.svelte';
+
+	let members = $state<FeaturedArtist[]>([]);
+	let loading = $state(true);
+	let busy = $state(false);
+
+	const supported = $derived(auth.user?.permissioned_spaces?.supported ?? false);
+
+	async function load() {
+		loading = true;
+		try {
+			const res = await fetch(`${API_URL}/artists/me/private-media/members`, {
+				credentials: 'include'
+			});
+			if (res.ok) members = await res.json();
+		} catch (_e) {
+			console.error('failed to load private media members:', _e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function add(artist: FeaturedArtist) {
+		busy = true;
+		try {
+			const res = await fetch(`${API_URL}/artists/me/private-media/members`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				credentials: 'include',
+				body: JSON.stringify({ actor: artist.did })
+			});
+			if (!res.ok) {
+				const detail = await res.json().catch(() => null);
+				toast.error(detail?.detail ?? "couldn't add them");
+				return;
+			}
+			members = [...members, await res.json()];
+			toast.success(`@${artist.handle} can hear your private tracks`);
+		} catch (_e) {
+			console.error('failed to add private media member:', _e);
+			toast.error("couldn't add them");
+		} finally {
+			busy = false;
+		}
+	}
+
+	async function remove(did: string) {
+		const who = members.find((m) => m.did === did);
+		busy = true;
+		try {
+			const res = await fetch(
+				`${API_URL}/artists/me/private-media/members/${encodeURIComponent(did)}`,
+				{ method: 'DELETE', credentials: 'include' }
+			);
+			if (!res.ok) {
+				toast.error("couldn't remove them");
+				return;
+			}
+			members = members.filter((m) => m.did !== did);
+			if (who) toast.info(`removed @${who.handle} — anything already playing stops within two hours`);
+		} catch (_e) {
+			console.error('failed to remove private media member:', _e);
+			toast.error("couldn't remove them");
+		} finally {
+			busy = false;
+		}
+	}
+
+	onMount(() => {
+		if (supported) void load();
+		else loading = false;
+	});
+</script>
+
+{#if supported}
+	<section class="private-media-section">
+		<div class="section-header">
+			<h2>private tracks</h2>
+			{#if members.length > 0}
+				<span class="count">{members.length} {members.length === 1 ? 'listener' : 'listeners'}</span>
+			{/if}
+		</div>
+		<p class="lede">
+			only you can play your private tracks. add people here and they can too. they need an
+			account on a PDS that supports private media, and the list is kept on yours.
+		</p>
+
+		{#if loading}
+			<div class="loading-container">
+				<WaveLoading size="lg" message="loading..." />
+			</div>
+		{:else}
+			<HandleSearch
+				selected={members}
+				onAdd={add}
+				onRemove={remove}
+				maxFeatures={100}
+				disabled={busy}
+			/>
+			{#if members.length === 0}
+				<p class="empty">nobody yet — your private tracks are yours alone.</p>
+			{/if}
+		{/if}
+	</section>
+{/if}
+
+<style>
+	.private-media-section {
+		margin-bottom: 2.5rem;
+	}
+
+	.section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 0.5rem;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	.section-header h2 {
+		margin-bottom: 0;
+	}
+
+	.count {
+		font-size: var(--text-sm);
+		color: var(--text-tertiary);
+	}
+
+	.lede {
+		margin: 0 0 1rem;
+		font-size: var(--text-sm);
+		color: var(--text-tertiary);
+	}
+
+	.empty {
+		margin: 0.75rem 0 0;
+		color: var(--text-muted);
+		font-size: var(--text-sm);
+	}
+
+	.loading-container {
+		display: flex;
+		justify-content: center;
+		padding: 2rem 1rem;
+	}
+</style>

--- a/frontend/src/routes/portal/manage/+page.svelte
+++ b/frontend/src/routes/portal/manage/+page.svelte
@@ -5,6 +5,7 @@
 	import ProfileSection from '$lib/components/portal/ProfileSection.svelte';
 	import SharesSection from '$lib/components/portal/SharesSection.svelte';
 	import DataSection from '$lib/components/portal/DataSection.svelte';
+	import PrivateMediaSection from '$lib/components/portal/PrivateMediaSection.svelte';
 	import CopyrightSection from '$lib/components/CopyrightSection.svelte';
 	import type { Track } from '$lib/types';
 	import { API_URL } from '$lib/config';
@@ -87,6 +88,8 @@
 		<ProfileSection {atprotofansEligible} {checkingAtprotofans} />
 
 		<CopyrightSection />
+
+		<PrivateMediaSection />
 
 		<SharesSection />
 


### PR DESCRIPTION
PR 4 of the access-list arc (#1897): the artist-facing list, on `/portal/manage`.

<details>
<summary>the section</summary>

`PrivateMediaSection.svelte`, shown only when `permissioned_spaces.supported`. Reuses `HandleSearch` (the featured-artists multi-select) against `GET/POST/DELETE /artists/me/private-media/members` (#1900). Copy: *"only you can play your private tracks. add people here and they can too. they need an account on a PDS that supports private media, and the list is kept on yours."* Removal toasts *"anything already playing stops within two hours"* — the credential lifetime the protocol leaves us. The visibility picker's private note now mentions the list.

</details>

<details>
<summary>e2e: the cross-account proof</summary>

An optional leg in `private-media.mjs`, on when `ALPHA_TEST_HANDLE` / `ALPHA_TEST_PASSWORD` are set: a second account (intended: `nate.spaces-alpha.bsky.network`, on the **official** implementation) signs in, must have the reader grant, gets `404` on the private track, is added by the owner **through the portal UI**, reads `200` and streams `206` through its own PDS's delegation token, is removed through the UI, and gets `404` again. With bufo.uk on zds as owner, one run proves both implementations and cross-host membership. Skipped with a note when the secrets are absent.

</details>

Depends on #1898 (reader grant, published + re-consented on staging) and #1900 (endpoints) being on staging before the e2e leg can pass. Visual change — staging review before any prod release, per the arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)