### PR TITLE
client writes phase 0: browser OAuth session + verified ingest echo

### DIFF
--- a/backend/src/backend/api/ingest.py
+++ b/backend/src/backend/api/ingest.py
@@ -1,0 +1,131 @@
+"""verified read-after-write for client-authored records.
+
+a client that writes a record to its own PDS tells us the AT URI here, and we
+index it immediately instead of waiting for jetstream. the claim is never
+trusted: the record is fetched from the caller's own PDS and dispatched to the
+same ingest functions the firehose path uses, so a forged or malformed URI
+indexes nothing. jetstream remains the reconciler — this route only moves
+"when", never "whether" (#1796 makes it also a durability backstop for our own
+users' writes).
+"""
+
+import httpx
+import logfire
+from atproto_oauth.security import is_safe_url
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from backend._internal import Session as AuthSession
+from backend._internal import require_auth
+from backend._internal.tasks.ingest import (
+    SubjectNotFoundError,
+    ingest_like_create,
+    ingest_like_delete,
+)
+from backend.config import settings
+from backend.utilities.rate_limit import limiter
+
+router = APIRouter(prefix="/ingest", tags=["ingest"])
+
+_FETCH_TIMEOUT_SECONDS = 10.0
+
+
+class IngestRecordRequest(BaseModel):
+    uri: str = Field(min_length=1, max_length=1024)
+
+
+class IngestRecordResponse(BaseModel):
+    status: str
+
+
+def _parse_own_record_uri(uri: str, did: str) -> tuple[str, str]:
+    """(collection, rkey) of an at:// URI in the caller's own repo; 4xx otherwise."""
+    prefix = "at://"
+    if not uri.startswith(prefix):
+        raise HTTPException(status_code=400, detail="not an at:// URI")
+    parts = uri.removeprefix(prefix).split("/")
+    if len(parts) != 3 or not all(parts):
+        raise HTTPException(status_code=400, detail="malformed at:// URI")
+    repo, collection, rkey = parts
+    if repo != did:
+        raise HTTPException(status_code=403, detail="record is not in your repo")
+    return collection, rkey
+
+
+def _supported_collections() -> set[str]:
+    return {settings.atproto.like_collection}
+
+
+@router.post("/record")
+@limiter.limit(settings.rate_limit.default_limit)
+async def ingest_record(
+    request: Request,
+    body: IngestRecordRequest,
+    auth_session: AuthSession = Depends(require_auth),
+) -> IngestRecordResponse:
+    """index a record the caller just wrote to (or deleted from) their own PDS.
+
+    the record's current state on the PDS decides what happens: present →
+    create/update ingest; absent → delete ingest. either way the PDS is the
+    source, so the response reflects reality even when the client lies.
+    """
+    collection, rkey = _parse_own_record_uri(body.uri, auth_session.did)
+    if collection not in _supported_collections():
+        raise HTTPException(
+            status_code=404, detail=f"collection not indexed here: {collection}"
+        )
+
+    pds_url = (auth_session.oauth_session or {}).get("pds_url")
+    if not pds_url or not is_safe_url(pds_url):
+        raise HTTPException(status_code=502, detail="your PDS endpoint is not usable")
+
+    async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT_SECONDS) as client:
+        try:
+            response = await client.get(
+                f"{pds_url}/xrpc/com.atproto.repo.getRecord",
+                params={
+                    "repo": auth_session.did,
+                    "collection": collection,
+                    "rkey": rkey,
+                },
+            )
+        except httpx.HTTPError as e:
+            raise HTTPException(
+                status_code=502, detail="could not reach your PDS"
+            ) from e
+
+    with logfire.span(
+        "ingest echo",
+        uri=body.uri,
+        collection=collection,
+        pds_status=response.status_code,
+    ):
+        if response.status_code == 200:
+            payload = response.json()
+            record = payload.get("value")
+            if not isinstance(record, dict):
+                raise HTTPException(
+                    status_code=502, detail="PDS returned a malformed record"
+                )
+            try:
+                await ingest_like_create(
+                    auth_session.did,
+                    rkey,
+                    record,
+                    body.uri,
+                    cid=payload.get("cid"),
+                )
+            except SubjectNotFoundError as e:
+                raise HTTPException(
+                    status_code=404, detail="the record's subject is not indexed here"
+                ) from e
+            return IngestRecordResponse(status="indexed")
+
+        if response.status_code in (400, 404):
+            await ingest_like_delete(auth_session.did, rkey, body.uri)
+            return IngestRecordResponse(status="deleted")
+
+        raise HTTPException(
+            status_code=502,
+            detail=f"your PDS answered {response.status_code}",
+        )

