### PR TITLE
comments: the stack dodges fixed chrome over its ends and clips to its capacity

### DIFF
--- a/frontend/src/lib/comment-emission.test.ts
+++ b/frontend/src/lib/comment-emission.test.ts
@@ -6,7 +6,8 @@ import {
 	EMISSION_STACK_MAX,
 	emissionCapacity,
 	emissionLayout,
-	emissionShift
+	emissionShift,
+	emissionStackHeight
 } from './comment-emission';
 
 describe('emissionCapacity', () => {
@@ -38,14 +39,33 @@ describe('emissionLayout', () => {
 
 describe('emissionShift', () => {
 	it('leaves a stack that fits where it is', () => {
-		expect(emissionShift(195, 200, 390)).toBe(0);
+		expect(emissionShift(95, 295, 390)).toBe(0);
 	});
 
 	it('pushes a stack in from the right edge', () => {
-		expect(emissionShift(300, 280, 390)).toBe(390 - 16 - 440);
+		expect(emissionShift(160, 440, 390)).toBe(390 - 16 - 440);
 	});
 
 	it('pushes a stack in from the left edge', () => {
-		expect(emissionShift(80, 280, 390)).toBe(16 + 60);
+		expect(emissionShift(-60, 220, 390)).toBe(16 + 60);
+	});
+
+	it('moves left of something fixed over its right end', () => {
+		expect(emissionShift(180, 380, 390, [{ left: 330, right: 380 }])).toBe(330 - 16 - 380);
+	});
+
+	it('moves right of something fixed over its left end', () => {
+		expect(emissionShift(20, 220, 390, [{ left: 0, right: 60 }])).toBe(60 + 16 - 20);
+	});
+
+	it('keeps the viewport edge when an obstacle would push it out', () => {
+		expect(emissionShift(10, 290, 390, [{ left: 250, right: 300 }])).toBe(6);
+	});
+});
+
+describe('emissionStackHeight', () => {
+	it('is the bubbles plus the gaps between them', () => {
+		expect(emissionStackHeight(1)).toBe(36);
+		expect(emissionStackHeight(3)).toBe(36 * 3 + 4 * 2);
 	});
 });

--- a/frontend/src/lib/comment-emission.ts
+++ b/frontend/src/lib/comment-emission.ts
@@ -52,11 +52,37 @@ export function emissionLayout(bands: EmissionBands): EmissionLayout {
 	return below >= above ? { placement: 'below', capacity: below } : { placement: 'above', capacity: above };
 }
 
-/** how far to shift a stack centered at `centerX` so it stays `margin` inside the viewport. */
-export function emissionShift(centerX: number, width: number, viewportWidth: number, margin = 16): number {
-	const left = centerX - width / 2;
-	const right = centerX + width / 2;
-	if (left < margin) return margin - left;
-	if (right > viewportWidth - margin) return viewportWidth - margin - right;
-	return 0;
+/** a horizontal span something else already occupies, in viewport px. */
+export interface EmissionObstacle {
+	left: number;
+	right: number;
+}
+
+/**
+ * how far to shift a stack spanning [left, right] so it stays `margin` inside
+ * the viewport and clear of anything fixed over its ends (the queue toggle,
+ * say). obstacles win over centering; the viewport edge wins over obstacles.
+ */
+export function emissionShift(
+	left: number,
+	right: number,
+	viewportWidth: number,
+	obstacles: EmissionObstacle[] = [],
+	margin = 16
+): number {
+	let shift = 0;
+	for (const o of obstacles) {
+		const overlapsRight = o.left < right + shift && o.right > left + shift && o.left > left + shift;
+		const overlapsLeft = o.right > left + shift && o.left < right + shift && !overlapsRight;
+		if (overlapsRight) shift += o.left - margin - (right + shift);
+		else if (overlapsLeft) shift += o.right + margin - (left + shift);
+	}
+	if (left + shift < margin) shift = margin - left;
+	if (right + shift > viewportWidth - margin) shift = viewportWidth - margin - right;
+	return shift;
+}
+
+/** the stack's tallest allowed height for `capacity` bubbles, in px; evicted bubbles fade inside it. */
+export function emissionStackHeight(capacity: number): number {
+	return capacity * EMISSION_BUBBLE_PX + Math.max(0, capacity - 1) * EMISSION_INNER_GAP_PX;
 }

--- a/frontend/src/lib/components/TrackComments.svelte
+++ b/frontend/src/lib/components/TrackComments.svelte
@@ -14,7 +14,9 @@
 		HEADER_CLEARANCE_PX,
 		emissionLayout,
 		emissionShift,
+		emissionStackHeight,
 		type EmissionBands,
+		type EmissionObstacle,
 		type EmissionPlacement
 	} from '$lib/comment-emission';
 	import { flip } from 'svelte/animate';
@@ -60,18 +62,34 @@
 	// plain let for the playback cursor: previous position must not retrigger.
 	let emissions = $state<Comment[]>([]);
 	let emissionPlace = $state<EmissionPlacement>('below');
-	let emissionCap = 1;
+	let emissionCap = $state(1);
 	let emissionShiftPx = $state(0);
 	let emissionsEl = $state<HTMLDivElement | null>(null);
 	const emissionTimers = new Map<number, ReturnType<typeof setTimeout>>();
 	let prevPlaybackMs = -1;
 	let triggerAnchor = $state<HTMLSpanElement | null>(null);
 
-	// once the stack has a size, keep it inside the viewport horizontally
+	// whatever is drawn over a point that is not the stack itself or the page
+	// behind it — fixed chrome such as the queue toggle
+	function obstacleAt(x: number, y: number): EmissionObstacle | null {
+		if (!emissionsEl) return null;
+		const hit = document.elementsFromPoint(x, y).find((el) => !emissionsEl?.contains(el));
+		if (!hit || hit === document.body || hit === document.documentElement) return null;
+		if (hit.contains(emissionsEl)) return null;
+		const r = hit.getBoundingClientRect();
+		return { left: r.left, right: r.right };
+	}
+
+	// once the stack has a size, keep it inside the viewport and clear of
+	// anything fixed over its ends
 	$effect(() => {
 		if (!emissionsEl || emissionPlace === 'docked' || emissions.length === 0) return;
 		const rect = emissionsEl.getBoundingClientRect();
-		emissionShiftPx = emissionShift(rect.left + rect.width / 2, rect.width, window.innerWidth);
+		const y = rect.top + Math.min(rect.height, 36) / 2;
+		const obstacles = [obstacleAt(rect.right - 4, y), obstacleAt(rect.left + 4, y)].filter(
+			(o): o is EmissionObstacle => o !== null
+		);
+		emissionShiftPx = emissionShift(rect.left, rect.right, window.innerWidth, obstacles);
 	});
 
 	function dismissEmission(id: number) {
@@ -342,6 +360,7 @@
 		<div
 			class="comment-emissions {emissionPlace}"
 			style:--shift="{emissionShiftPx}px"
+			style:max-height="{emissionStackHeight(emissionCap)}px"
 			bind:this={emissionsEl}
 		>
 			{#if emissionPlace !== 'docked'}<span class="comment-emission-tail" aria-hidden="true"></span>{/if}
@@ -539,6 +558,7 @@
 		flex-direction: column;
 		align-items: center;
 		gap: 4px;
+		overflow: hidden;
 		z-index: 40;
 	}
 

--- a/loq.toml
+++ b/loq.toml
@@ -379,7 +379,7 @@ max_lines = 524
 
 [[rules]]
 path = "frontend/src/lib/components/TrackComments.svelte"
-max_lines = 1221
+max_lines = 1241
 
 [[rules]]
 path = "backend/src/backend/api/artists.py"


### PR DESCRIPTION
two things visible in the 640 px staging shot after #1971:

- **the queue toggle** (fixed, bottom right) sat over the bubble's tail end. `emissionShift` now takes obstacles: the component probes `elementsFromPoint` at each end of the stack, and anything drawn there that is neither the stack nor the page behind it is a span to move away from. obstacles win over centering; the viewport edge wins over obstacles.
- **an evicted bubble** stayed in flow while it faded, so a burst past the band's capacity briefly poked a bubble below the band. the stack now has `max-height` = `emissionStackHeight(capacity)` with `overflow: hidden`, so a fading bubble is clipped inside the room the band actually has.

tests cover both obstacle sides, edge-vs-obstacle precedence, and the stack height. `bun run check` 0 errors, lint clean, 205 tests pass. same burst replay on staging follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z