### PR TITLE
fix(spaces): refusals are refusals, not 500s; honest copy about removal

### DIFF
--- a/backend/src/backend/_internal/atproto/spaces/client.py
+++ b/backend/src/backend/_internal/atproto/spaces/client.py
@@ -172,9 +172,10 @@ async def add_space_member(auth_session: AuthSession, *, space: str, did: str) -
 async def remove_space_member(
     auth_session: AuthSession, *, space: str, did: str
 ) -> None:
-    """take ``did`` off the member list and forget any credential plyr minted
-    for it. The PDS stops issuing new credentials at once; one already issued
-    keeps working until it expires, which the protocol leaves at two hours."""
+    """take ``did`` off the member list and forget the credential this process
+    minted for it. The PDS stops issuing new credentials at once; one already
+    issued lasts until its host's lifetime runs out (the protocol's default is
+    two hours). plyr's own reads re-check membership per request regardless."""
     await make_pds_request(
         auth_session,
         "POST",
@@ -266,13 +267,35 @@ def forget_credential(did: str, space: str) -> None:
     _credential_cache.pop((did, space), None)
 
 
+# the requester's own PDS answering that it cannot or will not delegate for this
+# space: no spaces support, no covering grant, or a refused request. anything
+# else (network, 5xx) is a real failure and propagates.
+_DELEGATION_REFUSALS = (
+    "MethodNotImplemented",
+    "XRPCNotSupported",
+    "InsufficientScope",
+    "InvalidRequest",
+    "AuthMissing",
+    "failed: 401",
+    "failed: 403",
+    "failed: 404",
+)
+
+
 async def _mint_credential(auth_session: AuthSession, space: str) -> SpaceCredential:
-    delegation_resp = await make_pds_request(
-        auth_session,
-        "GET",
-        "com.atproto.space.getDelegationToken",
-        params={"space": space},
-    )
+    try:
+        delegation_resp = await make_pds_request(
+            auth_session,
+            "GET",
+            "com.atproto.space.getDelegationToken",
+            params={"space": space},
+        )
+    except Exception as exc:
+        if any(marker in str(exc) for marker in _DELEGATION_REFUSALS):
+            raise SpaceAccessError(
+                f"requester's PDS did not delegate for {space}: {exc}"
+            ) from exc
+        raise
     delegation_token = delegation_resp["token"]
 
     authority = parse_space_uri(space).owner_did
@@ -295,16 +318,18 @@ async def _mint_credential(auth_session: AuthSession, space: str) -> SpaceCreden
     )
     if cred_resp.status_code != 200:
         body = cred_resp.text
+        # the error names com.atproto.space.getSpaceCredential declares; any 403
+        # is a refusal whatever the host calls it
         refused_errors = (
-            "AppNotPermitted",
-            "AppNotAuthorized",
-            "NotAMember",
-            "NotAuthorized",
-            "NotPermitted",
+            "SpaceNotFound",
             "SpaceDeleted",
             "UserNotAuthorized",
+            "AppNotAuthorized",
+            "NotAuthorized",
+            "InvalidDelegationToken",
+            "InvalidClientAttestation",
         )
