### PR TITLE
fix(queue): sync conflicts keep the user's intent; dismissed rows leave no dead nodes

### DIFF
--- a/frontend/src/lib/queue-sync.test.ts
+++ b/frontend/src/lib/queue-sync.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { queue } from './queue.svelte';
+import { auth } from './auth.svelte';
+import type { Track } from './types';
+
+function track(id: number): Track {
+	return {
+		id,
+		title: `t${id}`,
+		artist: 'a',
+		artist_did: 'did:plc:a',
+		artist_handle: 'a.test',
+		file_id: `f${id}`,
+		file_type: 'mp3',
+		play_count: 0,
+		like_count: 0,
+		created_at: '2026-01-01T00:00:00Z'
+	};
+}
+
+function queueResponse(revision: number, tracks: Track[]) {
+	return new Response(
+		JSON.stringify({
+			revision,
+			state: { track_ids: tracks.map((t) => t.file_id), current_index: 0 },
+			tracks
+		}),
+		{ headers: { etag: `"${revision}"` } }
+	);
+}
+
+describe('queue sync races', () => {
+	beforeEach(() => {
+		auth.isAuthenticated = true;
+		queue.clear();
+		queue.tracks = [track(1), track(2)];
+		queue.currentIndex = 0;
+		queue.revision = 1;
+	});
+
+	afterEach(() => {
+		auth.isAuthenticated = false;
+		queue.clear();
+		queue.revision = null;
+		vi.restoreAllMocks();
+	});
+
+	it('a 409 keeps the local queue and re-pushes it under the new revision', async () => {
+		const calls: { method: string; ifMatch: string | null }[] = [];
+		vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+			const method = init?.method ?? 'GET';
+			calls.push({
+				method,
+				ifMatch: new Headers(init?.headers).get('If-Match')
+			});
+			if (method === 'PUT' && calls.filter((c) => c.method === 'PUT').length === 1) {
+				return new Response('{"detail":"queue state conflict"}', { status: 409 });
+			}
+			if (method === 'GET') return queueResponse(5, [track(9)]);
+			return queueResponse(6, [track(1), track(2)]);
+		});
+
+		const ok = await queue.pushQueue();
+
+		expect(ok).toBe(true);
+		// the user's queue survived the conflict — the server's [f9] did not replace it
+		expect(queue.tracks.map((t) => t.file_id)).toEqual(['f1', 'f2']);
+		expect(queue.revision).toBe(6);
+		expect(calls.map((c) => `${c.method}:${c.ifMatch}`)).toEqual([
+			'PUT:"1"',
+			'GET:null',
+			'PUT:"5"'
+		]);
+	});
+
+	it('two conflicts in a row concede to the server', async () => {
+		vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+			const method = init?.method ?? 'GET';
+			if (method === 'PUT')
+				return new Response('{"detail":"queue state conflict"}', { status: 409 });
+			return queueResponse(7, [track(9)]);
+		});
+
+		const ok = await queue.pushQueue();
+
+		expect(ok).toBe(false);
+		expect(queue.tracks.map((t) => t.file_id)).toEqual(['f9']);
+		expect(queue.revision).toBe(7);
+	});
+
+	it('the success echo never clobbers a queue that changed mid-flight', async () => {
+		vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+			if ((init?.method ?? 'GET') === 'PUT') {
+				// the user acts while the request is in the air
+				queue.addTracks([track(3)]);
+				return queueResponse(2, [track(1), track(2)]);
+			}
+			return queueResponse(2, [track(1), track(2)]);
+		});
+
+		await queue.pushQueue();
+
+		expect(queue.tracks.map((t) => t.file_id)).toContain('f3');
+	});
+});

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -79,6 +79,8 @@ class Queue {
 
 	syncTimer: number | null = null;
 	pendingSync = false;
+	// bumped on every local mutation; guards server echoes from clobbering newer local state
+	mutationEpoch = 0;
 	channel: BroadcastChannel | null = null;
 	tabId: string | null = null;
 	private positionSaveInterval: number | null = null;
@@ -395,7 +397,7 @@ class Queue {
 		}
 	}
 
