### PR TITLE
uploads: resumable upload sessions for the web uploader

### DIFF
--- a/backend/src/backend/_internal/tasks/__init__.py
+++ b/backend/src/backend/_internal/tasks/__init__.py
@@ -34,7 +34,7 @@ from backend._internal.tasks.moderation import (
     scan_image_moderation,
     schedule_image_moderation_scan,
 )
-from backend._internal.tasks.reaper import reap_stuck_uploads
+from backend._internal.tasks.reaper import reap_abandoned_transfers, reap_stuck_uploads
 from backend._internal.tasks.ingest import (
     SubjectNotFoundError,
     ingest_account_reactivated,
@@ -143,6 +143,7 @@ def _build_background_tasks() -> list:
         run_track_audio_replace,
         optimize_track_audio,
         reap_stuck_uploads,
+        reap_abandoned_transfers,
     ]
 
 
@@ -189,6 +190,7 @@ __all__ = [
     "pds_delete_like",
     "pds_update_comment",
     "publish_moderation_decisions",
+    "reap_abandoned_transfers",
     "reap_stuck_uploads",
     "run_post_track_create_hooks",
     "scan_copyright",

--- a/backend/src/backend/_internal/tasks/reaper.py
+++ b/backend/src/backend/_internal/tasks/reaper.py
@@ -43,6 +43,7 @@ from backend._internal.notifications import notification_service
 from backend.models import Artist, Track
 from backend.models.job import Job, JobStatus, JobType
 from backend.storage import storage
+from backend.storage.keys import StagedUploadKey
 from backend.utilities.database import db_session
 
 logger = logging.getLogger(__name__)
@@ -121,6 +122,66 @@ async def reap_stuck_uploads(
                 threshold_minutes=int(STUCK_UPLOAD_THRESHOLD.total_seconds() / 60),
                 job_ids=[j.id for j in reaped],
             )
+
+
+ABANDONED_TRANSFER_THRESHOLD = timedelta(hours=24)
+
+
+async def reap_abandoned_transfers(
+    perpetual: Perpetual = Perpetual(every=timedelta(minutes=30), automatic=True),  # noqa: B008
+) -> None:
+    """close resumable upload sessions nobody has sent a part to in a day.
+
+    a session sits in `pending` / phase `transfer` while the browser sends
+    parts (each part heartbeats `updated_at`); a closed tab leaves it there
+    with an open R2 multipart upload. R2 aborts those itself after 7 days;
+    this just makes the job row say so sooner and stops the client resuming
+    into a session that will never finish. no notification — the user
+    walked away, nothing failed.
+    """
+    cutoff = datetime.now(UTC) - ABANDONED_TRANSFER_THRESHOLD
+    now = datetime.now(UTC)
+    async with db_session() as db:
+        stale_ids = (
+            select(Job.id)
+            .where(
+                Job.type == JobType.UPLOAD.value,
+                Job.status == JobStatus.PENDING.value,
+                Job.phase == "transfer",
+                Job.updated_at < cutoff,
+            )
+            .with_for_update(skip_locked=True)
+        )
+        result = await db.execute(
+            update(Job)
+            .where(Job.id.in_(stale_ids))
+            .values(
+                status=JobStatus.FAILED.value,
+                message="upload failed",
+                error="upload session expired — please re-upload",
+                completed_at=now,
+                updated_at=now,
+            )
+            .returning(Job)
+        )
+        abandoned = list(result.scalars().all())
+        await db.commit()
+
+    for job in abandoned:
+        transfer = (job.result or {}).get("transfer") or {}
+        try:
+            staged = StagedUploadKey(
+                upload_id=job.id, extension=str(transfer["extension"])
+            )
+            await storage.abort_staged_upload(staged, str(transfer["multipart_id"]))
+        except Exception as e:
+            logfire.warning(
+                "could not abort abandoned multipart upload",
+                job_id=job.id,
+                error=str(e),
+            )
+    if abandoned:
+        logfire.info("reaped abandoned upload sessions", count=len(abandoned))
 
 
 async def _maybe_cleanup_staged_blob(db, job: Job) -> None:

--- a/backend/src/backend/api/tracks/__init__.py
+++ b/backend/src/backend/api/tracks/__init__.py
@@ -12,6 +12,9 @@ from . import (
     shares as _shares,
 )  # /me/shares, /{track_id}/share, /{track_id}/ref/{code}/click
 from . import uploads as _uploads  # /, /uploads/{upload_id}/progress
+from . import (
+    upload_sessions as _upload_sessions,
+)  # /uploads, /uploads/{id}/parts/{n}, /uploads/{id}/finish
 from . import comments as _comments  # /{track_id}/comments, /comments/{comment_id}
 from . import mutations as _mutations  # /{track_id}, /{track_id}/restore-record
 from . import copyright as _copyright  # /{track_id}/copyright

--- a/backend/src/backend/api/tracks/upload_sessions.py
+++ b/backend/src/backend/api/tracks/upload_sessions.py
@@ -1,0 +1,353 @@
+"""resumable track uploads: start → parts → finish.
+
+the single-request `POST /tracks/` holds one HTTP request open for the
+whole transfer and then stages the bytes to storage before answering, so a
+large file means one very long request with nothing to show after the last
+byte. a session splits the transfer into fixed-size parts that land straight
+in an R2 multipart upload; each part is a short request the client can time
+out, retry and report on independently, and `finish` answers as soon as the
+parts are assembled. the worker then settles the staged bytes
+(`uploads._settle_staged_audio`) and runs the ordinary upload pipeline.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Annotated
+
+import logfire
+from botocore.exceptions import ClientError
+from fastapi import Depends, File, Form, HTTPException, Request, UploadFile
+from pydantic import BaseModel, Field
+
+from backend._internal import Session as AuthSession
+from backend._internal import require_artist_profile
+from backend._internal.jobs import job_service
+from backend.config import settings
+from backend.models.job import Job, JobStatus, JobType
+from backend.storage import storage
+from backend.storage.keys import StagedUploadKey
+from backend.utilities.audio_formats import AudioFormat
+from backend.utilities.rate_limit import limiter
+
+from .router import router
+from .uploads import (
+    UploadContext,
+    UploadStartResponse,
+    parse_upload_metadata,
+    schedule_track_upload,
+    stage_image_from_upload,
+)
+
+PART_SIZE_BYTES = 10 * 1024 * 1024
+MAX_PARTS = 10_000
+TRANSFER_PHASE = "transfer"
+
+
+class UploadSessionStart(BaseModel):
+    filename: str = Field(min_length=1)
+    size_bytes: int = Field(gt=0)
+
+
+class UploadSessionState(BaseModel):
+    upload_id: str
+    part_size_bytes: int
+    part_count: int
+    received_parts: list[int]
+
+
+class UploadPartReceipt(BaseModel):
+    part_number: int
+    etag: str
+
+
+@dataclass(frozen=True)
+class TransferState:
+    """what the job row remembers about an open transfer (`Job.result["transfer"]`)."""
+
+    multipart_id: str
+    filename: str
+    extension: str
+    size_bytes: int
+    part_size_bytes: int
+    part_count: int
+
+    def expected_part_size(self, part_number: int) -> int:
+        if part_number < self.part_count:
+            return self.part_size_bytes
+        return self.size_bytes - self.part_size_bytes * (self.part_count - 1)
+
+    def as_result(self) -> dict[str, dict[str, str | int]]:
+        return {
+            "transfer": {
+                "multipart_id": self.multipart_id,
+                "filename": self.filename,
+                "extension": self.extension,
+                "size_bytes": self.size_bytes,
+                "part_size_bytes": self.part_size_bytes,
+                "part_count": self.part_count,
+            }
+        }
+
+    @classmethod
+    def from_job(cls, job: Job) -> "TransferState | None":
+        transfer = (job.result or {}).get("transfer")
+        if not isinstance(transfer, dict):
+            return None
+        return cls(
+            multipart_id=str(transfer["multipart_id"]),
+            filename=str(transfer["filename"]),
+            extension=str(transfer["extension"]),
+            size_bytes=int(transfer["size_bytes"]),
+            part_size_bytes=int(transfer["part_size_bytes"]),
+            part_count=int(transfer["part_count"]),
+        )
+
+
+def _staged(upload_id: str, transfer: TransferState) -> StagedUploadKey:
+    return StagedUploadKey(upload_id=upload_id, extension=transfer.extension)
+
+
+async def _open_transfer(upload_id: str, did: str) -> tuple[Job, TransferState]:
+    """the caller's own upload session, still in the transfer phase."""
+    job = await job_service.get_job(upload_id)
+    if job is None or job.owner_did != did or job.type != JobType.UPLOAD.value:
+        raise HTTPException(status_code=404, detail="upload session not found")
+    transfer = TransferState.from_job(job)
+    if (
+        transfer is None
+        or job.phase != TRANSFER_PHASE
+        or job.status != JobStatus.PENDING.value
+    ):
+        raise HTTPException(status_code=409, detail="upload session is not open")
+    return job, transfer
+
+
+@router.post("/uploads")
+@limiter.limit(settings.rate_limit.upload_limit)
+async def start_upload_session(
+    request: Request,
+    body: UploadSessionStart,
+    auth_session: AuthSession = Depends(require_artist_profile),
+) -> UploadSessionState:
+    """open a resumable upload; the bytes arrive through `PUT .../parts/{n}`."""
+    extension = body.filename.rsplit(".", 1)[-1].lower() if "." in body.filename else ""
+    if AudioFormat.from_extension(f".{extension}") is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unsupported file type: .{extension}. "
+            f"supported: {AudioFormat.supported_extensions_str()}",
+        )
+    max_size = settings.storage.max_upload_size_mb * 1024 * 1024
+    if body.size_bytes > max_size:
+        raise HTTPException(
+            status_code=413,
+            detail=f"file too large (max {settings.storage.max_upload_size_mb}MB)",
+        )
+    part_count = math.ceil(body.size_bytes / PART_SIZE_BYTES)
+    if part_count > MAX_PARTS:
+        raise HTTPException(status_code=413, detail="file has too many parts")
+
+    upload_id = await job_service.create_job(
+        JobType.UPLOAD, auth_session.did, "waiting for your file..."
+    )
+    staged = StagedUploadKey(upload_id=upload_id, extension=extension)
+    multipart_id = await storage.begin_staged_upload(staged)
+    transfer = TransferState(
+        multipart_id=multipart_id,
+        filename=body.filename,
+        extension=extension,
+        size_bytes=body.size_bytes,
+        part_size_bytes=PART_SIZE_BYTES,
+        part_count=part_count,
+    )
+    await job_service.update_progress(
+        upload_id,
+        JobStatus.PENDING,
+        "uploading your file...",
+        phase=TRANSFER_PHASE,
+        result=transfer.as_result(),
+    )
+    logfire.info(
+        "upload session opened",
+        upload_id=upload_id,
+        size_bytes=body.size_bytes,
+        part_count=part_count,
+    )
+    return UploadSessionState(
+        upload_id=upload_id,
+        part_size_bytes=PART_SIZE_BYTES,
+        part_count=part_count,
+        received_parts=[],
+    )
+
+
+@router.get("/uploads/{upload_id}")
+async def get_upload_session(
+    upload_id: str,
+    auth_session: AuthSession = Depends(require_artist_profile),
+) -> UploadSessionState:
+    """which parts have landed — what a client needs to resume after a drop."""
+    _, transfer = await _open_transfer(upload_id, auth_session.did)
+    received = await storage.staged_part_numbers(
+        _staged(upload_id, transfer), transfer.multipart_id
+    )
+    return UploadSessionState(
+        upload_id=upload_id,
+        part_size_bytes=transfer.part_size_bytes,
+        part_count=transfer.part_count,
+        received_parts=received,
+    )
+
+
+@router.put("/uploads/{upload_id}/parts/{part_number}")
+async def put_upload_part(
+    upload_id: str,
+    part_number: int,
+    request: Request,
+    auth_session: AuthSession = Depends(require_artist_profile),
+) -> UploadPartReceipt:
+    """one fixed-size slice of the file; re-sending a part number replaces it."""
+    _, transfer = await _open_transfer(upload_id, auth_session.did)
+    if not 1 <= part_number <= transfer.part_count:
+        raise HTTPException(
+            status_code=400,
+            detail=f"part_number must be between 1 and {transfer.part_count}",
+        )
+    body = await request.body()
+    expected = transfer.expected_part_size(part_number)
+    if len(body) != expected:
+        raise HTTPException(
+            status_code=400,
+            detail=f"part {part_number} must be {expected} bytes, got {len(body)}",
+        )
+    etag = await storage.put_staged_part(
+        _staged(upload_id, transfer), transfer.multipart_id, part_number, body
+    )
+    await job_service.heartbeat(upload_id)
+    return UploadPartReceipt(part_number=part_number, etag=etag)
+
+
+@router.post("/uploads/{upload_id}/finish")
+async def finish_upload_session(
+    upload_id: str,
+    request: Request,
+    title: Annotated[str, Form()],
+    auth_session: AuthSession = Depends(require_artist_profile),
+    album: Annotated[str | None, Form()] = None,
+    album_id: Annotated[str | None, Form()] = None,
+    features: Annotated[str | None, Form()] = None,
+    tags: Annotated[str | None, Form()] = None,
+    visibility: Annotated[str, Form()] = "public",
+    copyright: Annotated[str | None, Form()] = None,
+    description: Annotated[str | None, Form()] = None,
+    self_labels: Annotated[str | None, Form()] = None,
+    auto_tag: Annotated[str | None, Form()] = None,
+    image: UploadFile | None = File(None),
+) -> UploadStartResponse:
+    """assemble the parts and queue the track; same fields as `POST /tracks/` minus `file`.
+
+    a missing part leaves the session open (409) so the client can resend it;
+    only a fully assembled file is handed to the worker.
+    """
+    _, transfer = await _open_transfer(upload_id, auth_session.did)
+    meta = parse_upload_metadata(
+        auth_session,
+        filename=transfer.filename,
+        title=title,
+        album=album,
+        album_id=album_id,
+        features=features,
+        tags=tags,
+        visibility=visibility,
+        copyright=copyright,
+        description=description,
+        self_labels=self_labels,
+        auto_tag=auto_tag,
+    )
+    staged = _staged(upload_id, transfer)
+
+    received = await storage.staged_part_numbers(staged, transfer.multipart_id)
+    missing = sorted(set(range(1, transfer.part_count + 1)) - set(received))
+    if missing:
+        logfire.info(
+            "upload session incomplete", upload_id=upload_id, missing=missing[:20]
+        )
+        raise HTTPException(
+            status_code=409,
+            detail=f"upload incomplete — {len(missing)} part(s) missing",
+        )
+    try:
+        size = await storage.complete_staged_upload(staged, transfer.multipart_id)
+    except (ClientError, ValueError) as e:
+        logfire.info("upload session incomplete", upload_id=upload_id, error=str(e))
+        raise HTTPException(
+            status_code=409, detail="upload incomplete — some parts are missing"
+        ) from e
+    if size != transfer.size_bytes:
+        await storage.delete_staged(staged)
+        await job_service.update_progress(
+            upload_id,
+            JobStatus.FAILED,
+            "upload failed",
+            error="uploaded size does not match the declared size",
+        )
+        raise HTTPException(
+            status_code=400,
+            detail=f"uploaded {size} bytes but {transfer.size_bytes} were declared",
+        )
+
+    enqueued = False
+    image_id: str | None = None
+    try:
+        image_id, image_url, thumbnail_url = await stage_image_from_upload(
+            image, is_private=meta.is_private
+        )
+        ctx = UploadContext(
+            upload_id=upload_id,
+            auth_session=auth_session,
+            audio_file_id="",
+            filename=transfer.filename,
+            duration=None,
+            title=meta.title,
+            artist_did=auth_session.did,
+            album=meta.album,
+            album_id=meta.album_id,
+            features_json=meta.features_json,
+            tags=meta.tags,
+            self_labels=meta.self_labels,
+            description=meta.description,
+            image_id=image_id,
+            image_url=image_url,
+            thumbnail_url=thumbnail_url,
+            support_gate=meta.support_gate,
+            copyright_rights=meta.copyright_rights,
+            auto_tag=meta.auto_tag,
+            visibility=meta.visibility,
+            staged=True,
+        )
+        await job_service.update_progress(
+            upload_id,
+            JobStatus.PENDING,
+            "upload queued for processing",
+            phase="queued",
+            progress_pct=0.0,
+        )
+        await schedule_track_upload(ctx)
+        enqueued = True
+    finally:
+        if not enqueued:
+            await storage.delete_staged(staged)
+            if image_id:
+                await storage.discard_staged(image_id)
+            await job_service.update_progress(
+                upload_id,
+                JobStatus.FAILED,
+                "upload failed",
+                error="upload aborted before queueing",
+            )
+
+    return UploadStartResponse(
+        upload_id=upload_id,
+        status="pending",
+        message="upload queued for processing",
+    )

