### PR TITLE
status maintenance: run on claude-fable-5-1

### DIFF
--- a/.github/workflows/status-maintenance.yml
+++ b/.github/workflows/status-maintenance.yml
@@ -13,7 +13,7 @@ name: status maintenance
 
 # the model is named once here so the PR body can say which one wrote the run
 env:
-  STATUS_MODEL: claude-opus-5
+  STATUS_MODEL: claude-fable-5-1
 
 on:
   schedule:

--- a/docs/internal/tools/status-maintenance.md
+++ b/docs/internal/tools/status-maintenance.md
@@ -100,7 +100,7 @@ needed" can still be read: `gh run download <run id> --name status-run-outputs-<
 ## model
 
 the model is set once, as the workflow-level `STATUS_MODEL` env
-(`claude-opus-5` today), resolved with the optional `model` dispatch input
+(`claude-fable-5-1` since September 5, 2026; `claude-opus-5` before), resolved with the optional `model` dispatch input
 into `MODEL`, passed to `--model` for both Claude steps, and printed into the
 PR body ("written by …") so every maintenance PR says which model wrote it.
 


### PR DESCRIPTION
the weekly run moves from `claude-opus-5` to `claude-fable-5-1` (`STATUS_MODEL`). tried first with the `model` input on a research-only run against the September 2–4 window: the CI org accepts the model, the step cost $2.20 vs $1.86, and the ecosystem context mapped writing to specific PRs and known issues more tightly — three on-target documents opus had missed, and a closing \"bears on\" sentence per entry. the writer step has not run on fable yet; the next run is its first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)