### PR TITLE
docs: pass for September 1–2 — flags, uploads, player, release, passing comments; restore the client-writes plan

### DIFF
--- a/backend/src/backend/_internal/CLAUDE.md
+++ b/backend/src/backend/_internal/CLAUDE.md
@@ -15,6 +15,7 @@ internal services and business logic.
 - **uploads**: streaming chunked uploads to R2/filesystem, duplicate detection via file_id
 - **moderation**: copyright scanning via AudD, sensitive image flagging
 - **jobs**: job tracking for long-running operations (exports)
+- **notifications**: the operator DM bot (a Bluesky app-password session via `atproto`). `ensure_ready()` re-runs `setup()` lazily when the service is broken, rate-limited by a cooldown; a DM that fails with a *session* error (`ExpiredToken`/`InvalidToken`/401) discards the client, re-logs in through `ensure_ready()`, and is retried once (#1953). network errors keep the session. only the worker process boots it — see `worker.py`
 
 gotchas:
 - ATProto records organized under `_internal/atproto/records/` by lexicon namespace

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -17,6 +17,7 @@ organized knowledge base for plyr.fm development.
 - **[configuration.md](./backend/configuration.md)** - environment setup and settings
 - **[database/](./backend/database/)** - connection pooling, neon-specific patterns
 - **[feature-flags.md](./backend/feature-flags.md)** - per-user feature rollout system
+- **[resumable-uploads.md](./backend/resumable-uploads.md)** - the web upload path: start → parts → finish, worker-side settle, the client's staged transfer
 - **[streaming-uploads.md](./backend/streaming-uploads.md)** - SSE progress tracking
 - **[audio-streaming.md](./backend/audio-streaming.md)** - the `GET /audio` dispatch tree (public / gated / private), driven by visibility + support_gate
 - **[album-uploads.md](./backend/album-uploads.md)** - multi-track album upload flow (create → finalize) and why the ATProto list record is authoritative for track order
@@ -37,6 +38,14 @@ organized knowledge base for plyr.fm development.
 - **[keyboard-shortcuts.md](./frontend/keyboard-shortcuts.md)** - global shortcuts
 - **[navigation.md](./frontend/navigation.md)** - SvelteKit routing patterns
 - **[search.md](./frontend/search.md)** - unified search with Cmd+K
+- **[queue.md](./frontend/queue.md)** - the queue as a direct-manipulation surface
+- **[portals.md](./frontend/portals.md)** - the portal and its manage page
+- **[toast-notifications.md](./frontend/toast-notifications.md)** - the toast stack and its copy rules
+- **[passing-comments.md](./frontend/passing-comments.md)** - timestamped comments surfacing during playback: the stack, DOM-measured placement, the icon's breath
+- **[design-tokens.md](./frontend/design-tokens.md)** - CSS variables from `+layout.svelte`
+- **[data-loading.md](./frontend/data-loading.md)** - `+page.ts` vs client fetches
+- **[collection-pages.md](./frontend/collection-pages.md)** - album and playlist pages
+- **[redirect-after-login.md](./frontend/redirect-after-login.md)** - the return-url cookie and the auth-redirect helpers
 
 ### deployment
 - **[environments.md](./deployment/environments.md)** - staging vs production

--- a/docs/internal/backend/feature-flags.md
+++ b/docs/internal/backend/feature-flags.md
@@ -31,16 +31,22 @@ each row represents one flag enabled for one user. the unique constraint prevent
 
 ## known flags
 
-flags are documented in `backend/_internal/feature_flags.py`:
+flags are documented in `backend/src/backend/_internal/feature_flags.py`:
 
 ```python
 KNOWN_FLAGS = frozenset({
-    "lossless-uploads",  # enable AIFF/FLAC upload support
-    "pds-audio-uploads",  # enable PDS audio blob uploads
+    "vibe-search",  # semantic vibe search in Cmd+K
+    "copyright-paradigm",  # the indiemusi.ch copyright paradigm UI + endpoints
+    "skip-buttons",  # ±skip buttons in the player + media-session seek handlers
 })
 ```
 
-add new flags to `KNOWN_FLAGS` for documentation purposes.
+`KNOWN_FLAGS` is documentation: `/auth/me` returns whatever rows the table
+holds, so a flag enabled before its name lands in the set still reaches the
+client. add new flags to `KNOWN_FLAGS` all the same.
+
+flag-gated UI is not general availability. the public docs describe only what
+every user gets; a flagged feature is described here and in `STATUS.md`.
 
 ## checking flags in code
 
@@ -50,12 +56,12 @@ add new flags to `KNOWN_FLAGS` for documentation purposes.
 from backend._internal import has_flag, get_user_flags
 
 # check a specific flag
-if await has_flag(db, user_did, "lossless-uploads"):
+if await has_flag(db, user_did, "skip-buttons"):
     # feature is enabled for this user
     pass
 
 # get all flags for a user
-flags = await get_user_flags(db, user_did)  # ["lossless-uploads", "pds-audio-uploads", ...]
+flags = await get_user_flags(db, user_did)  # ["skip-buttons", "vibe-search", ...]
 ```
 
 ### frontend
@@ -63,12 +69,11 @@ flags = await get_user_flags(db, user_did)  # ["lossless-uploads", "pds-audio-up
 flags are returned in the `/auth/me` response:
 
 ```typescript
-// $lib/state/auth.svelte.ts
-const auth = getAuth();
+// $lib/auth.svelte.ts holds the signed-in user; flag names live in $lib/config.ts
+import { auth } from '$lib/auth.svelte';
+import { SKIP_BUTTONS_FLAG } from '$lib/config';
 
-if (auth.user?.enabled_flags.includes("lossless-uploads")) {
-    // show lossless upload UI
-}
+const skipButtons = $derived(auth.user?.enabled_flags?.includes(SKIP_BUTTONS_FLAG) ?? false);
 ```
 
 ## api
@@ -82,7 +87,7 @@ returns the current user's enabled flags:
     "did": "did:plc:abc123",
     "handle": "alice.bsky.social",
     "linked_accounts": [...],
-    "enabled_flags": ["lossless-uploads"]
+    "enabled_flags": ["skip-buttons"]
 }
 ```
 
@@ -94,10 +99,10 @@ manage flags via the admin script (requires `DATABASE_URL`):
 cd backend
 
 # enable a flag for a user
-DATABASE_URL="..." uv run python ../scripts/feature_flag.py enable --user zzstoatzz.io --flag lossless-uploads
+DATABASE_URL="..." uv run python ../scripts/feature_flag.py enable --user zzstoatzz.io --flag skip-buttons
 
 # disable a flag
-DATABASE_URL="..." uv run python ../scripts/feature_flag.py disable --user zzstoatzz.io --flag lossless-uploads
+DATABASE_URL="..." uv run python ../scripts/feature_flag.py disable --user zzstoatzz.io --flag skip-buttons
 
 # list flags for a user
 DATABASE_URL="..." uv run python ../scripts/feature_flag.py list --user zzstoatzz.io
@@ -110,13 +115,16 @@ users can be specified by handle or DID.
 
 ## adding a new flag
 
-1. **add to KNOWN_FLAGS** in `backend/_internal/feature_flags.py`:
+1. **add to KNOWN_FLAGS** in `backend/src/backend/_internal/feature_flags.py`:
    ```python
    KNOWN_FLAGS = frozenset({
-       "lossless-uploads",
+       "vibe-search",
+       "copyright-paradigm",
+       "skip-buttons",
        "new-feature",  # description of what this enables
    })
    ```
+   and the matching `NEW_FEATURE_FLAG` constant in `frontend/src/lib/config.ts`.
 
 2. **check the flag** in backend code where the feature is gated:
    ```python

--- a/docs/internal/backend/resumable-uploads.md
+++ b/docs/internal/backend/resumable-uploads.md
@@ -74,9 +74,19 @@ browser                                api                              R2 / wor
 
 `frontend/src/lib/upload-session.ts` is the transport: `startUploadSession`,
 `uploadParts` (3 in flight, a 60s *stall* timeout per part — measured from the last progress event, so a slow part is never cut off — plus a 15 min ceiling, 5 attempts with exponential
-backoff, progress = acknowledged bytes), `finishUploadSession`. it takes an
-injectable `send` so its tests exercise the retry and progress logic without a
-DOM. `uploader.svelte.ts` composes it with the unchanged SSE follow-up.
+backoff, progress = acknowledged bytes), `getUploadSession` (which parts the
+server holds, for resuming), `finishUploadSession`. it takes an injectable
+`send` so its tests exercise the retry and progress logic without a DOM.
+
+`frontend/src/lib/staged-transfer.svelte.ts` wraps the transport as observable
+state — `StagedTransfer` with `status`/`loaded`/`total`/`error`, `retry()`
+resuming from `received_parts`, `abort()` — and `uploader.svelte.ts` composes
+that with the unchanged SSE follow-up: `uploader.stage(file)` starts a
+transfer, `uploader.upload(staged | file, …)` waits for it and calls `finish`.
+the `/upload` page stages **at submit**, not at file selection: a chosen file
+is previewed from the local file (`AudioPreview.svelte`) and nothing leaves
+the browser until the user presses upload (#1957 withdrew transfer-on-select —
+a mistakenly chosen file must not sit in staging).
 
 `replaceAudio` (`PUT /tracks/{id}/audio`) still uses the single-request path.
 

--- a/docs/internal/deployment/environments.md
+++ b/docs/internal/deployment/environments.md
@@ -65,7 +65,9 @@ connects to `plyr-dev` neon database, local Redis, and uses `fm.plyr.dev` atprot
 3. backend available at `https://api.plyr.fm`
 
 **frontend**:
-1. release script merges `main` → `production-fe` branch
+1. release script fast-forwards `production-fe` to `main` with a direct push
+   (`git push origin main:production-fe` — no local branch, no merge; the
+   push refuses a non-fast-forward the way `--ff-only` did)
 2. cloudflare pages production environment tracks `production-fe` branch
 3. uses production environment with `PUBLIC_API_URL=https://api.plyr.fm`
 4. available at `https://plyr.fm`
@@ -78,7 +80,8 @@ just release
 
 this will:
 1. create timestamped github tag (triggers backend deploy)
-2. merge main → production-fe (triggers frontend deploy)
+2. push main → production-fe (triggers frontend deploy)
+3. mirror `main` and the tags to tangled
 
 for a frontend-only diff, `just release` intentionally exits with “no backend
 changes since last release.” Use:

--- a/docs/internal/frontend/keyboard-shortcuts.md
+++ b/docs/internal/frontend/keyboard-shortcuts.md
@@ -81,6 +81,12 @@ seeks backward 10 seconds in the current track.
 
 seeks forward 10 seconds in the current track.
 
+both arrows go through `queue.seekBy(seconds)`, which clamps to the track.
+the step is a fixed 10 s here; the player's on-screen skip buttons (behind
+the `skip-buttons` flag) use a different, duration-dependent step from
+`$lib/skip-step.ts` (5 / 10 / 15 s), on purpose — the keys are a power-user
+nudge, the buttons are the visible affordance sized to the track.
+
 ### J - previous track
 
 goes to the previous track in the queue. if more than 3 seconds into the current track, restarts it instead.

