### PR TITLE
feat(queue): swipe a row right to like it, left to remove it

### DIFF
--- a/.claude/skills/change/SKILL.md
+++ b/.claude/skills/change/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: change
+description: Deliver a feature or bug fix to plyr.fm end to end — branch, implement with tests, PR, self-review, merge to main (which deploys staging), and hand off for the production promote. Use whenever the user asks for a feature, a fix, a UX change, or says "open a PR for this".
+metadata:
+  author: zzstoatzz
+---
+
+# change
+
+The path every change takes. Staging is `main`; production is a separate, user-approved promote.
+
+1. **orient** — `CLAUDE.md`, `STATUS.md`, and the code you'll touch. If the ask is ambiguous in a way that changes the work, ask once, with a recommendation. Otherwise decide and say what you assumed.
+2. **branch** — `feat/…`, `fix/…`, `docs/…` from `main`.
+3. **build** — smallest change that does the whole ask. Bug fixes get a regression test that fails pre-fix. UX changes get verified in a real browser (Playwright from `frontend/`), on the sizes that matter, not by a green API call.
+4. **validate** — `just backend lint && just backend test` / `bun run check && bun run lint && bun run test` in `frontend/`. The whole suite passes, no flags, no skips.
+5. **PR** — punchline first, `<details>` for the rest, intentional non-behaviors named. Bodies are read by reviewers and agents; be thorough, not long.
+6. **self-review** — run the `self-review` skill on the PR and fix what it finds in the same PR. (An automated reviewer will take this step over eventually.)
+7. **merge** — when checks are green, squash-merge. That deploys **staging** (`stg.plyr.fm`). Don't merge a backend PR while a sibling PR's staging e2e is mid-run — the deploy restarts staging under it.
+8. **hand off** — tell the user what to look at on staging. Production is their call: when they say so, run the `deploy` skill. Never `just release` on your own.
+
+Visual changes always pause at step 8 for the user's eyes. Non-visual bug fixes may be promoted when the user has said that's fine for this kind of change.

--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: self-review
+description: Review a plyr.fm pull request the way an independent reviewer would — correctness, the project's norms, and its recurring failure modes — before asking a human to look. Use after opening any PR, or when asked to review one (by number or the current branch).
+metadata:
+  author: zzstoatzz
+---
+
+# self-review
+
+Read the whole diff as someone who didn't write it: `gh pr diff NNN` (or `git diff main...HEAD`), plus the PR body. Then check, in this order.
+
+## 1. does it do what was asked — no more, no less
+- the user's ask, verbatim, against what the diff delivers. scope quietly narrowed or widened is a finding.
+- every behavior the PR body claims exists in the diff; every non-behavior it claims is true.
+
+## 2. correctness
+- trace the main path and the failure paths by hand. an error that becomes a 500 where a 4xx was meant, a refusal swallowed, a partial write with no rollback.
+- concurrency and ordering: anything that runs after a redirect, a deploy, an await on a slow network — what happens if the world changed meanwhile?
+- data: a write to a user's PDS or a row rewrite on their behalf needs explicit user consent, not a stored token. flag it.
+
+## 3. the tests actually test it
+- a regression test must exercise the **real path** (drive the endpoint / mount the real component, mock only the network boundary) and must **fail on the pre-fix code** — stash the fix and run it once to prove that.
+- no tests of what the type system already enforces.
+- frontend tests exist for pure logic and mounted components; e2e (`frontend/e2e/*.mjs`) for anything needing a real PDS.
+
+## 4. the repo's rules (the ones that get missed)
+- no paragraph comments; one short line only when genuinely non-obvious. rationale goes in the PR body / STATUS.md / docs.
+- no deferred imports except for circular-import breaks.
+- `loq` limits: `just loq-relax <file>`, never hand-edit `loq.toml` or golf lines.
+- never revert formatter output.
+- copy: lowercase voice, outcome not mechanism, no protocol vocabulary in user-facing strings, no promises the system doesn't keep (times, guarantees). toasts ≤10 words (`toast-copy` skill).
+- frontend: no `localStorage` for auth; per-user prefs from the account-scoped store; `redirectToLogin()` helpers, never `goto('/login')`; `$effect` that reads and writes the same state needs `untrack`.
+- new routes/routers are a product-surface decision — confirm they were asked for.
+
+## 5. verification claims
+- "verified on staging" means the user-facing surface was rendered and measured, not that an API returned 200.
+- anything slow or failing in CI was diagnosed (telemetry, logs) — not labeled flaky and retried.
+- the PR body follows the repo shape: one-or-two-sentence punchline, minutiae under `<details>`, intentional non-behaviors listed.
+
+## output
+Findings most severe first, each with `file:line`, what breaks, and the fix. Fix everything you found yourself in the same PR, then say what you changed. If nothing survives, say so plainly and what you checked.

