### PR TITLE
comments: the passing-comment bubble rises above its row before it docks at the player

### DIFF
--- a/frontend/src/lib/comment-emission.test.ts
+++ b/frontend/src/lib/comment-emission.test.ts
@@ -1,22 +1,42 @@
 import { describe, expect, it } from 'vitest';
-import { EMISSION_SPACE_PX, emissionPlacement } from './comment-emission';
+import {
+	EMISSION_SPACE_PX,
+	HEADER_CLEARANCE_PX,
+	emissionPlacement,
+	emissionShift
+} from './comment-emission';
 
 describe('emissionPlacement', () => {
 	it('hangs below the trigger when the bubble fits above the player', () => {
-		expect(emissionPlacement(300, 844, 110)).toBe('anchored');
-		expect(emissionPlacement(844 - 110 - EMISSION_SPACE_PX, 844, 110)).toBe('anchored');
+		expect(emissionPlacement(270, 300, 844, 110)).toBe('below');
+		expect(emissionPlacement(650, 844 - 110 - EMISSION_SPACE_PX, 844, 110)).toBe('below');
 	});
 
-	it('docks above the player when the trigger sits just above it', () => {
-		expect(emissionPlacement(844 - 110 - EMISSION_SPACE_PX + 1, 844, 110)).toBe('docked');
-		expect(emissionPlacement(700, 844, 110)).toBe('docked');
+	it('rises above the row when the band below the trigger is taken by the player', () => {
+		expect(emissionPlacement(670, 700, 844, 110)).toBe('above');
+		expect(emissionPlacement(HEADER_CLEARANCE_PX + EMISSION_SPACE_PX, 760, 844, 110)).toBe('above');
 	});
 
-	it('docks when the trigger has scrolled off the top', () => {
-		expect(emissionPlacement(-20, 844, 110)).toBe('docked');
+	it('docks only when neither band exists', () => {
+		expect(emissionPlacement(HEADER_CLEARANCE_PX + EMISSION_SPACE_PX - 1, 760, 844, 110)).toBe('docked');
+		expect(emissionPlacement(-40, -10, 844, 110)).toBe('docked');
 	});
 
-	it('treats no player as full-height room', () => {
-		expect(emissionPlacement(780, 844, 0)).toBe('anchored');
+	it('treats no player as full-height room below', () => {
+		expect(emissionPlacement(760, 780, 844, 0)).toBe('below');
+	});
+});
+
+describe('emissionShift', () => {
+	it('leaves a bubble that fits where it is', () => {
+		expect(emissionShift(195, 200, 390)).toBe(0);
+	});
+
+	it('pushes a bubble in from the right edge', () => {
+		expect(emissionShift(300, 280, 390)).toBe(390 - 16 - 440);
+	});
+
+	it('pushes a bubble in from the left edge', () => {
+		expect(emissionShift(80, 280, 390)).toBe(16 + 60);
 	});
 });

--- a/frontend/src/lib/comment-emission.ts
+++ b/frontend/src/lib/comment-emission.ts
@@ -1,22 +1,38 @@
 /**
- * where a passing-comment bubble can surface without being hidden.
+ * where a passing-comment bubble can surface without covering anything.
  *
- * it hangs below the comments trigger when the space between the trigger
- * and the fixed footer player can hold it; otherwise it docks just above
- * the player, the way the comments panel does, so it is never drawn
- * underneath it or off the bottom of the viewport.
+ * it hangs below the comments trigger when the band between the trigger
+ * and the fixed footer player can hold it; otherwise it rises above the
+ * trigger's row into the space there; only when neither band exists does
+ * it dock at the player's edge. the bubble is also kept inside the
+ * viewport horizontally, since its trigger may sit near an edge.
  */
 
-export type EmissionPlacement = 'anchored' | 'docked';
+export type EmissionPlacement = 'below' | 'above' | 'docked';
 
 /** bubble height plus its gap to the trigger, in px; generous so a two-line wrap still fits. */
 export const EMISSION_SPACE_PX = 56;
 
+/** the page header's height; a bubble rising under it would be covered. */
+export const HEADER_CLEARANCE_PX = 64;
+
 export function emissionPlacement(
+	anchorTop: number,
 	anchorBottom: number,
 	viewportHeight: number,
 	playerHeight: number
 ): EmissionPlacement {
 	if (anchorBottom < 0) return 'docked';
-	return anchorBottom + EMISSION_SPACE_PX <= viewportHeight - playerHeight ? 'anchored' : 'docked';
+	if (anchorBottom + EMISSION_SPACE_PX <= viewportHeight - playerHeight) return 'below';
+	if (anchorTop - EMISSION_SPACE_PX >= HEADER_CLEARANCE_PX) return 'above';
+	return 'docked';
+}
+
+/** how far to shift a bubble centered at `centerX` so it stays `margin` inside the viewport. */
+export function emissionShift(centerX: number, width: number, viewportWidth: number, margin = 16): number {
+	const left = centerX - width / 2;
+	const right = centerX + width / 2;
+	if (left < margin) return margin - left;
+	if (right > viewportWidth - margin) return viewportWidth - margin - right;
+	return 0;
 }

--- a/frontend/src/lib/components/TrackComments.svelte
+++ b/frontend/src/lib/components/TrackComments.svelte
@@ -9,7 +9,7 @@
 	import { toast } from '$lib/toast.svelte';
 	import type { Track } from '$lib/types';
 	import { fade, fly } from 'svelte/transition';
-	import { emissionPlacement } from '$lib/comment-emission';
+	import { emissionPlacement, emissionShift, type EmissionPlacement } from '$lib/comment-emission';
 	import RichText from '$lib/components/RichText.svelte';
 	import SensitiveImage from '$lib/components/SensitiveImage.svelte';
 	import { redirectToLogin } from '$lib/utils/auth-redirect';
@@ -50,10 +50,19 @@
 	// timestamp (the soundcloud move). plain let: previous position must not
 	// retrigger the effect.
 	let emission = $state<Comment | null>(null);
-	let emissionDocked = $state(false);
+	let emissionPlace = $state<EmissionPlacement>('below');
+	let emissionShiftPx = $state(0);
+	let emissionEl = $state<HTMLButtonElement | null>(null);
 	let emissionTimer: ReturnType<typeof setTimeout> | null = null;
 	let prevPlaybackMs = -1;
 	let triggerAnchor = $state<HTMLSpanElement | null>(null);
+
+	// once the bubble has a size, keep it inside the viewport horizontally
+	$effect(() => {
+		if (!emissionEl || emissionPlace === 'docked') return;
+		const rect = emissionEl.getBoundingClientRect();
+		emissionShiftPx = emissionShift(rect.left + rect.width / 2, rect.width, window.innerWidth);
+	});
 
 	function playerHeightPx(): number {
 		const raw = window.getComputedStyle(document.documentElement).getPropertyValue('--player-height');
@@ -63,9 +72,14 @@
 
 	function showEmission(comment: Comment) {
 		if (emissionTimer) clearTimeout(emissionTimer);
-		const anchorBottom = triggerAnchor?.getBoundingClientRect().bottom ?? 0;
-		emissionDocked =
-			emissionPlacement(anchorBottom, window.innerHeight, playerHeightPx()) === 'docked';
+		const anchor = triggerAnchor?.getBoundingClientRect();
+		emissionPlace = emissionPlacement(
+			anchor?.top ?? 0,
+			anchor?.bottom ?? 0,
+			window.innerHeight,
+			playerHeightPx()
+		);
+		emissionShiftPx = 0;
 		emission = comment;
 		emissionTimer = setTimeout(() => (emission = null), 4000);
 	}
@@ -284,16 +298,17 @@
 	<span class="comments-trigger-anchor" bind:this={triggerAnchor}>
 	{#if emission}
 		<button
-			class="comment-emission"
-			class:docked={emissionDocked}
-			transition:fly={{ y: emissionDocked ? 8 : -8, duration: reduceMotionComments ? 0 : 300 }}
+			class="comment-emission {emissionPlace}"
+			style:--shift="{emissionShiftPx}px"
+			bind:this={emissionEl}
+			transition:fly={{ y: emissionPlace === 'below' ? -8 : 8, duration: reduceMotionComments ? 0 : 300 }}
 			onclick={() => {
 				emission = null;
 				commentsOpen = true;
 			}}
 			aria-label={`comment at ${formatTimestamp(emission.timestamp_ms)} from @${emission.user_handle}: ${emission.text}`}
 		>
-			{#if !emissionDocked}<span class="comment-emission-tail" aria-hidden="true"></span>{/if}
+			{#if emissionPlace !== 'docked'}<span class="comment-emission-tail" aria-hidden="true"></span>{/if}
 			{#if emission.user_avatar_url}
 				<img src={emission.user_avatar_url} alt="" class="comment-emission-avatar" />
 			{/if}
@@ -467,7 +482,7 @@
 		position: absolute;
 		top: calc(100% + 0.4rem);
 		left: 50%;
-		translate: -50% 0;
+		translate: calc(-50% + var(--shift, 0px)) 0;
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
@@ -488,11 +503,12 @@
 		z-index: 40;
 	}
 
-	/* points at the trigger it came from; docked bubbles have no origin to point at */
+	/* points at the trigger it came from; docked bubbles have no origin to point at.
+	   the tail stays under the trigger even when the bubble has been shifted inward */
 	.comment-emission-tail {
 		position: absolute;
 		top: -5px;
-		left: 50%;
+		left: calc(50% - var(--shift, 0px));
 		width: 9px;
 		height: 9px;
 		translate: -50% 0;
@@ -502,8 +518,19 @@
 		border-top: 1px solid var(--glass-border, var(--border-default));
 	}
 
-	/* no room under the trigger: sit just above the footer player, where the
-	   comments panel docks, instead of being drawn underneath it */
+	/* the band below the trigger belongs to the player: rise into the space above the row */
+	.comment-emission.above {
+		top: auto;
+		bottom: calc(100% + 0.4rem);
+	}
+
+	.comment-emission.above .comment-emission-tail {
+		top: auto;
+		bottom: -5px;
+		rotate: 225deg;
+	}
+
+	/* neither band exists: sit at the player's edge, where the comments panel docks */
 	.comment-emission.docked {
 		position: fixed;
 		top: auto;

--- a/loq.toml
+++ b/loq.toml
@@ -379,7 +379,7 @@ max_lines = 524
 
 [[rules]]
 path = "frontend/src/lib/components/TrackComments.svelte"
-max_lines = 1132
+max_lines = 1159
 
 [[rules]]
 path = "backend/src/backend/api/artists.py"


### PR DESCRIPTION
nate on #1962's docked bubble: "thoughtlessly placed. unaware of what else is on the page, it weirdly blocks the stuff that's there even tho we have so much space." docking at the player's edge put the bubble over the share/download/comments row that sits right there on phones, while the band above that row was empty.

`emissionPlacement(anchorTop, anchorBottom, viewportHeight, playerHeight)` now has three answers, tried in order: **below** the trigger when the bubble fits between it and the player; **above** the trigger's row when there is room under the header (64 px clearance); **docked** at the player's edge only when neither band exists or the trigger has scrolled off the top. the "above" bubble has its tail flipped to point down at the trigger.

`emissionShift()` keeps the bubble inside the viewport horizontally (16 px margin) when its trigger sits near an edge, and the tail is counter-shifted so it still points at the trigger.

tests cover each placement and both shift directions. `bun run check` 0 errors, lint clean, 202 tests pass. staging verification at two viewport heights follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z