### PR TITLE
jetstream: rotate hosts on an unechoed own write, not on quiet; refresh DIDs for a new account's first records; dispatch profile create

### DIFF
--- a/backend/src/backend/_internal/atproto/client.py
+++ b/backend/src/backend/_internal/atproto/client.py
@@ -532,7 +532,7 @@ _RECORD_WRITE_OPERATIONS = {
 }
 
 
-def _log_own_record_write(endpoint: str, payload: dict[str, Any] | None) -> None:
+async def _log_own_record_write(endpoint: str, payload: dict[str, Any] | None) -> None:
     """emit the write half of the jetstream echo signal.
 
     every record plyr writes to a PDS in its own namespace must come back
@@ -540,6 +540,9 @@ def _log_own_record_write(endpoint: str, payload: dict[str, Any] | None) -> None
     on "writes happened but zero dispatches" is the only quiet-immune way to
     detect an ingest blackout: fm.plyr.* traffic is user writes, so a silent
     window alone cannot distinguish an outage from a quiet night (#1739).
+
+    the same write is stamped in redis so the consumer can tell a host that
+    is not delivering our records from a network that has none to deliver.
     """
     operation = _RECORD_WRITE_OPERATIONS.get(endpoint)
     collection = (payload or {}).get("collection", "")
@@ -551,6 +554,10 @@ def _log_own_record_write(endpoint: str, payload: dict[str, Any] | None) -> None
         operation=operation,
         repo=(payload or {}).get("repo"),
     )
+    with contextlib.suppress(RedisError, OSError):
+        await get_async_redis_client().set(
+            settings.jetstream.last_write_key, str(time.time())
+        )
 
 
 async def make_pds_request(
@@ -597,7 +604,7 @@ async def make_pds_request(
             success_codes,
             parse_response,
         )
-        _log_own_record_write(endpoint, payload)
+        await _log_own_record_write(endpoint, payload)
         return result
 
     oauth_session = reconstruct_oauth_session(oauth_data)
@@ -634,7 +641,7 @@ async def make_pds_request(
             ) from e
 
         if response.status_code in success_codes:
-            _log_own_record_write(endpoint, payload)
+            await _log_own_record_write(endpoint, payload)
             if response.status_code == 204 or not parse_response:
                 return {}
             return response.json()

--- a/backend/src/backend/_internal/jetstream.py
+++ b/backend/src/backend/_internal/jetstream.py
@@ -19,6 +19,7 @@ import logfire
 import orjson
 import websockets
 from atproto_core.nsid import NSID
+from redis.exceptions import RedisError
 from sqlalchemy import select
 from websockets.asyncio.client import ClientConnection
 
@@ -53,6 +54,8 @@ logger = logging.getLogger(__name__)
 # `_process_event` drops everything outside `_known_dids`.
 BSKY_PROFILE_COLLECTION = "app.bsky.actor.profile"
 
+_UNKNOWN_DID_REFRESH_SECONDS = 10.0
+
 
 class JetstreamConsumer:
     """consumes ATProto Jetstream events for this environment's collections.
@@ -81,11 +84,12 @@ class JetstreamConsumer:
         self._last_did_refresh: float = 0.0
         self._shutdown_event = asyncio.Event()
         self._host_index = 0
-        # blind-host detection: a host can stay connected and keep delivering
-        # some collections while dropping ours entirely. tracked separately so
-        # "our collections are silent" can be told apart from "the network is".
+        self._started_at: float = time.time()
+        # firehose time of the newest event seen in our own collections, and
+        # the write timestamp a rotation was last spent on
         self._last_own_event: float = 0.0
-        self._last_any_event: float = 0.0
+        self._rotated_for_write: float = 0.0
+        self._last_write_check: float = 0.0
 
     def stop(self) -> None:
         """signal the consumer to shut down and unblock the recv loop.
@@ -139,10 +143,6 @@ class JetstreamConsumer:
         url = self._build_url()
         logger.info("jetstream connecting to %s", url)
 
-        # a fresh connection has not yet proven anything about this host
-        self._last_own_event = 0.0
-        self._last_any_event = 0.0
-
         with logfire.span(
             "jetstream consume",
             known_dids=len(self._known_dids),
@@ -156,7 +156,6 @@ class JetstreamConsumer:
                     known_dids=len(self._known_dids),
                     endpoint=self._current_endpoint(),
                 )
-                self._last_own_event = self._last_any_event = time.monotonic()
 
                 async for raw in ws:
                     if self._shutdown_event.is_set():
@@ -167,26 +166,14 @@ class JetstreamConsumer:
                     except (orjson.JSONDecodeError, TypeError):
                         continue
 
-                    self._last_any_event = time.monotonic()
                     if self._is_own_collection_event(event):
-                        self._last_own_event = self._last_any_event
+                        self._last_own_event = event.get("time_us", 0) / 1_000_000
 
                     await self._process_event(event)
                     await self._maybe_flush_cursor()
                     await self._maybe_refresh_dids()
 
-                    if self._is_blind():
-                        # info, not warn: this fires on every quiet fm.plyr
-                        # window (see _is_blind), so it is a breadcrumb for
-                        # rotation history, not a failure signal.
-                        logfire.info(
-                            "jetstream host is serving other collections but "
-                            "none of ours, rotating",
-                            endpoint=self._current_endpoint(),
-                            silent_seconds=round(
-                                time.monotonic() - self._last_own_event
-                            ),
-                        )
+                    if await self._own_write_unechoed():
                         return  # the reconnect loop rotates and resumes
 
     async def _process_event(self, event: dict[str, Any]) -> None:
@@ -233,8 +220,14 @@ class JetstreamConsumer:
             return
 
         did = event.get("did")
-        if not did or did not in self._known_dids:
+        if not did:
             return
+        if did not in self._known_dids:
+            if not self._is_own_collection_event(event):
+                return
+            await self._refresh_known_dids_for_unknown(did)
+            if did not in self._known_dids:
+                return
 
         # a commit proves the repo is being served, which is what `active`
         # claims to describe — so it retires a stale `deactivated` flag that
@@ -320,11 +313,16 @@ class JetstreamConsumer:
             ("list", "delete"): ingest_list_delete,
         }
 
