### PR TITLE
upload: preview the chosen file and start its transfer on selection

### DIFF
--- a/frontend/src/lib/audio/peaks.ts
+++ b/frontend/src/lib/audio/peaks.ts
@@ -21,15 +21,14 @@ export interface PeaksOptions {
 	decodeSampleRate?: number;
 }
 
-function decodeContext(sampleRate: number | undefined): BaseAudioContext {
-	if (sampleRate !== undefined) {
-		try {
-			return new OfflineAudioContext(1, 1, sampleRate);
-		} catch (e) {
-			console.error('offline decode unavailable, decoding at full rate:', e);
-		}
+function offlineContext(sampleRate: number | undefined): OfflineAudioContext | null {
+	if (sampleRate === undefined) return null;
+	try {
+		return new OfflineAudioContext(1, 1, sampleRate);
+	} catch (e) {
+		console.error('offline decode unavailable, decoding at full rate:', e);
+		return null;
 	}
-	return new (audioContextCtor())();
 }
 
 export async function extractPeaks(
@@ -39,7 +38,9 @@ export async function extractPeaks(
 ): Promise<number[]> {
 	const arrayBuffer = source instanceof Blob ? await source.arrayBuffer() : source;
 
-	const ctx = decodeContext(options.decodeSampleRate);
+	const offline = offlineContext(options.decodeSampleRate);
+	const realtime = offline === null ? new (audioContextCtor())() : null;
+	const ctx: BaseAudioContext = offline ?? realtime ?? new (audioContextCtor())();
 
 	try {
 		// decodeAudioData mutates/consumes the buffer on some implementations,
@@ -78,8 +79,8 @@ export async function extractPeaks(
 		return peaks;
 	} finally {
 		// safari's AudioContext keeps the mic indicator alive if not closed
-		if (ctx instanceof AudioContext) {
-			await ctx.close().catch(() => undefined);
+		if (realtime) {
+			await realtime.close().catch(() => undefined);
 		}
 	}
 }

--- a/frontend/src/lib/audio/peaks.ts
+++ b/frontend/src/lib/audio/peaks.ts
@@ -16,13 +16,30 @@ import { audioContextCtor } from './wav';
  * make it trivial to cache peaks in localStorage, IndexedDB, or memoized
  * maps once we start reusing the Waveform component elsewhere in the app.
  */
+export interface PeaksOptions {
+	/** decode through an OfflineAudioContext at this rate so long files cost a fraction of the PCM. */
+	decodeSampleRate?: number;
+}
+
+function decodeContext(sampleRate: number | undefined): BaseAudioContext {
+	if (sampleRate !== undefined) {
+		try {
+			return new OfflineAudioContext(1, 1, sampleRate);
+		} catch (e) {
+			console.error('offline decode unavailable, decoding at full rate:', e);
+		}
+	}
+	return new (audioContextCtor())();
+}
+
 export async function extractPeaks(
 	source: Blob | ArrayBuffer,
-	buckets: number = 120
+	buckets: number = 120,
+	options: PeaksOptions = {}
 ): Promise<number[]> {
 	const arrayBuffer = source instanceof Blob ? await source.arrayBuffer() : source;
 
-	const ctx = new (audioContextCtor())();
+	const ctx = decodeContext(options.decodeSampleRate);
 
 	try {
 		// decodeAudioData mutates/consumes the buffer on some implementations,
@@ -61,7 +78,7 @@ export async function extractPeaks(
 		return peaks;
 	} finally {
 		// safari's AudioContext keeps the mic indicator alive if not closed
-		if ('close' in ctx) {
+		if (ctx instanceof AudioContext) {
 			await ctx.close().catch(() => undefined);
 		}
 	}

--- a/frontend/src/lib/audio/probe.test.ts
+++ b/frontend/src/lib/audio/probe.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+	audioFormatOf,
+	canRenderWaveform,
+	formatClock,
+	formatMegabytes,
+	isUsableDuration,
+	mediaDuration,
+	type MediaDurationSource,
+	WAVEFORM_MAX_BYTES,
+	WAVEFORM_MAX_SECONDS
+} from './probe';
+
+/** jsdom has no media pipeline: a source whose duration the test drives. */
+class FakeMedia extends EventTarget implements MediaDurationSource {
+	duration = Number.NaN;
+	currentTime = 0;
+	seekHistory: number[] = [];
+
+	/** a header-less container: seeking past the end reveals the real length. */
+	revealOnSeek(seconds: number): void {
+		Object.defineProperty(this, 'currentTime', {
+			set: (t: number) => {
+				this.seekHistory.push(t);
+				if (t > seconds && !isUsableDuration(this.duration)) {
+					this.duration = seconds;
+					void Promise.resolve().then(() => this.dispatchEvent(new Event('durationchange')));
+				}
+			},
+			get: () => this.seekHistory.at(-1) ?? 0
+		});
+	}
+}
+
+describe('mediaDuration', () => {
+	it('returns a known duration without seeking', async () => {
+		const fake = new FakeMedia();
+		fake.duration = 42.5;
+		expect(await mediaDuration(fake)).toBe(42.5);
+		expect(fake.seekHistory).toEqual([]);
+	});
+
+	it('scans a header-less container by seeking past the end, then rewinds', async () => {
+		const fake = new FakeMedia();
+		fake.revealOnSeek(12.25);
+		expect(await mediaDuration(fake)).toBe(12.25);
+		expect(fake.seekHistory[0]).toBeGreaterThan(1e100);
+		expect(fake.seekHistory.at(-1)).toBe(0);
+	});
+
+	it('gives up on a media error', async () => {
+		const fake = new FakeMedia();
+		const pending = mediaDuration(fake);
+		fake.dispatchEvent(new Event('error'));
+		expect(await pending).toBeNull();
+	});
+
+	it('gives up when the scan never reports', async () => {
+		const fake = new FakeMedia();
+		expect(await mediaDuration(fake, 5)).toBeNull();
+	});
+});
+
+describe('audioFormatOf', () => {
+	it('takes the extension from the name', () => {
+		expect(audioFormatOf('FastMCP_4.M4A')).toBe('m4a');
+		expect(audioFormatOf('song.final.flac')).toBe('flac');
+	});
+
+	it('falls back to the mime type when the name has no extension', () => {
+		expect(audioFormatOf('', 'audio/webm;codecs=opus')).toBe('webm');
+		expect(audioFormatOf('recording', 'audio/mp4')).toBe('m4a');
+		expect(audioFormatOf('recording')).toBe('');
+	});
+});
+
+describe('canRenderWaveform', () => {
+	it('allows a short file and refuses anything past either cap', () => {
+		expect(canRenderWaveform(50 * 1024 * 1024, 200)).toBe(true);
+		expect(canRenderWaveform(WAVEFORM_MAX_BYTES + 1, 200)).toBe(false);
+		expect(canRenderWaveform(1024, WAVEFORM_MAX_SECONDS + 1)).toBe(false);
+		expect(canRenderWaveform(1024, 200, 100)).toBe(false);
+		expect(canRenderWaveform(1024, null)).toBe(false);
+	});
+});
+
+describe('formatting', () => {
+	it('formats clock times', () => {
+		expect(formatClock(0)).toBe('0:00');
+		expect(formatClock(75.9)).toBe('1:15');
+		expect(formatClock(3600 + 65)).toBe('1:01:05');
+		expect(formatClock(Number.POSITIVE_INFINITY)).toBe('0:00');
+	});
+
+	it('formats sizes with fewer decimals as they grow', () => {
+		expect(formatMegabytes(3.14159 * 1024 * 1024)).toBe('3.1 MB');
+		expect(formatMegabytes(200.4 * 1024 * 1024)).toBe('200 MB');
+	});
+});

--- a/frontend/src/lib/audio/probe.test.ts
+++ b/frontend/src/lib/audio/probe.test.ts
@@ -3,7 +3,7 @@ import {
 	audioFormatOf,
 	canRenderWaveform,
 	formatClock,
-	formatMegabytes,
+	formatFileSize,
 	isUsableDuration,
 	mediaDuration,
 	type MediaDurationSource,
@@ -93,7 +93,9 @@ describe('formatting', () => {
 	});
 
 	it('formats sizes with fewer decimals as they grow', () => {
-		expect(formatMegabytes(3.14159 * 1024 * 1024)).toBe('3.1 MB');
-		expect(formatMegabytes(200.4 * 1024 * 1024)).toBe('200 MB');
+		expect(formatFileSize(3.14159 * 1024 * 1024)).toBe('3.1 MB');
+		expect(formatFileSize(200.4 * 1024 * 1024)).toBe('200 MB');
+		expect(formatFileSize(8 * 1024)).toBe('8 KB');
+		expect(formatFileSize(10)).toBe('1 KB');
 	});
 });

--- a/frontend/src/lib/audio/probe.ts
+++ b/frontend/src/lib/audio/probe.ts
@@ -102,7 +102,8 @@ export function formatClock(seconds: number): string {
 	return `${h}:${m.toString().padStart(2, '0')}:${ss}`;
 }
 
-export function formatMegabytes(bytes: number): string {
+export function formatFileSize(bytes: number): string {
 	const mb = bytes / 1024 / 1024;
+	if (mb < 1) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
 	return `${mb >= 100 ? mb.toFixed(0) : mb.toFixed(1)} MB`;
 }

--- a/frontend/src/lib/audio/probe.ts
+++ b/frontend/src/lib/audio/probe.ts
@@ -1,0 +1,108 @@
+/**
+ * what the browser can learn about an audio file before a byte is sent:
+ * its format from the name, its duration from the container header, and
+ * whether a waveform can be decoded within a memory budget.
+ */
+
+import { extensionForMime } from '$lib/recorder.svelte';
+
+/** how long to wait for a header-less container to be scanned for its length. */
+export const DURATION_SCAN_TIMEOUT_MS = 15_000;
+
+/**
+ * the waveform's decoded PCM is kept at this rate, but the browser still
+ * decodes at the file's own rate first: measured in chromium at roughly
+ * 100 MB of transient memory per minute of audio (2026-09-01, an 85 MB
+ * hour-long m4a took the process to +5.5 GB). the caps keep that transient
+ * near a gigabyte on desktop and a few hundred megabytes on touch devices.
+ */
+export const WAVEFORM_DECODE_RATE = 8000;
+export const WAVEFORM_MAX_SECONDS = 10 * 60;
+export const WAVEFORM_MAX_SECONDS_TOUCH = 3 * 60;
+export const WAVEFORM_MAX_BYTES = 100 * 1024 * 1024;
+
+export function waveformMaxSeconds(): number {
+	const touch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+	return touch ? WAVEFORM_MAX_SECONDS_TOUCH : WAVEFORM_MAX_SECONDS;
+}
+
+export function isUsableDuration(d: number): boolean {
+	return Number.isFinite(d) && d > 0;
+}
+
+/** bare lowercase extension from a filename, or from the mime type when the name has none. */
+export function audioFormatOf(name: string, mime = ''): string {
+	const dot = name.lastIndexOf('.');
+	if (dot !== -1 && dot < name.length - 1) return name.slice(dot + 1).toLowerCase();
+	return mime === '' ? '' : extensionForMime(mime);
+}
+
+/** the slice of HTMLMediaElement that `mediaDuration` drives. */
+export interface MediaDurationSource {
+	duration: number;
+	currentTime: number;
+	addEventListener(type: 'durationchange' | 'error', listener: () => void): void;
+	removeEventListener(type: 'durationchange' | 'error', listener: () => void): void;
+}
+
+/**
+ * the element's duration once the browser knows it.
+ *
+ * MediaRecorder output (webm/ogg) carries no duration in its header, so the
+ * element reports Infinity, 0, or NaN until it has scanned to the end. seeking
+ * past any plausible time makes it scan and emit `durationchange` with the
+ * real value; the position is then put back to the start.
+ */
+export function mediaDuration(
+	el: MediaDurationSource,
+	timeoutMs = DURATION_SCAN_TIMEOUT_MS
+): Promise<number | null> {
+	if (isUsableDuration(el.duration)) return Promise.resolve(el.duration);
+	return new Promise((resolve) => {
+		const cleanup = () => {
+			clearTimeout(timer);
+			el.removeEventListener('durationchange', onChange);
+			el.removeEventListener('error', onError);
+		};
+		const done = (value: number | null) => {
+			cleanup();
+			resolve(value);
+		};
+		const onChange = () => {
+			if (!isUsableDuration(el.duration)) return;
+			el.currentTime = 0;
+			done(el.duration);
+		};
+		const onError = () => done(null);
+		const timer = setTimeout(() => done(null), timeoutMs);
+		el.addEventListener('durationchange', onChange);
+		el.addEventListener('error', onError);
+		el.currentTime = 1e101;
+	});
+}
+
+/** whether decoding a waveform for this file stays inside the memory budget. */
+export function canRenderWaveform(
+	sizeBytes: number,
+	durationSeconds: number | null,
+	maxSeconds = WAVEFORM_MAX_SECONDS
+): boolean {
+	if (sizeBytes > WAVEFORM_MAX_BYTES) return false;
+	return durationSeconds !== null && durationSeconds <= maxSeconds;
+}
+
+/** `m:ss`, or `h:mm:ss` from an hour up. */
+export function formatClock(seconds: number): string {
+	const whole = isUsableDuration(seconds) ? Math.floor(seconds) : 0;
+	const h = Math.floor(whole / 3600);
+	const m = Math.floor((whole % 3600) / 60);
+	const s = whole % 60;
+	const ss = s.toString().padStart(2, '0');
+	if (h === 0) return `${m}:${ss}`;
+	return `${h}:${m.toString().padStart(2, '0')}:${ss}`;
+}
+
+export function formatMegabytes(bytes: number): string {
+	const mb = bytes / 1024 / 1024;
+	return `${mb >= 100 ? mb.toFixed(0) : mb.toFixed(1)} MB`;
+}

--- a/frontend/src/lib/components/AudioPreview.stories.svelte
+++ b/frontend/src/lib/components/AudioPreview.stories.svelte
@@ -1,0 +1,92 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import AudioPreview from './AudioPreview.svelte';
+	import { StagedTransfer, type StagedTransport } from '$lib/staged-transfer.svelte';
+	import { UploadPartError, type UploadSessionState } from '$lib/upload-session';
+	import { __testing } from '$lib/audio/wav';
+
+	// a real, playable file: half a second of 440 Hz, encoded on the spot so the
+	// stories carry no binary fixture.
+	function tone(): File {
+		const sampleRate = 8000;
+		const frames = sampleRate / 2;
+		const samples = Float32Array.from(
+			{ length: frames },
+			(_, i) => Math.sin((2 * Math.PI * 440 * i) / sampleRate) * (1 - i / frames)
+		);
+		const buffer: AudioBuffer = {
+			numberOfChannels: 1,
+			length: frames,
+			sampleRate,
+			duration: frames / sampleRate,
+			getChannelData: () => samples,
+			copyFromChannel: (destination, _ch, start = 0) =>
+				destination.set(samples.subarray(start, start + destination.length)),
+			copyToChannel: (source, _ch, start = 0) => samples.set(source, start)
+		};
+		return new File([__testing.encodeWav(buffer)], 'tone.wav', { type: 'audio/wav' });
+	}
+
+	const session: UploadSessionState = {
+		upload_id: 'story',
+		part_size_bytes: 1024,
+		part_count: 4,
+		received_parts: []
+	};
+
+	// transports that park the transfer in one state so each story is stable.
+	function stuckAt(loaded: number): StagedTransport {
+		return {
+			start: async () => session,
+			resume: async () => session,
+			parts: ({ onProgress }) => {
+				onProgress(loaded, 4096);
+				return new Promise(() => {});
+			}
+		};
+	}
+	const done: StagedTransport = {
+		start: async () => session,
+		resume: async () => session,
+		parts: async ({ onProgress }) => onProgress(4096, 4096)
+	};
+	const broken: StagedTransport = {
+		start: async () => session,
+		resume: async () => session,
+		parts: async ({ onProgress }) => {
+			onProgress(1536, 4096);
+			throw new UploadPartError(2, { kind: 'network' });
+		}
+	};
+	const describe = () => 'upload failed (failed at 37%): connection was interrupted';
+
+	const { Story } = defineMeta({
+		title: 'upload/AudioPreview',
+		component: AudioPreview,
+		parameters: { layout: 'padded' }
+	});
+</script>
+
+<Story name="Chosen file, no transfer">
+	<AudioPreview source={tone()} />
+</Story>
+
+<Story name="Transferring">
+	<AudioPreview source={tone()} transfer={new StagedTransfer(tone(), stuckAt(2560), describe)} />
+</Story>
+
+<Story name="Received">
+	<AudioPreview source={tone()} transfer={new StagedTransfer(tone(), done, describe)} />
+</Story>
+
+<Story name="Failed with retry">
+	<AudioPreview source={tone()} transfer={new StagedTransfer(tone(), broken, describe)} />
+</Story>
+
+<Story name="Recording with a fallback length">
+	<AudioPreview
+		source={new Blob([tone()], { type: 'audio/webm' })}
+		name="voice memo"
+		fallbackDurationSeconds={1}
+	/>
+</Story>

--- a/frontend/src/lib/components/AudioPreview.stories.svelte
+++ b/frontend/src/lib/components/AudioPreview.stories.svelte
@@ -5,11 +5,11 @@
 	import { UploadPartError, type UploadSessionState } from '$lib/upload-session';
 	import { __testing } from '$lib/audio/wav';
 
-	// a real, playable file: half a second of 440 Hz, encoded on the spot so the
+	// a real, playable file: two seconds of 440 Hz, encoded on the spot so the
 	// stories carry no binary fixture.
 	function tone(): File {
 		const sampleRate = 8000;
-		const frames = sampleRate / 2;
+		const frames = sampleRate * 2;
 		const samples = Float32Array.from(
 			{ length: frames },
 			(_, i) => Math.sin((2 * Math.PI * 440 * i) / sampleRate) * (1 - i / frames)
@@ -62,7 +62,6 @@
 
 	const { Story } = defineMeta({
 		title: 'upload/AudioPreview',
-		component: AudioPreview,
 		parameters: { layout: 'padded' }
 	});
 </script>
@@ -87,6 +86,6 @@
 	<AudioPreview
 		source={new Blob([tone()], { type: 'audio/webm' })}
 		name="voice memo"
-		fallbackDurationSeconds={1}
+		fallbackDurationSeconds={2}
 	/>
 </Story>

--- a/frontend/src/lib/components/AudioPreview.svelte
+++ b/frontend/src/lib/components/AudioPreview.svelte
@@ -1,0 +1,318 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import Waveform from './Waveform.svelte';
+	import {
+		audioFormatOf,
+		canRenderWaveform,
+		formatClock,
+		formatMegabytes,
+		mediaDuration,
+		waveformMaxSeconds,
+		WAVEFORM_DECODE_RATE
+	} from '$lib/audio/probe';
+	import type { StagedTransfer } from '$lib/staged-transfer.svelte';
+
+	interface Props {
+		/** the audio to look at and play — a chosen file or a fresh recording. */
+		source: Blob;
+		/** shown as the title; a File's own name when omitted. */
+		name?: string;
+		/** a length known before the browser has scanned the container (a recording's tick count). */
+		fallbackDurationSeconds?: number;
+		/** the file's journey into staging, when it started ahead of the form. */
+		transfer?: StagedTransfer | null;
+		height?: number;
+	}
+
+	let {
+		source,
+		name = source instanceof File ? source.name : '',
+		fallbackDurationSeconds = 0,
+		transfer = null,
+		height = 72
+	}: Props = $props();
+
+	let audioEl = $state<HTMLAudioElement | null>(null);
+	let currentTime = $state(0);
+	let scannedDuration = $state<number | null>(null);
+	let scanned = $state(false);
+	let playable = $state(true);
+	let isPlaying = $state(false);
+	let objectUrl = $state<string | null>(null);
+
+	const format = $derived(audioFormatOf(name, source.type));
+	const durationSeconds = $derived(
+		scannedDuration ?? (fallbackDurationSeconds > 0 ? fallbackDurationSeconds : null)
+	);
+	const waveform = $derived(
+		scanned && canRenderWaveform(source.size, durationSeconds, waveformMaxSeconds())
+	);
+	const progress = $derived(
+		durationSeconds !== null && durationSeconds > 0 ? currentTime / durationSeconds : 0
+	);
+	const facts = $derived(
+		[
+			format,
+			formatMegabytes(source.size),
+			durationSeconds === null ? null : formatClock(durationSeconds)
+		]
+			.filter((fact) => fact !== null && fact !== '')
+			.join(' · ')
+	);
+
+	$effect(() => {
+		const url = URL.createObjectURL(source);
+		objectUrl = url;
+		scannedDuration = null;
+		scanned = false;
+		playable = true;
+		isPlaying = false;
+		currentTime = 0;
+		return () => URL.revokeObjectURL(url);
+	});
+
+	onDestroy(() => {
+		if (objectUrl) URL.revokeObjectURL(objectUrl);
+	});
+
+	async function handleLoadedMetadata() {
+		if (!audioEl) return;
+		scannedDuration = await mediaDuration(audioEl);
+		scanned = true;
+	}
+
+	function handleError() {
+		playable = false;
+		scanned = true;
+	}
+
+	function togglePlay() {
+		if (!audioEl) return;
+		if (isPlaying) audioEl.pause();
+		else audioEl.play().catch((e) => console.error('playback failed:', e));
+	}
+
+	function seek(ratio: number) {
+		if (audioEl && durationSeconds !== null) audioEl.currentTime = ratio * durationSeconds;
+	}
+</script>
+
+<div class="preview">
+	<div class="heading">
+		{#if name}<span class="name">{name}</span>{/if}
+		<span class="facts">{facts}</span>
+	</div>
+
+	{#if waveform}
+		<div class="wf-wrap">
+			<Waveform
+				{source}
+				decodeSampleRate={WAVEFORM_DECODE_RATE}
+				{progress}
+				onSeek={playable ? seek : undefined}
+				{height}
+			/>
+		</div>
+	{:else if scanned && playable}
+		<p class="note">no waveform for a file this long</p>
+	{/if}
+
+	{#if objectUrl}
+		<audio
+			bind:this={audioEl}
+			bind:currentTime
+			src={objectUrl}
+			preload="metadata"
+			onloadedmetadata={handleLoadedMetadata}
+			onerror={handleError}
+			onplay={() => (isPlaying = true)}
+			onpause={() => (isPlaying = false)}
+			onended={() => (isPlaying = false)}
+		></audio>
+	{/if}
+
+	{#if playable}
+		<div class="playback-row">
+			<button
+				type="button"
+				class="play-btn"
+				onclick={togglePlay}
+				aria-label={isPlaying ? 'pause' : 'play'}
+			>
+				{#if isPlaying}
+					<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+						<rect x="6" y="5" width="4" height="14" rx="1" />
+						<rect x="14" y="5" width="4" height="14" rx="1" />
+					</svg>
+				{:else}
+					<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+						<path d="M8 5v14l11-7z" />
+					</svg>
+				{/if}
+			</button>
+			<span class="time-display" aria-live="off">
+				{formatClock(currentTime)} / {durationSeconds === null
+					? '–:––'
+					: formatClock(durationSeconds)}
+			</span>
+		</div>
+	{:else}
+		<p class="note">this browser can't play {format || 'this file'} — it will still upload</p>
+	{/if}
+
+	{#if transfer}
+		<div class="transfer" class:failed={transfer.status === 'failed'}>
+			<progress max={transfer.total} value={transfer.loaded} aria-label="file transfer"></progress>
+			<div class="transfer-row">
+				{#if transfer.status === 'transferred'}
+					<span class="transfer-text">file received — publish when you're ready</span>
+				{:else if transfer.status === 'failed'}
+					<span class="transfer-text">{transfer.error ?? "your file didn't finish sending"}</span>
+					<button type="button" class="retry" onclick={() => transfer.retry()}>retry</button>
+				{:else if transfer.status === 'transferring'}
+					<span class="transfer-text">receiving your file… {transfer.progressPercent}%</span>
+				{:else}
+					<span class="transfer-text">getting ready…</span>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.preview {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		padding: 1rem;
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-lg);
+		background: var(--bg-secondary);
+	}
+
+	.heading {
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+		min-width: 0;
+	}
+
+	.name {
+		font-size: var(--text-sm);
+		color: var(--text-primary);
+		overflow-wrap: anywhere;
+	}
+
+	.facts {
+		font-size: var(--text-xs);
+		color: var(--text-muted);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.wf-wrap {
+		padding: 0.25rem 0;
+	}
+
+	.note {
+		margin: 0;
+		font-size: var(--text-xs);
+		color: var(--text-muted);
+	}
+
+	.playback-row {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.play-btn {
+		width: 40px;
+		height: 40px;
+		border-radius: var(--radius-full);
+		background: var(--accent);
+		color: var(--accent-contrast, var(--text-primary));
+		border: none;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		cursor: pointer;
+		flex-shrink: 0;
+		box-shadow: 0 4px 12px color-mix(in srgb, var(--accent) 28%, transparent);
+	}
+
+	.play-btn:hover {
+		background: var(--accent-hover);
+	}
+
+	.time-display {
+		font-size: var(--text-sm);
+		color: var(--text-muted);
+		font-variant-numeric: tabular-nums;
+		letter-spacing: 0.02em;
+	}
+
+	.transfer {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+	}
+
+	progress {
+		width: 100%;
+		height: 4px;
+		appearance: none;
+		border: none;
+		border-radius: var(--radius-full);
+		overflow: hidden;
+		background: var(--bg-tertiary);
+	}
+
+	progress::-webkit-progress-bar {
+		background: var(--bg-tertiary);
+	}
+
+	progress::-webkit-progress-value {
+		background: var(--accent);
+		transition: width 200ms ease;
+	}
+
+	progress::-moz-progress-bar {
+		background: var(--accent);
+	}
+
+	.failed progress::-webkit-progress-value,
+	.failed progress::-moz-progress-bar {
+		background: var(--error);
+	}
+
+	.transfer-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	.transfer-text {
+		font-size: var(--text-xs);
+		color: var(--text-muted);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.failed .transfer-text {
+		color: var(--error);
+	}
+
+	.retry {
+		font-size: var(--text-xs);
+		padding: 0.25rem 0.625rem;
+		border-radius: var(--radius-full);
+		border: 1px solid var(--border-default);
+		background: transparent;
+		color: var(--text-primary);
+		cursor: pointer;
+	}
+
+	.retry:hover {
+		background: var(--bg-hover);
+	}
+</style>

--- a/frontend/src/lib/components/AudioPreview.svelte
+++ b/frontend/src/lib/components/AudioPreview.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { onDestroy } from 'svelte';
 	import Waveform from './Waveform.svelte';
 	import {
 		audioFormatOf,
@@ -69,10 +68,6 @@
 		isPlaying = false;
 		currentTime = 0;
 		return () => URL.revokeObjectURL(url);
-	});
-
-	onDestroy(() => {
-		if (objectUrl) URL.revokeObjectURL(objectUrl);
 	});
 
 	async function handleLoadedMetadata() {
@@ -165,7 +160,7 @@
 			<progress max={transfer.total} value={transfer.loaded} aria-label="file transfer"></progress>
 			<div class="transfer-row">
 				{#if transfer.status === 'transferred'}
-					<span class="transfer-text">file received — publish when you're ready</span>
+					<span class="transfer-text">file received — upload when you're ready</span>
 				{:else if transfer.status === 'failed'}
 					<span class="transfer-text">{transfer.error ?? "your file didn't finish sending"}</span>
 					<button type="button" class="retry" onclick={() => transfer.retry()}>retry</button>

--- a/frontend/src/lib/components/AudioPreview.svelte
+++ b/frontend/src/lib/components/AudioPreview.svelte
@@ -5,7 +5,7 @@
 		audioFormatOf,
 		canRenderWaveform,
 		formatClock,
-		formatMegabytes,
+		formatFileSize,
 		mediaDuration,
 		waveformMaxSeconds,
 		WAVEFORM_DECODE_RATE
@@ -53,7 +53,7 @@
 	const facts = $derived(
 		[
 			format,
-			formatMegabytes(source.size),
+			formatFileSize(source.size),
 			durationSeconds === null ? null : formatClock(durationSeconds)
 		]
 			.filter((fact) => fact !== null && fact !== '')
@@ -205,18 +205,19 @@
 
 	.facts {
 		font-size: var(--text-xs);
-		color: var(--text-muted);
+		color: var(--text-secondary);
 		font-variant-numeric: tabular-nums;
 	}
 
 	.wf-wrap {
 		padding: 0.25rem 0;
+		--wf-base: color-mix(in srgb, var(--text-muted) 55%, transparent);
 	}
 
 	.note {
 		margin: 0;
 		font-size: var(--text-xs);
-		color: var(--text-muted);
+		color: var(--text-secondary);
 	}
 
 	.playback-row {
@@ -246,7 +247,7 @@
 
 	.time-display {
 		font-size: var(--text-sm);
-		color: var(--text-muted);
+		color: var(--text-secondary);
 		font-variant-numeric: tabular-nums;
 		letter-spacing: 0.02em;
 	}
@@ -280,7 +281,10 @@
 		background: var(--accent);
 	}
 
-	.failed progress::-webkit-progress-value,
+	.failed progress::-webkit-progress-value {
+		background: var(--error);
+	}
+
 	.failed progress::-moz-progress-bar {
 		background: var(--error);
 	}
@@ -294,7 +298,7 @@
 
 	.transfer-text {
 		font-size: var(--text-xs);
-		color: var(--text-muted);
+		color: var(--text-secondary);
 		font-variant-numeric: tabular-nums;
 	}
 

--- a/frontend/src/lib/components/Waveform.svelte
+++ b/frontend/src/lib/components/Waveform.svelte
@@ -8,6 +8,8 @@
 		source?: Blob | string | null;
 		/** number of bars to render when decoding from source. ignored if peaks is provided. */
 		barCount?: number;
+		/** decode `source` at this sample rate; see `extractPeaks`. */
+		decodeSampleRate?: number;
 		/** visual height of the waveform in pixels. */
 		height?: number;
 		/** playback progress 0..1, drives the playhead overlay. */
@@ -22,6 +24,7 @@
 		peaks: peaksProp,
 		source = null,
 		barCount = 120,
+		decodeSampleRate,
 		height = 64,
 		progress = 0,
 		onSeek,
@@ -64,13 +67,13 @@
 			try {
 				let result: number[];
 				if (source instanceof Blob) {
-					result = await extractPeaks(source, barCount);
+					result = await extractPeaks(source, barCount, { decodeSampleRate });
 				} else {
 					const res = await fetch(source);
 					if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
 					const buf = await res.arrayBuffer();
 					if (aborted) return;
-					result = await extractPeaks(buf, barCount);
+					result = await extractPeaks(buf, barCount, { decodeSampleRate });
 				}
 				if (aborted) return;
 				decodedPeaks = result;

--- a/frontend/src/lib/staged-transfer.svelte.ts
+++ b/frontend/src/lib/staged-transfer.svelte.ts
@@ -81,7 +81,8 @@ export class StagedTransfer {
 		this.#abort.abort();
 	}
 
-	async #run(): Promise<string> {
+	/** the attempt promise itself, with a handler attached so a failure nobody awaits yet is not "unhandled". */
+	#run(): Promise<string> {
 		const attempt = this.#drive();
 		attempt.catch(() => undefined);
 		return attempt;

--- a/frontend/src/lib/staged-transfer.svelte.ts
+++ b/frontend/src/lib/staged-transfer.svelte.ts
@@ -1,0 +1,118 @@
+/**
+ * a file moving into a resumable upload session ahead of the form.
+ *
+ * the bytes start travelling the moment a file is chosen and land in plyr's
+ * staging storage; nothing is published, and nothing reaches the PDS, until
+ * `finish` is called with the form. a dropped transfer resumes from the parts
+ * the server already holds, and a re-selected or abandoned file is simply
+ * aborted — the server reaps the open session on its own schedule.
+ */
+
+import {
+	getUploadSession,
+	startUploadSession,
+	uploadParts,
+	type UploadPartsOptions,
+	type UploadSessionState
+} from './upload-session';
+
+export interface StagedTransport {
+	start: (file: File) => Promise<UploadSessionState>;
+	resume: (uploadId: string) => Promise<UploadSessionState>;
+	parts: (options: UploadPartsOptions) => Promise<void>;
+}
+
+export const sessionTransport: StagedTransport = {
+	start: startUploadSession,
+	resume: getUploadSession,
+	parts: uploadParts
+};
+
+export type TransferStatus = 'opening' | 'transferring' | 'transferred' | 'failed';
+
+/** copy for a failed attempt; null when the failure was handled by a redirect. */
+export type FailureDescriber = (failure: Error, progressPercent: number) => string | null;
+
+export class StagedTransfer {
+	readonly file: File;
+	status = $state<TransferStatus>('opening');
+	loaded = $state(0);
+	total = $state(0);
+	error = $state<string | null>(null);
+	/** set once `upload()` owns the transfer; leaving the page no longer aborts it. */
+	claimed = false;
+	onProgress: ((loaded: number, total: number) => void) | null = null;
+
+	#uploadId: string | null = null;
+	#abort = new AbortController();
+	#attempt: Promise<string>;
+	readonly #transport: StagedTransport;
+	readonly #describe: FailureDescriber;
+
+	constructor(file: File, transport: StagedTransport, describe: FailureDescriber) {
+		this.file = file;
+		this.total = file.size;
+		this.#transport = transport;
+		this.#describe = describe;
+		this.#attempt = this.#run();
+	}
+
+	get uploadId(): string | null {
+		return this.#uploadId;
+	}
+
+	get progressPercent(): number {
+		return this.total === 0 ? 0 : Math.round((this.loaded / this.total) * 100);
+	}
+
+	/** resolves with the upload id once every part is acknowledged; rejects with the attempt's failure. */
+	whenTransferred(): Promise<string> {
+		return this.#attempt;
+	}
+
+	retry(): void {
+		if (this.status !== 'failed') return;
+		this.#abort = new AbortController();
+		this.error = null;
+		this.#attempt = this.#run();
+	}
+
+	abort(): void {
+		this.#abort.abort();
+	}
+
+	async #run(): Promise<string> {
+		const attempt = this.#drive();
+		attempt.catch(() => undefined);
+		return attempt;
+	}
+
+	async #drive(): Promise<string> {
+		this.status = 'opening';
+		try {
+			const session =
+				this.#uploadId === null
+					? await this.#transport.start(this.file)
+					: await this.#transport.resume(this.#uploadId);
+			this.#uploadId = session.upload_id;
+			this.status = 'transferring';
+			await this.#transport.parts({
+				file: this.file,
+				session,
+				signal: this.#abort.signal,
+				onProgress: (loaded, total) => {
+					this.loaded = loaded;
+					this.total = total;
+					this.onProgress?.(loaded, total);
+				}
+			});
+			this.status = 'transferred';
+			return session.upload_id;
+		} catch (error) {
+			const failure = error instanceof Error ? error : new Error(String(error));
+			this.status = 'failed';
+			this.error = this.#describe(failure, this.progressPercent);
+			throw failure;
+		}
+	}
+}

--- a/frontend/src/lib/staged-transfer.test.ts
+++ b/frontend/src/lib/staged-transfer.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { StagedTransfer, type StagedTransport } from './staged-transfer.svelte';
+import { UploadPartError, type UploadSessionState } from './upload-session';
+
+const file = new File([new Uint8Array(10)], 'song.wav');
+
+const state = (received: number[] = []): UploadSessionState => ({
+	upload_id: 'u1',
+	part_size_bytes: 4,
+	part_count: 3,
+	received_parts: received
+});
+
+const describe_ = (failure: Error, percent: number) => `${failure.message} at ${percent}%`;
+
+describe('StagedTransfer', () => {
+	it('opens a session, sends the parts and settles with the upload id', async () => {
+		const seen: string[] = [];
+		const transport: StagedTransport = {
+			start: async () => {
+				seen.push('start');
+				return state();
+			},
+			resume: async () => {
+				seen.push('resume');
+				return state();
+			},
+			parts: async ({ onProgress }) => {
+				seen.push('parts');
+				onProgress(4, 10);
+				onProgress(10, 10);
+			}
+		};
+		const staged = new StagedTransfer(file, transport, describe_);
+		expect(staged.status).toBe('opening');
+
+		expect(await staged.whenTransferred()).toBe('u1');
+		expect(staged.status).toBe('transferred');
+		expect(staged.loaded).toBe(10);
+		expect(staged.progressPercent).toBe(100);
+		expect(seen).toEqual(['start', 'parts']);
+	});
+
+	it('records a described failure and resumes from the parts the server holds on retry', async () => {
+		let attempt = 0;
+		const sessions: UploadSessionState[] = [];
+		const transport: StagedTransport = {
+			start: async () => state(),
+			resume: async (uploadId) => {
+				expect(uploadId).toBe('u1');
+				return state([1, 2]);
+			},
+			parts: async ({ session, onProgress }) => {
+				sessions.push(session);
+				attempt++;
+				if (attempt === 1) {
+					onProgress(4, 10);
+					throw new UploadPartError(2, { kind: 'network' });
+				}
+				onProgress(10, 10);
+			}
+		};
+		const staged = new StagedTransfer(file, transport, describe_);
+
+		await expect(staged.whenTransferred()).rejects.toBeInstanceOf(UploadPartError);
+		expect(staged.status).toBe('failed');
+		expect(staged.error).toBe('part 2 failed: network at 40%');
+
+		staged.retry();
+		expect(staged.status).toBe('opening');
+		expect(await staged.whenTransferred()).toBe('u1');
+		expect(staged.error).toBeNull();
+		expect(sessions.map((s) => s.received_parts)).toEqual([[], [1, 2]]);
+	});
+
+	it('retry is a no-op while a transfer is still moving', async () => {
+		let starts = 0;
+		const transport: StagedTransport = {
+			start: async () => {
+				starts++;
+				return state();
+			},
+			resume: async () => state(),
+			parts: async () => {}
+		};
+		const staged = new StagedTransfer(file, transport, describe_);
+		staged.retry();
+		await staged.whenTransferred();
+		expect(starts).toBe(1);
+	});
+
+	it('abort reaches the part sender through the signal', async () => {
+		let aborted = false;
+		const transport: StagedTransport = {
+			start: async () => state(),
+			resume: async () => state(),
+			parts: ({ signal }) =>
+				new Promise((_, reject) => {
+					signal?.addEventListener('abort', () => {
+						aborted = true;
+						reject(new UploadPartError(1, { kind: 'network' }));
+					});
+				})
+		};
+		const staged = new StagedTransfer(file, transport, describe_);
+		while (staged.status !== 'transferring') await Promise.resolve();
+		staged.abort();
+		await expect(staged.whenTransferred()).rejects.toBeInstanceOf(UploadPartError);
+		expect(aborted).toBe(true);
+		expect(staged.status).toBe('failed');
+	});
+});

--- a/frontend/src/lib/upload-session.test.ts
+++ b/frontend/src/lib/upload-session.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+	getUploadSession,
 	PartAttemptError,
 	planParts,
 	uploadParts,
 	UploadPartError,
+	UploadSessionHttpError,
 	type PartSender,
 	type UploadSessionState
 } from './upload-session';
@@ -104,5 +106,38 @@ describe('uploadParts', () => {
 			})
 		).rejects.toMatchObject({ failure: { kind: 'network' }, partNumber: 1 });
 		expect(calls).toBe(2);
+	});
+});
+
+describe('getUploadSession', () => {
+	const withFetch = async (response: Response, run: () => Promise<void>) => {
+		const original = globalThis.fetch;
+		const calls: string[] = [];
+		globalThis.fetch = async (input) => {
+			calls.push(String(input));
+			return response;
+		};
+		try {
+			await run();
+		} finally {
+			globalThis.fetch = original;
+		}
+		return calls;
+	};
+
+	it('parses the parts the server already holds', async () => {
+		const calls = await withFetch(Response.json(session({ received_parts: [1, 3] })), async () => {
+			const resumed = await getUploadSession('u1');
+			expect(resumed.received_parts).toEqual([1, 3]);
+		});
+		expect(calls[0]).toMatch(/\/tracks\/uploads\/u1$/);
+	});
+
+	it('surfaces the server detail on an error', async () => {
+		await withFetch(Response.json({ detail: 'upload not found' }, { status: 404 }), async () => {
+			await expect(getUploadSession('gone')).rejects.toMatchObject(
+				new UploadSessionHttpError(404, 'upload not found')
+			);
+		});
 	});
 });

--- a/frontend/src/lib/upload-session.ts
+++ b/frontend/src/lib/upload-session.ts
@@ -134,6 +134,15 @@ export async function startUploadSession(file: File): Promise<UploadSessionState
 	return parseSessionState(await response.json());
 }
 
+/** which parts the server already holds, so a dropped transfer resumes instead of restarting. */
+export async function getUploadSession(uploadId: string): Promise<UploadSessionState> {
+	const response = await fetch(`${API_URL}/tracks/uploads/${uploadId}`, { credentials: 'include' });
+	if (!response.ok) {
+		throw new UploadSessionHttpError(response.status, await errorDetail(response));
+	}
+	return parseSessionState(await response.json());
+}
+
 export async function finishUploadSession(uploadId: string, form: FormData): Promise<string> {
 	const response = await fetch(`${API_URL}/tracks/uploads/${uploadId}/finish`, {
 		method: 'POST',

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -7,13 +7,8 @@ import { tracksCache } from './tracks.svelte';
 import type { FeaturedArtist } from './types';
 import type { TrackRights } from './components/CopyrightRightsPanel.svelte';
 import { setReturnUrl } from './utils/return-url';
-import {
-	finishUploadSession,
-	startUploadSession,
-	uploadParts,
-	UploadPartError,
-	UploadSessionHttpError
-} from './upload-session';
+import { finishUploadSession, UploadPartError, UploadSessionHttpError } from './upload-session';
+import { sessionTransport, StagedTransfer, type StagedTransport } from './staged-transfer.svelte';
 
 interface UploadTask {
 	id: string;
@@ -26,7 +21,7 @@ interface UploadTask {
 	toastId: string;
 	eventSource?: EventSource;
 	xhr?: XMLHttpRequest;
-	abort?: AbortController;
+	abort?: { abort(): void };
 }
 
 interface UploadProgressCallback {
@@ -182,8 +177,24 @@ function describeUploadFailure(
 class UploaderState {
 	activeUploads = $state<Map<string, UploadTask>>(new Map());
 
+	/**
+	 * start moving a chosen file into staging before the form is submitted.
+	 * `upload()` takes the result to finish; an unclaimed transfer is the
+	 * caller's to abort when the file is re-chosen or the page is left.
+	 */
+	stage(file: File, transport: StagedTransport = sessionTransport): StagedTransfer {
+		const fileSizeMB = file.size / 1024 / 1024;
+		const isMobile = isMobileDevice();
+		if (isMobile && fileSizeMB > MOBILE_LARGE_FILE_THRESHOLD_MB) {
+			toast.info(`uploading ${Math.round(fileSizeMB)}MB file on mobile - ensure stable connection`, 5000);
+		}
+		return new StagedTransfer(file, transport, (failure, percent) =>
+			describeUploadFailure(failure, percent, fileSizeMB, isMobile)
+		);
+	}
+
 	upload(
-		file: File,
+		source: File | StagedTransfer,
 		title: string,
 		album: string,
 		features: FeaturedArtist[],
@@ -199,15 +210,14 @@ class UploaderState {
 		copyright?: TrackRights | null,
 		selfLabels: string[] = []
 	): void {
+		if (!browser) return;
+		const staged = source instanceof StagedTransfer ? source : this.stage(source);
+		staged.claimed = true;
+		const file = staged.file;
 		const taskId = crypto.randomUUID();
 		const fileSizeMB = file.size / 1024 / 1024;
 		const isMobile = isMobileDevice();
 		const displayName = label ?? title;
-
-		// warn about large files on mobile
-		if (isMobile && fileSizeMB > MOBILE_LARGE_FILE_THRESHOLD_MB) {
-			toast.info(`uploading ${Math.round(fileSizeMB)}MB file on mobile - ensure stable connection`, 5000);
-		}
 
 		const uploadMessage = fileSizeMB > 10
 			? `uploading "${displayName}"... (large file)`
@@ -215,10 +225,6 @@ class UploaderState {
 		// 0 means infinite/persist until dismissed
 		const toastId = toast.info(uploadMessage, 0);
 
-		// track upload progress for error messages
-		let lastProgressPercent = 0;
-
-		if (!browser) return;
 		const formData = new FormData();
 		formData.append('title', title);
 		if (albumId) {
@@ -252,17 +258,16 @@ class UploaderState {
 			formData.append('self_labels', JSON.stringify(selfLabels));
 		}
 
-		const abort = new AbortController();
 		const task: UploadTask = {
 			id: taskId,
-			upload_id: '',
+			upload_id: staged.uploadId ?? '',
 			file,
 			title,
 			album,
 			features,
 			tags,
 			toastId,
-			abort
+			abort: staged
 		};
 		this.activeUploads.set(taskId, task);
 
@@ -273,29 +278,25 @@ class UploaderState {
 			callbacks?.onError?.(message);
 		};
 
+		const showTransfer = (loaded: number, total: number) => {
+			toast.update(toastId, `retrieving your file... ${Math.round((loaded / total) * 100)}%`);
+			callbacks?.onProgress?.(loaded, total);
+		};
+		staged.onProgress = showTransfer;
+		if (staged.status === 'transferring') showTransfer(staged.loaded, staged.total);
+
 		void (async () => {
 			try {
-				const session = await startUploadSession(file);
-				task.upload_id = session.upload_id;
-				await uploadParts({
-					file,
-					session,
-					signal: abort.signal,
-					onProgress: (loaded, total) => {
-						const percent = Math.round((loaded / total) * 100);
-						lastProgressPercent = percent;
-						toast.update(toastId, `retrieving your file... ${percent}%`);
-						callbacks?.onProgress?.(loaded, total);
-					}
-				});
+				const sessionId = await staged.whenTransferred();
+				task.upload_id = sessionId;
 				toast.update(toastId, 'finishing up…');
-				const upload_id = await finishUploadSession(session.upload_id, formData);
+				const upload_id = await finishUploadSession(sessionId, formData);
 				task.upload_id = upload_id;
 				callbacks?.onSuccess?.(upload_id);
 				this.followProcessing(task, displayName, onSuccess);
 			} catch (error) {
 				const failure: UploadFailure = error instanceof Error ? error : new Error(String(error));
-				const message = describeUploadFailure(failure, lastProgressPercent, fileSizeMB, isMobile);
+				const message = describeUploadFailure(failure, staged.progressPercent, fileSizeMB, isMobile);
 				if (message === null) {
 					toast.dismiss(toastId);
 					this.activeUploads.delete(taskId);

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -128,11 +128,18 @@ function buildTimeoutErrorMessage(progressPercent: number, fileSizeMB: number, i
 	return `upload timed out${progressInfo}: try again with a better connection`;
 }
 
+type UploadFailure = UploadSessionHttpError | UploadPartError | Error;
+
+/** a transfer the server refused for want of a session; submit's preflight owns the sign-in bounce. */
+function sessionExpired(error: UploadFailure): boolean {
+	if (error instanceof UploadSessionHttpError) return error.status === 401;
+	return error instanceof UploadPartError && error.failure.kind === 'http' && error.failure.status === 401;
+}
+
 /**
  * map a session-upload failure to toast copy. returns null when the failure
  * was handled by a redirect (scope upgrade, sign-in) and no toast is due.
  */
-type UploadFailure = UploadSessionHttpError | UploadPartError | Error;
 
 function describeUploadFailure(
 	error: UploadFailure,
@@ -189,7 +196,9 @@ class UploaderState {
 			toast.info(`uploading ${Math.round(fileSizeMB)}MB file on mobile - ensure stable connection`, 5000);
 		}
 		return new StagedTransfer(file, transport, (failure, percent) =>
-			describeUploadFailure(failure, percent, fileSizeMB, isMobile)
+			sessionExpired(failure)
+				? 'your session expired — sign in to finish your upload'
+				: describeUploadFailure(failure, percent, fileSizeMB, isMobile)
 		);
 	}
 

--- a/frontend/src/routes/record/+page.svelte
+++ b/frontend/src/routes/record/+page.svelte
@@ -4,7 +4,7 @@
 	import { goto } from '$app/navigation';
 	import Header from '$lib/components/Header.svelte';
 	import TagInput from '$lib/components/TagInput.svelte';
-	import Waveform from '$lib/components/Waveform.svelte';
+	import AudioPreview from '$lib/components/AudioPreview.svelte';
 	import VisibilityPicker, { type Visibility } from '$lib/components/VisibilityPicker.svelte';
 	import { auth } from '$lib/auth.svelte';
 	import { toast } from '$lib/toast.svelte';
@@ -20,6 +20,7 @@
 	import { Recorder, RecorderError, extensionForMime } from '$lib/recorder.svelte';
 	import { isWebPlayableExtension } from '$lib/utils/web-playable';
 	import { toWav } from '$lib/audio/wav';
+	import { formatClock } from '$lib/audio/probe';
 	import logo from '$lib/assets/logo.png';
 
 	type RecordState = 'idle' | 'recording' | 'preview' | 'converting' | 'uploading';
@@ -31,17 +32,9 @@
 	let title = $state('');
 	let tags = $state<string[]>([]);
 	let visibility = $state<Visibility>('public');
-	let previewUrl = $state<string | null>(null);
 	let previewBlob = $state<Blob | null>(null);
-	let audioEl = $state<HTMLAudioElement | null>(null);
-	let currentTime = $state(0);
-	let duration = $state(0);
-	let isPlaying = $state(false);
-	// captured at recording stop-time from the live-tick counter. gives us a
-	// correct (1s-resolution) display duration immediately, before the browser
-	// has finished scanning the blob for its real length. we prefer the audio
-	// element's duration once it becomes a positive finite number, but fall
-	// back to this so the UI never shows "0:00" for a valid recording.
+	// the live tick count at stop time: a length the preview can show before the
+	// browser has scanned the recording for its real one
 	let capturedDuration = $state(0);
 
 	const reducedMotion =
@@ -54,16 +47,6 @@
 		auth.user?.permissioned_spaces?.granted ?? false
 	);
 
-
-	const effectiveDuration = $derived(
-		Number.isFinite(duration) && duration > 0 ? duration : capturedDuration
-	);
-	const playbackProgress = $derived(
-		effectiveDuration > 0 ? currentTime / effectiveDuration : 0
-	);
-	const timeDisplay = $derived(
-		`${formatTime(currentTime)} / ${formatTime(effectiveDuration)}`
-	);
 	const recorder = new Recorder({
 		maxSeconds: MAX_SECONDS,
 		warnAtSeconds: WARN_SECONDS,
@@ -73,60 +56,9 @@
 	});
 
 	const remainingDisplay = $derived(
-		formatTime(Math.max(0, MAX_SECONDS - recorder.elapsedSeconds))
+		formatClock(Math.max(0, MAX_SECONDS - recorder.elapsedSeconds))
 	);
-
-	function handleSeek(ratio: number) {
-		if (audioEl && effectiveDuration > 0) {
-			audioEl.currentTime = ratio * effectiveDuration;
-		}
-	}
-
-	function togglePlay() {
-		if (!audioEl) return;
-		if (isPlaying) audioEl.pause();
-		else audioEl.play().catch((e) => console.error('playback failed:', e));
-	}
-
-	function isUsableDuration(d: number): boolean {
-		return Number.isFinite(d) && d > 0;
-	}
-
-	// MediaRecorder-produced webm/ogg blobs have no duration written into the
-	// container header — the recorder streams output without knowing the final
-	// length. different browsers surface this as Infinity (Firefox), 0 (some
-	// Chrome versions), or NaN until the file is scanned to EOF. the
-	// MDN-documented fix is to seek to a huge time value; the browser clamps
-	// to real EOF, scans the file, and emits a `durationchange` with the real
-	// duration, at which point we reset currentTime to 0.
-	function handleLoadedMetadata() {
-		if (!audioEl) return;
-		if (isUsableDuration(audioEl.duration)) return;
-
-		const el = audioEl;
-		const onDurationChange = () => {
-			if (isUsableDuration(el.duration)) {
-				el.currentTime = 0;
-				el.removeEventListener('durationchange', onDurationChange);
-			}
-		};
-		el.addEventListener('durationchange', onDurationChange);
-		// jump past any plausible duration — the browser clamps to real EOF
-		el.currentTime = 1e101;
-	}
-
-	const elapsedDisplay = $derived(formatTime(recorder.elapsedSeconds));
-
-	function formatTime(seconds: number): string {
-		if (!Number.isFinite(seconds) || seconds < 0) seconds = 0;
-		const mm = Math.floor(seconds / 60)
-			.toString()
-			.padStart(2, '0');
-		const ss = Math.floor(seconds % 60)
-			.toString()
-			.padStart(2, '0');
-		return `${mm}:${ss}`;
-	}
+	const elapsedDisplay = $derived(formatClock(recorder.elapsedSeconds));
 
 	async function startRecording() {
 		try {
@@ -139,10 +71,6 @@
 
 	function finalizeRecording(blob: Blob, elapsedSeconds: number) {
 		previewBlob = blob;
-		if (previewUrl) URL.revokeObjectURL(previewUrl);
-		previewUrl = URL.createObjectURL(blob);
-		// capture the elapsed tick count as a fallback duration — shown until
-		// the audio element reports a real positive finite duration
 		capturedDuration = elapsedSeconds;
 		const now = new Date();
 		const pad = (n: number) => String(n).padStart(2, '0');
@@ -152,17 +80,10 @@
 	}
 
 	function reRecord() {
-		if (previewUrl) {
-			URL.revokeObjectURL(previewUrl);
-			previewUrl = null;
-		}
 		previewBlob = null;
 		title = '';
 		tags = [];
-		currentTime = 0;
-		duration = 0;
 		capturedDuration = 0;
-		isPlaying = false;
 		void clearStashedRecording();
 		uiState = 'idle';
 	}
@@ -287,8 +208,6 @@
 		const stashed = await takeStashedRecording();
 		if (!stashed) return;
 		previewBlob = stashed.blob;
-		if (previewUrl) URL.revokeObjectURL(previewUrl);
-		previewUrl = URL.createObjectURL(stashed.blob);
 		title = stashed.title;
 		tags = stashed.tags;
 		capturedDuration = stashed.capturedDuration;
@@ -309,7 +228,6 @@
 
 	onDestroy(() => {
 		recorder.dispose();
-		if (previewUrl) URL.revokeObjectURL(previewUrl);
 	});
 </script>
 
@@ -382,47 +300,12 @@
 	{:else if uiState === 'preview'}
 		<div class="preview-card">
 			{#if previewBlob}
-				<div class="wf-wrap">
-					<Waveform
-						source={previewBlob}
-						progress={playbackProgress}
-						onSeek={handleSeek}
-						height={96}
-					/>
-				</div>
-			{/if}
-			{#if previewUrl}
-				<!-- hidden native element — custom controls below drive it -->
-				<audio
-					bind:this={audioEl}
-					bind:currentTime
-					bind:duration
-					src={previewUrl}
-					onloadedmetadata={handleLoadedMetadata}
-					onplay={() => (isPlaying = true)}
-					onpause={() => (isPlaying = false)}
-					onended={() => (isPlaying = false)}
-				></audio>
-				<div class="playback-row">
-					<button
-						type="button"
-						class="play-btn"
-						onclick={togglePlay}
-						aria-label={isPlaying ? 'pause' : 'play'}
-					>
-						{#if isPlaying}
-							<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-								<rect x="6" y="5" width="4" height="14" rx="1" />
-								<rect x="14" y="5" width="4" height="14" rx="1" />
-							</svg>
-						{:else}
-							<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-								<path d="M8 5v14l11-7z" />
-							</svg>
-						{/if}
-					</button>
-					<span class="time-display" aria-live="off">{timeDisplay}</span>
-				</div>
+				<AudioPreview
+					source={previewBlob}
+					name={title}
+					fallbackDurationSeconds={capturedDuration}
+					height={96}
+				/>
 			{/if}
 
 			<div class="form-group">
@@ -622,7 +505,6 @@
 		color: var(--text-muted);
 	}
 
-
 	.preview-card {
 		background: color-mix(in srgb, var(--track-bg, var(--bg-primary)) 70%, transparent);
 		backdrop-filter: blur(14px);
@@ -634,51 +516,6 @@
 		flex-direction: column;
 		gap: clamp(1rem, 2.5vh, 1.25rem);
 		box-shadow: 0 8px 32px color-mix(in srgb, #000 30%, transparent);
-	}
-
-	.wf-wrap {
-		padding: 0.5rem 0;
-	}
-
-	.playback-row {
-		display: flex;
-		align-items: center;
-		gap: 0.875rem;
-		margin-top: -0.25rem;
-	}
-
-	.play-btn {
-		width: 44px;
-		height: 44px;
-		border-radius: 50%;
-		background: var(--accent);
-		color: var(--text-primary);
-		border: none;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		cursor: pointer;
-		flex-shrink: 0;
-		box-shadow: 0 4px 12px color-mix(in srgb, var(--accent) 28%, transparent);
-		transition:
-			transform 0.15s ease,
-			box-shadow 0.2s ease;
-	}
-
-	.play-btn:hover {
-		transform: translateY(-1px);
-		box-shadow: 0 6px 16px color-mix(in srgb, var(--accent) 38%, transparent);
-	}
-
-	.play-btn:active {
-		transform: scale(0.94);
-	}
-
-	.time-display {
-		font-size: var(--text-sm);
-		color: var(--text-muted);
-		font-variant-numeric: tabular-nums;
-		letter-spacing: 0.02em;
 	}
 
 	.form-group {
@@ -785,7 +622,6 @@
 
 	@media (prefers-reduced-motion: reduce) {
 		.record-btn,
-		.play-btn,
 		.primary-btn,
 		.secondary-btn,
 		.mic-aura::before,

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -614,9 +614,7 @@
 				<span
 					>{visibility === "private" && !permissionedGranted
 						? "approve private media"
-						: staged && staged.status !== "transferred"
-							? "publish when received"
-							: "upload track"}</span
+						: "upload track"}</span
 				>
 			</button>
 

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from "svelte";
+	import { onDestroy, onMount } from "svelte";
 	import { browser } from "$app/environment";
 	import Header from "$lib/components/Header.svelte";
 	import HandleSearch from "$lib/components/HandleSearch.svelte";
@@ -8,6 +8,7 @@
 	import PdsTooltip from "$lib/components/PdsTooltip.svelte";
 	import InfoTooltip from "$lib/components/InfoTooltip.svelte";
 	import WaveLoading from "$lib/components/WaveLoading.svelte";
+	import AudioPreview from "$lib/components/AudioPreview.svelte";
 	import TagInput from "$lib/components/TagInput.svelte";
 	import CopyrightRightsPanel from "$lib/components/CopyrightRightsPanel.svelte";
 	import VisibilityPicker from "$lib/components/VisibilityPicker.svelte";
@@ -28,6 +29,7 @@
 	} from "$lib/upload-form-stash";
 	import { stashUploadFiles, takeUploadFiles } from "$lib/record-stash";
 	import { startPermissionedScopeUpgrade } from "$lib/uploader.svelte";
+	import type { StagedTransfer } from "$lib/staged-transfer.svelte";
 
 	const AUDIO_EXTENSIONS = [".mp3", ".wav", ".m4a", ".aiff", ".aif", ".flac"];
 	const AUDIO_MIME_TYPES = [
@@ -67,6 +69,8 @@
 	let title = $state("");
 	let albumTitle = $state("");
 	let file = $state<File | null>(null);
+	// the chosen file's transfer into staging; starts on selection, finished by submit
+	let staged = $state<StagedTransfer | null>(null);
 	let imageFile = $state<File | null>(null);
 	let featuredArtists = $state<FeaturedArtist[]>([]);
 	let uploadTags = $state<string[]>([]);
@@ -131,7 +135,7 @@
 			clearTrackFormStash();
 			const files = await takeUploadFiles();
 			if (files) {
-				file = files.file;
+				chooseFile(files.file);
 				imageFile = files.imageFile;
 			}
 			if (visibility === "private" && !permissionedGranted) {
@@ -150,6 +154,16 @@
 		await Promise.all([loadMyAlbums(), loadArtistProfile()]);
 		loading = false;
 	});
+
+	onDestroy(() => {
+		if (staged && !staged.claimed) staged.abort();
+	});
+
+	function chooseFile(selected: File | null) {
+		if (staged && !staged.claimed) staged.abort();
+		file = selected;
+		staged = selected ? uploader.stage(selected) : null;
+	}
 
 	async function loadArtistProfile() {
 		if (!auth.user) return;
@@ -203,7 +217,7 @@
 	}
 
 	async function submitUpload() {
-		if (!file) return;
+		if (!file || !staged) return;
 
 		// private media has no transcode step (audio is stored as-is as a PDS
 		// blob), so reject non-web-playable formats here instead of uploading the
@@ -241,6 +255,7 @@
 		}
 
 		const uploadFile = file;
+		const uploadTransfer = staged;
 		const uploadTitle = title;
 		const uploadAlbum = albumTitle;
 		const uploadFeatures = [...featuredArtists];
@@ -256,6 +271,7 @@
 			albumTitle = "";
 			description = "";
 			file = null;
+			staged = null;
 			imageFile = null;
 			featuredArtists = [];
 			uploadTags = [];
@@ -294,7 +310,7 @@
 		}
 
 		uploader.upload(
-			uploadFile,
+			uploadTransfer,
 			uploadTitle,
 			uploadAlbum,
 			uploadFeatures,
@@ -331,7 +347,7 @@
 					`unsupported file type. supported: ${AUDIO_EXTENSIONS.join(", ")}`,
 				);
 				target.value = "";
-				file = null;
+				chooseFile(null);
 				return;
 			}
 
@@ -343,14 +359,14 @@
 						`audio file too large (${sizeMB.toFixed(1)}MB). max: ${config.max_upload_size_mb}MB`,
 					);
 					target.value = "";
-					file = null;
+					chooseFile(null);
 					return;
 				}
 			} catch (_e) {
 				console.error("failed to validate file size:", _e);
 			}
 
-			file = selected;
+			chooseFile(selected);
 		}
 	}
 
@@ -448,9 +464,9 @@
 					supported: {AUDIO_EXTENSIONS.map(e => e.slice(1)).join(", ")}
 				</p>
 				{#if file}
-					<p class="file-info">
-						{file.name} ({(file.size / 1024 / 1024).toFixed(2)} MB)
-					</p>
+					<div class="file-preview">
+						<AudioPreview source={file} transfer={staged} />
+					</div>
 				{/if}
 			</div>
 
@@ -598,7 +614,9 @@
 				<span
 					>{visibility === "private" && !permissionedGranted
 						? "approve private media"
-						: "upload track"}</span
+						: staged && staged.status !== "transferred"
+							? "publish when received"
+							: "upload track"}</span
 				>
 			</button>
 
@@ -781,6 +799,10 @@
 		margin-top: 0.5rem;
 		font-size: var(--text-sm);
 		color: var(--text-muted);
+	}
+
+	.file-preview {
+		margin-top: 0.75rem;
 	}
 
 	button {

--- a/loq.toml
+++ b/loq.toml
@@ -335,7 +335,7 @@ max_lines = 1424
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"
-max_lines = 534
+max_lines = 541
 
 [[rules]]
 path = "frontend/src/routes/track/[[]id[]]/+page.svelte"

--- a/loq.toml
+++ b/loq.toml
@@ -175,7 +175,7 @@ max_lines = 1299
 
 [[rules]]
 path = "frontend/src/routes/upload/+page.svelte"
-max_lines = 930
+max_lines = 952
 
 [[rules]]
 path = "services/moderation/src/admin.rs"


### PR DESCRIPTION
choosing an audio file on `/upload` now shows what the browser knows about it (format, size, duration, a waveform under a measured decode budget, and playback) and starts moving its bytes into the resumable upload session right away. submit still owns publishing: `finish` runs only when the form is sent, so nothing is published and nothing reaches the PDS before that. `/record` renders its recording preview through the same component and duration mechanism instead of its own copy.

<details>
<summary>what changed</summary>

- `lib/staged-transfer.svelte.ts` (new): `StagedTransfer`, the file's journey into staging — opens the session, sends parts, exposes `status`/`loaded`/`total`/`error` as `$state`, `whenTransferred()` for the submit path, `retry()` that resumes from the parts the server already holds (`GET /tracks/uploads/{id}`, new client call `getUploadSession`), and `abort()`. transport is injected (`StagedTransport`) so tests and stories drive it without mocking modules.
- `lib/uploader.svelte.ts`: `stage(file)` starts a transfer; `upload()` now takes `File | StagedTransfer`. a `File` is staged on the spot, so `/record` and the album form are unchanged in behavior. the toast keeps showing transfer progress once `upload()` claims a transfer that is still moving.
- `lib/audio/probe.ts` (new): `mediaDuration()` (the seek-past-the-end scan for header-less MediaRecorder output, previously inline in `/record`), `audioFormatOf`, `canRenderWaveform` + caps, `formatClock`, `formatFileSize`.
- `lib/audio/peaks.ts` + `Waveform.svelte`: optional `decodeSampleRate` decodes through an `OfflineAudioContext` so the retained PCM is mono 8 kHz instead of stereo at the file's rate.
- `lib/components/AudioPreview.svelte` (new) + stories: name, facts line, waveform, play/pause with seek, and the transfer bar with retry. `/upload` mounts it under the file input; `/record` replaces its inline waveform + `<audio>` + playback row with it.
- `routes/upload/+page.svelte`: `chooseFile()` aborts the previous transfer and stages the new one; a restored draft re-stages; `submitUpload()` hands the transfer to `upload()`; the submit button stays enabled while parts are still in flight; submit waits for the transfer and the toast shows its progress. leaving the page aborts an unclaimed transfer.
</details>

<details>
<summary>the waveform cap, measured</summary>

decoding is the expensive part, and the low-rate trick only shrinks what is kept afterwards. measured 2026-09-01 with playwright against a local static server, RSS delta of the whole browser process tree during `decodeAudioData`:

| file | chromium, full rate | chromium, offline 8 kHz | webkit (playwright build) |
|---|---|---|---|
| 60 min m4a, 85 MB | +6.9 GB, 2.0 s | +5.5 GB, 3.1 s | `EncodingError` (no AAC) |
| 4 min m4a, 5.8 MB | +552 MB, 0.15 s | +396 MB, 0.2 s | `EncodingError` (no AAC) |

roughly 100 MB of transient memory per minute of audio in chromium. caps: 10 minutes on desktop, 3 minutes on touch devices, 100 MB either way; above that the card says "no waveform for a file this long" and everything else still shows. header-only duration reads cost under 80 ms for the 85 MB file in both engines. playwright's webkit cannot decode AAC at all, so real Safari is unmeasured; the touch cap is a guess on the conservative side.
</details>

<details>
<summary>intentional non-behaviors</summary>

- no abort endpoint. a re-selected or abandoned file leaves its session for the existing 24 h reaper, same as a closed tab today; an endpoint would change nothing the user can see.
- no album-form changes beyond keeping it working on the `File` path.
- no server-side peaks. if the client cap proves too low for typical files, the transcoder computing peaks is the next step, not a bigger client budget.
- the recording timer on `/record` now reads `0:12` instead of `00:12`, since both pages share one clock formatter.
- the mobile large-file warning fires at selection time now, since that is when bytes start moving.
</details>

<details>
<summary>verification</summary>

- `bun run check` 0 errors, `bun run lint` (eslint + oxlint) clean, `bun run test` 190 passed, `bun run test-storybook` (axe) 39 passed after moving the card's secondary text off `--text-muted` (3.2:1 on the card background).
- self-review fixes: a 401 during a background transfer now shows the inline message with retry instead of bouncing to sign-in without a stashed draft (submit's preflight owns that); the realtime AudioContext is closed by reference rather than `instanceof AudioContext`, which throws where only `webkitAudioContext` exists.
- storybook matrix: 5 states × 390/1280 px × dark/light, screenshots reviewed; measured `.preview` box, waveform height 72 px, progress bar 4 px, radius `--radius-lg`. one bug found and fixed from the screenshots: the failed state's bar stayed accent-colored because a combined `::-webkit-progress-value, ::-moz-progress-bar` selector is dropped whole by chromium.
- the real pages need a signed-in session, so `/upload` and `/record` are verified on staging: the "private upload end to end" workflow selects a file and clicks submit immediately, which is exactly the wait-for-transfer path.
- regression tests: `staged-transfer.test.ts` (success, described failure + resume with `received_parts`, retry no-op while moving, abort through the signal), `probe.test.ts` (the seek-to-scan mechanism against a fake media source, format fallback, caps, formatting), `upload-session.test.ts` (`getUploadSession` parse + error detail).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z