### PR TITLE
TrackItem: truncate the feat. credit line instead of overflowing the card

### DIFF
--- a/frontend/src/lib/components/TrackItem.svelte
+++ b/frontend/src/lib/components/TrackItem.svelte
@@ -733,7 +733,14 @@
 		align-items: center;
 		gap: 0.35rem;
 		min-width: 0;
+		max-width: 100%;
+		overflow: hidden;
 		flex-wrap: nowrap;
+	}
+
+	.artist-line:has(.features-inline) .artist-link {
+		max-width: 60%;
+		flex-shrink: 0;
 	}
 
 	.artist-line.only-features {
@@ -763,11 +770,12 @@
 	}
 
 	.features-inline {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.25rem;
+		display: inline;
 		color: var(--text-secondary);
+		min-width: 0;
 		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	.features-label {


### PR DESCRIPTION
On mobile a long \`feat.\` list ran past the track card's right edge and under the ⋮ menu button (seen on the home feed today). The credit line now ellipsizes inside the card; rows without features render exactly as before.

<details>
<summary>details</summary>

- \`.artist-line\` gets \`max-width: 100%; overflow: hidden\` so the inline-flex row can't grow past \`.track-info\`.
- \`.features-inline\` becomes a plain inline run with \`overflow: hidden; text-overflow: ellipsis\`, so truncation happens once at the end instead of per-link (the per-link version rendered \`kn… , openguitar.haiku.g…\`).
- \`.artist-link\` only takes \`max-width: 60%; flex-shrink: 0\` when a sibling \`.features-inline\` exists (\`:has\`) — the unconditional version shrink-wrapped no-feature rows to \`tarz…\`.
- verified at 390px against the prod API: \`.artist-line\` right edge == \`.track-info\` right edge (327px) on every row with features; screenshots reviewed for the no-feature, one-feature and two-feature cases.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1tfe86u4VMB9DbgBKL6Sb