### PR TITLE
fix(queue): rows no longer clip on phones; the swipe has weight

### DIFF
--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -317,6 +317,7 @@
 			onLeft: () => handleRemoveTrack(index),
 			onRight: () => handleSwipeLike(track),
 			onUpdate: (state) => handleSwipeUpdate(index, state),
+			dismissLeft: true,
 			ignore: '.drag-handle'
 		}}
 		ondragstart={(e) => handleDragStart(e, index)}
@@ -1095,6 +1096,7 @@
 
 	.swipe-row {
 		position: relative;
+		flex-shrink: 0;
 		border-radius: var(--radius-md);
 		overflow: hidden;
 	}
@@ -1112,7 +1114,8 @@
 
 	.swipe-reveal svg {
 		transform: scale(calc(0.7 + var(--swipe-progress) * 0.3));
-		transition: transform 0.1s ease-out;
+		opacity: calc(0.6 + var(--swipe-progress) * 0.4);
+		transition: transform 0.12s ease-out, opacity 0.12s ease-out;
 	}
 
 	.swipe-reveal.like {
@@ -1130,8 +1133,17 @@
 		opacity: calc(0.55 + var(--swipe-progress) * 0.45);
 	}
 
+	.swipe-row.armed .swipe-reveal {
+		filter: brightness(1.12);
+	}
+
 	.swipe-row.armed .swipe-reveal svg {
-		transform: scale(1.15);
+		transform: scale(1.2);
+		transition: transform 0.16s cubic-bezier(0.2, 0.9, 0.3, 1.3);
+	}
+
+	.swipe-row.swiping .queue-track {
+		box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
 	}
 
 	.swipe-row.swiping .queue-track {

--- a/frontend/src/lib/swipe.test.ts
+++ b/frontend/src/lib/swipe.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { resolveSwipe, swipeable, type SwipeState } from './swipe';
+import { displacement, resolveSwipe, swipeable, type SwipeState } from './swipe';
 
 describe('resolveSwipe', () => {
 	it('commits past 35% of the width, never under the 72px floor', () => {
@@ -37,6 +37,18 @@ function pointer(node: HTMLElement, type: string, x: number, y: number, extra: P
 	);
 }
 
+describe('displacement', () => {
+	it('follows the finger to the threshold, then resists', () => {
+		expect(displacement(50, 300)).toBe(50);
+		expect(displacement(-105, 300)).toBe(-105);
+		const past = displacement(205, 300);
+		expect(past).toBeGreaterThan(105);
+		expect(past).toBeLessThan(145);
+		// resistance grows with overshoot
+		expect(displacement(405, 300) - displacement(305, 300)).toBeLessThan(displacement(305, 300) - displacement(205, 300));
+	});
+});
+
 describe('swipeable', () => {
 	let node: HTMLElement;
 	let onLeft: ReturnType<typeof vi.fn<() => void>>;
@@ -63,7 +75,7 @@ describe('swipeable', () => {
 		pointer(node, 'pointerdown', 200, 50);
 		pointer(node, 'pointermove', 150, 52);
 		pointer(node, 'pointermove', 60, 55);
-		expect(node.style.transform).toBe('translateX(-140px)');
+		expect(node.style.transform).toBe(`translateX(${displacement(-140, 300)}px)`);
 		pointer(node, 'pointerup', 60, 55);
 		expect(onLeft).toHaveBeenCalledTimes(1);
 		expect(onRight).not.toHaveBeenCalled();
@@ -140,6 +152,37 @@ describe('swipeable', () => {
 		pointer(node, 'pointerup', 60, 50);
 		expect(onLeft).not.toHaveBeenCalled();
 		expect(node.style.transform).toBe('');
+	});
+
+	it('with dismissLeft, a committed left swipe slides out and collapses before removing', () => {
+		vi.useFakeTimers();
+		action.destroy();
+		const wrapper = document.createElement('div');
+		Object.defineProperty(wrapper, 'getBoundingClientRect', { value: () => ({ height: 64 }) });
+		document.body.appendChild(wrapper);
+		wrapper.appendChild(node);
+		action = swipeable(node, { onLeft, onUpdate, dismissLeft: true });
+		pointer(node, 'pointerdown', 200, 50);
+		pointer(node, 'pointermove', 40, 50);
+		pointer(node, 'pointerup', 40, 50);
+		expect(node.style.transform).toBe('translateX(-316px)');
+		expect(onLeft).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(180);
+		expect(wrapper.style.height).toBe('64px');
+		vi.advanceTimersByTime(200);
+		expect(onLeft).toHaveBeenCalledTimes(1);
+		expect(onUpdate).toHaveBeenLastCalledWith({ side: null, progress: 0, committed: false, dx: 0 });
+		vi.useRealTimers();
+		wrapper.remove();
+	});
+
+	it('crossing the threshold arms once and emits committed', () => {
+		pointer(node, 'pointerdown', 200, 50);
+		pointer(node, 'pointermove', 120, 50);
+		expect(onUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ committed: false }));
+		pointer(node, 'pointermove', 80, 50);
+		expect(onUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ committed: true, side: 'left' }));
+		pointer(node, 'pointerup', 80, 50);
 	});
 
 	it('a right mouse button never starts a swipe', () => {

--- a/frontend/src/lib/swipe.ts
+++ b/frontend/src/lib/swipe.ts
@@ -2,7 +2,7 @@ export type SwipeSide = 'left' | 'right';
 
 export interface SwipeState {
 	side: SwipeSide | null;
-	/** 0..1 — how far toward the commit threshold the row has travelled */
+	/** 0..1 — how far toward the commit threshold the gesture has travelled */
 	progress: number;
 	committed: boolean;
 	dx: number;
@@ -20,13 +20,31 @@ export function resolveSwipe(dx: number, width: number, fraction = 0.35, minPx =
 	};
 }
 
+/**
+ * where the row actually sits for a given finger travel: one-to-one up to
+ * the threshold, then rubber-banding so the row feels like it has mass
+ * instead of skating off the screen.
+ */
+export function displacement(dx: number, width: number, fraction = 0.35, minPx = 72): number {
+	const threshold = Math.max(minPx, width * fraction);
+	const distance = Math.abs(dx);
+	if (distance <= threshold) return dx;
+	const overshoot = distance - threshold;
+	const damped = threshold + overshoot * (0.3 / (1 + overshoot / width));
+	return Math.sign(dx) * damped;
+}
+
 const ENGAGE_PX = 6;
+const SNAP_BACK = 'transform 260ms cubic-bezier(0.2, 0.9, 0.3, 1.1)';
+const SLIDE_OUT = 'transform 180ms cubic-bezier(0.4, 0, 1, 1)';
 const IDLE: SwipeState = { side: null, progress: 0, committed: false, dx: 0 };
 
 export interface SwipeParams {
 	onLeft?: () => void;
 	onRight?: () => void;
 	onUpdate?: (_state: SwipeState) => void;
+	/** a committed left swipe slides the row out and collapses its wrapper before onLeft */
+	dismissLeft?: boolean;
 	disabled?: boolean;
 	/** selector for descendants that own their own gesture (e.g. a drag handle) */
 	ignore?: string;
@@ -35,9 +53,9 @@ export interface SwipeParams {
 /**
  * Svelte action: drag a row sideways with a finger or a mouse. Vertical
  * intent is left to the browser (scroll) and to the row's own drag handlers;
- * once the gesture is horizontal it owns the pointer, translates the node,
- * and on release either commits (past the threshold) or snaps back. The
- * click that follows a swipe is swallowed.
+ * once the gesture is horizontal it owns the pointer, moves the node with
+ * resistance past the threshold, and on release either commits or springs
+ * back. The click that follows a swipe is swallowed.
  */
 export function swipeable(node: HTMLElement, params: SwipeParams = {}) {
 	let current = params;
@@ -47,26 +65,56 @@ export function swipeable(node: HTMLElement, params: SwipeParams = {}) {
 	let dx = 0;
 	let engaged = false;
 	let abandoned = false;
+	let armed = false;
 	let swallowClick = false;
+	let settling = false;
 
 	node.style.touchAction = 'pan-y';
 
 	const emit = (state: SwipeState) => current.onUpdate?.(state);
 
-	function reset(animate: boolean) {
-		node.style.transition = animate ? 'transform 180ms ease-out' : '';
+	function reset(transition: string | null) {
+		node.style.transition = transition ?? '';
 		node.style.transform = '';
 		pointerId = null;
 		engaged = false;
 		abandoned = false;
+		armed = false;
 		dx = 0;
 		emit(IDLE);
+	}
+
+	function dismiss(then: () => void) {
+		settling = true;
+		const wrapper = node.parentElement;
+		const height = wrapper?.getBoundingClientRect().height ?? 0;
+		node.style.transition = SLIDE_OUT;
+		node.style.transform = `translateX(${-node.offsetWidth - 16}px)`;
+		const collapse = () => {
+			if (wrapper && height) {
+				wrapper.style.height = `${height}px`;
+				wrapper.style.overflow = 'hidden';
+				wrapper.style.transition = 'height 160ms ease-out, margin 160ms ease-out';
+				requestAnimationFrame(() => {
+					wrapper.style.height = '0px';
+					wrapper.style.marginBottom = '-0.5rem';
+				});
+				setTimeout(finish, 170);
+			} else {
+				finish();
+			}
+		};
+		const finish = () => {
+			settling = false;
+			then();
+		};
+		setTimeout(collapse, 180);
 	}
 
 	function onPointerDown(e: PointerEvent) {
 		// a swallow only applies to the click that trails a swipe, never to a new gesture
 		swallowClick = false;
-		if (current.disabled || pointerId !== null) return;
+		if (current.disabled || settling || pointerId !== null) return;
 		if (e.pointerType === 'mouse' && e.button !== 0) return;
 		if (current.ignore && (e.target as Element | null)?.closest?.(current.ignore)) return;
 		pointerId = e.pointerId;
@@ -75,6 +123,7 @@ export function swipeable(node: HTMLElement, params: SwipeParams = {}) {
 		dx = 0;
 		engaged = false;
 		abandoned = false;
+		armed = false;
 		node.style.transition = '';
 	}
 
@@ -92,8 +141,14 @@ export function swipeable(node: HTMLElement, params: SwipeParams = {}) {
 			node.setPointerCapture?.(e.pointerId);
 		}
 		e.preventDefault();
-		node.style.transform = `translateX(${dx}px)`;
-		emit(resolveSwipe(dx, node.offsetWidth));
+		const width = node.offsetWidth;
+		node.style.transform = `translateX(${displacement(dx, width)}px)`;
+		const state = resolveSwipe(dx, width);
+		if (state.committed !== armed) {
+			armed = state.committed;
+			if (armed) navigator.vibrate?.(8);
+		}
+		emit(state);
 	}
 
 	function onPointerUp(e: PointerEvent) {
@@ -105,14 +160,23 @@ export function swipeable(node: HTMLElement, params: SwipeParams = {}) {
 		}
 		const state = resolveSwipe(dx, node.offsetWidth);
 		swallowClick = true;
-		reset(true);
+		if (state.committed && state.side === 'left' && current.dismissLeft) {
+			pointerId = null;
+			engaged = false;
+			dismiss(() => {
+				emit(IDLE);
+				current.onLeft?.();
+			});
+			return;
+		}
+		reset(SNAP_BACK);
 		if (state.committed && state.side === 'right') current.onRight?.();
 		if (state.committed && state.side === 'left') current.onLeft?.();
 	}
 
 	function onPointerCancel(e: PointerEvent) {
 		if (e.pointerId !== pointerId) return;
-		reset(true);
+		reset(SNAP_BACK);
 	}
 
 	// the row is also HTML5-draggable for reordering; a sideways gesture is ours

--- a/loq.toml
+++ b/loq.toml
@@ -103,7 +103,7 @@ max_lines = 1196
 
 [[rules]]
 path = "frontend/src/lib/components/Queue.svelte"
-max_lines = 1344
+max_lines = 1356
 
 [[rules]]
 path = "frontend/src/lib/components/SearchModal.svelte"


### PR DESCRIPTION
Two things from nate's phone after #1907 landed on staging.

**Clipped rows** — every up-next row was cut off at the subtitle. `.queue-tracks` is a flex column; the new `.swipe-row` wrapper carries `overflow: hidden`, which drops a flex item's implicit `min-height: auto` and lets it shrink below its content. The old rows never shrank because their overflow was visible. Fix: `flex-shrink: 0` on the wrapper. Measured on a 390×844 viewport: wrapper 77px = row 77px, content 75px.

**The swipe felt cheap.** Changes, all in `swipe.ts` + a few CSS lines:
- `displacement()` — the row follows the finger one-to-one to the threshold, then rubber-bands (damping that increases with overshoot), so it has mass instead of skating off.
- snap-back is a spring: 260ms `cubic-bezier(0.2, 0.9, 0.3, 1.1)`.
- `dismissLeft`: a committed remove slides the row fully out (180ms), then collapses its slot's height and the list gap (160ms) before `onLeft` runs — the list closes up rather than jumping.
- crossing the threshold arms once: the icon pops (spring-ish scale), the reveal brightens, `navigator.vibrate(8)` where the platform offers it. The row lifts with a shadow while dragging.

<details>
<summary>verification</summary>

- 12 unit tests on `swipe.ts` (3 new: resistance curve, arm-once/committed emit, dismiss sequence with fake timers — slide, collapse, then `onLeft`).
- real browser against the staging API, desktop and phone viewport: past-threshold transform is held at −141/−155px on a 300–390px row (resistance), `.armed` present, release removes (3→2, 4→3), no leftover collapsed wrapper. Screenshots of the armed frame checked.
- svelte-check, eslint, 151 frontend tests.

</details>

Not in this PR: the duplicate toasts in the screenshot were multiple swipes stacking correctly (nate confirmed); nothing to change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)