### PR TITLE
status maintenance: window_since input; publish run outputs to the summary and an artifact

### DIFF
--- a/.github/workflows/status-maintenance.yml
+++ b/.github/workflows/status-maintenance.yml
@@ -29,6 +29,10 @@ on:
         description: "print the window report to the job log and stop (no Claude, no PR)"
         type: boolean
         default: false
+      window_since:
+        description: "override the window start (ISO time) — for reruns and evaluating the process against a past window"
+        type: string
+        default: ""
   pull_request:
     types: [closed]
     branches: [main]
@@ -58,7 +62,11 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          uv run scripts/status_window.py > window_report.md
+          if [ -n "${{ inputs.window_since }}" ]; then
+            uv run scripts/status_window.py --since "${{ inputs.window_since }}" > window_report.md
+          else
+            uv run scripts/status_window.py > window_report.md
+          fi
           cat window_report.md
 
       - uses: anthropics/claude-code-action@v1
@@ -80,7 +88,7 @@ jobs:
 
             ## task 1: gather the window report
 
-            the window is from the moment the LAST status-maintenance PR was MERGED (not opened) until now. `scripts/status_window.py` computed it before you started and wrote `window_report.md` into the working directory. run:
+            the window is from the moment the LAST status-maintenance PR was MERGED (not opened) until now — unless the report's first line says the start was given, in which case someone chose the window deliberately (a rerun or an evaluation) and you cover it even if STATUS.md already documents that work. `scripts/status_window.py` computed it before you started and wrote `window_report.md` into the working directory. run:
 
             ```bash
             date
@@ -318,6 +326,31 @@ jobs:
       # this run was dispatched on main, so its run-level branch/sha point at
       # main — the only durable join to the merge run is the branch name, which
       # phase 2 reads from the merged PR's head ref.
+      # the run's outputs are reviewable even when it opened no PR: they go to
+      # the job summary and an artifact named by run id
+      - name: Publish run outputs
+        if: ${{ !inputs.report_only }}
+        run: |
+          for f in window_report.md ecosystem_context.md podcast_script.txt; do
+            if [ -f "$f" ]; then
+              { printf '## %s\n\n' "$f"; if [ "$f" = podcast_script.txt ]; then printf '```\n'; cat "$f"; printf '\n```\n'; else cat "$f"; fi; printf '\n\n'; } >> "$GITHUB_STEP_SUMMARY"
+            else
+              printf '## %s\n\nnot produced by this run\n\n' "$f" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+      - name: Upload run outputs artifact
+        if: ${{ !inputs.report_only }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: status-run-outputs-${{ github.run_id }}
+          path: |
+            window_report.md
+            ecosystem_context.md
+            podcast_script.txt
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Resolve PR branch
         if: ${{ !inputs.report_only }}
         id: prbranch

--- a/docs/internal/tools/status-maintenance.md
+++ b/docs/internal/tools/status-maintenance.md
@@ -78,6 +78,13 @@ citing only what it read. the parent uses it like the posts: one clause where
 a change responds to something written, never a segment. the file is posted
 into the PR body so the reviewer can judge what was found.
 
+## run outputs
+
+every run (not just one that opens a PR) writes `window_report.md`,
+`ecosystem_context.md` and `podcast_script.txt` to the job summary and to an
+artifact `status-run-outputs-<run id>`, so a run that judged "no maintenance
+needed" can still be read: `gh run download <run id> --name status-run-outputs-<run id>`.
+
 ## model
 
 the model is set once, as the workflow-level `STATUS_MODEL` env
@@ -149,6 +156,7 @@ dry, matter-of-fact, slightly sardonic. avoid:
 |-------|------|---------|-------------|
 | `skip_audio` | boolean | false | skip audio generation |
 | `report_only` | boolean | false | print the window report to the job log and stop — no Claude run, no PR |
+| `window_since` | string | "" | override the window start (ISO time) for reruns and for evaluating the process against a past window; the prompt then covers that window even if STATUS.md already documents it |
 
 ## secrets required
 


### PR DESCRIPTION
a run that judges \"no maintenance needed\" opens no PR, and the PR body was the only place its window report, ecosystem context and transcript landed — so two runs after #2013 left nothing to read. every run now writes the three files to the job summary and to an artifact named by run id, and a `window_since` dispatch input forces a window start for reruns and for evaluating the process against a past window (the prompt covers a given window even when STATUS.md already documents it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)