### PR TITLE
comments: measure the stack's shift from its unshifted position

### DIFF
--- a/frontend/src/lib/components/TrackComments.svelte
+++ b/frontend/src/lib/components/TrackComments.svelte
@@ -85,11 +85,15 @@
 	$effect(() => {
 		if (!emissionsEl || emissionPlace === 'docked' || emissions.length === 0) return;
 		const rect = emissionsEl.getBoundingClientRect();
+		// measure from where the stack sits unshifted, so a re-run after a shift
+		// sees the same obstacle and lands on the same answer
+		const left = rect.left - emissionShiftPx;
+		const right = rect.right - emissionShiftPx;
 		const y = rect.top + Math.min(rect.height, 36) / 2;
-		const obstacles = [obstacleAt(rect.right - 4, y), obstacleAt(rect.left + 4, y)].filter(
+		const obstacles = [obstacleAt(right - 4, y), obstacleAt(left + 4, y)].filter(
 			(o): o is EmissionObstacle => o !== null
 		);
-		emissionShiftPx = emissionShift(rect.left, rect.right, window.innerWidth, obstacles);
+		emissionShiftPx = emissionShift(left, right, window.innerWidth, obstacles);
 	});
 
 	function dismissEmission(id: number) {

--- a/loq.toml
+++ b/loq.toml
@@ -379,7 +379,7 @@ max_lines = 524
 
 [[rules]]
 path = "frontend/src/lib/components/TrackComments.svelte"
-max_lines = 1241
+max_lines = 1245
 
 [[rules]]
 path = "backend/src/backend/api/artists.py"


### PR DESCRIPTION
on staging the stack moved left for the queue toggle but stopped a few px short of the 16 px margin: the shift effect re-ran after the first shift, probed the ends where the stack now was, found a smaller overlap, and replaced the shift with that smaller answer. the probe and the arithmetic now use the unshifted ends (current rect minus the current shift), so every run sees the same obstacle and computes the same shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z