### PR TITLE
fix: hydrate queue metadata by selected track identity

### DIFF
--- a/backend/src/backend/_internal/queue.py
+++ b/backend/src/backend/_internal/queue.py
@@ -11,6 +11,7 @@ import asyncpg
 from cachetools import TTLCache
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from backend._internal.content_labels import (
@@ -187,6 +188,7 @@ class QueueService:
                     db,
                     queue_state.state.get("track_ids", []),
                     did,
+                    record_ids=queue_state.state.get("track_record_ids"),
                 )
                 # include auto_advance in state
                 state = {**queue_state.state, "auto_advance": auto_advance}
@@ -259,6 +261,7 @@ class QueueService:
                     db,
                     existing.state.get("track_ids", []),
                     did,
+                    record_ids=existing.state.get("track_record_ids"),
                 )
 
                 # notify other instances
@@ -329,29 +332,42 @@ class QueueService:
 
     async def _hydrate_tracks(
         self,
-        db,
+        db: AsyncSession,
         track_ids: list[str],
         viewer_did: str,
+        *,
+        record_ids: list[int] | None = None,
     ) -> list[dict[str, Any]]:
         """fetch track metadata for queue display, preserving order."""
-        if not track_ids:
+        if not (record_ids if record_ids is not None else track_ids):
             return []
 
         stmt = (
             select(Track)
             .options(selectinload(Track.artist), selectinload(Track.album_rel))
-            .where(Track.file_id.in_(track_ids))
+            .where(
+                Track.id.in_(record_ids)
+                if record_ids is not None
+                else Track.file_id.in_(track_ids)
+            )
+            .order_by(Track.id)
         )
         result = await db.execute(stmt)
         tracks = result.scalars().all()
-        track_by_file_id = {track.file_id: track for track in tracks}
-
-        # collect tracks in order
-        tracks_in_order = []
-        for file_id in track_ids:
-            track = track_by_file_id.get(file_id)
-            if track:
-                tracks_in_order.append(track)
+        if record_ids is not None:
+            track_by_id = {track.id: track for track in tracks}
+            tracks_in_order = [
+                track_by_id[id] for id in record_ids if id in track_by_id
+            ]
+        else:
+            track_by_file_id: dict[str, Track] = {}
+            for track in tracks:
+                track_by_file_id.setdefault(track.file_id, track)
+            tracks_in_order = [
+                track_by_file_id[file_id]
+                for file_id in track_ids
+                if file_id in track_by_file_id
+            ]
 
         # your own queue is the strongest destination there is: you put these
         # here. A track silently disappearing from it because it was labeled

--- a/backend/tests/api/test_queue.py
+++ b/backend/tests/api/test_queue.py
@@ -12,6 +12,69 @@ from backend.main import app
 from backend.models import Album, Artist, Track
 
 
+async def test_queue_preserves_upload_identity_with_shared_audio(
+    test_app: FastAPI, db_session: AsyncSession
+) -> None:
+    artist = Artist(
+        did="did:test:shared-audio", handle="shared.test", display_name="artist"
+    )
+    db_session.add(artist)
+    await db_session.flush()
+    original = Track(
+        title="original", file_id="shared-audio", file_type="mp3", artist_did=artist.did
+    )
+    reupload = Track(
+        title="reupload", file_id="shared-audio", file_type="mp3", artist_did=artist.did
+    )
+    db_session.add_all([original, reupload])
+    await db_session.commit()
+    record_ids = [original.id, reupload.id, original.id]
+    state = {
+        "track_ids": ["shared-audio"] * 3,
+        "track_record_ids": record_ids,
+        "current_index": 2,
+        "current_record_id": original.id,
+    }
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        put_response = await client.put("/queue/", json={"state": state})
+        assert put_response.status_code == 200
+        assert [track["id"] for track in put_response.json()["tracks"]] == record_ids
+        queue_service.cache.clear()
+        get_response = await client.get("/queue/")
+
+    assert get_response.status_code == 200
+    assert [track["id"] for track in get_response.json()["tracks"]] == record_ids
+
+
+async def test_queue_does_not_replace_missing_track_with_shared_audio(
+    test_app: FastAPI, db_session: AsyncSession
+) -> None:
+    artist = Artist(
+        did="did:test:remaining-upload", handle="remaining.test", display_name="artist"
+    )
+    db_session.add(artist)
+    await db_session.flush()
+    reupload = Track(
+        title="reupload", file_id="shared-audio", file_type="mp3", artist_did=artist.did
+    )
+    db_session.add(reupload)
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.put(
+            "/queue/",
+            json={"state": {"track_ids": ["shared-audio"], "track_record_ids": [-1]}},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["tracks"] == []
+
+
 # create a mock session object
 class MockSession(Session):
     """mock session for auth bypass in tests."""


### PR DESCRIPTION
Queue hydration confused two uploads sharing the same audio file: “ft sando (live on logan)” became bufo.uk’s “test” in the player while the correct audio continued. Honor optional database track IDs in queue snapshots so metadata belongs to the selected upload.

<details>
<summary>Compatibility and validation</summary>

- Preserve distinct uploads, repeated queue entries, and their order. Missing record IDs never fall back to another upload of the same audio.
- Legacy file-ID-only snapshots remain readable with deterministic lowest-ID resolution; those snapshots cannot recover which upload was selected.
- Backend support ships before the frontend starts writing record IDs. Queue state remains JSONB; no migration is needed.
- Both new API regression tests failed against the old implementation and pass with this change, covering PUT and uncached GET hydration.
- Full backend suite: 1,626 passed, 25 existing skips. Backend lint/type checks and the client API contract check passed.

</details>
