### PR TITLE
comments: place the passing-comment stack in the measured free band around its row

### DIFF
--- a/frontend/src/lib/comment-emission.test.ts
+++ b/frontend/src/lib/comment-emission.test.ts
@@ -1,48 +1,46 @@
 import { describe, expect, it } from 'vitest';
 import {
-	EMISSION_SPACE_PX,
-	EMISSION_STACK_PX,
-	HEADER_CLEARANCE_PX,
-	emissionPlacement,
+	EMISSION_GAP_PX,
+	EMISSION_ROW_PX,
+	EMISSION_STACK_MAX,
+	emissionCapacity,
+	emissionLayout,
 	emissionShift
 } from './comment-emission';
 
-describe('emissionPlacement', () => {
-	it('hangs below the trigger when a full stack fits above the player', () => {
-		expect(emissionPlacement(270, 300, 844, 110)).toBe('below');
-		expect(emissionPlacement(500, 844 - 110 - EMISSION_STACK_PX, 844, 110)).toBe('below');
+describe('emissionCapacity', () => {
+	it('counts whole bubbles that fit after the gap', () => {
+		expect(emissionCapacity(0)).toBe(0);
+		expect(emissionCapacity(EMISSION_GAP_PX + EMISSION_ROW_PX - 1)).toBe(0);
+		expect(emissionCapacity(EMISSION_GAP_PX + EMISSION_ROW_PX)).toBe(1);
+		expect(emissionCapacity(53)).toBe(1);
+		expect(emissionCapacity(1000)).toBe(EMISSION_STACK_MAX);
+	});
+});
+
+describe('emissionLayout', () => {
+	it('takes the band with more room, below on a tie', () => {
+		expect(emissionLayout({ above: 300, below: 300 })).toEqual({ placement: 'below', capacity: 3 });
+		expect(emissionLayout({ above: 300, below: 53 })).toEqual({ placement: 'above', capacity: 3 });
+		expect(emissionLayout({ above: 10, below: 53 })).toEqual({ placement: 'below', capacity: 1 });
 	});
 
-	it('rises above the row when the band below the trigger is taken by the player', () => {
-		expect(emissionPlacement(600, 700, 844, 110)).toBe('above');
-		expect(emissionPlacement(HEADER_CLEARANCE_PX + EMISSION_STACK_PX, 760, 844, 110)).toBe('above');
-	});
-
-	it('docks only when neither band exists', () => {
-		expect(emissionPlacement(HEADER_CLEARANCE_PX + EMISSION_STACK_PX - 1, 760, 844, 110)).toBe('docked');
-		expect(emissionPlacement(-40, -10, 844, 110)).toBe('docked');
-	});
-
-	it('takes the room one bubble needs when asked for one', () => {
-		expect(emissionPlacement(640, 670, 844, 110, EMISSION_SPACE_PX)).toBe('below');
-		expect(emissionPlacement(640, 670, 844, 110)).toBe('above');
-	});
-
-	it('treats no player as full-height room below', () => {
-		expect(emissionPlacement(600, 620, 844, 0)).toBe('below');
+	it('docks one bubble when neither band holds one', () => {
+		expect(emissionLayout({ above: 10, below: 20 })).toEqual({ placement: 'docked', capacity: 1 });
+		expect(emissionLayout({ above: -40, below: -10 })).toEqual({ placement: 'docked', capacity: 1 });
 	});
 });
 
 describe('emissionShift', () => {
-	it('leaves a bubble that fits where it is', () => {
+	it('leaves a stack that fits where it is', () => {
 		expect(emissionShift(195, 200, 390)).toBe(0);
 	});
 
-	it('pushes a bubble in from the right edge', () => {
+	it('pushes a stack in from the right edge', () => {
 		expect(emissionShift(300, 280, 390)).toBe(390 - 16 - 440);
 	});
 
-	it('pushes a bubble in from the left edge', () => {
+	it('pushes a stack in from the left edge', () => {
 		expect(emissionShift(80, 280, 390)).toBe(16 + 60);
 	});
 });

--- a/frontend/src/lib/comment-emission.ts
+++ b/frontend/src/lib/comment-emission.ts
@@ -1,44 +1,53 @@
 /**
- * where a passing-comment bubble can surface without covering anything.
+ * where passing-comment bubbles can surface without covering anything.
  *
- * it hangs below the comments trigger when the band between the trigger
- * and the fixed footer player can hold it; otherwise it rises above the
- * trigger's row into the space there; only when neither band exists does
- * it dock at the player's edge. the bubble is also kept inside the
+ * the trigger sits in a row of page content. the free band below that row
+ * (down to the next content or the fixed footer player) and the free band
+ * above it (up to the previous content or the header) are measured; the
+ * stack goes in the larger band and is capped to how many bubbles fit
+ * there. only when neither band holds a bubble does it dock at the
+ * player's edge, one bubble at a time. the stack is also kept inside the
  * viewport horizontally, since its trigger may sit near an edge.
  */
 
 export type EmissionPlacement = 'below' | 'above' | 'docked';
 
-/** one bubble's height plus its gap to the trigger, in px; generous so a two-line wrap still fits. */
-export const EMISSION_SPACE_PX = 56;
-/** each further bubble in a stack, in px. */
-export const EMISSION_ROW_PX = 40;
+/** free vertical room around the trigger's row, in px; negative when content presses in. */
+export interface EmissionBands {
+	above: number;
+	below: number;
+}
+
+export interface EmissionLayout {
+	placement: EmissionPlacement;
+	/** how many bubbles may show at once in this band. */
+	capacity: number;
+}
+
+/** gap between the trigger's row and the first bubble, in px. */
+export const EMISSION_GAP_PX = 8;
+/** one bubble's height plus the gap to the next, in px. */
+export const EMISSION_ROW_PX = 42;
 /** how many passing comments show at once; older ones leave early when a burst exceeds it. */
 export const EMISSION_STACK_MAX = 3;
 /** how long one bubble lives. */
 export const EMISSION_TTL_MS = 4000;
-
-/** the vertical room a full stack needs. */
-export const EMISSION_STACK_PX = EMISSION_SPACE_PX + (EMISSION_STACK_MAX - 1) * EMISSION_ROW_PX;
-
 /** the page header's height; a bubble rising under it would be covered. */
 export const HEADER_CLEARANCE_PX = 64;
 
-export function emissionPlacement(
-	anchorTop: number,
-	anchorBottom: number,
-	viewportHeight: number,
-	playerHeight: number,
-	needed = EMISSION_STACK_PX
-): EmissionPlacement {
-	if (anchorBottom < 0) return 'docked';
-	if (anchorBottom + needed <= viewportHeight - playerHeight) return 'below';
-	if (anchorTop - needed >= HEADER_CLEARANCE_PX) return 'above';
-	return 'docked';
+/** bubbles that fit in a free band of `freePx`. */
+export function emissionCapacity(freePx: number): number {
+	return Math.max(0, Math.min(EMISSION_STACK_MAX, Math.floor((freePx - EMISSION_GAP_PX) / EMISSION_ROW_PX)));
 }
 
-/** how far to shift a bubble centered at `centerX` so it stays `margin` inside the viewport. */
+export function emissionLayout(bands: EmissionBands): EmissionLayout {
+	const below = emissionCapacity(bands.below);
+	const above = emissionCapacity(bands.above);
+	if (below === 0 && above === 0) return { placement: 'docked', capacity: 1 };
+	return below >= above ? { placement: 'below', capacity: below } : { placement: 'above', capacity: above };
+}
+
+/** how far to shift a stack centered at `centerX` so it stays `margin` inside the viewport. */
 export function emissionShift(centerX: number, width: number, viewportWidth: number, margin = 16): number {
 	const left = centerX - width / 2;
 	const right = centerX + width / 2;

--- a/frontend/src/lib/components/TrackComments.svelte
+++ b/frontend/src/lib/components/TrackComments.svelte
@@ -10,10 +10,11 @@
 	import type { Track } from '$lib/types';
 	import { fade, fly } from 'svelte/transition';
 	import {
-		EMISSION_STACK_MAX,
 		EMISSION_TTL_MS,
-		emissionPlacement,
+		HEADER_CLEARANCE_PX,
+		emissionLayout,
 		emissionShift,
+		type EmissionBands,
 		type EmissionPlacement
 	} from '$lib/comment-emission';
 	import { flip } from 'svelte/animate';
@@ -59,6 +60,7 @@
 	// plain let for the playback cursor: previous position must not retrigger.
 	let emissions = $state<Comment[]>([]);
 	let emissionPlace = $state<EmissionPlacement>('below');
+	let emissionCap = 1;
 	let emissionShiftPx = $state(0);
 	let emissionsEl = $state<HTMLDivElement | null>(null);
 	const emissionTimers = new Map<number, ReturnType<typeof setTimeout>>();
@@ -80,7 +82,7 @@
 	}
 
 	function clearEmissions() {
-		for (const id of [...emissionTimers.keys()]) dismissEmission(id);
+		for (const id of Array.from(emissionTimers.keys())) dismissEmission(id);
 	}
 
 	function playerHeightPx(): number {
@@ -89,22 +91,34 @@
 		return Number.isFinite(px) ? px : 0;
 	}
 
+	// the free bands around the trigger's row: up to the previous content (or the
+	// header) and down to the next content (or the fixed player)
+	function freeBands(): EmissionBands {
+		const row = triggerAnchor?.parentElement;
+		if (!row) return { above: 0, below: 0 };
+		const rect = row.getBoundingClientRect();
+		const prevBottom = row.previousElementSibling?.getBoundingClientRect().bottom ?? 0;
+		const nextTop = row.nextElementSibling?.getBoundingClientRect().top ?? Number.POSITIVE_INFINITY;
+		const playerTop = window.innerHeight - playerHeightPx();
+		return {
+			above: rect.top - Math.max(prevBottom, HEADER_CLEARANCE_PX),
+			below: Math.min(nextTop, playerTop) - rect.bottom
+		};
+	}
+
 	function showEmission(comment: Comment) {
 		if (emissions.length === 0) {
-			const anchor = triggerAnchor?.getBoundingClientRect();
-			emissionPlace = emissionPlacement(
-				anchor?.top ?? 0,
-				anchor?.bottom ?? 0,
-				window.innerHeight,
-				playerHeightPx()
-			);
+			const bands = freeBands();
+			const layout = emissionLayout(bands);
+			emissionPlace = layout.placement;
+			emissionCap = layout.capacity;
 			emissionShiftPx = 0;
 		}
 		const existing = emissionTimers.get(comment.id);
 		if (existing) clearTimeout(existing);
 		else {
 			emissions = [comment, ...emissions];
-			for (const stale of emissions.slice(EMISSION_STACK_MAX)) dismissEmission(stale.id);
+			for (const stale of emissions.slice(emissionCap)) dismissEmission(stale.id);
 		}
 		emissionTimers.set(
 			comment.id,

--- a/loq.toml
+++ b/loq.toml
@@ -379,7 +379,7 @@ max_lines = 524
 
 [[rules]]
 path = "frontend/src/lib/components/TrackComments.svelte"
-max_lines = 1207
+max_lines = 1221
 
 [[rules]]
 path = "backend/src/backend/api/artists.py"


### PR DESCRIPTION
#1968's "above the row" fallback was still blind to the page: on the track page the band above the share/comments row holds the play button and the listen count, so the stack covered those instead of the row (nate: "unaware of what else is on the page").

the component now measures the two free bands around the trigger's row from the DOM — above: the row's top minus the previous sibling's bottom (or the header); below: the next sibling's top or the player's top minus the row's bottom — and `emissionLayout(bands)` picks the larger band and caps the stack to `emissionCapacity(free)`, the whole bubbles that fit there (42 px each after an 8 px gap, at most 3). when neither band holds a bubble it docks at the player one bubble at a time, the least bad case rather than the first fallback.

on the phone layout from nate's screenshot (row parked 53 px above the player, listen count directly above the row) that yields one bubble below the row in the space that is genuinely empty; at a full phone height it yields the three-bubble stack below.

tests cover capacity boundaries, band choice and ties, and the dock-only-when-nothing-fits case. `bun run check` 0 errors, eslint + oxlint clean, 201 tests pass. staging: the same five-comment burst at 640 and 844 px tall follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z