### PR TITLE
player: spotify's footer structure and a like button, behind the skip-buttons flag

### DIFF
--- a/frontend/src/lib/components/AddToMenu.svelte
+++ b/frontend/src/lib/components/AddToMenu.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { likes } from '$lib/likes.svelte';
 	import { likeTrack, unlikeTrack } from '$lib/tracks.svelte';
 	import { toast } from '$lib/toast.svelte';
 	import { API_URL } from '$lib/config';
@@ -112,6 +113,7 @@
 				liked = previousState;
 				toast.error('failed to update like');
 			} else {
+				likes.record(trackId, liked);
 				onLikeChange?.(liked);
 				if (liked) {
 					toast.success(`liked ${trackTitle}`);

--- a/frontend/src/lib/components/LikeToggle.svelte
+++ b/frontend/src/lib/components/LikeToggle.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import { likes } from '$lib/likes.svelte';
+	import type { Track } from '$lib/types';
+
+	interface Props {
+		track: Track;
+		size?: number;
+	}
+
+	let { track, size = 18 }: Props = $props();
+
+	const liked = $derived(likes.isLiked(track));
+</script>
+
+<button
+	type="button"
+	class="like-toggle"
+	class:liked
+	onclick={() => void likes.toggle(track)}
+	aria-pressed={liked}
+	aria-label={liked ? `unlike ${track.title}` : `like ${track.title}`}
+	title={liked ? 'unlike' : 'like'}
+>
+	<svg
+		width={size}
+		height={size}
+		viewBox="0 0 24 24"
+		fill={liked ? 'currentColor' : 'none'}
+		stroke="currentColor"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		aria-hidden="true"
+	>
+		<path
+			d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"
+		></path>
+	</svg>
+</button>
+
+<style>
+	.like-toggle {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.4rem;
+		background: transparent;
+		border: none;
+		border-radius: var(--radius-full);
+		color: var(--text-tertiary);
+		cursor: pointer;
+		transition:
+			color 0.15s,
+			background 0.15s,
+			transform 0.15s;
+	}
+
+	.like-toggle:hover {
+		color: var(--accent);
+		background: color-mix(in srgb, var(--accent) 10%, transparent);
+	}
+
+	.like-toggle.liked {
+		color: var(--accent);
+	}
+
+	.like-toggle:active {
+		transform: scale(0.92);
+	}
+</style>

--- a/frontend/src/lib/components/Player.svelte
+++ b/frontend/src/lib/components/Player.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
 	import Player from './player/Player.svelte';
+
+	interface Props {
+		queueOpen?: boolean;
+		onToggleQueue?: () => void;
+	}
+
+	let { queueOpen = false, onToggleQueue }: Props = $props();
 </script>
 
-<Player />
+<Player {queueOpen} {onToggleQueue} />

--- a/frontend/src/lib/components/Queue.svelte
+++ b/frontend/src/lib/components/Queue.svelte
@@ -9,8 +9,7 @@
 	import SensitiveImage from './SensitiveImage.svelte';
 	import ScrollingText from './ScrollingText.svelte';
 	import { trackCoverUrl, trackThumbnailUrl } from '$lib/track-cover';
-	import { auth } from '$lib/auth.svelte';
-	import { likeTrack, unlikeTrack } from '$lib/tracks.svelte';
+	import { likes } from '$lib/likes.svelte';
 	import { swipeable, type SwipeState } from '$lib/swipe';
 	import { HINTS, hintSeen, markHintSeen } from '$lib/hints.svelte';
 	import {
@@ -174,21 +173,7 @@
 	}
 
 	async function handleSwipeLike(track: Track) {
-		if (!auth.isAuthenticated) {
-			toast.error('sign in to like tracks');
-			return;
-		}
-		if (track.is_liked) {
-			if (await unlikeTrack(track.id)) {
-				track.is_liked = false;
-				toast.info(`unliked ${track.title}`);
-			}
-			return;
-		}
-		if (await likeTrack(track.id, track.file_id, track.gated)) {
-			track.is_liked = true;
-			toast.success(`liked ${track.title}`);
-		}
+		await likes.toggle(track);
 	}
 
 
@@ -427,7 +412,7 @@
 		style="--swipe-progress: {swipe?.progress ?? 0}"
 	>
 		<div class="swipe-reveal like" aria-hidden="true">
-			<svg width="20" height="20" viewBox="0 0 24 24" fill={track.is_liked ? 'none' : 'currentColor'} stroke="currentColor" stroke-width="2">
+			<svg width="20" height="20" viewBox="0 0 24 24" fill={likes.isLiked(track) ? 'none' : 'currentColor'} stroke="currentColor" stroke-width="2">
 				<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
 			</svg>
 		</div>

--- a/frontend/src/lib/components/TrackActionsMenu.svelte
+++ b/frontend/src/lib/components/TrackActionsMenu.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { likes } from '$lib/likes.svelte';
 	import { likeTrack, unlikeTrack } from '$lib/tracks.svelte';
 	import { toast } from '$lib/toast.svelte';
 	import { API_URL } from '$lib/config';
@@ -136,6 +137,7 @@
 				liked = previousState;
 				toast.error('failed to update like');
 			} else {
+				likes.record(trackId, liked);
 				if (liked) {
 					toast.success(`liked ${trackTitle}`);
 				} else {

--- a/frontend/src/lib/components/player/PlaybackControls.svelte
+++ b/frontend/src/lib/components/player/PlaybackControls.svelte
@@ -7,8 +7,12 @@
 	import { SKIP_BUTTONS_FLAG } from '$lib/config';
 	import { skipStepSeconds } from '$lib/skip-step';
 
-	// radio mode: live stream — no prev/next or scrubbing, just play/pause + volume
-	let { radioMode = false }: { radioMode?: boolean } = $props();
+	import VolumeControl from './VolumeControl.svelte';
+
+	// radio mode: live stream — no prev/next or scrubbing, just play/pause + volume.
+	// stacked: the transport on one row and the scrubber on its own full-width
+	// row beneath it, with volume owned by the footer's right cluster
+	let { radioMode = false, stacked = false }: { radioMode?: boolean; stacked?: boolean } = $props();
 
 	const skipButtons = $derived(auth.user?.enabled_flags?.includes(SKIP_BUTTONS_FLAG) ?? false);
 	const skipStep = $derived(skipStepSeconds(player.duration));
@@ -23,12 +27,6 @@
 	let progressPercent = $derived.by(() => {
 		if (!player.duration || player.duration === 0) return 0;
 		return (seekValue / player.duration) * 100;
-	});
-
-	let volumeState = $derived.by(() => {
-		if (player.volume === 0) return 'muted';
-		if (player.volume >= 0.99) return 'max';
-		return 'normal';
 	});
 
 	function animateSeek() {
@@ -120,7 +118,24 @@
 	}
 </script>
 
-<div class="player-controls" class:radio-mode={radioMode}>
+<div class="player-controls" class:radio-mode={radioMode} class:stacked>
+	{#if stacked && !radioMode}
+		<button
+			class="control-btn shuffle"
+			class:active={queue.shuffle}
+			onclick={() => queue.toggleShuffle()}
+			title={queue.shuffle ? 'shuffle on' : 'shuffle'}
+			aria-pressed={queue.shuffle}
+		>
+			<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+				<polyline points="16 3 21 3 21 8"></polyline>
+				<line x1="4" y1="20" x2="21" y2="3"></line>
+				<polyline points="21 16 21 21 16 21"></polyline>
+				<line x1="15" y1="15" x2="21" y2="21"></line>
+				<line x1="4" y1="4" x2="9" y2="9"></line>
+			</svg>
+		</button>
+	{/if}
 	{#if radioMode}
 		<!-- live stream: a static ∞ marker holds play/pause in its normal slot
 		     instead of letting it jump left where the prev button used to be -->
@@ -243,38 +258,9 @@
 		<span class="live-pill">live</span>
 	{/if}
 
-	<div class="volume-control">
-		<div class="volume-icon" class:muted={volumeState === 'muted'}>
-			{#if volumeState === 'muted'}
-				<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-					<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
-					<line x1="23" y1="9" x2="17" y2="15"></line>
-					<line x1="17" y1="9" x2="23" y2="15"></line>
-				</svg>
-			{:else if volumeState === 'max'}
-				<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="max-volume">
-					<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
-					<path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>
-					<path d="M19.07 4.93a10 10 0 0 1 0 14.14"></path>
-				</svg>
-			{:else}
-				<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-					<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
-					<path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>
-				</svg>
-			{/if}
-		</div>
-		<input
-			type="range"
-			class="volume-bar"
-			class:muted={volumeState === 'muted'}
-			class:max={volumeState === 'max'}
-			min="0"
-			max="1"
-			step="0.01"
-			bind:value={player.volume}
-		/>
-	</div>
+	{#if !stacked}
+		<VolumeControl />
+	{/if}
 </div>
 
 <style>
@@ -335,6 +321,26 @@
 		transform: scale(0.95);
 	}
 
+	/* stacked (the stage layout): the transport centred on one row, the scrubber
+	   on a full-width row beneath — spotify's footer, which is what the flag tries */
+	.player-controls.stacked {
+		flex-wrap: wrap;
+		justify-content: center;
+		row-gap: 0.25rem;
+		column-gap: 0.75rem;
+	}
+
+	.player-controls.stacked .time-control {
+		flex-basis: 100%;
+		max-width: 722px;
+		margin: 0 auto;
+	}
+
+	.control-btn.shuffle svg {
+		width: 18px;
+		height: 18px;
+	}
+
 	/* the step count lives inside the svg so it scales with the glyph; the button
 	   must pass the app font down — a <button> otherwise carries the UA font */
 	.control-btn.skip {
@@ -378,45 +384,8 @@
 		font-variant-numeric: tabular-nums;
 	}
 
-	.seek-bar,
-	.volume-bar {
+	.seek-bar {
 		flex: 1;
-	}
-
-	.volume-control {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		color: var(--text-tertiary);
-		min-width: 140px;
-		position: relative;
-	}
-
-	.volume-icon {
-		display: flex;
-		align-items: center;
-		transition: all 0.3s;
-	}
-
-	.volume-icon.muted {
-		color: var(--error);
-		animation: shake 0.5s ease-in-out;
-	}
-
-	.volume-icon .max-volume {
-		color: var(--accent);
-		animation: pulse 0.5s ease-in-out;
-	}
-
-	@keyframes shake {
-		0%, 100% { transform: translateX(0); }
-		25% { transform: translateX(-3px); }
-		75% { transform: translateX(3px); }
-	}
-
-	@keyframes pulse {
-		0%, 100% { transform: scale(1); }
-		50% { transform: scale(1.15); }
 	}
 
 	input[type="range"] {
@@ -456,15 +425,6 @@
 		box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 20%, transparent);
 	}
 
-	input[type="range"].muted::-webkit-slider-thumb {
-		background: var(--error);
-	}
-
-	input[type="range"].max::-webkit-slider-thumb {
-		background: var(--accent);
-		box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 30%, transparent);
-	}
-
 	input[type="range"]::-moz-range-track {
 		background: color-mix(in srgb, var(--accent) 20%, transparent);
 		height: 4px;
@@ -491,15 +451,6 @@
 		background: var(--accent-hover);
 		transform: scale(1.2);
 		box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 20%, transparent);
-	}
-
-	input[type="range"].muted::-moz-range-thumb {
-		background: var(--error);
-	}
-
-	input[type="range"].max::-moz-range-thumb {
-		background: var(--accent);
-		box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 30%, transparent);
 	}
 
 	@media (max-width: 768px) {
@@ -529,6 +480,10 @@
 			grid-column: 7;
 		}
 
+		.control-btn.shuffle {
+			display: none;
+		}
+
 		/* skips sit on the scrubber row, under the thumb, not in the transport row */
 		.control-btn.skip {
 			grid-row: 2;
@@ -548,7 +503,6 @@
 			width: 24px;
 			height: 24px;
 		}
-
 
 		.control-btn svg {
 			width: 28px;
@@ -586,8 +540,5 @@
 			min-width: 38px;
 		}
 
-		.volume-control {
-			display: none;
-		}
 	}
 </style>

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -22,9 +22,22 @@
 	import { loginHref } from '$lib/utils/auth-redirect';
 	import { SKIP_BUTTONS_FLAG } from '$lib/config';
 	import { skipStepSeconds } from '$lib/skip-step';
+
+	interface Props {
+		queueOpen?: boolean;
+		onToggleQueue?: () => void;
+	}
+
+	let { queueOpen = false, onToggleQueue }: Props = $props();
+
+	// the stage layout: spotify's three regions, behind the same per-user flag
+	// as the skip buttons while it is judged
+	const stage = $derived(auth.user?.enabled_flags?.includes(SKIP_BUTTONS_FLAG) ?? false);
 	import { auth } from '$lib/auth.svelte';
 	import TrackInfo from './TrackInfo.svelte';
 	import PlaybackControls from './PlaybackControls.svelte';
+	import VolumeControl from './VolumeControl.svelte';
+	import LikeToggle from '$lib/components/LikeToggle.svelte';
 	import type { Track } from '$lib/types';
 
 	// atprotofans base URL for supporter CTAs
@@ -912,14 +925,41 @@
 			</div>
 		{/if}
 
-		<div class="player-content">
+		<div class="player-content" class:stage>
 			<TrackInfo
 				track={nowPlayingTrack}
 				isOnTrackDetailPage={Boolean(isOnTrackDetailPage)}
 				radioMode={Boolean(player.radio)}
 				bind:this={trackInfoRef}
-			/>
-			<PlaybackControls radioMode={Boolean(player.radio)} />
+			>
+				{#snippet like()}
+					{#if stage && nowPlayingTrack && !player.radio && nowPlayingTrack.id}
+						<LikeToggle track={nowPlayingTrack} />
+					{/if}
+				{/snippet}
+			</TrackInfo>
+			<PlaybackControls radioMode={Boolean(player.radio)} stacked={stage} />
+			{#if stage}
+				<div class="stage-right">
+					{#if onToggleQueue}
+						<button
+							class="stage-btn"
+							class:active={queueOpen}
+							onclick={onToggleQueue}
+							aria-pressed={queueOpen}
+							aria-label="toggle queue (Q)"
+							title={queueOpen ? 'hide queue (Q)' : 'show queue (Q)'}
+						>
+							<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+								<line x1="3" y1="6" x2="21" y2="6"></line>
+								<line x1="3" y1="12" x2="21" y2="12"></line>
+								<line x1="3" y1="18" x2="21" y2="18"></line>
+							</svg>
+						</button>
+					{/if}
+					<VolumeControl />
+				</div>
+			{/if}
 		</div>
 	</div>
 {/if}
@@ -960,6 +1000,41 @@
 			grid-template-columns: minmax(160px, 360px) minmax(0, 1fr);
 			gap: 1rem;
 		}
+	}
+
+	/* the stage layout: track on the left, transport + scrubber centred, queue and
+	   volume on the right — spotify's footer, which is what the flag tries */
+	.player-content.stage {
+		grid-template-columns: minmax(180px, 30%) minmax(0, 1fr) minmax(180px, 30%);
+	}
+
+	.stage-right {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		gap: 0.75rem;
+	}
+
+	.stage-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.5rem;
+		background: transparent;
+		border: none;
+		border-radius: var(--radius-full);
+		color: var(--text-tertiary);
+		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.stage-btn:hover,
+	.stage-btn.active {
+		color: var(--accent);
+	}
+
+	.stage-btn.active {
+		background: color-mix(in srgb, var(--accent) 10%, transparent);
 	}
 
 	.player.jam-active { --top-bar-color: linear-gradient(90deg, #ff6b6b, #ffd93d, #6bcb77, #4d96ff, #9b59b6, #ff6b6b); }
@@ -1016,6 +1091,15 @@
 			grid-template-columns: 48px 1fr auto auto auto auto auto auto;
 			grid-template-rows: auto auto;
 			gap: 0.5rem 0.75rem;
+		}
+
+		/* the phone keeps its two rows; the right cluster is desktop chrome */
+		.player-content.stage {
+			grid-template-columns: 48px 1fr auto auto auto auto auto auto;
+		}
+
+		.stage-right {
+			display: none;
 		}
 	}
 </style>

--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import type { Track } from '$lib/types';
 	import { onMount } from 'svelte';
 	import { browser } from '$app/environment';
@@ -6,12 +7,14 @@
 	import { IMAGE_WIDTHS, resizedImageUrl } from '$lib/utils/display-image';
 
 	interface Props {
+		/** a heart rendered beside the title (the stage layout) */
+		like?: Snippet;
 		track: Track;
 		isOnTrackDetailPage: boolean;
 		radioMode?: boolean;
 	}
 
-	let { track, isOnTrackDetailPage, radioMode = false }: Props = $props();
+	let { track, isOnTrackDetailPage, radioMode = false, like }: Props = $props();
 
 	let titleEl = $state<HTMLElement | null>(null);
 	let artistEl = $state<HTMLElement | null>(null);
@@ -166,6 +169,9 @@
 			</div>
 		</div>
 	</div>
+	{#if like}
+		<div class="player-like">{@render like()}</div>
+	{/if}
 </div>
 
 <style>
@@ -202,6 +208,12 @@
 		width: 100%;
 		height: 100%;
 		object-fit: cover;
+	}
+
+	.player-like {
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
 	}
 
 	.player-artwork-placeholder {
@@ -403,6 +415,15 @@
 			height: 48px;
 			grid-row: 1;
 			grid-column: 1;
+		}
+
+		.player-like {
+			grid-row: 1;
+			grid-column: 3;
+		}
+
+		.player-track:has(.player-like) .player-info {
+			grid-column: 2 / 3;
 		}
 
 		.player-info {

--- a/frontend/src/lib/components/player/VolumeControl.svelte
+++ b/frontend/src/lib/components/player/VolumeControl.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+	import { player } from '$lib/player.svelte';
+
+	let volumeState = $derived.by(() => {
+		if (player.volume === 0) return 'muted';
+		if (player.volume >= 0.99) return 'max';
+		return 'normal';
+	});
+</script>
+
+<div class="volume-control">
+	<div class="volume-icon" class:muted={volumeState === 'muted'}>
+		{#if volumeState === 'muted'}
+			<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+				<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+				<line x1="23" y1="9" x2="17" y2="15"></line>
+				<line x1="17" y1="9" x2="23" y2="15"></line>
+			</svg>
+		{:else if volumeState === 'max'}
+			<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="max-volume">
+				<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+				<path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>
+				<path d="M19.07 4.93a10 10 0 0 1 0 14.14"></path>
+			</svg>
+		{:else}
+			<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+				<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+				<path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>
+			</svg>
+		{/if}
+	</div>
+	<input
+		type="range"
+		class="volume-bar"
+		class:muted={volumeState === 'muted'}
+		class:max={volumeState === 'max'}
+		min="0"
+		max="1"
+		step="0.01"
+		aria-label="volume"
+		bind:value={player.volume}
+	/>
+</div>
+
+<style>
+	.volume-control {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		color: var(--text-tertiary);
+		min-width: 140px;
+		position: relative;
+	}
+
+	.volume-icon {
+		display: flex;
+		align-items: center;
+		transition: all 0.3s;
+	}
+
+	.volume-icon.muted {
+		color: var(--error);
+		animation: shake 0.5s ease-in-out;
+	}
+
+	.volume-icon .max-volume {
+		color: var(--accent);
+		animation: pulse 0.5s ease-in-out;
+	}
+
+	.volume-bar {
+		flex: 1;
+		-webkit-appearance: none;
+		appearance: none;
+		height: 4px;
+		background: var(--bg-hover);
+		border-radius: var(--radius-sm);
+		outline: none;
+		cursor: pointer;
+	}
+
+	.volume-bar::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		appearance: none;
+		width: 12px;
+		height: 12px;
+		border-radius: 50%;
+		background: var(--accent);
+		cursor: pointer;
+	}
+
+	.volume-bar::-moz-range-thumb {
+		width: 12px;
+		height: 12px;
+		border-radius: 50%;
+		background: var(--accent);
+		cursor: pointer;
+		border: none;
+	}
+
+
+	.volume-bar.muted::-webkit-slider-thumb {
+		background: var(--error);
+	}
+
+	.volume-bar.max::-webkit-slider-thumb {
+		background: var(--accent);
+		box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 30%, transparent);
+	}
+
+	.volume-bar.muted::-moz-range-thumb {
+		background: var(--error);
+	}
+
+	.volume-bar.max::-moz-range-thumb {
+		background: var(--accent);
+		box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 30%, transparent);
+	}
+
+	@keyframes shake {
+		0%,
+		100% {
+			transform: translateX(0);
+		}
+		25% {
+			transform: translateX(-2px);
+		}
+		75% {
+			transform: translateX(2px);
+		}
+	}
+
+	@keyframes pulse {
+		0%,
+		100% {
+			transform: scale(1);
+		}
+		50% {
+			transform: scale(1.15);
+		}
+	}
+
+	@media (max-width: 768px) {
+		.volume-control {
+			display: none;
+		}
+	}
+</style>

--- a/frontend/src/lib/likes.svelte.ts
+++ b/frontend/src/lib/likes.svelte.ts
@@ -1,0 +1,61 @@
+/**
+ * the one path for liking a track from any surface.
+ *
+ * a track's `is_liked` used to be flipped by whichever surface the tap
+ * happened on — the queue row, the track page's chip, the actions menu —
+ * each with its own optimistic copy, so two hearts for the same track could
+ * disagree. this owner keeps an overlay of the states it has set, keyed by
+ * track id, on top of whatever `is_liked` a track object arrived with; every
+ * heart reads through `isLiked()` and every tap goes through `toggle()`.
+ */
+
+import { auth } from './auth.svelte';
+import { toast } from './toast.svelte';
+import { likeTrack, unlikeTrack } from './tracks.svelte';
+import type { Track } from './types';
+
+class Likes {
+	#known = $state<Record<number, boolean>>({});
+	#pending = new Set<number>();
+
+	isLiked(track: Pick<Track, 'id' | 'is_liked'>): boolean {
+		return this.#known[track.id] ?? track.is_liked === true;
+	}
+
+	/** a surface that toggled a like on its own (the menus) tells the owner the result. */
+	record(trackId: number, liked: boolean): void {
+		this.#known[trackId] = liked;
+	}
+
+	/** optimistic flip, request, revert on failure. resolves to the liked state afterwards. */
+	async toggle(track: Track): Promise<boolean> {
+		if (!auth.isAuthenticated) {
+			toast.error('sign in to like tracks');
+			return this.isLiked(track);
+		}
+		if (this.#pending.has(track.id)) return this.isLiked(track);
+		const was = this.isLiked(track);
+		const next = !was;
+		this.#pending.add(track.id);
+		this.#known[track.id] = next;
+		track.is_liked = next;
+		if (track.like_count !== undefined) track.like_count = Math.max(0, track.like_count + (next ? 1 : -1));
+		try {
+			const ok = next ? await likeTrack(track.id, track.file_id, track.gated) : await unlikeTrack(track.id);
+			if (!ok) {
+				this.#known[track.id] = was;
+				track.is_liked = was;
+				if (track.like_count !== undefined) track.like_count = Math.max(0, track.like_count + (next ? -1 : 1));
+				toast.error('failed to update like');
+				return was;
+			}
+			if (next) toast.success(`liked ${track.title}`);
+			else toast.info(`unliked ${track.title}`);
+			return next;
+		} finally {
+			this.#pending.delete(track.id);
+		}
+	}
+}
+
+export const likes = new Likes();

--- a/frontend/src/lib/likes.test.ts
+++ b/frontend/src/lib/likes.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { likes } from './likes.svelte';
+import { auth } from './auth.svelte';
+import { toast } from './toast.svelte';
+import type { Track } from './types';
+
+// SAFETY: the owner reads only id, title, is_liked, like_count, file_id and gated; the rest of Track is never touched here
+const track = (id: number, liked = false): Track =>
+	({ id, title: `t${id}`, is_liked: liked, like_count: 3, file_id: 'f', gated: false }) as Track;
+
+const originalFetch = globalThis.fetch;
+const requests: string[] = [];
+let respond: (url: string) => Response = () => new Response('{}', { status: 200 });
+
+beforeEach(() => {
+	requests.length = 0;
+	respond = () => new Response('{}', { status: 200 });
+	globalThis.fetch = async (input, init) => {
+		const url = String(input);
+		requests.push(`${init?.method ?? 'GET'} ${new URL(url).pathname}`);
+		return respond(url);
+	};
+	auth.isAuthenticated = true;
+	toast.toasts = [];
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	auth.isAuthenticated = false;
+	toast.toasts = [];
+});
+
+describe('likes', () => {
+	it('flips optimistically, calls the endpoint, and every surface reads the same answer', async () => {
+		const t = track(7);
+		const done = likes.toggle(t);
+		expect(likes.isLiked(t)).toBe(true);
+		expect(t.like_count).toBe(4);
+		expect(await done).toBe(true);
+		expect(requests).toEqual(['POST /tracks/7/like']);
+		expect(likes.isLiked({ id: 7, is_liked: false })).toBe(true);
+		expect(toast.toasts.at(-1)?.message).toBe('liked t7');
+	});
+
+	it('reverts when the request fails', async () => {
+		const t = track(8, true);
+		respond = () => new Response('nope', { status: 500 });
+		expect(await likes.toggle(t)).toBe(true);
+		expect(t.is_liked).toBe(true);
+		expect(t.like_count).toBe(3);
+		expect(requests).toEqual(['DELETE /tracks/8/like']);
+		expect(toast.toasts.at(-1)?.message).toBe('failed to update like');
+	});
+
+	it('refuses without a session and asks for sign-in', async () => {
+		auth.isAuthenticated = false;
+		const t = track(9);
+		expect(await likes.toggle(t)).toBe(false);
+		expect(requests).toEqual([]);
+		expect(toast.toasts.at(-1)?.message).toBe('sign in to like tracks');
+	});
+
+	it('takes a result recorded by another surface', () => {
+		likes.record(10, true);
+		expect(likes.isLiked({ id: 10, is_liked: false })).toBe(true);
+	});
+});

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { SKIP_BUTTONS_FLAG } from '$lib/config';
 	import favicon from '$lib/assets/favicon.png';
 	import {
 		APP_NAME,
@@ -541,6 +542,7 @@
 {#if !isEmbed}
 	<button
 		class="queue-toggle"
+		class:stage={auth.user?.enabled_flags?.includes(SKIP_BUTTONS_FLAG) ?? false}
 		onclick={toggleQueue}
 		aria-pressed={showQueue}
 		aria-label="toggle queue (Q)"
@@ -553,7 +555,7 @@
 		</svg>
 	</button>
 
-	<Player />
+	<Player queueOpen={showQueue} onToggleQueue={toggleQueue} />
 {/if}
 <Toast />
 <SearchModal />
@@ -803,6 +805,13 @@
 	@supports (height: 100dvh) {
 		.queue-sidebar {
 			height: 100dvh; /* dynamic viewport height (accounts for mobile browser UI) */
+		}
+	}
+
+	/* the stage footer carries its own queue button on desktop */
+	@media (min-width: 769px) {
+		.queue-toggle.stage {
+			display: none;
 		}
 	}
 

--- a/loq.toml
+++ b/loq.toml
@@ -95,7 +95,7 @@ max_lines = 523
 
 [[rules]]
 path = "frontend/src/lib/components/AddToMenu.svelte"
-max_lines = 805
+max_lines = 806
 
 [[rules]]
 path = "frontend/src/lib/components/ProfileMenu.svelte"
@@ -111,7 +111,7 @@ max_lines = 627
 
 [[rules]]
 path = "frontend/src/lib/components/TrackActionsMenu.svelte"
-max_lines = 797
+max_lines = 799
 
 [[rules]]
 path = "frontend/src/lib/components/TrackItem.svelte"
@@ -123,7 +123,7 @@ max_lines = 622
 
 [[rules]]
 path = "frontend/src/lib/components/player/Player.svelte"
-max_lines = 1021
+max_lines = 1105
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"
@@ -131,7 +131,7 @@ max_lines = 999
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"
-max_lines = 858
+max_lines = 860
 
 [[rules]]
 path = "frontend/src/routes/costs/+page.svelte"


### PR DESCRIPTION
nate: standardize the player by copying spotify's structure and stop experimenting with it; the first concrete gain is a like button in the global player. phase A of the pitch, staging only, behind the existing per-user `skip-buttons` flag.

**the footer, flagged.** three regions like spotify's: left — artwork, title/artist and a heart; centre — `[shuffle][back][prev][play][next][fwd][repeat]` with the scrubber on its own full-width row beneath (max 722 px, centred); right — queue toggle and volume. on the phone the two-row layout stays and the heart appears beside the title, where spotify's compact bar puts it; the right cluster is desktop chrome. the floating queue button hides on desktop for flagged users since the footer carries one. unflagged users see the current footer untouched.

**likes get one owner.** `lib/likes.svelte.ts`: `isLiked(track)` reads an overlay of states the owner has set on top of a track's `is_liked`; `toggle(track)` is the optimistic flip → request → revert-on-failure path with the existing toast copy. the queue's swipe-like goes through it; `AddToMenu` and `TrackActionsMenu` keep their prop-fed local state but `record()` their result, so the footer heart and the track page heart agree for the same track. `LikeToggle.svelte` is the heart as a component.

**volume is a component.** `VolumeControl.svelte` extracted from `PlaybackControls` (both layouts render it; the stacked one puts it in the right cluster). `PlaybackControls` gains `stacked`.

<details>
<summary>not in this PR</summary>

- the now-playing page (`/now`) and the footer's "now playing view" button — phase B.
- speed, sleep timer, miniplayer, fullscreen, lyrics.
- deleting the old footer: that is the point of the flag — once this layout is accepted it becomes the player and the old one goes.
- #1812 (unlike can leave a track in the liked list) is a backend issue and unchanged.
</details>

tests: `likes.test.ts` (optimistic flip + endpoint + shared answer, revert on failure, sign-in refusal, recorded results). `bun run check` 0 errors, eslint + oxlint clean, 211 tests pass. staging screenshots at 390 and 1280 as the flagged test account follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z