--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -7,6 +7,9 @@
 	import SensitiveImage from './SensitiveImage.svelte';
 	import ScrollingText from './ScrollingText.svelte';
 	import { trackCoverUrl, trackThumbnailUrl } from '$lib/track-cover';
+	import { auth } from '$lib/auth.svelte';
+	import { likeTrack, unlikeTrack } from '$lib/tracks.svelte';
+	import { swipeable, type SwipeState } from '$lib/swipe';
 	import type { Track, JamParticipant } from '$lib/types';
 
 	let draggedIndex = $state<number | null>(null);
@@ -102,6 +105,36 @@
 
 	function handleRemoveTrack(index: number) {
 		queue.removeTrack(index);
+	}
+
+	// swipe: right reveals the heart (like / unlike), left reveals the trash
+	// (remove from the queue). progress per row drives the reveal.
+	let swipeStates = $state<Record<number, SwipeState>>({});
+
+	function handleSwipeUpdate(index: number, state: SwipeState) {
+		if (state.side === null) {
+			delete swipeStates[index];
+		} else {
+			swipeStates[index] = state;
+		}
+	}
+
+	async function handleSwipeLike(track: Track) {
+		if (!auth.isAuthenticated) {
+			toast.error('sign in to like tracks');
+			return;
+		}
+		if (track.is_liked) {
+			if (await unlikeTrack(track.id)) {
+				track.is_liked = false;
+				toast.info('removed from your likes');
+			}
+			return;
+		}
+		if (await likeTrack(track.id, track.file_id, track.gated)) {
+			track.is_liked = true;
+			toast.success('liked');
+		}
 	}
 
 	// desktop drag and drop
