### PR TITLE
fix(queue): drop the row-level l binding — it shadowed the global next-track shortcut

### DIFF
--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -127,12 +127,11 @@
 		return [...(queueTracksElement?.querySelectorAll<HTMLElement>('.queue-track') ?? [])];
 	}
 
-	// keyboard on a focused row: enter plays, delete removes, l likes,
-	// arrows move between rows. stopPropagation keeps the global shortcuts
-	// (l = next track, arrows = seek) out of the way while a row has focus.
+	// keyboard on a focused row: enter plays, delete removes, arrows move
+	// between rows. keys that carry global shortcuts (like l = next track)
+	// are left alone.
 	async function handleRowKeydown(
 		e: KeyboardEvent & { currentTarget: HTMLElement },
-		track: Track,
 		index: number
 	) {
 		if (e.key === 'Enter') {
@@ -147,12 +146,6 @@
 			await tick();
 			const rows = queueRows();
 			rows[Math.min(Math.max(position, 0), rows.length - 1)]?.focus();
-			return;
-		}
-		if (e.key === 'l' || e.key === 'L') {
-			e.preventDefault();
-			e.stopPropagation();
-			void handleSwipeLike(track);
 			return;
 		}
 		if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
@@ -382,7 +375,7 @@
 		ondrop={(e) => handleDrop(e, index)}
 		ondragend={handleDragEnd}
 		onclick={() => handleTrackClick(index)}
-		onkeydown={(e) => handleRowKeydown(e, track, index)}
+		onkeydown={(e) => handleRowKeydown(e, index)}
 	>
 		{@render media(track)}
 

--- a/frontend/src/lib/components/Queue.test.ts
+++ b/frontend/src/lib/components/Queue.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
 import Queue from '$lib/components/Queue.svelte';
 import { queue } from '$lib/queue.svelte';
-import { toast } from '$lib/toast.svelte';
 import type { Track } from '$lib/types';
 
 const TRACK: Track = {
@@ -89,19 +88,4 @@ describe('Queue keyboard', () => {
 		expect(document.activeElement).toBe(rows[0]);
 	});
 
-	it('l on a focused row asks signed-out users to sign in, not next-track', () => {
-		queue.tracks = [makeTrack(1), makeTrack(2)];
-		queue.currentIndex = 0;
-		component = mount(Queue, { target: document.body, props: {} });
-		flushSync();
-
-		toast.toasts.length = 0;
-		const row = focusRow(0);
-		const bubbled = vi.fn();
-		document.addEventListener('keydown', bubbled, { once: true });
-		press(row, 'l');
-		flushSync();
-		expect(toast.toasts.some((t) => t.message.includes('sign in to like'))).toBe(true);
-		expect(bubbled).not.toHaveBeenCalled();
-	});
 });


### PR DESCRIPTION
#1914 bound `l` on a focused queue row to like, which contextually overrode the global `l` (next track). nate flagged that as confusing — a global shortcut shouldn't change meaning based on focus, and the collision should have been raised as a question before shipping. This removes the `l` binding and its test; **Delete/Backspace** (remove) and **ArrowUp/ArrowDown** (move) stay — they collide with nothing.

Like-from-keyboard returns once a key is picked. Taken globally: `space ← → j l m q`. Candidates: `h` (heart), `+`, `.`, `Shift+L`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)