### PR TITLE
tracks: grey out play affordances while a rendition is still processing

### DIFF
--- a/frontend/src/lib/components/TrackCard.svelte
+++ b/frontend/src/lib/components/TrackCard.svelte
@@ -5,6 +5,7 @@
 	import { likersSheet } from '$lib/likers-sheet.svelte';
 	import { trackCoverUrl, trackThumbnailUrl } from '$lib/track-cover';
 	import type { Track } from '$lib/types';
+	import { isAwaitingPlayableRendition } from '$lib/audio-source';
 
 	interface Props {
 		track: Track;
@@ -21,6 +22,7 @@
 	// cover art with album fallback (matches the player bar's rule)
 	let coverFullUrl = $derived(trackCoverUrl(track));
 	let coverThumbUrl = $derived(trackThumbnailUrl(track));
+	let isProcessing = $derived(isAwaitingPlayableRendition(track));
 
 	let isMobile = $state(false);
 
@@ -85,13 +87,17 @@
 <button
 	class="track-card"
 	class:playing={isPlaying}
+	class:processing={isProcessing}
 	class:tooltip-open={showLikersTooltip}
+	aria-disabled={isProcessing}
+	title={isProcessing ? 'still processing — playable shortly' : undefined}
 	onclick={(e) => {
 		if (e.target instanceof HTMLAnchorElement || (e.target as HTMLElement).closest('a')) return;
+		if (isProcessing) return;
 		onPlay(track);
 	}}
 >
-	<div class="artwork" class:gated={track.gated} class:avatar-fallback={!coverFullUrl && track.artist_avatar_url}>
+	<div class="artwork" class:gated={track.gated} class:processing={isProcessing} class:avatar-fallback={!coverFullUrl && track.artist_avatar_url}>
 		{#if coverFullUrl || coverThumbUrl}
 			<SensitiveImage src={coverThumbUrl ?? coverFullUrl}>
 				<img
@@ -117,7 +123,11 @@
 				</svg>
 			</div>
 		{/if}
-		{#if track.gated}
+		{#if isProcessing}
+			<div class="processing-badge" title="still processing — playable shortly">
+				<svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true"><circle cx="12" cy="12" r="8"/><path d="M12 8v4l2.5 2.5"/></svg>
+			</div>
+		{:else if track.gated}
 			<div class="gated-badge" title="supporters only">
 				<svg width="8" height="8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
 					<path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"/>
@@ -246,6 +256,16 @@
 		color: var(--text-muted);
 	}
 
+	.track-card.processing {
+		cursor: default;
+	}
+
+	.track-card.processing .artwork,
+	.track-card.processing .title {
+		opacity: 0.5;
+	}
+
+	.processing-badge,
 	.gated-badge {
 		position: absolute;
 		bottom: -3px;
@@ -260,6 +280,11 @@
 		border-radius: var(--radius-full);
 		color: white;
 		z-index: 1;
+	}
+
+	.processing-badge {
+		background: var(--bg-tertiary);
+		color: var(--text-muted);
 	}
 
 	.info {

--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -204,9 +204,9 @@
 	class="track-container"
 	class:playing={isPlaying}
 	class:processing={isProcessing}
-	class:lossless={hasPlayableLossless(track.original_file_type) || isLosslessFormat(track.file_type)}
+	class:lossless={!isProcessing && (hasPlayableLossless(track.original_file_type) || isLosslessFormat(track.file_type))}
 	class:likers-tooltip-open={showLikersTooltip}
-	title={hasPlayableLossless(track.original_file_type) || isLosslessFormat(track.file_type) ? 'lossless audio available' : undefined}
+	title={isProcessing ? 'still processing — playable shortly' : hasPlayableLossless(track.original_file_type) || isLosslessFormat(track.file_type) ? 'lossless audio available' : undefined}
 >
 	{#if showIndex}
 		<span class="track-index">{index + 1}</span>
@@ -397,7 +397,10 @@
 						{/if}
 					</span>
 				{/if}
-			{#if hasPlayableLossless(track.original_file_type) || isLosslessFormat(track.file_type)}
+			{#if isProcessing}
+				<span class="meta-separator">·</span>
+				<span class="processing-indicator" title="still processing — playable shortly">processing</span>
+			{:else if hasPlayableLossless(track.original_file_type) || isLosslessFormat(track.file_type)}
 				<span class="meta-separator">·</span>
 				<span class="lossless-indicator" title="lossless audio available">lossless</span>
 			{/if}
@@ -953,6 +956,12 @@
 
 	.lossless-indicator:hover {
 		color: var(--accent);
+	}
+
+	.processing-indicator {
+		color: var(--text-muted);
+		font-weight: 500;
+		cursor: default;
 	}
 
 	.action-button {

--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -7,6 +7,7 @@
 	import CommentersTooltip from './CommentersTooltip.svelte';
 	import SensitiveImage from './SensitiveImage.svelte';
 	import { hasPlayableLossless, isLosslessFormat } from '$lib/audio-support';
+	import { isAwaitingPlayableRendition } from '$lib/audio-source';
 	import { likersSheet } from '$lib/likers-sheet.svelte';
 	import { trackCoverUrl, trackThumbnailUrl } from '$lib/track-cover';
 	import type { Track } from '$lib/types';
@@ -79,6 +80,7 @@
 	// the player bar's existing inheritance rule.
 	let coverFullUrl = $derived(trackCoverUrl(track));
 	let coverThumbUrl = $derived(trackThumbnailUrl(track));
+	let isProcessing = $derived(isAwaitingPlayableRendition(track));
 
 	// reset local UI state when track changes (component may be recycled)
 	// using $effect.pre so state is ready before render
@@ -201,6 +203,7 @@
 <div
 	class="track-container"
 	class:playing={isPlaying}
+	class:processing={isProcessing}
 	class:lossless={hasPlayableLossless(track.original_file_type) || isLosslessFormat(track.file_type)}
 	class:likers-tooltip-open={showLikersTooltip}
 	title={hasPlayableLossless(track.original_file_type) || isLosslessFormat(track.file_type) ? 'lossless audio available' : undefined}
@@ -215,7 +218,8 @@
 		     before, without nesting interactive controls inside a button. -->
 		<button
 			class="track-play"
-			aria-label="play {track.title}"
+			aria-label={isProcessing ? `${track.title} is still processing` : `play ${track.title}`}
+			disabled={isProcessing}
 			onclick={async () => {
 				if (track.gated) {
 					await playTrack(track);
@@ -224,7 +228,7 @@
 				}
 			}}
 		></button>
-		<div class="track-image-wrapper" class:gated={track.gated}>
+		<div class="track-image-wrapper" class:gated={track.gated} class:processing={isProcessing}>
 			{#if (coverFullUrl || coverThumbUrl) && !trackImageError}
 				<SensitiveImage src={coverThumbUrl ?? coverFullUrl}>
 					<div class="track-image">
@@ -264,7 +268,11 @@
 					</svg>
 				</div>
 			{/if}
-			{#if track.gated}
+			{#if isProcessing}
+				<div class="processing-badge" title="still processing — playable shortly">
+					<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true"><circle cx="12" cy="12" r="8"/><path d="M12 8v4l2.5 2.5"/></svg>
+				</div>
+			{:else if track.gated}
 				<div class="gated-badge" title="supporters only">
 					<svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
 						<path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"/>
@@ -580,6 +588,16 @@
 		pointer-events: none;
 	}
 
+	.track-container.processing .track-title,
+	.track-container.processing .track-image-wrapper {
+		opacity: 0.5;
+	}
+
+	.track-play:disabled {
+		cursor: default;
+	}
+
+	.processing-badge,
 	.gated-badge {
 		position: absolute;
 		bottom: -4px;
@@ -594,6 +612,11 @@
 		border-radius: var(--radius-full);
 		color: white;
 		z-index: 1;
+	}
+
+	.processing-badge {
+		background: var(--bg-tertiary);
+		color: var(--text-muted);
 	}
 
 	.track-image,

--- a/frontend/src/lib/components/TrackItem.test.ts
+++ b/frontend/src/lib/components/TrackItem.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import TrackItem from '$lib/components/TrackItem.svelte';
+import TrackCard from '$lib/components/TrackCard.svelte';
+import type { Track } from '$lib/types';
+
+// jsdom's <audio> answers '' to every canPlayType, so an aiff interim rendition
+// is "awaiting playable" here — same as Chrome/Firefox in real life.
+function track(overrides: Partial<Track> = {}): Track {
+	return {
+		id: 1,
+		title: 'food chain',
+		artist: 'woody',
+		artist_did: 'did:plc:a',
+		artist_handle: 'woody.test',
+		file_id: 'f1',
+		file_type: 'mp3',
+		play_count: 0,
+		like_count: 0,
+		created_at: '2026-01-01T00:00:00Z',
+		...overrides
+	};
+}
+
+const PROCESSING = track({
+	file_type: 'aiff',
+	original_file_id: 'o1',
+	original_file_type: 'aiff',
+	is_optimizing: true
+});
+
+vi.stubGlobal('matchMedia', (query: string) => ({
+	matches: false,
+	media: query,
+	addEventListener: () => {},
+	removeEventListener: () => {}
+}));
+
+let component: object | null = null;
+
+afterEach(() => {
+	if (component) unmount(component);
+	component = null;
+	document.body.innerHTML = '';
+});
+
+describe('TrackItem processing state', () => {
+	it('disables play and shows the processing badge while the rendition is undecodable', () => {
+		const onPlay = vi.fn();
+		component = mount(TrackItem, { target: document.body, props: { track: PROCESSING, onPlay } });
+		flushSync();
+
+		const play = document.querySelector('button.track-play');
+		if (!(play instanceof HTMLButtonElement)) throw new Error('play button not rendered');
+		expect(play.disabled).toBe(true);
+		expect(document.querySelector('.processing-badge')).not.toBeNull();
+		play.click();
+		expect(onPlay).not.toHaveBeenCalled();
+	});
+
+	it('plays normally once the mp3 rendition has landed', () => {
+		const onPlay = vi.fn();
+		const ready = track({ original_file_id: 'o1', original_file_type: 'aiff', is_optimizing: false });
+		component = mount(TrackItem, { target: document.body, props: { track: ready, onPlay } });
+		flushSync();
+
+		const play = document.querySelector('button.track-play');
+		if (!(play instanceof HTMLButtonElement)) throw new Error('play button not rendered');
+		expect(play.disabled).toBe(false);
+		expect(document.querySelector('.processing-badge')).toBeNull();
+		play.click();
+		expect(onPlay).toHaveBeenCalledWith(ready);
+	});
+});
+
+describe('TrackCard processing state', () => {
+	it('ignores clicks and shows the processing badge while the rendition is undecodable', () => {
+		const onPlay = vi.fn();
+		component = mount(TrackCard, { target: document.body, props: { track: PROCESSING, onPlay } });
+		flushSync();
+
+		const card = document.querySelector('button.track-card');
+		if (!(card instanceof HTMLButtonElement)) throw new Error('card not rendered');
+		expect(card.getAttribute('aria-disabled')).toBe('true');
+		expect(document.querySelector('.processing-badge')).not.toBeNull();
+		card.click();
+		expect(onPlay).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/lib/components/TrackItem.test.ts
+++ b/frontend/src/lib/components/TrackItem.test.ts
@@ -4,8 +4,7 @@ import TrackItem from '$lib/components/TrackItem.svelte';
 import TrackCard from '$lib/components/TrackCard.svelte';
 import type { Track } from '$lib/types';
 
-// jsdom's <audio> answers '' to every canPlayType, so an aiff interim rendition
-// is "awaiting playable" here — same as Chrome/Firefox in real life.
+// jsdom's <audio> can't play aiff, so an aiff interim is "awaiting playable" here.
 function track(overrides: Partial<Track> = {}): Track {
 	return {
 		id: 1,

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -549,7 +549,7 @@ $effect(() => {
 							</span>
 						{/if}
 						</div>
-						<button class="btn-play" class:playing={isCurrentlyPlaying} disabled={isProcessing} onclick={handlePlay} aria-label={isProcessing ? 'still processing — playable shortly' : isCurrentlyPlaying ? 'pause' : 'play'} title={isProcessing ? 'still processing — playable shortly' : isCurrentlyPlaying ? 'pause' : 'play'}>
+						<button class="btn-play" class:playing={isCurrentlyPlaying} disabled={isProcessing && !isCurrentlyPlaying} onclick={handlePlay} aria-label={isProcessing && !isCurrentlyPlaying ? 'still processing — playable shortly' : isCurrentlyPlaying ? 'pause' : 'play'} title={isProcessing && !isCurrentlyPlaying ? 'still processing — playable shortly' : isCurrentlyPlaying ? 'pause' : 'play'}>
 							{#if isCurrentlyPlaying}
 								<svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor">
 									<path d="M6 4h4v16H6zM14 4h4v16h-4z"/>

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -23,6 +23,7 @@
 	import { player } from '$lib/player.svelte';
 	import { queue } from '$lib/queue.svelte';
 	import { playTrack, guardGatedTrack } from '$lib/playback.svelte';
+	import { isAwaitingPlayableRendition } from '$lib/audio-source';
 	import { auth } from '$lib/auth.svelte';
 	import { preferences } from '$lib/preferences.svelte';
 	import { toast } from '$lib/toast.svelte';
@@ -41,6 +42,7 @@
 	let isAdultLabeled = $derived(
 		track?.labels?.some((label) => label === 'sexual' || label === 'porn') ?? false
 	);
+	let isProcessing = $derived(track ? isAwaitingPlayableRendition(track) : false);
 	let mayPlayAdultAudio = $derived(
 		!isAdultLabeled ||
 		preferences.showSensitiveAudio ||
@@ -445,6 +447,9 @@ $effect(() => {
 				<div class="track-info">
 					<h1 class="track-title">
 						{track.title}
+						{#if isProcessing}
+							<span class="processing-badge" title="still processing — playable shortly">processing</span>
+						{/if}
 						{#if track.gated}
 							<span class="gated-badge" title="supporters only">
 								<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
@@ -544,7 +549,7 @@ $effect(() => {
 							</span>
 						{/if}
 						</div>
-						<button class="btn-play" class:playing={isCurrentlyPlaying} onclick={handlePlay} aria-label={isCurrentlyPlaying ? 'pause' : 'play'} title={isCurrentlyPlaying ? 'pause' : 'play'}>
+						<button class="btn-play" class:playing={isCurrentlyPlaying} disabled={isProcessing} onclick={handlePlay} aria-label={isProcessing ? 'still processing — playable shortly' : isCurrentlyPlaying ? 'pause' : 'play'} title={isProcessing ? 'still processing — playable shortly' : isCurrentlyPlaying ? 'pause' : 'play'}>
 							{#if isCurrentlyPlaying}
 								<svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor">
 									<path d="M6 4h4v16H6zM14 4h4v16h-4z"/>
@@ -1030,6 +1035,24 @@ $effect(() => {
 
 	.track-actions .btn-queue {
 		justify-self: start;
+	}
+
+	.btn-play:disabled {
+		opacity: 0.4;
+		cursor: default;
+	}
+
+	.processing-badge {
+		display: inline-block;
+		vertical-align: middle;
+		margin-left: 0.5rem;
+		padding: 0.1rem 0.5rem;
+		font-size: 0.7rem;
+		font-weight: 500;
+		letter-spacing: 0.02em;
+		color: var(--text-muted);
+		background: var(--bg-tertiary);
+		border-radius: var(--radius-full, 999px);
 	}
 
 	.btn-play {


### PR DESCRIPTION
non-web-playable uploads (AIFF, recorder webm/ogg) publish immediately on an interim rendition that Chrome/Firefox can't decode; until the mp3 lands (~4.5–5 min in prod today, see #1933) the only signal was a toast *after* you clicked play. this surfaces the state up front: the row/card/track page dim, show a "processing" hint, and the play control is inert.

<details>
<summary>design</summary>

- predicate is the existing `isAwaitingPlayableRendition(track)` (`audio-source.ts`) — server-computed `is_optimizing` && `!canPlayFormat(file_type)`. no new data, no new requests.
- **TrackItem**: `disabled` on the stretched play button, artwork + title at 0.5 opacity, clock badge in the artwork corner (same slot as the gated lock), and "· processing" replaces "· lossless" in the meta line — the interim aiff is lossless on paper but this browser can't play it, so advertising lossless there was misleading. hover title on the row says "still processing — playable shortly".
- **TrackCard**: `aria-disabled` + click no-op (the card itself is the button and contains links, so a real `disabled` would break navigation), same dim + badge.
- **track page**: `btn-play` disabled at 0.4 opacity, a small "processing" pill after the title.
- `handleProcessing()` in the Player (toast + skip) stays as the fallback for queued/auto-advanced tracks and for stale payloads.

</details>

<details>
<summary>intentional non-behaviors</summary>

- browser-dependent by design: Safari plays AIFF natively, so a Safari user sees a live play button on the same track a Chrome user sees greyed. that matches what actually happens on click today.
- no polling: the state flips to playable on the next payload refresh, not live. a light poll on rows in this state is a possible follow-up.
- the notification DM still fires before the rendition exists (#1932) — separate change.

</details>

<details>
<summary>verification</summary>

- `bun run check` / `lint` / `test` green; new `TrackItem.test.ts` covers disabled + badge for the processing row, normal play once `is_optimizing` clears, and the card's click no-op.
- rendered locally through a mutating proxy on `api-stg` marking one row, one top card and the track page as processing; dark + light × 390 + 1280 checked, `getBoundingClientRect` confirmed the badge sits inside the artwork box and `btn-play` reports `disabled=true`, opacity 0.4.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)