### PR TITLE
release: fast-forward production-fe with a direct push instead of a local checkout

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -117,13 +117,10 @@ def main() -> int:
     print(f"\n✓ release {version} created")
     print("✓ production backend deployment starting...")
 
-    # merge main -> production-fe to trigger frontend deployment
+    # fast-forward production-fe to main to trigger frontend deployment.
+    # a plain push refuses a non-fast-forward, so no local branch is needed.
     print("\n🔄 updating production-fe branch...")
-    subprocess.run(["git", "fetch", "origin"], check=True)
-    subprocess.run(["git", "checkout", "production-fe"], check=True)
-    subprocess.run(["git", "merge", "main", "--ff-only"], check=True)
-    subprocess.run(["git", "push", "origin", "production-fe"], check=True)
-    subprocess.run(["git", "checkout", "main"], check=True)
+    subprocess.run(["git", "push", "origin", "main:production-fe"], check=True)
 
     print("✓ production frontend deployment starting...")
 


### PR DESCRIPTION
`just release` exited at `git checkout production-fe` on both promotes today: with no local `production-fe` and the branch on both the github and tangled remotes, git refuses the ambiguous checkout, after the GitHub release exists and the backend deploy has started. the frontend step is now one `git push origin main:production-fe`, which refuses a non-fast-forward exactly as the old `merge --ff-only` did, and needs no local branch or checkout dance.

`origin` pushes to both github and tangled (a second pushurl), so the branch lands on both, and the trailing `git push tangled main --tags` is unchanged.

no deploy: the script runs on the operator's machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z