-        # profile updates are a special case (nested collection)
-        if collection.endswith(".actor.profile") and operation == "update":
+        # the profile record is written at sign-up and rewritten on edit; the
+        # task only copies fields, so create and update are the same ingest
+        if collection.endswith(".actor.profile") and operation in (
+            "create",
+            "update",
+        ):
             await docket.add(ingest_profile_update)(did=did, record=record or {})
-            logfire.debug(
-                "jetstream dispatched profile.update",
+            logfire.info(
+                "jetstream dispatched profile.{operation}",
+                operation=operation,
                 did=did,
             )
             return
@@ -379,28 +377,42 @@ class JetstreamConsumer:
         if self._cursor is not None:
             self._cursor -= 10_000_000
 
-    def _is_blind(self) -> bool:
-        """is this host delivering other collections but none of ours?
+    async def _own_write_unechoed(self) -> bool:
+        """has a record plyr wrote failed to come back through this host?
 
         the failure this catches never disconnects: jetstream2 kept serving
         `app.bsky.actor.profile` for 10h on 2026-07-30 while dropping every
-        `fm.plyr.*` event. requiring recent *other* traffic separates a blind
-        host from a fully quiet stream — but NOT from an organically quiet
-        fm.plyr window, because the profile mirror flows constantly and keeps
-        `_last_any_event` fresh. so on any night with no fm.plyr writes this
-        trips on every host, one rotation per timeout, by design: rotating is
-        cheap and the false positive costs a reconnect. it does mean a
-        rotation is not evidence of a broken host — the trustworthy outage
-        signal is the write echo ("pds record write" with no matching
-        "jetstream dispatched"), which is quiet-immune.
+        `fm.plyr.*` event. quiet is not evidence — a night with no writes looks
+        the same on a healthy host — so the only trigger is plyr's own write
+        stamp (`_log_own_record_write`) going unanswered past the grace period.
+        one rotation per write: if the next host lacks the record too, the
+        network does, and the write-echo alert is the right place for that.
         """
-        timeout = settings.jetstream.blind_host_timeout_seconds
-        if timeout <= 0 or not self._last_own_event or not self._last_any_event:
+        grace = settings.jetstream.echo_grace_seconds
+        now = time.time()
+        if grace <= 0 or now - self._last_write_check < 10:
             return False
-        now = time.monotonic()
-        return (now - self._last_own_event) > timeout and (
-            now - self._last_any_event
-        ) < (timeout / 2)
+        self._last_write_check = now
+        try:
+            raw = await get_async_redis_client().get(settings.jetstream.last_write_key)
+        except (RedisError, OSError, ValueError):
+            return False
+        if not raw:
+            return False
+        written = float(raw)
+        if written <= max(self._rotated_for_write, self._started_at):
+            return False
+        if self._last_own_event >= written - 2 or now - written < grace:
+            return False
+        self._rotated_for_write = written
+        replay_from = int((written - 10) * 1_000_000)
+        self._cursor = min(self._cursor or replay_from, replay_from)
+        logfire.warn(
+            "jetstream host has not echoed plyr's own write, rotating",
+            endpoint=self._current_endpoint(),
+            unechoed_seconds=round(now - written),
+        )
+        return True
 
     def _build_url(self) -> str:
         """build WebSocket URL with query parameters."""
@@ -416,7 +428,11 @@ class JetstreamConsumer:
         try:
             redis = get_async_redis_client()
             if raw := await redis.get(settings.jetstream.cursor_key):
-                self._cursor = int(raw)
+                stored = int(raw)
+                # a rewind for rotation must survive the reload that follows it
+                self._cursor = (
+                    stored if self._cursor is None else min(self._cursor, stored)
+                )
                 logger.info("jetstream resuming from cursor %d", self._cursor)
         except Exception:
             logger.debug("jetstream could not load cursor from redis")
@@ -461,6 +477,15 @@ class JetstreamConsumer:
         except Exception:
             logger.warning("jetstream could not refresh known DIDs", exc_info=True)
         self._last_did_refresh = time.monotonic()
+
+    async def _refresh_known_dids_for_unknown(self, did: str) -> None:
+        """a commit in our namespace from a DID we do not know is usually an
+        account created since the last refresh — its first records land
+        seconds after the artist row, well inside the refresh interval."""
+        if time.monotonic() - self._last_did_refresh < _UNKNOWN_DID_REFRESH_SECONDS:
+            return
+        logger.info("jetstream refreshing known DIDs for unknown %s", did)
+        await self._refresh_known_dids()
 
     async def _maybe_refresh_dids(self) -> None:
         """refresh known DIDs if enough time has elapsed."""

--- a/backend/src/backend/_internal/jetstream.py
+++ b/backend/src/backend/_internal/jetstream.py
@@ -55,6 +55,7 @@ logger = logging.getLogger(__name__)
 BSKY_PROFILE_COLLECTION = "app.bsky.actor.profile"
 
 _UNKNOWN_DID_REFRESH_SECONDS = 10.0
+_ECHO_SKEW_SECONDS = 30.0
 
 
 class JetstreamConsumer:
@@ -313,8 +314,7 @@ class JetstreamConsumer:
             ("list", "delete"): ingest_list_delete,
         }
 
-        # the profile record is written at sign-up and rewritten on edit; the
-        # task only copies fields, so create and update are the same ingest
+        # written at sign-up, rewritten on edit: the same ingest either way
         if collection.endswith(".actor.profile") and operation in (
             "create",
             "update",
@@ -402,7 +402,9 @@ class JetstreamConsumer:
         written = float(raw)
         if written <= max(self._rotated_for_write, self._started_at):
             return False
-        if self._last_own_event >= written - 2 or now - written < grace:
+        if self._last_own_event >= written - _ECHO_SKEW_SECONDS:
+            return False
+        if now - written < grace:
             return False
         self._rotated_for_write = written
         replay_from = int((written - 10) * 1_000_000)

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -979,12 +979,18 @@ class JetstreamSettings(AppSettingsSection):
         ],
         description="Jetstream hosts, tried round-robin on each reconnect",
     )
-    blind_host_timeout_seconds: float = Field(
-        default=1800.0,
+    echo_grace_seconds: float = Field(
+        default=120.0,
         description=(
-            "Rotate hosts when no record in our own collections arrives for this "
-            "long while other traffic is still flowing (a host serving some "
-            "collections but not ours). 0 disables the check."
+            "Rotate hosts when a record plyr wrote to a PDS has not come back "
+            "through the firehose within this long. 0 disables the check."
+        ),
+    )
+    last_write_key: str = Field(
+        default="plyr:jetstream:last_own_write",
+        description=(
+            "Redis key holding the wall-clock time of plyr's latest record write "
+            "in its own namespace"
         ),
     )
     cursor_key: str = Field(

--- a/backend/tests/_internal/test_record_write_echo_log.py
+++ b/backend/tests/_internal/test_record_write_echo_log.py
@@ -6,19 +6,33 @@ log, because the ingest-blackout alert is defined as "writes happened but zero
 stops matching plyr's namespace, the alert goes permanently silent.
 """
 
-from unittest.mock import patch
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from backend._internal.atproto.client import _log_own_record_write
 from backend.config import settings
+
+
+@pytest.fixture
+def redis() -> Iterator[MagicMock]:
+    client = MagicMock()
+    client.set = AsyncMock()
+    with patch(
+        "backend._internal.atproto.client.get_async_redis_client",
+        return_value=client,
+    ):
+        yield client
 
 
 def _own(collection_suffix: str) -> str:
     return f"{settings.atproto.app_namespace}.{collection_suffix}"
 
 
-def test_own_namespace_create_emits() -> None:
+async def test_own_namespace_create_emits(redis: MagicMock) -> None:
     with patch("backend._internal.atproto.client.logfire.info") as info:
-        _log_own_record_write(
+        await _log_own_record_write(
             "com.atproto.repo.createRecord",
             {"collection": _own("track"), "repo": "did:plc:abc"},
         )
@@ -27,34 +41,55 @@ def test_own_namespace_create_emits() -> None:
     assert info.call_args.kwargs["operation"] == "create"
 
 
-def test_own_namespace_delete_emits() -> None:
+async def test_own_namespace_delete_emits(redis: MagicMock) -> None:
     with patch("backend._internal.atproto.client.logfire.info") as info:
-        _log_own_record_write(
+        await _log_own_record_write(
             "com.atproto.repo.deleteRecord",
             {"collection": _own("like"), "repo": "did:plc:abc"},
         )
     assert info.call_args.kwargs["operation"] == "delete"
 
 
-def test_foreign_namespace_is_silent() -> None:
+async def test_foreign_namespace_is_silent(redis: MagicMock) -> None:
     with patch("backend._internal.atproto.client.logfire.info") as info:
-        _log_own_record_write(
+        await _log_own_record_write(
             "com.atproto.repo.createRecord",
             {"collection": "app.bsky.feed.post", "repo": "did:plc:abc"},
         )
     info.assert_not_called()
 
 
-def test_non_write_endpoint_is_silent() -> None:
+async def test_non_write_endpoint_is_silent(redis: MagicMock) -> None:
     with patch("backend._internal.atproto.client.logfire.info") as info:
-        _log_own_record_write(
+        await _log_own_record_write(
             "com.atproto.repo.getRecord",
             {"collection": _own("track")},
         )
     info.assert_not_called()
 
 
-def test_missing_payload_is_silent() -> None:
+async def test_missing_payload_is_silent(redis: MagicMock) -> None:
     with patch("backend._internal.atproto.client.logfire.info") as info:
-        _log_own_record_write("com.atproto.repo.createRecord", None)
+        await _log_own_record_write("com.atproto.repo.createRecord", None)
     info.assert_not_called()
+
+
+async def test_own_namespace_write_stamps_redis(redis: MagicMock) -> None:
+    """the consumer rotates hosts off this stamp, not off a quiet timer."""
+    with patch("backend._internal.atproto.client.logfire.info"):
+        await _log_own_record_write(
+            "com.atproto.repo.createRecord",
+            {"collection": _own("like"), "repo": "did:plc:abc"},
+        )
+    redis.set.assert_awaited_once()
+    key, value = redis.set.call_args.args
+    assert key == settings.jetstream.last_write_key
+    assert float(value) > 0
+
+
+async def test_foreign_namespace_does_not_stamp(redis: MagicMock) -> None:
+    await _log_own_record_write(
+        "com.atproto.repo.createRecord",
+        {"collection": "app.bsky.feed.post", "repo": "did:plc:abc"},
+    )
+    redis.set.assert_not_called()

--- a/backend/tests/test_jetstream.py
+++ b/backend/tests/test_jetstream.py
@@ -176,6 +176,105 @@ class TestJetstreamConsumer:
         await consumer._process_event(event)
         consumer._dispatch.assert_not_called()  # type: ignore[union-attr]
 
+    async def test_own_collection_commit_from_unknown_did_refreshes_dids(self) -> None:
+        """a new account's first records land seconds after its artist row
+        and inside the refresh interval; that like used to be dropped."""
+        consumer = JetstreamConsumer()
+        consumer._known_dids = {"did:plc:known"}
+        consumer._last_did_refresh = 0.0
+
+        async def refresh() -> None:
+            consumer._known_dids.add("did:plc:new")
+            consumer._last_did_refresh = time.monotonic()
+
+        consumer._refresh_known_dids = refresh  # type: ignore[method-assign]
+        consumer._dispatch = AsyncMock()  # type: ignore[method-assign]
+        await consumer._process_event(
+            {
+                "kind": "commit",
+                "did": "did:plc:new",
+                "time_us": 1,
+                "commit": {
+                    "collection": settings.atproto.like_collection,
+                    "operation": "create",
+                    "rkey": "abc",
+                    "record": {},
+                },
+            }
+        )
+        consumer._dispatch.assert_called_once()  # type: ignore[union-attr]
+        assert consumer._dispatch.call_args.kwargs["did"] == "did:plc:new"  # type: ignore[union-attr]
+
+    async def test_unknown_did_refresh_is_rate_limited(self) -> None:
+        consumer = JetstreamConsumer()
+        consumer._known_dids = {"did:plc:known"}
+        consumer._last_did_refresh = time.monotonic()
+        consumer._refresh_known_dids = AsyncMock()  # type: ignore[method-assign]
+        consumer._dispatch = AsyncMock()  # type: ignore[method-assign]
+        await consumer._process_event(
+            {
+                "kind": "commit",
+                "did": "did:plc:new",
+                "commit": {
+                    "collection": settings.atproto.like_collection,
+                    "operation": "create",
+                    "rkey": "abc",
+                },
+            }
+        )
+        consumer._refresh_known_dids.assert_not_called()  # type: ignore[union-attr]
+        consumer._dispatch.assert_not_called()  # type: ignore[union-attr]
+
+    async def test_bsky_commit_from_unknown_did_does_not_refresh(self) -> None:
+        """~2 profile commits a second network-wide must not hit the database."""
+        consumer = JetstreamConsumer()
+        consumer._known_dids = {"did:plc:known"}
+        consumer._last_did_refresh = 0.0
+        consumer._refresh_known_dids = AsyncMock()  # type: ignore[method-assign]
+        await consumer._process_event(
+            {
+                "kind": "commit",
+                "did": "did:plc:stranger",
+                "commit": {
+                    "collection": BSKY_PROFILE_COLLECTION,
+                    "operation": "update",
+                    "rkey": "self",
+                },
+            }
+        )
+        consumer._refresh_known_dids.assert_not_called()  # type: ignore[union-attr]
+
+    async def test_dispatches_profile_create(self) -> None:
+        """sign-up writes the profile record; it must echo like any other write."""
+        consumer = JetstreamConsumer()
+        consumer._known_dids = {"did:plc:jetstream_test"}
+        dispatched: list[object] = []
+        mock_docket = MagicMock()
+
+        def add(task: object) -> object:
+            dispatched.append(task)
+
+            async def call(**kwargs: object) -> None:
+                pass
+
+            return call
+
+        mock_docket.add = add
+        event = {
+            "kind": "commit",
+            "did": "did:plc:jetstream_test",
+            "time_us": 1,
+            "commit": {
+                "collection": settings.atproto.profile_collection,
+                "operation": "create",
+                "rkey": "self",
+                "record": {"bio": "hi"},
+            },
+        }
+        with patch("backend._internal.jetstream.get_docket", return_value=mock_docket):
+            await consumer._process_event(event)
+        assert dispatched == [ingest_profile_update]
+
     async def test_skips_non_commit_non_identity_non_account_events(self) -> None:
         consumer = JetstreamConsumer()
         consumer._known_dids = {"did:plc:jetstream_test"}
@@ -2726,40 +2825,101 @@ class TestHostRotation:
             consumer._rotate_host()
         assert consumer._cursor == 1_000_000_000 - 10_000_000
 
-
-class TestBlindHostDetection:
-    def test_other_traffic_flowing_but_ours_silent_is_blind(self) -> None:
+    async def test_a_rewound_cursor_survives_the_reload_before_reconnect(self) -> None:
+        """`run` reloads the cursor from redis before every connection; the
+        stored value is the pre-rewind position, so loading must never move
+        forward past what is in memory."""
         consumer = JetstreamConsumer()
-        now = time.monotonic()
-        with patch.object(settings.jetstream, "blind_host_timeout_seconds", 1800.0):
-            consumer._last_own_event = now - 3600  # an hour of nothing from us
-            consumer._last_any_event = now - 5  # bsky events still arriving
-            assert consumer._is_blind() is True
+        consumer._cursor = 1_000_000_000 - 10_000_000
+        redis = MagicMock()
+        redis.get = AsyncMock(return_value="1000000000")
+        with patch(
+            "backend._internal.jetstream.get_async_redis_client", return_value=redis
+        ):
+            await consumer._load_cursor()
+        assert consumer._cursor == 1_000_000_000 - 10_000_000
 
-    def test_a_quiet_network_is_not_blind(self) -> None:
-        """both silent means no traffic, not a bad host — don't rotate."""
-        consumer = JetstreamConsumer()
-        now = time.monotonic()
-        with patch.object(settings.jetstream, "blind_host_timeout_seconds", 1800.0):
-            consumer._last_own_event = now - 3600
-            consumer._last_any_event = now - 3600
-            assert consumer._is_blind() is False
 
-    def test_recent_own_traffic_is_not_blind(self) -> None:
-        consumer = JetstreamConsumer()
-        now = time.monotonic()
-        with patch.object(settings.jetstream, "blind_host_timeout_seconds", 1800.0):
-            consumer._last_own_event = now - 10
-            consumer._last_any_event = now - 5
-            assert consumer._is_blind() is False
+def _redis_with_write(written: float | None) -> MagicMock:
+    redis = MagicMock()
+    redis.get = AsyncMock(return_value=None if written is None else str(written))
+    return redis
 
-    def test_detection_can_be_disabled(self) -> None:
+
+class TestEchoDrivenRotation:
+    """a host is only judged blind when plyr's own write fails to echo."""
+
+    def _consumer(self) -> JetstreamConsumer:
         consumer = JetstreamConsumer()
-        now = time.monotonic()
-        with patch.object(settings.jetstream, "blind_host_timeout_seconds", 0.0):
-            consumer._last_own_event = now - 86400
-            consumer._last_any_event = now - 1
-            assert consumer._is_blind() is False
+        consumer._started_at = time.time() - 3600
+        consumer._cursor = int(time.time() * 1_000_000)
+        return consumer
+
+    async def _check(self, consumer: JetstreamConsumer, written: float | None) -> bool:
+        with (
+            patch.object(settings.jetstream, "echo_grace_seconds", 120.0),
+            patch(
+                "backend._internal.jetstream.get_async_redis_client",
+                return_value=_redis_with_write(written),
+            ),
+        ):
+            return await consumer._own_write_unechoed()
+
+    async def test_a_write_unechoed_past_grace_rotates_and_replays_it(self) -> None:
+        consumer = self._consumer()
+        written = time.time() - 300
+        consumer._last_own_event = written - 60  # last thing of ours predates it
+        assert await self._check(consumer, written) is True
+        assert consumer._cursor == int((written - 10) * 1_000_000)
+
+    async def test_one_rotation_per_write(self) -> None:
+        """the next host missing the record too means the network lacks it."""
+        consumer = self._consumer()
+        written = time.time() - 300
+        assert await self._check(consumer, written) is True
+        consumer._last_write_check = 0.0
+        assert await self._check(consumer, written) is False
+
+    async def test_an_echoed_write_is_not_blind(self) -> None:
+        consumer = self._consumer()
+        written = time.time() - 300
+        consumer._last_own_event = written + 3
+        assert await self._check(consumer, written) is False
+
+    async def test_a_write_inside_grace_waits(self) -> None:
+        consumer = self._consumer()
+        assert await self._check(consumer, time.time() - 30) is False
+
+    async def test_a_quiet_network_never_rotates(self) -> None:
+        """no write stamp at all — the old timer-based heuristic is gone."""
+        consumer = self._consumer()
+        consumer._last_own_event = 0.0
+        assert await self._check(consumer, None) is False
+        assert not hasattr(consumer, "_is_blind")
+
+    async def test_a_write_before_startup_is_ignored(self) -> None:
+        """its echo may have arrived before this process existed."""
+        consumer = self._consumer()
+        assert await self._check(consumer, consumer._started_at - 10) is False
+
+    async def test_detection_can_be_disabled(self) -> None:
+        consumer = self._consumer()
+        with patch.object(settings.jetstream, "echo_grace_seconds", 0.0):
+            assert await consumer._own_write_unechoed() is False
+
+    async def test_checks_redis_at_most_every_ten_seconds(self) -> None:
+        consumer = self._consumer()
+        redis = _redis_with_write(time.time() - 300)
+        with (
+            patch.object(settings.jetstream, "echo_grace_seconds", 120.0),
+            patch(
+                "backend._internal.jetstream.get_async_redis_client",
+                return_value=redis,
+            ),
+        ):
+            consumer._last_write_check = time.time()
+            assert await consumer._own_write_unechoed() is False
+        redis.get.assert_not_called()
 
     def test_bsky_profile_events_do_not_count_as_ours(self) -> None:
         """the exact traffic that made the blind host look alive."""

--- a/backend/tests/test_jetstream.py
+++ b/backend/tests/test_jetstream.py
@@ -2868,7 +2868,7 @@ class TestEchoDrivenRotation:
     async def test_a_write_unechoed_past_grace_rotates_and_replays_it(self) -> None:
         consumer = self._consumer()
         written = time.time() - 300
-        consumer._last_own_event = written - 60  # last thing of ours predates it
+        consumer._last_own_event = written - 120  # last thing of ours predates it
         assert await self._check(consumer, written) is True
         assert consumer._cursor == int((written - 10) * 1_000_000)
 
@@ -2884,6 +2884,14 @@ class TestEchoDrivenRotation:
         consumer = self._consumer()
         written = time.time() - 300
         consumer._last_own_event = written + 3
+        assert await self._check(consumer, written) is False
+
+    async def test_clock_skew_between_stamp_and_firehose_is_tolerated(self) -> None:
+        """jetstream stamps `time_us` on its own clock; a few seconds behind
+        the app machine's write stamp is still the echo, not a blind host."""
+        consumer = self._consumer()
+        written = time.time() - 300
+        consumer._last_own_event = written - 5
         assert await self._check(consumer, written) is False
 
     async def test_a_write_inside_grace_waits(self) -> None:

--- a/docs/internal/architecture/jetstream-ingest.md
+++ b/docs/internal/architecture/jetstream-ingest.md
@@ -123,4 +123,31 @@ title back by an hour, while both PDS records were correct throughout.
 - **tombstones**: a deleted URI is tombstoned in Redis for 5 min so a cursor
   rewind can't resurrect a just-deleted record as a ghost. plyr always mints
   fresh TID rkeys, so a legitimate same-URI re-create never happens.
-- **unknown artist**: events for a DID with no `Artist` row are skipped.
+- **unknown artist**: events for a DID with no `Artist` row are skipped. the
+  known set refreshes from the database every five minutes, and a commit in
+  our own namespace from an unknown DID forces a refresh (rate-limited to one
+  per ten seconds) before the drop — a new account's first records land seconds
+  after its artist row, which is how a sign-up's like was lost on 2026-09-03.
+  Bluesky profile commits never force a refresh; they arrive for every DID on
+  the network.
+
+## hosts: rotate on evidence, never on quiet
+
+one jetstream instance can serve some collections and silently drop others
+(jetstream2 did exactly that for 10h on 2026-07-30) without ever disconnecting,
+so the consumer keeps a list of hosts and moves to the next one on every
+reconnect. what makes it *decide* to reconnect matters: `fm.plyr.*` traffic is
+user writes, so a silent window on a healthy host looks identical to a blind
+one, and a timer on silence just rotates through every host each quiet night.
+
+the trigger is plyr's own write instead. every own-namespace record write in
+`_internal/atproto/client.py` logs `pds record write` (the write half of the
+ingest-blackout alert, #1739) and stamps `jetstream.last_write_key` in redis
+with the wall-clock time. the consumer compares that stamp with the firehose
+time of the newest event it has seen in our collections; a write older than
+`jetstream.echo_grace_seconds` with nothing of ours since is a host that is not
+delivering our records, and the consumer rewinds the cursor to before the write
+and rotates. one rotation per write — if the next host lacks the record too,
+the network does, and the alert is the right place for that. writes stamped
+before the process started are ignored, since their echo may have arrived
+before it existed.

--- a/loq.toml
+++ b/loq.toml
@@ -215,7 +215,7 @@ max_lines = 1099
 
 [[rules]]
 path = "backend/tests/test_jetstream.py"
-max_lines = 2771
+max_lines = 2931
 
 [[rules]]
 path = "frontend/src/lib/components/embed/CollectionEmbed.svelte"
@@ -283,7 +283,7 @@ max_lines = 2589
 
 [[rules]]
 path = "backend/src/backend/_internal/atproto/client.py"
-max_lines = 921
+max_lines = 930
 
 [[rules]]
 path = "backend/src/backend/_internal/auth/oauth.py"

--- a/loq.toml
+++ b/loq.toml
@@ -215,7 +215,7 @@ max_lines = 1099
 
 [[rules]]
 path = "backend/tests/test_jetstream.py"
-max_lines = 2931
+max_lines = 2939
 
 [[rules]]
 path = "frontend/src/lib/components/embed/CollectionEmbed.svelte"


### PR DESCRIPTION
the `plyr-fm/jetstream ingest blackout` alert fired for ~10h on september 3 with writes=2, dispatches=0, while every jetstream host carried both records and the consumer was connected at the head of the stream. the two writes were one sign-up: the profile record, whose `create` was never in the dispatch table, and a like 20 s after the artist row, dropped as an unknown DID because the known set only refreshes every 5 minutes. no data was lost (the API writes the database before the PDS); the echo signal had two permanent holes. both are closed, and the quiet-window host rotation is replaced by one that only moves on evidence.

```
09-03 07:40:33 did:plc:2zxl… fm.plyr.actor.profile create   ← never dispatchable
09-03 07:40:52 did:plc:2zxl… fm.plyr.like create            ← artist row created 07:40:30, DID set 21 s stale
```
(replayed from jetstream1.us-east and jetstream2.us-west with the `fm.plyr.*` filter over 14 h: exactly these two commits on each)

<details>
<summary>what changed</summary>

- **new-account window**: a commit in our own namespace from an unknown DID forces a known-DID refresh (at most one per 10 s) before the drop. bluesky profile commits never force one; they arrive for every DID on the network.
- **profile create echoes**: `.actor.profile` `create` dispatches to `ingest_profile_update`, which only copies fields, so sign-ups produce a `jetstream dispatched` log like every other write.
- **rotation on evidence, not quiet**: `_is_blind` rotated hosts whenever `fm.plyr.*` was silent while bluesky traffic flowed, which is every quiet night on a healthy host. it is deleted along with `blind_host_timeout_seconds`. instead `_log_own_record_write` stamps redis (`jetstream.last_write_key`) with the wall-clock time of plyr's latest own-namespace write, and the consumer rotates when that write is older than `echo_grace_seconds` (120) with nothing of ours seen since (compared on firehose `time_us`). one rotation per write: a second host missing the same record means the network lacks it, and the alert is the right place for that. writes stamped before the process started are ignored.
- **the rewind now survives reconnect**: `run` reloads the cursor from redis before every connection, which overwrote both the existing 10 s rotation rewind and the new one. `_load_cursor` now never moves the cursor forward past the in-memory value.
</details>

<details>
<summary>intentional non-behaviors</summary>

- the alert itself is unchanged. after this, a sign-up's writes echo, so it stops firing on new accounts; it still fires when a write genuinely never comes back.
- `jetstream dispatched bsky profile.*` stays at debug so bluesky profile edits cannot mask a blackout in the alert's dispatch count.
- no backfill for the dropped like; the row exists (the API wrote it), only the echo was missed.
</details>

<details>
<summary>tests</summary>

`tests/test_jetstream.py`: unknown-DID refresh (fires for own collections, rate-limited, never for bluesky commits), profile create dispatch, `TestEchoDrivenRotation` (unechoed past grace rotates and rewinds; once per write; echoed, inside grace, pre-startup, disabled, and no-stamp cases never rotate; redis read at most every 10 s), rewound cursor survives `_load_cursor`. `tests/_internal/test_record_write_echo_log.py`: the write stamps redis for own namespace only. full backend suite green.
</details>

docs: `docs/internal/architecture/jetstream-ingest.md` gains a "hosts: rotate on evidence, never on quiet" section.

![bufo-investigates](https://all-the.bufo.zone/bufo-investigates.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
