### PR TITLE
comments: the stack's capacity math matches the bubble's real height

### DIFF
--- a/frontend/src/lib/comment-emission.test.ts
+++ b/frontend/src/lib/comment-emission.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+	EMISSION_BUBBLE_PX,
 	EMISSION_GAP_PX,
-	EMISSION_ROW_PX,
+	EMISSION_INNER_GAP_PX,
 	EMISSION_STACK_MAX,
 	emissionCapacity,
 	emissionLayout,
@@ -9,11 +10,15 @@ import {
 } from './comment-emission';
 
 describe('emissionCapacity', () => {
-	it('counts whole bubbles that fit after the gap', () => {
+	it('counts whole bubbles that fit: the row gap first, the inner gap between', () => {
+		const one = EMISSION_GAP_PX + EMISSION_BUBBLE_PX;
+		const each = EMISSION_BUBBLE_PX + EMISSION_INNER_GAP_PX;
 		expect(emissionCapacity(0)).toBe(0);
-		expect(emissionCapacity(EMISSION_GAP_PX + EMISSION_ROW_PX - 1)).toBe(0);
-		expect(emissionCapacity(EMISSION_GAP_PX + EMISSION_ROW_PX)).toBe(1);
-		expect(emissionCapacity(53)).toBe(1);
+		expect(emissionCapacity(one - 1)).toBe(0);
+		expect(emissionCapacity(one)).toBe(1);
+		expect(emissionCapacity(47)).toBe(1);
+		expect(emissionCapacity(one + each - 1)).toBe(1);
+		expect(emissionCapacity(one + each)).toBe(2);
 		expect(emissionCapacity(1000)).toBe(EMISSION_STACK_MAX);
 	});
 });
@@ -26,7 +31,7 @@ describe('emissionLayout', () => {
 	});
 
 	it('docks one bubble when neither band holds one', () => {
-		expect(emissionLayout({ above: 10, below: 20 })).toEqual({ placement: 'docked', capacity: 1 });
+		expect(emissionLayout({ above: 10, below: 41 })).toEqual({ placement: 'docked', capacity: 1 });
 		expect(emissionLayout({ above: -40, below: -10 })).toEqual({ placement: 'docked', capacity: 1 });
 	});
 });

--- a/frontend/src/lib/comment-emission.ts
+++ b/frontend/src/lib/comment-emission.ts
@@ -24,10 +24,12 @@ export interface EmissionLayout {
 	capacity: number;
 }
 
-/** gap between the trigger's row and the first bubble, in px. */
-export const EMISSION_GAP_PX = 8;
-/** one bubble's height plus the gap to the next, in px. */
-export const EMISSION_ROW_PX = 42;
+/** gap between the trigger's row and the first bubble, in px (the stack's css offset). */
+export const EMISSION_GAP_PX = 6;
+/** one bubble's rendered height, in px. */
+export const EMISSION_BUBBLE_PX = 36;
+/** gap between stacked bubbles, in px (the stack's css gap). */
+export const EMISSION_INNER_GAP_PX = 4;
 /** how many passing comments show at once; older ones leave early when a burst exceeds it. */
 export const EMISSION_STACK_MAX = 3;
 /** how long one bubble lives. */
@@ -35,9 +37,12 @@ export const EMISSION_TTL_MS = 4000;
 /** the page header's height; a bubble rising under it would be covered. */
 export const HEADER_CLEARANCE_PX = 64;
 
-/** bubbles that fit in a free band of `freePx`. */
+/** bubbles that fit in a free band of `freePx`: the first needs the row gap, each further one the inner gap. */
 export function emissionCapacity(freePx: number): number {
-	return Math.max(0, Math.min(EMISSION_STACK_MAX, Math.floor((freePx - EMISSION_GAP_PX) / EMISSION_ROW_PX)));
+	const first = EMISSION_GAP_PX + EMISSION_BUBBLE_PX;
+	if (freePx < first) return 0;
+	const more = Math.floor((freePx - first) / (EMISSION_BUBBLE_PX + EMISSION_INNER_GAP_PX));
+	return Math.min(EMISSION_STACK_MAX, 1 + more);
 }
 
 export function emissionLayout(bands: EmissionBands): EmissionLayout {

--- a/frontend/src/lib/components/TrackComments.svelte
+++ b/frontend/src/lib/components/TrackComments.svelte
@@ -532,13 +532,13 @@
 	   docked); newest bubble nearest the trigger */
 	.comment-emissions {
 		position: absolute;
-		top: calc(100% + 0.4rem);
+		top: calc(100% + 6px);
 		left: 50%;
 		translate: calc(-50% + var(--shift, 0px)) 0;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		gap: 0.35rem;
+		gap: 4px;
 		z-index: 40;
 	}
 
@@ -561,7 +561,7 @@
 	/* the band below the trigger belongs to the player: rise into the space above the row */
 	.comment-emissions.above {
 		top: auto;
-		bottom: calc(100% + 0.4rem);
+		bottom: calc(100% + 6px);
 		flex-direction: column-reverse;
 	}
 


### PR DESCRIPTION
on the 640 px phone layout the band under the comments row measured 47 px — correct — but `emissionCapacity` demanded 50 for one bubble (a notional 42 px row plus an 8 px gap) when a bubble is 36 px tall, so the stack docked over the row instead of using the room. the first bubble now needs the 6 px row offset plus its 36 px height, each further one 4 px more, and the stack's css offset and gap are those same numbers so the arithmetic and the render agree.

tests cover the first-bubble and second-bubble thresholds. `bun run check` 0 errors, lint clean, 201 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z