--- a/backend/src/backend/api/tracks/upload_sessions.py
+++ b/backend/src/backend/api/tracks/upload_sessions.py
@@ -10,6 +10,7 @@ parts are assembled. the worker then settles the staged bytes
 (`uploads._settle_staged_audio`) and runs the ordinary upload pipeline.
 """
 
+import contextlib
 import math
 from dataclasses import dataclass
 from typing import Annotated
@@ -39,7 +40,7 @@ from .uploads import (
 )
 
 PART_SIZE_BYTES = 10 * 1024 * 1024
-MAX_PARTS = 10_000
+MAX_PARTS = 1_000
 TRANSFER_PHASE = "transfer"
 
 
@@ -246,8 +247,9 @@ async def finish_upload_session(
 ) -> UploadStartResponse:
     """assemble the parts and queue the track; same fields as `POST /tracks/` minus `file`.
 
-    a missing part leaves the session open (409) so the client can resend it;
-    only a fully assembled file is handed to the worker.
+    a missing part (409) or a rejected cover image (413) leaves the session
+    open so the client can fix and retry; the multipart is only completed
+    once nothing else can refuse the upload.
     """
     _, transfer = await _open_transfer(upload_id, auth_session.did)
     meta = parse_upload_metadata(
@@ -276,32 +278,25 @@ async def finish_upload_session(
             status_code=409,
             detail=f"upload incomplete — {len(missing)} part(s) missing",
         )
-    try:
-        size = await storage.complete_staged_upload(staged, transfer.multipart_id)
-    except (ClientError, ValueError) as e:
-        logfire.info("upload session incomplete", upload_id=upload_id, error=str(e))
-        raise HTTPException(
-            status_code=409, detail="upload incomplete — some parts are missing"
-        ) from e
-    if size != transfer.size_bytes:
-        await storage.delete_staged(staged)
-        await job_service.update_progress(
-            upload_id,
-            JobStatus.FAILED,
-            "upload failed",
-            error="uploaded size does not match the declared size",
-        )
-        raise HTTPException(
-            status_code=400,
-            detail=f"uploaded {size} bytes but {transfer.size_bytes} were declared",
-        )
+
+    image_id, image_url, thumbnail_url = await stage_image_from_upload(
+        image, is_private=meta.is_private
+    )
 
     enqueued = False
-    image_id: str | None = None
     try:
-        image_id, image_url, thumbnail_url = await stage_image_from_upload(
-            image, is_private=meta.is_private
-        )
+        try:
+            size = await storage.complete_staged_upload(staged, transfer.multipart_id)
+        except (ClientError, ValueError) as e:
+            logfire.info("upload session incomplete", upload_id=upload_id, error=str(e))
+            raise HTTPException(
+                status_code=409, detail="upload incomplete — some parts are missing"
+            ) from e
+        if size != transfer.size_bytes:
+            raise HTTPException(
+                status_code=400,
+                detail=f"uploaded {size} bytes but {transfer.size_bytes} were declared",
+            )
         ctx = UploadContext(
             upload_id=upload_id,
             auth_session=auth_session,
@@ -336,15 +331,18 @@ async def finish_upload_session(
         enqueued = True
     finally:
         if not enqueued:
-            await storage.delete_staged(staged)
+            with contextlib.suppress(Exception):
+                await storage.delete_staged(staged)
             if image_id:
-                await storage.discard_staged(image_id)
-            await job_service.update_progress(
-                upload_id,
-                JobStatus.FAILED,
-                "upload failed",
-                error="upload aborted before queueing",
-            )
+                with contextlib.suppress(Exception):
+                    await storage.discard_staged(image_id)
+            with contextlib.suppress(Exception):
+                await job_service.update_progress(
+                    upload_id,
+                    JobStatus.FAILED,
+                    "upload failed",
+                    error="upload aborted before queueing",
+                )
 
     return UploadStartResponse(
         upload_id=upload_id,

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import hashlib
 import json
 import logging
 import tempfile
@@ -68,6 +69,7 @@ from backend.config import settings
 from backend.models import Album, Artist, Track, UserPreferences
 from backend.models.job import JobStatus, JobType
 from backend.storage import storage
+from backend.storage.keys import AudioKey, StagedUploadKey
 from backend.utilities.audio import extract_duration, is_alac
 from backend.utilities.audio_formats import AudioFormat
 from backend.utilities.database import db_session
@@ -158,6 +160,13 @@ class UploadContext:
     # boundary so the worker only writes the permissioned record.
     audio_blob: BlobRef | None = None
 
+    staged: bool = False
+
+    @property
+    def staged_key(self) -> StagedUploadKey:
+        """where a resumable upload's bytes wait until the worker settles them."""
+        return StagedUploadKey(upload_id=self.upload_id, extension=self.audio_extension)
+
     @property
     def private(self) -> bool:
         """private (permissioned-space) media."""
@@ -172,6 +181,13 @@ class UploadContext:
     def audio_extension(self) -> str:
         """source-format extension, normalized (lowercase, no leading dot)."""
         return Path(self.filename).suffix.lower().lstrip(".")
+
+    @property
+    def audio_format(self) -> AudioFormat:
+        fmt = AudioFormat.from_extension(f".{self.audio_extension}")
+        if fmt is None:
+            raise UploadPhaseError(f"unsupported file type: .{self.audio_extension}")
+        return fmt
 
 
 @dataclass
@@ -597,6 +613,85 @@ async def _transcode_audio(
         transcoded_file_id=transcoded_file_id,
         transcoded_file_type=target_format,
     )
+
+
+async def _settle_staged_audio(ctx: UploadContext) -> None:
+    """phase 0 (resumable uploads only): turn staged bytes into what the
+    single-request handler would have produced — a content-hash `file_id`
+    in the right bucket (or a PDS blob for private media), plus the duration
+    and ALAC scan the handler used to do while the bytes were on its /tmp.
+
+    the staged object is read exactly once: hashed as it streams onto the
+    worker's disk, scanned from that local copy, then promoted with a
+    server-side copy — the worker never re-uploads the audio. on any
+    failure the staged object is deleted; nothing else exists yet.
+    """
+    staged = ctx.staged_key
+    await job_service.update_progress(
+        ctx.upload_id, JobStatus.PROCESSING, "checking your file...", phase="settle"
+    )
+    with (
+        logfire.span("settle staged audio", upload_id=ctx.upload_id),
+        tempfile.NamedTemporaryFile(suffix=f".{ctx.audio_extension}") as tmp,
+    ):
+        try:
+            digest = hashlib.sha256()
+            size = 0
+            async with aiofiles.open(tmp.name, "wb") as out:
+                async for chunk in storage.stream_staged(staged):
+                    digest.update(chunk)
+                    size += len(chunk)
+                    await out.write(chunk)
+            if size == 0:
+                raise UploadPhaseError("uploaded file is empty")
+            file_id = digest.hexdigest()[:16]
+
+            def _scan() -> tuple[int | None, bool]:
+                with open(tmp.name, "rb") as f:
+                    duration = extract_duration(f)
+                alac = False
+                if ctx.audio_format is AudioFormat.M4A:
+                    with open(tmp.name, "rb") as f:
+                        alac = is_alac(f)
+                return duration, alac
+
+            ctx.duration, ctx.needs_transcode = await anyio.to_thread.run_sync(_scan)
+
+            if ctx.private:
+
+                def _body() -> AsyncIterable[bytes]:
+                    async def _gen() -> AsyncIterable[bytes]:
+                        async with aiofiles.open(tmp.name, "rb") as af:
+                            while chunk := await af.read(CHUNK_SIZE):
+                                yield chunk
+
+                    return _gen()
+
+                ctx.audio_blob = await upload_blob(
+                    ctx.auth_session,
+                    body_factory=_body,
+                    content_length=size,
+                    content_type=ctx.audio_format.media_type,
+                )
+                await storage.delete_staged(staged)
+            else:
+                is_gated = ctx.support_gate is not None
+                await storage.promote_staged(
+                    staged,
+                    AudioKey.for_file(file_id, ctx.audio_extension),
+                    gated=is_gated,
+                )
+                await job_service.set_cleanup_hints(
+                    ctx.upload_id,
+                    file_id=file_id,
+                    file_type=ctx.audio_extension,
+                    is_gated=is_gated,
+                )
+            ctx.audio_file_id = file_id
+        except Exception:
+            with contextlib.suppress(Exception):
+                await storage.delete_staged(staged)
+            raise
 
 
 async def _validate_audio(ctx: UploadContext) -> AudioInfo:
@@ -1194,9 +1289,10 @@ async def _cleanup_staged_media_pre_db(
         # `_store_audio` either didn't run, or returned the staged file
         # as-is (web-playable). either way, only ctx.audio_file_id is
         # in storage, in the bucket the handler chose.
-        await _delete_staged_audio(
-            ctx.audio_file_id, ctx.audio_extension, gated=is_gated
-        )
+        if ctx.audio_file_id:
+            await _delete_staged_audio(
+                ctx.audio_file_id, ctx.audio_extension, gated=is_gated
+            )
 
     if ctx.image_id:
         with contextlib.suppress(Exception):
@@ -1223,6 +1319,12 @@ async def _process_upload_background(ctx: UploadContext) -> None:
             await job_service.update_progress(
                 ctx.upload_id, JobStatus.PROCESSING, "processing upload..."
             )
+
+            # phase 0: a resumable upload's bytes are still under the staged
+            # key; settle them into a content-hash object (or a PDS blob) so
+            # every later phase sees exactly what a single-request upload sees.
+            if ctx.staged:
+                await _settle_staged_audio(ctx)
 
             # phase 1: validate and prepare audio
             audio_info = await _validate_audio(ctx)
@@ -1354,6 +1456,7 @@ async def run_track_upload(
     audio_blob: BlobRef | None = None,
     visibility: str = "public",
     needs_transcode: bool = False,
+    staged: bool = False,
     concurrency: ConcurrencyLimit = ConcurrencyLimit("artist_did", max_concurrent=3),
 ) -> None:
     """docket task entry point for track uploads.
@@ -1391,7 +1494,12 @@ async def run_track_upload(
         # without a fresh sign-in, so clean up the staged storage objects
         # rather than leaving them as durable orphans. private media has no R2
         # object (the audio is a PDS blob); nothing to delete there.
-        if visibility != "private":
+        if staged:
+            with contextlib.suppress(Exception):
+                await storage.delete_staged(
+                    StagedUploadKey.from_filename(upload_id, filename)
+                )
+        elif visibility != "private":
             await _delete_staged_audio(
                 audio_file_id,
                 Path(filename).suffix.lower().lstrip(".") or None,
@@ -1431,6 +1539,7 @@ async def run_track_upload(
         visibility=visibility,
         audio_blob=audio_blob,
         needs_transcode=needs_transcode,
+        staged=staged,
     )
     await _process_upload_background(ctx)
 
@@ -1473,6 +1582,163 @@ async def schedule_track_upload(ctx: UploadContext) -> None:
         visibility=ctx.visibility,
         audio_blob=ctx.audio_blob,
         needs_transcode=ctx.needs_transcode,
+        staged=ctx.staged,
+    )
+
+
+_VISIBILITIES = frozenset({"public", "unlisted", "supporters", "private"})
+
+
+@dataclass(frozen=True)
+class UploadMetadata:
+    """the validated, non-audio half of an upload request.
+
+    shared by the single-request `POST /tracks/` and the resumable
+    `POST /tracks/uploads/{id}/finish`, so both accept exactly the same
+    fields and reject them for exactly the same reasons.
+    """
+
+    title: str
+    audio_format: AudioFormat
+    audio_extension: str
+    album: str | None
+    album_id: str | None
+    features_json: str | None
+    tags: list[str]
+    self_labels: list[str]
+    description: str | None
+    visibility: str
+    support_gate: dict | None
+    copyright_rights: dict | None
+    auto_tag: bool
+
+    @property
+    def is_private(self) -> bool:
+        return self.visibility == "private"
+
+    @property
+    def is_gated(self) -> bool:
+        return self.support_gate is not None
+
+
+def parse_upload_metadata(
+    auth_session: AuthSession,
+    *,
+    filename: str | None,
+    title: str,
+    album: str | None,
+    album_id: str | None,
+    features: str | None,
+    tags: str | None,
+    visibility: str,
+    copyright: str | None,
+    description: str | None,
+    self_labels: str | None,
+    auto_tag: str | None,
+) -> UploadMetadata:
+    """validate upload form fields; raises HTTPException with the user-facing detail."""
+    if album and album_id:
+        raise HTTPException(
+            status_code=400,
+            detail="album and album_id are mutually exclusive — provide one or the other",
+        )
+
+    try:
+        validated_tags = parse_tags_json(tags)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    try:
+        validated_self_labels = parse_self_label_values_json(self_labels)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    if visibility not in _VISIBILITIES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"invalid visibility: {visibility} (one of {sorted(_VISIBILITIES)})",
+        )
+    is_private = visibility == "private"
+    support_gate: dict | None = {"type": "any"} if visibility == "supporters" else None
+
+    copyright_rights: dict | None = None
+    if copyright:
+        if visibility in ("supporters", "private"):
+            raise HTTPException(
+                status_code=400,
+                detail=f"copyright cannot combine with {visibility} visibility",
+            )
+        try:
+            copyright_rights = TrackRightsInput.model_validate_json(
+                copyright
+            ).model_dump(by_alias=True, exclude_none=True)
+        except ValidationError as e:
+            raise HTTPException(
+                status_code=400, detail=f"invalid copyright payload: {e}"
+            ) from e
+        support_gate = {"type": "copyright"}
+
+    if not filename:
+        raise HTTPException(status_code=400, detail="no filename provided")
+
+    ext = Path(filename).suffix.lower()
+    audio_format = AudioFormat.from_extension(ext)
+    if not audio_format:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unsupported file type: {ext}. "
+            f"supported: {AudioFormat.supported_extensions_str()}",
+        )
+
+    if is_private:
+        if not session_has_private_media_access(auth_session):
+            raise HTTPException(status_code=403, detail="permissioned_scope_required")
+        if not audio_format.is_web_playable:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"private media currently supports web-playable audio only "
+                    f"({ext} needs transcoding); convert to mp3/wav/m4a/flac first"
+                ),
+            )
+
+    return UploadMetadata(
+        title=title,
+        audio_format=audio_format,
+        audio_extension=ext.lstrip("."),
+        album=album,
+        album_id=album_id,
+        features_json=features,
+        tags=validated_tags,
+        self_labels=validated_self_labels,
+        description=description,
+        visibility=visibility,
+        support_gate=support_gate,
+        copyright_rights=copyright_rights,
+        auto_tag=auto_tag == "true",
+    )
+
+
+async def stage_image_from_upload(
+    image: UploadFile | None, *, is_private: bool
+) -> tuple[str | None, str | None, str | None]:
+    """read an optional cover image and stage it; (image_id, image_url, thumbnail_url).
+
+    best-effort: a missing or invalid image never fails the upload. private
+    media has no public cover in this MVP.
+    """
+    if not (image and image.filename) or is_private:
+        return None, None, None
+    max_image_size = 20 * 1024 * 1024
+    image_buffer = BytesIO()
+    image_bytes_read = 0
+    while chunk := await image.read(CHUNK_SIZE):
+        image_bytes_read += len(chunk)
+        if image_bytes_read > max_image_size:
+            raise HTTPException(status_code=413, detail="image too large (max 20MB)")
+        image_buffer.write(chunk)
+    return await stage_image_to_storage(
+        image_buffer.getvalue(), image.filename, image.content_type
     )
 
 
@@ -1539,82 +1805,30 @@ async def upload_track(
     Returns:
         dict: A payload containing `upload_id` for monitoring progress via SSE.
     """
-    # album and album_id are mutually exclusive
-    if album and album_id:
-        raise HTTPException(
-            status_code=400,
-            detail="album and album_id are mutually exclusive — provide one or the other",
-        )
-
-    # validate tags upfront before any processing
-    try:
-        validated_tags = parse_tags_json(tags)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-
-    try:
-        validated_self_labels = parse_self_label_values_json(self_labels)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-
-    # visibility is the single source of truth; derive the transient gating flags.
-    _VISIBILITIES = {"public", "unlisted", "supporters", "private"}
-    if visibility not in _VISIBILITIES:
-        raise HTTPException(
-            status_code=400,
-            detail=f"invalid visibility: {visibility} (one of {sorted(_VISIBILITIES)})",
-        )
-    is_private = visibility == "private"
-    # supporters → atprotofans gate; carried as support_gate on the public record
-    parsed_support_gate: dict | None = (
-        {"type": "any"} if visibility == "supporters" else None
-    )
-
-    # copyright (indiemusi) is orthogonal — it rides on a public/unlisted track and
-    # gates audio at the app layer. it can't combine with supporters or private.
-    parsed_copyright: dict | None = None
-    if copyright:
-        if visibility in ("supporters", "private"):
-            raise HTTPException(
-                status_code=400,
-                detail=f"copyright cannot combine with {visibility} visibility",
-            )
-        try:
-            parsed_copyright = TrackRightsInput.model_validate_json(
-                copyright
-            ).model_dump(by_alias=True, exclude_none=True)
-        except ValidationError as e:
-            raise HTTPException(
-                status_code=400, detail=f"invalid copyright payload: {e}"
-            ) from e
-        parsed_support_gate = {"type": "copyright"}
-
-    # validate audio file type upfront
     if not file.filename:
         raise HTTPException(status_code=400, detail="no filename provided")
-
-    ext = Path(file.filename).suffix.lower()
-    audio_format = AudioFormat.from_extension(ext)
-    if not audio_format:
-        raise HTTPException(
-            status_code=400,
-            detail=f"unsupported file type: {ext}. "
-            f"supported: {AudioFormat.supported_extensions_str()}",
-        )
-
-    # web-playable only: the blob is written at publish time, and the deferred
-    # transcode path still targets the public repo.
-    if is_private:
-        if not session_has_private_media_access(auth_session):
-            raise HTTPException(status_code=403, detail="permissioned_scope_required")
-        if not audio_format.is_web_playable:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    f"private media currently supports web-playable audio only "
-                    f"({ext} needs transcoding); convert to mp3/wav/m4a/flac first"
-                ),
-            )
+    filename = file.filename
+    meta = parse_upload_metadata(
+        auth_session,
+        filename=filename,
+        title=title,
+        album=album,
+        album_id=album_id,
+        features=features,
+        tags=tags,
+        visibility=visibility,
+        copyright=copyright,
+        description=description,
+        self_labels=self_labels,
+        auto_tag=auto_tag,
+    )
+    audio_format = meta.audio_format
+    is_private = meta.is_private
+    parsed_support_gate = meta.support_gate
+    parsed_copyright = meta.copyright_rights
+    validated_tags = meta.tags
+    validated_self_labels = meta.self_labels
+    ext = f".{meta.audio_extension}"
 
     # stage audio + image to shared object storage BEFORE enqueueing the
     # docket task. only stable file_ids travel over Redis to the worker —
