### PR TITLE
fix: preserve selected uploads across queue sync

### DIFF
--- a/docs/internal/frontend/queue.md
+++ b/docs/internal/frontend/queue.md
@@ -11,9 +11,26 @@ The queue is a cross-device, server-authoritative data model with optimistic loc
 - `queue_state` table (`did`, `state`, `revision`, `updated_at`). `state` is JSONB containing `track_ids`, `current_index`, `current_track_id`, `shuffle`, `repeat_mode`, `original_order_ids`, and the continuation-tail fields (`continuation_from_index`, `continuation_suppressed`, `continuation_label`). The server persists `state` opaquely, so new tail fields need no schema or endpoint change.
 - `QueueService` keeps a TTL LRU cache (`maxsize 100`, `ttl 5m`). Cache entries include both the raw state and the hydrated track list.
 - On startup the service opens an asyncpg connection, registers a `queue_changes` listener, and reconnects on failure. Notifications simply invalidate the cache entry; consumers fetch on demand.
-- `GET /queue/` returns `{ state, revision, tracks }`. `tracks` is hydrated server-side by joining against `tracks`+`artists`. Duplicate queue entries are preserved—hydration walks the `track_ids` array by index so the same `file_id` can appear multiple times. Response includes an ETag (`"revision"`).
+- `GET /queue/` returns `{ state, revision, tracks }`. `tracks` is hydrated server-side by joining against `tracks`+`artists`. Hydration walks `track_record_ids` (database track IDs) in order, preserving distinct uploads of the same audio and repeated entries. Response includes an ETag (`"revision"`).
 - `PUT /queue/` expects an optional `If-Match: "revision"`. Mismatched revisions return 409. Successful writes increment the revision, emit LISTEN/NOTIFY, and rehydrate so the response mirrors GET semantics.
 - Hydration preserves order even when duplicates exist by pairing each `track_id` position with the track returned by the DB. We never de-duplicate on the server.
+
+### track identity
+
+Audio `file_id` is not a track identity: two artists can upload identical bytes.
+The queue writes `track_record_ids`, `original_order_record_ids`, and
+`current_record_id` alongside the legacy file-ID fields. Both server hydration
+and frontend restoration use the record IDs when present. A missing record is
+omitted, never replaced by another upload sharing its audio. The current index
+still distinguishes repeated occurrences of the same record.
+
+Older saved queues and older clients remain readable through the file-ID fields.
+Those snapshots cannot identify which upload was originally selected; hydration
+chooses the lowest track ID deterministically. Playing the intended track again
+with the updated frontend saves its exact identity. No database migration is
+needed because queue state is JSONB. Deploy backend support before the frontend
+that writes record IDs; the previous backend would echo the new fields without
+using them to hydrate metadata.
 
 ## client implementation (Svelte 5)
 

