### PR TITLE
player: the skip buttons pass the app font down to their numerals

### DIFF
--- a/frontend/src/lib/components/player/PlaybackControls.svelte
+++ b/frontend/src/lib/components/player/PlaybackControls.svelte
@@ -333,7 +333,12 @@
 		transform: scale(0.95);
 	}
 
-	/* the step count lives inside the svg so it scales with the glyph */
+	/* the step count lives inside the svg so it scales with the glyph; the button
+	   must pass the app font down — a <button> otherwise carries the UA font */
+	.control-btn.skip {
+		font-family: inherit;
+	}
+
 	.control-btn.skip svg text {
 		fill: currentColor;
 	}


### PR DESCRIPTION
#1963 set `font-family: inherit` on the numerals, but SVG text inherits from its parent `<button>`, and a button carries the UA font unless styled — so the "15" never reached the global `--font-family`. the skip buttons now inherit the app font themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z