### PR TITLE
status maintenance: build the window report in its own step; report_only input

### DIFF
--- a/.github/workflows/status-maintenance.yml
+++ b/.github/workflows/status-maintenance.yml
@@ -21,6 +21,10 @@ on:
         description: "skip audio generation"
         type: boolean
         default: false
+      report_only:
+        description: "print the window report to the job log and stop (no Claude, no PR)"
+        type: boolean
+        default: false
   pull_request:
     types: [closed]
     branches: [main]
@@ -42,7 +46,19 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
 
+      # the report is deterministic, so it is built here where its output is
+      # in the job log and the Cloudflare secrets never enter the Claude step
+      - name: Generate the window report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          uv run scripts/status_window.py > window_report.md
+          cat window_report.md
+
       - uses: anthropics/claude-code-action@v1
+        if: ${{ !inputs.report_only }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
@@ -59,15 +75,14 @@ jobs:
 
             ## task 1: gather the window report
 
-            the window is from the moment the LAST status-maintenance PR was MERGED (not opened) until now. `scripts/status_window.py` computes it and everything else you need to know about the window:
+            the window is from the moment the LAST status-maintenance PR was MERGED (not opened) until now. `scripts/status_window.py` computed it before you started and wrote `window_report.md` into the working directory. run:
 
             ```bash
             date
-            uv run scripts/status_window.py > window_report.md
             git log --oneline -50
             ```
 
-            read window_report.md in full. it is the ground truth for this run and contains:
+            then read window_report.md in full. it is the ground truth for this run and contains:
             - the window and which maintenance PR opened it
             - backend releases (GitHub releases, timestamp tags) published in the window and the PRs each carried to production
             - frontend promotes — Cloudflare Pages production deployments of `production-fe`, the only record a frontend-only release leaves
@@ -275,8 +290,6 @@ jobs:
 
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       # carry the generated audio + transcript to phase 2 (the merge run is a
       # separate run with a fresh checkout, so it can't see these files
@@ -287,6 +300,7 @@ jobs:
       # main — the only durable join to the merge run is the branch name, which
       # phase 2 reads from the merged PR's head ref.
       - name: Resolve PR branch
+        if: ${{ !inputs.report_only }}
         id: prbranch
         run: echo "branch=$(git branch --show-current)" >> "$GITHUB_OUTPUT"
 

--- a/docs/internal/tools/status-maintenance.md
+++ b/docs/internal/tools/status-maintenance.md
@@ -32,8 +32,8 @@ days; a push re-enables them.
 
 ## the window report
 
-the run begins by generating `window_report.md` with `scripts/status_window.py`
-(also runnable locally: `uv run scripts/status_window.py`, or with
+a plain workflow step generates `window_report.md` with `scripts/status_window.py`
+before Claude starts, and prints it to the job log (also runnable locally: `uv run scripts/status_window.py`, or with
 `--since <iso time>`). the report is the run's ground truth:
 
 - **window**: from the merge time of the most recently merged PR whose branch
@@ -127,6 +127,7 @@ dry, matter-of-fact, slightly sardonic. avoid:
 | input | type | default | description |
 |-------|------|---------|-------------|
 | `skip_audio` | boolean | false | skip audio generation |
+| `report_only` | boolean | false | print the window report to the job log and stop — no Claude run, no PR |
 
 ## secrets required
 

--- a/scripts/status_window.py
+++ b/scripts/status_window.py
@@ -165,20 +165,20 @@ def first_tag_containing(sha: str) -> tuple[str, datetime] | None:
     return tag, parse_time(when)
 
 
-def promotes(since: datetime) -> list[dict] | None:
+def promotes(since: datetime) -> list[dict] | str:
+    """production-fe deployments in the window, or the reason they are unknown."""
     token = os.environ.get("CLOUDFLARE_API_TOKEN") or os.environ.get(
         "SCRIPT_CF_API_TOKEN"
     )
     if not token:
-        return None
+        return "no CLOUDFLARE_API_TOKEN (or SCRIPT_CF_API_TOKEN) in the environment"
     account = os.environ.get("CLOUDFLARE_ACCOUNT_ID", PAGES_ACCOUNT)
     query = urllib.parse.urlencode({"env": "production", "per_page": 50})
     url = f"https://api.cloudflare.com/client/v4/accounts/{account}/pages/projects/{PAGES_PROJECT}/deployments?{query}"
     try:
         body = fetch_json(url, {"Authorization": f"Bearer {token}"})
     except Exception as exc:
-        print(f"<!-- pages deployments unavailable: {exc} -->", file=sys.stderr)
-        return None
+        return f"Pages API failed: {exc} (does the token have Pages read on project `{PAGES_PROJECT}`?)"
     out = []
     for d in body.get("result", []):
         meta = d.get("deployment_trigger", {}).get("metadata", {})
@@ -204,7 +204,7 @@ def is_ancestor(sha: str, of: str) -> bool:
     return result.returncode == 0
 
 
-def landed(pr: dict, promoted: list[dict] | None) -> str:
+def landed(pr: dict, promoted: list[dict] | str) -> str:
     sha = (pr.get("mergeCommit") or {}).get("oid")
     kind = classify([f["path"] for f in pr.get("files", [])])
     if kind == "docs":
@@ -214,8 +214,8 @@ def landed(pr: dict, promoted: list[dict] | None) -> str:
     candidates: list[tuple[datetime, str]] = []
     if tagged := first_tag_containing(sha):
         candidates.append((tagged[1], f"prod via release {tagged[0]}"))
-    if kind == "frontend":
-        for p in promoted or []:
+    if kind == "frontend" and isinstance(promoted, list):
+        for p in promoted:
             if p["sha"] and is_ancestor(sha, p["sha"]):
                 candidates.append(
                     (p["at"], f"prod via frontend promote {fmt(p['at'])}")
@@ -223,8 +223,8 @@ def landed(pr: dict, promoted: list[dict] | None) -> str:
                 break
     if candidates:
         return min(candidates)[1]
-    if kind == "frontend" and promoted is None:
-        return "no release; frontend promote unknown (no Cloudflare token)"
+    if kind == "frontend" and isinstance(promoted, str):
+        return "no release; frontend promote unknown (Pages unavailable)"
     return "staging only"
 
 
@@ -331,12 +331,13 @@ def main() -> int:
 
     print("\n## frontend promotes in the window (`production-fe` on Cloudflare Pages)")
     promoted = promotes(since)
-    if promoted is None:
-        print("- unavailable: set CLOUDFLARE_API_TOKEN (or SCRIPT_CF_API_TOKEN)")
+    if isinstance(promoted, str):
+        print(f"- unavailable: {promoted}")
     elif not promoted:
         print("- none")
-    for p in promoted or []:
-        print(f"- {fmt(p['at'])} — `{p['sha'][:8]}` ({p['status']})")
+    else:
+        for p in promoted:
+            print(f"- {fmt(p['at'])} — `{p['sha'][:8]}` ({p['status']})")
 
     print("\n## PRs merged in the window and where they landed")
     prs = merged_prs(since)


### PR DESCRIPTION
the first maintenance run with the window report (#2009) could not read Cloudflare Pages, so the frontend promotes were missing and the run re-dated #2001–#2004 to the later backend release. the reason was invisible: the script ran inside the Claude step, whose tool output never reaches the job log. the report is now built in its own plain step before Claude starts, printed to the log, with the Cloudflare secrets scoped to that step; a `report_only` dispatch input runs just that step to preview a window with no Claude run and no PR; and the report's "unavailable" line carries the actual error.

<details>
<summary>intentional non-behaviors</summary>

- #2009 is left as opened; whether its release-date correction stands is a merge-time call once the promotes are visible.
- the Claude step no longer receives `CLOUDFLARE_*`; nothing in the prompt needs them.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