--- a/frontend/src/lib/queue-identity.test.ts
+++ b/frontend/src/lib/queue-identity.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { queue } from './queue.svelte';
+import { auth } from './auth.svelte';
+import type { Track } from './types';
+
+const original = {
+	id: 1249,
+	title: 'ft sando (live on logan)',
+	artist: 'nate',
+	artist_handle: 'zzstoatzz.io',
+	file_id: 'shared-audio',
+	file_type: 'm4a',
+	play_count: 2
+} satisfies Track;
+const reupload = { ...original, id: 1261, title: 'test', artist: 'oi bruv cheers innit' };
+
+afterEach(() => {
+	auth.isAuthenticated = false;
+	queue.clear();
+	queue.revision = null;
+	vi.restoreAllMocks();
+});
+
+describe('queue track identity', () => {
+	it('saves track identities alongside legacy audio IDs and accepts the echo', async () => {
+		auth.isAuthenticated = true;
+		queue.setQueue([original, reupload, original], 2);
+		const fetch = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+			const state = {
+				track_ids: ['shared-audio', 'shared-audio', 'shared-audio'],
+				track_record_ids: [1249, 1261, 1249],
+				original_order_record_ids: [1249, 1261, 1249],
+				current_record_id: 1249,
+				current_index: 2
+			};
+			expect(await new Request(input, init).json()).toMatchObject({ state });
+			return new Response(JSON.stringify({ revision: 1, state, tracks: [original, reupload] }));
+		});
+
+		expect(await queue.pushQueue()).toBe(true);
+		expect(fetch).toHaveBeenCalledOnce();
+		expect(queue.tracks.map((track) => track.id)).toEqual([1249, 1261, 1249]);
+		expect(queue.currentTrack?.title).toBe(original.title);
+	});
+
+	it('restores distinct uploads and repeated entries sharing an audio file', () => {
+		const snapshot = {
+			revision: 1,
+			state: {
+				track_ids: ['shared-audio', 'shared-audio', 'shared-audio'],
+				track_record_ids: [original.id, reupload.id, original.id],
+				original_order_ids: ['shared-audio', 'shared-audio', 'shared-audio'],
+				original_order_record_ids: [reupload.id, original.id, original.id],
+				current_track_id: 'shared-audio',
+				current_record_id: original.id,
+				current_index: 2,
+				shuffle: true
+			},
+			tracks: [original, reupload]
+		};
+
+		queue.applySnapshot(snapshot);
+
+		expect(queue.tracks.map((track) => track.id)).toEqual([1249, 1261, 1249]);
+		expect(queue.originalOrder.map((track) => track.id)).toEqual([1261, 1249, 1249]);
+		expect(queue.currentIndex).toBe(2);
+		expect(queue.currentTrack?.title).toBe(original.title);
+	});
+
+	it('does not substitute a shared-file upload for a missing track', () => {
+		queue.playNow(original);
+		const snapshot = {
+			revision: 2,
+			state: {
+				track_ids: ['shared-audio'],
+				track_record_ids: [original.id],
+				original_order_ids: ['shared-audio'],
+				original_order_record_ids: [original.id],
+				current_track_id: 'shared-audio',
+				current_record_id: original.id,
+				current_index: 0,
+				shuffle: false
+			},
+			tracks: [reupload]
+		};
+
+		queue.applySnapshot(snapshot);
+
+		expect(queue.tracks).toEqual([]);
+		expect(queue.originalOrder).toEqual([]);
+	});
+
+	it('finds the selected upload after a preceding missing track is removed', () => {
+		expect(queue.resolveCurrentIndex('shared-audio', 1, [original, reupload], original.id)).toBe(0);
+	});
+});

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -24,6 +24,16 @@ export function shuffleInPlace<T>(arr: T[]): T[] {
 	return arr;
 }
 
+function restoreTrackOrder<Id extends string | number>(
+	ids: readonly Id[],
+	tracksById: ReadonlyMap<Id, Track>
+): Track[] {
+	return ids.flatMap((id) => {
+		const track = tracksById.get(id);
+		return track ? [{ ...track }] : [];
+	});
+}
+
 /** bridge for routing queue mutations through a jam's WebSocket transport */
 export interface JamBridge {
 	pushQueueState(): void;
@@ -227,10 +237,7 @@ class Queue {
 		if (this.jamBridge) return; // jam owns the queue state
 
 		// while we have unsent or in-flight local changes, skip non-forced fetches
-		if (
-			!force &&
-			(this.syncInProgress || this.syncTimer !== null || this.pendingSync)
-		) {
+		if (!force && (this.syncInProgress || this.syncTimer !== null || this.pendingSync)) {
 			return;
 		}
 
@@ -280,10 +287,10 @@ class Queue {
 
 	applySnapshot(snapshot: QueueResponse) {
 		const { state, tracks } = snapshot;
-		const trackIds = state.track_ids ?? [];
+		const trackIds = state.track_record_ids ?? state.track_ids ?? [];
 		const serverTracks = tracks ?? [];
 
-		// build track lookup by file_id from server tracks (deduplicated)
+		const trackById = new Map(serverTracks.map((track) => [track.id, track]));
 		const trackByFileId = new Map<string, Track>();
 		for (const track of serverTracks) {
 			if (track) {
@@ -291,36 +298,29 @@ class Queue {
 			}
 		}
 
-		// build ordered tracks array, using track metadata for each file_id
-		const orderedTracks: Track[] = [];
-		for (const fileId of trackIds) {
-			const track = trackByFileId.get(fileId);
-			if (track) {
-				// always use a copy to ensure each queue position is independent
-				orderedTracks.push({ ...track });
-			}
-		}
+		const orderedTracks =
+			state.track_record_ids !== undefined
+				? restoreTrackOrder(state.track_record_ids, trackById)
+				: restoreTrackOrder(state.track_ids ?? [], trackByFileId);
 
-		if (orderedTracks.length > 0 || trackIds.length === 0) {
+		if (state.track_record_ids !== undefined || orderedTracks.length > 0 || trackIds.length === 0) {
 			this.tracks = orderedTracks;
 		}
 
-		// build original order array
-		const originalIds =
-			state.original_order_ids && state.original_order_ids.length > 0
-				? state.original_order_ids
-				: trackIds;
+		const originalRecordIds = state.original_order_record_ids ?? state.track_record_ids;
+		const originalFileIds = state.original_order_ids?.length
+			? state.original_order_ids
+			: (state.track_ids ?? []);
+		const originalTracks =
+			originalRecordIds !== undefined
+				? restoreTrackOrder(originalRecordIds, trackById)
+				: restoreTrackOrder(originalFileIds, trackByFileId);
 
-		const originalTracks: Track[] = [];
-		for (const fileId of originalIds) {
-			const track = trackByFileId.get(fileId);
-			if (track) {
-				// always use a copy to ensure independence
-				originalTracks.push({ ...track });
-			}
-		}
-
-		if (originalTracks.length > 0 || originalIds.length === 0) {
+		if (
+			state.track_record_ids !== undefined ||
+			originalTracks.length > 0 ||
+			(originalRecordIds ?? originalFileIds).length === 0
+		) {
 			this.originalOrder = originalTracks.length ? originalTracks : [...orderedTracks];
 		}
 
@@ -334,7 +334,8 @@ class Queue {
 		this.currentIndex = this.resolveCurrentIndex(
 			state.current_track_id,
 			state.current_index,
-			this.tracks
+			this.tracks,
+			state.current_record_id
 		);
 
 		// restore the continuation boundary (clamped). older states
@@ -350,14 +351,24 @@ class Queue {
 			this.continuationFromIndex < this.tracks.length ? (state.continuation_label ?? null) : null;
 	}
 
-	resolveCurrentIndex(currentTrackId: string | null, index: number, tracks: Track[]): number {
+	resolveCurrentIndex(
+		currentTrackId: string | null,
+		index: number,
+		tracks: Track[],
+		currentRecordId?: number | null
+	): number {
 		if (tracks.length === 0) return 0;
 
 		const indexInRange = Number.isInteger(index) && index >= 0 && index < tracks.length;
 
 		// trust the explicit index first – the server always sends the correct slot
-		if (indexInRange) {
+		if (indexInRange && (currentRecordId == null || tracks[index].id === currentRecordId)) {
 			return index;
+		}
+
+		if (currentRecordId != null) {
+			const match = tracks.findIndex((track) => track.id === currentRecordId);
+			return match === -1 ? (indexInRange ? index : 0) : match;
 		}
 
 		if (currentTrackId) {
@@ -419,11 +430,14 @@ class Queue {
 		try {
 			const state: QueueState = {
 				track_ids: this.tracks.map((t) => t.file_id),
+				track_record_ids: this.tracks.map((t) => t.id),
 				current_index: this.currentIndex,
 				current_track_id: this.currentTrack?.file_id ?? null,
+				current_record_id: this.currentTrack?.id ?? null,
 				shuffle: this.shuffle,
 				repeat_mode: this.repeatMode,
 				original_order_ids: this.originalOrder.map((t) => t.file_id),
+				original_order_record_ids: this.originalOrder.map((t) => t.id),
 				progress_ms: this.progressMs,
 				continuation_from_index: this.continuationFromIndex,
 				continuation_label: this.continuationLabel
@@ -567,11 +581,7 @@ class Queue {
 		// play before recommendations) but never before the current track —
 		// which may itself be in the continuation once playback advances into it
 		const insertAt = Math.max(this.continuationFromIndex, this.currentIndex + 1);
-		this.tracks = [
-			...this.tracks.slice(0, insertAt),
-			...tracks,
-			...this.tracks.slice(insertAt)
-		];
+		this.tracks = [...this.tracks.slice(0, insertAt), ...tracks, ...this.tracks.slice(insertAt)];
 		this.originalOrder = [...this.originalOrder, ...tracks];
 
 		// keep the continuation suffix starting after the inserted explicit tracks
@@ -736,7 +746,7 @@ class Queue {
 
 		if (this.currentIndex < this.tracks.length - 1) {
 			this.lastUpdateWasLocal = true;
-		this.mutationEpoch += 1;
+			this.mutationEpoch += 1;
 			this.currentIndex += 1;
 			this.syncState();
 		}
@@ -747,7 +757,7 @@ class Queue {
 
 		if (this.currentIndex > 0 || forceSkip) {
 			this.lastUpdateWasLocal = true;
-		this.mutationEpoch += 1;
+			this.mutationEpoch += 1;
 			if (this.currentIndex > 0) {
 				this.currentIndex -= 1;
 			}
@@ -817,7 +827,10 @@ class Queue {
 		this.mutationEpoch += 1;
 		const updated = [...this.tracks];
 		const [moved] = updated.splice(fromIndex, 1);
-		const insertAt = Math.max(this.currentIndex + 1, Math.min(this.continuationFromIndex, updated.length));
+		const insertAt = Math.max(
+			this.currentIndex + 1,
+			Math.min(this.continuationFromIndex, updated.length)
+		);
 		updated.splice(insertAt, 0, moved);
 		this.tracks = updated;
 		this.continuationFromIndex = Math.min(this.continuationFromIndex + 1, updated.length);
@@ -946,9 +959,7 @@ class Queue {
 			const inQueue = new Set(this.tracks.map((t) => t.file_id));
 			const currentId = this.currentTrack?.file_id;
 			const candidates = () =>
-				forYouCache.tracks.filter(
-					(t) => !inQueue.has(t.file_id) && t.file_id !== currentId
-				);
+				forYouCache.tracks.filter((t) => !inQueue.has(t.file_id) && t.file_id !== currentId);
 
 			let fresh = candidates();
 			if (fresh.length < CONTINUATION_BATCH && forYouCache.hasMore) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -107,10 +107,13 @@ export type RepeatMode = 'none' | 'one';
 
 export interface QueueState {
 	track_ids: string[];
+	track_record_ids?: number[];
 	current_index: number;
 	current_track_id: string | null;
+	current_record_id?: number | null;
 	shuffle: boolean;
 	original_order_ids: string[];
+	original_order_record_ids?: number[];
 	auto_advance?: boolean;
 	progress_ms?: number;
 	/** index where the auto-generated continuation tail begins (== length when none) */
@@ -220,7 +223,14 @@ export interface ActivityCollection {
 }
 
 export interface ActivityEvent {
-	type: 'like' | 'track' | 'comment' | 'join' | 'playlist_create' | 'album_release' | 'track_added_to_playlist';
+	type:
+		| 'like'
+		| 'track'
+		| 'comment'
+		| 'join'
+		| 'playlist_create'
+		| 'album_release'
+		| 'track_added_to_playlist';
 	actor: ActivityActor;
 	track: ActivityTrack | null;
 	comment_text: string | null;

--- a/loq.toml
+++ b/loq.toml
@@ -127,7 +127,7 @@ max_lines = 1137
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"
-max_lines = 999
+max_lines = 1010
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"


### PR DESCRIPTION
Preserve the track the listener selected when queue sync returns multiple uploads of the same audio. Queue saves and restores now use database track IDs, keeping the title, artist, artwork, repeated entries, and shuffle order attached to the chosen upload.

<details>
<summary>Compatibility and validation</summary>

- Requires the backend identity hydration support in #2027 to be deployed first.
- Keep legacy audio-ID fields for older clients and read older snapshots. Missing record IDs are omitted rather than replaced with another upload.
- Preserve the indexed occurrence for repeated tracks; locate the selected record when removal shifts its index.
- Regression tests reproduce the shared-file metadata swap on the old implementation, and cover save/echo, repeated entries, original order, and missing records.
- Frontend typecheck, lint, and all 216 tests passed. A browser queue-sync round trip kept “ft sando (live on logan)” and the correct artwork in the footer, with no page errors.
- Document the JSONB compatibility and backend-first rollout; adjust the file’s line limit through `just loq-relax`.

</details>
