### PR TITLE
fix(queue): the like toast names the track, same as everywhere else

### DIFF
--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -177,13 +177,13 @@
 		if (track.is_liked) {
 			if (await unlikeTrack(track.id)) {
 				track.is_liked = false;
-				toast.info('removed from your likes');
+				toast.info(`unliked ${track.title}`);
 			}
 			return;
 		}
 		if (await likeTrack(track.id, track.file_id, track.gated)) {
 			track.is_liked = true;
-			toast.success('liked');
+			toast.success(`liked ${track.title}`);
 		}
 	}
 


### PR DESCRIPTION
nate's find: swipe-like toasted a bare "liked" while the actions menu toasts `liked <title>`. The queue now uses the same strings (`liked ${title}` / `unliked ${title}`). Copy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)