### PR TITLE
fix(swipe): decide the gesture once, with a horizontal bias

### DIFF
--- a/frontend/src/lib/swipe.test.ts
+++ b/frontend/src/lib/swipe.test.ts
@@ -97,6 +97,26 @@ describe('swipeable', () => {
 		expect(onLeft).not.toHaveBeenCalled();
 	});
 
+	it('a thumb-arc opening (slightly more vertical than horizontal) is still a swipe', () => {
+		pointer(node, 'pointerdown', 200, 50);
+		// dx 7, dy 9: more vertical than horizontal, but plausibly a swipe
+		pointer(node, 'pointermove', 193, 59);
+		expect(node.style.transform).not.toBe('');
+		pointer(node, 'pointermove', 60, 62);
+		pointer(node, 'pointerup', 60, 62);
+		expect(onLeft).toHaveBeenCalledTimes(1);
+	});
+
+	it('a clearly vertical opening still scrolls', () => {
+		pointer(node, 'pointerdown', 200, 50);
+		// dx 3, dy 12: unambiguous scroll
+		pointer(node, 'pointermove', 197, 62);
+		expect(node.style.transform).toBe('');
+		pointer(node, 'pointermove', 60, 70);
+		pointer(node, 'pointerup', 60, 70);
+		expect(onLeft).not.toHaveBeenCalled();
+	});
+
 	it('a sideways gesture cancels the native drag; a vertical one does not', () => {
 		pointer(node, 'pointerdown', 200, 50);
 		pointer(node, 'pointermove', 180, 51);

--- a/frontend/src/lib/swipe.ts
+++ b/frontend/src/lib/swipe.ts
@@ -34,7 +34,10 @@ export function displacement(dx: number, width: number, fraction = 0.35, minPx =
 	return Math.sign(dx) * damped;
 }
 
-const ENGAGE_PX = 6;
+const SLOP_PX = 8;
+// a swipe wins any contest it plausibly means to win: horizontal engages up to
+// ~53° off-axis, because thumbs arc and scrolling has the rest of the screen
+const HORIZONTAL_BIAS = 0.75;
 const SNAP_BACK = 'transform 260ms cubic-bezier(0.2, 0.9, 0.3, 1.1)';
 const SLIDE_OUT = 'transform 180ms cubic-bezier(0.4, 0, 1, 1)';
 const IDLE: SwipeState = { side: null, progress: 0, committed: false, dx: 0 };
@@ -143,11 +146,13 @@ export function swipeable(node: HTMLElement, params: SwipeParams = {}) {
 		dx = e.clientX - startX;
 		const dy = e.clientY - startY;
 		if (!engaged) {
-			if (Math.abs(dy) > ENGAGE_PX && Math.abs(dy) >= Math.abs(dx)) {
+			// wait out the thumb's opening wobble, then decide ONCE by angle —
+			// an early vertical blip must not steal a horizontal swipe
+			if (Math.hypot(dx, dy) < SLOP_PX) return;
+			if (Math.abs(dx) < Math.abs(dy) * HORIZONTAL_BIAS) {
 				abandoned = true;
 				return;
 			}
-			if (Math.abs(dx) <= ENGAGE_PX) return;
 			engaged = true;
 			node.setPointerCapture?.(e.pointerId);
 		}


### PR DESCRIPTION
nate: "you can very easily accidentally trigger the vertical motions by trying to go horizontally." Confirmed as an implementation issue: engagement abandoned the swipe at the *first* pointer event where vertical travel edged past 6px and dominated — which is exactly how a thumb-arc swipe opens.

Now: the gesture accumulates until **8px of total travel**, then decides **once** by angle, with a horizontal bias — a swipe wins up to ~53° off-axis (`|dx| ≥ 0.75·|dy|`). Rationale: thumbs arc, and vertical scrolling has the whole rest of the screen; the row is the only place a horizontal gesture can mean anything. Clearly vertical openings still scroll (`touch-action: pan-y` unchanged).

Tests: a thumb-arc opening (dx 7 / dy 9) engages and completes a remove — **fails on the previous rule** (proven by stashing the fix); a clearly vertical opening (dx 3 / dy 12) still scrolls; the full 14-test swipe suite and 163 frontend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)