### PR TITLE
player: radio on phones — ∞ marker and play no longer share a column; queue ends the live row

### DIFF
--- a/frontend/src/lib/components/player/PlaybackControls.svelte
+++ b/frontend/src/lib/components/player/PlaybackControls.svelte
@@ -547,13 +547,18 @@
 			display: none;
 		}
 
+		.control-btn.play-pause {
+			grid-column: 7;
+			justify-self: end;
+		}
+
+		/* radio: no next, so the ∞ marker takes play's slot and play ends the row */
 		.control-btn.infinity {
 			grid-column: 7;
 		}
 
-		.control-btn.play-pause {
-			grid-column: 7;
-			justify-self: end;
+		.radio-mode .control-btn.play-pause {
+			grid-column: 8;
 		}
 
 		.control-btn.next {
@@ -577,6 +582,10 @@
 		.scrub-trailing {
 			display: flex;
 			align-items: center;
+		}
+
+		.live-row .live-pill {
+			flex: 1;
 		}
 
 		.time {


### PR DESCRIPTION
Two phone radio bugs found while verifying #2003 on staging:

- Since #2000 the radio ∞ marker and play/pause both sat in grid column 7 on phones, so the marker rendered under the pause glyph. This is live on prod. Play now ends the row (column 8) in radio mode; the marker keeps 7.
- The queue button hugged the centred LIVE pill instead of ending the row. The pill now stretches so the button sits at the end, matching the track row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZu2smoHWg1GPCzMTeaD1z