### PR TITLE
fix: stop clipping player metadata descenders

### DIFF
--- a/frontend/src/lib/components/player/TrackInfo.svelte
+++ b/frontend/src/lib/components/player/TrackInfo.svelte
@@ -315,7 +315,7 @@
 		transition: color 0.2s;
 		min-width: 0;
 		white-space: nowrap;
-		line-height: 1.15;
+		line-height: 1.4;
 	}
 
 	/* radio source indicator — sits in the album/single slot, tinted to signal


### PR DESCRIPTION
The player’s “single” label clipped the handwritten font’s descender. Give metadata rows a 1.4 line height so the full glyph is visible.

<details>
<summary>Validation</summary>

- Checked the rendered player at 1280px and 390px in dark and light themes.
- Frontend typecheck and lint passed; all 212 frontend tests passed.
- One CSS declaration changes. Horizontal overflow and scrolling remain in place.

</details>
