### PR TITLE
style(toast): the toasts wear the app's glass

### DIFF
--- a/frontend/src/lib/components/Toast.svelte
+++ b/frontend/src/lib/components/Toast.svelte
@@ -52,20 +52,21 @@
 		pointer-events: none;
 	}
 
+	/* the same glass the queue cards and preview panels wear */
 	.toast {
 		display: inline-flex;
 		align-items: flex-start;
-		gap: 0.5rem;
-		padding: 0.5rem 1rem;
-		background: rgba(10, 10, 10, 0.6);
-		backdrop-filter: blur(12px);
-		-webkit-backdrop-filter: blur(12px);
-		border: 1px solid rgba(255, 255, 255, 0.06);
+		gap: 0.6rem;
+		padding: 0.6rem 1rem;
+		background: color-mix(in srgb, var(--track-bg, var(--bg-primary)) 78%, transparent);
+		backdrop-filter: blur(14px);
+		-webkit-backdrop-filter: blur(14px);
+		border: 1px solid var(--glass-border, var(--border-subtle));
 		border-radius: var(--radius-md);
 		pointer-events: none;
 		font-size: var(--text-sm);
 		max-width: 450px;
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+		box-shadow: 0 8px 24px color-mix(in srgb, #000 30%, transparent);
 	}
 
 	.toast-icon {


### PR DESCRIPTION
nate's ask, direction 1 only, aesthetic only: the toast container hardcoded `rgba(10,10,10,.6)` + `rgba(255,255,255,.06)` — a dark slab regardless of theme. It now uses the recipe the queue cards and preview panels already wear: theme surface via `color-mix(in srgb, var(--track-bg, var(--bg-primary)) 78%, transparent)`, `--glass-border`, `blur(14px)`, and the card shadow. Behavior, stacking, timing, copy: untouched.

<details>
<summary>ui-check matrix</summary>

Cells verified (dev server against the staging API; toasts spawned via the store — success, a long wrapping error, info, stacked ×3):

| cell | measured |
|---|---|
| dark/1280 | bg `srgb 0.07/0.69`, token border, 8px stack gaps, no overflow, 16px off viewport bottom |
| dark/390 | same tokens, no overflow (max right 342/390) |
| light/1280 | bg `srgb 1 1 1/0.73` — **the theme bug the hardcoded color had, gone**; frosted white card over content |
| light/390 | same, wraps to two lines cleanly |

Eyes on dark/390 and light/1280 screenshots: radius/border/shadow match the track-card family; neighbors (FAB, player bar, list) clear; long message wraps inside the border.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)