### PR TITLE
likes: the owner learns the viewer's liked ids instead of trusting the track object

### DIFF
--- a/frontend/src/lib/components/LikeToggle.svelte
+++ b/frontend/src/lib/components/LikeToggle.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { auth } from '$lib/auth.svelte';
 	import { likes } from '$lib/likes.svelte';
 	import type { Track } from '$lib/types';
 
@@ -8,6 +9,10 @@
 	}
 
 	let { track, size = 18 }: Props = $props();
+
+	$effect(() => {
+		if (auth.isAuthenticated) void likes.ensureLoaded();
+	});
 
 	const liked = $derived(likes.isLiked(track));
 </script>

--- a/frontend/src/lib/likes.svelte.ts
+++ b/frontend/src/lib/likes.svelte.ts
@@ -11,15 +11,45 @@
 
 import { auth } from './auth.svelte';
 import { toast } from './toast.svelte';
-import { likeTrack, unlikeTrack } from './tracks.svelte';
+import { fetchLikedTracks, likeTrack, unlikeTrack } from './tracks.svelte';
 import type { Track } from './types';
 
 class Likes {
 	#known = $state<Record<number, boolean>>({});
 	#pending = new Set<number>();
+	/** the viewer's liked ids, loaded once per session; null until then */
+	#liked = $state<Set<number> | null>(null);
+	#loading: Promise<void> | null = null;
+
+	/**
+	 * a track object cannot be trusted to carry the viewer's `is_liked` — the
+	 * queue's server sync hands back tracks without it — so the owner learns
+	 * the viewer's liked ids itself. cheap, once, and only when signed in.
+	 */
+	ensureLoaded(): Promise<void> {
+		if (!auth.isAuthenticated || this.#liked !== null) return Promise.resolve();
+		this.#loading ??= fetchLikedTracks()
+			.then((tracks) => {
+				this.#liked = new Set(tracks.map((t) => t.id));
+			})
+			.catch((e) => console.error('failed to load liked ids:', e))
+			.finally(() => {
+				this.#loading = null;
+			});
+		return this.#loading;
+	}
+
+	/** forget the loaded list (sign-out); the next `ensureLoaded` refetches */
+	reset(): void {
+		this.#liked = null;
+		this.#known = {};
+	}
 
 	isLiked(track: Pick<Track, 'id' | 'is_liked'>): boolean {
-		return this.#known[track.id] ?? track.is_liked === true;
+		const known = this.#known[track.id];
+		if (known !== undefined) return known;
+		if (this.#liked !== null) return this.#liked.has(track.id);
+		return track.is_liked === true;
 	}
 
 	/** a surface that toggled a like on its own (the menus) tells the owner the result. */
@@ -38,6 +68,10 @@ class Likes {
 		const next = !was;
 		this.#pending.add(track.id);
 		this.#known[track.id] = next;
+		if (this.#liked !== null) {
+			if (next) this.#liked.add(track.id);
+			else this.#liked.delete(track.id);
+		}
 		track.is_liked = next;
 		if (track.like_count !== undefined) track.like_count = Math.max(0, track.like_count + (next ? 1 : -1));
 		try {

--- a/frontend/src/lib/likes.test.ts
+++ b/frontend/src/lib/likes.test.ts
@@ -28,6 +28,7 @@ afterEach(() => {
 	globalThis.fetch = originalFetch;
 	auth.isAuthenticated = false;
 	toast.toasts = [];
+	likes.reset();
 });
 
 describe('likes', () => {
@@ -58,6 +59,18 @@ describe('likes', () => {
 		expect(await likes.toggle(t)).toBe(false);
 		expect(requests).toEqual([]);
 		expect(toast.toasts.at(-1)?.message).toBe('sign in to like tracks');
+	});
+
+	it('learns the viewer\'s liked ids once and answers from them over the object', async () => {
+		respond = (url) =>
+			url.includes('/tracks/liked')
+				? Response.json({ tracks: [{ id: 11, title: 'a' }, { id: 12, title: 'b' }] })
+				: new Response('{}', { status: 200 });
+		await likes.ensureLoaded();
+		await likes.ensureLoaded();
+		expect(requests.filter((r) => r.includes('/tracks/liked')).length).toBe(1);
+		expect(likes.isLiked({ id: 11, is_liked: false })).toBe(true);
+		expect(likes.isLiked({ id: 13, is_liked: true })).toBe(false);
 	});
 
 	it('takes a result recorded by another surface', () => {


### PR DESCRIPTION
found on staging with the flagged test account: the API said `is_liked: true` and the track page's chip showed liked, but the footer heart started false. the queue's server sync replaces the played track with a server copy that has no viewer-specific `is_liked`, and the heart read that object.

the owner now loads the viewer's liked ids once per session (`fetchLikedTracks`, only when signed in, deduped while in flight) and answers `isLiked` from its overlay first, then that set, then the object's field. `toggle` keeps the set current; `reset()` forgets it. `LikeToggle` asks for the load on mount.

test: loads once across two calls and answers from the set over the object's stale field. `bun run check` 0 errors, lint clean, 212 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z