### PR TITLE
status maintenance: a window report of releases, promotes and public posts feeds the run

### DIFF
--- a/.github/workflows/status-maintenance.yml
+++ b/.github/workflows/status-maintenance.yml
@@ -57,29 +57,33 @@ jobs:
             2. archive content MUST be moved to .status_history/, not deleted
             3. podcast tone MUST be dry, matter-of-fact, slightly sardonic - NOT enthusiastic or complimentary
 
-            ## task 1: gather temporal context
+            ## task 1: gather the window report
 
-            CRITICAL: you must determine the correct time window by finding when the LAST status maintenance PR was MERGED (not opened).
+            the window is from the moment the LAST status-maintenance PR was MERGED (not opened) until now. `scripts/status_window.py` computes it and everything else you need to know about the window:
 
-            run these commands:
             ```bash
             date
-            # get the most recently merged status-maintenance PR (filter by branch name, sort by merge date)
-            # NOTE: excluding #724 and #846 which were reverted - remove these exclusions after next successful run
-            gh pr list --state merged --search "status-maintenance" --limit 20 --json number,title,mergedAt,headRefName | jq '[.[] | select(.headRefName | startswith("status-maintenance-")) | select(.number != 724 and .number != 846 and .number != 882)] | sort_by(.mergedAt) | reverse | .[0]'
+            uv run scripts/status_window.py > window_report.md
             git log --oneline -50
-            ls -la .status_history/ 2>/dev/null || echo "no archive directory yet"
-            wc -l STATUS.md
             ```
 
