### PR TITLE
BufoEasterEgg: call find-bufo.com and send X-Client

### DIFF
--- a/frontend/src/lib/components/BufoEasterEgg.svelte
+++ b/frontend/src/lib/components/BufoEasterEgg.svelte
@@ -87,7 +87,9 @@
 			if (include.length > 0) {
 				params.set('include', include.join(','));
 			}
-			const response = await fetch(`https://find-bufo.fly.dev/api/search?${params}`);
+			const response = await fetch(`https://find-bufo.com/api/search?${params}`, {
+				headers: { 'X-Client': 'plyr.fm' }
+			});
 			if (response.ok) {
 				const data = await response.json();
 				bufos = data.results || [];


### PR DESCRIPTION
the bufo easter egg has been silently failing since 2026-08-28: it fetched \`find-bufo.fly.dev\`, the rust fly app destroyed when find-bufo.com moved to the zig server. point it at \`https://find-bufo.com/api/search\` and send \`X-Client: plyr.fm\` so find-bufo attributes the traffic (same convention as typeahead.waow.tech).

<details>
<summary>verification</summary>

- API contract unchanged: same query params, \`results[].url/name/score\`
- \`OPTIONS\` preflight with \`Access-Control-Request-Headers: x-client\` from \`Origin: https://plyr.fm\` → 204; \`GET\` → 200 with \`access-control-allow-origin: *\`
- find-bufo.com denies the \`bigbufo_*\` tile set by default, matching plyr's existing exclude pattern

frontend-only — promote with \`just release-frontend-only\`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCkppptjTLXRvorWp12NsK