### PR TITLE
notifications: re-login and retry once when the bot's bsky session is rejected

### DIFF
--- a/backend/src/backend/_internal/notifications.py
+++ b/backend/src/backend/_internal/notifications.py
@@ -7,6 +7,13 @@ from dataclasses import dataclass
 
 import logfire
 from atproto import AsyncClient, client_utils, models
+from atproto_client.exceptions import (
+    BadRequestError,
+    LoginRequiredError,
+    NetworkError,
+    UnauthorizedError,
+)
+from atproto_client.models.common import XrpcError
 
 from backend._internal.transparency import Segment
 from backend.config import settings
@@ -35,7 +42,22 @@ class NotificationResult:
     success: bool
     recipient_did: str
     error: str | None = None
-    error_type: str | None = None  # "dm_blocked", "network", "auth", "unknown"
+    error_type: str | None = (
+        None  # "dm_blocked", "network", "auth", "session", "unknown"
+    )
+
+
+_SESSION_ERRORS = frozenset({"ExpiredToken", "InvalidToken"})
+
+
+def _is_session_error(e: Exception) -> bool:
+    """true when the bot's session itself is dead, so only a fresh login helps."""
+    if isinstance(e, UnauthorizedError | LoginRequiredError):
+        return True
+    if isinstance(e, BadRequestError):
+        content = e.response.content if e.response is not None else None
+        return isinstance(content, XrpcError) and content.error in _SESSION_ERRORS
+    return False
 
 
 class NotificationService:
@@ -100,9 +122,18 @@ class NotificationService:
             logger.exception(
                 "failed to authenticate notification bot or resolve recipient"
             )
-            self.client = None
-            self.dm_client = None
-            self.recipient_did = None
+            self._reset()
+
+    def _reset(self) -> None:
+        self.client = None
+        self.dm_client = None
+        self.recipient_did = None
+
+    def _discard_session(self) -> None:
+        """forget a dead session so the next `ensure_ready()` logs in again."""
+        logger.warning("notification bot session rejected; will re-authenticate")
+        self._reset()
+        self._last_setup_attempt = 0.0
 
     async def ensure_ready(self) -> str | None:
         """return the resolved recipient DID if the service is ready, else None.
@@ -124,10 +155,21 @@ class NotificationService:
     async def _send_dm_to_did(
         self, recipient_did: str, message_text: str
     ) -> NotificationResult:
-        """send a DM to a specific DID.
+        """send a DM to a specific DID, re-authenticating once if the session is dead.
 
         returns NotificationResult with success status and error details.
         """
