### PR TITLE
player: the queue button lives in the phone bar; the floating queue button is gone

### DIFF
--- a/frontend/src/lib/components/player/PlaybackControls.svelte
+++ b/frontend/src/lib/components/player/PlaybackControls.svelte
@@ -502,7 +502,8 @@
 	}
 
 	/* the phone bar: art, title, heart, play, next on the first row; skips flank
-	   the scrubber on the second. prev, repeat and shuffle live in the queue */
+	   the scrubber on the second with the queue button at its end. prev, repeat
+	   and shuffle live in the queue */
 	@media (max-width: 768px) {
 		.player-controls,
 		.transport {
@@ -545,22 +546,22 @@
 		}
 
 		.control-btn.skip-forward {
-			grid-column: 8;
+			grid-column: 7;
 		}
 
 		.time-control {
 			grid-row: 2;
-			grid-column: 1 / 9;
+			grid-column: 1 / 8;
 		}
 
 		.player-controls:has(.skip) .time-control {
-			grid-column: 2 / 8;
+			grid-column: 2 / 7;
 		}
 
 		/* radio: "live" takes the scrubber's row instead of the control row */
 		.live-pill {
 			grid-row: 2;
-			grid-column: 1 / 9;
+			grid-column: 1 / 8;
 		}
 
 		.time {

--- a/frontend/src/lib/components/player/Player.svelte
+++ b/frontend/src/lib/components/player/Player.svelte
@@ -1104,9 +1104,17 @@
 			gap: 0.5rem 0.75rem;
 		}
 
-		/* the phone keeps its two rows; the right cluster is desktop chrome */
+		/* the phone keeps its two rows; the queue button ends the scrubber row,
+		   volume is desktop chrome */
 		.player-right {
-			display: none;
+			display: contents;
+		}
+
+		.queue-btn {
+			grid-row: 2;
+			grid-column: 8;
+			justify-self: end;
+			padding: 0.25rem;
 		}
 	}
 </style>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -539,20 +539,6 @@
 </div>
 
 {#if !isEmbed}
-	<button
-		class="queue-toggle"
-		onclick={toggleQueue}
-		aria-pressed={showQueue}
-		aria-label="toggle queue (Q)"
-		title={showQueue ? 'hide queue (Q)' : 'show queue (Q)'}
-	>
-		<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-			<line x1="3" y1="6" x2="21" y2="6"></line>
-			<line x1="3" y1="12" x2="21" y2="12"></line>
-			<line x1="3" y1="18" x2="21" y2="18"></line>
-		</svg>
-	</button>
-
 	<Player queueOpen={showQueue} onToggleQueue={toggleQueue} />
 {/if}
 <Toast />
@@ -810,33 +796,7 @@
 		}
 	}
 
-	.queue-toggle {
-		position: fixed;
-		bottom: calc(var(--player-height, 0px) + 20px + env(safe-area-inset-bottom, 0px));
-		right: 20px;
-		width: 48px;
-		height: 48px;
-		border-radius: var(--radius-full);
-		background: var(--bg-secondary);
-		border: 1px solid var(--border-default);
-		color: var(--text-secondary);
-		cursor: pointer;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		transition: all 0.2s;
-		z-index: 60;
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-		transform: translate3d(0, var(--visual-viewport-offset, 0px), 0);
-		will-change: transform;
-	}
 
-	.queue-toggle:hover {
-		background: var(--bg-hover);
-		color: var(--accent);
-		border-color: var(--accent);
-		transform: translate3d(0, var(--visual-viewport-offset, 0px), 0) scale(1.05);
-	}
 
 	@media (max-width: 768px) {
 		.main-content.with-queue {
@@ -847,16 +807,7 @@
 			width: 100%;
 		}
 
-		.queue-toggle {
-			bottom: calc(var(--player-height, 0px) + 20px + env(safe-area-inset-bottom, 0px));
-		}
 
 	}
 
-	/* the footer carries its own queue button on desktop; the fab is the phone's */
-	@media (min-width: 769px) {
-		.queue-toggle {
-			display: none;
-		}
-	}
 </style>


### PR DESCRIPTION
The floating queue button is deleted. Desktop already has the queue button in the footer's right cluster; on phones that same button now ends the scrubber row: skip-back, times and scrubber, skip-forward, queue.

<details>
<summary>details</summary>

- `+layout.svelte`: the `.queue-toggle` fab markup and styles are removed. `toggleQueue`/`showQueue` stay (Q shortcut, the footer button, the panel).
- `Player.svelte`: on phones `.player-right` is `display: contents` so `.queue-btn` can take grid row 2, column 8; `VolumeControl` is already hidden there.
- `PlaybackControls.svelte`: skip-forward moves to column 7, the scrubber spans 2–7 (1–8 without skips), the radio live pill spans 1–8.
- consequence: with nothing playing there is no footer, so the queue panel is reachable only via Q until playback starts. same as Spotify.

staging only — nate reviews the phone bar before this promotes.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z