--- a/docs/internal/frontend/passing-comments.md
+++ b/docs/internal/frontend/passing-comments.md
@@ -1,0 +1,83 @@
+---
+title: "passing comments"
+---
+
+a timestamped comment surfaces on the track page as playback crosses its
+moment — the soundcloud move. it is a small bubble that grows out of the
+comments trigger, lives a few seconds, and opens the comments panel when
+tapped. `TrackComments.svelte` owns the behavior; `lib/comment-emission.ts`
+owns the placement arithmetic, which is pure and tested.
+
+## the stack
+
+every comment whose `timestamp_ms` falls between the previous playback tick
+and the current one is surfaced (a jump or the first tick after play/seek is
+skipped, so seeking never sprays missed comments). bubbles form an ephemeral
+stack:
+
+- newest nearest the trigger; each bubble lives `EMISSION_TTL_MS` (4 s) on
+  its own timer; a comment already showing has its timer refreshed rather
+  than being duplicated
+- capped at `EMISSION_STACK_MAX` (3), or fewer if the band it sits in holds
+  fewer — the oldest leaves early when a burst exceeds the cap
+- bubbles enter with `emerge` (a short fade over a few px from the trigger's
+  side, `cubicOut`, no overshoot) and leave with a fade; the rest reflow with
+  `animate:flip`
+- tapping any bubble clears the stack and opens the panel
+
+## placement is measured, not named
+
+the trigger sits in a row of page content, and what surrounds that row
+differs by page and viewport: on phones the row is often the last thing
+above the fixed player; on desktop it sits 16 px under the listen count and
+against the player. a rule that names a region ("below the trigger", "above
+the row") is blind to that, and every version that used one covered
+something. so the component measures four free bands from the DOM at
+emission time (`freeBands()`):
+
+- **below**: from the row's bottom to the next sibling's top or the player's
+  top, whichever is nearer
+- **above**: from the previous sibling's bottom (or the header clearance) to
+  the row's top
+- **right** / **left**: along the row, from the trigger to its neighbour or
+  the viewport margin, less anything fixed drawn over that stretch (the queue
+  toggle), and zero if the trigger itself is under the player
+
+`emissionLayout(bands)` then picks: the roomier vertical band, capped to the
+whole bubbles that fit (`emissionCapacity`: the first needs the 6 px row
+offset plus its 36 px height, each further one 4 px more — the same numbers
+the css uses); else the roomier side, one bubble sized to that room; else
+docked at the player's edge, one bubble, the only case where covering
+something is accepted because nothing else is visible.
+
+horizontally the stack is centered on the trigger, kept inside the viewport,
+and moved off anything fixed drawn over its ends. the probe is
+`document.elementsFromPoint` at the ends of where the stack will sit *after*
+the viewport clamp (an end past the viewport edge sees nothing), 8 and 24 px
+in and 8 px past each end, and the obstacle is the nearest `button`/`a`
+ancestor of the hit, not the icon inside it. the tail is counter-shifted so
+it still points at the trigger.
+
+## the icon is the source
+
+when a comment passes, the trigger takes one breath: its colour eases to the
+accent and the icon pulses once to 1.08 and back over 520 ms; the bubble
+emerges 140 ms after that begins. one gesture, not four — an earlier version
+had an expanding ring, a count bump, a glow and an overshoot, and read as
+"corny and heavy handed". `prefers-reduced-motion` gets a plain fade with no
+pulse.
+
+## verifying a change
+
+placement can only be judged in the real page. the pattern that caught every
+regression in the #1962–#1980 arc: post a burst of timestamped comments on a
+staging track as the test account, play from just before them at 390×640 and
+390×844 and at a desktop size with the row scrolled into view, and read the
+stack's rect against the row, the player and the queue toggle every ~300 ms.
+a screenshot at one size is not a check; the failures were always at the
+other size.
+
+## sources
+
+- PRs #1962, #1968–#1980 (September 1–2, 2026); `STATUS.md` "passing
+  comments became a stack that reads the page"

--- a/docs/internal/frontend/state-management.md
+++ b/docs/internal/frontend/state-management.md
@@ -210,6 +210,34 @@ plyr.fm uses global state managers following the Svelte 5 runes pattern for cros
 - shows toast notifications for progress/completion
 - triggers cache refresh on success
 - server-sent events for real-time progress
+- `stage(file)` returns a `StagedTransfer` (`frontend/src/lib/staged-transfer.svelte.ts`):
+  the resumable session as observable `$state` — `status`, `loaded`, `total`,
+  `error`, `retry()` resuming from the parts the server already holds,
+  `abort()`. `upload()` takes a `File` or a `StagedTransfer`. nothing leaves
+  the browser until the form is submitted; the `/upload` page stages at
+  submit time so the same card that previewed the file shows its transfer
+  (see `docs/internal/backend/resumable-uploads.md`)
+
+### audio probe (`frontend/src/lib/audio/probe.ts`)
+- what the browser can learn about an audio file locally: format from the
+  name, duration from the container header (`mediaDuration`, the
+  seek-past-the-end scan for header-less MediaRecorder output), and whether a
+  waveform can be decoded within a memory budget (`canRenderWaveform`)
+- `AudioPreview.svelte` (used by `/upload` and `/record`) owns the element and
+  the probing; `Waveform.svelte` decodes at a low sample rate through an
+  `OfflineAudioContext`, but decoding still costs the browser roughly 100 MB
+  of transient memory per minute of audio, so the caps are 10 min on desktop,
+  3 on touch, 100 MB either way
+
+### skip step (`frontend/src/lib/skip-step.ts`)
+- one ladder for how far a skip moves by track length: under 60 s → 5,
+  under 180 s → 10, else 15, and 15 before the duration is known. the player's
+  skip buttons, their labels, and the media-session seek handlers all read it;
+  `queue.seekBy(seconds)` owns the clamped relative seek
+
+### comment emission (`frontend/src/lib/comment-emission.ts`)
+- placement and capacity for the passing-comment bubbles on the track page;
+  see `docs/internal/frontend/passing-comments.md`
 
 ### tracks cache (`frontend/src/lib/tracks.svelte.ts`)
 - caches track list globally in localStorage
@@ -276,8 +304,14 @@ export const globalState = new GlobalState();
 
 ### upload flow
 
-1. user clicks upload on dedicated `/upload` page (linked from portal or ProfileMenu)
-2. `uploader.upload()` called - returns immediately
+1. user opens the dedicated `/upload` page (linked from portal or ProfileMenu)
+   and chooses a file; `AudioPreview` shows format, size, duration, a
+   waveform (under the decode cap) and playback, all from the local file —
+   nothing has been sent yet
+2. on submit, `uploader.stage(file)` opens the resumable session and sends the
+   parts (the card shows the transfer bar, with retry on a drop), then
+   `uploader.upload(staged, …)` waits for it and calls `finish` — returns
+   immediately
 3. user navigates to homepage
 4. homepage renders cached tracks instantly (no blocking)
 5. upload completes in background
@@ -353,11 +387,18 @@ when a track plays, we update `navigator.mediaSession.metadata` with:
 
 ### action handlers
 
-set up in `onMount`, these respond to system media controls:
-- `play` / `pause` - toggle playback
-- `previoustrack` / `nexttrack` - navigate queue
-- `seekto` - jump to position
-- `seekbackward` / `seekforward` - skip 10 seconds
+these respond to system media controls:
+- `play` / `pause` - toggle playback (registered once)
+- `seekto` - jump to position (registered once; load-bearing — without it iOS
+  renders the lock-screen scrubber but ignores drags)
+- `previoustrack` / `nexttrack` - navigate queue; (de)registered reactively
+  from `queue.hasPrevious` / `queue.hasNext` and radio mode, because the OS
+  only shows ⏮/⏭ for commands it believes are live
+- `seekbackward` / `seekforward` - registered reactively only for users with
+  the `skip-buttons` flag and not in radio mode; the offset is the OS's
+  `seekOffset` when it sends one, else `skipStepSeconds(player.duration)`.
+  once these exist, iOS shows ±skip buttons in place of ⏮/⏭ — that trade is
+  why they are flagged
 
 ### position state
 
@@ -365,7 +406,9 @@ reactive effects keep `navigator.mediaSession.setPositionState()` synced with pl
 
 ### implementation notes
 
-- handlers are registered once in `onMount`
+- play/pause/seekto are registered once in `onMount`; prev/next and the skip
+  handlers are `$effect`s that call `setActionHandler(action, fn | null)` —
+  a no-op inside a callback tells the OS nothing, registration does
 - metadata updates reactively via `$effect` when `player.currentTrack` changes
 - playback state syncs reactively with `player.paused`
 - position updates on every `player.currentTime` / `player.duration` change

--- a/docs/plans/2026-08-31-client-side-writes.md
+++ b/docs/plans/2026-08-31-client-side-writes.md
@@ -1,0 +1,183 @@
+> **status (2026-09-02): phase 0 shipped as #1948–#1950 and was reverted the
+> same day in #1952.** it made the frontend a second OAuth client and chained
+> its consent after the cookie login, so every sign-in showed two
+> authorization screens. the rule that came out of it: **there is exactly one
+> login flow; scope grows only when the user reaches for a feature that needs
+> it, never at sign-in and never for a scope nothing uses yet.** the direction
+> below stands; the "sign-in chaining" design in phase 0 does not, and must be
+> redesigned before any phase ships. this file is restored from the reverted
+> commit so the direction and the rejected design are both on record.
+
+# plan: client-side writes — the browser authors records, plyr becomes the appview
+
+**date**: 2026-08-31
+**context**: the direction settled after #1947 — the backend should not be writing
+records on users' behalf. the file an artist uploads goes in their PDS as-is;
+plyr indexes, mirrors for delivery, and serves app state. this plan makes that
+migration incremental: one write type at a time, staging-proven, measured, with
+the server path as the standing fallback.
+
+## goal
+
+records in `fm.plyr.*` are written by the signed-in user's own browser session
+(`@atproto/oauth-client-browser` → `Agent` → `com.atproto.repo.createRecord` /
+`uploadBlob`), and the backend's role for those writes shrinks to what an
+appview does: verify, index, mirror, serve.
+
+## current state
+
+- the backend is a confidential OAuth client and authors every record. the
+  browser holds only an opaque session cookie.
+- the appview half already runs: jetstream ingests `fm.plyr.*` from any repo;
+  `ingest_track_create` / `ingest_like_create` / `ingest_like_delete` exist;
+  `mirror_pds_blob` copies PDS audio into R2; reserve-then-publish handles the
+  backend's own record echoes.
+- plyr serves a `did:web` document (`api/meta.py`), so it can verify
+  service-auth JWTs when identity migrates.
+- #1947's resumable upload is the GA upload path and remains so until the
+  upload phase here replaces it.
+
+## resolved decisions (evidence in the 2026-08-30/31 session)
+
+- **no feature flag / opt-in.** the fallback that must exist anyway — no
+  browser session ⇒ use the server endpoint — is the degradation mechanism.
+  merge → staging (e2e) → prod, per phase. revert is a frontend deploy.
+- **scopes grow progressively.** the authserver requires consent only for
+  scopes not previously granted to this client
+  (`oauth-provider.ts:checkConsentRequired`); re-auth with granted scopes is a
+  silent redirect. each phase adds its `repo:`/`blob:` scopes via the existing
+  scope-upgrade redirect pattern. phase 1 requests exactly
+  `atproto repo:fm.plyr.like?action=create&action=delete`.
+- **the browser client is a public client** with its own permanent identity:
+  `client_id` = `https://plyr.fm/oauth-client-metadata.json` (served by the
+  frontend, derived from the request origin so staging gets
+  `https://stg.plyr.fm/...`). choose once; grants are keyed to it.
+- **verified echo, not trust and not waiting.** after a client write, the
+  client calls the appview with the `at://` URI; the appview fetches the
+  record from the PDS itself and indexes it through the same ingest functions
+  jetstream uses. this preserves read-your-own-write and makes jetstream loss
+  (#1796) non-fatal for our own users. the claim is never trusted — the PDS
+  read is the source. this is the plan's one new API route.
+
+## not doing (until the pattern is proven)
+
+- private media / spaces writes (permissioned scope in a browser session is
+  its own design)
+- teal scrobbles, SDK/dev-token surface, Subsonic
+- retiring the cookie session or the confidential client (that is the final
+  identity phase, and only after every write has migrated)
+- transcoded renditions in the PDS: from the upload phase onward the PDS blob
+  is the uploaded file, and plyr-side mp3s never overwrite it
+
+## phases
+
+### phase 0: the browser session exists
+
+**changes**:
+- `frontend/src/routes/oauth-client-metadata.json/+server.ts` — public-client
+  metadata derived from origin (`token_endpoint_auth_method: "none"`,
+  `dpop_bound_access_tokens: true`, phase-1 scope). loopback client for
+  127.0.0.1 dev (rally's `src/data/oauth.ts` is the model).
+- `frontend/src/lib/atproto/client.ts` — `BrowserOAuthClient` setup,
+  `client.init()` on boot, `restore(did)`, session store; exposes
+  `agentFor(did): Agent | null`.
+- ~~sign-in chaining: after the existing cookie callback completes
+  (`/auth/callback` bounce), if no browser session exists for the signed-in
+  DID, run `client.signIn(handle)` once. subsequent sign-ins are silent
+  (consent already granted).~~ **rejected** — a second `client_id` is a
+  second consent screen for every user, however "once" it is; see the status
+  note at the top.
+- `backend/src/backend/api/ingest.py` (new router, the one new surface):
+  `POST /ingest/record {uri}` — authenticated (cookie), owner-checked
+  (URI repo == session DID), fetches the record from the user's PDS
+  (`is_safe_url`-validated endpoint, same stance as ingest), dispatches to the
+  existing `ingest_*` function for the collection; 404s for collections we
+  don't index. rate-limited.
+- logfire baselines: jetstream ingest lag for `fm.plyr.like`, like-endpoint
+  latency/error rates.
+
+**success criteria**:
+- [ ] `just backend test` + `bun run check && bun run lint && bun run test`
+- [ ] staging: sign in fresh → exactly one extra consent screen, then a
+      browser session exists (`client.restore(did)` returns an agent); second
+      sign-in shows no consent screen
+- [ ] e2e sign-in flow (`frontend/e2e/lib.mjs signIn`) updated for the chained
+      authorize and green
+- [ ] `POST /ingest/record` with a hand-written like record (pdsx) indexes it;
+      with a forged URI for another repo it 403s
+
+### phase 1: likes
+
+**changes**:
+- `frontend/src/lib/likes` call sites (LikeButton flows): with a browser
+  session — `createRecord`/`deleteRecord` on `fm.plyr.like` (record shape
+  mirrors `_internal/atproto/records/fm_plyr/like.py`; rkey/subject semantics
+  copied exactly), optimistic UI, then `POST /ingest/record`; without one —
+  the existing `POST /tracks/{id}/like` endpoint, unchanged.
+- backend: nothing removed. `ingest_like_create`/`ingest_like_delete` handle
+  the echo and the jetstream copy idempotently (verify + regression test).
+- logfire: tag client-written likes (the echo route) so the two paths are
+  comparable.
+
+**success criteria**:
+- [ ] regression test: echo then jetstream replay of the same like does not
+      double-count; delete echo then replay does not resurrect
+- [ ] staging e2e: like a track with a browser session → liked list contains
+      it in the same page load; unlike → gone (the #1812 assertion, now on the
+      client path)
+- [ ] parity gate before prod promote: client-path like p95
+      time-to-indexed ≤ server-path p95 + jetstream lag baseline unchanged,
+      error rate not worse, over ≥ a week of staging + own-use on prod
+- [ ] pull the plug drill: with the echo route 500ing (staged fault), likes
+      still land via jetstream and the UI's optimistic state survives
+
+### phase 2: comments, then lists (albums/playlists), then profile
+
+same pattern per collection: scope upgrade adds `repo:fm.plyr.comment` (etc.),
+client writes + echo, server endpoint kept as fallback, ingest idempotency
+regression tests, parity gate. lists carry an extra check: ordered-membership
+semantics under interleaved client/jetstream delivery (#1736's unordered-update
+caveat applies to lists — the version guard work may become a prerequisite
+here; decide when phase 1 data is in).
+
+### phase 3: track upload
+
+**changes**:
+- scope upgrade adds `repo:fm.plyr.track` + `blob:audio/*`.
+- `frontend/src/lib/uploader.svelte.ts`: with a browser session —
+  `uploadBlob` (the file as chosen, one XHR with progress) then
+  `createRecord` with the `BlobRef`, then echo; the SSE job UI is replaced by
+  ingest-driven state for this path. without a session — the #1947 resumable
+  path, unchanged.
+- `ingest_track_create` hardening for first-party volume: it becomes the
+  publish path, not the exception path (mirror scheduling, duplicate checks,
+  gating fields authored client-side).
+- `audio_optimize` stops writing mp3s to the PDS — renditions are plyr-side
+  delivery copies only.
+
+**success criteria**:
+- [ ] e2e upload through the browser session lands: record in the repo with
+      the original file's blob, R2 mirror exists, track plays
+- [ ] AIFF upload: PDS keeps the AIFF; plyr serves the mp3 rendition
+- [ ] parity gates on upload success rate and time-to-playable vs #1947 path
+
+### phase 4: identity
+
+backend endpoints accept a service-auth JWT (`aud` = plyr's `did:web`,
+`lxm` check — `packages/bsky/src/auth-verifier.ts` is the model) alongside the
+cookie; the browser calls plyr through the PDS (`Agent.withProxy` /
+`atproto-proxy`) or directly with the JWT. once client writes are GA, sign-in
+becomes the browser client alone; the confidential client and cookie shrink to
+the SDK/dev-token surface. detailed separately when reached — this plan only
+commits to not blocking it.
+
+## testing
+
+- ingest idempotency (echo + jetstream replay) is the load-bearing invariant;
+  every phase adds its regression tests there
+- staging e2e extends per phase (sign-in chain, client-side like, later
+  client-side upload)
+- parity gates are logfire queries, written down with the phase, run before
+  each prod promote
+- fault drills: echo route down; jetstream blind window (#1796) — client
+  writes must survive both

--- a/docs/public/artists.md
+++ b/docs/public/artists.md
@@ -25,7 +25,7 @@ your catalog isn't trapped here — other apps can access your tracks without pl
 
    ![plyr.fm sign-in page — enter your atmosphere account to get started](/screenshots/login-page.png)
 
-2. **upload** — click the upload button and drop your audio file (MP3, WAV, or M4A)
+2. **upload** — click the upload button and choose your audio file (MP3, WAV, M4A, FLAC, AIFF). as soon as you pick it, the form shows what it knows about the file — format, size, length, a waveform for shorter tracks, and a play button to check it's the right one — without sending anything. nothing leaves your browser until you press upload, so picking the wrong file costs nothing.
 
    ![the upload form — title, audio file, description, album, tags, and artwork](/screenshots/upload-form.png)
 

--- a/docs/public/listeners.md
+++ b/docs/public/listeners.md
@@ -87,6 +87,7 @@ if there's no download icon, the artist has switched downloads off, or the audio
 | key | action |
 |-----|--------|
 | `space` | play / pause |
+| `←` / `→` | seek back / forward 10 seconds |
 | `j` | previous track |
 | `l` | next track |
 | `q` | toggle queue |

--- a/docs/public/troubleshooting.md
+++ b/docs/public/troubleshooting.md
@@ -37,8 +37,9 @@ description: "common issues and solutions for plyr.fm"
 
 **solutions**:
 - check file size — uploads are limited (see `GET /config` for current limits)
-- supported formats: **MP3**, **WAV**, **M4A**. other formats will be rejected
-- ensure you have a stable connection — large files (especially WAV) upload via streaming and can fail on intermittent connections
+- supported formats: **MP3**, **WAV**, **M4A**, **FLAC**, **AIFF**. other formats will be rejected
+- picked the wrong file? just choose another — nothing is sent until you press upload
+- ensure you have a stable connection — large files (especially WAV) go up in parts, and a dropped part is retried; if the card under the file shows a failure, its **retry** picks up from the parts that already arrived
 - check the upload progress indicator in the portal for status
 
 ### track appears without audio

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -3,14 +3,18 @@
 SvelteKit with bun (not npm/pnpm).
 
 key patterns:
-- **state**: global managers in `lib/*.svelte.ts` using `$state` runes (player, queue, uploader, tracks cache)
+- **state**: global managers in `lib/*.svelte.ts` using `$state` runes (player, queue, uploader, tracks cache; `staged-transfer.svelte.ts` is a per-upload state object the uploader hands out)
 - **components**: reusable ui in `lib/components/` (LikeButton, Toast, Player, etc)
 - **routes**: pages in `routes/` with `+page.svelte` and `+page.ts` for data loading
-- **design tokens**: use CSS variables from `+layout.svelte` - never hardcode colors, radii, or font sizes (see `docs/frontend/design-tokens.md`)
+- **design tokens**: use CSS variables from `+layout.svelte` - never hardcode colors, radii, or font sizes (see `docs/internal/frontend/design-tokens.md`)
 
 gotchas:
-- **svelte 5 runes mode**: component-local state MUST use `$state()` - plain `let` has no reactivity (see `docs/frontend/state-management.md`)
+- **svelte 5 runes mode**: component-local state MUST use `$state()` - plain `let` has no reactivity (see `docs/internal/frontend/state-management.md`)
 - toast positioning: bottom-left above player footer (not top-right)
 - queue sync: uses BroadcastChannel for cross-tab, not SSE
 - preferences: managed in UserMenu (desktop) and ProfileMenu (mobile) components, not dedicated state file
 - keyboard shortcuts: handled in root layout (+layout.svelte), with context-aware filtering
+- keyboard seeks go through `queue.seekBy()` at a fixed 10 s; the player's skip buttons (flag `skip-buttons`) use the duration ladder in `lib/skip-step.ts` — two rules on purpose
+- flag-gated UI reads `auth.user?.enabled_flags` against a constant in `lib/config.ts`; never ship a flagged feature into the public docs as if it were GA
+- icons with text inside an svg inside a `<button>`: the button must `font-family: inherit` or the text renders in the UA font, not the app's `--font-family`; serif fonts need `font-variant-numeric: lining-nums`
+- the passing-comment bubbles on the track page measure their room from the DOM (`lib/comment-emission.ts`); don't place them by rule — see `docs/internal/frontend/passing-comments.md`


### PR DESCRIPTION
a sweep of `docs/` and the CLAUDE.md files against everything shipped September 1–2. the one surprise: the revert of client-writes phase 0 (#1952) deleted `docs/plans/2026-08-31-client-side-writes.md`, so the rule that came out of the revert — one login flow, scope only when a feature needs it — lived nowhere but STATUS.md. restored from the reverted commit with a status note at the top and the sign-in-chaining design struck through as rejected.

<details>
<summary>stale → current</summary>

- `docs/internal/backend/feature-flags.md`: `KNOWN_FLAGS` listed `lossless-uploads` and `pds-audio-uploads`, neither of which exists; now `vibe-search`, `copyright-paradigm`, `skip-buttons`, the real file path, the `$lib/config.ts` constant pattern, and the note that flag-gated UI is not GA and stays out of the public docs.
- `docs/internal/frontend/state-management.md`: uploader gains `stage()`/`StagedTransfer`; new sections for the audio probe (with the measured decode budget), the skip-step ladder, and comment emission; the media-session action handlers are described as they are — play/pause/seekto once, prev/next reactive, skip handlers reactive and flag-gated, with the iOS trade named; the upload flow example starts with the local preview and sends nothing until submit.
- `docs/internal/frontend/keyboard-shortcuts.md`: arrows route through `queue.seekBy()`; the deliberate difference between the fixed 10 s keys and the duration-ladder buttons is stated.
- `docs/internal/deployment/environments.md`: the frontend release step is a fast-forward push, not a merge; the tangled mirror step is listed.
- `docs/internal/backend/resumable-uploads.md`: client section names `getUploadSession`, the staged transfer, and that staging happens at submit (why #1957 withdrew transfer-on-select).
- `docs/public/artists.md`, `troubleshooting.md`, `listeners.md`: the preview card and "nothing leaves your browser until you press upload"; the real format list (FLAC and AIFF were missing); retry from received parts; the arrow-key seeks in the shortcut table. the flagged skip buttons are deliberately not documented publicly.
- `frontend/CLAUDE.md`: two broken doc links fixed; `staged-transfer`; the two seek rules; flag-gated UI; the svg-text-in-button font gotcha; the comment-bubble pointer.
- `backend/src/backend/_internal/CLAUDE.md`: notifications was absent; now describes the bot's session recovery (#1953).
- `docs/internal/README.md`: index gains `resumable-uploads.md` and seven frontend docs that existed but were unlisted.
</details>

<details>
<summary>new</summary>

- `docs/internal/frontend/passing-comments.md`: the stack, why placement is measured from the DOM rather than named, the capacity arithmetic, the obstacle probe, the icon's breath, and how to verify a change (the burst replay at three sizes that caught every regression in #1962–#1980).
</details>

not touched: dated retrospectives and research notes, which describe their moment; `docs/site/public/screenshots/upload-form.png`, which predates the preview card — the alt text still describes the fields correctly, and a fresh capture is a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z