### PR TITLE
chore(spaces): the grant is the only capability signal — drop the advertised-scopes check

### DIFF
--- a/backend/src/backend/_internal/atproto/spaces/__init__.py
+++ b/backend/src/backend/_internal/atproto/spaces/__init__.py
@@ -6,7 +6,6 @@ read from the token's expanded ``space:`` grant — see
 """
 
 from backend._internal.atproto.spaces.capability import (
-    pds_supports_spaces,
     session_has_private_media_access,
 )
 from backend._internal.atproto.spaces.uris import (
@@ -21,6 +20,5 @@ __all__ = [
     "build_space_uri",
     "parse_space_record_uri",
     "parse_space_uri",
-    "pds_supports_spaces",
     "session_has_private_media_access",
 ]

--- a/backend/src/backend/_internal/atproto/spaces/capability.py
+++ b/backend/src/backend/_internal/atproto/spaces/capability.py
@@ -1,34 +1,15 @@
 """whether a session can use permissioned spaces (private media).
 
-Two questions, each answered by the thing that actually knows:
-
-- **can this PDS do spaces at all?** its OAuth authorization server lists a
-  ``space:`` scope in ``scopes_supported``. Declarative, available before we
-  ask the user for anything, and stable enough to cache per issuer. This
-  decides whether private media is offered.
-- **may this session write to the space?** the granted token carries the
-  expanded ``space:`` grant (see
-  [space_scope][backend._internal.auth.space_scope]). This decides whether a
-  write is allowed.
-
-Never offer what the first question says is impossible, and never authorize on
-anything but the second.
+One question, answered by the thing that knows: the granted token. A
+spaces-capable PDS expands ``include:<ns>.privateMediaAccess`` into
+``space:`` grants at consent; any other PDS leaves it unexpanded. Authorization
+server metadata cannot carry this — the reference provider lists only
+``atproto`` and the ``transition:*`` hints ("other atproto scopes can't be
+enumerated as they are dynamic"), and every implementation now matches it.
 """
-
-import logging
-
-import httpx
-from atproto_oauth.security import is_safe_url
-from redis.exceptions import RedisError
 
 from backend._internal.auth.session import Session as AuthSession
 from backend._internal.auth.space_scope import private_media_grant_present
-from backend.utilities.redis import get_async_redis_client
-
-logger = logging.getLogger(__name__)
-
-_CACHE_PREFIX = "spaces_supported:v1:"
-_CACHE_TTL_SECONDS = 6 * 60 * 60
 
 
 def session_has_private_media_access(auth_session: AuthSession) -> bool:
@@ -37,56 +18,3 @@ def session_has_private_media_access(auth_session: AuthSession) -> bool:
     if data.get("auth_type") == "app_password":
         return True
     return private_media_grant_present(data.get("scope", ""), auth_session.did)
-
-
-def advertises_spaces(metadata: dict) -> bool:
-    """whether authorization-server metadata offers any ``space:`` scope."""
-    scopes = metadata.get("scopes_supported")
-    if not isinstance(scopes, list):
-        return False
-    return any(
-        isinstance(scope, str) and (scope == "space" or scope.startswith("space:"))
-        for scope in scopes
-    )
-
-
-async def pds_supports_spaces(auth_session: AuthSession) -> bool:
-    """whether the session's authorization server advertises a ``space:`` scope.
-
-    A transient failure answers "no": offering private media we cannot deliver
-    is worse than hiding it for one page load.
-    """
-    issuer = (auth_session.oauth_session or {}).get("authserver_iss")
-    if not issuer:
-        return False
-    issuer = issuer.rstrip("/")
-
-    redis = None
-    cache_key = f"{_CACHE_PREFIX}{issuer}"
-    try:
-        redis = get_async_redis_client()
-        if (cached := await redis.get(cache_key)) is not None:
-            return cached == "1"
-    except RedisError as exc:
-        logger.debug("spaces capability cache read failed: %s", exc)
-        redis = None
-
-    url = f"{issuer}/.well-known/oauth-authorization-server"
-    if not is_safe_url(url):
-        return False
-    try:
-        async with httpx.AsyncClient(timeout=10) as http:
-            response = await http.get(url)
-        if response.status_code != 200:
-            return False
-        supported = advertises_spaces(response.json())
-    except (httpx.HTTPError, ValueError) as exc:
-        logger.debug("could not read authserver metadata for %s: %s", issuer, exc)
-        return False
-
-    if redis is not None:
-        try:
-            await redis.set(cache_key, "1" if supported else "0", ex=_CACHE_TTL_SECONDS)
-        except RedisError as exc:
-            logger.debug("spaces capability cache write failed: %s", exc)
-    return supported

--- a/backend/src/backend/api/auth.py
+++ b/backend/src/backend/api/auth.py
@@ -41,7 +41,6 @@ from backend._internal import (
     switch_active_account,
 )
 from backend._internal.atproto.spaces import (
-    pds_supports_spaces,
     session_has_private_media_access,
 )
 from backend._internal.auth import get_refresh_token_lifetime_days
@@ -76,8 +75,9 @@ class LinkedAccountResponse(BaseModel):
 class PermissionedSpacesStatus(BaseModel):
     """private-media availability for this session.
 
-    ``granted``: the token carries the expanded space grant. ``supported``:
-    offer the option — true unless an upgrade on this PDS came back without it.
+    ``granted``: the token carries the expanded space grant. ``supported``
+    equals it — the grant is the only capability signal — and stays for
+    clients that key on it.
     """
 
     supported: bool = False
@@ -537,7 +537,6 @@ async def get_current_user(
     current_user_flags = await get_user_flags(db, session.did)
 
     granted = session_has_private_media_access(session)
-    spaces_supported = granted or await pds_supports_spaces(session)
 
     return CurrentUserResponse(
         did=session.did,
@@ -552,7 +551,7 @@ async def get_current_user(
         ],
         enabled_flags=current_user_flags,
         permissioned_spaces=PermissionedSpacesStatus(
-            supported=spaces_supported, granted=granted
+            supported=granted, granted=granted
         ),
     )
 

--- a/backend/tests/_internal/test_permissioned_spaces.py
+++ b/backend/tests/_internal/test_permissioned_spaces.py
@@ -132,29 +132,6 @@ def test_session_access(prod_namespace):
     assert cap.session_has_private_media_access(app_pw)
 
 
-@pytest.mark.parametrize(
-    ("scopes", "expected"),
-    [
-        (["atproto", "repo:*", "include:*", "space:*"], True),
-        (["atproto", "space"], True),
-        (["atproto", "transition:generic", "transition:email"], False),
-        (["atproto", "repo:*", "blob:*/*"], False),
-        # a scope that merely mentions space is not a space scope
-        (["atproto", "rpc:com.atproto.space.listSpaces"], False),
-        (None, False),
-        ("space:*", False),
-    ],
-)
-def test_advertises_spaces_reads_scopes_supported(scopes, expected):
-    metadata = {} if scopes is None else {"scopes_supported": scopes}
-    assert cap.advertises_spaces(metadata) is expected
-
-
-async def test_pds_supports_spaces_without_issuer_is_false():
-    session = Session(session_id="s", did="did:plc:x", handle="x", oauth_session={})
-    assert await cap.pds_supports_spaces(session) is False
-
-
 def _login_harness(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, bool]]:
     from backend._internal.atproto import handles
 

--- a/backend/tests/api/test_scope_upgrade.py
+++ b/backend/tests/api/test_scope_upgrade.py
@@ -354,37 +354,24 @@ async def test_non_permissioned_start_failure_is_not_swallowed(
     assert "invalid_scope" in response.json()["detail"]
 
 
-async def test_auth_me_hides_private_media_when_the_authserver_lacks_space_scopes(
+async def test_auth_me_supported_is_the_grant(
     test_app: FastAPI, db_session: AsyncSession, upgrade_artist: Artist
 ):
-    """a PDS that does not advertise space scopes must not be offered private media."""
-    from backend._internal.atproto.spaces import capability as cap
-
-    bsky = {"scopes_supported": ["atproto", "transition:generic", "transition:email"]}
-    zds = {"scopes_supported": ["atproto", "repo:*", "include:*", "space:*"]}
-    assert cap.advertises_spaces(bsky) is False
-    assert cap.advertises_spaces(zds) is True
-
-    with patch(
-        "backend.api.auth.pds_supports_spaces",
-        new_callable=AsyncMock,
-        return_value=False,
-    ):
-        async with AsyncClient(
-            transport=ASGITransport(app=test_app), base_url="http://test"
-        ) as client:
-            response = await client.get("/auth/me")
+    """the expanded grant is the only capability signal: supported == granted."""
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get("/auth/me")
     assert response.status_code == 200
-    spaces = response.json()["permissioned_spaces"]
-    assert spaces == {"supported": False, "granted": False}
+    assert response.json()["permissioned_spaces"] == {
+        "supported": False,
+        "granted": False,
+    }
 
-    with patch(
-        "backend.api.auth.pds_supports_spaces",
-        new_callable=AsyncMock,
-        return_value=True,
-    ):
+    with patch("backend.api.auth.session_has_private_media_access", return_value=True):
         async with AsyncClient(
             transport=ASGITransport(app=test_app), base_url="http://test"
         ) as client:
             response = await client.get("/auth/me")
-    assert response.json()["permissioned_spaces"]["supported"] is True
+    spaces = response.json()["permissioned_spaces"]
+    assert spaces["supported"] is True and spaces["granted"] is True

--- a/docs/internal/architecture/permissioned-private-media.md
+++ b/docs/internal/architecture/permissioned-private-media.md
@@ -222,9 +222,9 @@ PDS expands the include into `space:` grants at consent (`granted: true`), any o
 leaves it unexpanded and private media stays hidden, and an authserver that rejects the
 include at PAR with `invalid_scope` gets the sign-in again without it. `scopes_supported`
 cannot carry this — the reference oauth-provider only ever lists `atproto` and the
-`transition:*` hints ("other atproto scopes can't be enumerated as they are dynamic"), so
-the Bluesky-hosted alpha PDS (`spaces-alpha.host.bsky.network`) advertises nothing; zds is
-the one implementation that adds `space:*`. Sessions signed in before this (no include)
+`transition:*` hints ("other atproto scopes can't be enumerated as they are dynamic"), and
+every implementation now matches it (zds briefly listed granular scopes and removed them
+to match the reference). `/auth/me.supported` therefore equals `granted`. Sessions signed in before this (no include)
 take the one-time OAuth scope upgrade the first time they choose private; the upload or
 recording is held across that redirect and completes on return without another click.
 


### PR DESCRIPTION
From the zds side: zds is removing its granular `scopes_supported` entries (`repo:* blob:*/* rpc:* account:* identity:* include:* space:*`) to match the reference provider exactly — `atproto` + `transition:*`. They were a zds invention; the reference omits dynamic scopes on purpose, rsky and atproto-crates don't list them, and neither Bulletin nor secretsky reads the metadata (both request `include:` at login and check the token). #1885 built on the one hint that happened to exist; #1891 kept it only so pre-#1891 zds sessions stayed offered "private" until re-consent. Once zds deploys (commit `3ee10e6`, nate's call when), that branch answers false everywhere.

So: `/auth/me.supported == granted`. `advertises_spaces`, the per-issuer Redis cache and the authserver metadata fetch are deleted; `capability.py` is a pure token check again. `supported` stays in the response for clients that key on it. Pre-#1891 sessions on zds lose the private option until their next sign-in (the only way they could use it anyway — the grant is what writes). Staging-only like the rest of the arc.

Independent of #1898 (which adds `reader` to the same response).

🤖 Generated with [Claude Code](https://claude.com/claude-code)