### PR TITLE
player: the stage bar on a phone is art, title, heart, play

### DIFF
--- a/frontend/src/lib/components/player/PlaybackControls.svelte
+++ b/frontend/src/lib/components/player/PlaybackControls.svelte
@@ -484,6 +484,19 @@
 			display: none;
 		}
 
+		/* the stage bar on a phone is spotify's compact bar: art, title, heart, play.
+		   prev/next/repeat live in the queue and the now-playing view */
+		.player-controls.stacked .control-btn.prev,
+		.player-controls.stacked .control-btn.next,
+		.player-controls.stacked .control-btn.repeat {
+			display: none;
+		}
+
+		.player-controls.stacked .control-btn.play-pause {
+			grid-column: 4;
+			justify-self: end;
+		}
+
 		/* skips sit on the scrubber row, under the thumb, not in the transport row */
 		.control-btn.skip {
 			grid-row: 2;

--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -420,6 +420,7 @@
 		.player-like {
 			grid-row: 1;
 			grid-column: 3;
+			justify-self: end;
 		}
 
 		.player-track:has(.player-like) .player-info {


### PR DESCRIPTION
staging at 390 px: the heart took an eighth grid column in a row that was already full (art, title, heart, prev, play, next, repeat, skip), so the `1fr` title column collapsed and the title and artist vanished. spotify's compact phone bar is art, title, heart, play — nothing else in the row — so under the flag prev/next/repeat are hidden there (they live in the queue and the coming now-playing view), play sits at the row's end, and the scrubber row with the skips stays beneath. desktop unchanged; unflagged phones unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z