+        result = await self._send_dm_once(recipient_did, message_text)
+        if result.error_type != "session":
+            return result
+        self._discard_session()
+        if await self.ensure_ready() is None:
+            return result
+        return await self._send_dm_once(recipient_did, message_text)
+
+    async def _send_dm_once(
+        self, recipient_did: str, message_text: str
+    ) -> NotificationResult:
         if not self.dm_client:
             return NotificationResult(
                 success=False,
@@ -176,9 +218,17 @@ class NotificationService:
                 error_type = "unknown"
 
                 # try to categorize the error
-                if "blocked" in error_str.lower() or "not allowed" in error_str.lower():
+                if _is_session_error(e):
+                    error_type = "session"
+                elif (
+                    "blocked" in error_str.lower() or "not allowed" in error_str.lower()
+                ):
                     error_type = "dm_blocked"
-                elif "timeout" in error_str.lower() or "connect" in error_str.lower():
+                elif (
+                    isinstance(e, NetworkError)
+                    or "timeout" in error_str.lower()
+                    or "connect" in error_str.lower()
+                ):
                     error_type = "network"
                 elif "auth" in error_str.lower() or "401" in error_str:
                     error_type = "auth"

--- a/backend/src/backend/_internal/notifications.py
+++ b/backend/src/backend/_internal/notifications.py
@@ -42,9 +42,7 @@ class NotificationResult:
     success: bool
     recipient_did: str
     error: str | None = None
-    error_type: str | None = (
-        None  # "dm_blocked", "network", "auth", "session", "unknown"
-    )
+    error_type: str | None = None  # dm_blocked|network|auth|session|unknown
 
 
 _SESSION_ERRORS = frozenset({"ExpiredToken", "InvalidToken"})

--- a/backend/tests/_internal/test_notification_service.py
+++ b/backend/tests/_internal/test_notification_service.py
@@ -9,9 +9,13 @@ send attempt (rate-limited by cooldown) so a transient upstream outage
 doesn't permanently break the service.
 """
 
-from unittest.mock import patch
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from atproto_client.exceptions import BadRequestError, InvokeTimeoutError
+from atproto_client.models.common import XrpcError
+from atproto_client.request import Response
 
 from backend._internal.notifications import NotificationService, _origin
 
@@ -54,8 +58,6 @@ class TestEnsureReady:
     async def test_skips_setup_within_cooldown(self) -> None:
         service = NotificationService()
         # "just attempted setup" — cooldown should suppress the retry
-        import time
-
         service._last_setup_attempt = time.monotonic()
 
         with (
@@ -102,3 +104,96 @@ class TestAlertOrigin:
             mock_settings.app.name = "plyr.fm"
             mock_settings.observability.environment = env
             assert _origin() == f"plyr.fm [{env}]"
+
+
+class TestSessionRecovery:
+    """regression: on 2026-09-01 the bot's bsky session was revoked mid-life
+    (`ExpiredToken: Token has been revoked`) and every DM failed until the
+    next deploy, because `recipient_did` stayed set so `ensure_ready()` never
+    re-ran setup(). a dead session must be discarded and re-established on the
+    next send, and the send retried once.
+    """
+
+    @staticmethod
+    def _revoked() -> BadRequestError:
+        return BadRequestError(
+            Response(
+                success=False,
+                status_code=400,
+                content=XrpcError(
+                    error="ExpiredToken", message="Token has been revoked"
+                ),
+                headers={},
+            )
+        )
+
+    @staticmethod
+    def _dm_client(fail_with: Exception | None) -> MagicMock:
+        convo = MagicMock()
+        if fail_with is not None:
+            convo.get_convo_for_members = AsyncMock(side_effect=fail_with)
+        else:
+            convo.get_convo_for_members = AsyncMock(
+                return_value=MagicMock(convo=MagicMock(id="convo-1"))
+            )
+        convo.send_message = AsyncMock()
+        client = MagicMock()
+        client.chat.bsky.convo = convo
+        return client
+
+    async def test_revoked_session_relogs_in_and_resends(self) -> None:
+        service = NotificationService()
+        service.recipient_did = "did:plc:recipient"
+        service.dm_client = self._dm_client(self._revoked())
+        service._last_setup_attempt = time.monotonic()
+        fresh = self._dm_client(None)
+
+        async def relogin() -> None:
+            service._last_setup_attempt = time.monotonic()
+            service.dm_client = fresh
+            service.recipient_did = "did:plc:recipient"
+
+        with (
+            patch(NOTIF_SETTINGS) as mock_settings,
+            patch.object(service, "setup", side_effect=relogin) as mock_setup,
+        ):
+            mock_settings.notify.enabled = True
+            result = await service._send_dm_to_did("did:plc:recipient", "hi")
+
+        assert result.success
+        mock_setup.assert_awaited_once()
+        fresh.chat.bsky.convo.send_message.assert_awaited_once()
+
+    async def test_revoked_session_is_discarded_when_relogin_fails(self) -> None:
+        service = NotificationService()
+        service.recipient_did = "did:plc:recipient"
+        service.dm_client = self._dm_client(self._revoked())
+
+        async def still_broken() -> None:
+            service._last_setup_attempt = time.monotonic()
+
+        with (
+            patch(NOTIF_SETTINGS) as mock_settings,
+            patch.object(service, "setup", side_effect=still_broken) as mock_setup,
+        ):
+            mock_settings.notify.enabled = True
+            result = await service._send_dm_to_did("did:plc:recipient", "hi")
+
+        assert not result.success
+        assert result.error_type == "session"
+        mock_setup.assert_awaited_once()
+        assert service.recipient_did is None
+        assert service.dm_client is None
+
+    async def test_network_failure_keeps_the_session(self) -> None:
+        service = NotificationService()
+        service.recipient_did = "did:plc:recipient"
+        service.dm_client = self._dm_client(InvokeTimeoutError())
+
+        with patch.object(service, "setup") as mock_setup:
+            result = await service._send_dm_to_did("did:plc:recipient", "hi")
+
+        assert not result.success
+        assert result.error_type == "network"
+        mock_setup.assert_not_called()
+        assert service.recipient_did == "did:plc:recipient"


### PR DESCRIPTION
when the notification bot's Bluesky session is revoked or expired mid-life, the service now discards it, re-authenticates through the existing `ensure_ready()` path, and retries the DM once. before, `recipient_did` stayed set so the re-login path was never taken and every DM failed until the next deploy.

**field evidence (prod, 2026-09-01):** the bot logged in at 06:53 UTC with the release restart. at 15:40 UTC the send for track 1265 failed with `BadRequestError … XrpcError(error='ExpiredToken', message='Token has been revoked')`, and the copyright-scan DM 20s later failed the same way. nothing re-authenticated until the 19:16 UTC restart. why the refresh token was revoked is not visible in telemetry; this PR makes the bot survive it regardless.

<details>
<summary>design</summary>

- `_is_session_error()` classifies by exception type: `UnauthorizedError`, `LoginRequiredError`, or a `BadRequestError` whose XRPC error is `ExpiredToken` / `InvalidToken`. string matching on `"auth"`/`"401"` did not catch `Token has been revoked`.
- `_send_dm_to_did()` wraps `_send_dm_once()`: on a `session` result it calls `_discard_session()` (clears client state and zeroes the setup cooldown), then `ensure_ready()`, then one more `_send_dm_once()`. if re-login fails, the original failure result is returned and the setup cooldown still applies to later sends, so a real outage is not amplified.
- `setup()`'s failure branch and the new discard share `_reset()`.
- network errors are now also classified by type (`NetworkError`), because `InvokeTimeoutError` stringifies to an empty message and was landing in `unknown` (that is how track 1264's timeout logged).
</details>

<details>
<summary>intentional non-behaviors</summary>

- no scheduled retry for tracks whose DM failed for non-session reasons. `notification_sent` stays false as before; the only retry trigger is still Jetstream's identity-update hook. that is a separate gap.
- no re-send of the two missed prod DMs (1264, 1265) in this PR; done as a one-off after this deploys.
- concurrent sends that both hit a dead session each re-login once; there is no lock. worker concurrency bounds it, and the pre-fix `ensure_ready()` had the same shape for setup failures.
- `post_publicly()` is unchanged: it already goes through `ensure_ready()`, and a transparency post that fails on a dead session is retried by its caller's cursor walk.
</details>

<details>
<summary>tests</summary>

`tests/_internal/test_notification_service.py::TestSessionRecovery`, three cases, all fail on main and pass here:
- revoked session → setup re-run once → send retried and succeeds
- revoked session and re-login still failing → failure returned, client state cleared
- network timeout → classified `network`, session kept, no re-login

`just backend test`: 1612 passed, 25 skipped. `just backend lint` clean.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z