### PR TITLE
player: center the phone skip buttons in their grid columns

### DIFF
--- a/frontend/src/lib/components/player/PlaybackControls.svelte
+++ b/frontend/src/lib/components/player/PlaybackControls.svelte
@@ -538,6 +538,7 @@
 		.control-btn.skip {
 			grid-row: 2;
 			padding: 0.25rem;
+			justify-self: center;
 		}
 
 		.control-btn.skip-back {

--- a/loq.toml
+++ b/loq.toml
@@ -347,7 +347,7 @@ max_lines = 668
 
 [[rules]]
 path = "frontend/src/lib/components/player/PlaybackControls.svelte"
-max_lines = 596
+max_lines = 597
 
 [[rules]]
 path = "backend/src/backend/_internal/clients/moderation.py"


### PR DESCRIPTION
follow-up to #1958 from the staging measurement: on phones the skip-back button sat in the 48 px artwork column and skip-forward in a narrower auto column, so the two read as different sizes. `justify-self: center` on both.

measured on staging as the flagged test account (390/1280 × dark/light): each skip moves playback by exactly 15 s both ways; unflagged (anonymous) layout is byte-for-byte where it was — no skip buttons, transport row unchanged, phone scrubber spans the full row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z