-        if any(error in body for error in refused_errors):
+        if cred_resp.status_code == 403 or any(e in body for e in refused_errors):
             raise SpaceAccessError(f"space authority refused credential: {body}")
         raise Exception(f"getSpaceCredential failed: {cred_resp.status_code} {body}")
     return SpaceCredential(

--- a/backend/src/backend/api/artists.py
+++ b/backend/src/backend/api/artists.py
@@ -582,9 +582,11 @@ async def remove_private_media_member(
 ) -> Response:
     """stop an account from hearing the caller's private tracks.
 
-    the PDS refuses them a new credential at once; one already issued keeps
-    working until it expires, which the protocol leaves at two hours.
+    plyr stops serving them on their next request; the PDS refuses them a new
+    credential at once, and one already issued lasts its host's lifetime.
     """
+    if did == auth_session.did:
+        raise HTTPException(status_code=400, detail="you can't remove yourself")
     space = await ensure_personal_space(auth_session)
     await remove_space_member(auth_session, space=space, did=did)
     await db.execute(

--- a/backend/tests/_internal/test_permissioned_spaces.py
+++ b/backend/tests/_internal/test_permissioned_spaces.py
@@ -544,7 +544,7 @@ async def test_mint_credential_maps_zds_access_refusal(
         AsyncMock(
             return_value=httpx.Response(
                 403,
-                json={"error": "NotPermitted", "message": "requester denied"},
+                json={"error": "UserNotAuthorized", "message": "requester denied"},
             )
         ),
     )
@@ -566,6 +566,89 @@ async def test_mint_credential_maps_zds_access_refusal(
     with pytest.raises(space_client.SpaceAccessError, match="authority refused"):
         await space_client._mint_credential(
             session, "at://did:plc:x/space/fm.plyr.privateMedia/self"
+        )
+
+
+@pytest.mark.parametrize(
+    ("status", "error"),
+    [
+        (400, "SpaceNotFound"),
+        (401, "InvalidDelegationToken"),
+        (403, "WhateverThisHostSays"),
+    ],
+)
+async def test_mint_credential_maps_lexicon_refusals_and_any_403(
+    monkeypatch: pytest.MonkeyPatch, status: int, error: str
+) -> None:
+    monkeypatch.setattr(
+        space_client, "make_pds_request", AsyncMock(return_value={"token": "d"})
+    )
+    monkeypatch.setattr(
+        space_client,
+        "_space_token_request",
+        AsyncMock(return_value=httpx.Response(status, json={"error": error})),
+    )
+    monkeypatch.setattr(
+        space_client, "_space_host_url", AsyncMock(return_value="https://host.test")
+    )
+    monkeypatch.setattr(
+        space_client, "create_space_client_attestation", lambda _audience: None
+    )
+    session = Session(
+        session_id="s",
+        did="did:plc:x",
+        handle="x.test",
+        oauth_session={"pds_url": "https://p"},
+    )
+    with pytest.raises(space_client.SpaceAccessError):
+        await space_client._mint_credential(
+            session, "at://did:plc:owner/space/fm.plyr.privateMedia/self"
+        )
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        'PDS request failed: 404 {"error":"MethodNotImplemented"}',
+        'PDS request failed: 403 {"error":"InsufficientScope"}',
+    ],
+)
+async def test_mint_credential_refuses_cleanly_when_the_readers_pds_cannot_delegate(
+    monkeypatch: pytest.MonkeyPatch, message: str
+) -> None:
+    """a member on a non-spaces PDS, or without the reader grant, is a refusal — not a 500."""
+    monkeypatch.setattr(
+        space_client, "make_pds_request", AsyncMock(side_effect=Exception(message))
+    )
+    session = Session(
+        session_id="s",
+        did="did:plc:member",
+        handle="m.test",
+        oauth_session={"pds_url": "https://p"},
+    )
+    with pytest.raises(space_client.SpaceAccessError, match="did not delegate"):
+        await space_client._mint_credential(
+            session, "at://did:plc:owner/space/fm.plyr.privateMedia/self"
+        )
+
+
+async def test_mint_credential_propagates_real_failures(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        space_client,
+        "make_pds_request",
+        AsyncMock(side_effect=Exception("PDS request failed: 502 <empty body>")),
+    )
+    session = Session(
+        session_id="s",
+        did="did:plc:member",
+        handle="m.test",
+        oauth_session={"pds_url": "https://p"},
+    )
+    with pytest.raises(Exception, match="502"):
+        await space_client._mint_credential(
+            session, "at://did:plc:owner/space/fm.plyr.privateMedia/self"
         )
 
 

--- a/backend/tests/api/test_private_media_members.py
+++ b/backend/tests/api/test_private_media_members.py
@@ -198,3 +198,13 @@ async def test_members_require_auth():
         transport=ASGITransport(app=app), base_url="http://test"
     ) as c:
         assert (await c.get("/artists/me/private-media/members")).status_code == 401
