### PR TITLE
status maintenance: post the podcast transcript into the PR body

### DIFF
--- a/.github/workflows/status-maintenance.yml
+++ b/.github/workflows/status-maintenance.yml
@@ -284,6 +284,26 @@ jobs:
         id: prbranch
         run: echo "branch=$(git branch --show-current)" >> "$GITHUB_OUTPUT"
 
+      # the transcript is what a reviewer needs before merging (the audio only
+      # uploads after the merge), so put it in the PR body where it can be read
+      - name: Post transcript to the PR
+        if: startsWith(steps.prbranch.outputs.branch, 'status-maintenance-')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.prbranch.outputs.branch }}
+        run: |
+          if [ ! -f podcast_script.txt ]; then
+            echo "no podcast_script.txt, nothing to post"
+            exit 0
+          fi
+          BODY=$(gh pr view "$BRANCH" --json body --jq .body)
+          {
+            printf '%s\n\n<details>\n<summary>podcast transcript</summary>\n\n```\n' "$BODY"
+            cat podcast_script.txt
+            printf '\n```\n\n</details>\n'
+          } > pr-body.md
+          gh pr edit "$BRANCH" --body-file pr-body.md
+
       - name: Upload audio + transcript artifact
         uses: actions/upload-artifact@v4
         with:

--- a/docs/internal/tools/status-maintenance.md
+++ b/docs/internal/tools/status-maintenance.md
@@ -8,8 +8,11 @@ automated workflow that archives old STATUS.md content and generates audio updat
 
 1. **archives old content**: moves previous month's sections from STATUS.md to `.status_history/YYYY-MM.md`
 2. **generates audio**: creates a podcast-style audio update covering recent work
-3. **opens PR**: commits changes and opens a PR for review
-4. **uploads audio**: after PR merge, uploads the audio to plyr.fm
+3. **opens PR**: commits changes and opens a PR for review, with the podcast
+   transcript in the PR body under a collapsible section so it can be read
+   before deciding to merge
+4. **uploads audio**: after PR merge, uploads the audio to plyr.fm (the
+   transcript becomes the track description)
 
 ## workflow file
 


### PR DESCRIPTION
nate: "post the transcript somewhere we can read so we can read it before we decide to merge the status maintenance PR."

`podcast_script.txt` was only a build artifact that became the track description after the merge. a deterministic step after the claude action now reads it and appends it to the maintenance PR's body under `<details><summary>podcast transcript</summary>`, via `gh pr edit --body-file`. runs only on `status-maintenance-*` branches and is a no-op when audio was skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z