### PR TITLE
supporters: verify attested.network payment attestations

### DIFF
--- a/backend/src/backend/_internal/__init__.py
+++ b/backend/src/backend/_internal/__init__.py
@@ -51,7 +51,7 @@ from backend._internal.feature_flags import (
 from backend._internal.notifications import notification_service
 from backend._internal.now_playing import now_playing_service
 from backend._internal.queue import queue_service
-from backend._internal.atprotofans import get_supported_artists, validate_supporter
+from backend._internal.supporters import get_supported_artists, validate_supporter
 
 __all__ = [
     "KNOWN_FLAGS",

--- a/backend/src/backend/_internal/atprotofans.py
+++ b/backend/src/backend/_internal/atprotofans.py
@@ -14,19 +14,13 @@ the signer is the artist's own DID.
 see: https://atprotofans.leaflet.pub/3mabsmts3rs2b
 """
 
-import asyncio
 import logging
 
 import httpx
 import logfire
 from pydantic import BaseModel
-from redis.exceptions import RedisError
-
-from backend.utilities.redis import get_async_redis_client
 
 logger = logging.getLogger(__name__)
-
-SUPPORTER_CACHE_TTL = 300  # 5 minutes
 
 
 class SupporterValidation(BaseModel):
@@ -36,64 +30,17 @@ class SupporterValidation(BaseModel):
     profile: dict | None = None
 
 
-def _cache_key(supporter_did: str, artist_did: str) -> str:
-    return f"supporter:{supporter_did}:{artist_did}"
-
-
-async def _get_cached(supporter_did: str, artist_did: str) -> bool | None:
-    """check Redis for cached supporter validation. returns True/False or None on miss."""
-    try:
-        redis = get_async_redis_client()
-        val = await redis.get(_cache_key(supporter_did, artist_did))
-        if val is not None:
-            return val == "1"
-    except (RuntimeError, RedisError):
-        pass
-    return None
-
-
-async def _set_cached(supporter_did: str, artist_did: str, valid: bool) -> None:
-    """cache supporter validation result in Redis."""
-    try:
-        redis = get_async_redis_client()
-        await redis.set(
-            _cache_key(supporter_did, artist_did),
-            "1" if valid else "0",
-            ex=SUPPORTER_CACHE_TTL,
-        )
-    except (RuntimeError, RedisError):
-        logger.debug("failed to cache supporter validation")
-
-
-async def validate_supporter(
+async def check_atprotofans_support(
     supporter_did: str,
     artist_did: str,
     timeout: float = 5.0,
-) -> SupporterValidation:
-    """validate if a user supports an artist via atprotofans.
+) -> SupporterValidation | None:
+    """validate supporter status via the atprotofans validateSupporter endpoint.
 
     for direct atprotofans contributions, the signer is the artist's DID.
-    results are cached in Redis for 5 minutes.
-
-    args:
-        supporter_did: DID of the potential supporter
-        artist_did: DID of the artist (also used as signer)
-        timeout: request timeout in seconds
-
-    returns:
-        SupporterValidation with valid=True if supporter, valid=False otherwise
+    returns None on transient failures (timeout, transport error) so the
+    caller knows not to cache the answer.
     """
-    # check cache first
-    cached = await _get_cached(supporter_did, artist_did)
-    if cached is not None:
-        logfire.info(
-            "atprotofans cache hit",
-            valid=cached,
-            supporter_did=supporter_did,
-            artist_did=artist_did,
-        )
-        return SupporterValidation(valid=cached)
-
     url = "https://atprotofans.com/xrpc/com.atprotofans.validateSupporter"
     params = {
         "supporter": supporter_did,
@@ -116,7 +63,6 @@ async def validate_supporter(
                         status_code=response.status_code,
                         response_text=response.text[:200],
                     )
-                    await _set_cached(supporter_did, artist_did, False)
                     return SupporterValidation(valid=False)
 
                 data = response.json()
@@ -128,7 +74,6 @@ async def validate_supporter(
                     has_profile=data.get("profile") is not None,
                 )
 
-                await _set_cached(supporter_did, artist_did, is_valid)
                 return SupporterValidation(
                     valid=is_valid,
                     profile=data.get("profile"),
@@ -136,37 +81,11 @@ async def validate_supporter(
 
         except httpx.TimeoutException:
             logfire.warn("atprotofans validation timeout")
-            return SupporterValidation(valid=False)
+            return None
         except Exception as e:
             logfire.error(
                 "atprotofans validation error",
                 error=str(e),
                 exc_info=True,
             )
-            return SupporterValidation(valid=False)
-
-
-async def get_supported_artists(
-    supporter_did: str,
-    artist_dids: set[str],
-    timeout: float = 5.0,
-) -> set[str]:
-    """batch check which artists a user supports.
-
-    args:
-        supporter_did: DID of the potential supporter
-        artist_dids: set of artist DIDs to check
-        timeout: request timeout per check
-
-    returns:
-        set of artist DIDs the user supports
-    """
-    if not artist_dids:
-        return set()
-
-    async def check_one(artist_did: str) -> str | None:
-        result = await validate_supporter(supporter_did, artist_did, timeout)
-        return artist_did if result.valid else None
-
-    results = await asyncio.gather(*[check_one(did) for did in artist_dids])
-    return {did for did in results if did is not None}
+            return None

--- a/backend/src/backend/_internal/attested.py
+++ b/backend/src/backend/_internal/attested.py
@@ -1,0 +1,131 @@
+"""attested.network payment attestation verification.
+
+verifies portable payment attestations (spec: https://attested.network):
+the payer holds a `network.attested.payment.{oneTime,recurring}` record in
+their own PDS with `subject` = recipient DID, cross-signed by a broker proof
+(`network.attested.payment.proof`, same rkey) in a trusted broker's repo.
+
+verification checks the proof exists in a trusted broker's repo with
+`status: "verified"` and that the payer record's signature strongRef matches
+the proof record's actual CID. live proofs do not pin the payer record's
+current content (observed 2026-08-26: 0/7 sampled proofs match), so mutable
+payer-record fields are taken on the payer's word pending broker guidance.
+"""
+
+import logging
+
+import httpx
+import logfire
+
+from backend._internal.slingshot import resolve_mini_doc_safe
+from backend.config import settings
+
+logger = logging.getLogger(__name__)
+
+PROOF_COLLECTION = "network.attested.payment.proof"
+PAYMENT_COLLECTIONS = (
+    "network.attested.payment.oneTime",
+    "network.attested.payment.recurring",
+)
+MAX_LIST_PAGES = 5
+
+
+async def check_attested_support(
+    supporter_did: str,
+    artist_did: str,
+    timeout: float = 5.0,
+) -> bool:
+    """check whether supporter_did holds a broker-verified payment attestation for artist_did."""
+    with logfire.span(
+        "attested.check_support",
+        supporter_did=supporter_did,
+        artist_did=artist_did,
+    ):
+        try:
+            return await _check(supporter_did, artist_did, timeout)
+        except httpx.TimeoutException:
+            logfire.warn("attested verification timeout")
+            return False
+        except Exception as e:
+            logfire.error("attested verification error", error=str(e), exc_info=True)
+            return False
+
+
+async def _check(supporter_did: str, artist_did: str, timeout: float) -> bool:
+    doc = await resolve_mini_doc_safe(supporter_did)
+    if doc is None:
+        return False
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        for record in await _payment_records(client, doc["pds"], supporter_did):
+            if record.get("value", {}).get(
+                "subject"
+            ) == artist_did and await _proof_verifies(client, record):
+                logfire.info(
+                    "attested support verified",
+                    record_uri=record.get("uri"),
+                    supporter_did=supporter_did,
+                    artist_did=artist_did,
+                )
+                return True
+    return False
+
+
+async def _payment_records(
+    client: httpx.AsyncClient, pds: str, repo: str
+) -> list[dict]:
+    records: list[dict] = []
+    for collection in PAYMENT_COLLECTIONS:
+        cursor: str | None = None
+        for _ in range(MAX_LIST_PAGES):
+            params: dict[str, str | int] = {
+                "repo": repo,
+                "collection": collection,
+                "limit": 100,
+            }
+            if cursor:
+                params["cursor"] = cursor
+            response = await client.get(
+                f"{pds}/xrpc/com.atproto.repo.listRecords", params=params
+            )
+            if response.status_code != 200:
+                break
+            data = response.json()
+            records.extend(data.get("records", []))
+            if not (cursor := data.get("cursor")):
+                break
+    return records
+
+
+async def _proof_verifies(client: httpx.AsyncClient, record: dict) -> bool:
+    rkey = record.get("uri", "").rsplit("/", 1)[-1]
+    for signature in record.get("value", {}).get("signatures", []):
+        uri = signature.get("uri", "")
+        if not uri.startswith("at://"):
+            continue
+        parts = uri.removeprefix("at://").split("/")
+        if len(parts) != 3:
+            continue
+        broker_did, collection, proof_rkey = parts
+        if (
+            broker_did not in settings.atproto.trusted_payment_brokers
+            or collection != PROOF_COLLECTION
+            or proof_rkey != rkey
+        ):
+            continue
+        broker_doc = await resolve_mini_doc_safe(broker_did)
+        if broker_doc is None:
+            continue
+        response = await client.get(
+            f"{broker_doc['pds']}/xrpc/com.atproto.repo.getRecord",
+            params={"repo": broker_did, "collection": collection, "rkey": proof_rkey},
+        )
+        if response.status_code != 200:
+            continue
+        proof = response.json()
+        if (
+            proof.get("cid") == signature.get("cid")
+            and proof.get("value", {}).get("status") == "verified"
+        ):
+            return True
+    return False

--- a/backend/src/backend/_internal/attested.py
+++ b/backend/src/backend/_internal/attested.py
@@ -12,6 +12,7 @@ current content (observed 2026-08-26: 0/7 sampled proofs match), so mutable
 payer-record fields are taken on the payer's word pending broker guidance.
 """
 
+import asyncio
 import logging
 
 import httpx
@@ -28,6 +29,7 @@ PAYMENT_COLLECTIONS = (
     "network.attested.payment.recurring",
 )
 MAX_LIST_PAGES = 5
+OVERALL_DEADLINE = 10.0
 
 
 async def check_attested_support(
@@ -42,8 +44,9 @@ async def check_attested_support(
         artist_did=artist_did,
     ):
         try:
-            return await _check(supporter_did, artist_did, timeout)
-        except httpx.TimeoutException:
+            async with asyncio.timeout(OVERALL_DEADLINE):
+                return await _check(supporter_did, artist_did, timeout)
+        except (httpx.TimeoutException, TimeoutError):
             logfire.warn("attested verification timeout")
             return False
         except Exception as e:

--- a/backend/src/backend/_internal/supporters.py
+++ b/backend/src/backend/_internal/supporters.py
@@ -3,7 +3,8 @@
 answers "does DID X support artist DID Y" from, in order: attested.network
 payment attestations (broker-verified, portable across apps), then the
 atprotofans validateSupporter endpoint. results are cached per pair in Redis;
-transient failures are not cached. all supporter gating flows through here —
+transient atprotofans failures are not cached. all supporter gating flows
+through here —
 new verification sources become branches of validate_supporter, not new
 call sites.
 """

--- a/backend/src/backend/_internal/supporters.py
+++ b/backend/src/backend/_internal/supporters.py
@@ -1,0 +1,111 @@
+"""supporter verification choke point.
+
+answers "does DID X support artist DID Y" from, in order: attested.network
+payment attestations (broker-verified, portable across apps), then the
+atprotofans validateSupporter endpoint. results are cached per pair in Redis;
+transient failures are not cached. all supporter gating flows through here —
+new verification sources become branches of validate_supporter, not new
+call sites.
+"""
+
+import asyncio
+import logging
+
+import logfire
+from redis.exceptions import RedisError
+
+from backend._internal.atprotofans import SupporterValidation, check_atprotofans_support
+from backend._internal.attested import check_attested_support
+from backend.utilities.redis import get_async_redis_client
+
+logger = logging.getLogger(__name__)
+
+SUPPORTER_CACHE_TTL = 300  # 5 minutes
+
+
+def _cache_key(supporter_did: str, artist_did: str) -> str:
+    return f"supporter:{supporter_did}:{artist_did}"
+
+
+async def _get_cached(supporter_did: str, artist_did: str) -> bool | None:
+    """check Redis for cached supporter validation. returns True/False or None on miss."""
+    try:
+        redis = get_async_redis_client()
+        val = await redis.get(_cache_key(supporter_did, artist_did))
+        if val is not None:
+            return val == "1"
+    except (RuntimeError, RedisError):
+        pass
+    return None
+
+
+async def _set_cached(supporter_did: str, artist_did: str, valid: bool) -> None:
+    """cache supporter validation result in Redis."""
+    try:
+        redis = get_async_redis_client()
+        await redis.set(
+            _cache_key(supporter_did, artist_did),
+            "1" if valid else "0",
+            ex=SUPPORTER_CACHE_TTL,
+        )
+    except (RuntimeError, RedisError):
+        logger.debug("failed to cache supporter validation")
+
+
+async def validate_supporter(
+    supporter_did: str,
+    artist_did: str,
+    timeout: float = 5.0,
+) -> SupporterValidation:
+    """validate whether a user supports an artist.
+
+    checks attested.network payment attestations first, then atprotofans.
+    results are cached in Redis for 5 minutes; a transient atprotofans
+    failure is treated as not-a-supporter without caching.
+    """
+    cached = await _get_cached(supporter_did, artist_did)
+    if cached is not None:
+        logfire.info(
+            "supporter cache hit",
+            valid=cached,
+            supporter_did=supporter_did,
+            artist_did=artist_did,
+        )
+        return SupporterValidation(valid=cached)
+
+    if await check_attested_support(supporter_did, artist_did, timeout):
+        await _set_cached(supporter_did, artist_did, True)
+        return SupporterValidation(valid=True)
+
+    result = await check_atprotofans_support(supporter_did, artist_did, timeout)
+    if result is None:
+        return SupporterValidation(valid=False)
+
+    await _set_cached(supporter_did, artist_did, result.valid)
+    return result
+
+
+async def get_supported_artists(
+    supporter_did: str,
+    artist_dids: set[str],
+    timeout: float = 5.0,
+) -> set[str]:
+    """batch check which artists a user supports.
+
+    args:
+        supporter_did: DID of the potential supporter
+        artist_dids: set of artist DIDs to check
+        timeout: request timeout per check
+
+    returns:
+        set of artist DIDs the user supports
+    """
+    if not artist_dids:
+        return set()
+
+    async def check_one(artist_did: str) -> str | None:
+        result = await validate_supporter(supporter_did, artist_did, timeout)
+        return artist_did if result.valid else None
+
+    results = await asyncio.gather(*[check_one(did) for did in artist_dids])
+    return {did for did in results if did is not None}

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -395,6 +395,11 @@ class AtprotoSettings(AppSettingsSection):
         validation_alias="ATPROTO_APP_NAMESPACE",
         description="ATProto app namespace used for record collections",
     )
+    trusted_payment_brokers: list[str] = Field(
+        default=["did:plc:7srqsetux75b6flzbbyag2ro"],  # broker.atmosphere.money
+        validation_alias="ATPROTO_TRUSTED_PAYMENT_BROKERS",
+        description="DIDs whose network.attested.payment.proof records are accepted as payment verification",
+    )
     old_app_namespace: str | None = Field(
         default=None,
         validation_alias="ATPROTO_OLD_APP_NAMESPACE",

--- a/backend/tests/_internal/test_attested.py
+++ b/backend/tests/_internal/test_attested.py
@@ -1,0 +1,161 @@
+"""tests for attested.network payment attestation verification.
+
+fixtures mirror the live record shapes observed 2026-08-26: a payer record
+in the supporter's repo whose signatures strongRef points at a proof record
+(same rkey) in the broker's repo, verified by matching the proof record's
+actual CID against the strongRef and checking status "verified".
+"""
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from backend._internal.attested import check_attested_support
+from backend._internal.slingshot import MiniDoc
+
+SUPPORTER_DID = "did:plc:supporter123"
+ARTIST_DID = "did:plc:artist456"
+BROKER_DID = "did:plc:7srqsetux75b6flzbbyag2ro"
+SUPPORTER_PDS = "https://pds.supporter.example"
+BROKER_PDS = "https://pds.broker.example"
+RKEY = "byufwlvuo4u7c"
+PROOF_URI = f"at://{BROKER_DID}/network.attested.payment.proof/{RKEY}"
+PROOF_RECORD_CID = "bafyreiproofrecordcid"
+
+
+def _payer_record(
+    subject: str = ARTIST_DID, signature_cid: str = PROOF_RECORD_CID
+) -> dict[str, Any]:
+    return {
+        "uri": f"at://{SUPPORTER_DID}/network.attested.payment.oneTime/{RKEY}",
+        "cid": "bafyreipayerrecordcid",
+        "value": {
+            "$type": "network.attested.payment.oneTime",
+            "txnid": RKEY,
+            "subject": subject,
+            "amount": 2500,
+            "currency": "USD",
+            "signatures": [
+                {
+                    "$type": "com.atproto.repo.strongRef",
+                    "uri": PROOF_URI,
+                    "cid": signature_cid,
+                }
+            ],
+        },
+    }
+
+
+def _proof_response(status: str = "verified") -> dict[str, Any]:
+    return {
+        "uri": PROOF_URI,
+        "cid": PROOF_RECORD_CID,
+        "value": {"$type": "network.attested.payment.proof", "status": status},
+    }
+
+
+def _mini_doc(did: str, pds: str) -> MiniDoc:
+    return MiniDoc(did=did, handle="someone.example", pds=pds, signing_key="")
+
+
+def _client_for(
+    payer_records: list[dict[str, Any]], proof: dict[str, Any] | None
+) -> AsyncMock:
+    def respond(url: str, params: dict[str, Any] | None = None) -> MagicMock:
+        response = MagicMock()
+        params = params or {}
+        if "listRecords" in url:
+            records = (
+                payer_records
+                if params.get("collection") == "network.attested.payment.oneTime"
+                else []
+            )
+            response.status_code = 200
+            response.json.return_value = {"records": records}
+        elif "getRecord" in url and proof is not None:
+            response.status_code = 200
+            response.json.return_value = proof
+        else:
+            response.status_code = 404
+            response.json.return_value = {}
+        return response
+
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.get = AsyncMock(side_effect=respond)
+    return client
+
+
+@pytest.fixture
+def _resolver() -> Iterator[AsyncMock]:
+    docs = {
+        SUPPORTER_DID: _mini_doc(SUPPORTER_DID, SUPPORTER_PDS),
+        BROKER_DID: _mini_doc(BROKER_DID, BROKER_PDS),
+    }
+    resolver = AsyncMock(side_effect=lambda did: docs.get(did))
+    with patch("backend._internal.attested.resolve_mini_doc_safe", resolver):
+        yield resolver
+
+
+async def test_verified_attestation_validates(_resolver: AsyncMock) -> None:
+    client = _client_for([_payer_record()], _proof_response())
+    with patch("backend._internal.attested.httpx.AsyncClient", return_value=client):
+        assert await check_attested_support(SUPPORTER_DID, ARTIST_DID) is True
+
+
+async def test_wrong_subject_does_not_validate(_resolver: AsyncMock) -> None:
+    client = _client_for(
+        [_payer_record(subject="did:plc:someoneelse")], _proof_response()
+    )
+    with patch("backend._internal.attested.httpx.AsyncClient", return_value=client):
+        assert await check_attested_support(SUPPORTER_DID, ARTIST_DID) is False
+
+
+async def test_proof_cid_mismatch_does_not_validate(_resolver: AsyncMock) -> None:
+    """a signature strongRef that doesn't match the proof record's CID is rejected."""
+    client = _client_for(
+        [_payer_record(signature_cid="bafyreisomethingelse")], _proof_response()
+    )
+    with patch("backend._internal.attested.httpx.AsyncClient", return_value=client):
+        assert await check_attested_support(SUPPORTER_DID, ARTIST_DID) is False
+
+
+async def test_unverified_proof_status_does_not_validate(_resolver: AsyncMock) -> None:
+    client = _client_for([_payer_record()], _proof_response(status="pending"))
+    with patch("backend._internal.attested.httpx.AsyncClient", return_value=client):
+        assert await check_attested_support(SUPPORTER_DID, ARTIST_DID) is False
+
+
+async def test_untrusted_broker_does_not_validate(_resolver: AsyncMock) -> None:
+    """a proof from a broker outside the allowlist is never fetched or trusted."""
+    record = _payer_record()
+    record["value"]["signatures"][0]["uri"] = (
+        f"at://did:plc:evilbroker/network.attested.payment.proof/{RKEY}"
+    )
+    client = _client_for([record], _proof_response())
+    with patch("backend._internal.attested.httpx.AsyncClient", return_value=client):
+        assert await check_attested_support(SUPPORTER_DID, ARTIST_DID) is False
+    assert all("getRecord" not in call.args[0] for call in client.get.call_args_list)
+
+
+async def test_proof_rkey_must_match_record_rkey(_resolver: AsyncMock) -> None:
+    """a signature pointing at a proof for a different transaction is rejected."""
+    record = _payer_record()
+    record["value"]["signatures"][0]["uri"] = (
+        f"at://{BROKER_DID}/network.attested.payment.proof/otherrkey"
+    )
+    client = _client_for([record], _proof_response())
+    with patch("backend._internal.attested.httpx.AsyncClient", return_value=client):
+        assert await check_attested_support(SUPPORTER_DID, ARTIST_DID) is False
+
+
+async def test_unresolvable_supporter_pds_is_false() -> None:
+    with patch(
+        "backend._internal.attested.resolve_mini_doc_safe",
+        AsyncMock(return_value=None),
+    ):
+        assert await check_attested_support(SUPPORTER_DID, ARTIST_DID) is False

--- a/backend/tests/_internal/test_supporters.py
+++ b/backend/tests/_internal/test_supporters.py
@@ -1,10 +1,11 @@
-"""tests for atprotofans supporter validation caching."""
+"""tests for the supporter verification choke point (caching + branch order)."""
 
+from collections.abc import Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend._internal.atprotofans import (
+from backend._internal.supporters import (
     SUPPORTER_CACHE_TTL,
     _cache_key,
     get_supported_artists,
@@ -26,16 +27,31 @@ async def _clear_supporter_cache() -> None:
         pass
 
 
-async def test_validate_supporter_caches_result() -> None:
-    """first call hits external API, second call hits Redis cache."""
+@pytest.fixture
+def _no_attested_support() -> Iterator[None]:
+    """make the attested branch report no support."""
+    with patch(
+        "backend._internal.supporters.check_attested_support",
+        AsyncMock(return_value=False),
+    ):
+        yield
+
+
+def _atprotofans_client(valid: bool) -> AsyncMock:
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"valid": True, "profile": None}
+    mock_response.json.return_value = {"valid": valid, "profile": None}
 
     mock_client = AsyncMock()
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mock_client.get = AsyncMock(return_value=mock_response)
+    return mock_client
+
+
+async def test_validate_supporter_caches_result(_no_attested_support: None) -> None:
+    """first call hits external API, second call hits Redis cache."""
+    mock_client = _atprotofans_client(valid=True)
 
     with patch(
         "backend._internal.atprotofans.httpx.AsyncClient", return_value=mock_client
@@ -56,16 +72,9 @@ async def test_validate_supporter_caches_result() -> None:
     assert cached == "1"
 
 
-async def test_validate_supporter_caches_negative() -> None:
+async def test_validate_supporter_caches_negative(_no_attested_support: None) -> None:
     """non-supporter results are also cached to avoid repeated lookups."""
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {"valid": False}
-
-    mock_client = AsyncMock()
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client = _atprotofans_client(valid=False)
 
     with patch(
         "backend._internal.atprotofans.httpx.AsyncClient", return_value=mock_client
@@ -82,16 +91,9 @@ async def test_validate_supporter_caches_negative() -> None:
     assert cached == "0"
 
 
-async def test_cache_ttl_is_set() -> None:
+async def test_cache_ttl_is_set(_no_attested_support: None) -> None:
     """cached value should have a TTL."""
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {"valid": True, "profile": None}
-
-    mock_client = AsyncMock()
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client = _atprotofans_client(valid=True)
 
     with patch(
         "backend._internal.atprotofans.httpx.AsyncClient", return_value=mock_client
@@ -101,6 +103,40 @@ async def test_cache_ttl_is_set() -> None:
     redis = get_async_redis_client()
     ttl = await redis.ttl(_cache_key(SUPPORTER_DID, ARTIST_DID))
     assert 0 < ttl <= SUPPORTER_CACHE_TTL
+
+
+async def test_attested_support_short_circuits_atprotofans() -> None:
+    """a verified attestation validates without consulting atprotofans, and caches."""
+    atprotofans = AsyncMock()
+    with (
+        patch(
+            "backend._internal.supporters.check_attested_support",
+            AsyncMock(return_value=True),
+        ),
+        patch("backend._internal.supporters.check_atprotofans_support", atprotofans),
+    ):
+        result = await validate_supporter(SUPPORTER_DID, ARTIST_DID)
+
+    assert result.valid is True
+    atprotofans.assert_not_called()
+
+    redis = get_async_redis_client()
+    assert await redis.get(_cache_key(SUPPORTER_DID, ARTIST_DID)) == "1"
+
+
+async def test_transient_atprotofans_failure_not_cached(
+    _no_attested_support: None,
+) -> None:
+    """a timeout answers not-a-supporter without poisoning the cache."""
+    with patch(
+        "backend._internal.supporters.check_atprotofans_support",
+        AsyncMock(return_value=None),
+    ):
+        result = await validate_supporter(SUPPORTER_DID, ARTIST_DID)
+
+    assert result.valid is False
+    redis = get_async_redis_client()
+    assert await redis.get(_cache_key(SUPPORTER_DID, ARTIST_DID)) is None
 
 
 async def test_get_supported_artists_uses_cache() -> None:


### PR DESCRIPTION
supporter-gated content now unlocks for anyone holding a broker-verified attested.network payment attestation for the artist — support that happened in any ATM app (e.g. a Supper subscription) counts in plyr, with plyr writing nothing. phase 0 of the ATM integration plan (`docs/internal/research/2026-08-26-atm-integration-plan.md`, design #1871, stance #1722).

## design

`validate_supporter` moves from `_internal/atprotofans.py` to a neutral choke point, `_internal/supporters.py`, which owns the per-pair redis cache (5-minute TTL, negatives included — unchanged) and consults, in order:

1. **attested.network** (`_internal/attested.py`, new): resolve the viewer's PDS via slingshot (safe-URL-checked), list `network.attested.payment.{oneTime,recurring}` from *their own repo*, filter `subject == artist DID`, and accept a record only when a `signatures` strongRef resolves to a `network.attested.payment.proof` record at the **same rkey** in a **trusted broker's** repo whose actual CID matches the strongRef and whose `status` is `"verified"`.
2. **atprotofans** `validateSupporter` — behavior unchanged; kept until the service dies.

trusted brokers are a settings allowlist (`ATPROTO_TRUSTED_PAYMENT_BROKERS`), seeded with `did:plc:7srqsetux75b6flzbbyag2ro` (broker.atmosphere.money). no adapter layer — the function boundary is the abstraction, per #1871.

all consumers (`api/audio.py`, `api/albums/downloads.py`, `api/tracks/listing.py`, `api/for_you.py`) import through `backend._internal` and are untouched.

<details>
<summary>verification shape, validated against live records</summary>

fixture shapes were taken from a live payment (payer record `at://did:plc:crz3gkadxdgwokagvw2jfvp6/network.attested.payment.oneTime/byufwlvuo4u7c`, proof in `pds.atmosphere.money`): payer record carries `txnid` (= rkey), `subject`, `amount`, `currency`, `signatures[strongRef → proof]`, `entitlements[]`; proof carries `{cid, status: "verified"}`.

**known limitation** (observed 2026-08-26, 0/7 sampled proofs): the proof's inner `cid` does **not** pin the payer record's *current* content — recomputing the record's DAG-CBOR CID with/without `signatures` matches neither. so verification pins the *proof* (strongRef cid == proof record's actual CID) and trusts the broker's status, but mutable payer-record fields (notably `subject`) are taken on the payer's word. forging support for artist B therefore requires a real broker-verified payment to *someone*. flagged as a question for the ATM folks; noted in the module docstring.

</details>

<details>
<summary>intentional non-behaviors</summary>

- plyr writes no `network.attested.*` or `money.atmosphere.*` records, ever (position doc `2026-08-25-plyr-atm-position.md`).
- no liveness check on `recurring` records — a record's existence is the signal until ATM events exist (phase 1+); same "ever supported" semantics atprotofans has today.
- private-record-policy payments won't appear in repo reads — correct per spec, not a gap.
- transient atprotofans failures still answer not-a-supporter without caching (pre-existing behavior, now explicit via `check_atprotofans_support` returning `None`).
- attested transient failures also fall through to atprotofans rather than short-circuiting to a cached negative on their own.
- `MAX_LIST_PAGES = 5` caps repo pagination at 500 records per collection per check.

</details>

<details>
<summary>tests</summary>

- `tests/_internal/test_attested.py` (new): verified attestation validates; wrong subject, proof-CID mismatch, unverified status, untrusted broker (asserts the proof is never even fetched), rkey mismatch, unresolvable PDS all refuse.
- `tests/_internal/test_supporters.py` (renamed from `test_atprotofans.py`): existing cache tests preserved; new tests for attested short-circuiting atprotofans and for transient failures not poisoning the cache.
- full backend suite: 1597 passed, 25 skipped.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)