-            determine:
-            - what is today's date?
-            - when was the last status-maintenance PR MERGED? (use the mergedAt field from the jq output - it's the most recent PR with a branch starting with "status-maintenance-")
-            - what shipped SINCE that merge date? (this is your focus window - NOT "last week")
-            - does .status_history/ exist? (this implies whether or not this is the first episode)
-            - how many lines is STATUS.md currently?
+            read window_report.md in full. it is the ground truth for this run and contains:
+            - the window and which maintenance PR opened it
+            - backend releases (GitHub releases, timestamp tags) published in the window and the PRs each carried to production
+            - frontend promotes — Cloudflare Pages production deployments of `production-fe`, the only record a frontend-only release leaves
+            - every PR merged in the window with a `landed` column: `prod via release <tag>`, `prod via frontend promote <time>`, `staging only`, or `docs only`
+            - public posts in the window from the plyr.fm account, and from zzstoatzz.io where they mention plyr
+            - project scope: first commit, release count, STATUS.md's line count, and the arcs already archived in .status_history/ (titles for the newest months; read the older files when you need them)
 
-            IMPORTANT: the time window for this maintenance run is from the last merged status-maintenance PR until now. if the last PR was merged on Dec 2nd and today is Dec 8th, you should focus on everything from Dec 3rd onwards, NOT just "the last week".
+            IMPORTANT: if the last PR was merged on Dec 2nd and today is Dec 8th, the window is Dec 2nd onwards, NOT "the last week".
+
+            ## how to use the report
+
+            - **the subject is the diff.** the episode and the STATUS.md changes are about what changed in the window. the releases, promotes, posts and archived arcs are context for placing that work, never a list to recite — a recap of releases is duplicative of the release page.
+            - **the `landed` column decides tense.** "shipped", "launched", "live" and "in production" are only for rows landed in prod, and the first mention names when (the release or promote date). a row that is `staging only` is "merged" or "on staging", however confident its PR body sounds. never say "shipped" from a merge date.
+            - **the posts are what the audience was told.** when a change was announced, one clause noting it is enough; when a significant change went out unannounced, say so once. do not read posts aloud.
+            - **the archived arcs are the project's memory.** use them to place the window — what this continues, what it closes, what it reverses — one phrase at a time, and only where a listener with no history would otherwise be lost.
+            - **STATUS.md must agree with the report.** if STATUS.md calls something shipped that the report shows as `staging only`, or the reverse, correct STATUS.md in this PR and say so in the PR body.
 
             ## task 2: archive old month sections
 
@@ -126,10 +130,7 @@ jobs:
             before writing anything, you need to deeply understand what happened in the time window.
             use subagents liberally to investigate in parallel:
 
-            1. **get the full picture of PRs merged in the time window**:
-               ```bash
-               gh pr list --state merged --search "merged:>={mergedAt date}" --limit 50 --json number,title,body,mergedAt,additions,deletions,files
-               ```
+            1. **start from the PR table in window_report.md** — it lists every PR merged in the window and where each landed. read bodies with `gh pr view {number} --json body` for the ones that matter:
 
             2. **for each significant PR, read its body and understand the design decisions**:
                - what problem was being solved?
@@ -222,7 +223,8 @@ jobs:
 
             read the commit messages and PR bodies carefully to understand what changed.
 
-            - if something is completely NEW (didn't exist before), say it "shipped" or "launched"
+            - "shipped" and "launched" mean the `landed` column in window_report.md says prod; a merged PR that is `staging only` is not shipped, whatever its body says
+            - if something is completely NEW (didn't exist before) and is in prod, say it "shipped" or "launched"
             - if something existing got improved or fixed, call it what it is: fixes, improvements, polish
 
             don't rely on commit message prefixes like `feat:` or `fix:` - they're not always accurate.
@@ -245,11 +247,12 @@ jobs:
 
             run: uv run scripts/generate_tts.py podcast_script.txt update.wav
 
-            keep podcast_script.txt in place — do NOT delete it. a later
-            workflow step uploads both update.wav and podcast_script.txt as a
-            build artifact so the phase-2 upload job can attach the transcript
-            as the track description. neither file is committed to the repo
-            (both are gitignored).
+            keep podcast_script.txt and window_report.md in place — do NOT
+            delete them. a later workflow step posts the report and the
+            transcript into the PR body and uploads update.wav and
+            podcast_script.txt as a build artifact so the phase-2 upload job
+            can attach the transcript as the track description. none of these
+            files is committed to the repo (all are gitignored).
 
             ## task 4: open PR
 
@@ -257,8 +260,9 @@ jobs:
             1. first, generate a unique branch name: BRANCH="status-maintenance-$(date +%Y%m%d-%H%M%S)"
             2. git checkout -b $BRANCH
             3. git add .status_history/ STATUS.md
-               (do NOT add update.wav or podcast_script.txt — they are
-               gitignored and carried to phase 2 as a build artifact instead)
+               (do NOT add update.wav, podcast_script.txt or window_report.md —
+               they are gitignored; the audio and transcript are carried to
+               phase 2 as a build artifact instead)
             4. git commit -m "chore: status maintenance"
             5. git push -u origin $BRANCH
             6. gh pr create with a title and body you craft:
@@ -271,6 +275,8 @@ jobs:
 
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       # carry the generated audio + transcript to phase 2 (the merge run is a
       # separate run with a fresh checkout, so it can't see these files
@@ -284,23 +290,32 @@ jobs:
         id: prbranch
         run: echo "branch=$(git branch --show-current)" >> "$GITHUB_OUTPUT"
 
-      # the transcript is what a reviewer needs before merging (the audio only
-      # uploads after the merge), so put it in the PR body where it can be read
-      - name: Post transcript to the PR
+      # the reviewer needs the window report (what landed where, what was
+      # posted) to check the transcript's claims, and the transcript itself
+      # (the audio only uploads after the merge), so both go in the PR body
+      - name: Post the window report and transcript to the PR
         if: startsWith(steps.prbranch.outputs.branch, 'status-maintenance-')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ steps.prbranch.outputs.branch }}
         run: |
-          if [ ! -f podcast_script.txt ]; then
-            echo "no podcast_script.txt, nothing to post"
+          if [ ! -f podcast_script.txt ] && [ ! -f window_report.md ]; then
+            echo "nothing to post"
             exit 0
           fi
           BODY=$(gh pr view "$BRANCH" --json body --jq .body)
           {
-            printf '%s\n\n<details>\n<summary>podcast transcript</summary>\n\n```\n' "$BODY"
-            cat podcast_script.txt
-            printf '\n```\n\n</details>\n'
+            printf '%s\n' "$BODY"
+            if [ -f window_report.md ]; then
+              printf '\n<details>\n<summary>window report — what landed where, what was posted</summary>\n\n'
+              cat window_report.md
+              printf '\n\n</details>\n'
+            fi
+            if [ -f podcast_script.txt ]; then
+              printf '\n<details>\n<summary>podcast transcript</summary>\n\n```\n'
+              cat podcast_script.txt
+              printf '\n```\n\n</details>\n'
+            fi
           } > pr-body.md
           gh pr edit "$BRANCH" --body-file pr-body.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ update.wav
 podcast_script.txt
 frontend/static/atlas.json
 atlas.json
+window_report.md

--- a/docs/internal/tools/status-maintenance.md
+++ b/docs/internal/tools/status-maintenance.md
@@ -8,9 +8,10 @@ automated workflow that archives old STATUS.md content and generates audio updat
 
 1. **archives old content**: moves previous month's sections from STATUS.md to `.status_history/YYYY-MM.md`
 2. **generates audio**: creates a podcast-style audio update covering recent work
-3. **opens PR**: commits changes and opens a PR for review, with the podcast
-   transcript in the PR body under a collapsible section so it can be read
-   before deciding to merge
+3. **opens PR**: commits changes and opens a PR for review, with the window
+   report (what landed where, what was posted) and the podcast transcript in
+   the PR body under collapsible sections so both can be read before deciding
+   to merge
 4. **uploads audio**: after PR merge, uploads the audio to plyr.fm (the
    transcript becomes the track description)
 
@@ -29,29 +30,49 @@ automated workflow that archives old STATUS.md content and generates audio updat
 github pauses scheduled workflows in repositories with no activity for 60
 days; a push re-enables them.
 
-## how it determines the time window
+## the window report
 
-the workflow finds the most recently merged PR with a branch starting with `status-maintenance-`:
+the run begins by generating `window_report.md` with `scripts/status_window.py`
+(also runnable locally: `uv run scripts/status_window.py`, or with
+`--since <iso time>`). the report is the run's ground truth:
 
-```bash
-gh pr list --state merged --search "status-maintenance" --limit 20 \
-  --json number,title,mergedAt,headRefName | \
-  jq '[.[] | select(.headRefName | startswith("status-maintenance-"))] | sort_by(.mergedAt) | reverse | .[0]'
-```
+- **window**: from the merge time of the most recently merged PR whose branch
+  starts with `status-maintenance-` until now
+- **backend releases**: GitHub releases (timestamp tags) published in the
+  window, each with the PRs it carried to production (from the squash subjects
+  between consecutive tags)
+- **frontend promotes**: Cloudflare Pages production deployments of
+  `production-fe` in the window — a `just release-frontend-only` is a bare
+  branch push that triggers no GitHub workflow, so Pages is its only record.
+  needs `CLOUDFLARE_API_TOKEN` (or `SCRIPT_CF_API_TOKEN` with Pages read)
+  and `CLOUDFLARE_ACCOUNT_ID`; without them the section says so and the
+  frontend rows below fall back to "promote unknown"
+- **PRs merged in the window** with a `landed` column: `prod via release
+  <tag>`, `prod via frontend promote <time>`, `staging only`, or `docs only`.
+  a PR is classified by its files (`backend/`, `scripts/`, `services/` →
+  needs a release; `frontend/` only → a promote or a release, whichever came
+  first); landing is decided by `git tag --contains` and
+  `git merge-base --is-ancestor` against the promoted commits
+- **public posts** in the window from the plyr.fm account, and from
+  zzstoatzz.io where the post mentions plyr, read from the public AppView
+  without auth
+- **project scope**: first commit, release count, STATUS.md line count, the
+  months still carrying detail, and the arcs archived in `.status_history/`
+  (titles for the newest three months, counts for the rest)
 
-everything merged since that date is considered "new work" for the audio script.
+the report goes into the maintenance PR body above the transcript, so a
+reviewer can check every "shipped" against where it actually landed.
 
-### handling reverted PRs
+### what the prompt does with it
 
-if a status-maintenance PR is merged then reverted, it still appears as "merged" in GitHub's API. this can cause the workflow to think there's no new content.
-
-**workaround**: temporarily add an exclusion to the jq filter:
-
-```bash
-| select(.number != 724)  # exclude reverted PR
-```
-
-remove the exclusion after the next successful run.
+the subject of the episode and of the STATUS.md edits is the diff — what
+changed in the window. the releases, promotes, posts and archived arcs are
+context: "shipped" is reserved for rows landed in production and names the
+date; merged-but-not-promoted work is "on staging"; an announcement gets one
+clause, an unannounced significant change gets one sentence; the archive
+places the window in the project's history in a phrase, not a recap. if
+STATUS.md disagrees with the report about what is in production, the run
+corrects STATUS.md.
 
 ## archival rules
 
@@ -114,6 +135,7 @@ dry, matter-of-fact, slightly sardonic. avoid:
 | `ANTHROPIC_API_KEY` | claude code |
 | `GOOGLE_API_KEY` | gemini TTS |
 | `PLYR_BOT_TOKEN` | plyr.fm upload |
+| `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` | Pages deployment history for the frontend promotes in the window report |
 
 ## manual run
 

--- a/scripts/status_window.py
+++ b/scripts/status_window.py
@@ -112,7 +112,7 @@ def merged_prs(since: datetime) -> list[dict]:
             "--search",
             f"merged:>={since.date().isoformat()}",
             "--limit",
-            "100",
+            "300",
             "--json",
             "number,title,mergedAt,mergeCommit,files,url",
         )

--- a/scripts/status_window.py
+++ b/scripts/status_window.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""the status-maintenance window report: what changed, where it landed, what was said.
+
+prints markdown for the window since the last merged status-maintenance PR:
+
+  1. backend releases (GitHub releases, timestamp tags) and the PRs each carried
+  2. frontend promotes — Cloudflare Pages production deployments of `production-fe`,
+     the only record a `just release-frontend-only` leaves
+  3. every PR merged in the window with where it landed: a release tag, a promote
+     time, or "staging only"
+  4. public posts from the plyr.fm account, and from zzstoatzz.io where they
+     mention plyr, via the public AppView (no auth)
+  5. project scope: first commit, release count, the arcs in `.status_history/`,
+     and STATUS.md's line count and archivable months
+
+usage:
+    uv run scripts/status_window.py                # window since the last maintenance merge
+    uv run scripts/status_window.py --since 2026-08-26T00:00:00Z
+
+credentials (optional; the promote section is skipped without them):
+    CLOUDFLARE_API_TOKEN or SCRIPT_CF_API_TOKEN — Pages read on the account
+    CLOUDFLARE_ACCOUNT_ID                        — defaults to the plyr.fm account
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+
+REPO = "zzstoatzz/plyr.fm"
+PAGES_PROJECT = "plyr-fm"
+PAGES_ACCOUNT = "3e9ba01cd687b3c4d29033908177072e"
+PUBLIC_APPVIEW = "https://public.api.bsky.app/xrpc"
+POST_ACCOUNTS = {"plyr.fm": None, "zzstoatzz.io": "plyr"}
+
+BACKEND_PREFIXES = ("backend/", "scripts/", "services/", "pyproject.toml", "uv.lock")
+FRONTEND_PREFIXES = ("frontend/",)
+PR_REF = re.compile(r"\(#(\d+)\)")
+ARC_HEADING = re.compile(r"^#{3,4} (.+)$", re.MULTILINE)
+MONTH_ONLY = re.compile(
+    r"^(early |late |mid[- ])?[A-Z][a-z]+ \d{4}( work)?( \(.*\))?$", re.IGNORECASE
+)
+ARC_TITLE_MONTHS = 3
+MONTH_HEADING = re.compile(r"^### ([A-Z][a-z]+ \d{4})$", re.MULTILINE)
+
+
+def sh(*args: str) -> str:
+    return subprocess.run(
+        args, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def gh(*args: str) -> str:
+    return sh("gh", *args, "-R", REPO)
+
+
+def fetch_json(url: str, headers: dict[str, str] | None = None) -> dict:
+    request = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def parse_time(raw: str) -> datetime:
+    return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def fmt(when: datetime) -> str:
+    return when.strftime("%Y-%m-%d %H:%MZ")
+
+
+def last_maintenance_merge() -> tuple[int | None, datetime | None]:
+    rows = json.loads(
+        gh(
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--search",
+            "status-maintenance",
+            "--limit",
+            "30",
+            "--json",
+            "number,mergedAt,headRefName",
+        )
+    )
+    merged = [r for r in rows if r["headRefName"].startswith("status-maintenance-")]
+    if not merged:
+        return None, None
+    latest = max(merged, key=lambda r: r["mergedAt"])
+    return latest["number"], parse_time(latest["mergedAt"])
+
+
+def merged_prs(since: datetime) -> list[dict]:
+    rows = json.loads(
+        gh(
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--search",
+            f"merged:>={since.date().isoformat()}",
+            "--limit",
+            "100",
+            "--json",
+            "number,title,mergedAt,mergeCommit,files,url",
+        )
+    )
+    rows = [r for r in rows if parse_time(r["mergedAt"]) >= since]
+    return sorted(rows, key=lambda r: r["mergedAt"])
+
+
+def classify(files: list[str]) -> str:
+    if any(f.startswith(BACKEND_PREFIXES) for f in files):
+        return "backend"
+    if any(f.startswith(FRONTEND_PREFIXES) for f in files):
+        return "frontend"
+    return "docs"
+
+
+def releases(since: datetime) -> list[dict]:
+    rows = json.loads(
+        gh("release", "list", "--limit", "40", "--json", "tagName,publishedAt")
+    )
+    rows = sorted(rows, key=lambda r: r["publishedAt"])
+    out = []
+    for previous, current in zip([None, *rows[:-1]], rows, strict=True):
+        published = parse_time(current["publishedAt"])
+        if published < since:
+            continue
+        span = (
+            f"{previous['tagName']}..{current['tagName']}"
+            if previous
+            else current["tagName"]
+        )
+        subjects = sh("git", "log", "--format=%s", span).splitlines()
+        prs = sorted({int(found[-1]) for s in subjects if (found := PR_REF.findall(s))})
+        out.append({"tag": current["tagName"], "at": published, "prs": prs})
+    return out
+
+
+def first_tag_containing(sha: str) -> tuple[str, datetime] | None:
+    tags = sh(
+        "git",
+        "tag",
+        "--contains",
+        sha,
+        "--sort=creatordate",
+        "--format=%(refname:short) %(creatordate:iso-strict)",
+    ).splitlines()
+    if not tags:
+        return None
+    tag, when = tags[0].split()
+    return tag, parse_time(when)
+
+
+def promotes(since: datetime) -> list[dict] | None:
+    token = os.environ.get("CLOUDFLARE_API_TOKEN") or os.environ.get(
+        "SCRIPT_CF_API_TOKEN"
+    )
+    if not token:
+        return None
+    account = os.environ.get("CLOUDFLARE_ACCOUNT_ID", PAGES_ACCOUNT)
+    query = urllib.parse.urlencode({"env": "production", "per_page": 50})
+    url = f"https://api.cloudflare.com/client/v4/accounts/{account}/pages/projects/{PAGES_PROJECT}/deployments?{query}"
+    try:
+        body = fetch_json(url, {"Authorization": f"Bearer {token}"})
+    except Exception as exc:
+        print(f"<!-- pages deployments unavailable: {exc} -->", file=sys.stderr)
+        return None
+    out = []
+    for d in body.get("result", []):
+        meta = d.get("deployment_trigger", {}).get("metadata", {})
+        if meta.get("branch") != "production-fe":
+            continue
+        created = parse_time(d["created_on"])
+        if created < since:
+            continue
+        out.append(
+            {
+                "at": created,
+                "sha": meta.get("commit_hash", ""),
+                "status": d.get("latest_stage", {}).get("status"),
+            }
+        )
+    return sorted(out, key=lambda p: p["at"])
+
+
+def is_ancestor(sha: str, of: str) -> bool:
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", sha, of], capture_output=True
+    )
+    return result.returncode == 0
+
+
+def landed(pr: dict, promoted: list[dict] | None) -> str:
+    sha = (pr.get("mergeCommit") or {}).get("oid")
+    kind = classify([f["path"] for f in pr.get("files", [])])
+    if kind == "docs":
+        return "docs only"
+    if not sha:
+        return "unknown (no merge commit)"
+    candidates: list[tuple[datetime, str]] = []
+    if tagged := first_tag_containing(sha):
+        candidates.append((tagged[1], f"prod via release {tagged[0]}"))
+    if kind == "frontend":
+        for p in promoted or []:
+            if p["sha"] and is_ancestor(sha, p["sha"]):
+                candidates.append(
+                    (p["at"], f"prod via frontend promote {fmt(p['at'])}")
+                )
+                break
+    if candidates:
+        return min(candidates)[1]
+    if kind == "frontend" and promoted is None:
+        return "no release; frontend promote unknown (no Cloudflare token)"
+    return "staging only"
+
+
+def posts(since: datetime) -> list[dict]:
+    out = []
+    for handle, needle in POST_ACCOUNTS.items():
+        query = urllib.parse.urlencode({"actor": handle, "limit": 100})
+        try:
+            feed = fetch_json(f"{PUBLIC_APPVIEW}/app.bsky.feed.getAuthorFeed?{query}")
+        except Exception as exc:
+            print(f"<!-- feed for {handle} unavailable: {exc} -->", file=sys.stderr)
+            continue
+        for item in feed.get("feed", []):
+            post = item["post"]
+            record = post.get("record", {})
+            if "reason" in item or post["author"]["handle"] != handle:
+                continue
+            created = parse_time(record.get("createdAt", "1970-01-01T00:00:00Z"))
+            if created < since:
+                continue
+            blob = json.dumps(record) + json.dumps(post.get("embed", {}))
+            if needle and needle not in blob.lower():
+                continue
+            rkey = post["uri"].rsplit("/", 1)[-1]
+            out.append(
+                {
+                    "at": created,
+                    "handle": handle,
+                    "reply": "reply" in record,
+                    "text": record.get("text", "").replace("\n", " ").strip(),
+                    "embed": post.get("embed", {})
+                    .get("$type", "")
+                    .split(".")[-1]
+                    .replace("#view", ""),
+                    "url": f"https://bsky.app/profile/{handle}/post/{rkey}",
+                }
+            )
+    return sorted(out, key=lambda p: p["at"])
+
+
+def project_scope(now: datetime) -> list[str]:
+    lines = []
+    first = sh("git", "log", "--reverse", "--format=%ad", "--date=short").splitlines()[
+        0
+    ]
+    release_count = len(sh("git", "tag").splitlines())
+    lines.append(f"- first commit {first}; {release_count} production releases to date")
+    status = Path("STATUS.md").read_text()
+    line_count = status.count("\n")
+    current_month = now.strftime("%B %Y")
+    archivable = [m for m in MONTH_HEADING.findall(status) if m != current_month]
+    detailed = [
+        m
+        for m in archivable
+        if "See `.status_history/" not in status.split(f"### {m}")[1].split("### ")[0]
+    ]
+    lines.append(
+        f"- STATUS.md is {line_count} lines (ceiling 500); month sections still carrying detail: "
+        + (", ".join(detailed) if detailed else "none")
+    )
+    lines.append(
+        "- arcs already archived, by month (titles for the newest months; read the files for the rest):"
+    )
+    archives = sorted(Path(".status_history").glob("*.md"))
+    for index, path in enumerate(archives):
+        headings = [
+            h for h in ARC_HEADING.findall(path.read_text()) if not MONTH_ONLY.match(h)
+        ]
+        lines.append(f"  - `{path.name}` — {len(headings)} arcs")
+        if index >= len(archives) - ARC_TITLE_MONTHS:
+            lines.extend(f"    - {h[:110]}" for h in headings)
+    return lines
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n\n")[0])
+    parser.add_argument(
+        "--since", help="ISO time; default = last merged status-maintenance PR"
+    )
+    args = parser.parse_args()
+    now = datetime.now(UTC)
+
+    if args.since:
+        since, source = parse_time(args.since), "given"
+    else:
+        number, merged_at = last_maintenance_merge()
+        since = merged_at or datetime(2025, 10, 28, tzinfo=UTC)
+        source = (
+            f"status-maintenance PR #{number} merged"
+            if number
+            else "no maintenance PR found; project start"
+        )
+
+    print("# status window report")
+    print(f"window: {fmt(since)} → {fmt(now)} ({source})")
+
+    print("\n## backend releases in the window (production)")
+    rel = releases(since)
+    for r in rel:
+        prs = ", ".join(f"#{n}" for n in r["prs"]) or "no PR-tagged commits"
+        print(f"- `{r['tag']}` at {fmt(r['at'])} — {prs}")
+    if not rel:
+        print("- none")
+
+    print("\n## frontend promotes in the window (`production-fe` on Cloudflare Pages)")
+    promoted = promotes(since)
+    if promoted is None:
+        print("- unavailable: set CLOUDFLARE_API_TOKEN (or SCRIPT_CF_API_TOKEN)")
+    elif not promoted:
+        print("- none")
+    for p in promoted or []:
+        print(f"- {fmt(p['at'])} — `{p['sha'][:8]}` ({p['status']})")
+
+    print("\n## PRs merged in the window and where they landed")
+    prs = merged_prs(since)
+    print("| PR | merged | title | landed |")
+    print("|---|---|---|---|")
+    for pr in prs:
+        title = pr["title"].replace("|", "\\|")[:90]
+        print(
+            f"| [#{pr['number']}]({pr['url']}) | {fmt(parse_time(pr['mergedAt']))} | {title} | {landed(pr, promoted)} |"
+        )
+    if not prs:
+        print("| — | — | none | — |")
+
+    print("\n## public posts in the window")
+    found = posts(since)
+    for p in found:
+        kind = "reply" if p["reply"] else "post"
+        embed = f" [{p['embed']}]" if p["embed"] else ""
+        print(
+            f"- {fmt(p['at'])} @{p['handle']} ({kind}{embed}): {p['text'][:200]} — {p['url']}"
+        )
+    if not found:
+        print("- none")
+
+    print("\n## project scope")
+    print("\n".join(project_scope(now)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
the weekly status-maintenance run only knew which PRs merged since the last run, so its transcript called merges to main "shipped" and never named a production release. it now starts from a window report that says where every PR actually landed, what was released or promoted, and what was posted publicly. the subject stays the diff; the report is context for tense and placement, not a list to recite.

```
| PR | merged | title | landed |
| #1989 | 2026-09-02 08:16Z | player: the stage bar on a phone is art, title, heart, play | prod via release 2026.0902.232901 |
| #2005 | 2026-09-03 02:12Z | status: the footer became spotify's … | docs only |
| #2006 | 2026-09-03 17:40Z | jetstream: rotate hosts on an unechoed own write … | prod via release 2026.0903.222140 |
```
(from a real run of `uv run scripts/status_window.py` against this repo)

<details>
<summary>what the report reads, and why each source</summary>

- **backend releases**: `gh release list`, PRs per release from the squash subjects between consecutive tags (the last `(#N)` in a subject, since status PRs cite other PR numbers in their titles).
- **frontend promotes**: Cloudflare Pages production deployments of `production-fe` for the `plyr-fm` project. a `just release-frontend-only` is a bare branch push that triggers no GitHub workflow, so Pages is the only record. reads `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`, which the repo already has; without them the section says so and frontend rows fall back to "promote unknown".
- **landed per PR**: classified by files (`backend/`, `scripts/`, `services/` need a release; `frontend/` only takes a promote or a release, whichever came first); `git tag --contains` and `git merge-base --is-ancestor` against the promoted commits decide.
- **public posts**: the plyr.fm account's feed, and zzstoatzz.io posts mentioning plyr, from the public AppView with no auth.
- **project scope**: first commit, release count, STATUS.md line count and months still carrying detail, and the arcs in `.status_history/` (titles for the newest three months, counts for the rest) so the hosts can place the window without re-reading the archive.
</details>

<details>
<summary>prompt and workflow changes</summary>

- task 1 runs the script and reads `window_report.md`; the hand-rolled `gh pr list | jq` window logic and its stale exclusions for reverted PRs #724/#846/#882 are gone.
- a "how to use the report" section: `landed` decides tense ("shipped" only for prod, with the date; `staging only` is "merged"), posts get one clause, archived arcs place the window in a phrase, and STATUS.md is corrected in the PR if it disagrees with the report about production.
- the investigation phase starts from the PR table instead of a second `gh pr list`.
- the PR-body step posts the report under its own `<details>` above the transcript; `window_report.md` is gitignored like the audio and transcript.
- `docs/internal/tools/status-maintenance.md` describes the report and its credentials.
</details>

<details>
<summary>intentional non-behaviors</summary>

- no tests: the script is a standalone uv script over `gh`, `git`, and two public HTTP APIs, and was exercised against the live repo (output above). the pure parts are small (`classify`, PR extraction).
- the duplicated arc entries in `.status_history/2026-07.md`, visible in the report's project-scope section, are left as they are; that is archive hygiene for a maintenance run, not this change.
- the local `SCRIPT_CF_API_TOKEN` is zone-analytics only and returns 403 for Pages; the CI token is the one with Pages access.
</details>

![bufo-looks-for-an-issue](https://all-the.bufo.zone/bufo-looks-for-an-issue.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