--- a/backend/src/backend/api/meta.py
+++ b/backend/src/backend/api/meta.py
@@ -36,6 +36,7 @@ async def get_public_config() -> dict[str, int | str | list[str]]:
 
     return {
         "max_upload_size_mb": settings.storage.max_upload_size_mb,
+        "app_namespace": settings.atproto.app_namespace,
         "max_image_size_mb": 20,  # hardcoded limit for cover art
         "browser_observability": settings.app.browser_observability,
         "default_hidden_tags": DEFAULT_HIDDEN_TAGS,

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -43,6 +43,7 @@ from backend.api import (
     xrpc_router,
 )
 from backend.api.albums import router as albums_router
+from backend.api.ingest import router as ingest_router
 from backend.api.lists import router as lists_router
 from backend.api.migration import router as migration_router
 from backend.api.subsonic import compat_router as subsonic_compat_router
@@ -193,6 +194,7 @@ app.include_router(queue_router)
 app.include_router(radio_router)
 app.include_router(now_playing_router)
 app.include_router(migration_router)
+app.include_router(ingest_router)
 app.include_router(exports_router)
 app.include_router(for_you_router)
 app.include_router(jams_router)

--- a/backend/tests/api/test_ingest_echo.py
+++ b/backend/tests/api/test_ingest_echo.py
@@ -1,0 +1,207 @@
+"""POST /ingest/record — verified read-after-write for client-authored records.
+
+the route must never trust the claimed URI: what gets indexed is what the
+caller's PDS actually returns. these tests drive the real endpoint with the
+PDS fetch as the only mocked boundary, and assert the invariant the whole
+client-writes migration leans on — echo followed by a jetstream replay of the
+same event is idempotent in both directions.
+"""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import Session, require_auth
+from backend._internal.tasks.ingest import ingest_like_create, ingest_like_delete
+from backend.config import settings
+from backend.models import Artist, Track
+from backend.models.track_like import TrackLike
+
+LISTENER_DID = "did:test:listener"
+LIKE_COLLECTION = settings.atproto.like_collection
+
+
+class _ListenerSession(Session):
+    def __init__(self) -> None:
+        self.did = LISTENER_DID
+        self.handle = "listener.test"
+        self.session_id = "test_session_ingest_echo"
+        self.oauth_session = {
+            "did": self.did,
+            "handle": self.handle,
+            "pds_url": "https://listener.test.pds",
+            "scope": "atproto",
+            "access_token": "t",
+            "refresh_token": "r",
+            "dpop_private_key_pem": "fake",
+            "dpop_authserver_nonce": "",
+            "dpop_pds_nonce": "",
+        }
+
+
+@pytest.fixture
+def listener_app(
+    db_session: AsyncSession, fastapi_app: FastAPI
+) -> Generator[FastAPI, None, None]:
+    async def _session() -> Session:
+        return _ListenerSession()
+
+    fastapi_app.dependency_overrides[require_auth] = _session
+    yield fastapi_app
+    fastapi_app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def track(db_session: AsyncSession) -> Track:
+    artist = Artist(did="did:test:artist", handle="artist.test", display_name="artist")
+    db_session.add(artist)
+    track = Track(
+        title="liked track",
+        artist_did=artist.did,
+        file_id="echo1234",
+        file_type="mp3",
+        atproto_record_uri="at://did:test:artist/fm.plyr.track/echo1234",
+        atproto_record_cid="bafyecho",
+    )
+    db_session.add(track)
+    await db_session.commit()
+    await db_session.refresh(track)
+    return track
+
+
+def _like_uri(rkey: str = "3likeecho") -> str:
+    return f"at://{LISTENER_DID}/{LIKE_COLLECTION}/{rkey}"
+
+
+def _like_record(track: Track) -> dict:
+    return {
+        "$type": LIKE_COLLECTION,
+        "subject": {"uri": track.atproto_record_uri, "cid": track.atproto_record_cid},
+        "createdAt": "2026-08-31T00:00:00Z",
+    }
+
+
+def _pds_answers(status_code: int, payload: dict | None = None):
+    """patch the route's PDS fetch — the one network boundary."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    ctx = patch("backend.api.ingest.httpx.AsyncClient")
+    return ctx, response
+
+
+async def _like_count(db: AsyncSession) -> int:
+    result = await db.execute(select(func.count()).select_from(TrackLike))
+    return result.scalar_one()
+
+
+def _post(client: TestClient, uri: str):
+    return client.post("/ingest/record", json={"uri": uri})
+
+
+async def test_echo_indexes_a_like_and_replay_is_idempotent(
+    listener_app: FastAPI, db_session: AsyncSession, track: Track
+) -> None:
+    uri = _like_uri()
+    ctx, response = _pds_answers(
+        200, {"uri": uri, "cid": "bafylike", "value": _like_record(track)}
+    )
+    with TestClient(listener_app) as client, ctx as mock_client:
+        mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+            return_value=response
+        )
+        resp = _post(client, uri)
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"status": "indexed"}
+        assert await _like_count(db_session) == 1
+
+        # the client double-clicks / retries: still one row
+        assert _post(client, uri).json() == {"status": "indexed"}
+        assert await _like_count(db_session) == 1
+
+    # jetstream later replays the same create event: still one row
+    await ingest_like_create(LISTENER_DID, "3likeecho", _like_record(track), uri)
+    assert await _like_count(db_session) == 1
+
+
+async def test_echo_of_a_deleted_record_removes_the_like(
+    listener_app: FastAPI, db_session: AsyncSession, track: Track
+) -> None:
+    uri = _like_uri()
+    await ingest_like_create(LISTENER_DID, "3likeecho", _like_record(track), uri)
+    assert await _like_count(db_session) == 1
+
+    ctx, response = _pds_answers(400, {"error": "RecordNotFound"})
+    with TestClient(listener_app) as client, ctx as mock_client:
+        mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+            return_value=response
+        )
+        resp = _post(client, uri)
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "deleted"}
+    assert await _like_count(db_session) == 0
+
+    # jetstream later replays the delete: still gone, no error
+    await ingest_like_delete(LISTENER_DID, "3likeecho", uri)
+    assert await _like_count(db_session) == 0
+
+
+async def test_echo_never_trusts_the_claim_when_the_pds_disagrees(
+    listener_app: FastAPI, db_session: AsyncSession, track: Track
+) -> None:
+    """a claimed create for a record the PDS does not have indexes nothing."""
+    uri = _like_uri("3neverwritten")
+    ctx, response = _pds_answers(400, {"error": "RecordNotFound"})
+    with TestClient(listener_app) as client, ctx as mock_client:
+        mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+            return_value=response
+        )
+        assert _post(client, uri).json() == {"status": "deleted"}
+    assert await _like_count(db_session) == 0
+
+
+async def test_echo_rejects_a_record_in_someone_elses_repo(
+    listener_app: FastAPI, db_session: AsyncSession
+) -> None:
+    with TestClient(listener_app) as client:
+        resp = _post(client, f"at://did:test:artist/{LIKE_COLLECTION}/3x")
+        assert resp.status_code == 403
+
+
+async def test_echo_rejects_unindexed_collections_and_malformed_uris(
+    listener_app: FastAPI, db_session: AsyncSession
+) -> None:
+    with TestClient(listener_app) as client:
+        assert (
+            _post(client, f"at://{LISTENER_DID}/app.bsky.feed.post/3x").status_code
+            == 404
+        )
+        assert _post(client, "https://not-an-at-uri").status_code == 400
+        assert (
+            _post(client, f"at://{LISTENER_DID}/{LIKE_COLLECTION}").status_code == 400
+        )
+
+
+async def test_echo_for_an_unindexed_subject_is_a_404(
+    listener_app: FastAPI, db_session: AsyncSession
+) -> None:
+    uri = _like_uri()
+    record = {
+        "$type": LIKE_COLLECTION,
+        "subject": {
+            "uri": "at://did:test:artist/fm.plyr.track/unknown",
+            "cid": "bafyx",
+        },
+        "createdAt": "2026-08-31T00:00:00Z",
+    }
+    ctx, response = _pds_answers(200, {"uri": uri, "cid": "bafylike", "value": record})
+    with TestClient(listener_app) as client, ctx as mock_client:
+        mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+            return_value=response
+        )
+        assert _post(client, uri).status_code == 404

--- a/docs/plans/2026-08-31-client-side-writes.md
+++ b/docs/plans/2026-08-31-client-side-writes.md
@@ -1,0 +1,171 @@
+# plan: client-side writes — the browser authors records, plyr becomes the appview
+
+**date**: 2026-08-31
+**context**: the direction settled after #1947 — the backend should not be writing
+records on users' behalf. the file an artist uploads goes in their PDS as-is;
+plyr indexes, mirrors for delivery, and serves app state. this plan makes that
+migration incremental: one write type at a time, staging-proven, measured, with
+the server path as the standing fallback.
+
+## goal
+
+records in `fm.plyr.*` are written by the signed-in user's own browser session
+(`@atproto/oauth-client-browser` → `Agent` → `com.atproto.repo.createRecord` /
+`uploadBlob`), and the backend's role for those writes shrinks to what an
+appview does: verify, index, mirror, serve.
+
+## current state
+
+- the backend is a confidential OAuth client and authors every record. the
+  browser holds only an opaque session cookie.
+- the appview half already runs: jetstream ingests `fm.plyr.*` from any repo;
+  `ingest_track_create` / `ingest_like_create` / `ingest_like_delete` exist;
+  `mirror_pds_blob` copies PDS audio into R2; reserve-then-publish handles the
+  backend's own record echoes.
+- plyr serves a `did:web` document (`api/meta.py`), so it can verify
+  service-auth JWTs when identity migrates.
+- #1947's resumable upload is the GA upload path and remains so until the
+  upload phase here replaces it.
+
+## resolved decisions (evidence in the 2026-08-30/31 session)
+
+- **no feature flag / opt-in.** the fallback that must exist anyway — no
+  browser session ⇒ use the server endpoint — is the degradation mechanism.
+  merge → staging (e2e) → prod, per phase. revert is a frontend deploy.
+- **scopes grow progressively.** the authserver requires consent only for
+  scopes not previously granted to this client
+  (`oauth-provider.ts:checkConsentRequired`); re-auth with granted scopes is a
+  silent redirect. each phase adds its `repo:`/`blob:` scopes via the existing
+  scope-upgrade redirect pattern. phase 1 requests exactly
+  `atproto repo:fm.plyr.like?action=create&action=delete`.
+- **the browser client is a public client** with its own permanent identity:
+  `client_id` = `https://plyr.fm/oauth-client-metadata.json` (served by the
+  frontend, derived from the request origin so staging gets
+  `https://stg.plyr.fm/...`). choose once; grants are keyed to it.
+- **verified echo, not trust and not waiting.** after a client write, the
+  client calls the appview with the `at://` URI; the appview fetches the
+  record from the PDS itself and indexes it through the same ingest functions
+  jetstream uses. this preserves read-your-own-write and makes jetstream loss
+  (#1796) non-fatal for our own users. the claim is never trusted — the PDS
+  read is the source. this is the plan's one new API route.
+
+## not doing (until the pattern is proven)
+
+- private media / spaces writes (permissioned scope in a browser session is
+  its own design)
+- teal scrobbles, SDK/dev-token surface, Subsonic
+- retiring the cookie session or the confidential client (that is the final
+  identity phase, and only after every write has migrated)
+- transcoded renditions in the PDS: from the upload phase onward the PDS blob
+  is the uploaded file, and plyr-side mp3s never overwrite it
+
+## phases
+
+### phase 0: the browser session exists
+
+**changes**:
+- `frontend/src/routes/oauth-client-metadata.json/+server.ts` — public-client
+  metadata derived from origin (`token_endpoint_auth_method: "none"`,
+  `dpop_bound_access_tokens: true`, phase-1 scope). loopback client for
+  127.0.0.1 dev (rally's `src/data/oauth.ts` is the model).
+- `frontend/src/lib/atproto/client.ts` — `BrowserOAuthClient` setup,
+  `client.init()` on boot, `restore(did)`, session store; exposes
+  `agentFor(did): Agent | null`.
+- sign-in chaining: after the existing cookie callback completes
+  (`/auth/callback` bounce), if no browser session exists for the signed-in
+  DID, run `client.signIn(handle)` once. subsequent sign-ins are silent
+  (consent already granted).
+- `backend/src/backend/api/ingest.py` (new router, the one new surface):
+  `POST /ingest/record {uri}` — authenticated (cookie), owner-checked
+  (URI repo == session DID), fetches the record from the user's PDS
+  (`is_safe_url`-validated endpoint, same stance as ingest), dispatches to the
+  existing `ingest_*` function for the collection; 404s for collections we
+  don't index. rate-limited.
+- logfire baselines: jetstream ingest lag for `fm.plyr.like`, like-endpoint
+  latency/error rates.
+
+**success criteria**:
+- [ ] `just backend test` + `bun run check && bun run lint && bun run test`
+- [ ] staging: sign in fresh → exactly one extra consent screen, then a
+      browser session exists (`client.restore(did)` returns an agent); second
+      sign-in shows no consent screen
+- [ ] e2e sign-in flow (`frontend/e2e/lib.mjs signIn`) updated for the chained
+      authorize and green
+- [ ] `POST /ingest/record` with a hand-written like record (pdsx) indexes it;
+      with a forged URI for another repo it 403s
+
+### phase 1: likes
+
+**changes**:
+- `frontend/src/lib/likes` call sites (LikeButton flows): with a browser
+  session — `createRecord`/`deleteRecord` on `fm.plyr.like` (record shape
+  mirrors `_internal/atproto/records/fm_plyr/like.py`; rkey/subject semantics
+  copied exactly), optimistic UI, then `POST /ingest/record`; without one —
+  the existing `POST /tracks/{id}/like` endpoint, unchanged.
+- backend: nothing removed. `ingest_like_create`/`ingest_like_delete` handle
+  the echo and the jetstream copy idempotently (verify + regression test).
+- logfire: tag client-written likes (the echo route) so the two paths are
+  comparable.
+
+**success criteria**:
+- [ ] regression test: echo then jetstream replay of the same like does not
+      double-count; delete echo then replay does not resurrect
+- [ ] staging e2e: like a track with a browser session → liked list contains
+      it in the same page load; unlike → gone (the #1812 assertion, now on the
+      client path)
+- [ ] parity gate before prod promote: client-path like p95
+      time-to-indexed ≤ server-path p95 + jetstream lag baseline unchanged,
+      error rate not worse, over ≥ a week of staging + own-use on prod
+- [ ] pull the plug drill: with the echo route 500ing (staged fault), likes
+      still land via jetstream and the UI's optimistic state survives
+
+### phase 2: comments, then lists (albums/playlists), then profile
+
+same pattern per collection: scope upgrade adds `repo:fm.plyr.comment` (etc.),
+client writes + echo, server endpoint kept as fallback, ingest idempotency
+regression tests, parity gate. lists carry an extra check: ordered-membership
+semantics under interleaved client/jetstream delivery (#1736's unordered-update
+caveat applies to lists — the version guard work may become a prerequisite
+here; decide when phase 1 data is in).
+
+### phase 3: track upload
+
+**changes**:
+- scope upgrade adds `repo:fm.plyr.track` + `blob:audio/*`.
+- `frontend/src/lib/uploader.svelte.ts`: with a browser session —
+  `uploadBlob` (the file as chosen, one XHR with progress) then
+  `createRecord` with the `BlobRef`, then echo; the SSE job UI is replaced by
+  ingest-driven state for this path. without a session — the #1947 resumable
+  path, unchanged.
+- `ingest_track_create` hardening for first-party volume: it becomes the
+  publish path, not the exception path (mirror scheduling, duplicate checks,
+  gating fields authored client-side).
+- `audio_optimize` stops writing mp3s to the PDS — renditions are plyr-side
+  delivery copies only.
+
+**success criteria**:
+- [ ] e2e upload through the browser session lands: record in the repo with
+      the original file's blob, R2 mirror exists, track plays
+- [ ] AIFF upload: PDS keeps the AIFF; plyr serves the mp3 rendition
+- [ ] parity gates on upload success rate and time-to-playable vs #1947 path
+
+### phase 4: identity
+
+backend endpoints accept a service-auth JWT (`aud` = plyr's `did:web`,
+`lxm` check — `packages/bsky/src/auth-verifier.ts` is the model) alongside the
+cookie; the browser calls plyr through the PDS (`Agent.withProxy` /
+`atproto-proxy`) or directly with the JWT. once client writes are GA, sign-in
+becomes the browser client alone; the confidential client and cookie shrink to
+the SDK/dev-token surface. detailed separately when reached — this plan only
+commits to not blocking it.
+
+## testing
+
+- ingest idempotency (echo + jetstream replay) is the load-bearing invariant;
+  every phase adds its regression tests there
+- staging e2e extends per phase (sign-in chain, client-side like, later
+  client-side upload)
+- parity gates are logfire queries, written down with the phase, run before
+  each prod promote
+- fault drills: echo route down; jetstream blind window (#1796) — client
+  writes must survive both

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,7 +5,8 @@
     "": {
       "name": "frontend",
       "dependencies": {
-        "@atproto/api": "^0.18.7",
+        "@atproto/api": "^0.20.42",
+        "@atproto/oauth-client-browser": "^0.5.4",
         "@opentelemetry/auto-instrumentations-web": "^0.59.0",
         "@pydantic/logfire-browser": "^0.14.0",
         "hls.js": "^1.6.16",
@@ -58,19 +59,47 @@
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
-    "@atproto/api": ["@atproto/api@0.18.7", "", { "dependencies": { "@atproto/common-web": "^0.4.7", "@atproto/lexicon": "^0.6.0", "@atproto/syntax": "^0.4.2", "@atproto/xrpc": "^0.7.7", "await-lock": "^2.2.2", "multiformats": "^9.9.0", "tlds": "^1.234.0", "zod": "^3.23.8" } }, "sha512-vUluqN1XU5AX5tgfSJjjjUzALCMq8DjdI0jlIhRYyn2Chb0ZOCU8k0ZTpUAcuDFE2FoxxW4S3kvtlHwLMtN5dQ=="],
+    "@atproto-labs/did-resolver": ["@atproto-labs/did-resolver@0.3.7", "", { "dependencies": { "@atproto-labs/fetch": "^0.3.5", "@atproto-labs/pipe": "^0.2.4", "@atproto-labs/simple-store": "^0.5.1", "@atproto-labs/simple-store-memory": "^0.2.6", "@atproto/did": "^0.5.4", "zod": "^3.23.8" } }, "sha512-F3M3U5cU1QSAXX3J5auGEc5N2pgDgpirAjvyDFsytXuyWfrjWfTPd/H+DZrrED7gK+noW0cAWtxxjdX7/cTSVQ=="],
 
-    "@atproto/common-web": ["@atproto/common-web@0.4.7", "", { "dependencies": { "@atproto/lex-data": "0.0.3", "@atproto/lex-json": "0.0.3", "zod": "^3.23.8" } }, "sha512-vjw2+81KPo2/SAbbARGn64Ln+6JTI0FTI4xk8if0ebBfDxFRmHb2oSN1y77hzNq/ybGHqA2mecfhS03pxC5+lg=="],
+    "@atproto-labs/fetch": ["@atproto-labs/fetch@0.3.5", "", { "dependencies": { "@atproto-labs/pipe": "^0.2.4" } }, "sha512-iDFZEoNqfL17EVKE+uNzdUD7YF8LWhEhxeBtP6x+PNuAxoXv3ip9vLmB8nNzNxFwVn++FipfDtSiPqmziv1bdA=="],
 
-    "@atproto/lex-data": ["@atproto/lex-data@0.0.3", "", { "dependencies": { "@atproto/syntax": "0.4.2", "multiformats": "^9.9.0", "tslib": "^2.8.1", "uint8arrays": "3.0.0", "unicode-segmenter": "^0.14.0" } }, "sha512-ivo1IpY/EX+RIpxPgCf4cPhQo5bfu4nrpa1vJCt8hCm9SfoonJkDFGa0n4SMw4JnXZoUcGcrJ46L+D8bH6GI2g=="],
+    "@atproto-labs/handle-resolver": ["@atproto-labs/handle-resolver@0.4.8", "", { "dependencies": { "@atproto-labs/simple-store": "^0.5.1", "@atproto-labs/simple-store-memory": "^0.2.6", "@atproto/did": "^0.5.4", "zod": "^3.23.8" } }, "sha512-38I+j8Efs+cCgW/NX9RFKKu7qv/AF+FqxlKS8sWjXlNZSHQZqPj5cnKVQhSsJCs4ypPB84iKch8w4/STd33bLg=="],
 
-    "@atproto/lex-json": ["@atproto/lex-json@0.0.3", "", { "dependencies": { "@atproto/lex-data": "0.0.3", "tslib": "^2.8.1" } }, "sha512-ZVcY7XlRfdPYvQQ2WroKUepee0+NCovrSXgXURM3Xv+n5jflJCoczguROeRr8sN0xvT0ZbzMrDNHCUYKNnxcjw=="],
+    "@atproto-labs/identity-resolver": ["@atproto-labs/identity-resolver@0.4.7", "", { "dependencies": { "@atproto-labs/did-resolver": "^0.3.7", "@atproto-labs/handle-resolver": "^0.4.8" } }, "sha512-lKDaiBHoxrqTOFdSKAAPpplEtbbFrH4djGjnXJtOSMnZ46k7+G7AkCr1xycGGPOBYfyF54zRnTp0Tt8iu86qWg=="],
 
-    "@atproto/lexicon": ["@atproto/lexicon@0.6.0", "", { "dependencies": { "@atproto/common-web": "^0.4.7", "@atproto/syntax": "^0.4.2", "iso-datestring-validator": "^2.2.2", "multiformats": "^9.9.0", "zod": "^3.23.8" } }, "sha512-5veb8aD+J5M0qszLJ+73KSFsFrJBgAY/nM1TSAJvGY7fNc9ZAT+PSUlmIyrdye9YznAZ07yktalls/TwNV7cHQ=="],
+    "@atproto-labs/pipe": ["@atproto-labs/pipe@0.2.4", "", {}, "sha512-n67jCcrC+ouAeO10cWkpPzzLMlDi/lDCU30Us+LGqhOPhT6c4t5ASdBLQi9W3jUQtRzQBt3G9zipF+xKWNvVbw=="],
 
-    "@atproto/syntax": ["@atproto/syntax@0.4.2", "", {}, "sha512-X9XSRPinBy/0VQ677j8VXlBsYSsUXaiqxWVpGGxJYsAhugdQRb0jqaVKJFtm6RskeNkV6y9xclSUi9UYG/COrA=="],
+    "@atproto-labs/simple-store": ["@atproto-labs/simple-store@0.5.1", "", {}, "sha512-vfvoDhu6ds6BT3Pqe+d2/LBU1WpDRtt69y6zltlfMCoucPm82m1j50/Wb6xTvv+oZ+2j0JyZVXsmXQ12SWYQJg=="],
 
-    "@atproto/xrpc": ["@atproto/xrpc@0.7.7", "", { "dependencies": { "@atproto/lexicon": "^0.6.0", "zod": "^3.23.8" } }, "sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA=="],
+    "@atproto-labs/simple-store-memory": ["@atproto-labs/simple-store-memory@0.2.6", "", { "dependencies": { "@atproto-labs/simple-store": "^0.5.1", "lru-cache": "^10.2.0" } }, "sha512-DD1v7MEfYF3BAcEpMTTpzfBLWLoI2HuyBhku2YpjHoqPrRrhCtE1alkxfPHjtjJVIjuU/XNU0cF/wB3+5FiKsA=="],
+
+    "@atproto/api": ["@atproto/api@0.20.42", "", { "dependencies": { "@atproto/common-web": "^0.5.10", "@atproto/lexicon": "^0.7.12", "@atproto/syntax": "^0.7.5", "@atproto/xrpc": "^0.8.11", "await-lock": "^3.0.0", "multiformats": "^13.0.0", "tlds": "^1.234.0", "zod": "^3.23.8" } }, "sha512-x86WgkHFcNqDIo8gf52npc1KvFXlIPDLAJdIhiH1uUAwiQxDw8/WU0iH3pTl1OXMKkB93kwxG0ihx0fTi5FPbw=="],
+
+    "@atproto/common-web": ["@atproto/common-web@0.5.10", "", { "dependencies": { "@atproto/lex-data": "^0.1.7", "@atproto/lex-json": "^0.1.6", "@atproto/syntax": "^0.7.5", "zod": "^3.23.8" } }, "sha512-w4JUdsJ3VXt8ewkavYh5m/u0UbxDtFdCKhNZPEpJ0U1vcWIjDaSInIexteETDgD7fBJAhidIEi30MGz1kk49ug=="],
+
+    "@atproto/did": ["@atproto/did@0.5.4", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-BlnwQ+obL+4ZA71KH/EzZ3TY+cpSxnLiUI85mjBJIQwvDF/oN2sQA18wIj9jpduviIt2b/cMtlJuzHjzBkfXvw=="],
+
+    "@atproto/jwk": ["@atproto/jwk@0.7.4", "", { "dependencies": { "multiformats": "^13.0.0", "zod": "^3.23.8" } }, "sha512-tq7TUDmNfe1yDfpRgdGQMJdl9TUlJmREQNCag9yg5w8Evu+TOiFiLgiOCbo7X4ouRPSgd1DpOzXbUa8UyKKMZA=="],
+
+    "@atproto/jwk-jose": ["@atproto/jwk-jose@0.2.4", "", { "dependencies": { "@atproto/jwk": "^0.7.4", "jose": "^5.2.0" } }, "sha512-gzDoA0JTwnc0ZJOBLM7WX9xFxtynRS2K1Bofb8epzoMWDQvyvfbPcfkdPrKFM7NXCFUVpGpBnsCB8KFPTf1rCg=="],
+
+    "@atproto/jwk-webcrypto": ["@atproto/jwk-webcrypto@0.3.4", "", { "dependencies": { "@atproto/jwk": "^0.7.4", "@atproto/jwk-jose": "^0.2.4", "zod": "^3.23.8" } }, "sha512-UsFIUozqnRecXPo6HgKV4PW4FqYHxX1V3iAe0rRV6Q2RSfYD8V2mZ89pv8NpvJynnaqJArBQ7HZlcg0F4tRYhA=="],
+
+    "@atproto/lex-data": ["@atproto/lex-data@0.1.7", "", { "dependencies": { "multiformats": "^13.0.0", "tslib": "^2.8.1", "unicode-segmenter": "^0.14.0" } }, "sha512-kW/dPLqo/WgCLV+XESR4JKwV6c1rZWJGOfuPupZGTjEDAKoBbKXdaEzX9/1vKQYbZ9U3j0DS/n7OFFK7wBugyQ=="],
+
+    "@atproto/lex-json": ["@atproto/lex-json@0.1.6", "", { "dependencies": { "@atproto/lex-data": "^0.1.7", "tslib": "^2.8.1" } }, "sha512-mvrAd0lbyuecIHjyld8QN6MN6CBf4j0GCxLzegsvLh0SvDf+GbYWklkcQqmITL44yFQOwmA/QNIQj0Uvh7+R/g=="],
+
+    "@atproto/lexicon": ["@atproto/lexicon@0.7.12", "", { "dependencies": { "@atproto/common-web": "^0.5.10", "@atproto/syntax": "^0.7.5", "multiformats": "^13.0.0", "zod": "^3.23.8" } }, "sha512-bXVWXc2+ctVVUc3CEuWV9mVXRMMQcWmdzmyRE7w2Rli0B36HADU49Vvi7PWTw26zFFqumYVl9b23bW3vrzAzbg=="],
+
+    "@atproto/oauth-client": ["@atproto/oauth-client@0.8.4", "", { "dependencies": { "@atproto-labs/did-resolver": "^0.3.7", "@atproto-labs/fetch": "^0.3.5", "@atproto-labs/handle-resolver": "^0.4.8", "@atproto-labs/identity-resolver": "^0.4.7", "@atproto-labs/simple-store": "^0.5.1", "@atproto-labs/simple-store-memory": "^0.2.6", "@atproto/did": "^0.5.4", "@atproto/jwk": "^0.7.4", "@atproto/oauth-types": "^0.7.5", "@atproto/xrpc": "^0.8.11", "core-js": "^3.50.0", "multiformats": "^13.0.0", "zod": "^3.23.8" } }, "sha512-fO3V+4f3Tm6tHKxjXoE/fNREcO3IjQVGPpyfX7FTrkJhu+pWk68TQ5bwUNon14zxIUr8V5RQq2egY5CA/x0wKQ=="],
+
+    "@atproto/oauth-client-browser": ["@atproto/oauth-client-browser@0.5.4", "", { "dependencies": { "@atproto-labs/did-resolver": "^0.3.7", "@atproto-labs/handle-resolver": "^0.4.8", "@atproto-labs/simple-store": "^0.5.1", "@atproto/did": "^0.5.4", "@atproto/jwk": "^0.7.4", "@atproto/jwk-webcrypto": "^0.3.4", "@atproto/oauth-client": "^0.8.4", "@atproto/oauth-types": "^0.7.5", "core-js": "^3.50.0" } }, "sha512-+mFzVwjDmi6n6ImfTuj9dIvM2nDjGp/uv01ONhXS6TbA30WG2cPBXqPjycPldc/OSc6F7TJ4/DQREBUCeDGn8w=="],
+
+    "@atproto/oauth-types": ["@atproto/oauth-types@0.7.5", "", { "dependencies": { "@atproto/did": "^0.5.4", "@atproto/jwk": "^0.7.4", "zod": "^3.23.8" } }, "sha512-x75O0HsKB1IGfBikAQrrTX6EL8Rt4Q0+wMcwhZQRGPk/N/WqbYbsW3Powj4R8ZJKSfWCpVfaw32Piu1pTi891Q=="],
+
+    "@atproto/syntax": ["@atproto/syntax@0.7.5", "", { "dependencies": { "iso-datestring-validator": "^2.2.2", "tslib": "^2.8.1" } }, "sha512-6vnLQK8OAzg0dO6z/xnvuXn5zMV0UMI54zbxk7G7BXhGlIlLMb1yo+JVYtAlv8Nxzr+AaFdNZ8AJt+L/QhJMFQ=="],
+
+    "@atproto/xrpc": ["@atproto/xrpc@0.8.11", "", { "dependencies": { "@atproto/lexicon": "^0.7.12", "zod": "^3.23.8" } }, "sha512-5M38m9REQouVIA4/Gh0wqo6Vncr3QbG7rb5oqlEbqB+f77pruCk4JLDipfrOrsXH+pdnVnU2IaPXvpsSAC7Mqw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
@@ -108,7 +137,7 @@
 
     "@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@7.27.1", "", { "dependencies": { "@babel/traverse": "^7.27.1", "@babel/types": "^7.27.1" } }, "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg=="],
 
-    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
@@ -118,7 +147,7 @@
 
     "@babel/helpers": ["@babel/helpers@7.28.4", "", { "dependencies": { "@babel/template": "^7.27.2", "@babel/types": "^7.28.4" } }, "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w=="],
 
-    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+    "@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
 
     "@babel/plugin-bugfix-firefox-class-in-computed-class-key": ["@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/traverse": "^7.28.5" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q=="],
 
@@ -250,9 +279,7 @@
 
     "@babel/traverse": ["@babel/traverse@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "debug": "^4.3.1" } }, "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ=="],
 
-    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
-
-    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+    "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
     "@blazediff/core": ["@blazediff/core@1.9.1", "", {}, "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA=="],
 
@@ -778,8 +805,6 @@
 
     "@vitest/browser-playwright": ["@vitest/browser-playwright@4.1.8", "", { "dependencies": { "@vitest/browser": "4.1.8", "@vitest/mocker": "4.1.8", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "playwright": "*", "vitest": "4.1.8" } }, "sha512-SR7FqgegaexEg73xvf3ArtygXegagMdXnL0EZMpxrWvvhQxvicD/E8p0ib0J91riPRtQUViyh67Xjw3NqvyhVg=="],
 
-    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.8", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.8", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.8", "vitest": "4.1.8" }, "optionalPeers": ["@vitest/browser"] }, "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw=="],
-
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.1.8", "", { "dependencies": { "@vitest/spy": "4.1.8", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw=="],
@@ -822,8 +847,6 @@
 
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
-    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.4", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA=="],
-
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
@@ -832,7 +855,7 @@
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
-    "await-lock": ["await-lock@2.2.2", "", {}, "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw=="],
+    "await-lock": ["await-lock@3.0.0", "", {}, "sha512-eO6fLiSnrJrMdjWMNK8zbVRXPs2TKJg78iKZd9wDpN3na5tcoV6EoeiOlMgk2QaAQ1gIrK1YuMsJHXWqz89tSA=="],
 
     "axe-core": ["axe-core@4.12.1", "", {}, "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA=="],
 
@@ -901,6 +924,8 @@
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
+
+    "core-js": ["core-js@3.50.0", "", {}, "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw=="],
 
     "core-js-compat": ["core-js-compat@3.46.0", "", { "dependencies": { "browserslist": "^4.26.3" } }, "sha512-p9hObIIEENxSV8xIu+V68JjSeARg6UVMG5mR+JEUguG3sI6MsiS1njz2jHmyJDvA+8jX/sytkBHup6kxhM9law=="],
 
@@ -1110,8 +1135,6 @@
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
-    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
-
     "idb": ["idb@7.1.1", "", {}, "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="],
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
@@ -1206,15 +1229,11 @@
 
     "iso-datestring-validator": ["iso-datestring-validator@2.2.2", "", {}, "sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA=="],
 
-    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
-
-    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
-
-    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
-
     "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
 
-    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
@@ -1274,10 +1293,6 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
-    "magicast": ["magicast@0.5.3", "", { "dependencies": { "@babel/parser": "^7.29.3", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw=="],
-
-    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
-
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
@@ -1302,7 +1317,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "multiformats": ["multiformats@9.9.0", "", {}, "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="],
+    "multiformats": ["multiformats@13.4.2", "", {}, "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -1598,8 +1613,6 @@
 
     "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 
-    "uint8arrays": ["uint8arrays@3.0.0", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA=="],
-
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
     "undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
@@ -1732,19 +1745,9 @@
 
     "@apideck/better-ajv-errors/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
-    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
-
-    "@babel/core/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
-
-    "@babel/core/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+    "@atproto-labs/simple-store-memory/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@babel/generator/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
-
-    "@babel/generator/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
-    "@babel/helper-annotate-as-pure/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
@@ -1754,31 +1757,7 @@
 
     "@babel/helper-create-regexp-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@babel/helper-member-expression-to-functions/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
-    "@babel/helper-module-imports/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
-    "@babel/helper-optimise-call-expression/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
-    "@babel/helper-skip-transparent-expression-wrappers/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
-    "@babel/helper-wrap-function/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
-    "@babel/helpers/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
     "@babel/preset-env/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@babel/preset-modules/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
-    "@babel/template/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
-
-    "@babel/template/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
-    "@babel/traverse/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
-
-    "@babel/traverse/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
-    "@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
@@ -1911,30 +1890,6 @@
     "youch/cookie": ["cookie@1.0.2", "", {}, "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="],
 
     "@apideck/better-ajv-errors/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/helper-annotate-as-pure/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/helper-member-expression-to-functions/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/helper-module-imports/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/helper-optimise-call-expression/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/helper-skip-transparent-expression-wrappers/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/helper-wrap-function/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/helpers/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/preset-modules/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/template/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 

--- a/frontend/e2e/lib.mjs
+++ b/frontend/e2e/lib.mjs
@@ -97,6 +97,17 @@ export async function authorizeOnPds(page, who = HANDLE, secret = PASSWORD) {
 	await page.waitForURL((u) => u.href.startsWith(APP), { timeout: 30000 });
 }
 
+/** the chained browser-client consent right after login; silent once granted. */
+async function approveChainedConsent(page, who, secret) {
+	await page.waitForTimeout(800);
+	if (await page.locator('input[name="username"]').count()) {
+		await authorizeOnPds(page, who, secret);
+		return;
+	}
+	await page.getByRole('button', { name: 'authorize' }).click();
+	await page.waitForURL((u) => u.href.startsWith(APP), { timeout: 30000 });
+}
+
 export async function signIn(page, who = HANDLE, secret = PASSWORD) {
 	await page.goto(`${APP}/login`, { waitUntil: 'networkidle' });
 	const handle = page.getByPlaceholder('you.example.com');
@@ -105,6 +116,12 @@ export async function signIn(page, who = HANDLE, secret = PASSWORD) {
 	await handle.press('Enter');
 	await page.waitForURL(/oauth\/authorize/, { timeout: 30000 });
 	await authorizeOnPds(page, who, secret);
+	try {
+		await page.waitForURL(/oauth\/authorize/, { timeout: 20000 });
+		await approveChainedConsent(page, who, secret);
+	} catch {
+		// no second redirect: this browser context already holds the session
+	}
 	await page.waitForTimeout(2500);
 	const terms = page.locator('.terms-overlay');
 	if (await terms.count()) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,7 +51,8 @@
 		"vitest": "^4.1.8"
 	},
 	"dependencies": {
-		"@atproto/api": "^0.18.7",
+		"@atproto/api": "^0.20.42",
+		"@atproto/oauth-client-browser": "^0.5.4",
 		"@opentelemetry/auto-instrumentations-web": "^0.59.0",
 		"@pydantic/logfire-browser": "^0.14.0",
 		"hls.js": "^1.6.16",

--- a/frontend/src/lib/atproto/client.ts
+++ b/frontend/src/lib/atproto/client.ts
@@ -1,0 +1,86 @@
+/**
+ * the browser's own atproto OAuth session — the client-writes substrate.
+ *
+ * this session is what lets the browser author records in the user's repo
+ * (`createRecord`/`uploadBlob` via an `Agent`) instead of asking the backend
+ * to. it exists alongside the cookie session: the cookie identifies the user
+ * to plyr's API; this identifies them to their own PDS. a user without one
+ * (older sign-in, cleared storage, new device) falls back to the server
+ * endpoints — callers must treat `agentFor` returning null as that fallback.
+ *
+ * everything here is loaded lazily so the OAuth library stays out of the main
+ * bundle for signed-out visitors.
+ */
+
+import { browser } from '$app/environment';
+import { getServerConfig } from '$lib/config';
+import { buildClientMetadata } from './metadata';
+import type { Agent } from '@atproto/api';
+import type { BrowserOAuthClient, OAuthSession } from '@atproto/oauth-client-browser';
+
+let clientPromise: Promise<BrowserOAuthClient> | null = null;
+
+async function getClient(): Promise<BrowserOAuthClient> {
+	if (!browser) throw new Error('atproto client is browser-only');
+	clientPromise ??= (async () => {
+		const [{ BrowserOAuthClient }, { app_namespace }] = await Promise.all([
+			import('@atproto/oauth-client-browser'),
+			getServerConfig()
+		]);
+		return new BrowserOAuthClient({
+			clientMetadata: buildClientMetadata(location.origin, app_namespace),
+			handleResolver: 'https://slingshot.microcosm.blue'
+		});
+	})();
+	return clientPromise;
+}
+
+async function toAgent(session: OAuthSession): Promise<Agent> {
+	const { Agent } = await import('@atproto/api');
+	return new Agent(session);
+}
+
+/**
+ * finish an in-flight authorization if the current URL is the callback.
+ * returns the page to send the user back to, or null when there was nothing
+ * to complete. only the callback page calls this.
+ */
+export async function completeCallback(): Promise<string | null> {
+	const client = await getClient();
+	const result = await client.init();
+	if (!result || result.state == null) return null;
+	return result.state.startsWith('/') ? result.state : '/';
+}
+
+/** the signed-in user's PDS agent, or null when this browser holds no session. */
+export async function agentFor(did: string): Promise<Agent | null> {
+	try {
+		const client = await getClient();
+		const session = await client.restore(did);
+		return await toAgent(session);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * make sure this browser can write to `did`'s repo; when it can't, redirect
+ * through the authserver (a silent round-trip once consent exists). resolves
+ * `false` only when no redirect was needed and no session could be restored.
+ */
+export async function ensureSession(
+	handle: string,
+	did: string,
+	returnTo: string
+): Promise<boolean> {
+	if (await agentFor(did)) return true;
+	const client = await getClient();
+	try {
+		await client.signIn(handle, { state: returnTo });
+	} catch (e) {
+		console.error('atproto sign-in could not start:', e);
+		return false;
+	}
+	// signIn navigates away; this only runs if it somehow returned
+	return false;
+}

--- a/frontend/src/lib/atproto/metadata.test.ts
+++ b/frontend/src/lib/atproto/metadata.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { buildClientMetadata, clientWriteScope } from './metadata';
+
+describe('buildClientMetadata', () => {
+	it('hosts its identity at the origin and points back at the callback route', () => {
+		const meta = buildClientMetadata('https://stg.plyr.fm', 'fm.plyr.stg');
+		expect(meta.client_id).toBe('https://stg.plyr.fm/oauth-client-metadata.json');
+		expect(meta.redirect_uris).toEqual(['https://stg.plyr.fm/atproto/callback']);
+		expect(meta.scope).toBe('atproto repo:fm.plyr.stg.like?action=create&action=delete');
+		expect(meta.token_endpoint_auth_method).toBe('none');
+		expect(meta.dpop_bound_access_tokens).toBe(true);
+	});
+
+	it('becomes a loopback client for local dev', () => {
+		const { client_id } = buildClientMetadata('http://127.0.0.1:5173', 'fm.plyr.dev');
+		if (client_id == null) throw new Error('loopback client_id missing');
+		expect(client_id.startsWith('http://localhost?redirect_uri=')).toBe(true);
+		expect(client_id).toContain(encodeURIComponent('http://127.0.0.1:5173/atproto/callback'));
+		expect(client_id).toContain(encodeURIComponent(clientWriteScope('fm.plyr.dev')));
+	});
+});

--- a/frontend/src/lib/atproto/metadata.ts
+++ b/frontend/src/lib/atproto/metadata.ts
@@ -1,0 +1,41 @@
+/**
+ * the browser OAuth client's identity, built in exactly one place.
+ *
+ * the authserver fetches `client_id` (a URL) and compares the hosted document
+ * to what the running client presents — the two must never drift, so both the
+ * served route (`routes/oauth-client-metadata.json/+server.ts`) and the
+ * in-browser client (`./client.ts`) call this builder. grants on users' PDSes
+ * are keyed to `client_id`, so the URL is permanent per environment.
+ */
+
+import type { OAuthClientMetadataInput } from '@atproto/oauth-client-browser';
+
+/** the scopes each migrated write type needs; grows per phase of the plan. */
+export function clientWriteScope(namespace: string): string {
+	return `atproto repo:${namespace}.like?action=create&action=delete`;
+}
+
+export function callbackPath(): string {
+	return '/atproto/callback';
+}
+
+export function buildClientMetadata(origin: string, namespace: string): OAuthClientMetadataInput {
+	const redirectUri = `${origin}${callbackPath()}`;
+	const scope = clientWriteScope(namespace);
+	const local = origin.startsWith('http://127.0.0.1') || origin.startsWith('http://localhost');
+	const clientId = local
+		? `http://localhost?redirect_uri=${encodeURIComponent(redirectUri)}&scope=${encodeURIComponent(scope)}`
+		: `${origin}/oauth-client-metadata.json`;
+	return {
+		client_id: clientId,
+		client_name: local ? 'plyr.fm (dev)' : 'plyr.fm',
+		client_uri: origin,
+		redirect_uris: [redirectUri],
+		scope,
+		grant_types: ['authorization_code', 'refresh_token'],
+		response_types: ['code'],
+		token_endpoint_auth_method: 'none',
+		application_type: 'web',
+		dpop_bound_access_tokens: true
+	};
+}

--- a/frontend/src/lib/auth.svelte.ts
+++ b/frontend/src/lib/auth.svelte.ts
@@ -92,6 +92,23 @@ class AuthManager {
 	getAuthHeaders(): Record<string, string> {
 		return {};
 	}
+
+	/**
+	 * make sure this browser holds the user's own atproto OAuth session (the
+	 * client-writes substrate). called right after a login exchange — the one
+	 * moment the user is already in an auth context. first ever call shows the
+	 * PDS consent screen once; after that the round-trip is silent, and once
+	 * the session is in this browser there is no navigation at all.
+	 */
+	async linkAtprotoSession(returnTo: string): Promise<void> {
+		if (!browser || !this.user) return;
+		try {
+			const { ensureSession } = await import('./atproto/client');
+			await ensureSession(this.user.handle, this.user.did, returnTo);
+		} catch (e) {
+			console.error('atproto session link failed:', e);
+		}
+	}
 }
 
 export const auth = new AuthManager();

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -16,6 +16,7 @@ export function getAtprotofansSupportUrl(did: string): string {
 
 interface ServerConfig {
 	max_upload_size_mb: number;
+	app_namespace: string;
 	max_image_size_mb: number;
 	browser_observability: boolean;
 	default_hidden_tags: string[];

--- a/frontend/src/routes/atproto/callback/+page.svelte
+++ b/frontend/src/routes/atproto/callback/+page.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { completeCallback } from '$lib/atproto/client';
+	import { toast } from '$lib/toast.svelte';
+
+	onMount(async () => {
+		try {
+			const returnTo = await completeCallback();
+			await goto(returnTo ?? '/', { replaceState: true });
+		} catch (e) {
+			console.error('atproto callback failed:', e);
+			toast.error('could not finish connecting to your account');
+			await goto('/', { replaceState: true });
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>signing you in — plyr.fm</title>
+</svelte:head>
+
+<main class="callback">
+	<p>finishing sign-in…</p>
+</main>
+
+<style>
+	.callback {
+		display: flex;
+		justify-content: center;
+		padding: 4rem 1rem;
+		color: var(--text-secondary);
+	}
+</style>

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -52,6 +52,7 @@
 					// invalidate all load functions so they rerun with the new session cookie
 					await invalidateAll();
 					await auth.refresh();
+					await auth.linkAtprotoSession('/library');
 					await preferences.fetch();
 				}
 			} catch (_e) {

--- a/frontend/src/routes/oauth-client-metadata.json/+server.ts
+++ b/frontend/src/routes/oauth-client-metadata.json/+server.ts
@@ -1,0 +1,11 @@
+import { json } from '@sveltejs/kit';
+import { getServerConfig } from '$lib/config';
+import { buildClientMetadata } from '$lib/atproto/metadata';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ url }) => {
+	const { app_namespace } = await getServerConfig();
+	return json(buildClientMetadata(url.origin, app_namespace), {
+		headers: { 'cache-control': 'public, max-age=300' }
+	});
+};

--- a/frontend/src/routes/portal/+page.svelte
+++ b/frontend/src/routes/portal/+page.svelte
@@ -68,6 +68,7 @@
 					// invalidate all load functions so they rerun with the new session cookie
 					await invalidateAll();
 					await auth.refresh();
+					await auth.linkAtprotoSession('/portal');
 					await preferences.fetch();
 					if (isScopeUpgrade) {
 						toast.success('copyright paradigm configured');

--- a/frontend/src/routes/profile/setup/+page.svelte
+++ b/frontend/src/routes/profile/setup/+page.svelte
@@ -35,6 +35,7 @@
 					// invalidate all load functions so they rerun with the new session cookie
 					await invalidateAll();
 					await auth.refresh();
+					await auth.linkAtprotoSession('/profile/setup');
 				}
 			} catch (_e) {
 				console.error('failed to exchange token:', _e);


### PR DESCRIPTION
phase 0 of [client-side writes](../blob/main/docs/plans/2026-08-31-client-side-writes.md): the browser gets its own atproto OAuth session, and the backend gets the verified read-after-write route the migration leans on. no write moves client-side yet — this PR is the substrate the likes phase plugs into.

three pieces:

1. **a browser public OAuth client.** `oauth-client-metadata.json` is served by the frontend (origin-derived, so staging and prod each get their permanent `client_id`; loopback client on 127.0.0.1), and `src/lib/atproto/client.ts` wraps `@atproto/oauth-client-browser` — lazily imported, so nothing lands in the main bundle until used. scope is exactly what phase 1 needs: `atproto repo:<ns>.like?action=create&action=delete`.
2. **sign-in chains the session.** right after a login exchange, `auth.linkAtprotoSession()` restores the browser session or round-trips the authserver (`state` carries the return path; `/atproto/callback` completes it). first ever trip shows the PDS consent screen once; after that the authserver skips consent for already-granted scopes (`oauth-provider.ts:checkConsentRequired`), and once the session is in IndexedDB there is no navigation at all.
3. **`POST /ingest/record`** — the client says "I wrote `at://…`", and the appview fetches the record from the caller's own PDS and dispatches it to the same ingest functions jetstream uses. present → create/update; absent → delete. the claim is never trusted; the PDS read is the source. this preserves read-your-own-write for client writes and makes jetstream loss (#1796) non-fatal for our own users.

<details>
<summary>design notes</summary>

- the metadata document and the in-browser client build from one shared `buildClientMetadata` — the authserver compares the hosted doc against what the client presents, so drift is sign-in breakage; one builder makes it unrepresentable.
- `app_namespace` is now in `GET /config` so the frontend never hardcodes an NSID; the metadata route and the client both read it from there.
- the echo route is collection-allowlisted (likes only, for now), owner-checked (URI repo must equal the session DID), rate-limited, and resolves the PDS from the caller's own session — no resolution of attacker-controlled input.
- delete-echo is derived, not claimed: the PDS answering RecordNotFound *is* the delete signal.
- no feature flag, per the plan: the fallback that must exist anyway (no browser session ⇒ server endpoints) is the degradation mechanism, and phase 0 changes no write path at all.

</details>

<details>
<summary>intentionally not in this PR</summary>

- no like (or any) write moves client-side — that's phase 1, with its own parity gates.
- the settings-page exchange variants (dev-token, scope-upgrade) don't chain the browser session; only the three regular login landings do.
- no `client.init()` at app boot — the session is restored on demand (`agentFor`), so signed-out visitors never load the OAuth library.
- comment/list/track collections are not accepted by the echo route yet.

</details>

<details>
<summary>tests + verification</summary>

- `tests/api/test_ingest_echo.py` (6): drives the real endpoint with the PDS fetch as the only mocked boundary — echo + jetstream replay idempotent in both directions, claims the PDS disagrees with index nothing, foreign-repo URIs 403, unindexed collections 404, missing subject 404.
- `metadata.test.ts`: hosted vs loopback client identity, callback route, scope shape.
- full suites green: backend 1615 passed, frontend 177 passed, `bun run check`/`lint` clean, production build under adapter-cloudflare clean.
- e2e `signIn` helper approves the chained consent (silently skipped when the browser context already holds the session); the staging run on merge exercises the full chain against the real zds authserver.
- not yet verified (needs staging): the consent round-trip UX on a real PDS, and the metadata route under CF Pages. that's what this draft's staging trip is for.

</details>

![bufo-is-ready-to-build-when-you-are](https://all-the.bufo.zone/bufo-is-ready-to-build-when-you-are.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCkppptjTLXRvorWp12NsK
