### PR TITLE
player: next button on the phone stage bar; add-menu sheet rises from above the player

### DIFF
--- a/frontend/src/lib/components/AddToMenu.svelte
+++ b/frontend/src/lib/components/AddToMenu.svelte
@@ -808,7 +808,7 @@
 		display: none;
 	}
 
-	/* mobile: show as top sheet */
+	/* mobile: a sheet above the player */
 	@media (max-width: 768px) {
 		.trigger-button {
 			width: 28px;
@@ -837,15 +837,15 @@
 		.menu-dropdown.open-upward,
 		.menu-dropdown.open-upward.align-start {
 			position: fixed;
-			top: 0;
-			bottom: auto;
+			top: auto;
+			bottom: max(var(--player-height, 0px), env(safe-area-inset-bottom, 0px));
 			left: 0;
 			right: 0;
 			width: 100%;
 			min-width: 100%;
 			max-width: 100vw;
-			border-radius: 0 0 16px 16px;
-			padding-top: env(safe-area-inset-top, 0);
+			border-radius: 16px 16px 0 0;
+			padding-bottom: 0.25rem;
 			z-index: 200;
 			-webkit-transform: translateZ(0);
 			transform: translateZ(0);

--- a/frontend/src/lib/components/player/PlaybackControls.svelte
+++ b/frontend/src/lib/components/player/PlaybackControls.svelte
@@ -708,15 +708,19 @@
 			padding: 0.5rem;
 		}
 
-		/* the stage bar on a phone is spotify's compact bar: art, title, heart, play.
-		   prev/next/repeat live in the queue and the now-playing view */
+		/* the stage bar on a phone: art, title, heart, play, next */
 		.player-controls.stacked .control-btn.prev,
-		.player-controls.stacked .control-btn.next,
 		.player-controls.stacked .control-btn.repeat {
 			display: none;
 		}
 
 		.player-controls.stacked .control-btn.play-pause {
+			grid-column: 7;
+			justify-self: end;
+		}
+
+		.player-controls.stacked .control-btn.next {
+			grid-row: 1;
 			grid-column: 8;
 			justify-self: end;
 		}

--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -421,15 +421,15 @@
 			grid-column: 1;
 		}
 
-		/* the stage bar: title takes the row, heart and play sit at its end */
+		/* the stage bar: title takes the row; heart, play and next sit at its end */
 		.player-like {
 			grid-row: 1;
-			grid-column: 7;
+			grid-column: 6;
 			justify-self: end;
 		}
 
 		.player-track:has(.player-like) .player-info {
-			grid-column: 2 / 7;
+			grid-column: 2 / 6;
 		}
 
 		.player-info {

--- a/loq.toml
+++ b/loq.toml
@@ -347,7 +347,7 @@ max_lines = 668
 
 [[rules]]
 path = "frontend/src/lib/components/player/PlaybackControls.svelte"
-max_lines = 781
+max_lines = 785
 
 [[rules]]
 path = "backend/src/backend/_internal/clients/moderation.py"


### PR DESCRIPTION
Two phone changes: the stage bar gains a next button (art, title, heart, play, next), and the add menu's phone sheet now opens from the bottom, sitting on top of the player strip, instead of dropping from the top of the screen.

<details>
<summary>details</summary>

- `PlaybackControls.svelte` / `TrackInfo.svelte`: under the flag on phones, next is shown at the row's end (col 8), play at col 7, heart at col 6, title spans 2–6. prev and repeat stay hidden on the bar.
- `AddToMenu.svelte` (all users, phone widths): the sheet is anchored at `bottom: max(--player-height, safe-area-inset-bottom)` with rounded top corners. `--player-height` is set on the document element, so the body-portaled sheet sees it. Applies everywhere the heart appears, including the track feed, per nate's request.

non-behaviors: desktop dropdowns unchanged; classic footer unchanged.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z