### PR TITLE
fix(queue): the empty-state cta closes the queue it lives under, and looks tappable

### DIFF
--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -2,6 +2,7 @@
 	import { queue } from '$lib/queue.svelte';
 	import { player } from '$lib/player.svelte';
 	import { goToIndex } from '$lib/playback.svelte';
+	import { goto } from '$app/navigation';
 	import { jam } from '$lib/jam.svelte';
 	import { toast } from '$lib/toast.svelte';
 	import SensitiveImage from './SensitiveImage.svelte';
@@ -12,6 +13,10 @@
 	import { swipeable, type SwipeState } from '$lib/swipe';
 	import { HINTS, hintSeen, markHintSeen } from '$lib/hints.svelte';
 	import type { Track, JamParticipant } from '$lib/types';
+
+	// the queue can cover the viewport (mobile); whoever renders it closes it
+	// when the empty-state CTA navigates, so the destination is actually seen
+	let { onNavigate }: { onNavigate?: () => void } = $props();
 
 	let draggedIndex = $state<number | null>(null);
 	let dragOverIndex = $state<number | null>(null);
@@ -600,7 +605,19 @@
 				{:else}
 					<div class="empty-up-next">
 						<span>nothing else in the queue</span>
-						<a href="/for-you" class="empty-cta">find something to play</a>
+						<a
+							href="/for-you"
+							class="empty-cta"
+							onclick={(e) => {
+								// closing the queue unmounts this anchor mid-click, which can
+								// drop the default navigation — drive it explicitly
+								e.preventDefault();
+								onNavigate?.();
+								void goto('/for-you');
+							}}
+						>
+							find something to play
+						</a>
 					</div>
 				{/if}
 			</section>
@@ -1283,14 +1300,26 @@
 	}
 
 	.empty-cta {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 44px;
+		padding: 0.6rem 1.25rem;
+		border-radius: var(--radius-md);
+		background: var(--accent);
+		color: var(--text-primary);
 		font-size: var(--text-sm);
-		color: var(--accent);
+		font-weight: 600;
 		text-decoration: none;
-		transition: color 0.15s ease;
+		transition: transform 0.15s ease;
 	}
 
 	.empty-cta:hover {
-		text-decoration: underline;
+		transform: translateY(-1px);
+	}
+
+	.empty-cta:active {
+		transform: scale(0.98);
 	}
 
 	.queue.empty {

--- a/frontend/src/lib/components/Queue.test.ts
+++ b/frontend/src/lib/components/Queue.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import Queue from '$lib/components/Queue.svelte';
+import { queue } from '$lib/queue.svelte';
+import type { Track } from '$lib/types';
+
+const TRACK: Track = {
+	id: 1,
+	title: 'only one',
+	artist: 'someone',
+	artist_did: 'did:plc:a',
+	artist_handle: 'someone.test',
+	file_id: 'f1',
+	file_type: 'mp3',
+	play_count: 0,
+	like_count: 0,
+	created_at: '2026-01-01T00:00:00Z'
+};
+
+let component: object | null = null;
+
+afterEach(() => {
+	if (component) unmount(component);
+	component = null;
+	queue.clear();
+	document.body.innerHTML = '';
+});
+
+describe('Queue empty-state cta', () => {
+	it('tells its host it is navigating, so a full-screen queue can close', () => {
+		queue.tracks = [TRACK];
+		queue.currentIndex = 0;
+		const onNavigate = vi.fn();
+		component = mount(Queue, { target: document.body, props: { onNavigate } });
+		flushSync();
+
+		const cta = document.querySelector('a.empty-cta');
+		if (!(cta instanceof HTMLAnchorElement)) throw new Error('cta not rendered');
+		expect(cta.textContent?.trim()).toBe('find something to play');
+		cta.addEventListener('click', (e) => e.preventDefault());
+		cta.click();
+		expect(onNavigate).toHaveBeenCalledTimes(1);
+	});
+});

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -540,7 +540,7 @@
 
 	{#if showQueue && !isEmbed}
 		<aside class="queue-sidebar">
-			<Queue />
+			<Queue onNavigate={() => showQueue && toggleQueue()} />
 		</aside>
 	{/if}
 </div>

--- a/loq.toml
+++ b/loq.toml
@@ -103,7 +103,7 @@ max_lines = 1196
 
 [[rules]]
 path = "frontend/src/lib/components/Queue.svelte"
-max_lines = 1364
+max_lines = 1393
 
 [[rules]]
 path = "frontend/src/lib/components/SearchModal.svelte"


### PR DESCRIPTION
nate's find: with the queue covering the viewport on mobile, tapping *find something to play* "doesn't take me anywhere" — the navigation happened underneath the queue.

- `Queue` gains an `onNavigate` prop; the layout passes `() => showQueue && toggleQueue()`, so using the CTA closes the queue and the destination is actually seen. The handler also drives `goto('/for-you')` explicitly — closing the queue unmounts the anchor mid-click, which can drop the default navigation.
- The CTA is now an app-style button (44px minimum target, accent background, the primary-button hover/active motion) instead of a small underlined link — the presentation nit.
- Component test: mounted `Queue` with one playing track renders the CTA and calls `onNavigate` on click.
- Phone-viewport verification: tap → queue closed, destination rendered. Note: `/for-you` 302s signed-out visitors to `/` by design, so anonymous users land on home's tracks — still "something to play".

Left open deliberately: nate's thought about a components/usage skill — noted, not rushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)