### PR TITLE
player: the stage layout is the player; drop the skip-buttons flag and the classic footer

### DIFF
--- a/backend/src/backend/_internal/feature_flags.py
+++ b/backend/src/backend/_internal/feature_flags.py
@@ -14,7 +14,6 @@ KNOWN_FLAGS = frozenset(
     {
         "vibe-search",  # enable semantic vibe search in Cmd+K
         "copyright-paradigm",  # enable the indiemusi.ch copyright paradigm UI + endpoints
-        "skip-buttons",  # ±15s skip buttons in the player + media-session seek handlers
     }
 )
 

--- a/docs/internal/backend/feature-flags.md
+++ b/docs/internal/backend/feature-flags.md
@@ -37,7 +37,6 @@ flags are documented in `backend/src/backend/_internal/feature_flags.py`:
 KNOWN_FLAGS = frozenset({
     "vibe-search",  # semantic vibe search in Cmd+K
     "copyright-paradigm",  # the indiemusi.ch copyright paradigm UI + endpoints
-    "skip-buttons",  # ±skip buttons in the player + media-session seek handlers
 })
 ```
 
@@ -56,12 +55,12 @@ every user gets; a flagged feature is described here and in `STATUS.md`.
 from backend._internal import has_flag, get_user_flags
 
 # check a specific flag
-if await has_flag(db, user_did, "skip-buttons"):
+if await has_flag(db, user_did, "vibe-search"):
     # feature is enabled for this user
     pass
 
 # get all flags for a user
-flags = await get_user_flags(db, user_did)  # ["skip-buttons", "vibe-search", ...]
+flags = await get_user_flags(db, user_did)  # ["vibe-search", "copyright-paradigm", ...]
 ```
 
 ### frontend
@@ -71,9 +70,9 @@ flags are returned in the `/auth/me` response:
 ```typescript
 // $lib/auth.svelte.ts holds the signed-in user; flag names live in $lib/config.ts
 import { auth } from '$lib/auth.svelte';
-import { SKIP_BUTTONS_FLAG } from '$lib/config';
+import { VIBE_SEARCH_FLAG } from '$lib/config';
 
-const skipButtons = $derived(auth.user?.enabled_flags?.includes(SKIP_BUTTONS_FLAG) ?? false);
+const vibeSearch = $derived(auth.user?.enabled_flags?.includes(VIBE_SEARCH_FLAG) ?? false);
 ```
 
 ## api
@@ -87,7 +86,7 @@ returns the current user's enabled flags:
     "did": "did:plc:abc123",
     "handle": "alice.bsky.social",
     "linked_accounts": [...],
-    "enabled_flags": ["skip-buttons"]
+    "enabled_flags": ["vibe-search"]
 }
 ```
 
@@ -99,10 +98,10 @@ manage flags via the admin script (requires `DATABASE_URL`):
 cd backend
 
 # enable a flag for a user
-DATABASE_URL="..." uv run python ../scripts/feature_flag.py enable --user zzstoatzz.io --flag skip-buttons
+DATABASE_URL="..." uv run python ../scripts/feature_flag.py enable --user zzstoatzz.io --flag vibe-search
 
 # disable a flag
-DATABASE_URL="..." uv run python ../scripts/feature_flag.py disable --user zzstoatzz.io --flag skip-buttons
+DATABASE_URL="..." uv run python ../scripts/feature_flag.py disable --user zzstoatzz.io --flag vibe-search
 
 # list flags for a user
 DATABASE_URL="..." uv run python ../scripts/feature_flag.py list --user zzstoatzz.io
@@ -120,7 +119,6 @@ users can be specified by handle or DID.
    KNOWN_FLAGS = frozenset({
        "vibe-search",
        "copyright-paradigm",
-       "skip-buttons",
        "new-feature",  # description of what this enables
    })
    ```

--- a/docs/internal/frontend/keyboard-shortcuts.md
+++ b/docs/internal/frontend/keyboard-shortcuts.md
@@ -82,8 +82,8 @@ seeks backward 10 seconds in the current track.
 seeks forward 10 seconds in the current track.
 
 both arrows go through `queue.seekBy(seconds)`, which clamps to the track.
-the step is a fixed 10 s here; the player's on-screen skip buttons (behind
-the `skip-buttons` flag) use a different, duration-dependent step from
+the step is a fixed 10 s here; the player's on-screen skip buttons use a
+different, duration-dependent step from
 `$lib/skip-step.ts` (5 / 10 / 15 s), on purpose — the keys are a power-user
 nudge, the buttons are the visible affordance sized to the track.
 

--- a/docs/internal/frontend/state-management.md
+++ b/docs/internal/frontend/state-management.md
@@ -394,8 +394,8 @@ these respond to system media controls:
 - `previoustrack` / `nexttrack` - navigate queue; (de)registered reactively
   from `queue.hasPrevious` / `queue.hasNext` and radio mode, because the OS
   only shows ⏮/⏭ for commands it believes are live
-- `seekbackward` / `seekforward` - registered reactively only for users with
-  the `skip-buttons` flag and not in radio mode; the offset is the OS's
+- `seekbackward` / `seekforward` - registered reactively whenever not in radio
+  mode; the offset is the OS's
   `seekOffset` when it sends one, else `skipStepSeconds(player.duration)`.
   once these exist, iOS shows ±skip buttons in place of ⏮/⏭ — that trade is
   why they are flagged

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -14,7 +14,7 @@ gotchas:
 - queue sync: uses BroadcastChannel for cross-tab, not SSE
 - preferences: managed in UserMenu (desktop) and ProfileMenu (mobile) components, not dedicated state file
 - keyboard shortcuts: handled in root layout (+layout.svelte), with context-aware filtering
-- keyboard seeks go through `queue.seekBy()` at a fixed 10 s; the player's skip buttons (flag `skip-buttons`) use the duration ladder in `lib/skip-step.ts` — two rules on purpose
+- keyboard seeks go through `queue.seekBy()` at a fixed 10 s; the player's skip buttons use the duration ladder in `lib/skip-step.ts` — two rules on purpose
 - flag-gated UI reads `auth.user?.enabled_flags` against a constant in `lib/config.ts`; never ship a flagged feature into the public docs as if it were GA
 - icons with text inside an svg inside a `<button>`: the button must `font-family: inherit` or the text renders in the UA font, not the app's `--font-family`; serif fonts need `font-variant-numeric: lining-nums`
 - the passing-comment bubbles on the track page measure their room from the DOM (`lib/comment-emission.ts`); don't place them by rule — see `docs/internal/frontend/passing-comments.md`

