### PR TITLE
layout: hide the queue fab on desktop again

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -810,13 +810,6 @@
 		}
 	}
 
-	/* the footer carries its own queue button on desktop */
-	@media (min-width: 769px) {
-		.queue-toggle {
-			display: none;
-		}
-	}
-
 	.queue-toggle {
 		position: fixed;
 		bottom: calc(var(--player-height, 0px) + 20px + env(safe-area-inset-bottom, 0px));
@@ -858,5 +851,12 @@
 			bottom: calc(var(--player-height, 0px) + 20px + env(safe-area-inset-bottom, 0px));
 		}
 
+	}
+
+	/* the footer carries its own queue button on desktop; the fab is the phone's */
+	@media (min-width: 769px) {
+		.queue-toggle {
+			display: none;
+		}
 	}
 </style>


### PR DESCRIPTION
Desktop showed two queue buttons after #2000: the hide rule lost its flag class and sat before the base rule at equal specificity, so `display: flex` won. The desktop hide rule now comes last in the stylesheet. Phones keep the fab for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z