### PR TITLE
feat(queue): touch reorder feels like picking the row up

### DIFF
--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -13,6 +13,13 @@
 	import { likeTrack, unlikeTrack } from '$lib/tracks.svelte';
 	import { swipeable, type SwipeState } from '$lib/swipe';
 	import { HINTS, hintSeen, markHintSeen } from '$lib/hints.svelte';
+	import {
+		displacements,
+		insertionSlot,
+		landingLineY,
+		moveTarget,
+		type PlannedRow
+	} from '$lib/reorder-plan';
 	import type { Track, JamParticipant } from '$lib/types';
 
 	// the queue can cover the viewport (mobile); whoever renders it closes it
@@ -214,75 +221,118 @@
 		dragOverIndex = null;
 	}
 
-	// touch drag and drop — initiated by a touch on the row's drag handle
+	// touch reorder: rows are measured once at pickup; the finger's position
+	// against those measurements decides the landing slot, neighbours animate
+	// out of the way, and a line marks the gap — the iOS home-screen contract.
+	const ROW_GAP = 8;
+	let dragPlan: { rows: PlannedRow[]; wrappers: HTMLElement[]; draggedPos: number } | null = null;
+	let dragSlot = $state<number | null>(null);
+	let dropLineY = $state<number | null>(null);
+
 	function handleTouchStart(event: TouchEvent & { currentTarget: HTMLElement }, index: number) {
+		if (!queueTracksElement) return;
 		const touch = event.touches[0];
 		touchDragIndex = index;
 		touchStartY = touch.clientY;
 		touchCurrentY = touch.clientY;
-		// lift the whole row, not just the handle the touch landed on
 		touchDragElement = event.currentTarget.closest('.queue-track');
 		touchDragElement?.classList.add('touch-dragging');
+		// the swipe wrapper clips its row (the reveal design); a lifted row must
+		// escape that clip and sit above its neighbours
+		const draggedWrapper = touchDragElement?.closest<HTMLElement>('.swipe-row');
+		if (draggedWrapper) {
+			draggedWrapper.style.overflow = 'visible';
+			draggedWrapper.style.zIndex = '100';
+		}
+
+		const wrappers = [...queueTracksElement.querySelectorAll<HTMLElement>('.swipe-row')];
+		const containerTop = queueTracksElement.getBoundingClientRect().top;
+		const rows: PlannedRow[] = wrappers.map((w) => {
+			const rect = w.getBoundingClientRect();
+			const row = w.querySelector<HTMLElement>('.queue-track');
+			return {
+				queueIndex: parseInt(row?.dataset.index ?? '0'),
+				top: rect.top - containerTop,
+				height: rect.height
+			};
+		});
+		const draggedPos = wrappers.findIndex((w) => w.contains(touchDragElement));
+		dragPlan = { rows, wrappers, draggedPos };
+		dragSlot = draggedPos;
+		navigator.vibrate?.(8);
 	}
 
 	function handleTouchMove(event: TouchEvent) {
-		if (touchDragIndex === null || !touchDragElement || !queueTracksElement) return;
+		if (touchDragIndex === null || !touchDragElement || !queueTracksElement || !dragPlan) return;
 
 		event.preventDefault();
 		const touch = event.touches[0];
 		touchCurrentY = touch.clientY;
 
-		// calculate visual offset
 		const offset = touchCurrentY - touchStartY;
-		touchDragElement.style.transform = `translateY(${offset}px)`;
+		touchDragElement.style.transform = `translateY(${offset}px) scale(1.03)`;
 
 		// hovering the empty up-next drop zone promotes instead of reordering
 		if (dropZoneElement) {
 			const rect = dropZoneElement.getBoundingClientRect();
 			dropZoneActive = touch.clientY >= rect.top && touch.clientY <= rect.bottom;
 			if (dropZoneActive) {
-				dragOverIndex = null;
+				dragSlot = dragPlan.draggedPos;
+				settleNeighbours();
+				dropLineY = null;
 				return;
 			}
 		}
 
-		// find which track we're hovering over
-		const tracks = queueTracksElement.querySelectorAll<HTMLElement>('.queue-track');
-		for (let i = 0; i < tracks.length; i++) {
-			const track = tracks[i];
-			const rect = track.getBoundingClientRect();
-			const midY = rect.top + rect.height / 2;
-
-			if (touch.clientY < midY && i > 0) {
-				// get the actual index from the data attribute
-				const targetIndex = parseInt(track.dataset.index || '0');
-				if (targetIndex !== touchDragIndex) {
-					dragOverIndex = targetIndex;
-				}
-				break;
-			} else if (touch.clientY >= midY) {
-				const targetIndex = parseInt(track.dataset.index || '0');
-				if (targetIndex !== touchDragIndex) {
-					dragOverIndex = targetIndex;
-				}
-			}
+		const containerTop = queueTracksElement.getBoundingClientRect().top;
+		const { rows, draggedPos } = dragPlan;
+		const slot = insertionSlot(rows, draggedPos, touch.clientY - containerTop);
+		if (slot !== dragSlot) {
+			dragSlot = slot;
+			navigator.vibrate?.(4);
+			const shifts = displacements(rows, draggedPos, slot, ROW_GAP);
+			dragPlan.wrappers.forEach((w, i) => {
+				if (i === draggedPos) return;
+				w.style.transition = 'transform 180ms cubic-bezier(0.2, 0.9, 0.3, 1.05)';
+				w.style.transform = shifts[i] ? `translateY(${shifts[i]}px)` : '';
+			});
+			dropLineY = slot === draggedPos ? null : landingLineY(rows, draggedPos, slot, ROW_GAP);
 		}
+	}
+
+	function settleNeighbours() {
+		if (!dragPlan) return;
+		dragPlan.wrappers.forEach((w, i) => {
+			if (i === dragPlan!.draggedPos) return;
+			w.style.transform = '';
+		});
 	}
 
 	function handleTouchEnd() {
 		if (touchDragIndex !== null && dropZoneActive) {
 			queue.promoteToUpNext(touchDragIndex);
-		} else if (touchDragIndex !== null && dragOverIndex !== null && touchDragIndex !== dragOverIndex) {
-			queue.moveTrack(touchDragIndex, dragOverIndex);
+		} else if (touchDragIndex !== null && dragPlan && dragSlot !== null) {
+			const target = moveTarget(dragPlan.rows, dragPlan.draggedPos, dragSlot);
+			if (target !== null) queue.moveTrack(touchDragIndex, target);
 		}
 		dropZoneActive = false;
 
-		// cleanup
+		if (dragPlan) {
+			dragPlan.wrappers.forEach((w) => {
+				w.style.transition = '';
+				w.style.transform = '';
+				w.style.overflow = '';
+				w.style.zIndex = '';
+			});
+		}
 		if (touchDragElement) {
 			touchDragElement.classList.remove('touch-dragging');
 			touchDragElement.style.transform = '';
 		}
 
+		dragPlan = null;
+		dragSlot = null;
+		dropLineY = null;
 		touchDragIndex = null;
 		dragOverIndex = null;
 		touchDragElement = null;
@@ -587,6 +637,9 @@
 						ontouchend={handleTouchEnd}
 						ontouchcancel={handleTouchEnd}
 					>
+						{#if dropLineY !== null}
+							<div class="drop-line" style="top: {dropLineY}px" aria-hidden="true"></div>
+						{/if}
 						{#each explicitUpcoming as { track, index } (`${track.file_id}:${index}`)}
 							{@render queueRow(track, index)}
 						{/each}
@@ -1056,6 +1109,7 @@
 	}
 
 	.queue-tracks {
+		position: relative;
 		flex: 1;
 		overflow-y: auto;
 		display: flex;
@@ -1263,10 +1317,22 @@
 		z-index: 10;
 	}
 
-	/* applied dynamically via JS during touch drag */
+	/* applied dynamically via JS during touch drag — the lift */
 	:global(.queue-track.touch-dragging) {
 		z-index: 100;
-		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+		box-shadow: 0 14px 36px rgba(0, 0, 0, 0.45);
+		transition: box-shadow 0.15s ease;
+	}
+
+	.drop-line {
+		position: absolute;
+		left: 0.35rem;
+		right: 0.75rem;
+		height: 2px;
+		border-radius: 1px;
+		background: color-mix(in srgb, var(--accent) 55%, transparent);
+		pointer-events: none;
+		z-index: 50;
 	}
 
 	.track-info {

--- a/frontend/src/lib/reorder-plan.test.ts
+++ b/frontend/src/lib/reorder-plan.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { displacements, insertionSlot, landingLineY, moveTarget, type PlannedRow } from './reorder-plan';
+
+const GAP = 8;
+const rows: PlannedRow[] = [0, 1, 2, 3].map((i) => ({
+	queueIndex: i + 10,
+	top: 100 + i * 72,
+	height: 64
+}));
+
+describe('reorder plan', () => {
+	it('finds the slot from the finger against the captured midpoints', () => {
+		expect(insertionSlot(rows, 0, 100)).toBe(0);
+		expect(insertionSlot(rows, 0, 260)).toBe(1);
+		expect(insertionSlot(rows, 0, 300)).toBe(2);
+		expect(insertionSlot(rows, 3, 110)).toBe(0);
+	});
+
+	it('rows between the origin and the slot move out of the way', () => {
+		// dragging row 0 down past rows 1 and 2: they shift up
+		expect(displacements(rows, 0, 2, GAP)).toEqual([0, -72, -72, 0]);
+		// dragging row 3 up to the top: rows 0..2 shift down
+		expect(displacements(rows, 3, 0, GAP)).toEqual([72, 72, 72, 0]);
+		// staying put moves nobody
+		expect(displacements(rows, 1, 1, GAP)).toEqual([0, 0, 0, 0]);
+	});
+
+	it('the landing line sits at the gap the rows opened', () => {
+		expect(landingLineY(rows, 0, 2, GAP)).toBe(100 + 2 * 72 + 64 + 4);
+		expect(landingLineY(rows, 3, 0, GAP)).toBe(100 - 4);
+		expect(landingLineY(rows, 1, 1, GAP)).toBe(100 + 72 - 4);
+	});
+
+	it('the move target is the occupied slot, or null when staying put', () => {
+		expect(moveTarget(rows, 0, 2)).toBe(12);
+		expect(moveTarget(rows, 3, 0)).toBe(10);
+		expect(moveTarget(rows, 1, 1)).toBeNull();
+	});
+});

--- a/frontend/src/lib/reorder-plan.ts
+++ b/frontend/src/lib/reorder-plan.ts
@@ -1,0 +1,58 @@
+/**
+ * geometry for touch reordering: rows are measured once at pickup, and every
+ * later decision — where the drag would land, who moves out of the way, where
+ * the landing line sits — reads those measurements, never the moving DOM.
+ */
+
+export interface PlannedRow {
+	/** the row's queue index (data-index), used for the actual move */
+	queueIndex: number;
+	top: number;
+	height: number;
+}
+
+const mid = (row: PlannedRow) => row.top + row.height / 2;
+
+/** the visual slot (0..rows.length-1) the dragged row would land in. */
+export function insertionSlot(rows: PlannedRow[], draggedPos: number, fingerY: number): number {
+	let below = 0;
+	for (let i = 0; i < rows.length; i++) {
+		if (i === draggedPos) continue;
+		if (mid(rows[i]) < fingerY) below += 1;
+	}
+	return below;
+}
+
+/** per-row vertical shifts (px) that open the gap at `slot`, iOS-home-screen style. */
+export function displacements(
+	rows: PlannedRow[],
+	draggedPos: number,
+	slot: number,
+	gap: number
+): number[] {
+	const dragged = rows[draggedPos];
+	return rows.map((_, i) => {
+		if (i === draggedPos) return 0;
+		if (slot > draggedPos && i > draggedPos && i <= slot) return -(dragged.height + gap);
+		if (slot < draggedPos && i >= slot && i < draggedPos) return dragged.height + gap;
+		return 0;
+	});
+}
+
+/** the y of the landing line, in the same coordinate space as the measurements. */
+export function landingLineY(
+	rows: PlannedRow[],
+	draggedPos: number,
+	slot: number,
+	gap: number
+): number {
+	if (slot === draggedPos) return rows[draggedPos].top - gap / 2;
+	if (slot > draggedPos) return rows[slot].top + rows[slot].height + gap / 2;
+	return rows[slot].top - gap / 2;
+}
+
+/** the queue index to hand queue.moveTrack, or null for "stay put". */
+export function moveTarget(rows: PlannedRow[], draggedPos: number, slot: number): number | null {
+	if (slot === draggedPos) return null;
+	return rows[slot].queueIndex;
+}

--- a/loq.toml
+++ b/loq.toml
@@ -103,7 +103,7 @@ max_lines = 1196
 
 [[rules]]
 path = "frontend/src/lib/components/Queue.svelte"
-max_lines = 1435
+max_lines = 1494
 
 [[rules]]
 path = "frontend/src/lib/components/SearchModal.svelte"


### PR DESCRIPTION
nate's follow-up after the promote: mobile reordering "feels very cheap … you literally can't really tell where it's going to land." The iOS home-screen contract, implemented:

<details>
<summary>how</summary>

- `src/lib/reorder-plan.ts` — pure geometry, measured **once at pickup** and never re-read from the moving DOM: `insertionSlot` (finger vs captured midpoints), `displacements` (who shifts and by how much), `landingLineY`, `moveTarget`. 4 unit tests, including the case my first slot function got wrong.
- **Lift**: the dragged row scales to 1.03 under a deeper shadow, with an 8ms pickup haptic — and its swipe wrapper temporarily releases `overflow: hidden`/gains z-index so the lifted row actually rides above the list (first screenshot round caught it being clipped to a ghost).
- **Displacement**: as the finger crosses a captured midpoint, neighbours animate out of the way (180ms, the same spring family as the swipe) and a 4ms tick fires — the gap that opens is the landing slot.
- **The line**: a subtle accent line (55% mix) sits in the gap, absolutely positioned from the captured geometry.
- **Drop**: commits `queue.moveTrack` to exactly the slot the gap showed; every inline style is restored (verified programmatically). The empty-up-next promote zone still works. Desktop native drag untouched.

</details>

<details>
<summary>verification</summary>

- unit: 4 reorder-plan tests; 167 frontend tests total; svelte-check, eslint+oxlint.
- browser (390×844, CDP touch on the handle): mid-drag frame shows the lifted row visible at scale with shadow, the neighbour moved up into the vacated slot, the landing line in the gap; release lands the row where the gap was (order asserted before/after); all inline styles restored after drop.

</details>

Feel is the acceptance test — nate's thumb on staging decides. The scale (1.03), shadow depth, 180ms spring, and line opacity are each one constant if tuning is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)