### PR TITLE
comments: an obstacle is the control under the probe, not the icon inside it

### DIFF
--- a/frontend/src/lib/components/TrackComments.svelte
+++ b/frontend/src/lib/components/TrackComments.svelte
@@ -83,7 +83,9 @@
 			.find((el) => !emissionsEl?.contains(el) && !row?.contains(el));
 		if (!hit || hit === document.body || hit === document.documentElement) return null;
 		if (row && hit.contains(row)) return null;
-		const r = hit.getBoundingClientRect();
+		// the topmost hit is often an icon inside a button; the control is the obstacle
+		const control = hit.closest('button, a, [role="button"]') ?? hit;
+		const r = control.getBoundingClientRect();
 		return { left: r.left, right: r.right };
 	}
 

--- a/loq.toml
+++ b/loq.toml
@@ -379,7 +379,7 @@ max_lines = 524
 
 [[rules]]
 path = "frontend/src/lib/components/TrackComments.svelte"
-max_lines = 1379
+max_lines = 1381
 
 [[rules]]
 path = "backend/src/backend/api/artists.py"


### PR DESCRIPTION
on staging the stack still ended 2 px from the queue toggle: `elementsFromPoint` returns the topmost element, which is the svg inside the button, and its rect is narrower than the button. the obstacle is now the nearest `button`/`a`/`[role=button]` ancestor of the hit, so the 16 px margin is measured from the control's edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z