### PR TITLE
player: heart and play sit at the end of the phone stage bar

### DIFF
--- a/frontend/src/lib/components/player/PlaybackControls.svelte
+++ b/frontend/src/lib/components/player/PlaybackControls.svelte
@@ -493,7 +493,7 @@
 		}
 
 		.player-controls.stacked .control-btn.play-pause {
-			grid-column: 4;
+			grid-column: 8;
 			justify-self: end;
 		}
 

--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -417,14 +417,15 @@
 			grid-column: 1;
 		}
 
+		/* the stage bar: title takes the row, heart and play sit at its end */
 		.player-like {
 			grid-row: 1;
-			grid-column: 3;
+			grid-column: 7;
 			justify-self: end;
 		}
 
 		.player-track:has(.player-like) .player-info {
-			grid-column: 2 / 3;
+			grid-column: 2 / 7;
 		}
 
 		.player-info {


### PR DESCRIPTION
staging at 390 px after #1989: the row was art, title, heart, play, but play sat at column 4 with the empty columns' gaps after it, so it floated short of the edge. heart moves to column 7 and play to column 8, the title spans 2–7, and play aligns with the skip-forward button on the scrubber row beneath — spotify's bar, with the play at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z