### PR TITLE
comments: dock when the trigger is under the player; keep the margin from grazed chrome

### DIFF
--- a/frontend/src/lib/components/TrackComments.svelte
+++ b/frontend/src/lib/components/TrackComments.svelte
@@ -101,7 +101,8 @@
 		// probe where the stack will sit once inside the viewport, a little in
 		// from each end so a round button at the edge is not missed
 		const edge = emissionShift(left, right, window.innerWidth);
-		const obstacles = [right + edge - 8, right + edge - 24, left + edge + 8, left + edge + 24]
+		// just past each end too, so the margin holds against chrome the stack only grazes
+		const obstacles = [right + edge + 8, right + edge - 8, right + edge - 24, left + edge - 8, left + edge + 8, left + edge + 24]
 			.map((x) => obstacleAt(x, y))
 			.filter((o): o is EmissionObstacle => o !== null);
 		emissionShiftPx = emissionShift(left, right, window.innerWidth, obstacles);
@@ -161,11 +162,13 @@
 		let leftEdge = triggerAnchor.previousElementSibling?.getBoundingClientRect().right ?? 16;
 		const leftHit = obstacleAt(Math.max(leftEdge, self.left - 120), y);
 		if (leftHit && leftHit.right < self.left) leftEdge = Math.max(leftEdge, leftHit.right + 16);
+		// a trigger under the player cannot be seen, and neither can anything beside it
+		const hidden = self.bottom > playerTop;
 		return {
 			above: rect.top - Math.max(prevBottom, HEADER_CLEARANCE_PX),
 			below: Math.min(nextTop, playerTop) - rect.bottom,
-			right: rightEdge - self.right,
-			left: self.left - leftEdge
+			right: hidden ? 0 : rightEdge - self.right,
+			left: hidden ? 0 : self.left - leftEdge
 		};
 	}
 

--- a/loq.toml
+++ b/loq.toml
@@ -379,7 +379,7 @@ max_lines = 524
 
 [[rules]]
 path = "frontend/src/lib/components/TrackComments.svelte"
-max_lines = 1376
+max_lines = 1379
 
 [[rules]]
 path = "backend/src/backend/api/artists.py"


### PR DESCRIPTION
two things from the #1976 frame captures on staging:

- at 1280×800 with no scroll the share/comments row sits half under the fixed player, so the trigger itself is partly hidden — and a bubble beside it was cut by the player too. the side bands now read as zero when the trigger's bottom is below the player's top, so that case docks (the one place docking is right: nothing else is visible).
- on the phone the bubble ended 2 px from the queue toggle: the obstacle probes at 8 and 24 px in from the end never entered the round button. the probe now also looks 8 px past each end, so the 16 px margin holds against chrome the stack only grazes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z