### PR TITLE
stage player: load the viewer's liked ids for the footer heart

### DIFF
--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -33,6 +33,10 @@
 	// the stage layout: spotify's three regions, behind the same per-user flag
 	// as the skip buttons while it is judged
 	const stage = $derived(auth.user?.enabled_flags?.includes(SKIP_BUTTONS_FLAG) ?? false);
+
+	$effect(() => {
+		if (stage && auth.isAuthenticated) void likes.ensureLoaded();
+	});
 	import { auth } from '$lib/auth.svelte';
 	import TrackInfo from './TrackInfo.svelte';
 	import PlaybackControls from './PlaybackControls.svelte';

--- a/loq.toml
+++ b/loq.toml
@@ -123,7 +123,7 @@ max_lines = 622
 
 [[rules]]
 path = "frontend/src/lib/components/player/Player.svelte"
-max_lines = 1131
+max_lines = 1135
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"


### PR DESCRIPTION
#1993 dropped the `likes.ensureLoaded()` call the deleted `LikeToggle` carried, so the footer heart started unliked on a liked track (staging check: track page filled, footer menu offered "add to liked"). The load now runs from `Player.svelte` under the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z