@@ -1709,7 +1923,7 @@ async def upload_track(
             # copyright) go to the private bucket; public tracks to the public one.
             with open(file_path, "rb") as f:
                 audio_file_id = await stage_audio_to_storage(
-                    upload_id, f, file.filename, gated=is_gated
+                    upload_id, f, filename, gated=is_gated
                 )
             if audio_extension:
                 await job_service.set_cleanup_hints(
@@ -1724,27 +1938,15 @@ async def upload_track(
         # treats `image_id is None` as "no track artwork").
         # private media has no public cover in this MVP (a public imageUrl would
         # leak the artwork); cover-as-PDS-blob is a follow-up.
-        if image and image.filename and not is_private:
-            max_image_size = 20 * 1024 * 1024
-            image_buffer = BytesIO()
-            image_bytes_read = 0
-            while chunk := await image.read(CHUNK_SIZE):
-                image_bytes_read += len(chunk)
-                if image_bytes_read > max_image_size:
-                    raise HTTPException(
-                        status_code=413,
-                        detail="image too large (max 20MB)",
-                    )
-                image_buffer.write(chunk)
-            image_id, image_url, thumbnail_url = await stage_image_to_storage(
-                image_buffer.getvalue(), image.filename, image.content_type
-            )
+        image_id, image_url, thumbnail_url = await stage_image_from_upload(
+            image, is_private=is_private
+        )
 
         ctx = UploadContext(
             upload_id=upload_id,
             auth_session=auth_session,
             audio_file_id=audio_file_id,
-            filename=file.filename,
+            filename=filename,
             duration=duration,
             title=title,
             artist_did=auth_session.did,

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import tempfile
+import time
 from collections.abc import AsyncIterable, Callable
 from dataclasses import dataclass, field
 from io import BytesIO
@@ -29,6 +30,7 @@ from pydantic import BaseModel, ValidationError
 from sqlalchemy import delete, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.datastructures import UploadFile as StarletteUploadFile
 
 from backend._internal import Session as AuthSession
 from backend._internal import get_session, require_artist_profile
@@ -637,11 +639,15 @@ async def _settle_staged_audio(ctx: UploadContext) -> None:
         try:
             digest = hashlib.sha256()
             size = 0
+            last_beat = time.monotonic()
             async with aiofiles.open(tmp.name, "wb") as out:
                 async for chunk in storage.stream_staged(staged):
                     digest.update(chunk)
                     size += len(chunk)
                     await out.write(chunk)
+                    if time.monotonic() - last_beat >= 5:
+                        await job_service.heartbeat(ctx.upload_id)
+                        last_beat = time.monotonic()
             if size == 0:
                 raise UploadPhaseError("uploaded file is empty")
             file_id = digest.hexdigest()[:16]
@@ -667,12 +673,17 @@ async def _settle_staged_audio(ctx: UploadContext) -> None:
 
                     return _gen()
 
+                async def _heartbeat() -> None:
+                    await job_service.heartbeat(ctx.upload_id)
+
                 ctx.audio_blob = await upload_blob(
                     ctx.auth_session,
                     body_factory=_body,
                     content_length=size,
                     content_type=ctx.audio_format.media_type,
+                    heartbeat=_heartbeat,
                 )
+                ctx.audio_file_id = file_id
                 await storage.delete_staged(staged)
             else:
                 is_gated = ctx.support_gate is not None
@@ -681,13 +692,13 @@ async def _settle_staged_audio(ctx: UploadContext) -> None:
                     AudioKey.for_file(file_id, ctx.audio_extension),
                     gated=is_gated,
                 )
+                ctx.audio_file_id = file_id
                 await job_service.set_cleanup_hints(
                     ctx.upload_id,
                     file_id=file_id,
                     file_type=ctx.audio_extension,
                     is_gated=is_gated,
                 )
-            ctx.audio_file_id = file_id
         except Exception:
             with contextlib.suppress(Exception):
                 await storage.delete_staged(staged)
@@ -1320,9 +1331,6 @@ async def _process_upload_background(ctx: UploadContext) -> None:
                 ctx.upload_id, JobStatus.PROCESSING, "processing upload..."
             )
 
-            # phase 0: a resumable upload's bytes are still under the staged
-            # key; settle them into a content-hash object (or a PDS blob) so
-            # every later phase sees exactly what a single-request upload sees.
             if ctx.staged:
                 await _settle_staged_audio(ctx)
 
@@ -1720,7 +1728,7 @@ def parse_upload_metadata(
 
 
 async def stage_image_from_upload(
-    image: UploadFile | None, *, is_private: bool
+    image: StarletteUploadFile | None, *, is_private: bool
 ) -> tuple[str | None, str | None, str | None]:
     """read an optional cover image and stage it; (image_id, image_url, thumbnail_url).
 

--- a/backend/src/backend/storage/keys.py
+++ b/backend/src/backend/storage/keys.py
@@ -125,6 +125,43 @@ class AudioKey:
 
 
 @dataclass(frozen=True, slots=True)
+class StagedUploadKey:
+    """R2 key for bytes mid-transfer, stored under `staged/<upload_id>.<ext>`.
+
+    a resumable upload lands here part by part before anything knows its
+    content hash. the worker settles it into an `AudioKey` (or a PDS blob)
+    and deletes it; nothing is ever served from this prefix.
+    """
+
+    upload_id: str
+    extension: str
+
+    def __post_init__(self) -> None:
+        if not self.upload_id:
+            raise InvalidMediaExtension("upload_id is required")
+        if AudioFormat.from_extension(self.extension) is None:
+            raise InvalidMediaExtension(
+                f"unsupported audio extension: {self.extension!r} "
+                f"(supported: {AudioFormat.supported_extensions_str()})"
+            )
+
+    @classmethod
+    def from_filename(cls, upload_id: str, filename: str) -> StagedUploadKey:
+        return cls(
+            upload_id=upload_id,
+            extension=_strip_ext(PurePosixPath(filename).suffix),
+        )
+
+    @property
+    def key(self) -> str:
+        return f"staged/{self.upload_id}.{self.extension}"
+
+    @property
+    def format(self) -> AudioFormat:
+        return AudioFormat.from_extension(self.extension)  # type: ignore[return-value]
+
+
+@dataclass(frozen=True, slots=True)
 class ImageKey:
     """R2 key for an image object stored under `images/<file_id>.<ext>`.
 

--- a/backend/src/backend/storage/protocol.py
+++ b/backend/src/backend/storage/protocol.py
@@ -1,8 +1,13 @@
 """storage protocol for type-safe dependency injection."""
 
+from __future__ import annotations
+
 from collections.abc import AsyncIterator, Callable
 from io import BytesIO
-from typing import BinaryIO, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, BinaryIO, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from backend.storage.keys import AudioKey, StagedUploadKey
 
 
 @runtime_checkable
@@ -64,6 +69,38 @@ class StorageProtocol(Protocol):
         ...
 
     async def delete(self, file_id: str, file_type: str | None = None) -> bool: ...
+
+    async def begin_staged_upload(self, staged: StagedUploadKey) -> str: ...
+
+    async def put_staged_part(
+        self,
+        staged: StagedUploadKey,
+        multipart_id: str,
+        part_number: int,
+        body: bytes,
+    ) -> str: ...
+
+    async def complete_staged_upload(
+        self, staged: StagedUploadKey, multipart_id: str
+    ) -> int: ...
+
+    async def staged_part_numbers(
+        self, staged: StagedUploadKey, multipart_id: str
+    ) -> list[int]: ...
+
+    async def abort_staged_upload(
+        self, staged: StagedUploadKey, multipart_id: str
+    ) -> None: ...
+
+    def stream_staged(
+        self, staged: StagedUploadKey, *, chunk_size: int = 1024 * 1024
+    ) -> AsyncIterator[bytes]: ...
+
+    async def promote_staged(
+        self, staged: StagedUploadKey, audio: AudioKey, *, gated: bool
+    ) -> None: ...
+
+    async def delete_staged(self, staged: StagedUploadKey) -> None: ...
 
     async def discard_staged(
         self, file_id: str, file_type: str | None = None, *, gated: bool = False

--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterator, Callable
 from functools import reduce
 from io import BytesIO
 from pathlib import Path, PurePosixPath
-from typing import BinaryIO
+from typing import Any, BinaryIO
 from urllib.parse import quote
 
 import aioboto3
@@ -23,7 +23,12 @@ from backend.config import settings
 from backend.models.album import Album
 from backend.models.playlist import Playlist
 from backend.models.track import Track
-from backend.storage.keys import AudioKey, ImageKey, InvalidMediaExtension
+from backend.storage.keys import (
+    AudioKey,
+    ImageKey,
+    InvalidMediaExtension,
+    StagedUploadKey,
+)
 from backend.utilities.audio_formats import AudioFormat
 from backend.utilities.database import db_session
 from backend.utilities.hashing import hash_file_chunked
@@ -483,6 +488,160 @@ class R2Storage:
                 raise
             size = response.get("ContentLength")
             return int(size) if size is not None else None
+
+    def _staged_bucket(self) -> str:
+        if not self.private_audio_bucket_name:
+            raise ValueError("R2_PRIVATE_BUCKET not configured")
+        return self.private_audio_bucket_name
+
+    async def begin_staged_upload(self, staged: StagedUploadKey) -> str:
+        """open an R2 multipart upload for a resumable transfer.
+
+        staged bytes always live in the private bucket: the public bucket is
+        served verbatim from a custom domain, and a supporter-gated master
+        must never be reachable there, even under an unguessable key.
+        """
+        async with self._s3_client() as client:
+            response = await client.create_multipart_upload(
+                Bucket=self._staged_bucket(),
+                Key=staged.key,
+                ContentType=staged.format.media_type,
+            )
+        multipart_id = response["UploadId"]
+        logfire.info(
+            "R2 staged upload opened", key=staged.key, multipart_id=multipart_id
+        )
+        return multipart_id
+
+    async def put_staged_part(
+        self,
+        staged: StagedUploadKey,
+        multipart_id: str,
+        part_number: int,
+        body: bytes,
+    ) -> str:
+        """upload one part; returns its ETag."""
+        async with self._s3_client() as client:
+            response = await client.upload_part(
+                Bucket=self._staged_bucket(),
+                Key=staged.key,
+                UploadId=multipart_id,
+                PartNumber=part_number,
+                Body=body,
+            )
+        return response["ETag"]
+
+    async def complete_staged_upload(
+        self, staged: StagedUploadKey, multipart_id: str
+    ) -> int:
+        """assemble the parts R2 has received; returns the object size in bytes.
+
+        the part list is read back from R2 rather than tracked in the job row,
+        so a part retried after a lost response can't leave a stale ETag behind.
+        """
+        bucket = self._staged_bucket()
+        async with self._s3_client() as client:
+            parts: list[dict[str, Any]] = []
+            marker = 0
+            while True:
+                listed = await client.list_parts(
+                    Bucket=bucket,
+                    Key=staged.key,
+                    UploadId=multipart_id,
+                    PartNumberMarker=marker,
+                )
+                parts.extend(
+                    {"PartNumber": p["PartNumber"], "ETag": p["ETag"]}
+                    for p in listed.get("Parts", [])
+                )
+                if not listed.get("IsTruncated"):
+                    break
+                marker = listed["NextPartNumberMarker"]
+            if not parts:
+                raise ValueError("no parts uploaded")
+            parts.sort(key=operator.itemgetter("PartNumber"))
+            await client.complete_multipart_upload(
+                Bucket=bucket,
+                Key=staged.key,
+                UploadId=multipart_id,
+                MultipartUpload={"Parts": parts},
+            )
+            head = await client.head_object(Bucket=bucket, Key=staged.key)
+        size = int(head["ContentLength"])
+        logfire.info(
+            "R2 staged upload completed",
+            key=staged.key,
+            parts=len(parts),
+            size=size,
+        )
+        return size
+
+    async def staged_part_numbers(
+        self, staged: StagedUploadKey, multipart_id: str
+    ) -> list[int]:
+        """part numbers R2 has already accepted for this upload."""
+        async with self._s3_client() as client:
+            listed = await client.list_parts(
+                Bucket=self._staged_bucket(),
+                Key=staged.key,
+                UploadId=multipart_id,
+            )
+        return sorted(p["PartNumber"] for p in listed.get("Parts", []))
+
+    async def abort_staged_upload(
+        self, staged: StagedUploadKey, multipart_id: str
+    ) -> None:
+        async with self._s3_client() as client:
+            try:
+                await client.abort_multipart_upload(
+                    Bucket=self._staged_bucket(),
+                    Key=staged.key,
+                    UploadId=multipart_id,
+                )
+            except ClientError as e:
+                if e.response.get("Error", {}).get("Code") != "NoSuchUpload":
+                    raise
+
+    async def stream_staged(
+        self, staged: StagedUploadKey, *, chunk_size: int = STREAM_CHUNK_SIZE
+    ) -> AsyncIterator[bytes]:
+        async with self._s3_client() as client:
+            response = await client.get_object(
+                Bucket=self._staged_bucket(), Key=staged.key
+            )
+            async for chunk in response["Body"].iter_chunks(chunk_size=chunk_size):
+                yield chunk
+
+    async def promote_staged(
+        self, staged: StagedUploadKey, audio: AudioKey, *, gated: bool
+    ) -> None:
+        """server-side copy of a completed staged object to its content-hash key.
+
+        the copy carries the public cache headers the direct `save` path
+        writes; the staged object is deleted afterwards. a copy onto a key
+        that already holds these exact bytes (a re-upload of a published
+        file) is harmless — the duplicate check downstream rejects the track
+        and `discard_staged` keeps the referenced object.
+        """
+        src_bucket = self._staged_bucket()
+        dst_bucket = self.private_audio_bucket_name if gated else self.audio_bucket_name
+        with logfire.span(
+            "R2 promote_staged", src=staged.key, dst=audio.key, gated=gated
+        ):
+            async with self._s3_client() as client:
+                await client.copy_object(
+                    CopySource={"Bucket": src_bucket, "Key": staged.key},
+                    Bucket=dst_bucket,
+                    Key=audio.key,
+                    MetadataDirective="REPLACE",
+                    ContentType=audio.format.media_type,
+                    CacheControl=IMMUTABLE_CACHE_CONTROL,
+                )
+                await client.delete_object(Bucket=src_bucket, Key=staged.key)
+
+    async def delete_staged(self, staged: StagedUploadKey) -> None:
+        async with self._s3_client() as client:
+            await client.delete_object(Bucket=self._staged_bucket(), Key=staged.key)
 
     async def _reference_count(self, file_id: str) -> int:
         """how many live rows point at ``file_id``, across every media column.

--- a/backend/tests/_internal/test_stuck_upload_reaper.py
+++ b/backend/tests/_internal/test_stuck_upload_reaper.py
@@ -427,3 +427,54 @@ async def test_reaper_second_run_does_not_reclaim_already_failed_jobs(
     mock_notify.assert_awaited_once()
     await db_session.refresh(job)
     assert job.status == JobStatus.FAILED.value
+
+
+async def test_abandoned_transfer_is_closed_and_its_multipart_aborted(
+    db_session: AsyncSession,
+) -> None:
+    from backend._internal.tasks.reaper import reap_abandoned_transfers
+    from backend.storage.keys import StagedUploadKey
+
+    transfer = {
+        "multipart_id": "mp-1",
+        "filename": "song.wav",
+        "extension": "wav",
+        "size_bytes": 8,
+        "part_size_bytes": 8,
+        "part_count": 1,
+    }
+    stale = Job(
+        type=JobType.UPLOAD.value,
+        status=JobStatus.PENDING.value,
+        owner_did="did:test:walked-away",
+        message="uploading your file...",
+        phase="transfer",
+        result={"transfer": transfer},
+        updated_at=datetime.now(UTC) - timedelta(hours=25),
+    )
+    fresh = Job(
+        type=JobType.UPLOAD.value,
+        status=JobStatus.PENDING.value,
+        owner_did="did:test:still-sending",
+        message="uploading your file...",
+        phase="transfer",
+        result={"transfer": transfer},
+        updated_at=datetime.now(UTC) - timedelta(hours=1),
+    )
+    db_session.add_all([stale, fresh])
+    await db_session.commit()
+
+    with patch(
+        "backend._internal.tasks.reaper.storage.abort_staged_upload",
+        new=AsyncMock(),
+    ) as abort:
+        await reap_abandoned_transfers()
+
+    abort.assert_awaited_once_with(
+        StagedUploadKey(upload_id=stale.id, extension="wav"), "mp-1"
+    )
+    await db_session.refresh(stale)
+    await db_session.refresh(fresh)
+    assert stale.status == JobStatus.FAILED.value
+    assert "expired" in (stale.error or "")
+    assert fresh.status == JobStatus.PENDING.value

--- a/backend/tests/api/test_upload_sessions.py
+++ b/backend/tests/api/test_upload_sessions.py
@@ -1,0 +1,309 @@
+"""resumable upload sessions: start → parts → finish.
+
+drives the real endpoints against the in-memory multipart store in
+`MockStorage`; only the docket enqueue is mocked.
+"""
+
+import hashlib
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import backend.storage
+from backend._internal import Session, require_artist_profile
+from backend._internal.jobs import job_service
+from backend.api.tracks.uploads import UploadContext, _settle_staged_audio
+from backend.models.job import JobStatus, JobType
+from backend.storage.keys import StagedUploadKey
+
+PART = 8
+_AUDIO = bytes(range(20))  # 3 parts of 8, last is 4
+
+
+class _ArtistSession(Session):
+    def __init__(self, did: str = "did:test:artist") -> None:
+        self.did = did
+        self.handle = "artist.test"
+        self.session_id = f"session-{did}"
+        self.oauth_session = {
+            "did": did,
+            "handle": self.handle,
+            "pds_url": "https://test.pds",
+            "scope": "atproto transition:generic",
+            "access_token": "t",
+            "refresh_token": "r",
+            "dpop_private_key_pem": "fake",
+            "dpop_authserver_nonce": "",
+            "dpop_pds_nonce": "",
+        }
+
+
+@pytest.fixture
+def artist_app(
+    fastapi_app: FastAPI, db_session: AsyncSession
+) -> Generator[FastAPI, None, None]:
+    async def _profile() -> Session:
+        return _ArtistSession()
+
+    fastapi_app.dependency_overrides[require_artist_profile] = _profile
+    with patch("backend.api.tracks.upload_sessions.PART_SIZE_BYTES", PART):
+        yield fastapi_app
+    fastapi_app.dependency_overrides.clear()
+
+
+def _mock_storage():
+    return backend.storage._storage
+
+
+def _start(client: TestClient, size: int = len(_AUDIO)) -> dict:
+    resp = client.post(
+        "/tracks/uploads", json={"filename": "song.wav", "size_bytes": size}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _send_parts(
+    client: TestClient, upload_id: str, skip: set[int] | None = None
+) -> None:
+    skip = skip or set()
+    for n, start in enumerate(range(0, len(_AUDIO), PART), start=1):
+        if n in skip:
+            continue
+        resp = client.put(
+            f"/tracks/uploads/{upload_id}/parts/{n}",
+            content=_AUDIO[start : start + PART],
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["part_number"] == n
+
+
+def test_session_round_trip_enqueues_a_staged_upload(artist_app: FastAPI) -> None:
+    with (
+        TestClient(artist_app) as client,
+        patch(
+            "backend.api.tracks.upload_sessions.schedule_track_upload",
+            new=AsyncMock(),
+        ) as schedule,
+    ):
+        session = _start(client)
+        assert session["part_size_bytes"] == PART
+        assert session["part_count"] == 3
+        upload_id = session["upload_id"]
+
+        _send_parts(client, upload_id, skip={2})
+        state = client.get(f"/tracks/uploads/{upload_id}").json()
+        assert state["received_parts"] == [1, 3]
+
+        _send_parts(client, upload_id)
+        resp = client.post(
+            f"/tracks/uploads/{upload_id}/finish",
+            data={"title": "song", "visibility": "public", "tags": '["a"]'},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["upload_id"] == upload_id
+
+    schedule.assert_awaited_once()
+    assert schedule.await_args is not None
+    ctx: UploadContext = schedule.await_args.args[0]
+    assert ctx.staged is True
+    assert ctx.audio_file_id == ""
+    assert ctx.filename == "song.wav"
+    assert ctx.tags == ["a"]
+    assert ctx.upload_id == upload_id
+    assert _mock_storage().staged_objects[ctx.staged_key.key] == _AUDIO
+
+
+async def test_finish_with_a_missing_part_keeps_the_session_open(
+    artist_app: FastAPI,
+) -> None:
+    with (
+        TestClient(artist_app) as client,
+        patch(
+            "backend.api.tracks.upload_sessions.schedule_track_upload",
+            new=AsyncMock(),
+        ) as schedule,
+    ):
+        upload_id = _start(client)["upload_id"]
+        _send_parts(client, upload_id, skip={3})
+        resp = client.post(
+            f"/tracks/uploads/{upload_id}/finish", data={"title": "song"}
+        )
+        assert resp.status_code == 409
+        assert client.get(f"/tracks/uploads/{upload_id}").status_code == 200
+
+    schedule.assert_not_awaited()
+    job = await job_service.get_job(upload_id)
+    assert job is not None
+    assert job.status == JobStatus.PENDING.value
+    assert job.phase == "transfer"
+
+
+def test_part_of_the_wrong_size_is_rejected(artist_app: FastAPI) -> None:
+    with TestClient(artist_app) as client:
+        upload_id = _start(client)["upload_id"]
+        resp = client.put(f"/tracks/uploads/{upload_id}/parts/1", content=b"short")
+        assert resp.status_code == 400
+        assert "must be 8 bytes" in resp.json()["detail"]
+        resp = client.put(f"/tracks/uploads/{upload_id}/parts/4", content=b"x" * 8)
+        assert resp.status_code == 400
+
+
+def test_metadata_is_validated_before_the_parts_are_assembled(
+    artist_app: FastAPI,
+) -> None:
+    with TestClient(artist_app) as client:
+        upload_id = _start(client)["upload_id"]
+        _send_parts(client, upload_id)
+        resp = client.post(
+            f"/tracks/uploads/{upload_id}/finish",
+            data={"title": "song", "visibility": "sideways"},
+        )
+        assert resp.status_code == 400
+        assert "invalid visibility" in resp.json()["detail"]
+        assert client.get(f"/tracks/uploads/{upload_id}").json()["received_parts"] == [
+            1,
+            2,
+            3,
+        ]
+
+
+def test_start_rejects_unsupported_and_oversized_files(artist_app: FastAPI) -> None:
+    with TestClient(artist_app) as client:
+        resp = client.post(
+            "/tracks/uploads", json={"filename": "notes.txt", "size_bytes": 10}
+        )
+        assert resp.status_code == 400
+        resp = client.post(
+            "/tracks/uploads",
+            json={"filename": "song.wav", "size_bytes": 2 * 1024**3},
+        )
+        assert resp.status_code == 413
+
+
+async def test_another_artist_cannot_touch_the_session(artist_app: FastAPI) -> None:
+    foreign_id = await job_service.create_job(
+        JobType.UPLOAD, "did:test:someone-else", "uploading your file..."
+    )
+    await job_service.update_progress(
+        foreign_id,
+        JobStatus.PENDING,
+        "uploading your file...",
+        phase="transfer",
+        result={
+            "transfer": {
+                "multipart_id": "mp",
+                "filename": "x.wav",
+                "extension": "wav",
+                "size_bytes": 8,
+                "part_size_bytes": 8,
+                "part_count": 1,
+            }
+        },
+    )
+    with TestClient(artist_app) as client:
+        assert client.get(f"/tracks/uploads/{foreign_id}").status_code == 404
+        resp = client.put(f"/tracks/uploads/{foreign_id}/parts/1", content=b"x" * 8)
+        assert resp.status_code == 404
+
+
+async def test_settle_promotes_staged_bytes_to_their_content_hash(
+    db_session: AsyncSession,
+) -> None:
+    storage = _mock_storage()
+    staged = StagedUploadKey(upload_id="u-settle", extension="wav")
+    storage.staged_objects[staged.key] = _AUDIO
+    ctx = _staged_ctx("u-settle")
+
+    await _settle_staged_audio(ctx)
+
+    expected = hashlib.sha256(_AUDIO).hexdigest()[:16]
+    assert ctx.audio_file_id == expected
+    assert storage.promoted[f"audio/{expected}.wav"] == (staged.key, False)
+    assert staged.key not in storage.staged_objects
+
+
+async def test_settle_gated_upload_lands_in_the_private_bucket(
+    db_session: AsyncSession,
+) -> None:
+    storage = _mock_storage()
+    staged = StagedUploadKey(upload_id="u-gated", extension="wav")
+    storage.staged_objects[staged.key] = _AUDIO
+    ctx = _staged_ctx("u-gated", support_gate={"type": "any"})
+
+    await _settle_staged_audio(ctx)
+
+    assert storage.promoted[f"audio/{ctx.audio_file_id}.wav"][1] is True
+
+
+async def test_settle_private_upload_writes_the_pds_blob_and_no_r2_object(
+    db_session: AsyncSession,
+) -> None:
+    storage = _mock_storage()
+    staged = StagedUploadKey(upload_id="u-private", extension="wav")
+    storage.staged_objects[staged.key] = _AUDIO
+    ctx = _staged_ctx("u-private", visibility="private")
+    blob = {
+        "$type": "blob",
+        "ref": {"$link": "bafk"},
+        "mimeType": "audio/wav",
+        "size": 1,
+    }
+
+    with patch(
+        "backend.api.tracks.uploads.upload_blob", new=AsyncMock(return_value=blob)
+    ) as upload_blob:
+        await _settle_staged_audio(ctx)
+
+    upload_blob.assert_awaited_once()
+    assert upload_blob.await_args is not None
+    assert upload_blob.await_args.kwargs["content_length"] == len(_AUDIO)
+    assert ctx.audio_blob == blob
+    assert not any(
+        key.startswith("audio/") and value[0] == staged.key
+        for key, value in storage.promoted.items()
+    )
+    assert staged.key not in storage.staged_objects
+
+
+async def test_settle_failure_deletes_the_staged_object(
+    db_session: AsyncSession,
+) -> None:
+    storage = _mock_storage()
+    staged = StagedUploadKey(upload_id="u-empty", extension="wav")
+    storage.staged_objects[staged.key] = b""
+    ctx = _staged_ctx("u-empty")
+
+    with pytest.raises(Exception, match="empty"):
+        await _settle_staged_audio(ctx)
+
+    assert staged.key not in storage.staged_objects
+    assert ctx.audio_file_id == ""
+
+
+def _staged_ctx(
+    upload_id: str,
+    *,
+    visibility: str = "public",
+    support_gate: dict | None = None,
+) -> UploadContext:
+    return UploadContext(
+        upload_id=upload_id,
+        auth_session=_ArtistSession(),
+        audio_file_id="",
+        filename="song.wav",
+        duration=None,
+        title="song",
+        artist_did="did:test:artist",
+        album=None,
+        album_id=None,
+        features_json=None,
+        tags=[],
+        support_gate=support_gate,
+        visibility=visibility,
+        staged=True,
+    )

--- a/backend/tests/api/test_upload_sessions.py
+++ b/backend/tests/api/test_upload_sessions.py
@@ -172,6 +172,26 @@ def test_metadata_is_validated_before_the_parts_are_assembled(
         ]
 
 
+def test_rejected_cover_image_keeps_the_session_open(artist_app: FastAPI) -> None:
+    with TestClient(artist_app) as client:
+        upload_id = _start(client)["upload_id"]
+        _send_parts(client, upload_id)
+        resp = client.post(
+            f"/tracks/uploads/{upload_id}/finish",
+            data={"title": "song"},
+            files={
+                "image": (
+                    "cover.png",
+                    b"\x89PNG" + b"0" * (20 * 1024 * 1024),
+                    "image/png",
+                )
+            },
+        )
+        assert resp.status_code == 413
+        state = client.get(f"/tracks/uploads/{upload_id}").json()
+        assert state["received_parts"] == [1, 2, 3]
+
+
 def test_start_rejects_unsupported_and_oversized_files(artist_app: FastAPI) -> None:
     with TestClient(artist_app) as client:
         resp = client.post(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -132,9 +132,7 @@ class MockStorage(R2Storage):
         """Mock save_gated."""
         return "mock_gated_file_id_456"
 
-    # resumable uploads: a faithful in-memory multipart store, keyed by
-    # staged key, so endpoint tests drive the real start → parts → finish
-    # contract (uniform part sizes, completion from the parts that landed).
+    # in-memory multipart store so endpoint tests drive the real session contract
     async def begin_staged_upload(self, staged: StagedUploadKey) -> str:
         self.staged_parts[staged.key] = {}
         return f"multipart-{staged.upload_id}"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,7 +3,7 @@
 import asyncio
 import contextlib
 import os
-from collections.abc import AsyncGenerator, Callable, Generator
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Generator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from io import BytesIO
@@ -26,6 +26,7 @@ from sqlalchemy.orm import sessionmaker
 
 from backend.config import settings
 from backend.models import Base
+from backend.storage.keys import AudioKey, StagedUploadKey
 from backend.storage.r2 import R2Storage
 from backend.utilities.redis import clear_client_cache
 
@@ -91,7 +92,9 @@ class MockStorage(R2Storage):
 
     def __init__(self):
         # skip R2Storage.__init__ which requires credentials
-        pass
+        self.staged_parts: dict[str, dict[int, bytes]] = {}
+        self.staged_objects: dict[str, bytes] = {}
+        self.promoted: dict[str, tuple[str, bool]] = {}
 
     async def save(
         self,
@@ -128,6 +131,64 @@ class MockStorage(R2Storage):
     ) -> str:
         """Mock save_gated."""
         return "mock_gated_file_id_456"
+
+    # resumable uploads: a faithful in-memory multipart store, keyed by
+    # staged key, so endpoint tests drive the real start → parts → finish
+    # contract (uniform part sizes, completion from the parts that landed).
+    async def begin_staged_upload(self, staged: StagedUploadKey) -> str:
+        self.staged_parts[staged.key] = {}
+        return f"multipart-{staged.upload_id}"
+
+    async def put_staged_part(
+        self,
+        staged: StagedUploadKey,
+        multipart_id: str,
+        part_number: int,
+        body: bytes,
+    ) -> str:
+        self.staged_parts[staged.key][part_number] = body
+        return f'"etag-{part_number}"'
+
+    async def complete_staged_upload(
+        self, staged: StagedUploadKey, multipart_id: str
+    ) -> int:
+        parts = self.staged_parts.get(staged.key, {})
+        if not parts:
+            raise ValueError("no parts uploaded")
+        numbers = sorted(parts)
+        if numbers != list(range(1, numbers[-1] + 1)):
+            raise ValueError("InvalidPart")
+        body = b"".join(parts[n] for n in numbers)
+        self.staged_objects[staged.key] = body
+        del self.staged_parts[staged.key]
+        return len(body)
+
+    async def staged_part_numbers(
+        self, staged: StagedUploadKey, multipart_id: str
+    ) -> list[int]:
+        return sorted(self.staged_parts.get(staged.key, {}))
+
+    async def abort_staged_upload(
+        self, staged: StagedUploadKey, multipart_id: str
+    ) -> None:
+        self.staged_parts.pop(staged.key, None)
+
+    async def stream_staged(
+        self, staged: StagedUploadKey, *, chunk_size: int = 1024 * 1024
+    ) -> AsyncIterator[bytes]:
+        body = self.staged_objects[staged.key]
+        for start in range(0, len(body), chunk_size):
+            yield body[start : start + chunk_size]
+
+    async def promote_staged(
+        self, staged: StagedUploadKey, audio: AudioKey, *, gated: bool
+    ) -> None:
+        self.promoted[audio.key] = (staged.key, gated)
+        del self.staged_objects[staged.key]
+
+    async def delete_staged(self, staged: StagedUploadKey) -> None:
+        self.staged_objects.pop(staged.key, None)
+        self.staged_parts.pop(staged.key, None)
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/backend/tests/docker-compose.yml
+++ b/backend/tests/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     command:
       - postgres
       - -c
-      - max_connections=100
+      - max_connections=300
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U relay_test -d relay_test"]
       interval: 1s

--- a/docs/internal/backend/resumable-uploads.md
+++ b/docs/internal/backend/resumable-uploads.md
@@ -28,9 +28,9 @@ browser                                api                              R2 / wor
   │  PUT /tracks/uploads/{id}/parts/{n}  │  upload_part, heartbeat job      │  ×N, 3 in flight
   │ ───────────────────────────────────▶ │ ─────────────────────────────▶   │
   │                                      │                                  │
-  │  POST /tracks/uploads/{id}/finish    │  list_parts → all present?       │
-  │  (same form fields, minus file)      │  complete_multipart_upload       │
-  │ ───────────────────────────────────▶ │  stage image, enqueue worker     │
+  │  POST /tracks/uploads/{id}/finish    │  validate fields, list_parts,    │
+  │  (same form fields, minus file)      │  stage image, then complete      │
+  │ ───────────────────────────────────▶ │  multipart, enqueue worker       │
   │ ◀─ {upload_id}                       │                                  │
   │                                      │                                  │
   │  GET /tracks/uploads/{id}/progress   │        run_track_upload(staged=True)
@@ -51,9 +51,10 @@ browser                                api                              R2 / wor
   `audio.plyr.fm`; a supporter-gated master must never be reachable there, even
   under an unguessable key.
 - **`finish` validates the metadata before completing the multipart**, using the
-  same `parse_upload_metadata` as `POST /tracks/`; a 400 there leaves the parts
-  in place. a missing part is a 409 and the session stays open for the client to
-  resend (`GET /tracks/uploads/{id}` lists received parts).
+  same `parse_upload_metadata` as `POST /tracks/`; a 400 there, a 409 for a
+  missing part, or a 413 for a rejected cover image all leave the parts in place
+  and the session open (`GET /tracks/uploads/{id}` lists received parts). the
+  multipart is completed only once nothing else can refuse the upload.
 - **the worker settles** (`_settle_staged_audio`): the staged object is read
   once onto the worker's disk while its sha256 is computed; duration and the
   ALAC scan run from that local copy (the handler used to do this on its own
@@ -72,7 +73,7 @@ browser                                api                              R2 / wor
 ## client
 
 `frontend/src/lib/upload-session.ts` is the transport: `startUploadSession`,
-`uploadParts` (3 in flight, 120s per-part timeout, 5 attempts with exponential
+`uploadParts` (3 in flight, a 60s *stall* timeout per part — measured from the last progress event, so a slow part is never cut off — plus a 15 min ceiling, 5 attempts with exponential
 backoff, progress = acknowledged bytes), `finishUploadSession`. it takes an
 injectable `send` so its tests exercise the retry and progress logic without a
 DOM. `uploader.svelte.ts` composes it with the unchanged SSE follow-up.

--- a/docs/internal/backend/resumable-uploads.md
+++ b/docs/internal/backend/resumable-uploads.md
@@ -1,0 +1,88 @@
+# resumable uploads
+
+how the browser gets a track's bytes to plyr since `feat/resumable-upload-sessions`
+(August 2026). the single-request `POST /tracks/` still exists for the SDK and the
+integration suite; the web uploader no longer uses it.
+
+## why
+
+`POST /tracks/` held one HTTP request open for the whole transfer and then staged
+the bytes to R2 *inside the request* before answering. a 579-second production
+upload on August 24 decomposed as 346s of body transfer followed by 231s of `R2
+save` — the browser's progress bar sat at 100% with nothing to show, and the
+client's fixed 300s `xhr.timeout` (which counts the whole request) fired for an
+upload that then succeeded. the artist re-uploaded fifteen minutes later.
+
+the shape is the same one bluesky's video service and stream.place settled on:
+the transfer is many short requests, each independently timed out, retried and
+measured, and the server acknowledges the bytes the moment it has them.
+
+## the flow
+
+```
+browser                                api                              R2 / worker
+  │  POST /tracks/uploads {filename,size} │                                  │
+  │ ───────────────────────────────────▶ │  create_multipart_upload          │
+  │ ◀─ {upload_id, part_size, part_count}│  (private bucket, staged/<id>.ext)│
+  │                                      │                                  │
+  │  PUT /tracks/uploads/{id}/parts/{n}  │  upload_part, heartbeat job      │  ×N, 3 in flight
+  │ ───────────────────────────────────▶ │ ─────────────────────────────▶   │
+  │                                      │                                  │
+  │  POST /tracks/uploads/{id}/finish    │  list_parts → all present?       │
+  │  (same form fields, minus file)      │  complete_multipart_upload       │
+  │ ───────────────────────────────────▶ │  stage image, enqueue worker     │
+  │ ◀─ {upload_id}                       │                                  │
+  │                                      │                                  │
+  │  GET /tracks/uploads/{id}/progress   │        run_track_upload(staged=True)
+  │  (SSE, unchanged)                    │        phase 0: settle staged bytes
+  │                                      │          stream → hash + duration + ALAC
+  │                                      │          public/gated: copy_object → audio/<hash>.<ext>
+  │                                      │          private:      uploadBlob → PDS
+  │                                      │          delete staged/<id>.<ext>
+  │                                      │        phases 1–8: unchanged
+```
+
+- **parts are 10 MiB, uniform, last one shorter** — R2 requires ≥ 5 MiB and equal
+  sizes for every part but the last. the server rejects a part whose length is
+  not exactly what its number implies, so a truncated part can never be
+  assembled.
+- **staged bytes live in the private bucket** under `staged/<upload_id>.<ext>`
+  (`StagedUploadKey`). the public bucket is served verbatim from
+  `audio.plyr.fm`; a supporter-gated master must never be reachable there, even
+  under an unguessable key.
+- **`finish` validates the metadata before completing the multipart**, using the
+  same `parse_upload_metadata` as `POST /tracks/`; a 400 there leaves the parts
+  in place. a missing part is a 409 and the session stays open for the client to
+  resend (`GET /tracks/uploads/{id}` lists received parts).
+- **the worker settles** (`_settle_staged_audio`): the staged object is read
+  once onto the worker's disk while its sha256 is computed; duration and the
+  ALAC scan run from that local copy (the handler used to do this on its own
+  `/tmp`); then a server-side `copy_object` puts the bytes at their content-hash
+  key and the staged object is deleted. the worker never re-uploads audio.
+  private media goes to the PDS as a blob instead, as before. from
+  `_validate_audio` onward nothing knows the upload was resumable — PDS blob
+  before record, reserve-then-publish, the jetstream finalize race, the
+  optimize task: all untouched.
+- **abandoned sessions**: a session is `pending` / phase `transfer` while
+  parts arrive (each part heartbeats `updated_at`), so the stuck-upload reaper
+  ignores it. `reap_abandoned_transfers` fails sessions idle for 24h and aborts
+  their multipart upload; R2 aborts incomplete multipart uploads itself after
+  7 days regardless.
+
+## client
+
+`frontend/src/lib/upload-session.ts` is the transport: `startUploadSession`,
+`uploadParts` (3 in flight, 120s per-part timeout, 5 attempts with exponential
+backoff, progress = acknowledged bytes), `finishUploadSession`. it takes an
+injectable `send` so its tests exercise the retry and progress logic without a
+DOM. `uploader.svelte.ts` composes it with the unchanged SSE follow-up.
+
+`replaceAudio` (`PUT /tracks/{id}/audio`) still uses the single-request path.
+
+## not in scope (yet)
+
+- a PDS that refuses the blob still degrades to R2-only with a portal warning,
+  as before; making that a first-class job outcome is a separate change.
+- the PDS blob is the *playable* rendition, as before. storing the artist's
+  master in the PDS and deriving delivery renditions from the mirror is the
+  larger storage-semantics change this transport makes possible.

--- a/docs/internal/backend/streaming-uploads.md
+++ b/docs/internal/backend/streaming-uploads.md
@@ -5,6 +5,8 @@ title: "streaming uploads"
 **status**: implemented in PR #182
 **date**: 2025-11-03
 
+> the web uploader now transfers files as a resumable session — see [resumable-uploads.md](resumable-uploads.md). this page documents the single-request path (`POST /tracks/`) that the SDK still uses.
+
 ## overview
 
 plyr.fm uses streaming uploads for audio files to maintain constant memory usage regardless of file size. this prevents out-of-memory errors when handling large files on constrained environments (fly.io shared-cpu VMs).

--- a/frontend/src/lib/upload-session.test.ts
+++ b/frontend/src/lib/upload-session.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+	PartAttemptError,
+	planParts,
+	uploadParts,
+	UploadPartError,
+	type PartSender,
+	type UploadSessionState
+} from './upload-session';
+
+const session = (overrides: Partial<UploadSessionState> = {}): UploadSessionState => ({
+	upload_id: 'u1',
+	part_size_bytes: 4,
+	part_count: 3,
+	received_parts: [],
+	...overrides
+});
+
+const file = new File([new Uint8Array(10)], 'song.wav');
+const noSleep = () => Promise.resolve();
+
+describe('planParts', () => {
+	it('slices uniform parts with a shorter final part', () => {
+		expect(planParts(10, 4, 3)).toEqual([
+			{ partNumber: 1, start: 0, end: 4 },
+			{ partNumber: 2, start: 4, end: 8 },
+			{ partNumber: 3, start: 8, end: 10 }
+		]);
+	});
+});
+
+describe('uploadParts', () => {
+	it('sends only the parts the server has not received and reports acknowledged bytes', async () => {
+		const sent: number[] = [];
+		const progress: number[] = [];
+		const send: PartSender = async (url, body, options) => {
+			sent.push(Number(url.split('/').pop()));
+			options.onProgress(body.size);
+		};
+		await uploadParts({
+			file,
+			session: session({ received_parts: [2] }),
+			send,
+			sleep: noSleep,
+			onProgress: (loaded, total) => {
+				expect(total).toBe(10);
+				progress.push(loaded);
+			}
+		});
+		expect(sent.sort()).toEqual([1, 3]);
+		expect(progress[0]).toBe(4);
+		expect(progress.at(-1)).toBe(10);
+	});
+
+	it('retries a timed-out part with backoff and succeeds', async () => {
+		const attempts = new Map<number, number>();
+		const delays: number[] = [];
+		const send: PartSender = async (url, body, options) => {
+			const part = Number(url.split('/').pop());
+			const n = (attempts.get(part) ?? 0) + 1;
+			attempts.set(part, n);
+			if (part === 2 && n < 3) throw new PartAttemptError({ kind: 'timeout' });
+			options.onProgress(body.size);
+		};
+		await uploadParts({
+			file,
+			session: session(),
+			send,
+			sleep: async (ms) => {
+				delays.push(ms);
+			},
+			onProgress: () => {}
+		});
+		expect(attempts.get(2)).toBe(3);
+		expect(delays).toEqual([500, 1000]);
+	});
+
+	it('gives up on a client error without retrying', async () => {
+		let calls = 0;
+		const send: PartSender = async () => {
+			calls++;
+			throw new PartAttemptError({ kind: 'http', status: 409, detail: 'upload session is not open' });
+		};
+		await expect(
+			uploadParts({ file, session: session(), send, sleep: noSleep, concurrency: 1, onProgress: () => {} })
+		).rejects.toBeInstanceOf(UploadPartError);
+		expect(calls).toBe(1);
+	});
+
+	it('surfaces the exhausted failure after the attempt budget', async () => {
+		let calls = 0;
+		const send: PartSender = async () => {
+			calls++;
+			throw new PartAttemptError({ kind: 'network' });
+		};
+		await expect(
+			uploadParts({
+				file,
+				session: session({ part_count: 1, part_size_bytes: 10 }),
+				send,
+				sleep: noSleep,
+				attempts: 2,
+				onProgress: () => {}
+			})
+		).rejects.toMatchObject({ failure: { kind: 'network' }, partNumber: 1 });
+		expect(calls).toBe(2);
+	});
+});

--- a/frontend/src/lib/upload-session.ts
+++ b/frontend/src/lib/upload-session.ts
@@ -1,0 +1,266 @@
+/**
+ * resumable track upload transport: start → parts → finish.
+ *
+ * the file goes up as fixed-size parts (`PUT /tracks/uploads/{id}/parts/{n}`),
+ * a few in flight at a time. each part is its own short request with its own
+ * timeout and retry budget, so a slow transfer is never one long request that
+ * a fixed deadline can kill, and progress is measured from bytes the server
+ * has actually acknowledged. `finish` sends the metadata and returns the
+ * `upload_id` the processing SSE stream is keyed on.
+ */
+
+import { API_URL } from './config';
+
+export const PART_CONCURRENCY = 3;
+export const PART_TIMEOUT_MS = 120_000;
+export const PART_ATTEMPTS = 5;
+const RETRY_BASE_MS = 500;
+
+export interface UploadSessionState {
+	upload_id: string;
+	part_size_bytes: number;
+	part_count: number;
+	received_parts: number[];
+}
+
+export interface PartPlan {
+	partNumber: number;
+	start: number;
+	end: number;
+}
+
+export type PartFailure =
+	| { kind: 'network' }
+	| { kind: 'timeout' }
+	| { kind: 'http'; status: number; detail: string | null };
+
+/** what a single part attempt rejects with; `uploadParts` decides whether to retry. */
+export class PartAttemptError extends Error {
+	readonly failure: PartFailure;
+
+	constructor(failure: PartFailure) {
+		super(`part attempt failed: ${failure.kind}`);
+		this.failure = failure;
+	}
+}
+
+export class UploadPartError extends Error {
+	readonly failure: PartFailure;
+	readonly partNumber: number;
+
+	constructor(partNumber: number, failure: PartFailure) {
+		super(`part ${partNumber} failed: ${failure.kind}`);
+		this.failure = failure;
+		this.partNumber = partNumber;
+	}
+}
+
+/** slice boundaries for every part; the last part is the remainder. */
+export function planParts(sizeBytes: number, partSizeBytes: number, partCount: number): PartPlan[] {
+	const plans: PartPlan[] = [];
+	for (let partNumber = 1; partNumber <= partCount; partNumber++) {
+		const start = (partNumber - 1) * partSizeBytes;
+		plans.push({ partNumber, start, end: Math.min(start + partSizeBytes, sizeBytes) });
+	}
+	return plans;
+}
+
+function retryDelayMs(attempt: number): number {
+	return RETRY_BASE_MS * 2 ** (attempt - 1);
+}
+
+function isRetryable(failure: PartFailure): boolean {
+	if (failure.kind !== 'http') return true;
+	return failure.status >= 500 || failure.status === 429 || failure.status === 408;
+}
+
+function parseSessionState(session: UploadSessionState): UploadSessionState {
+	const { upload_id, part_size_bytes, part_count, received_parts } = session;
+	if (
+		upload_id == null ||
+		upload_id === '' ||
+		part_size_bytes == null ||
+		!Number.isFinite(part_size_bytes) ||
+		part_count == null ||
+		!Number.isFinite(part_count) ||
+		!Array.isArray(received_parts)
+	) {
+		throw new Error('malformed upload session');
+	}
+	return { upload_id, part_size_bytes, part_count, received_parts };
+}
+
+/** FastAPI's `detail` is a string for every error we raise; 422s carry a list. */
+interface ErrorBody {
+	detail?: string | object;
+}
+
+function detailOf(body: ErrorBody): string | null {
+	return body.detail == null || body.detail instanceof Object ? null : body.detail;
+}
+
+async function errorDetail(response: Response): Promise<string | null> {
+	try {
+		const body: ErrorBody = await response.json();
+		return detailOf(body);
+	} catch {
+		return null;
+	}
+}
+
+/** an HTTP error from `start` or `finish`, carrying the server's `detail`. */
+export class UploadSessionHttpError extends Error {
+	readonly status: number;
+	readonly detail: string | null;
+
+	constructor(status: number, detail: string | null) {
+		super(detail ?? `upload request failed (${status})`);
+		this.status = status;
+		this.detail = detail;
+	}
+}
+
+export async function startUploadSession(file: File): Promise<UploadSessionState> {
+	const response = await fetch(`${API_URL}/tracks/uploads`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		credentials: 'include',
+		body: JSON.stringify({ filename: file.name, size_bytes: file.size })
+	});
+	if (!response.ok) {
+		throw new UploadSessionHttpError(response.status, await errorDetail(response));
+	}
+	return parseSessionState(await response.json());
+}
+
+export async function finishUploadSession(uploadId: string, form: FormData): Promise<string> {
+	const response = await fetch(`${API_URL}/tracks/uploads/${uploadId}/finish`, {
+		method: 'POST',
+		credentials: 'include',
+		body: form
+	});
+	if (!response.ok) {
+		throw new UploadSessionHttpError(response.status, await errorDetail(response));
+	}
+	const body: { upload_id?: string } = await response.json();
+	if (body.upload_id == null || body.upload_id === '') throw new Error('malformed upload response');
+	return body.upload_id;
+}
+
+export interface SendPartOptions {
+	timeoutMs: number;
+	onProgress: (loadedBytes: number) => void;
+	signal?: AbortSignal;
+}
+
+/** one part over XHR — the only browser transport with upload progress events. */
+export function sendPart(url: string, body: Blob, options: SendPartOptions): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const xhr = new XMLHttpRequest();
+		xhr.open('PUT', url);
+		xhr.withCredentials = true;
+		xhr.timeout = options.timeoutMs;
+		xhr.upload.addEventListener('progress', (event) => {
+			if (event.lengthComputable) options.onProgress(event.loaded);
+		});
+		xhr.addEventListener('load', () => {
+			if (xhr.status >= 200 && xhr.status < 300) {
+				options.onProgress(body.size);
+				resolve();
+				return;
+			}
+			let detail: string | null = null;
+			try {
+				const parsed: ErrorBody = JSON.parse(xhr.responseText);
+				detail = detailOf(parsed);
+			} catch {
+				detail = null;
+			}
+			reject(new PartAttemptError({ kind: 'http', status: xhr.status, detail }));
+		});
+		xhr.addEventListener('error', () => reject(new PartAttemptError({ kind: 'network' })));
+		xhr.addEventListener('timeout', () => reject(new PartAttemptError({ kind: 'timeout' })));
+		xhr.addEventListener('abort', () => reject(new PartAttemptError({ kind: 'network' })));
+		options.signal?.addEventListener('abort', () => xhr.abort(), { once: true });
+		xhr.send(body);
+	});
+}
+
+export type PartSender = typeof sendPart;
+
+export interface UploadPartsOptions {
+	file: File;
+	session: UploadSessionState;
+	onProgress: (loadedBytes: number, totalBytes: number) => void;
+	send?: PartSender;
+	concurrency?: number;
+	attempts?: number;
+	timeoutMs?: number;
+	sleep?: (ms: number) => Promise<void>;
+	signal?: AbortSignal;
+}
+
+/**
+ * send every part the server has not already received, `concurrency` at a
+ * time, retrying each part with exponential backoff. progress is the sum of
+ * acknowledged bytes plus the in-flight bytes of parts still sending.
+ */
+export async function uploadParts(options: UploadPartsOptions): Promise<void> {
+	const {
+		file,
+		session,
+		onProgress,
+		send = sendPart,
+		concurrency = PART_CONCURRENCY,
+		attempts = PART_ATTEMPTS,
+		timeoutMs = PART_TIMEOUT_MS,
+		sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+		signal
+	} = options;
+	const received = new Set(session.received_parts);
+	const plans = planParts(file.size, session.part_size_bytes, session.part_count);
+	const pending = plans.filter((plan) => !received.has(plan.partNumber));
+	const loadedByPart = new Map<number, number>();
+	for (const plan of plans) {
+		if (received.has(plan.partNumber)) loadedByPart.set(plan.partNumber, plan.end - plan.start);
+	}
+	const report = () => {
+		let loaded = 0;
+		for (const bytes of loadedByPart.values()) loaded += bytes;
+		onProgress(loaded, file.size);
+	};
+	report();
+
+	let next = 0;
+	const worker = async (): Promise<void> => {
+		while (next < pending.length) {
+			if (signal?.aborted) throw new UploadPartError(0, { kind: 'network' });
+			const plan = pending[next++];
+			const body = file.slice(plan.start, plan.end);
+			const url = `${API_URL}/tracks/uploads/${session.upload_id}/parts/${plan.partNumber}`;
+			for (let attempt = 1; ; attempt++) {
+				try {
+					await send(url, body, {
+						timeoutMs,
+						signal,
+						onProgress: (bytes) => {
+							loadedByPart.set(plan.partNumber, bytes);
+							report();
+						}
+					});
+					break;
+				} catch (error) {
+					const partFailure: PartFailure =
+						error instanceof PartAttemptError ? error.failure : { kind: 'network' };
+					loadedByPart.set(plan.partNumber, 0);
+					report();
+					if (attempt >= attempts || !isRetryable(partFailure) || signal?.aborted) {
+						throw new UploadPartError(plan.partNumber, partFailure);
+					}
+					await sleep(retryDelayMs(attempt));
+				}
+			}
+		}
+	};
+	await Promise.all(Array.from({ length: Math.min(concurrency, pending.length) }, worker));
+}

--- a/frontend/src/lib/upload-session.ts
+++ b/frontend/src/lib/upload-session.ts
@@ -12,7 +12,8 @@
 import { API_URL } from './config';
 
 export const PART_CONCURRENCY = 3;
-export const PART_TIMEOUT_MS = 120_000;
+export const PART_STALL_MS = 60_000;
+export const PART_MAX_MS = 15 * 60_000;
 export const PART_ATTEMPTS = 5;
 const RETRY_BASE_MS = 500;
 
@@ -148,21 +149,41 @@ export async function finishUploadSession(uploadId: string, form: FormData): Pro
 }
 
 export interface SendPartOptions {
-	timeoutMs: number;
+	/** abort when no upload progress has been reported for this long */
+	stallMs: number;
+	/** absolute ceiling for one part, however slowly it moves */
+	maxMs: number;
 	onProgress: (loadedBytes: number) => void;
 	signal?: AbortSignal;
 }
 
-/** one part over XHR — the only browser transport with upload progress events. */
+/**
+ * one part over XHR — the only browser transport with upload progress events.
+ * a slow part is not a dead part: the timeout is measured from the last
+ * progress event, so a transfer that keeps moving is never cut off.
+ */
 export function sendPart(url: string, body: Blob, options: SendPartOptions): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const xhr = new XMLHttpRequest();
 		xhr.open('PUT', url);
 		xhr.withCredentials = true;
-		xhr.timeout = options.timeoutMs;
+		xhr.timeout = options.maxMs;
+		let stallTimer: ReturnType<typeof setTimeout> | undefined;
+		const armStall = () => {
+			if (stallTimer !== undefined) clearTimeout(stallTimer);
+			stallTimer = setTimeout(() => {
+				xhr.abort();
+				reject(new PartAttemptError({ kind: 'timeout' }));
+			}, options.stallMs);
+		};
+		const settle = () => {
+			if (stallTimer !== undefined) clearTimeout(stallTimer);
+		};
 		xhr.upload.addEventListener('progress', (event) => {
+			armStall();
 			if (event.lengthComputable) options.onProgress(event.loaded);
 		});
+		xhr.addEventListener('loadend', settle);
 		xhr.addEventListener('load', () => {
 			if (xhr.status >= 200 && xhr.status < 300) {
 				options.onProgress(body.size);
@@ -182,6 +203,7 @@ export function sendPart(url: string, body: Blob, options: SendPartOptions): Pro
 		xhr.addEventListener('timeout', () => reject(new PartAttemptError({ kind: 'timeout' })));
 		xhr.addEventListener('abort', () => reject(new PartAttemptError({ kind: 'network' })));
 		options.signal?.addEventListener('abort', () => xhr.abort(), { once: true });
+		armStall();
 		xhr.send(body);
 	});
 }
@@ -195,7 +217,8 @@ export interface UploadPartsOptions {
 	send?: PartSender;
 	concurrency?: number;
 	attempts?: number;
-	timeoutMs?: number;
+	stallMs?: number;
+	maxMs?: number;
 	sleep?: (ms: number) => Promise<void>;
 	signal?: AbortSignal;
 }
@@ -213,7 +236,8 @@ export async function uploadParts(options: UploadPartsOptions): Promise<void> {
 		send = sendPart,
 		concurrency = PART_CONCURRENCY,
 		attempts = PART_ATTEMPTS,
-		timeoutMs = PART_TIMEOUT_MS,
+		stallMs = PART_STALL_MS,
+		maxMs = PART_MAX_MS,
 		sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
 		signal
 	} = options;
@@ -241,7 +265,8 @@ export async function uploadParts(options: UploadPartsOptions): Promise<void> {
 			for (let attempt = 1; ; attempt++) {
 				try {
 					await send(url, body, {
-						timeoutMs,
+						stallMs,
+						maxMs,
 						signal,
 						onProgress: (bytes) => {
 							loadedByPart.set(plan.partNumber, bytes);

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -7,6 +7,13 @@ import { tracksCache } from './tracks.svelte';
 import type { FeaturedArtist } from './types';
 import type { TrackRights } from './components/CopyrightRightsPanel.svelte';
 import { setReturnUrl } from './utils/return-url';
+import {
+	finishUploadSession,
+	startUploadSession,
+	uploadParts,
+	UploadPartError,
+	UploadSessionHttpError
+} from './upload-session';
 
 interface UploadTask {
 	id: string;
@@ -19,6 +26,7 @@ interface UploadTask {
 	toastId: string;
 	eventSource?: EventSource;
 	xhr?: XMLHttpRequest;
+	abort?: AbortController;
 }
 
 interface UploadProgressCallback {
@@ -125,6 +133,51 @@ function buildTimeoutErrorMessage(progressPercent: number, fileSizeMB: number, i
 	return `upload timed out${progressInfo}: try again with a better connection`;
 }
 
+/**
+ * map a session-upload failure to toast copy. returns null when the failure
+ * was handled by a redirect (scope upgrade, sign-in) and no toast is due.
+ */
+type UploadFailure = UploadSessionHttpError | UploadPartError | Error;
+
+function describeUploadFailure(
+	error: UploadFailure,
+	progressPercent: number,
+	fileSizeMB: number,
+	isMobile: boolean
+): string | null {
+	if (error instanceof UploadSessionHttpError) {
+		if (error.status === 403 && error.detail === 'permissioned_scope_required') {
+			void startPermissionedScopeUpgrade();
+			return null;
+		}
+		if (error.status === 401 && error.detail === 'session_expired') {
+			toast.error('your session expired — sign in to finish your upload');
+			setReturnUrl('/upload');
+			if (browser) void goto('/login');
+			return null;
+		}
+		if (error.status === 413) return 'file too large: please use a smaller file';
+		if (error.status === 409) return 'upload incomplete — try again';
+		if (error.status >= 500) return 'server error: please try again in a moment';
+		return error.detail ?? `upload failed (${error.status})`;
+	}
+	if (error instanceof UploadPartError) {
+		const failure = error.failure;
+		if (failure.kind === 'timeout') return buildTimeoutErrorMessage(progressPercent, fileSizeMB, isMobile);
+		if (failure.kind === 'network') return buildNetworkErrorMessage(progressPercent, fileSizeMB, isMobile);
+		if (failure.status === 401) {
+			toast.error('your session expired — sign in to finish your upload');
+			setReturnUrl('/upload');
+			if (browser) void goto('/login');
+			return null;
+		}
+		if (failure.status === 413) return 'file too large: please use a smaller file';
+		if (failure.status >= 500) return 'server error: please try again in a moment';
+		return failure.detail ?? `upload failed (${failure.status})`;
+	}
+	return 'upload failed — try again';
+}
+
 // global upload manager using Svelte 5 runes
 class UploaderState {
 	activeUploads = $state<Map<string, UploadTask>>(new Map());
@@ -167,7 +220,6 @@ class UploaderState {
 
 		if (!browser) return;
 		const formData = new FormData();
-		formData.append('file', file);
 		formData.append('title', title);
 		if (albumId) {
 			formData.append('album_id', albumId);
@@ -200,184 +252,129 @@ class UploaderState {
 			formData.append('self_labels', JSON.stringify(selfLabels));
 		}
 
-		const xhr = new XMLHttpRequest();
-		xhr.open('POST', `${API_URL}/tracks/`);
-		xhr.withCredentials = true;
+		const abort = new AbortController();
+		const task: UploadTask = {
+			id: taskId,
+			upload_id: '',
+			file,
+			title,
+			album,
+			features,
+			tags,
+			toastId,
+			abort
+		};
+		this.activeUploads.set(taskId, task);
 
-		let uploadComplete = false;
+		const fail = (message: string) => {
+			toast.dismiss(toastId);
+			this.activeUploads.delete(taskId);
+			toast.error(message);
+			callbacks?.onError?.(message);
+		};
 
-		xhr.upload.addEventListener('progress', (e) => {
-			if (e.lengthComputable && !uploadComplete) {
-				const percent = Math.round((e.loaded / e.total) * 100);
-				lastProgressPercent = percent;
-				const progressMsg = `retrieving your file... ${percent}%`;
-				toast.update(toastId, progressMsg);
-				if (callbacks?.onProgress) {
-					callbacks.onProgress(e.loaded, e.total);
-				}
-			}
-		});
-
-		xhr.addEventListener('load', () => {
-			if (xhr.status >= 200 && xhr.status < 300) {
-				try {
-					uploadComplete = true;
-					const result = JSON.parse(xhr.responseText);
-					const upload_id = result.upload_id;
-
-					if (callbacks?.onSuccess) {
-						callbacks.onSuccess(upload_id);
+		void (async () => {
+			try {
+				const session = await startUploadSession(file);
+				task.upload_id = session.upload_id;
+				await uploadParts({
+					file,
+					session,
+					signal: abort.signal,
+					onProgress: (loaded, total) => {
+						const percent = Math.round((loaded / total) * 100);
+						lastProgressPercent = percent;
+						toast.update(toastId, `retrieving your file... ${percent}%`);
+						callbacks?.onProgress?.(loaded, total);
 					}
-
-					const task: UploadTask = {
-						id: taskId,
-						upload_id,
-						file,
-						title,
-						album,
-						features,
-						tags,
-						toastId,
-						xhr
-					};
-
-					this.activeUploads.set(taskId, task);
-
-					const eventSource = new EventSource(`${API_URL}/tracks/uploads/${upload_id}/progress`);
-					task.eventSource = eventSource;
-
-					eventSource.onmessage = (event) => {
-						const update: UploadProgressUpdate = JSON.parse(event.data);
-
-						// show backend processing messages
-						if (update.message && update.status === 'processing') {
-							// if we have meaningful server-side progress, show it
-							// (skip 0% as it looks wrong during phase transitions)
-							const serverProgress = update.server_progress_pct;
-							if (serverProgress !== undefined && serverProgress !== null && serverProgress > 0) {
-								toast.update(task.toastId, `${update.message} (${Math.round(serverProgress)}%)`);
-							} else {
-								toast.update(task.toastId, update.message);
-							}
-						}
-
-						if (update.status === 'completed') {
-							eventSource.close();
-							toast.dismiss(task.toastId);
-							this.activeUploads.delete(taskId);
-
-							const trackId = update.track_id ?? null;
-							toast.success(`"${displayName}" uploaded`, 5000, trackId ? {
-								label: 'view track',
-								href: `/track/${trackId}`
-							} : undefined);
-
-							const warnings: string[] = update.warnings ?? [];
-							const warningAction = update.pds_blob_failed
-								? { label: 'save to your PDS', href: '/portal/manage?save=pds' }
-								: undefined;
-							for (const w of warnings) {
-								toast.warning(w, 0, warningAction);
-							}
-
-							tracksCache.invalidate();
-							tracksCache.fetch(true);
-							if (onSuccess) {
-								onSuccess(
-									trackId !== null
-										? {
-												trackId,
-												atprotoUri: update.atproto_uri ?? null,
-												atprotoCid: update.atproto_cid ?? null
-											}
-										: undefined
-								);
-							}
-						}
-
-						if (update.status === 'failed') {
-							eventSource.close();
-							toast.dismiss(task.toastId);
-							this.activeUploads.delete(taskId);
-
-							const errorMsg = update.error || 'upload failed';
-							toast.error(errorMsg);
-						}
-					};
-
-					eventSource.onerror = () => {
-						eventSource.close();
-						toast.dismiss(task.toastId);
-						this.activeUploads.delete(taskId);
-						toast.error('lost connection to server');
-					};
-				} catch {
+				});
+				toast.update(toastId, 'finishing up…');
+				const upload_id = await finishUploadSession(session.upload_id, formData);
+				task.upload_id = upload_id;
+				callbacks?.onSuccess?.(upload_id);
+				this.followProcessing(task, displayName, onSuccess);
+			} catch (error) {
+				const failure: UploadFailure = error instanceof Error ? error : new Error(String(error));
+				const message = describeUploadFailure(failure, lastProgressPercent, fileSizeMB, isMobile);
+				if (message === null) {
 					toast.dismiss(toastId);
-					toast.error('failed to parse server response');
-					if (callbacks?.onError) {
-						callbacks.onError('failed to parse server response');
-					}
+					this.activeUploads.delete(taskId);
+					return;
 				}
-			} else {
-				toast.dismiss(toastId);
-				let errorMsg = `upload failed (${xhr.status} ${xhr.statusText})`;
-				try {
-					const error = JSON.parse(xhr.responseText);
-					// private media needs the permissioned-space scope granted — kick
-					// off the one-time opt-in upgrade, then the user retries the upload.
-					if (xhr.status === 403 && error.detail === 'permissioned_scope_required') {
-						void startPermissionedScopeUpgrade();
-						return;
-					}
-					// the atproto session's refresh token died — the upload couldn't
-					// authenticate to the PDS. /auth/me preflight can't catch this (it
-					// doesn't force a token refresh), so handle it at runtime: bounce to
-					// sign-in instead of showing a misleading "connection failed".
-					if (xhr.status === 401 && error.detail === 'session_expired') {
-						toast.error('your session expired — sign in to finish your upload');
-						setReturnUrl('/upload');
-						if (browser) void goto('/login');
-						return;
-					}
-					errorMsg = error.detail || errorMsg;
-				} catch {
-					if (xhr.status === 0) {
-						errorMsg = buildNetworkErrorMessage(lastProgressPercent, fileSizeMB, isMobile);
-					} else if (xhr.status >= 500) {
-						errorMsg = 'server error: please try again in a moment';
-					} else if (xhr.status === 413) {
-						errorMsg = 'file too large: please use a smaller file';
-					} else if (xhr.status === 408 || xhr.status === 504) {
-						errorMsg = buildTimeoutErrorMessage(lastProgressPercent, fileSizeMB, isMobile);
-					}
-				}
-				toast.error(errorMsg);
-				if (callbacks?.onError) {
-					callbacks.onError(errorMsg);
+				fail(message);
+			}
+		})();
+	}
+
+	/** subscribe to the worker's SSE progress once the transfer is done. */
+	private followProcessing(
+		task: UploadTask,
+		displayName: string,
+		onSuccess?: (_result?: UploadResult) => void
+	): void {
+		const eventSource = new EventSource(`${API_URL}/tracks/uploads/${task.upload_id}/progress`);
+		task.eventSource = eventSource;
+
+		eventSource.onmessage = (event) => {
+			const update: UploadProgressUpdate = JSON.parse(event.data);
+
+			if (update.message && update.status === 'processing') {
+				const serverProgress = update.server_progress_pct;
+				if (serverProgress !== undefined && serverProgress !== null && serverProgress > 0) {
+					toast.update(task.toastId, `${update.message} (${Math.round(serverProgress)}%)`);
+				} else {
+					toast.update(task.toastId, update.message);
 				}
 			}
-		});
 
-		xhr.addEventListener('error', () => {
-			toast.dismiss(toastId);
-			const errorMsg = buildNetworkErrorMessage(lastProgressPercent, fileSizeMB, isMobile);
-			toast.error(errorMsg);
-			if (callbacks?.onError) {
-				callbacks.onError(errorMsg);
+			if (update.status === 'completed') {
+				eventSource.close();
+				toast.dismiss(task.toastId);
+				this.activeUploads.delete(task.id);
+
+				const trackId = update.track_id ?? null;
+				toast.success(`"${displayName}" uploaded`, 5000, trackId ? {
+					label: 'view track',
+					href: `/track/${trackId}`
+				} : undefined);
+
+				const warnings: string[] = update.warnings ?? [];
+				const warningAction = update.pds_blob_failed
+					? { label: 'save to your PDS', href: '/portal/manage?save=pds' }
+					: undefined;
+				for (const w of warnings) {
+					toast.warning(w, 0, warningAction);
+				}
+
+				tracksCache.invalidate();
+				tracksCache.fetch(true);
+				if (onSuccess) {
+					onSuccess(
+						trackId !== null
+							? {
+									trackId,
+									atprotoUri: update.atproto_uri ?? null,
+									atprotoCid: update.atproto_cid ?? null
+								}
+							: undefined
+					);
+				}
 			}
-		});
 
-		xhr.addEventListener('timeout', () => {
-			toast.dismiss(toastId);
-			const errorMsg = buildTimeoutErrorMessage(lastProgressPercent, fileSizeMB, isMobile);
-			toast.error(errorMsg);
-			if (callbacks?.onError) {
-				callbacks.onError(errorMsg);
+			if (update.status === 'failed') {
+				eventSource.close();
+				toast.dismiss(task.toastId);
+				this.activeUploads.delete(task.id);
+				toast.error(update.error || 'upload failed');
 			}
-		});
+		};
 
-		xhr.timeout = 300000;
-		xhr.send(formData);
+		eventSource.onerror = () => {
+			eventSource.close();
+			toast.dismiss(task.toastId);
+			this.activeUploads.delete(task.id);
+			toast.error('lost connection to server');
+		};
 	}
 
 	/**

--- a/loq.toml
+++ b/loq.toml
@@ -39,7 +39,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 2070
+max_lines = 2078
 
 [[rules]]
 path = "backend/src/backend/config.py"

--- a/loq.toml
+++ b/loq.toml
@@ -39,7 +39,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 1883
+max_lines = 2070
 
 [[rules]]
 path = "backend/src/backend/config.py"
@@ -47,7 +47,7 @@ max_lines = 1266
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
-max_lines = 1025
+max_lines = 1184
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"
@@ -259,7 +259,7 @@ max_lines = 840
 
 [[rules]]
 path = "backend/tests/conftest.py"
-max_lines = 605
+max_lines = 666
 
 [[rules]]
 path = "backend/tests/api/track_audio_replace/test_pipeline.py"


### PR DESCRIPTION
the web uploader now sends a track as a resumable session — `POST /tracks/uploads` → `PUT …/parts/{n}` (10 MiB each, 3 in flight) → `POST …/finish` — landing straight in an R2 multipart upload, and the worker settles the bytes off the request path. no single request outlives one part, so the fixed 300 s `xhr.timeout` that misreported woody's 391–579 s uploads as failures (Aug 24–25; one was re-uploaded 15 minutes later) has nothing left to fire on.

the 579 s upload that prompted this, from its Logfire trace:

```
POST /tracks/            0s ──────────────────────────────── 579s   200
  (body transfer)        0s ───────────── 346s
  R2 save                              346s ────────── 579s   (231s, browser at 100%)
```

<details>
<summary>design</summary>

the shape is the one bluesky's video service and stream.place converged on: many short, independently timed-out and retried requests, with the server acknowledging bytes as it gets them.

- **start** opens an R2 multipart upload on `staged/<upload_id>.<ext>` in the **private** bucket (a supporter-gated master must never sit in the public bucket, even under an unguessable key). the job row is `pending` / phase `transfer` and remembers the multipart id, size, part size and count in `result.transfer`.
- **parts** are uniform 10 MiB, last one shorter (R2: ≥ 5 MiB, equal sizes). the server rejects a part whose length is not exactly what its number implies, so a truncated part can never be assembled. every part heartbeats the job. `GET /tracks/uploads/{id}` lists received parts for resume.
- **finish** takes the same form fields as `POST /tracks/` minus `file`; validation is the shared `parse_upload_metadata` (extracted from the old handler, not duplicated), and it runs before the multipart is completed, as do the part-list check (409) and cover-image staging (413) — every refusal leaves the parts in place and the session open. only then `complete_multipart_upload` and enqueue with `staged=True`.
- **worker phase 0** (`_settle_staged_audio`): stream the staged object once onto the worker's disk while hashing, scan duration/ALAC from that copy (the handler used to do this on its own `/tmp`), then a server-side `copy_object` to `audio/<hash>.<ext>` in the right bucket — or `uploadBlob` to the PDS for private media — and delete the staged object. the worker never re-uploads audio. from `_validate_audio` onward nothing knows the upload was resumable: PDS blob before record, reserve-then-publish, the jetstream finalize race, the optimize task are untouched.
- **abandoned sessions**: `reap_abandoned_transfers` fails sessions idle 24 h and aborts their multipart upload; R2 aborts incomplete multiparts itself after 7 days. the stuck-upload reaper ignores `pending` rows, so an in-flight transfer is never reaped.
- **client** (`upload-session.ts`): pure transport with an injectable `send`, so retry/backoff/progress logic is unit-tested without a DOM. progress is acknowledged bytes; a part is abandoned only after 60 s with no progress event (a slow part is not a dead part) or a 15 min ceiling, 5 attempts with exponential backoff, non-retryable on 4xx. `uploader.svelte.ts` composes it with the unchanged SSE follow-up.

</details>

<details>
<summary>intentionally unchanged</summary>

- `POST /tracks/` still exists and is byte-for-byte the same contract — the SDK and the integration suite use it.
- `replaceAudio` (`PUT /tracks/{id}/audio`) still uses the single-request path.
- a PDS that refuses the blob still degrades to R2-only with the portal warning; making that a first-class job outcome is separate.
- the PDS blob is still the *playable* rendition. storing the artist's master in the PDS and deriving delivery renditions from the mirror is the larger storage-semantics change this transport makes possible; not started here.

</details>

<details>
<summary>verification</summary>

- backend: `just backend test` — 1609 passed. one incidental fix under `backend/tests/docker-compose.yml`: the compose postgres was pinned at `max_connections=100` while `-n auto` scales workers with cores; sampling `pg_stat_activity` during a run showed `main` itself peaking at 94/100 on an 18-worker machine, and the handful of DB-touching tests added here tipped it into `TooManyConnectionsError` on unrelated tests. it is 300 now (peak observed 95). CI runners have fewer cores and never got near it. new: `tests/api/test_upload_sessions.py` (start → parts → finish against the in-memory multipart double in `MockStorage`; missing part keeps the session open; wrong-size part rejected; metadata validated before assembly; foreign session is 404; settle promotes to the content-hash key / private bucket for gated / PDS blob for private / deletes staged on failure) and an abandoned-transfer reaper test.
- frontend: `bun run check`, `bun run lint` (anti-slop clean), `bun run test` — 175 passed; `upload-session.test.ts` covers part planning, resume-skips-received, retry with backoff, no retry on 4xx, exhausted attempts.
- end to end against a local backend + worker wired to the real `audio-dev` / `audio-private-dev` buckets (scoped, expiring R2 token, deleted afterwards) with a dev token for the test account on the zat PDS (revoked afterwards). a 25.2 MB generated WAV, driven by script:

  ```
  session 0cce29ed… parts 3 part_size 10485760
    part (1, 10485760, 6.93s)  part (2, 10485760, 4.07s)
  finish w/ missing part → 409 "upload incomplete — 1 part(s) missing"
  received [1, 2]
    part (3, 5488524, 2.09s)
  short part → 400
  finish → 200 {"upload_id": "0cce29ed…", "status": "pending"}
    sse queued → settle "checking your file..." → pds_upload → atproto → completed
  track 66: file_id a4cca44353a74380 (= sha256 of the file), extra.duration 150,
            pds_blob_size 26460044, at://…/fm.plyr.dev.track/3mu7f3r3anq22
  promoted audio/a4cca44353a74380.wav: 26460044 bytes, audio/wav,
            "public, max-age=31536000, immutable"; staged/ empty; no open multiparts
  ```

  the test tracks were deleted through the API afterwards; the promoted objects are gone and the staged prefix and multipart list are empty.

</details>

docs: `docs/internal/backend/resumable-uploads.md`.

![bufo-ship](https://all-the.bufo.zone/bufo-ship.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCkppptjTLXRvorWp12NsK
