### PR TITLE
vite: bundle @atproto/api into SSR and alias tlds to its JSON

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -9,6 +9,7 @@ export default [
 	{
 		ignores: [
 			'.svelte-kit/**',
+			'.scratch/**',
 			'.vercel/**',
 			'build/**',
 			'node_modules/**',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,21 @@
+import { fileURLToPath } from 'node:url';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 import { SvelteKitPWA } from '@vite-pwa/sveltekit';
 
 export default defineConfig({
+	resolve: {
+		// @atproto/api does `import TLDs from 'tlds' with { type: 'json' }`;
+		// resolving 'tlds' straight to its JSON lets vite inline it, so the
+		// import-attributes syntax never survives into any emitted chunk
+		// (CF Pages' wrangler 3.x cannot parse it — see #1949/#1950)
+		alias: { tlds: fileURLToPath(new URL('./node_modules/tlds/index.json', import.meta.url)) }
+	},
+	ssr: {
+		// bundle it server-side too: left external, its dist files reach the
+		// CF Pages functions bundler verbatim, import attributes included
+		noExternal: ['@atproto/api']
+	},
 	plugins: [
 		sveltekit(),
 		SvelteKitPWA({


### PR DESCRIPTION
#1949 was necessary but not sufficient: CF Pages' vite run (unlike local) leaves `@atproto/api` external for SSR, so its dist files — `import TLDs from 'tlds' with { type: 'json' }` included — reach the Pages Functions bundler verbatim, and wrangler 3.x can't parse import attributes. staging has been serving static assets with **no worker** since #1948 merged (SvelteKit 404 on `/oauth-client-metadata.json` and `/atproto/callback`; the build log for deployment `58f6be1b` shows the Functions step failing on the same error).

two lines of config make the output deterministic instead of environment-dependent:
- `ssr.noExternal: ['@atproto/api']` — the package is bundled into emitted chunks everywhere
- `resolve.alias` `tlds` → its `index.json` — vite inlines the JSON, so the with-attributes import cannot survive bundling at all

verified locally: build green, `grep -r "with { type" .svelte-kit/{cloudflare,output}` empty, no external `@atproto/api` imports in `_worker.js`, check/tests green (177). the CF Pages build on merge is the real test.

also: `frontend/.scratch/` joins the eslint ignores, mirroring the git exclude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCkppptjTLXRvorWp12NsK