### PR TITLE
player: ±15s skip buttons and lock-screen skips behind the skip-buttons flag

### DIFF
--- a/backend/src/backend/_internal/feature_flags.py
+++ b/backend/src/backend/_internal/feature_flags.py
@@ -14,6 +14,7 @@ KNOWN_FLAGS = frozenset(
     {
         "vibe-search",  # enable semantic vibe search in Cmd+K
         "copyright-paradigm",  # enable the indiemusi.ch copyright paradigm UI + endpoints
+        "skip-buttons",  # ±15s skip buttons in the player + media-session seek handlers
     }
 )
 

--- a/frontend/src/lib/components/player/PlaybackControls.svelte
+++ b/frontend/src/lib/components/player/PlaybackControls.svelte
@@ -3,9 +3,13 @@
 	import { browser } from '$app/environment';
 	import { player } from '$lib/player.svelte';
 	import { queue } from '$lib/queue.svelte';
+	import { auth } from '$lib/auth.svelte';
+	import { SKIP_BUTTONS_FLAG, SKIP_STEP_SECONDS } from '$lib/config';
 
 	// radio mode: live stream — no prev/next or scrubbing, just play/pause + volume
 	let { radioMode = false }: { radioMode?: boolean } = $props();
+
+	const skipButtons = $derived(auth.user?.enabled_flags?.includes(SKIP_BUTTONS_FLAG) ?? false);
 
 	let seekValue = $state(0);
 	let isScrubbing = $state(false);
@@ -124,10 +128,25 @@
 			</svg>
 		</button>
 	{:else}
-		<button class="control-btn" onclick={handlePrevious} title="previous track / restart">
+		<button class="control-btn prev" onclick={handlePrevious} title="previous track / restart">
 			<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
 				<path d="M6 4h2v16H6V4zm12 0l-10 8 10 8V4z" />
 			</svg>
+		</button>
+	{/if}
+
+	{#if skipButtons && !radioMode}
+		<button
+			class="control-btn skip skip-back"
+			onclick={() => queue.seekBy(-SKIP_STEP_SECONDS)}
+			title="back {SKIP_STEP_SECONDS} seconds"
+			aria-label="back {SKIP_STEP_SECONDS} seconds"
+		>
+			<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+				<path d="M3 12a9 9 0 1 0 3-6.7" />
+				<path d="M3 4v5h5" />
+			</svg>
+			<span class="skip-step">{SKIP_STEP_SECONDS}</span>
 		</button>
 	{/if}
 
@@ -148,9 +167,24 @@
 		{/if}
 	</button>
 
+	{#if skipButtons && !radioMode}
+		<button
+			class="control-btn skip skip-forward"
+			onclick={() => queue.seekBy(SKIP_STEP_SECONDS)}
+			title="forward {SKIP_STEP_SECONDS} seconds"
+			aria-label="forward {SKIP_STEP_SECONDS} seconds"
+		>
+			<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+				<path d="M21 12a9 9 0 1 1-3-6.7" />
+				<path d="M21 4v5h-5" />
+			</svg>
+			<span class="skip-step">{SKIP_STEP_SECONDS}</span>
+		</button>
+	{/if}
+
 	{#if !radioMode}
 		<button
-			class="control-btn"
+			class="control-btn next"
 			class:disabled={!queue.hasNext}
 			onclick={() => queue.next()}
 			title="next track"
@@ -293,6 +327,29 @@
 
 	.control-btn.play-pause:active {
 		transform: scale(0.95);
+	}
+
+	/* skip: the icon carries its step count so the arc reads as "15 back", not "restart" */
+	.control-btn.skip {
+		position: relative;
+	}
+
+	.control-btn.skip svg {
+		width: 22px;
+		height: 22px;
+	}
+
+	.skip-step {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 8px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		pointer-events: none;
+		transform: translateY(1px);
 	}
 
 	.control-btn.disabled {
@@ -460,7 +517,8 @@
 			padding: 0.5rem;
 		}
 
-		.control-btn:nth-of-type(1) {
+		.control-btn.prev,
+		.control-btn.infinity {
 			grid-column: 4;
 		}
 
@@ -468,12 +526,31 @@
 			grid-column: 5;
 		}
 
-		.control-btn:nth-of-type(3) {
+		.control-btn.next {
 			grid-column: 6;
 		}
 
-		.control-btn:nth-of-type(4) {
+		.control-btn.repeat {
 			grid-column: 7;
+		}
+
+		/* skips sit on the scrubber row, under the thumb, not in the transport row */
+		.control-btn.skip {
+			grid-row: 2;
+			padding: 0.25rem;
+		}
+
+		.control-btn.skip-back {
+			grid-column: 1;
+		}
+
+		.control-btn.skip-forward {
+			grid-column: 8;
+		}
+
+		.control-btn.skip svg {
+			width: 24px;
+			height: 24px;
 		}
 
 		.control-btn svg {
@@ -493,13 +570,17 @@
 
 		.time-control {
 			grid-row: 2;
-			grid-column: 1 / 8;
+			grid-column: 1 / 9;
+		}
+
+		.player-controls:has(.skip) .time-control {
+			grid-column: 2 / 8;
 		}
 
 		/* radio: "live" takes the scrubber's row instead of the control row */
 		.live-pill {
 			grid-row: 2;
-			grid-column: 1 / 8;
+			grid-column: 1 / 9;
 			text-align: center;
 		}
 

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -20,6 +20,8 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import { loginHref } from '$lib/utils/auth-redirect';
+	import { SKIP_BUTTONS_FLAG, SKIP_STEP_SECONDS } from '$lib/config';
+	import { auth } from '$lib/auth.svelte';
 	import TrackInfo from './TrackInfo.svelte';
 	import PlaybackControls from './PlaybackControls.svelte';
 	import type { Track } from '$lib/types';
@@ -76,9 +78,8 @@
 			}
 		});
 
-		// deliberately NO seekbackward/seekforward: iOS replaces the ⏮/⏭ track
-		// buttons with 10s-skip buttons when those handlers exist, and seekto +
-		// the lock-screen scrubber already cover in-track seeking
+		// seekbackward/seekforward are registered reactively below, only under the
+		// skip-buttons flag: iOS shows them in place of ⏮/⏭ when they exist
 	}
 
 	// check if we're on the current track's detail page
@@ -233,6 +234,21 @@
 		navigator.mediaSession.setActionHandler(
 			'nexttrack',
 			!player.radio && queue.hasNext ? () => queue.next() : null
+		);
+	});
+
+	// lock-screen skips, only for the flag: registering them makes iOS show
+	// ±15s in place of the ⏮/⏭ arrows, which is the trade the flag exists to try
+	$effect(() => {
+		if (!('mediaSession' in navigator)) return;
+		const skips = !player.radio && (auth.user?.enabled_flags?.includes(SKIP_BUTTONS_FLAG) ?? false);
+		navigator.mediaSession.setActionHandler(
+			'seekbackward',
+			skips ? (details) => queue.seekBy(-(details.seekOffset ?? SKIP_STEP_SECONDS)) : null
+		);
+		navigator.mediaSession.setActionHandler(
+			'seekforward',
+			skips ? (details) => queue.seekBy(details.seekOffset ?? SKIP_STEP_SECONDS) : null
 		);
 	});
 
@@ -996,7 +1012,7 @@
 		}
 
 		.player-content {
-			grid-template-columns: 48px 1fr auto auto auto auto auto;
+			grid-template-columns: 48px 1fr auto auto auto auto auto auto;
 			grid-template-rows: auto auto;
 			gap: 0.5rem 0.75rem;
 		}

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -5,6 +5,9 @@ export const TYPEAHEAD_URL = 'https://typeahead.waow.tech';
 
 export const VIBE_SEARCH_FLAG = 'vibe-search';
 export const COPYRIGHT_PARADIGM_FLAG = 'copyright-paradigm';
+export const SKIP_BUTTONS_FLAG = 'skip-buttons';
+/** how far the in-player skip buttons and lock-screen skips move. */
+export const SKIP_STEP_SECONDS = 15;
 
 /**
  * generate atprotofans support URL for an artist.

--- a/frontend/src/lib/queue-context.test.ts
+++ b/frontend/src/lib/queue-context.test.ts
@@ -213,3 +213,43 @@ describe('shuffleInPlace (continuation ordering)', () => {
 		expect([...result].sort()).toEqual([1, 2, 3, 4]); // permutation, no loss
 	});
 });
+
+describe('queue.seekBy', () => {
+	const seeks: number[] = [];
+	beforeEach(() => {
+		seeks.length = 0;
+		player.audioElement = document.createElement('audio');
+		player.duration = 100;
+		player.currentTime = 50;
+		queue.setJamBridge({
+			pushQueueState() {},
+			play() {},
+			pause() {},
+			seek: (ms) => seeks.push(ms)
+		});
+	});
+	afterEach(() => {
+		queue.setJamBridge(null);
+		player.audioElement = undefined;
+		player.duration = 0;
+		player.currentTime = 0;
+	});
+
+	it('moves relative to the current position in milliseconds', () => {
+		queue.seekBy(15);
+		queue.seekBy(-15);
+		expect(seeks).toEqual([65000, 35000]);
+	});
+
+	it('clamps to the track bounds', () => {
+		queue.seekBy(60);
+		queue.seekBy(-80);
+		expect(seeks).toEqual([100000, 0]);
+	});
+
+	it('does nothing without a loaded duration', () => {
+		player.duration = 0;
+		queue.seekBy(15);
+		expect(seeks).toEqual([]);
+	});
+});

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -548,6 +548,13 @@ class Queue {
 		}
 	}
 
+	/** move by a signed number of seconds, clamped to the track; a no-op with nothing loaded. */
+	seekBy(seconds: number): void {
+		if (!player.audioElement || !player.duration) return;
+		const target = Math.max(0, Math.min(player.duration, player.currentTime + seconds));
+		this.seek(Math.round(target * 1000));
+	}
+
 	// ── track mutations (routed through bridge when jam active) ──
 
 	addTracks(tracks: Track[], playNow = false) {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -317,12 +317,12 @@
 
 			case 'ArrowLeft': // seek backward
 				event.preventDefault();
-				seekBy(-SEEK_AMOUNT);
+				queue.seekBy(-SEEK_AMOUNT);
 				break;
 
 			case 'ArrowRight': // seek forward
 				event.preventDefault();
-				seekBy(SEEK_AMOUNT);
+				queue.seekBy(SEEK_AMOUNT);
 				break;
 
 			case 'j': // previous track (youtube-style)
@@ -345,13 +345,6 @@
 				toggleMute();
 				break;
 		}