--- a/frontend/src/lib/components/AddToMenu.svelte
+++ b/frontend/src/lib/components/AddToMenu.svelte
@@ -539,6 +539,7 @@
 		border: none;
 		border-radius: var(--radius-full);
 		color: var(--text-secondary);
+		transition: color 150ms cubic-bezier(0.2, 0, 0, 1);
 	}
 
 	.trigger-button.plain svg {
@@ -550,7 +551,6 @@
 	.trigger-button.plain.menu-open {
 		background: transparent;
 		color: var(--text-primary);
-		transform: scale(1.06);
 	}
 
 	.trigger-button.plain.liked,
@@ -563,12 +563,6 @@
 		outline-offset: 2px;
 	}
 
-	@media (prefers-reduced-motion: reduce) {
-		.trigger-button.plain:hover,
-		.trigger-button.plain.menu-open {
-			transform: none;
-		}
-	}
 
 	.menu-item {
 		width: 100%;

--- a/frontend/src/lib/components/player/PlaybackControls.svelte
+++ b/frontend/src/lib/components/player/PlaybackControls.svelte
@@ -3,18 +3,11 @@
 	import { browser } from '$app/environment';
 	import { player } from '$lib/player.svelte';
 	import { queue } from '$lib/queue.svelte';
-	import { auth } from '$lib/auth.svelte';
-	import { SKIP_BUTTONS_FLAG } from '$lib/config';
 	import { skipStepSeconds } from '$lib/skip-step';
 
-	import VolumeControl from './VolumeControl.svelte';
+	// radio mode: live stream — no prev/next, skips or scrubbing, just play/pause
+	let { radioMode = false }: { radioMode?: boolean } = $props();
 
-	// radio mode: live stream — no prev/next or scrubbing, just play/pause + volume.
-	// stacked: the transport on one row and the scrubber on its own full-width
-	// row beneath it, with volume owned by the footer's right cluster
-	let { radioMode = false, stacked = false }: { radioMode?: boolean; stacked?: boolean } = $props();
-
-	const skipButtons = $derived(auth.user?.enabled_flags?.includes(SKIP_BUTTONS_FLAG) ?? false);
 	const skipStep = $derived(skipStepSeconds(player.duration));
 
 	let seekValue = $state(0);
@@ -118,9 +111,9 @@
 	}
 </script>
 
-<div class="player-controls" class:radio-mode={radioMode} class:stacked>
+<div class="player-controls" class:radio-mode={radioMode}>
 	<div class="transport">
-	{#if stacked && !radioMode}
+	{#if !radioMode}
 		<button
 			class="control-btn shuffle"
 			class:active={queue.shuffle}
@@ -143,19 +136,13 @@
 		</button>
 	{:else}
 		<button class="control-btn prev" onclick={handlePrevious} title="previous track / restart">
-			{#if stacked}
-				<svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-					<path d="M6 5h2v14H6zM19 5.5v13a.7.7 0 0 1-1.1.6L9 12.6a.7.7 0 0 1 0-1.2l8.9-6.5A.7.7 0 0 1 19 5.5z" />
-				</svg>
-			{:else}
-				<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-					<path d="M6 4h2v16H6V4zm12 0l-10 8 10 8V4z" />
-				</svg>
-			{/if}
+			<svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+				<path d="M6 5h2v14H6zM19 5.5v13a.7.7 0 0 1-1.1.6L9 12.6a.7.7 0 0 1 0-1.2l8.9-6.5A.7.7 0 0 1 19 5.5z" />
+			</svg>
 		</button>
 	{/if}
 
-	{#if skipButtons && !radioMode}
+	{#if !radioMode}
 		<button
 			class="control-btn skip skip-back"
 			onclick={() => queue.seekBy(-skipStep)}
@@ -177,29 +164,18 @@
 		onclick={() => queue.togglePlayPause()}
 		title={player.paused ? 'play' : 'pause'}
 	>
-		{#if stacked}
-			{#if !player.paused}
-				<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-					<path d="M7 5h3.5v14H7zM13.5 5H17v14h-3.5z" />
-				</svg>
-			{:else}
-				<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-					<path d="M8.5 5.6v12.8a.8.8 0 0 0 1.2.7l10.3-6.4a.8.8 0 0 0 0-1.4L9.7 4.9a.8.8 0 0 0-1.2.7z" />
-				</svg>
-			{/if}
-		{:else if !player.paused}
-			<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-				<rect x="6" y="4" width="4" height="16" rx="1"></rect>
-				<rect x="14" y="4" width="4" height="16" rx="1"></rect>
+		{#if !player.paused}
+			<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+				<path d="M7 5h3.5v14H7zM13.5 5H17v14h-3.5z" />
 			</svg>
 		{:else}
-			<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-				<path d="M8 5v14l11-7z"></path>
+			<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+				<path d="M8.5 5.6v12.8a.8.8 0 0 0 1.2.7l10.3-6.4a.8.8 0 0 0 0-1.4L9.7 4.9a.8.8 0 0 0-1.2.7z" />
 			</svg>
 		{/if}
 	</button>
 
-	{#if skipButtons && !radioMode}
+	{#if !radioMode}
 		<button
 			class="control-btn skip skip-forward"
 			onclick={() => queue.seekBy(skipStep)}
@@ -224,15 +200,9 @@
 			title="next track"
 			disabled={!queue.hasNext}
 		>
-			{#if stacked}
-				<svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-					<path d="M18 5h-2v14h2zM5 5.5v13a.7.7 0 0 0 1.1.6L15 12.6a.7.7 0 0 0 0-1.2L6.1 4.9A.7.7 0 0 0 5 5.5z" />
-				</svg>
-			{:else}
-				<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-					<path d="M16 4h2v16h-2V4zM6 4l10 8-10 8V4z"></path>
-				</svg>
-			{/if}
+			<svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+				<path d="M18 5h-2v14h2zM5 5.5v13a.7.7 0 0 0 1.1.6L15 12.6a.7.7 0 0 0 0-1.2L6.1 4.9A.7.7 0 0 0 5 5.5z" />
+			</svg>
 		</button>
 
 		<button
@@ -241,24 +211,12 @@
 			onclick={() => queue.toggleRepeatMode()}
 			title={queue.repeatMode === 'one' ? 'stop repeating' : 'repeat this track'}
 		>
-			{#if stacked}
-				<svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-					<path d="M17.2 2.4 21 6.1l-3.8 3.7V7.2H7.6a2.1 2.1 0 0 0-2.1 2.1V12H3.3V9.3a4.3 4.3 0 0 1 4.3-4.3h9.6V2.4zM6.8 21.6 3 17.9l3.8-3.7v2.6h9.6a2.1 2.1 0 0 0 2.1-2.1V12h2.2v2.7a4.3 4.3 0 0 1-4.3 4.3H6.8v2.6z" />
-					{#if queue.repeatMode === 'one'}
-						<text x="12" y="14.6" text-anchor="middle" font-size="7" font-weight="700" font-family="inherit" fill="currentColor" stroke="none">1</text>
-					{/if}
-				</svg>
-			{:else}
-				<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-				<path d="m17 2 4 4-4 4"></path>
-				<path d="M3 11v-1a4 4 0 0 1 4-4h14"></path>
-				<path d="m7 22-4-4 4-4"></path>
-				<path d="M21 13v1a4 4 0 0 1-4 4H3"></path>
+			<svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+				<path d="M17.2 2.4 21 6.1l-3.8 3.7V7.2H7.6a2.1 2.1 0 0 0-2.1 2.1V12H3.3V9.3a4.3 4.3 0 0 1 4.3-4.3h9.6V2.4zM6.8 21.6 3 17.9l3.8-3.7v2.6h9.6a2.1 2.1 0 0 0 2.1-2.1V12h2.2v2.7a4.3 4.3 0 0 1-4.3 4.3H6.8v2.6z" />
 				{#if queue.repeatMode === 'one'}
-					<path d="M11 10h1v4"></path>
+					<text x="12" y="14.6" text-anchor="middle" font-size="7" font-weight="700" font-family="inherit" fill="currentColor" stroke="none">1</text>
 				{/if}
 			</svg>
-			{/if}
 		</button>
 	{/if}
 	</div>
@@ -288,85 +246,32 @@
 	{:else}
 		<span class="live-pill">live</span>
 	{/if}
-
-	{#if !stacked}
-		<VolumeControl />
-	{/if}
 </div>
 
 <style>
 	.player-controls {
 		flex: 1;
 		display: flex;
-		align-items: center;
-		gap: 1rem;
+		flex-direction: column;
+		align-items: stretch;
+		gap: 0.2rem;
 		min-width: 0;
 		width: 100%;
 	}
 
-	/* radio: "live" fills the slot the scrubber would occupy, keeping play/pause
-	   left and volume right — same control row, no scrubber/skip */
+	/* radio: "live" takes the scrubber's place under play/pause */
 	.live-pill {
-		flex: 1;
 		font-size: var(--text-xs);
 		font-weight: 600;
 		letter-spacing: 0.08em;
 		text-transform: uppercase;
 		color: var(--accent);
+		text-align: center;
 	}
 
-	.control-btn {
-		background: transparent;
-		border: none;
-		color: inherit;
-		cursor: pointer;
-		padding: 0.6rem;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		transition: all 0.2s;
-		border-radius: var(--radius-full);
-	}
-
-	.control-btn svg {
-		width: 24px;
-		height: 24px;
-	}
-
-	.control-btn:hover {
-		color: var(--accent);
-		background: color-mix(in srgb, var(--accent) 10%, transparent);
-	}
-
-	.control-btn.active {
-		color: var(--accent);
-	}
-
-	/* secondary control: quieter than transport buttons */
-	.control-btn.repeat svg {
-		width: 18px;
-		height: 18px;
-	}
-
-	.control-btn.play-pause:active {
-		transform: scale(0.95);
-	}
-
-	/* the transport is a row only in the stage layout; elsewhere its children
-	   sit in the parent flex/grid as before */
+	/* the transport is one centred row that never wraps; the scrubber sits on its
+	   own row taking the whole centre column */
 	.transport {
-		display: contents;
-	}
-
-	/* stacked (the stage layout): the transport centred on one row that never
-	   wraps, the scrubber on its own row taking the whole centre column */
-	.player-controls.stacked {
-		flex-direction: column;
-		align-items: stretch;
-		gap: 0.2rem;
-	}
-
-	.player-controls.stacked .transport {
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -374,74 +279,50 @@
 		flex-wrap: nowrap;
 	}
 
-	.player-controls.stacked .control-btn {
+	/* transport idle secondary → primary on hover, active toggles carry a dot;
+	   keyboard focus is a ring */
+	.control-btn {
+		background: transparent;
+		border: none;
+		color: var(--text-secondary);
+		cursor: pointer;
 		padding: 0.4rem;
 		flex-shrink: 0;
-	}
-
-	.player-controls.stacked .control-btn svg {
-		width: 22px;
-		height: 22px;
-	}
-
-	.player-controls.stacked .control-btn.play-pause {
-		width: 36px;
-		height: 36px;
-		padding: 0;
-		background: var(--text-primary);
-		color: var(--bg-primary);
-	}
-
-	.player-controls.stacked .control-btn.play-pause:hover {
-		background: var(--text-primary);
-		color: var(--bg-primary);
-		transform: scale(1.05);
-	}
-
-	.player-controls.stacked .control-btn.play-pause svg {
-		width: 18px;
-		height: 18px;
-	}
-
-	.player-controls.stacked .time-control {
-		width: 100%;
-		max-width: none;
-		margin: 0;
-	}
-
-	/* stage polish — the conventions modern players share:
-	   transport idle secondary → primary on hover, active toggles carry a dot;
-	   the scrubber is thin with a hidden thumb until hovered, primary fill that
-	   turns accent under the pointer, a tall hit area; keyboard focus is a ring */
-	.player-controls.stacked .control-btn {
-		color: var(--text-secondary);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: var(--radius-full);
 		transition:
 			color 150ms cubic-bezier(0.2, 0, 0, 1),
 			transform 150ms cubic-bezier(0.2, 0, 0, 1),
 			background 150ms cubic-bezier(0.2, 0, 0, 1);
 	}
 
-	.player-controls.stacked .control-btn:hover {
-		color: var(--text-primary);
-		background: transparent;
+	.control-btn svg {
+		width: 22px;
+		height: 22px;
 	}
 
-	.player-controls.stacked .control-btn:active {
+	.control-btn:hover {
+		color: var(--text-primary);
+	}
+
+	.control-btn:active {
 		transform: scale(0.94);
 	}
 
-	.player-controls.stacked .control-btn.disabled,
-	.player-controls.stacked .control-btn:disabled {
+	.control-btn.disabled,
+	.control-btn:disabled {
 		opacity: 0.38;
 		pointer-events: none;
 	}
 
-	.player-controls.stacked .control-btn.active {
+	.control-btn.active {
 		color: var(--accent);
 		position: relative;
 	}
 
-	.player-controls.stacked .control-btn.active::after {
+	.control-btn.active::after {
 		content: '';
 		position: absolute;
 		left: 50%;
@@ -453,103 +334,33 @@
 		translate: -50% 0;
 	}
 
-	.player-controls.stacked .control-btn:focus-visible,
-	.player-controls.stacked .seek-bar:focus-visible {
+	.control-btn:focus-visible,
+	.seek-bar:focus-visible {
 		outline: 2px solid var(--text-primary);
 		outline-offset: 2px;
 	}
 
-	.player-controls.stacked .time {
-		color: var(--text-secondary);
-		font-size: var(--text-xs);
-		min-width: 40px;
-	}
-
-	.player-controls.stacked .time:last-child {
-		text-align: right;
-	}
-
-	.player-controls.stacked .seek-bar {
-		height: 20px;
-		margin: -8px 0;
-		--fill: var(--text-primary);
-		--rest: color-mix(in srgb, var(--text-primary) 28%, transparent);
-	}
-
-	.player-controls.stacked .seek-bar::-webkit-slider-runnable-track {
-		height: 4px;
-		border-radius: 2px;
-		margin-top: 8px;
-		background: linear-gradient(
-			to right,
-			var(--fill) 0%,
-			var(--fill) var(--progress, 0%),
-			var(--rest) var(--progress, 0%),
-			var(--rest) 100%
-		);
-		transition: background 150ms cubic-bezier(0.2, 0, 0, 1);
-	}
-
-	.player-controls.stacked .seek-bar::-moz-range-track {
-		height: 4px;
-		border-radius: 2px;
-		background: var(--rest);
-	}
-
-	.player-controls.stacked .seek-bar::-moz-range-progress {
-		height: 4px;
-		border-radius: 2px;
-		background: var(--fill);
-	}
-
-	.player-controls.stacked .seek-bar::-webkit-slider-thumb {
-		width: 12px;
-		height: 12px;
-		margin-top: -4px;
+	.control-btn.play-pause {
+		width: 36px;
+		height: 36px;
+		padding: 0;
 		background: var(--text-primary);
-		opacity: 0;
-		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
-		transform: none;
-		transition: opacity 150ms cubic-bezier(0.2, 0, 0, 1);
+		color: var(--bg-primary);
 	}
 
-	.player-controls.stacked .seek-bar::-moz-range-thumb {
-		width: 12px;
-		height: 12px;
+	.control-btn.play-pause:hover {
 		background: var(--text-primary);
-		border: none;
-		opacity: 0;
-		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
-		transition: opacity 150ms cubic-bezier(0.2, 0, 0, 1);
+		color: var(--bg-primary);
+		transform: scale(1.05);
 	}
 
-	.player-controls.stacked .seek-bar:hover,
-	.player-controls.stacked .seek-bar:focus-visible,
-	.player-controls.stacked .seek-bar:active {
-		--fill: var(--accent);
+	.control-btn.play-pause:active {
+		transform: scale(0.95);
 	}
 
-	.player-controls.stacked .seek-bar:hover::-webkit-slider-thumb,
-	.player-controls.stacked .seek-bar:focus-visible::-webkit-slider-thumb,
-	.player-controls.stacked .seek-bar:active::-webkit-slider-thumb {
-		opacity: 1;
-		transform: none;
-		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
-	}
-
-	.player-controls.stacked .seek-bar:hover::-moz-range-thumb,
-	.player-controls.stacked .seek-bar:focus-visible::-moz-range-thumb,
-	.player-controls.stacked .seek-bar:active::-moz-range-thumb {
-		opacity: 1;
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.player-controls.stacked .control-btn,
-		.player-controls.stacked .control-btn:active,
-		.player-controls.stacked .control-btn.play-pause:hover {
-			transform: none;
-			transition: color 150ms, background 150ms;
-		}
+	.control-btn.play-pause svg {
+		width: 18px;
+		height: 18px;
 	}
 
 	.control-btn.shuffle svg {
@@ -569,11 +380,6 @@
 		font-variant-numeric: lining-nums tabular-nums;
 	}
 
-	.control-btn.disabled {
-		opacity: 0.4;
-		pointer-events: none;
-	}
-
 	/* radio: static, non-interactive marker that holds play/pause in place */
 	.control-btn.infinity {
 		color: var(--text-tertiary);
@@ -586,91 +392,120 @@
 		background: transparent;
 	}
 
+	@media (prefers-reduced-motion: reduce) {
+		.control-btn,
+		.control-btn:active,
+		.control-btn.play-pause:hover {
+			transform: none;
+			transition: color 150ms, background 150ms;
+		}
+	}
+
 	.time-control {
-		flex: 1;
+		width: 100%;
 		display: flex;
 		align-items: center;
 		gap: 0.75rem;
 	}
 
 	.time {
-		font-size: var(--text-sm);
-		color: var(--text-tertiary);
-		min-width: 45px;
+		font-size: var(--text-xs);
+		color: var(--text-secondary);
+		min-width: 40px;
 		font-variant-numeric: tabular-nums;
 	}
 
-	.seek-bar {
-		flex: 1;
+	.time:last-child {
+		text-align: right;
 	}
 
-	input[type="range"] {
+	/* the scrubber: thin, a hidden thumb until hovered, primary fill that turns
+	   accent under the pointer, a 20px hit area around the 4px track */
+	.seek-bar {
+		flex: 1;
 		-webkit-appearance: none;
 		appearance: none;
 		background: transparent;
 		cursor: pointer;
+		height: 20px;
+		margin: -8px 0;
+		--fill: var(--text-primary);
+		--rest: color-mix(in srgb, var(--text-primary) 28%, transparent);
 	}
 
-	input[type="range"]::-webkit-slider-runnable-track {
+	.seek-bar::-webkit-slider-runnable-track {
+		height: 4px;
+		border-radius: 2px;
+		margin-top: 8px;
 		background: linear-gradient(
 			to right,
-			color-mix(in srgb, var(--accent) 60%, transparent) 0%,
-			color-mix(in srgb, var(--accent) 60%, transparent) var(--progress, 0%),
-			color-mix(in srgb, var(--accent) 20%, transparent) var(--progress, 0%),
-			color-mix(in srgb, var(--accent) 20%, transparent) 100%
+			var(--fill) 0%,
+			var(--fill) var(--progress, 0%),
+			var(--rest) var(--progress, 0%),
+			var(--rest) 100%
 		);
-		height: 4px;
-		border-radius: 2px;
+		transition: background 150ms cubic-bezier(0.2, 0, 0, 1);
 	}
 
-	input[type="range"]::-webkit-slider-thumb {
+	.seek-bar::-moz-range-track {
+		height: 4px;
+		border-radius: 2px;
+		background: var(--rest);
+	}
+
+	.seek-bar::-moz-range-progress {
+		height: 4px;
+		border-radius: 2px;
+		background: var(--fill);
+	}
+
+	.seek-bar::-webkit-slider-thumb {
 		-webkit-appearance: none;
 		appearance: none;
-		background: var(--accent);
-		height: 14px;
-		width: 14px;
+		width: 12px;
+		height: 12px;
+		margin-top: -4px;
 		border-radius: var(--radius-full);
-		margin-top: -5px;
-		transition: all 0.2s;
-		box-shadow: 0 0 0 8px transparent;
+		background: var(--text-primary);
+		opacity: 0;
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+		transition: opacity 150ms cubic-bezier(0.2, 0, 0, 1);
 	}
 
-	input[type="range"]::-webkit-slider-thumb:hover {
-		background: var(--accent-hover);
-		transform: scale(1.2);
-		box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 20%, transparent);
-	}
-
-	input[type="range"]::-moz-range-track {
-		background: color-mix(in srgb, var(--accent) 20%, transparent);
-		height: 4px;
-		border-radius: 2px;
-	}
-
-	input[type="range"]::-moz-range-progress {
-		background: color-mix(in srgb, var(--accent) 60%, transparent);
-		height: 4px;
-		border-radius: 2px;
-	}
-
-	input[type="range"]::-moz-range-thumb {
-		background: var(--accent);
-		height: 14px;
-		width: 14px;
+	.seek-bar::-moz-range-thumb {
+		width: 12px;
+		height: 12px;
 		border-radius: var(--radius-full);
+		background: var(--text-primary);
 		border: none;
-		transition: all 0.2s;
-		box-shadow: 0 0 0 8px transparent;
+		opacity: 0;
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+		transition: opacity 150ms cubic-bezier(0.2, 0, 0, 1);
 	}
 
-	input[type="range"]::-moz-range-thumb:hover {
-		background: var(--accent-hover);
-		transform: scale(1.2);
-		box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 20%, transparent);
+	.seek-bar:hover,
+	.seek-bar:focus-visible,
+	.seek-bar:active {
+		--fill: var(--accent);
 	}
 
+	.seek-bar:hover::-webkit-slider-thumb,
+	.seek-bar:focus-visible::-webkit-slider-thumb,
+	.seek-bar:active::-webkit-slider-thumb {
+		opacity: 1;
+	}
+
+	.seek-bar:hover::-moz-range-thumb,
+	.seek-bar:focus-visible::-moz-range-thumb,
+	.seek-bar:active::-moz-range-thumb {
+		opacity: 1;
+	}
+
+	/* the phone bar: art, title, heart, play, next on the first row; skips flank
+	   the scrubber on the second. prev, repeat and shuffle live in the queue */
 	@media (max-width: 768px) {
-		.player-controls {
+		.player-controls,
+		.transport {
 			display: contents;
 		}
 
@@ -680,52 +515,25 @@
 		}
 
 		.control-btn.prev,
-		.control-btn.infinity {
-			grid-column: 4;
-		}
-
-		.control-btn.play-pause {
-			grid-column: 5;
-		}
-
-		.control-btn.next {
-			grid-column: 6;
-		}
-
-		.control-btn.repeat {
-			grid-column: 7;
-		}
-
+		.control-btn.repeat,
 		.control-btn.shuffle {
 			display: none;
 		}
 
-		.player-controls.stacked .transport {
-			display: contents;
+		.control-btn.infinity {
+			grid-column: 7;
 		}
 
-		.player-controls.stacked .control-btn {
-			padding: 0.5rem;
-		}
-
-		/* the stage bar on a phone: art, title, heart, play, next */
-		.player-controls.stacked .control-btn.prev,
-		.player-controls.stacked .control-btn.repeat {
-			display: none;
-		}
-
-		.player-controls.stacked .control-btn.play-pause {
+		.control-btn.play-pause {
 			grid-column: 7;
 			justify-self: end;
 		}
 
-		.player-controls.stacked .control-btn.next {
-			grid-row: 1;
+		.control-btn.next {
 			grid-column: 8;
 			justify-self: end;
 		}
 
-		/* skips sit on the scrubber row, under the thumb, not in the transport row */
 		.control-btn.skip {
 			grid-row: 2;
 			padding: 0.25rem;
@@ -738,26 +546,6 @@
 
 		.control-btn.skip-forward {
 			grid-column: 8;
-		}
-
-		.control-btn.skip svg {
-			width: 24px;
-			height: 24px;
-		}
-
-		.control-btn svg {
-			width: 28px;
-			height: 28px;
-		}
-
-		.control-btn.repeat svg {
-			width: 22px;
-			height: 22px;
-		}
-
-		.control-btn.play-pause svg {
-			width: 32px;
-			height: 32px;
 		}
 
 		.time-control {
@@ -773,13 +561,10 @@
 		.live-pill {
 			grid-row: 2;
 			grid-column: 1 / 9;
-			text-align: center;
 		}
 
 		.time {
-			font-size: var(--text-xs);
 			min-width: 38px;
 		}
-
 	}
 </style>

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -20,7 +20,6 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import { loginHref } from '$lib/utils/auth-redirect';
-	import { SKIP_BUTTONS_FLAG } from '$lib/config';
 	import { skipStepSeconds } from '$lib/skip-step';
 
 	interface Props {
@@ -30,12 +29,8 @@
 
 	let { queueOpen = false, onToggleQueue }: Props = $props();
 
-	// the stage layout: spotify's three regions, behind the same per-user flag
-	// as the skip buttons while it is judged
-	const stage = $derived(auth.user?.enabled_flags?.includes(SKIP_BUTTONS_FLAG) ?? false);
-
 	$effect(() => {
-		if (stage && auth.isAuthenticated) void likes.ensureLoaded();
+		if (auth.isAuthenticated) void likes.ensureLoaded();
 	});
 	import { auth } from '$lib/auth.svelte';
 	import TrackInfo from './TrackInfo.svelte';
@@ -97,8 +92,7 @@
 			}
 		});
 
-		// seekbackward/seekforward are registered reactively below, only under the
-		// skip-buttons flag: iOS shows them in place of ⏮/⏭ when they exist
+		// seekbackward/seekforward are registered reactively below
 	}
 
 	// check if we're on the current track's detail page
@@ -256,11 +250,10 @@
 		);
 	});
 
-	// lock-screen skips, only for the flag: registering them makes iOS show
-	// ±15s in place of the ⏮/⏭ arrows, which is the trade the flag exists to try
+	// lock-screen skips: registering them makes iOS show ±skip in place of ⏮/⏭
 	$effect(() => {
 		if (!('mediaSession' in navigator)) return;
-		const skips = !player.radio && (auth.user?.enabled_flags?.includes(SKIP_BUTTONS_FLAG) ?? false);
+		const skips = !player.radio;
 		navigator.mediaSession.setActionHandler(
 			'seekbackward',
 			skips ? (details) => queue.seekBy(-(details.seekOffset ?? skipStepSeconds(player.duration))) : null
@@ -930,7 +923,7 @@
 			</div>
 		{/if}
 
-		<div class="player-content" class:stage>
+		<div class="player-content">
 			<TrackInfo
 				track={nowPlayingTrack}
 				isOnTrackDetailPage={Boolean(isOnTrackDetailPage)}
@@ -938,7 +931,7 @@
 				bind:this={trackInfoRef}
 			>
 				{#snippet like()}
-					{#if stage && nowPlayingTrack && !player.radio && nowPlayingTrack.id}
+					{#if nowPlayingTrack && !player.radio && nowPlayingTrack.id}
 						<AddToMenu
 							trackId={nowPlayingTrack.id}
 							trackTitle={nowPlayingTrack.title}
@@ -953,28 +946,26 @@
 					{/if}
 				{/snippet}
 			</TrackInfo>
-			<PlaybackControls radioMode={Boolean(player.radio)} stacked={stage} />
-			{#if stage}
-				<div class="stage-right">
-					{#if onToggleQueue}
-						<button
-							class="stage-btn"
-							class:active={queueOpen}
-							onclick={onToggleQueue}
-							aria-pressed={queueOpen}
-							aria-label="toggle queue (Q)"
-							title={queueOpen ? 'hide queue (Q)' : 'show queue (Q)'}
-						>
-							<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-								<line x1="3" y1="6" x2="21" y2="6"></line>
-								<line x1="3" y1="12" x2="21" y2="12"></line>
-								<line x1="3" y1="18" x2="21" y2="18"></line>
-							</svg>
-						</button>
-					{/if}
-					<VolumeControl stage />
-				</div>
-			{/if}
+			<PlaybackControls radioMode={Boolean(player.radio)} />
+			<div class="player-right">
+				{#if onToggleQueue}
+					<button
+						class="queue-btn"
+						class:active={queueOpen}
+						onclick={onToggleQueue}
+						aria-pressed={queueOpen}
+						aria-label="toggle queue (Q)"
+						title={queueOpen ? 'hide queue (Q)' : 'show queue (Q)'}
+					>
+						<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+							<line x1="3" y1="6" x2="21" y2="6"></line>
+							<line x1="3" y1="12" x2="21" y2="12"></line>
+							<line x1="3" y1="18" x2="21" y2="18"></line>
+						</svg>
+					</button>
+				{/if}
+				<VolumeControl />
+			</div>
 		</div>
 	</div>
 {/if}
@@ -1001,36 +992,24 @@
 	.player::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 1px; background: var(--top-bar-color); opacity: 0.32; filter: saturate(0.9) brightness(0.75); box-shadow: 0 0 0 transparent; transition: opacity 0.15s ease-out, filter 0.15s ease-out, box-shadow 0.2s ease-out; pointer-events: none; z-index: 2; }
 	.player.is-playing::before { opacity: 0.95; filter: saturate(1.25) brightness(1.28); box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 65%, transparent), 0 0 14px color-mix(in srgb, var(--accent) 45%, transparent); }
 
+	/* track on the left, transport + scrubber centred, queue and volume on the right */
 	.player-content {
 		width: 100%;
 		margin: 0;
 		display: grid;
-		grid-template-columns: minmax(200px, 420px) minmax(0, 1fr);
+		grid-template-columns: minmax(120px, 24%) minmax(0, 1fr) minmax(120px, 24%);
 		align-items: center;
 		gap: 1.5rem;
 	}
 
-	@media (max-width: 1100px) {
-		.player-content {
-			grid-template-columns: minmax(160px, 360px) minmax(0, 1fr);
-			gap: 1rem;
-		}
-	}
-
-	/* the stage layout: track on the left, transport + scrubber centred, queue and
-	   volume on the right — spotify's footer, which is what the flag tries */
-	.player-content.stage {
-		grid-template-columns: minmax(120px, 24%) minmax(0, 1fr) minmax(120px, 24%);
-	}
-
-	.stage-right {
+	.player-right {
 		display: flex;
 		align-items: center;
 		justify-content: flex-end;
 		gap: 0.75rem;
 	}
 
-	.stage-btn {
+	.queue-btn {
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
@@ -1044,15 +1023,15 @@
 		transition: color 150ms cubic-bezier(0.2, 0, 0, 1);
 	}
 
-	.stage-btn:hover {
+	.queue-btn:hover {
 		color: var(--text-primary);
 	}
 
-	.stage-btn.active {
+	.queue-btn.active {
 		color: var(--accent);
 	}
 
-	.stage-btn.active::after {
+	.queue-btn.active::after {
 		content: '';
 		position: absolute;
 		left: 50%;
@@ -1064,7 +1043,7 @@
 		translate: -50% 0;
 	}
 
-	.stage-btn:focus-visible {
+	.queue-btn:focus-visible {
 		outline: 2px solid var(--text-primary);
 		outline-offset: 2px;
 	}
@@ -1126,11 +1105,7 @@
 		}
 
 		/* the phone keeps its two rows; the right cluster is desktop chrome */
-		.player-content.stage {
-			grid-template-columns: 48px 1fr auto auto auto auto auto auto;
-		}
-
-		.stage-right {
+		.player-right {
 			display: none;
 		}
 	}

--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -7,7 +7,7 @@
 	import { IMAGE_WIDTHS, resizedImageUrl } from '$lib/utils/display-image';
 
 	interface Props {
-		/** a heart rendered beside the title (the stage layout) */
+		/** the heart rendered beside the title (absent in radio mode) */
 		like?: Snippet;
 		track: Track;
 		isOnTrackDetailPage: boolean;
@@ -421,7 +421,7 @@
 			grid-column: 1;
 		}
 
-		/* the stage bar: title takes the row; heart, play and next sit at its end */
+		/* the phone bar: title takes the row; heart, play and next sit at its end */
 		.player-like {
 			grid-row: 1;
 			grid-column: 6;

--- a/frontend/src/lib/components/player/VolumeControl.svelte
+++ b/frontend/src/lib/components/player/VolumeControl.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
 	import { player } from '$lib/player.svelte';
 
-	/** stage: the polished look — click-to-mute icon, thin track, thumb on hover */
-	let { stage = false }: { stage?: boolean } = $props();
-
 	// the level to come back to after a mute; a fresh session unmutes to 0.7
 	let lastVolume = 0.7;
 
@@ -23,7 +20,7 @@
 	});
 </script>
 
-<div class="volume-control" class:stage>
+<div class="volume-control">
 	<button
 		type="button"
 		class="volume-icon"
@@ -66,13 +63,18 @@
 </div>
 
 <style>
+	/* spotify's ~93px slider: thin, click-to-mute icon, thumb only under the pointer */
 	.volume-control {
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
-		color: var(--text-tertiary);
-		min-width: 140px;
+		width: 125px;
+		color: var(--text-secondary);
 		position: relative;
+	}
+
+	.volume-control:hover {
+		color: var(--text-primary);
 	}
 
 	.volume-icon {
@@ -92,74 +94,6 @@
 		border-radius: var(--radius-sm);
 	}
 
-	/* stage: spotify's ~93px slider, thin, thumb only under the pointer */
-	.volume-control.stage {
-		min-width: 0;
-		width: 125px;
-		color: var(--text-secondary);
-	}
-
-	.volume-control.stage:hover {
-		color: var(--text-primary);
-	}
-
-	.volume-control.stage .volume-bar {
-		height: 4px;
-		background: linear-gradient(
-			to right,
-			var(--text-primary) 0%,
-			var(--text-primary) calc(var(--level, 0) * 100%),
-			color-mix(in srgb, var(--text-primary) 28%, transparent) calc(var(--level, 0) * 100%),
-			color-mix(in srgb, var(--text-primary) 28%, transparent) 100%
-		);
-		transition: background 150ms cubic-bezier(0.2, 0, 0, 1);
-	}
-
-	.volume-control.stage .volume-bar:hover,
-	.volume-control.stage .volume-bar:active,
-	.volume-control.stage .volume-bar:focus-visible {
-		background: linear-gradient(
-			to right,
-			var(--accent) 0%,
-			var(--accent) calc(var(--level, 0) * 100%),
-			color-mix(in srgb, var(--text-primary) 28%, transparent) calc(var(--level, 0) * 100%),
-			color-mix(in srgb, var(--text-primary) 28%, transparent) 100%
-		);
-	}
-
-	.volume-control.stage .volume-bar::-webkit-slider-thumb {
-		width: 12px;
-		height: 12px;
-		background: var(--text-primary);
-		opacity: 0;
-		transition: opacity 150ms cubic-bezier(0.2, 0, 0, 1);
-	}
-
-	.volume-control.stage .volume-bar::-moz-range-thumb {
-		width: 12px;
-		height: 12px;
-		background: var(--text-primary);
-		opacity: 0;
-		transition: opacity 150ms cubic-bezier(0.2, 0, 0, 1);
-	}
-
-	.volume-control.stage .volume-bar:hover::-webkit-slider-thumb,
-	.volume-control.stage .volume-bar:active::-webkit-slider-thumb,
-	.volume-control.stage .volume-bar:focus-visible::-webkit-slider-thumb {
-		opacity: 1;
-	}
-
-	.volume-control.stage .volume-bar:hover::-moz-range-thumb,
-	.volume-control.stage .volume-bar:active::-moz-range-thumb,
-	.volume-control.stage .volume-bar:focus-visible::-moz-range-thumb {
-		opacity: 1;
-	}
-
-	.volume-control.stage .volume-bar:focus-visible {
-		outline: 2px solid var(--text-primary);
-		outline-offset: 4px;
-	}
-
 	.volume-icon.muted {
 		color: var(--error);
 		animation: shake 0.5s ease-in-out;
@@ -175,10 +109,34 @@
 		-webkit-appearance: none;
 		appearance: none;
 		height: 4px;
-		background: var(--bg-hover);
 		border-radius: var(--radius-sm);
 		outline: none;
 		cursor: pointer;
+		background: linear-gradient(
+			to right,
+			var(--text-primary) 0%,
+			var(--text-primary) calc(var(--level, 0) * 100%),
+			color-mix(in srgb, var(--text-primary) 28%, transparent) calc(var(--level, 0) * 100%),
+			color-mix(in srgb, var(--text-primary) 28%, transparent) 100%
+		);
+		transition: background 150ms cubic-bezier(0.2, 0, 0, 1);
+	}
+
+	.volume-bar:hover,
+	.volume-bar:active,
+	.volume-bar:focus-visible {
+		background: linear-gradient(
+			to right,
+			var(--accent) 0%,
+			var(--accent) calc(var(--level, 0) * 100%),
+			color-mix(in srgb, var(--text-primary) 28%, transparent) calc(var(--level, 0) * 100%),
+			color-mix(in srgb, var(--text-primary) 28%, transparent) 100%
+		);
+	}
+
+	.volume-bar:focus-visible {
+		outline: 2px solid var(--text-primary);
+		outline-offset: 4px;
 	}
 
 	.volume-bar::-webkit-slider-thumb {
@@ -187,19 +145,34 @@
 		width: 12px;
 		height: 12px;
 		border-radius: 50%;
-		background: var(--accent);
+		background: var(--text-primary);
 		cursor: pointer;
+		opacity: 0;
+		transition: opacity 150ms cubic-bezier(0.2, 0, 0, 1);
 	}
 
 	.volume-bar::-moz-range-thumb {
 		width: 12px;
 		height: 12px;
 		border-radius: 50%;
-		background: var(--accent);
+		background: var(--text-primary);
 		cursor: pointer;
 		border: none;
+		opacity: 0;
+		transition: opacity 150ms cubic-bezier(0.2, 0, 0, 1);
 	}
 
+	.volume-bar:hover::-webkit-slider-thumb,
+	.volume-bar:active::-webkit-slider-thumb,
+	.volume-bar:focus-visible::-webkit-slider-thumb {
+		opacity: 1;
+	}
+
+	.volume-bar:hover::-moz-range-thumb,
+	.volume-bar:active::-moz-range-thumb,
+	.volume-bar:focus-visible::-moz-range-thumb {
+		opacity: 1;
+	}
 
 	.volume-bar.muted::-webkit-slider-thumb {
 		background: var(--error);

--- a/frontend/src/lib/components/player/VolumeControl.svelte
+++ b/frontend/src/lib/components/player/VolumeControl.svelte
@@ -106,6 +106,8 @@
 
 	.volume-bar {
 		flex: 1;
+		min-width: 0;
+		width: 100%;
 		-webkit-appearance: none;
 		appearance: none;
 		height: 4px;

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -5,7 +5,6 @@ export const TYPEAHEAD_URL = 'https://typeahead.waow.tech';
 
 export const VIBE_SEARCH_FLAG = 'vibe-search';
 export const COPYRIGHT_PARADIGM_FLAG = 'copyright-paradigm';
-export const SKIP_BUTTONS_FLAG = 'skip-buttons';
 
 /**
  * generate atprotofans support URL for an artist.

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { SKIP_BUTTONS_FLAG } from '$lib/config';
 	import favicon from '$lib/assets/favicon.png';
 	import {
 		APP_NAME,
@@ -542,7 +541,6 @@
 {#if !isEmbed}
 	<button
 		class="queue-toggle"
-		class:stage={auth.user?.enabled_flags?.includes(SKIP_BUTTONS_FLAG) ?? false}
 		onclick={toggleQueue}
 		aria-pressed={showQueue}
 		aria-label="toggle queue (Q)"
@@ -812,9 +810,9 @@
 		}
 	}
 
-	/* the stage footer carries its own queue button on desktop */
+	/* the footer carries its own queue button on desktop */
 	@media (min-width: 769px) {
-		.queue-toggle.stage {
+		.queue-toggle {
 			display: none;
 		}
 	}


### PR DESCRIPTION
The footer nate has been trying behind `skip-buttons` becomes the footer for everyone, and the classic one is deleted along with the flag.

<details>
<summary>what everyone gets</summary>

- **desktop**: three regions. track art, title and the heart (opens the add menu: like, or add to a playlist) on the left; shuffle, previous, ±skip, play, ±skip, next, repeat centred on one row with the scrubber beneath spanning the centre column; queue button and volume on the right. the floating queue button is gone on desktop; the phone keeps it.
- **phone**: art, title, heart, play, next on the first row; the skip buttons flank the scrubber on the second. previous, repeat and shuffle live in the queue.
- **skip step** follows track length (5 / 10 / 15 s, `lib/skip-step.ts`).
- **lock screen**: `seekbackward`/`seekforward` are registered for all, so iOS shows ±skip in place of ⏮/⏭ there. this was the trade the flag existed to try; nate accepted it.
- the polish from #1992 (hover roles, active dots, hidden-until-hover thumbs, click-to-mute, focus rings, reduced motion) is now the baseline.

</details>

<details>
<summary>what was deleted</summary>

- `PlaybackControls`: the `stacked` prop, every `{:else}` classic glyph, the classic flex row, the accent-gradient scrubber, the classic phone column rules, its own `VolumeControl` mount. the style block is rewritten as one layout.
- `Player`: the `stage` derivation and `class:stage`, the classic two-column grid and its 1100px variant; `.stage-right`/`.stage-btn` renamed `.player-right`/`.queue-btn`.
- `VolumeControl`: the `stage` prop; the polished slider is the slider.
- `+layout`: the flag-gated `.queue-toggle.stage` rule (desktop hides the fab unconditionally now).
- `lib/config.ts`: `SKIP_BUTTONS_FLAG`; backend `KNOWN_FLAGS`: `skip-buttons` (existing rows for nate and the staging test account become unknown and inert; `feature_flag.py` can clear them).
- docs: feature-flags examples now use `vibe-search`; keyboard-shortcuts and state-management drop the flag wording; frontend CLAUDE.md likewise.

</details>

non-behaviors: radio mode unchanged (∞ marker + live pill, no skips); keyboard seeks stay a fixed 10 s; the queue panel is untouched. backend change is the flag list only, so this goes out as a full release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z