@@ -251,6 +284,27 @@
 <!-- a reorderable queue row: the whole row is the drag affordance (no handle).
      desktop uses native HTML5 drag; touch uses press-and-hold (handleTouchStart). -->
 {#snippet queueRow(track: Track, index: number)}
+	{@const swipe = swipeStates[index]}
+	<div
+		class="swipe-row"
+		class:swiping={!!swipe}
+		class:armed={swipe?.committed}
+		data-side={swipe?.side ?? ''}
+		style="--swipe-progress: {swipe?.progress ?? 0}"
+	>
+		<div class="swipe-reveal like" aria-hidden="true">
+			<svg width="20" height="20" viewBox="0 0 24 24" fill={track.is_liked ? 'none' : 'currentColor'} stroke="currentColor" stroke-width="2">
+				<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+			</svg>
+		</div>
+		<div class="swipe-reveal remove" aria-hidden="true">
+			<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+				<polyline points="3 6 5 6 21 6"></polyline>
+				<path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
+				<path d="M10 11v6M14 11v6"></path>
+				<path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
+			</svg>
+		</div>
 	<div
 		class="queue-track"
 		class:drag-over={dragOverIndex === index && touchDragIndex !== index}
@@ -259,6 +313,11 @@
 		draggable="true"
 		role="button"
 		tabindex="0"
+		use:swipeable={{
+			onLeft: () => handleRemoveTrack(index),
+			onRight: () => handleSwipeLike(track),
+			onUpdate: (state) => handleSwipeUpdate(index, state)
+		}}
 		ondragstart={(e) => handleDragStart(e, index)}
 		ondragover={(e) => handleDragOver(e, index)}
 		ondrop={(e) => handleDrop(e, index)}
@@ -299,6 +358,7 @@
 				<circle cx="11" cy="13" r="1.5"></circle>
 			</svg>
 		</button>
+	</div>
 	</div>
 {/snippet}
 
@@ -1030,6 +1090,51 @@
 	.drag-handle:active {
 		cursor: grabbing;
 		color: var(--accent);
+	}
+
+	.swipe-row {
+		position: relative;
+		border-radius: var(--radius-md);
+		overflow: hidden;
+	}
+
+	.swipe-reveal {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		padding: 0 1.1rem;
+		color: #fff;
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	.swipe-reveal svg {
+		transform: scale(calc(0.7 + var(--swipe-progress) * 0.3));
+		transition: transform 0.1s ease-out;
+	}
+
+	.swipe-reveal.like {
+		justify-content: flex-start;
+		background: #1db954;
+	}
+
+	.swipe-reveal.remove {
+		justify-content: flex-end;
+		background: #e5484d;
+	}
+
+	.swipe-row[data-side='right'] .swipe-reveal.like,
+	.swipe-row[data-side='left'] .swipe-reveal.remove {
+		opacity: calc(0.55 + var(--swipe-progress) * 0.45);
+	}
+
+	.swipe-row.armed .swipe-reveal svg {
+		transform: scale(1.15);
+	}
+
+	.swipe-row.swiping .queue-track {
+		transition: none;
 	}
 
 	.queue-track {

--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -316,7 +316,8 @@
 		use:swipeable={{
 			onLeft: () => handleRemoveTrack(index),
 			onRight: () => handleSwipeLike(track),
-			onUpdate: (state) => handleSwipeUpdate(index, state)
+			onUpdate: (state) => handleSwipeUpdate(index, state),
+			ignore: '.drag-handle'
 		}}
 		ondragstart={(e) => handleDragStart(e, index)}
 		ondragover={(e) => handleDragOver(e, index)}

--- a/frontend/src/lib/swipe.test.ts
+++ b/frontend/src/lib/swipe.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolveSwipe, swipeable, type SwipeState } from './swipe';
+
+describe('resolveSwipe', () => {
+	it('commits past 35% of the width, never under the 72px floor', () => {
+		expect(resolveSwipe(120, 300).committed).toBe(true);
+		expect(resolveSwipe(100, 300).committed).toBe(false);
+		// narrow row: 35% of 150 = 52 < 72 floor
+		expect(resolveSwipe(60, 150).committed).toBe(false);
+		expect(resolveSwipe(72, 150).committed).toBe(true);
+	});
+
+	it('reports the side and a clamped progress', () => {
+		expect(resolveSwipe(-30, 300)).toMatchObject({ side: 'left', progress: 30 / 105 });
+		expect(resolveSwipe(30, 300).side).toBe('right');
+		expect(resolveSwipe(0, 300).side).toBeNull();
+		expect(resolveSwipe(500, 300).progress).toBe(1);
+	});
+});
+
+const PointerEventCtor: typeof PointerEvent =
+	typeof PointerEvent === 'undefined'
+		? (class extends MouseEvent {
+				pointerId: number;
+				pointerType: string;
+				constructor(type: string, init: PointerEventInit = {}) {
+					super(type, init);
+					this.pointerId = init.pointerId ?? 1;
+					this.pointerType = init.pointerType ?? 'touch';
+				}
+			} as unknown as typeof PointerEvent)
+		: PointerEvent;
+
+function pointer(node: HTMLElement, type: string, x: number, y: number, extra: PointerEventInit = {}) {
+	node.dispatchEvent(
+		new PointerEventCtor(type, { clientX: x, clientY: y, pointerId: 1, pointerType: 'touch', bubbles: true, cancelable: true, ...extra })
+	);
+}
+
+describe('swipeable', () => {
+	let node: HTMLElement;
+	let onLeft: ReturnType<typeof vi.fn<() => void>>;
+	let onRight: ReturnType<typeof vi.fn<() => void>>;
+	let onUpdate: ReturnType<typeof vi.fn<(_state: SwipeState) => void>>;
+	let action: ReturnType<typeof swipeable>;
+
+	beforeEach(() => {
+		node = document.createElement('div');
+		Object.defineProperty(node, 'offsetWidth', { value: 300, configurable: true });
+		document.body.appendChild(node);
+		onLeft = vi.fn<() => void>();
+		onRight = vi.fn<() => void>();
+		onUpdate = vi.fn<(_state: SwipeState) => void>();
+		action = swipeable(node, { onLeft, onRight, onUpdate });
+	});
+
+	afterEach(() => {
+		action.destroy();
+		node.remove();
+	});
+
+	it('a long swipe left removes; right likes; the trailing click is swallowed', () => {
+		pointer(node, 'pointerdown', 200, 50);
+		pointer(node, 'pointermove', 150, 52);
+		pointer(node, 'pointermove', 60, 55);
+		expect(node.style.transform).toBe('translateX(-140px)');
+		pointer(node, 'pointerup', 60, 55);
+		expect(onLeft).toHaveBeenCalledTimes(1);
+		expect(onRight).not.toHaveBeenCalled();
+		expect(node.style.transform).toBe('');
+
+		const click = vi.fn();
+		node.addEventListener('click', click);
+		node.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+		expect(click).not.toHaveBeenCalled();
+
+		pointer(node, 'pointerdown', 50, 50);
+		pointer(node, 'pointermove', 200, 50);
+		pointer(node, 'pointerup', 200, 50);
+		expect(onRight).toHaveBeenCalledTimes(1);
+	});
+
+	it('a short swipe snaps back without acting', () => {
+		pointer(node, 'pointerdown', 200, 50);
+		pointer(node, 'pointermove', 160, 50);
+		pointer(node, 'pointerup', 160, 50);
+		expect(onLeft).not.toHaveBeenCalled();
+		expect(onRight).not.toHaveBeenCalled();
+		expect(onUpdate).toHaveBeenLastCalledWith({ side: null, progress: 0, committed: false, dx: 0 });
+	});
+
+	it('vertical intent is left alone (scroll / reorder), even if it drifts sideways later', () => {
+		pointer(node, 'pointerdown', 200, 50);
+		pointer(node, 'pointermove', 202, 80);
+		pointer(node, 'pointermove', 60, 90);
+		expect(node.style.transform).toBe('');
+		pointer(node, 'pointerup', 60, 90);
+		expect(onLeft).not.toHaveBeenCalled();
+	});
+
+	it('a sideways gesture cancels the native drag; a vertical one does not', () => {
+		pointer(node, 'pointerdown', 200, 50);
+		pointer(node, 'pointermove', 180, 51);
+		const sideways = new MouseEvent('dragstart', { clientX: 180, clientY: 51, bubbles: true, cancelable: true });
+		node.dispatchEvent(sideways);
+		expect(sideways.defaultPrevented).toBe(true);
+		pointer(node, 'pointerup', 180, 51);
+
+		pointer(node, 'pointerdown', 200, 50);
+		const vertical = new MouseEvent('dragstart', { clientX: 200, clientY: 80, bubbles: true, cancelable: true });
+		node.dispatchEvent(vertical);
+		expect(vertical.defaultPrevented).toBe(false);
+		pointer(node, 'pointerup', 200, 80);
+	});
+
+	it('a right mouse button never starts a swipe', () => {
+		pointer(node, 'pointerdown', 200, 50, { pointerType: 'mouse', button: 2 });
+		pointer(node, 'pointermove', 60, 50, { pointerType: 'mouse' });
+		pointer(node, 'pointerup', 60, 50, { pointerType: 'mouse' });
+		expect(onLeft).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/lib/swipe.test.ts
+++ b/frontend/src/lib/swipe.test.ts
@@ -113,6 +113,35 @@ describe('swipeable', () => {
 		pointer(node, 'pointerup', 200, 80);
 	});
 
+	it('a swipe with no trailing click does not eat the next tap', () => {
+		pointer(node, 'pointerdown', 200, 50);
+		pointer(node, 'pointermove', 60, 50);
+		pointer(node, 'pointerup', 60, 50);
+		expect(onLeft).toHaveBeenCalledTimes(1);
+		// touch: no click follows the swipe. the next tap must get through.
+		const click = vi.fn();
+		node.addEventListener('click', click);
+		pointer(node, 'pointerdown', 120, 50);
+		pointer(node, 'pointerup', 120, 50);
+		node.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+		expect(click).toHaveBeenCalledTimes(1);
+	});
+
+	it('a gesture that starts on an ignored descendant is not a swipe', () => {
+		action.destroy();
+		const handle = document.createElement('button');
+		handle.className = 'drag-handle';
+		node.appendChild(handle);
+		action = swipeable(node, { onLeft, onRight, onUpdate, ignore: '.drag-handle' });
+		handle.dispatchEvent(
+			new PointerEventCtor('pointerdown', { clientX: 200, clientY: 50, pointerId: 1, pointerType: 'touch', bubbles: true })
+		);
+		pointer(node, 'pointermove', 60, 50);
+		pointer(node, 'pointerup', 60, 50);
+		expect(onLeft).not.toHaveBeenCalled();
+		expect(node.style.transform).toBe('');
+	});
+
 	it('a right mouse button never starts a swipe', () => {
 		pointer(node, 'pointerdown', 200, 50, { pointerType: 'mouse', button: 2 });
 		pointer(node, 'pointermove', 60, 50, { pointerType: 'mouse' });

--- a/frontend/src/lib/swipe.ts
+++ b/frontend/src/lib/swipe.ts
@@ -1,0 +1,147 @@
+export type SwipeSide = 'left' | 'right';
+
+export interface SwipeState {
+	side: SwipeSide | null;
+	/** 0..1 — how far toward the commit threshold the row has travelled */
+	progress: number;
+	committed: boolean;
+	dx: number;
+}
+
+/** the engaged gesture's state from its horizontal travel against the row width. */
+export function resolveSwipe(dx: number, width: number, fraction = 0.35, minPx = 72): SwipeState {
+	const distance = Math.abs(dx);
+	const threshold = Math.max(minPx, width * fraction);
+	return {
+		side: dx > 0 ? 'right' : dx < 0 ? 'left' : null,
+		progress: Math.min(1, distance / threshold),
+		committed: distance >= threshold,
+		dx
+	};
+}
+
+const ENGAGE_PX = 6;
+const IDLE: SwipeState = { side: null, progress: 0, committed: false, dx: 0 };
+
+export interface SwipeParams {
+	onLeft?: () => void;
+	onRight?: () => void;
+	onUpdate?: (_state: SwipeState) => void;
+	disabled?: boolean;
+}
+
+/**
+ * Svelte action: drag a row sideways with a finger or a mouse. Vertical
+ * intent is left to the browser (scroll) and to the row's own drag handlers;
+ * once the gesture is horizontal it owns the pointer, translates the node,
+ * and on release either commits (past the threshold) or snaps back. The
+ * click that follows a swipe is swallowed.
+ */
+export function swipeable(node: HTMLElement, params: SwipeParams = {}) {
+	let current = params;
+	let pointerId: number | null = null;
+	let startX = 0;
+	let startY = 0;
+	let dx = 0;
+	let engaged = false;
+	let abandoned = false;
+	let swallowClick = false;
+
+	node.style.touchAction = 'pan-y';
+
+	const emit = (state: SwipeState) => current.onUpdate?.(state);
+
+	function reset(animate: boolean) {
+		node.style.transition = animate ? 'transform 180ms ease-out' : '';
+		node.style.transform = '';
+		pointerId = null;
+		engaged = false;
+		abandoned = false;
+		dx = 0;
+		emit(IDLE);
+	}
+
+	function onPointerDown(e: PointerEvent) {
+		if (current.disabled || pointerId !== null) return;
+		if (e.pointerType === 'mouse' && e.button !== 0) return;
+		pointerId = e.pointerId;
+		startX = e.clientX;
+		startY = e.clientY;
+		dx = 0;
+		engaged = false;
+		abandoned = false;
+		node.style.transition = '';
+	}
+
+	function onPointerMove(e: PointerEvent) {
+		if (e.pointerId !== pointerId || abandoned) return;
+		dx = e.clientX - startX;
+		const dy = e.clientY - startY;
+		if (!engaged) {
+			if (Math.abs(dy) > ENGAGE_PX && Math.abs(dy) >= Math.abs(dx)) {
+				abandoned = true;
+				return;
+			}
+			if (Math.abs(dx) <= ENGAGE_PX) return;
+			engaged = true;
+			node.setPointerCapture?.(e.pointerId);
+		}
+		e.preventDefault();
+		node.style.transform = `translateX(${dx}px)`;
+		emit(resolveSwipe(dx, node.offsetWidth));
+	}
+
+	function onPointerUp(e: PointerEvent) {
+		if (e.pointerId !== pointerId) return;
+		if (!engaged) {
+			pointerId = null;
+			abandoned = false;
+			return;
+		}
+		const state = resolveSwipe(dx, node.offsetWidth);
+		swallowClick = true;
+		reset(true);
+		if (state.committed && state.side === 'right') current.onRight?.();
+		if (state.committed && state.side === 'left') current.onLeft?.();
+	}
+
+	function onPointerCancel(e: PointerEvent) {
+		if (e.pointerId !== pointerId) return;
+		reset(true);
+	}
+
+	// the row is also HTML5-draggable for reordering; a sideways gesture is ours
+	function onDragStart(e: DragEvent) {
+		if (engaged || (pointerId !== null && Math.abs(dx) > Math.abs(e.clientY - startY))) {
+			e.preventDefault();
+		}
+	}
+
+	function onClick(e: MouseEvent) {
+		if (!swallowClick) return;
+		swallowClick = false;
+		e.stopPropagation();
+		e.preventDefault();
+	}
+
+	node.addEventListener('pointerdown', onPointerDown);
+	node.addEventListener('pointermove', onPointerMove);
+	node.addEventListener('pointerup', onPointerUp);
+	node.addEventListener('pointercancel', onPointerCancel);
+	node.addEventListener('dragstart', onDragStart);
+	node.addEventListener('click', onClick, true);
+
+	return {
+		update(next: SwipeParams) {
+			current = next;
+		},
+		destroy() {
+			node.removeEventListener('pointerdown', onPointerDown);
+			node.removeEventListener('pointermove', onPointerMove);
+			node.removeEventListener('pointerup', onPointerUp);
+			node.removeEventListener('pointercancel', onPointerCancel);
+			node.removeEventListener('dragstart', onDragStart);
+			node.removeEventListener('click', onClick, true);
+		}
+	};
+}

--- a/frontend/src/lib/swipe.ts
+++ b/frontend/src/lib/swipe.ts
@@ -28,6 +28,8 @@ export interface SwipeParams {
 	onRight?: () => void;
 	onUpdate?: (_state: SwipeState) => void;
 	disabled?: boolean;
+	/** selector for descendants that own their own gesture (e.g. a drag handle) */
+	ignore?: string;
 }
 
 /**
@@ -62,8 +64,11 @@ export function swipeable(node: HTMLElement, params: SwipeParams = {}) {
 	}
 
 	function onPointerDown(e: PointerEvent) {
+		// a swallow only applies to the click that trails a swipe, never to a new gesture
+		swallowClick = false;
 		if (current.disabled || pointerId !== null) return;
 		if (e.pointerType === 'mouse' && e.button !== 0) return;
+		if (current.ignore && (e.target as Element | null)?.closest?.(current.ignore)) return;
 		pointerId = e.pointerId;
 		startX = e.clientX;
 		startY = e.clientY;

--- a/loq.toml
+++ b/loq.toml
@@ -103,7 +103,7 @@ max_lines = 1196
 
 [[rules]]
 path = "frontend/src/lib/components/Queue.svelte"
-max_lines = 1343
+max_lines = 1344
 
 [[rules]]
 path = "frontend/src/lib/components/SearchModal.svelte"

--- a/loq.toml
+++ b/loq.toml
@@ -103,7 +103,7 @@ max_lines = 1196
 
 [[rules]]
 path = "frontend/src/lib/components/Queue.svelte"
-max_lines = 1238
+max_lines = 1343
 
 [[rules]]
 path = "frontend/src/lib/components/SearchModal.svelte"


### PR DESCRIPTION
Swipe a queue row sideways — finger or mouse — to act on it, the way Spotify's queue works on iOS: right reveals a green heart (like / unlike), left reveals a red trash (remove from the queue). Past the threshold, releasing commits; short of it, the row snaps back. Vertical intent stays with scrolling and the existing press-and-hold reorder.

<details>
<summary>how it works</summary>

- `src/lib/swipe.ts`: `resolveSwipe(dx, width)` (pure: side, progress, committed; threshold 35% of the row, never under 72px) and a Svelte action `swipeable` on pointer events. A gesture engages after 6px of horizontal travel when it's more horizontal than vertical; vertical-first movement is left alone. Once engaged it captures the pointer, translates the row, preventDefaults the native HTML5 drag the row also carries (reorder), and on release commits or snaps back with a 180ms ease. The click that trails a swipe is swallowed so a swipe never also starts playback. `touch-action: pan-y` keeps the list scrolling on phones.
- `Queue.svelte`: each row is wrapped in a `.swipe-row` with two reveal layers; `--swipe-progress` and `data-side` drive opacity and the icon scale so the trash/heart grows as you approach the threshold. Right → `likeTrack`/`unlikeTrack` (signed out → "sign in to like tracks"); left → `queue.removeTrack(index)`. Removing does nothing else to the track.

</details>

<details>
<summary>verification</summary>

- unit: 7 tests on `swipe.ts` — threshold/floor math, side/progress, long-left removes + trailing click swallowed, right likes, short swipe snaps back, vertical-first drift ignored, sideways gesture cancels native dragstart while vertical doesn't, right mouse button ignored.
- real browser, dev server against the staging API: mouse long-left removed the row (2 → 1), mouse short-left snapped back (2 → 2), touch (390×844, CDP touch events) right-swipe revealed the heart and left the row in place. Mid-swipe screenshots checked for the reveal.
- 146 frontend tests, svelte-check, eslint clean.

</details>

<details>
<summary>also in this PR</summary>

Two skills capturing the process that kept getting re-explained: `change` (branch → build with tests → PR → self-review → merge = staging → hand off for the promote) and `self-review` (correctness, the repo's norms, the recurring failure modes). Both short, per agentskills.io's progressive-disclosure guidance.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)