### PR TITLE
add menu: judge outside clicks by the event path, not the target's ancestors

### DIFF
--- a/frontend/src/lib/components/AddToMenu.svelte
+++ b/frontend/src/lib/components/AddToMenu.svelte
@@ -73,7 +73,8 @@
 
 	// close menu when clicking outside
 	function handleClickOutside(event: MouseEvent) {
-		if (!(event.target instanceof Element && event.target.closest('.add-to-menu, .add-to-menu-sheet'))) {
+		const inside = event.composedPath().some((node) => node instanceof Element && node.matches('.add-to-menu, .add-to-menu-sheet'));
+		if (!inside) {
 			menuOpen = false;
 			showPlaylistPicker = false;
 		}

--- a/loq.toml
+++ b/loq.toml
@@ -95,7 +95,7 @@ max_lines = 523
 
 [[rules]]
 path = "frontend/src/lib/components/AddToMenu.svelte"
-max_lines = 870
+max_lines = 871
 
 [[rules]]
 path = "frontend/src/lib/components/ProfileMenu.svelte"


### PR DESCRIPTION
On phones, tapping "add to playlist" in the add menu closed the sheet instead of showing the picker (staging, both the footer heart and the track page heart, since #1996).

With the sheet portaled to `body`, Svelte dispatches its clicks from the document-level listener, so the component's own document click listener now runs for taps inside the sheet. By then the tapped item has been swapped out for the picker view, so `closest()` on the detached target found no wrapper and the menu closed. The listener now checks the event's composed path, which still holds the sheet wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z