### PR TITLE
fix(pds): editing a track no longer deletes its audio from the PDS

### DIFF
--- a/backend/src/backend/_internal/atproto/records/fm_plyr/track.py
+++ b/backend/src/backend/_internal/atproto/records/fm_plyr/track.py
@@ -13,6 +13,7 @@ from backend._internal.atproto.profiles import resolve_dids
 from backend._internal.atproto.self_labels import build_self_labels
 from backend.config import settings
 from backend.models import Track
+from backend.utilities.audio_formats import AudioFormat
 
 logger = logging.getLogger(__name__)
 
@@ -297,6 +298,23 @@ async def update_record(
     return result["uri"], result["cid"]
 
 
+def audio_blob_ref(track: Track) -> BlobRef | None:
+    """the record's ``audioBlob`` for a track whose audio lives on the PDS.
+
+    a rebuilt record must keep referencing the blob: a PDS garbage-collects a
+    blob the moment no record references it, so dropping the field here is
+    what deletes the audio from the user's account.
+    """
+    if not track.pds_blob_cid:
+        return None
+    return {
+        "$type": "blob",
+        "ref": {"$link": track.pds_blob_cid},
+        "mimeType": AudioFormat(track.file_type).media_type,
+        "size": track.pds_blob_size or 0,
+    }
+
+
 async def rebuild_track_pds_record(
     track: Track,
     auth_session: AuthSession,
@@ -338,6 +356,7 @@ async def rebuild_track_pds_record(
         features=track.features if track.features else None,
         image_url=image_url_override or await track.get_image_url(),
         support_gate=track.support_gate,
+        audio_blob=audio_blob_ref(track),
         description=track.description,
         self_labels=track.self_labels,
     )

--- a/backend/tests/api/test_track_edit_pds_sync.py
+++ b/backend/tests/api/test_track_edit_pds_sync.py
@@ -139,3 +139,57 @@ async def test_editing_creator_self_label_syncs_to_pds(
 
     await db_session.refresh(published_track)
     assert published_track.self_labels == ["sexual"]
+
+
+@pytest.fixture
+async def track_on_pds(db_session: AsyncSession) -> Track:
+    """a public track whose audio is also a blob on the PDS (audio_storage both)."""
+    artist = Artist(did=_ARTIST_DID, handle="editor.bsky.social", display_name="Editor")
+    db_session.add(artist)
+    await db_session.flush()
+    track = Track(
+        title="on the pds",
+        artist_did=_ARTIST_DID,
+        file_id="edit_sync_pds",
+        file_type="mp3",
+        extra={"duration": 180},
+        r2_url="https://audio.example.com/edit_sync_pds.mp3",
+        audio_storage="both",
+        pds_blob_cid="bafkreiblobonpds",
+        pds_blob_size=2562132,
+        atproto_record_uri=f"at://{_ARTIST_DID}/fm.plyr.track/editsyncpds",
+        atproto_record_cid="bafyoriginal",
+    )
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+    return track
+
+
+async def test_editing_keeps_the_audio_blob_in_the_pds_record(
+    test_app: FastAPI, db_session: AsyncSession, track_on_pds: Track
+) -> None:
+    """a rebuilt record must still reference the audio blob — a PDS
+    garbage-collects a blob no record references, which deletes the audio."""
+    pds = AsyncMock(
+        return_value={"uri": track_on_pds.atproto_record_uri, "cid": "bafyupdated"}
+    )
+    with patch("backend._internal.atproto.records.fm_plyr.track.make_pds_request", pds):
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.patch(
+                f"/tracks/{track_on_pds.id}", data={"title": "renamed, still on pds"}
+            )
+    assert response.status_code == 200, response.text
+
+    pds.assert_awaited_once()
+    assert pds.await_args is not None
+    record = pds.await_args.args[3]["record"]
+    assert record["audioBlob"] == {
+        "$type": "blob",
+        "ref": {"$link": "bafkreiblobonpds"},
+        "mimeType": "audio/mpeg",
+        "size": 2562132,
+    }
+    assert record["audioUrl"] == "https://audio.example.com/edit_sync_pds.mp3"


### PR DESCRIPTION
nate's 4:32 am upload (track 1247) went to his PDS — `uploadBlob` 200, record written with `audioBlob` at 09:35:07Z — and then his 09:43Z edit (visibility → unlisted) **deleted it**: `rebuild_track_pds_record` rebuilds the record from the row with `audio_url` only and never passes `audio_blob`. The official PDS garbage-collects any blob no record references; `sync.getBlob` for the CID now answers `Blob not found`. Jetstream ingest then mirrored the blob-less record into the DB (`audio_storage='r2'`, `pds_blob_cid=NULL`) and left `pds_blob_size` behind — the signature.

<details>
<summary>blast radius (production, read-only query)</summary>

**66 tracks across 21 artists** match `audio_storage='r2' AND pds_blob_size IS NOT NULL AND pds_blob_cid IS NULL`: graham.systems (7), whereditgo.diamonds (6), darkhart.whereditgo.diamonds (6), gingerbag1 (5), cummington.wang (5), antitor.nl (4), valerierayne13 (4), just.cameron.stream (4), waow.tech (3), psingletary.com (3), bismark.blacksky.app (3), timrowe.org (3), jdhitsolutions.com (3), eurocity.band (2), renderg.host (2), and one each for annamist.com, replyomatic, pixeline.be, pat-ou, joe.germuska.com, zzstoatzz.io — March 18 through today. Every one of those has its audio **only in R2** now. Repair (re-upload from R2 + rewrite the record) is a PDS write on each user's behalf and is not in this PR.

</details>

<details>
<summary>the fix</summary>

`audio_blob_ref(track)` builds the `{"$type":"blob","ref":{"$link":cid},"mimeType","size"}` reference from the row (`mimeType` via `AudioFormat(file_type).media_type`) and `rebuild_track_pds_record` passes it alongside `audio_url`, the same pairing the publish path and the optimize task use (`audio_storage='both'`). Tracks without a blob CID are unchanged.

Regression test: PATCH on a track with `pds_blob_cid` set; the `putRecord` payload must carry the exact `audioBlob` and still carry `audioUrl`. Fails on the previous code (`KeyError: 'audioBlob'`). Full backend suite: 1568 passed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)