### PR TITLE
add menu: portal the phone top sheet to body

### DIFF
--- a/frontend/src/lib/components/AddToMenu.svelte
+++ b/frontend/src/lib/components/AddToMenu.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { portal } from 'svelte-portal';
+	import { MOBILE_BREAKPOINT } from '$lib/breakpoints';
 	import { likes } from '$lib/likes.svelte';
 	import { likeTrack, unlikeTrack } from '$lib/tracks.svelte';
 	import { toast } from '$lib/toast.svelte';
@@ -56,6 +58,7 @@
 	let loadingPlaylists = $state(false);
 	let addingToPlaylist = $state<string | null>(null);
 	let openUpward = $state(false);
+	let phoneSheet = $state(false);
 	let triggerRef = $state<HTMLButtonElement | null>(null);
 
 	// filter out the excluded playlist (must be after playlists state declaration)
@@ -70,7 +73,7 @@
 
 	// close menu when clicking outside
 	function handleClickOutside(event: MouseEvent) {
-		if (!(event.target instanceof Element && event.target.closest('.add-to-menu'))) {
+		if (!(event.target instanceof Element && event.target.closest('.add-to-menu, .add-to-menu-sheet'))) {
 			menuOpen = false;
 			showPlaylistPicker = false;
 		}
@@ -94,6 +97,7 @@
 			const menuHeight = 300; // approximate menu height
 			const playerHeight = 150; // approximate player height
 			openUpward = spaceBelow < menuHeight + playerHeight;
+			phoneSheet = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`).matches;
 		}
 
 		menuOpen = !menuOpen;
@@ -291,7 +295,7 @@
 		</svg>
 	</button>
 
-	{#if menuOpen}
+	{#snippet menu()}
 		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 		<div class="menu-backdrop" role="presentation" onclick={() => { menuOpen = false; showPlaylistPicker = false; }}></div>
 		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
@@ -435,6 +439,14 @@
 				</div>
 			{/if}
 		</div>
+	{/snippet}
+
+	{#if menuOpen}
+		{#if phoneSheet}
+			<div class="add-to-menu-sheet" use:portal={'body'}>{@render menu()}</div>
+		{:else}
+			{@render menu()}
+		{/if}
 	{/if}
 </div>
 

--- a/loq.toml
+++ b/loq.toml
@@ -95,7 +95,7 @@ max_lines = 523
 
 [[rules]]
 path = "frontend/src/lib/components/AddToMenu.svelte"
-max_lines = 857
+max_lines = 869
 
 [[rules]]
 path = "frontend/src/lib/components/ProfileMenu.svelte"


### PR DESCRIPTION
The add menu's phone top sheet is `position: fixed`, and the player footer's backdrop-filter and transform make the footer its containing block, so from the stage bar's heart the sheet rendered as a 2px sliver. On phone widths the sheet and backdrop now mount on `body` via `svelte-portal` (already used by the profile and links menus). The outside-click handler counts the portaled sheet as inside. Desktop dropdowns are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z