### PR TITLE
status maintenance: run weekly on a schedule

### DIFF
--- a/.github/workflows/status-maintenance.yml
+++ b/.github/workflows/status-maintenance.yml
@@ -12,6 +12,9 @@
 name: status maintenance
 
 on:
+  schedule:
+    # mondays 14:00 UTC (9am central): archive, podcast, PR — a human still merges
+    - cron: "0 14 * * 1"
   workflow_dispatch:
     inputs:
       skip_audio:

--- a/docs/internal/tools/status-maintenance.md
+++ b/docs/internal/tools/status-maintenance.md
@@ -17,10 +17,14 @@ automated workflow that archives old STATUS.md content and generates audio updat
 
 ## triggers
 
-- **manual**: `workflow_dispatch` (run from Actions tab)
+- **weekly**: `schedule` — mondays 14:00 UTC (9am central). the run opens the
+  PR; a human merges it, and the merge triggers the audio upload
+- **manual**: `workflow_dispatch` (run from Actions tab, or
+  `gh workflow run "status maintenance" --ref main`)
 - **on PR merge**: uploads audio after status-maintenance PR is merged
 
-schedule is currently disabled but can be enabled for weekly runs.
+github pauses scheduled workflows in repositories with no activity for 60
+days; a push re-enables them.
 
 ## how it determines the time window
 


### PR DESCRIPTION
the workflow's job condition already accepted `schedule` but none was defined, so the archive + podcast + PR only happened when someone remembered to dispatch it (and on 2026-09-02 nobody did). mondays 14:00 UTC. the run still only opens a PR; merging it — and therefore the audio upload — stays a human step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z