### PR TITLE
uploader: honest toast for the 0%-instant upload failure

### DIFF
--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -108,7 +108,7 @@ function buildNetworkErrorMessage(progressPercent: number, fileSizeMB: number, i
 		return `upload failed${progressInfo}: the server had trouble processing your file. please try again in a moment`;
 	}
 
-	return `upload failed${progressInfo}: connection failed. check your internet connection and try again`;
+	return `upload failed before sending — try re-selecting the file`;
 }
 
 function buildTimeoutErrorMessage(progressPercent: number, fileSizeMB: number, isMobile: boolean): string {


### PR DESCRIPTION
the generic fallback toast blamed the user's internet connection for a failure mode where the browser never sent a single byte — which is usually a file-read failure, not a network one. new copy: `upload failed before sending — try re-selecting the file`.

## motivation

field report today (woody): four upload attempts across two days, each producing the CORS preflight (`OPTIONS /tracks/` in Logfire) but never the `POST /tracks/` — the request died inside the browser. console showed `net::ERR_ACCESS_DENIED`: macOS denied the browser read access to the .aiff on a NAS (network-volume TCC permission). the toast told him "connection failed. check your internet connection and try again", and he correctly observed his internet was fine.

<details>
<summary>design notes</summary>

- `buildNetworkErrorMessage`'s final branch is only reached at exactly 0% progress (the >0% and >=100% cases return earlier), so "before sending" is a statement of fact, not a guess. `progressInfo` is always empty there, so it's dropped.
- the copy deliberately does not enumerate causes (NAS permissions, cloud placeholders, `ERR_UPLOAD_FILE_CHANGED`) — it states what happened and the one step that resolves the common cases: re-selecting the file re-acquires a fresh file handle.
- the mobile-large-file, interrupted (>0%), and server-side (100%) branches are untouched; genuine connectivity failures mid-transfer still get connectivity copy.
- intentional non-behavior: no attempt to distinguish file-read failure from connection-refused at 0% — XHR exposes no signal to tell them apart, so the copy claims neither.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)