### PR TITLE
status maintenance: model dispatch input, defaulting to STATUS_MODEL

### DIFF
--- a/.github/workflows/status-maintenance.yml
+++ b/.github/workflows/status-maintenance.yml
@@ -37,6 +37,10 @@ on:
         description: "stop after the ecosystem research (no writer, no PR); read ecosystem_context.md from the job summary or artifact"
         type: boolean
         default: false
+      model:
+        description: "model for this run only (default: STATUS_MODEL from the workflow env)"
+        type: string
+        default: ""
   pull_request:
     types: [closed]
     branches: [main]
@@ -57,6 +61,10 @@ jobs:
           fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v7
+
+      # one resolved model for both Claude steps and the PR body line
+      - name: Resolve the model
+        run: echo "MODEL=${{ inputs.model || env.STATUS_MODEL }}" >> "$GITHUB_ENV"
 
       # the report is deterministic, so it is built here where its output is
       # in the job log and the Cloudflare secrets never enter the Claude step
@@ -83,7 +91,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --model ${{ env.STATUS_MODEL }}
+            --model ${{ env.MODEL }}
             --mcp-config .github/mcp/status-maintenance.json
             --allowedTools "Read,Write,Bash,mcp__pub-search__search,mcp__pub-search__get_document,mcp__pub-search__find_similar,mcp__pub-search__author_profile"
           prompt: |
@@ -119,7 +127,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           display_report: "true"
           claude_args: |
-            --model ${{ env.STATUS_MODEL }}
+            --model ${{ env.MODEL }}
             --allowedTools "Read,Write,Edit,Bash,Fetch,Task"
           prompt: |
             you are maintaining the plyr.fm (pronounced "player FM") project status file.
@@ -418,7 +426,7 @@ jobs:
             exit 0
           fi
           {
-            printf '%s\n\nwritten by `%s` (claude-code-action).\n' "$BODY" "$STATUS_MODEL"
+            printf '%s\n\nwritten by `%s` (claude-code-action).\n' "$BODY" "$MODEL"
             if [ -f window_report.md ]; then
               printf '\n<details>\n<summary>window report — what landed where, what was posted</summary>\n\n'
               cat window_report.md

--- a/docs/internal/tools/status-maintenance.md
+++ b/docs/internal/tools/status-maintenance.md
@@ -100,8 +100,9 @@ needed" can still be read: `gh run download <run id> --name status-run-outputs-<
 ## model
 
 the model is set once, as the workflow-level `STATUS_MODEL` env
-(`claude-opus-5` today), passed to `--model`, and printed into the PR body
-("written by …") so every maintenance PR says which model wrote it.
+(`claude-opus-5` today), resolved with the optional `model` dispatch input
+into `MODEL`, passed to `--model` for both Claude steps, and printed into the
+PR body ("written by …") so every maintenance PR says which model wrote it.
 
 ### what the prompt does with it
 
@@ -170,6 +171,7 @@ dry, matter-of-fact, slightly sardonic. avoid:
 | `report_only` | boolean | false | print the window report to the job log and stop — no Claude run, no PR |
 | `window_since` | string | "" | override the window start (ISO time) for reruns and for evaluating the process against a past window; the prompt then covers that window even if STATUS.md already documents it |
 | `research_only` | boolean | false | stop after the ecosystem research — no writer, no PR; read `ecosystem_context.md` from the job summary or the run artifact |
+| `model` | string | "" | model for this run only; empty means `STATUS_MODEL` from the workflow env |
 
 ## secrets required
 

--- a/loq.toml
+++ b/loq.toml
@@ -395,4 +395,4 @@ max_lines = 502
 
 [[rules]]
 path = ".github/workflows/status-maintenance.yml"
-max_lines = 519
+max_lines = 527


### PR DESCRIPTION
a `model` dispatch input overrides the model for one run — both Claude steps and the PR body line read the resolved `MODEL` — so another model can be tried against a past window without moving the default (`STATUS_MODEL`, still `claude-opus-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)