+
+
+async def test_remove_rejects_self(db_session: AsyncSession, artist: Artist, as_owner):
+    with patch("backend.api.artists.remove_space_member", AsyncMock()) as remove:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            r = await c.delete(f"/artists/me/private-media/members/{_ARTIST}")
+    assert r.status_code == 400
+    remove.assert_not_awaited()

--- a/frontend/src/lib/components/portal/PrivateMediaSection.svelte
+++ b/frontend/src/lib/components/portal/PrivateMediaSection.svelte
@@ -64,7 +64,7 @@
 				return;
 			}
 			members = members.filter((m) => m.did !== did);
-			if (who) toast.info(`removed @${who.handle} — anything already playing stops within two hours`);
+			if (who) toast.info(`removed @${who.handle} — they can't play your private tracks anymore`);
 		} catch (_e) {
 			console.error('failed to remove private media member:', _e);
 			toast.error("couldn't remove them");
@@ -89,7 +89,8 @@
 		</div>
 		<p class="lede">
 			only you can play your private tracks. add people here and they can too. they need an
-			account on a PDS that supports private media, and the list is kept on yours.
+			account on a PDS that supports private media and to have signed in to plyr.fm, and the
+			list is kept on your PDS.
 		</p>
 
 		{#if loading}

--- a/loq.toml
+++ b/loq.toml
@@ -355,7 +355,7 @@ max_lines = 689
 
 [[rules]]
 path = "backend/tests/_internal/test_permissioned_spaces.py"
-max_lines = 796
+max_lines = 879
 
 [[rules]]
 path = "frontend/src/routes/u/[[]handle[]]/+page.svelte"
@@ -383,4 +383,8 @@ max_lines = 1091
 
 [[rules]]
 path = "backend/src/backend/api/artists.py"
-max_lines = 597
+max_lines = 599
+
+[[rules]]
+path = "backend/src/backend/_internal/atproto/spaces/client.py"
+max_lines = 523


### PR DESCRIPTION
Findings from reviewing the access-list arc against Proposal 0016 and the `getSpaceCredential` lexicon before release.

<details>
<summary>what changed</summary>

- **Refusal names match the lexicon.** `client.py` listed `AppNotPermitted`, `NotAMember`, `NotPermitted` (not in the lexicon) and missed `SpaceNotFound`, `InvalidDelegationToken`, `InvalidClientAttestation`, which fell through to a bare exception → 500 at `/audio`. Now: the seven declared names, plus any 403, → `SpaceAccessError` → 403.
- **A member whose PDS can't delegate is a refusal.** `getDelegationToken` on a non-spaces PDS (`MethodNotImplemented`/404) or without the reader grant (`InsufficientScope`) raised a bare exception → 500. Now `SpaceAccessError`; real failures (5xx, network) still propagate. Table-tested both ways.
- `DELETE /artists/me/private-media/members/{self}` → 400 app-side instead of a PDS refusal.
- Copy: the removal toast no longer says "stops within two hours" — the protocol's lifetime is a *default*, and plyr re-checks membership on every request so via plyr it's immediate. The section lede also says the member must have signed in to plyr.fm, and that the list is kept on the artist's PDS.

</details>

Not changed, recorded in the design doc (#1897): the credential cache is per-process (other machines keep a removed member's credential up to 50 min — harmless via plyr because membership is re-checked in SQL per request); the members table has no `space`/`relation` column, which is the friction if Habitat-style relations are adopted; `SpaceDeleted` doesn't purge derived rows; nothing consumes `reader` in the frontend yet and there is no "shared with you" surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)