-	async pushQueue(): Promise<boolean> {
+	async pushQueue(retryingAfterConflict = false): Promise<boolean> {
 		if (!browser) return false;
 		if (!this.isAuthenticated()) return false; // skip if not authenticated
 		if (this.jamBridge) return false; // jam owns the queue state
@@ -412,6 +414,7 @@ class Queue {
 
 		this.syncInProgress = true;
 		this.pendingSync = false;
+		const epochAtSend = this.mutationEpoch;
 
 		try {
 			const state: QueueState = {
@@ -448,7 +451,22 @@ class Queue {
 			}
 
 			if (response.status === 409) {
-				console.warn('queue conflict detected, fetching latest state');
+				// the server moved on, but the local state is the user's intent —
+				// adopt the new revision and push it again. a second conflict in a
+				// row means another writer is active; concede to the server then.
+				if (retryingAfterConflict) {
+					console.warn('queue conflict persisted, adopting server state');
+					await this.fetchQueue(true);
+					return false;
+				}
+				const latest = await fetch(`${API_URL}/queue/`, { credentials: 'include' });
+				if (latest.ok) {
+					const data: QueueResponse = await latest.json();
+					this.revision = data.revision;
+					this.etag = latest.headers.get('etag');
+					this.syncInProgress = false;
+					return this.pushQueue(true);
+				}
 				await this.fetchQueue(true);
 				return false;
 			}
@@ -467,7 +485,12 @@ class Queue {
 			this.revision = data.revision;
 			this.etag = newEtag;
 
-			this.applySnapshot(data);
+			// the echo describes the state we sent; if the user changed the queue
+			// while the request was in flight, applying it would revert them —
+			// the pending re-push carries the newer state instead
+			if (this.mutationEpoch === epochAtSend && !this.pendingSync) {
+				this.applySnapshot(data);
+			}
 
 			// notify other tabs about the queue update
 			const sourceTabId = this.tabId ?? this.createTabId();
@@ -531,6 +554,7 @@ class Queue {
 		if (tracks.length === 0) return;
 
 		this.lastUpdateWasLocal = true;
+		this.mutationEpoch += 1;
 
 		// explicit adds slot ahead of the continuation tail (so the user's own picks
 		// play before recommendations) but never before the current track —
@@ -568,6 +592,7 @@ class Queue {
 		if (fresh.length === 0) return;
 
 		this.lastUpdateWasLocal = true;
+		this.mutationEpoch += 1;
 		// if there's no tail yet, it begins where the current queue ends
 		if (this.continuationFromIndex >= this.tracks.length) {
 			this.continuationFromIndex = this.tracks.length;
@@ -611,6 +636,7 @@ class Queue {
 		}
 		this.continuationFromIndex = this.tracks.length;
 		this.lastUpdateWasLocal = true;
+		this.mutationEpoch += 1;
 		this.syncState();
 	}
 
@@ -621,6 +647,7 @@ class Queue {
 		}
 
 		this.lastUpdateWasLocal = true;
+		this.mutationEpoch += 1;
 		this.tracks = [...tracks];
 		this.originalOrder = [...tracks];
 		this.currentIndex = this.clampIndex(startIndex);
@@ -655,6 +682,7 @@ class Queue {
 		if (tracks.length === 0) return;
 		player.radio = null; // playing a track leaves radio mode
 		this.lastUpdateWasLocal = true;
+		this.mutationEpoch += 1;
 
 		const start = Math.max(0, Math.min(startIndex, tracks.length - 1));
 		const tapped = tracks[start];
@@ -675,6 +703,7 @@ class Queue {
 
 	clear() {
 		this.lastUpdateWasLocal = true;
+		this.mutationEpoch += 1;
 		this.tracks = [];
 		this.originalOrder = [];
 		this.currentIndex = 0;
@@ -687,6 +716,7 @@ class Queue {
 
 		player.radio = null; // playing a queue item leaves radio mode
 		this.lastUpdateWasLocal = true;
+		this.mutationEpoch += 1;
 		this.currentIndex = index;
 		this.syncState();
 	}
@@ -699,6 +729,7 @@ class Queue {
 
 		if (this.currentIndex < this.tracks.length - 1) {
 			this.lastUpdateWasLocal = true;
+		this.mutationEpoch += 1;
 			this.currentIndex += 1;
 			this.syncState();
 		}
@@ -709,6 +740,7 @@ class Queue {
 
 		if (this.currentIndex > 0 || forceSkip) {
 			this.lastUpdateWasLocal = true;
+		this.mutationEpoch += 1;
 			if (this.currentIndex > 0) {
 				this.currentIndex -= 1;
 			}
@@ -726,6 +758,7 @@ class Queue {
 		}
 
 		this.lastUpdateWasLocal = true;
+		this.mutationEpoch += 1;
 
 		// shuffle only the explicit up-next; leave the current track, history,
 		// and the auto-generated continuation tail untouched
@@ -774,6 +807,7 @@ class Queue {
 		if (!this.isContinuationIndex(fromIndex)) return;
 
 		this.lastUpdateWasLocal = true;
+		this.mutationEpoch += 1;
 		const updated = [...this.tracks];
 		const [moved] = updated.splice(fromIndex, 1);
 		const insertAt = Math.max(this.currentIndex + 1, Math.min(this.continuationFromIndex, updated.length));
@@ -799,6 +833,7 @@ class Queue {
 		if (fromIndex === toIndex) return;
 
 		this.lastUpdateWasLocal = true;
+		this.mutationEpoch += 1;
 		const updated = [...this.tracks];
 		const [moved] = updated.splice(fromIndex, 1);
 		updated.splice(toIndex, 0, moved);
@@ -835,6 +870,7 @@ class Queue {
 		if (index === this.currentIndex) return;
 
 		this.lastUpdateWasLocal = true;
+		this.mutationEpoch += 1;
 		const updated = [...this.tracks];
 		const [removed] = updated.splice(index, 1);
 
@@ -874,6 +910,7 @@ class Queue {
 		if (end <= start) return;
 
 		this.lastUpdateWasLocal = true;
+		this.mutationEpoch += 1;
 		const removedIds = new Set(this.tracks.slice(start, end).map((t) => t.file_id));
 		this.tracks = [...this.tracks.slice(0, start), ...this.tracks.slice(end)];
 		this.originalOrder = this.originalOrder.filter((t) => !removedIds.has(t.file_id));

--- a/frontend/src/lib/swipe.test.ts
+++ b/frontend/src/lib/swipe.test.ts
@@ -159,6 +159,11 @@ describe('swipeable', () => {
 		vi.advanceTimersByTime(200);
 		expect(onLeft).toHaveBeenCalledTimes(1);
 		expect(onUpdate).toHaveBeenLastCalledWith({ side: null, progress: 0, committed: false, dx: 0 });
+		// the keyed list may reuse these nodes for a future row — no trace remains
+		vi.advanceTimersByTime(32);
+		expect(wrapper.style.height).toBe('');
+		expect(wrapper.style.overflow).toBe('');
+		expect(node.style.transform).toBe('');
 		vi.useRealTimers();
 		wrapper.remove();
 	});

--- a/frontend/src/lib/swipe.ts
+++ b/frontend/src/lib/swipe.ts
@@ -107,6 +107,17 @@ export function swipeable(node: HTMLElement, params: SwipeParams = {}) {
 		const finish = () => {
 			settling = false;
 			then();
+			// the keyed list may hand these nodes to a future row — leave no trace
+			requestAnimationFrame(() => {
+				if (wrapper) {
+					wrapper.style.height = '';
+					wrapper.style.overflow = '';
+					wrapper.style.transition = '';
+					wrapper.style.marginBottom = '';
+				}
+				node.style.transition = '';
+				node.style.transform = '';
+			});
 		};
 		setTimeout(collapse, 180);
 	}

--- a/loq.toml
+++ b/loq.toml
@@ -127,7 +127,7 @@ max_lines = 1009
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"
-max_lines = 955
+max_lines = 992
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"


### PR DESCRIPTION
nate's staging report: adds toast then "weirdly disappear", reappear on refresh; plus a row-sized hole with the count disagreeing. Two distinct bugs, both confirmed.

<details>
<summary>the sync race (spans + code)</summary>

Staging spans at 07:22Z: 11 `PUT /queue/` + 12 `GET /queue/` + one 409 in a minute. The client's 409 handler was `fetchQueue(true)` — **server state wholesale over local**, discarding the mutation the toast had already confirmed; a later push rewrote the full local list, which is why refresh showed the track. Separately, even a 200's echo snapshot was applied over local state, so anything done while a push was in flight vanished until the pending re-push.

Now: a 409 adopts the server's revision/etag and **re-pushes the local state once** (local is the user's intent); a second consecutive conflict concedes to the server (another writer is active — e.g. a second device). A `mutationEpoch` counter (bumped at all 14 local mutation sites) guards the success echo: if the queue changed mid-flight, the echo is skipped and the pending push carries the newer state.

</details>

<details>
<summary>the invisible row</summary>

The swipe dismiss left `height: 0; overflow: hidden; margin-bottom: -0.5rem` on the row's wrapper. The `{#each}` key is `file_id:index`, so re-adding the same track at the same position hands Svelte the dead node back — an invisible row, "UP NEXT 2" with one visible (the screenshot). The dismiss now clears every style it set, one frame after the removal.

</details>

<details>
<summary>verification</summary>

- new `queue-sync.test.ts`: 409 → GET → re-push under the new revision with the local list intact (asserts the exact `If-Match` sequence `"1" → GET → "5"`); double-409 concedes; the echo never clobbers a mid-flight mutation.
- `swipe.test.ts`: after the dismiss sequence, wrapper and node styles are fully cleared (fake timers through the rAF).
- browser repro: add → swipe-remove → re-add the same track → `dom=1 visible=1` (pre-fix: visible=0).
- 161 frontend tests, svelte-check, eslint+oxlint.

</details>

Next, separately: the horizontal-vs-vertical gesture discrimination nate raised — tuning the engagement rule so a sloppy horizontal swipe doesn't fall into scroll/reorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)