### PR TITLE
player: stage polish — hover roles, active dots, hidden-until-hover scrubber thumb, click-to-mute, heart pop, focus rings

### DIFF
--- a/frontend/src/lib/components/LikeToggle.svelte
+++ b/frontend/src/lib/components/LikeToggle.svelte
@@ -15,6 +15,15 @@
 	});
 
 	const liked = $derived(likes.isLiked(track));
+
+	// a pop when a like lands; the key remounts the svg so it replays each time
+	let popKey = $state(0);
+	let previous: boolean | null = null;
+	$effect(() => {
+		const now = liked;
+		if (previous !== null && now && !previous) popKey += 1;
+		previous = now;
+	});
 </script>
 
 <button
@@ -26,7 +35,10 @@
 	aria-label={liked ? `unlike ${track.title}` : `like ${track.title}`}
 	title={liked ? 'unlike' : 'like'}
 >
+	{#key popKey}
 	<svg
+		class="heart"
+		class:pop={popKey > 0 && liked}
 		width={size}
 		height={size}
 		viewBox="0 0 24 24"
@@ -41,6 +53,7 @@
 			d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"
 		></path>
 	</svg>
+	{/key}
 </button>
 
 <style>
@@ -71,5 +84,36 @@
 
 	.like-toggle:active {
 		transform: scale(0.92);
+	}
+
+	.like-toggle:focus-visible {
+		outline: 2px solid var(--text-primary);
+		outline-offset: 2px;
+	}
+
+	.heart.pop {
+		animation: heart-pop 400ms cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	}
+
+	@keyframes heart-pop {
+		0% {
+			transform: scale(0.7);
+		}
+		60% {
+			transform: scale(1.2);
+		}
+		100% {
+			transform: scale(1);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.heart.pop {
+			animation: none;
+		}
+
+		.like-toggle:active {
+			transform: none;
+		}
 	}
 </style>

--- a/frontend/src/lib/components/player/PlaybackControls.svelte
+++ b/frontend/src/lib/components/player/PlaybackControls.svelte
@@ -409,6 +409,149 @@
 		margin: 0;
 	}
 
+	/* stage polish — the conventions modern players share:
+	   transport idle secondary → primary on hover, active toggles carry a dot;
+	   the scrubber is thin with a hidden thumb until hovered, primary fill that
+	   turns accent under the pointer, a tall hit area; keyboard focus is a ring */
+	.player-controls.stacked .control-btn {
+		color: var(--text-secondary);
+		transition:
+			color 150ms cubic-bezier(0.2, 0, 0, 1),
+			transform 150ms cubic-bezier(0.2, 0, 0, 1),
+			background 150ms cubic-bezier(0.2, 0, 0, 1);
+	}
+
+	.player-controls.stacked .control-btn:hover {
+		color: var(--text-primary);
+		background: transparent;
+	}
+
+	.player-controls.stacked .control-btn:active {
+		transform: scale(0.94);
+	}
+
+	.player-controls.stacked .control-btn.disabled,
+	.player-controls.stacked .control-btn:disabled {
+		opacity: 0.38;
+		pointer-events: none;
+	}
+
+	.player-controls.stacked .control-btn.active {
+		color: var(--accent);
+		position: relative;
+	}
+
+	.player-controls.stacked .control-btn.active::after {
+		content: '';
+		position: absolute;
+		left: 50%;
+		bottom: 1px;
+		width: 4px;
+		height: 4px;
+		border-radius: var(--radius-full);
+		background: var(--accent);
+		translate: -50% 0;
+	}
+
+	.player-controls.stacked .control-btn:focus-visible,
+	.player-controls.stacked .seek-bar:focus-visible {
+		outline: 2px solid var(--text-primary);
+		outline-offset: 2px;
+	}
+
+	.player-controls.stacked .time {
+		color: var(--text-secondary);
+		font-size: var(--text-xs);
+		min-width: 40px;
+	}
+
+	.player-controls.stacked .time:last-child {
+		text-align: right;
+	}
+
+	.player-controls.stacked .seek-bar {
+		height: 20px;
+		margin: -8px 0;
+		--fill: var(--text-primary);
+		--rest: color-mix(in srgb, var(--text-primary) 28%, transparent);
+	}
+
+	.player-controls.stacked .seek-bar::-webkit-slider-runnable-track {
+		height: 4px;
+		border-radius: 2px;
+		margin-top: 8px;
+		background: linear-gradient(
+			to right,
+			var(--fill) 0%,
+			var(--fill) var(--progress, 0%),
+			var(--rest) var(--progress, 0%),
+			var(--rest) 100%
+		);
+		transition: background 150ms cubic-bezier(0.2, 0, 0, 1);
+	}
+
+	.player-controls.stacked .seek-bar::-moz-range-track {
+		height: 4px;
+		border-radius: 2px;
+		background: var(--rest);
+	}
+
+	.player-controls.stacked .seek-bar::-moz-range-progress {
+		height: 4px;
+		border-radius: 2px;
+		background: var(--fill);
+	}
+
+	.player-controls.stacked .seek-bar::-webkit-slider-thumb {
+		width: 12px;
+		height: 12px;
+		margin-top: -4px;
+		background: var(--text-primary);
+		opacity: 0;
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+		transform: none;
+		transition: opacity 150ms cubic-bezier(0.2, 0, 0, 1);
+	}
+
+	.player-controls.stacked .seek-bar::-moz-range-thumb {
+		width: 12px;
+		height: 12px;
+		background: var(--text-primary);
+		border: none;
+		opacity: 0;
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+		transition: opacity 150ms cubic-bezier(0.2, 0, 0, 1);
+	}
+
+	.player-controls.stacked .seek-bar:hover,
+	.player-controls.stacked .seek-bar:focus-visible,
+	.player-controls.stacked .seek-bar:active {
+		--fill: var(--accent);
+	}
+
+	.player-controls.stacked .seek-bar:hover::-webkit-slider-thumb,
+	.player-controls.stacked .seek-bar:focus-visible::-webkit-slider-thumb,
+	.player-controls.stacked .seek-bar:active::-webkit-slider-thumb {
+		opacity: 1;
+		transform: none;
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+	}
+
+	.player-controls.stacked .seek-bar:hover::-moz-range-thumb,
+	.player-controls.stacked .seek-bar:focus-visible::-moz-range-thumb,
+	.player-controls.stacked .seek-bar:active::-moz-range-thumb {
+		opacity: 1;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.player-controls.stacked .control-btn,
+		.player-controls.stacked .control-btn:active,
+		.player-controls.stacked .control-btn.play-pause:hover {
+			transform: none;
+			transition: color 150ms, background 150ms;
+		}
+	}
+
 	.control-btn.shuffle svg {
 		width: 18px;
 		height: 18px;

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -957,7 +957,7 @@
 							</svg>
 						</button>
 					{/if}
-					<VolumeControl />
+					<VolumeControl stage />
 				</div>
 			{/if}
 		</div>
@@ -1023,18 +1023,35 @@
 		background: transparent;
 		border: none;
 		border-radius: var(--radius-full);
-		color: var(--text-tertiary);
+		color: var(--text-secondary);
 		cursor: pointer;
-		transition: all 0.15s;
+		position: relative;
+		transition: color 150ms cubic-bezier(0.2, 0, 0, 1);
 	}
 
-	.stage-btn:hover,
+	.stage-btn:hover {
+		color: var(--text-primary);
+	}
+
 	.stage-btn.active {
 		color: var(--accent);
 	}
 
-	.stage-btn.active {
-		background: color-mix(in srgb, var(--accent) 10%, transparent);
+	.stage-btn.active::after {
+		content: '';
+		position: absolute;
+		left: 50%;
+		bottom: 1px;
+		width: 4px;
+		height: 4px;
+		border-radius: var(--radius-full);
+		background: var(--accent);
+		translate: -50% 0;
+	}
+
+	.stage-btn:focus-visible {
+		outline: 2px solid var(--text-primary);
+		outline-offset: 2px;
 	}
 
 	.player.jam-active { --top-bar-color: linear-gradient(90deg, #ff6b6b, #ffd93d, #6bcb77, #4d96ff, #9b59b6, #ff6b6b); }

--- a/frontend/src/lib/components/player/VolumeControl.svelte
+++ b/frontend/src/lib/components/player/VolumeControl.svelte
@@ -1,6 +1,21 @@
 <script lang="ts">
 	import { player } from '$lib/player.svelte';
 
+	/** stage: the polished look — click-to-mute icon, thin track, thumb on hover */
+	let { stage = false }: { stage?: boolean } = $props();
+
+	// the level to come back to after a mute; a fresh session unmutes to 0.7
+	let lastVolume = 0.7;
+
+	function toggleMute() {
+		if (player.volume > 0) {
+			lastVolume = player.volume;
+			player.volume = 0;
+		} else {
+			player.volume = lastVolume > 0 ? lastVolume : 0.7;
+		}
+	}
+
 	let volumeState = $derived.by(() => {
 		if (player.volume === 0) return 'muted';
 		if (player.volume >= 0.99) return 'max';
@@ -8,8 +23,15 @@
 	});
 </script>
 
-<div class="volume-control">
-	<div class="volume-icon" class:muted={volumeState === 'muted'}>
+<div class="volume-control" class:stage>
+	<button
+		type="button"
+		class="volume-icon"
+		class:muted={volumeState === 'muted'}
+		onclick={toggleMute}
+		aria-label={volumeState === 'muted' ? 'unmute' : 'mute'}
+		title={volumeState === 'muted' ? 'unmute' : 'mute'}
+	>
 		{#if volumeState === 'muted'}
 			<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 				<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
@@ -28,7 +50,7 @@
 				<path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>
 			</svg>
 		{/if}
-	</div>
+	</button>
 	<input
 		type="range"
 		class="volume-bar"
@@ -38,6 +60,7 @@
 		max="1"
 		step="0.01"
 		aria-label="volume"
+		style:--level={player.volume}
 		bind:value={player.volume}
 	/>
 </div>
@@ -55,7 +78,86 @@
 	.volume-icon {
 		display: flex;
 		align-items: center;
+		padding: 0;
+		background: transparent;
+		border: none;
+		color: inherit;
+		cursor: pointer;
 		transition: all 0.3s;
+	}
+
+	.volume-icon:focus-visible {
+		outline: 2px solid var(--text-primary);
+		outline-offset: 2px;
+		border-radius: var(--radius-sm);
+	}
+
+	/* stage: spotify's ~93px slider, thin, thumb only under the pointer */
+	.volume-control.stage {
+		min-width: 0;
+		width: 125px;
+		color: var(--text-secondary);
+	}
+
+	.volume-control.stage:hover {
+		color: var(--text-primary);
+	}
+
+	.volume-control.stage .volume-bar {
+		height: 4px;
+		background: linear-gradient(
+			to right,
+			var(--text-primary) 0%,
+			var(--text-primary) calc(var(--level, 0) * 100%),
+			color-mix(in srgb, var(--text-primary) 28%, transparent) calc(var(--level, 0) * 100%),
+			color-mix(in srgb, var(--text-primary) 28%, transparent) 100%
+		);
+		transition: background 150ms cubic-bezier(0.2, 0, 0, 1);
+	}
+
+	.volume-control.stage .volume-bar:hover,
+	.volume-control.stage .volume-bar:active,
+	.volume-control.stage .volume-bar:focus-visible {
+		background: linear-gradient(
+			to right,
+			var(--accent) 0%,
+			var(--accent) calc(var(--level, 0) * 100%),
+			color-mix(in srgb, var(--text-primary) 28%, transparent) calc(var(--level, 0) * 100%),
+			color-mix(in srgb, var(--text-primary) 28%, transparent) 100%
+		);
+	}
+
+	.volume-control.stage .volume-bar::-webkit-slider-thumb {
+		width: 12px;
+		height: 12px;
+		background: var(--text-primary);
+		opacity: 0;
+		transition: opacity 150ms cubic-bezier(0.2, 0, 0, 1);
+	}
+
+	.volume-control.stage .volume-bar::-moz-range-thumb {
+		width: 12px;
+		height: 12px;
+		background: var(--text-primary);
+		opacity: 0;
+		transition: opacity 150ms cubic-bezier(0.2, 0, 0, 1);
+	}
+
+	.volume-control.stage .volume-bar:hover::-webkit-slider-thumb,
+	.volume-control.stage .volume-bar:active::-webkit-slider-thumb,
+	.volume-control.stage .volume-bar:focus-visible::-webkit-slider-thumb {
+		opacity: 1;
+	}
+
+	.volume-control.stage .volume-bar:hover::-moz-range-thumb,
+	.volume-control.stage .volume-bar:active::-moz-range-thumb,
+	.volume-control.stage .volume-bar:focus-visible::-moz-range-thumb {
+		opacity: 1;
+	}
+
+	.volume-control.stage .volume-bar:focus-visible {
+		outline: 2px solid var(--text-primary);
+		outline-offset: 4px;
 	}
 
 	.volume-icon.muted {

--- a/loq.toml
+++ b/loq.toml
@@ -123,7 +123,7 @@ max_lines = 622
 
 [[rules]]
 path = "frontend/src/lib/components/player/Player.svelte"
-max_lines = 1105
+max_lines = 1122
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"
@@ -347,7 +347,7 @@ max_lines = 668
 
 [[rules]]
 path = "frontend/src/lib/components/player/PlaybackControls.svelte"
-max_lines = 638
+max_lines = 781
 
 [[rules]]
 path = "backend/src/backend/_internal/clients/moderation.py"


### PR DESCRIPTION
a polish pass on the stage footer against what modern players share (Spotify, Apple Music web, YouTube Music, Tidal, SoundCloud; Vidstack and Plyr as open-source references; M3 and WCAG for targets, states and focus). everything is scoped to the stage layout; the classic footer is untouched.

- **transport**: idle secondary text → primary on hover (Spotify/Tidal/YTM), no background tint; active shuffle/repeat in accent with a 4px dot beneath (Spotify); disabled prev/next dimmed to 38% (M3) rather than hidden; 150ms `cubic-bezier(0.2,0,0,1)` (M3 standard easing).
- **scrubber**: 4px track, primary fill that turns accent on hover/drag (Spotify's green-on-hover), inactive track at 28% of primary, a 12px thumb hidden until hover/focus/drag (Spotify, YouTube), a 20px hit area around the 4px track (Vidstack's thin-visual/tall-hit pattern), tabular secondary time labels.
- **volume**: the icon is a button that mutes and restores the previous level (all references); 125px slider in the same idiom as the scrubber.
- **heart**: a 400ms overshoot pop when a like lands (Spotify's ≤500ms toggle), replayed per like via a keyed svg.
- **focus-visible**: 2px primary ring, 2px offset, on every control and both sliders (WCAG 2.4.13); never on plain `:focus`.
- **reduced motion**: no scale on press/hover, no pop; colour feedback stays.

`bun run check` 0 errors, lint clean, 212 tests, 39 story checks. staging verification follows: hover and focus states read from the DOM at desktop width, plus the phone bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z