-	}
-
-	function seekBy(seconds: number) {
-		if (!player.audioElement || !player.duration) return;
-
-		const newTime = Math.max(0, Math.min(player.duration, player.currentTime + seconds));
-		queue.seek(newTime * 1000);
 	}
 
 	function handlePreviousTrack() {

--- a/loq.toml
+++ b/loq.toml
@@ -123,11 +123,11 @@ max_lines = 622
 
 [[rules]]
 path = "frontend/src/lib/components/player/Player.svelte"
-max_lines = 1009
+max_lines = 1020
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"
-max_lines = 992
+max_lines = 999
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"
@@ -347,7 +347,7 @@ max_lines = 668
 
 [[rules]]
 path = "frontend/src/lib/components/player/PlaybackControls.svelte"
-max_lines = 515
+max_lines = 596
 
 [[rules]]
 path = "backend/src/backend/_internal/clients/moderation.py"


### PR DESCRIPTION
skip back / skip forward (15 s) in the player, and the matching media-session `seekbackward`/`seekforward` handlers, for users with the new `skip-buttons` feature flag. a UX experiment for one person on staging, not a product decision: the lock-screen half replaces ⏮/⏭ with ±15 s on iOS, which is exactly the trade the flag exists to try by feel.

<details>
<summary>what changed</summary>

- `feature_flags.py`: `skip-buttons` added to `KNOWN_FLAGS`. `config.ts`: `SKIP_BUTTONS_FLAG`, `SKIP_STEP_SECONDS = 15`.
- `queue.svelte.ts`: `seekBy(seconds)` — the clamped relative seek that `+layout.svelte` carried privately for the arrow keys. the layout now calls it; the arrow-key step stays 10 s and is not flagged.
- `PlaybackControls.svelte`: under the flag (and not in radio mode), a back and a forward button whose icon carries "15". desktop: flanking play/pause. phone: on the scrubber row, one each side of the seek bar, where the thumb already is; the transport row keeps its four buttons. the phone grid's `nth-of-type` placement becomes class-based (`prev`/`next`/`repeat`/`infinity`) so inserting buttons cannot shift the others, and the footer grid gains an 8th `auto` column that is empty (zero width) without the flag.
- `Player.svelte`: a reactive effect registers `seekbackward`/`seekforward` (`details.seekOffset ?? 15`) when the flag is on and not in radio mode, and unregisters them otherwise. `seekto`, play/pause and the reactive prev/next registration are untouched.
</details>

<details>
<summary>the iOS caveat, up front</summary>

per the #1860–#1869 investigation, iOS shows skip buttons *instead of* the track arrows once `seekbackward`/`seekforward` exist, and lock-screen scrubbing on real iPhones has been dead under every handler recipe tried. skip handlers together with `seekto` is a combination that has not been on a physical phone yet. that is part of what this flag is for; nothing here changes behavior for anyone without the flag.
</details>

<details>
<summary>tests and checks</summary>

- `queue-context.test.ts`: `seekBy` moves in ms relative to the position, clamps to `[0, duration]`, and is a no-op with no duration (through the jam-bridge seam, no module mocks).
- `bun run check` 0 errors, eslint + oxlint clean, `bun run test` 193 passed, backend ruff/ty clean. loq relaxed for the three player files.
- visual: verified on staging after merge with the flag enabled for nate's DID; the flag is per-user, so the storybook matrix does not cover it.
</details>

<details>
<summary>not doing</summary>

- per-track configuration of the media-session control surface. nate raised it and parked it as "potentially sloppy".
- any prod flag row, any change to the embed players, any change to the arrow-key step.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z