### PR TITLE
status maintenance: keep the Claude execution file with the run outputs

### DIFF
--- a/.github/workflows/status-maintenance.yml
+++ b/.github/workflows/status-maintenance.yml
@@ -70,9 +70,11 @@ jobs:
           cat window_report.md
 
       - uses: anthropics/claude-code-action@v1
+        id: claude
         if: ${{ !inputs.report_only }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          display_report: "true"
           claude_args: |
             --model ${{ env.STATUS_MODEL }}
             --mcp-config .github/mcp/status-maintenance.json
@@ -339,8 +341,17 @@ jobs:
             fi
           done
 
+      # the execution file is the full Claude transcript (every tool call and
+      # result) — the only way to see what a run that opened no PR actually did
+      - name: Collect the Claude execution file
+        if: ${{ !inputs.report_only && always() }}
+        run: |
+          if [ -n "${{ steps.claude.outputs.execution_file }}" ] && [ -f "${{ steps.claude.outputs.execution_file }}" ]; then
+            cp "${{ steps.claude.outputs.execution_file }}" claude-execution.json
+          fi
+
       - name: Upload run outputs artifact
-        if: ${{ !inputs.report_only }}
+        if: ${{ !inputs.report_only && always() }}
         uses: actions/upload-artifact@v4
         with:
           name: status-run-outputs-${{ github.run_id }}
@@ -348,6 +359,7 @@ jobs:
             window_report.md
             ecosystem_context.md
             podcast_script.txt
+            claude-execution.json
           if-no-files-found: ignore
           retention-days: 14
 

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ frontend/static/atlas.json
 atlas.json
 window_report.md
 ecosystem_context.md
+claude-execution.json

--- a/docs/internal/tools/status-maintenance.md
+++ b/docs/internal/tools/status-maintenance.md
@@ -81,8 +81,9 @@ into the PR body so the reviewer can judge what was found.
 ## run outputs
 
 every run (not just one that opens a PR) writes `window_report.md`,
-`ecosystem_context.md` and `podcast_script.txt` to the job summary and to an
-artifact `status-run-outputs-<run id>`, so a run that judged "no maintenance
+`ecosystem_context.md` and `podcast_script.txt` to the job summary and, with
+`claude-execution.json` (the full Claude transcript: every tool call and
+result), to an artifact `status-run-outputs-<run id>`, so a run that judged "no maintenance
 needed" can still be read: `gh run download <run id> --name status-run-outputs-<run id>`.
 
 ## model


### PR DESCRIPTION
two runs after #2013 produced no `ecosystem_context.md` and no PR, and nothing said why — the action hides the transcript unless asked. the execution file (every tool call and result) now joins the `status-run-outputs-<run id>` artifact, and the action's own report goes to the step summary (`display_report`), so a run that opened no PR can still be read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)