### PR TITLE
Edit owned tracks in place from the track page and portal

### DIFF
--- a/docs/internal/frontend/design-tokens.md
+++ b/docs/internal/frontend/design-tokens.md
@@ -117,3 +117,20 @@ border-radius: var(--radius-md);
 font-size: var(--text-base);
 background: var(--bg-tertiary);
 ```
+
+## motion
+
+The shared track editor starts the adoption of these tokens:
+
+```css
+--motion-feedback: 140ms;
+--motion-enter: 200ms;
+--motion-exit: 140ms;
+--ease-surface: cubic-bezier(0.2, 0, 0, 1);
+```
+
+Use feedback timing for control hover/press changes, and surface timing for
+opening and closing dialogs. Disable movement under `prefers-reduced-motion`.
+The editor reads its exit duration from the token before unmounting so visual
+and focus restoration timing stay aligned. See [interaction quality](./interaction-quality.md)
+for the ongoing adoption plan.

--- a/docs/internal/frontend/interaction-quality.md
+++ b/docs/internal/frontend/interaction-quality.md
@@ -1,0 +1,83 @@
+---
+title: "interaction quality"
+---
+
+# interaction quality
+
+Track editing is the first focused pass toward more consistent interactions.
+An owner should be able to edit the track where they are already viewing it;
+the portal and track page should open the same editor. This is a direction for
+ongoing work, not a claim that every existing interaction follows these rules.
+
+## principles
+
+- Put the common action close to the object it changes. Keep the user in context
+  and update visible track details after a successful save.
+- Use the same words for the same action. An owner action is “edit track”; its
+  primary action is “save changes”. Order common metadata ahead of less frequent
+  visibility, rights, and audio operations.
+- Give each interaction one keyboard owner. Suggestions consume their first
+  Escape; the dialog handles the next. Playback shortcuts must not intercept
+  dialog controls.
+- Keep pending work and failures visible where the action happened. Preserve
+  edits on failure and explain partial saves. A notification beneath a modal is
+  not sufficient feedback.
+- Make closing predictable: explicit close, Escape, and backdrop dismissal
+  follow the same unsaved-change and pending-operation rules. Restore focus to
+  the trigger after closing.
+- Use brief movement to show state changes, with a reduced-motion alternative.
+  Keep pressed, hover, focus, disabled, and pending states distinguishable.
+  Future native haptics should reinforce these semantics.
+
+## existing foundations
+
+`ConfirmDialog.svelte` uses native `dialog.showModal()` for browser-managed
+modal behavior and top-layer stacking. `BottomSheet.svelte` provides mobile
+safe-area handling, swipe dismissal, a 150ms backdrop fade and a 200ms ease-out
+panel transition, plus reduced-motion styling. Shared colors, typography and
+radii come from the [design tokens](./design-tokens.md).
+
+Native dialogs are a useful foundation for new editors. Older modal code is not
+a uniform accessibility or dismissal contract to copy unchanged.
+
+## track editor
+
+`EditTrackModal.svelte` is shared by the track page and portal. Only the owner
+sees the track-page action. The shell owns native modal focus, scroll locking,
+dirty dismissal, reduced motion, and propagation of saved metadata to the page,
+player, and queue. `TrackEditForm.svelte` owns the draft and save sequence;
+artwork, access/rights, and audio/history are separate field components.
+
+Metadata edits invalidate the discovery cache and refresh the current queue's
+hydrated metadata through its normal optimistic write path. The mutation epoch
+prevents a queue response started before the edit from overwriting it. Queue
+order, selected occurrence, and progress are preserved.
+
+Existing copyright records are preserved unless the owner explicitly changes
+them. Metadata and copyright use separate endpoints, so partial failures keep
+the editor open and explain which operation failed. Audio replacement stays in
+the background, with the uploader's typed status callback also feeding inline
+progress and errors while the editor is open.
+
+## prioritized follow-ups
+
+1. **Unify modal semantics.** `SearchModal.svelte`, `FeedbackModal.svelte`,
+   `LogoutModal.svelte`, and `DownloadAskModal.svelte` use always-mounted dialog
+   divs hidden by opacity and pointer-events. Hidden controls can remain in the
+   tab order, and focus containment/restoration varies. Preserve SearchModal's
+   deliberate mobile keyboard focus behavior when migrating it.
+2. **Scope nested dismissal.** `BottomSheet.svelte` listens for Escape and Tab
+   on the window. A nested confirmation should own its keyboard events without
+   also closing or moving focus in the underlying sheet.
+3. **Adopt shared motion tokens.** The edit flow introduces `--motion-feedback`
+   (140ms), `--motion-enter` (200ms), `--motion-exit` (140ms), and `--ease-surface`.
+   Older components mix durations, broad `transition: all`, and easing curves.
+   Migrate touched components to the tokens while preserving useful distinctions.
+   Check actual animated properties under reduced motion: `Toast.svelte` uses a
+   600ms Svelte fade, which its CSS `transition` override does not control.
+4. **Review notification layering.** `Toast.svelte` uses document z-index 9999;
+   native modal dialogs render above it. Dialog errors need visible inline
+   feedback, and notification placement should have a deliberate app-wide rule.
+
+Keep each follow-up bounded and verify keyboard, pointer, small-screen, and
+reduced-motion behavior before extending a pattern across the app.

--- a/frontend/src/lib/audio-replacement-status.test.ts
+++ b/frontend/src/lib/audio-replacement-status.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { uploader, type AudioReplacementStatus } from './uploader.svelte';
+
+class ReplacementRequest extends EventTarget {
+	static latest: ReplacementRequest;
+	upload = new EventTarget();
+	status = 200;
+	statusText = 'OK';
+	responseText = JSON.stringify({ upload_id: 'replacement' });
+	withCredentials = false;
+	timeout = 0;
+	constructor() {
+		super();
+		ReplacementRequest.latest = this;
+	}
+	open(): void {
+		/* No network is needed for transport events. */
+	}
+	send(): void {
+		/* The test controls upload progress and completion. */
+	}
+}
+
+class ReplacementEvents {
+	static latest: ReplacementEvents;
+	onmessage: ((event: MessageEvent<string>) => void) | null = null;
+	onerror: (() => void) | null = null;
+	closed = false;
+	constructor() {
+		ReplacementEvents.latest = this;
+	}
+	close(): void {
+		this.closed = true;
+	}
+}
+
+afterEach(() => {
+	uploader.activeUploads.clear();
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+function begin(onComplete?: () => Promise<void>): AudioReplacementStatus[] {
+	vi.stubGlobal('XMLHttpRequest', ReplacementRequest);
+	vi.stubGlobal('EventSource', ReplacementEvents);
+	vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+		Response.json({ tracks: [], total: 0, has_more: false })
+	);
+	const statuses: AudioReplacementStatus[] = [];
+	uploader.replaceAudio(
+		7,
+		new File(['audio'], 'replacement.mp3'),
+		'track',
+		onComplete,
+		(status) => {
+			statuses.push(status);
+		}
+	);
+	return statuses;
+}
+
+describe('audio replacement inline status', () => {
+	it('reports upload, processing, success, and a rejected refresh without rejecting globally', async () => {
+		const statuses = begin(async () => {
+			throw new Error('refresh unavailable');
+		});
+		expect(statuses.at(-1)?.message).toBe('uploading replacement audio…');
+		ReplacementRequest.latest.upload.dispatchEvent(
+			new ProgressEvent('progress', { lengthComputable: true, loaded: 5, total: 10 })
+		);
+		expect(statuses.at(-1)?.message).toContain('50%');
+		ReplacementRequest.latest.dispatchEvent(new Event('load'));
+		expect(statuses.at(-1)?.message).toBe('processing replacement audio…');
+		ReplacementEvents.latest.onmessage?.(
+			new MessageEvent('message', {
+				data: JSON.stringify({
+					status: 'processing',
+					message: 'optimizing audio',
+					server_progress_pct: 75
+				})
+			})
+		);
+		expect(statuses.at(-1)?.message).toBe('optimizing audio (75%)');
+		ReplacementEvents.latest.onmessage?.(
+			new MessageEvent('message', { data: JSON.stringify({ status: 'completed' }) })
+		);
+		expect(statuses.at(-1)).toEqual({ type: 'success', message: 'audio replaced' });
+		await vi.waitFor(() =>
+			expect(statuses.at(-1)).toEqual({
+				type: 'warning',
+				message: 'audio replaced — reload to see the update'
+			})
+		);
+		expect(ReplacementEvents.latest.closed).toBe(true);
+	});
+
+	it('reports the HTTP error to the inline consumer', () => {
+		const statuses = begin();
+		ReplacementRequest.latest.status = 403;
+		ReplacementRequest.latest.responseText = JSON.stringify({ detail: 'not your track' });
+		ReplacementRequest.latest.dispatchEvent(new Event('load'));
+		expect(statuses.at(-1)).toEqual({ type: 'error', message: 'not your track' });
+	});
+
+	it('reports malformed progress and closes the failed stream', () => {
+		const statuses = begin();
+		ReplacementRequest.latest.dispatchEvent(new Event('load'));
+		ReplacementEvents.latest.onmessage?.(new MessageEvent('message', { data: 'invalid json' }));
+		expect(statuses.at(-1)?.type).toBe('error');
+		expect(ReplacementEvents.latest.closed).toBe(true);
+	});
+});

--- a/frontend/src/lib/components/AlbumSelect.svelte
+++ b/frontend/src/lib/components/AlbumSelect.svelte
@@ -2,39 +2,52 @@
 	import type { AlbumSummary } from '$lib/types';
 
 	interface Props {
+		id?: string;
 		albums: AlbumSummary[];
 		value: string;
 		placeholder?: string;
 		disabled?: boolean;
 	}
 
-	let { albums = [], value = $bindable(''), placeholder = 'album name', disabled = false }: Props = $props();
+	let {
+		id,
+		albums = [],
+		value = $bindable(''),
+		placeholder = 'album name',
+		disabled = false
+	}: Props = $props();
 
 	let showResults = $state(false);
 	let filteredAlbums = $derived.by(() => {
 		if (!value || value.length === 0) {
 			return albums;
 		}
-		return albums.filter(album =>
-			album.title.toLowerCase().includes(value.toLowerCase())
-		);
+		return albums.filter((album) => album.title.toLowerCase().includes(value.toLowerCase()));
 	});
 
 	let exactMatch = $derived.by(() => {
-		return albums.find(a => a.title.toLowerCase() === value.toLowerCase());
+		return albums.find((a) => a.title.toLowerCase() === value.toLowerCase());
 	});
 
 	let similarAlbums = $derived.by(() => {
 		if (exactMatch || !value) return [];
-		return albums.filter(a =>
-			a.title.toLowerCase() !== value.toLowerCase() &&
-			a.title.toLowerCase().includes(value.toLowerCase())
+		return albums.filter(
+			(a) =>
+				a.title.toLowerCase() !== value.toLowerCase() &&
+				a.title.toLowerCase().includes(value.toLowerCase())
 		);
 	});
 
 	function selectAlbum(albumTitle: string) {
 		value = albumTitle;
 		showResults = false;
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape' && showResults) {
+			event.preventDefault();
+			showResults = false;
+		}
 	}
 
 	function handleClickOutside(e: MouseEvent) {
@@ -49,14 +62,21 @@
 <div class="album-select-container">
 	<div class="input-wrapper">
 		<input
+			{id}
+			onkeydown={handleKeydown}
+			aria-label={id ? undefined : 'album'}
 			type="text"
 			bind:value
-			placeholder={placeholder}
+			{placeholder}
 			{disabled}
 			class="album-input"
 			maxlength="256"
-			onfocus={() => { if (albums.length > 0) showResults = true; }}
-			oninput={() => { showResults = albums.length > 0; }}
+			onfocus={() => {
+				if (albums.length > 0) showResults = true;
+			}}
+			oninput={() => {
+				showResults = albums.length > 0;
+			}}
 			autocomplete="off"
 		/>
 
@@ -72,7 +92,8 @@
 						<div class="album-info">
 							<div class="album-title">{album.title}</div>
 							<div class="album-stats">
-								{album.track_count} {album.track_count === 1 ? 'track' : 'tracks'}
+								{album.track_count}
+								{album.track_count === 1 ? 'track' : 'tracks'}
 							</div>
 						</div>
 					</button>
@@ -83,7 +104,7 @@
 
 	{#if !exactMatch && similarAlbums.length > 0}
 		<p class="similar-hint">
-			similar: {similarAlbums.map(a => a.title).join(', ')}
+			similar: {similarAlbums.map((a) => a.title).join(', ')}
 		</p>
 	{/if}
 </div>

--- a/frontend/src/lib/components/AutocompleteInteraction.test.ts
+++ b/frontend/src/lib/components/AutocompleteInteraction.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import TagInput from './TagInput.svelte';
+import HandleAutocomplete from './HandleAutocomplete.svelte';
+import HandleSearch from './HandleSearch.svelte';
+import AlbumSelect from './AlbumSelect.svelte';
+
+const cleanup: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+	for (const dispose of cleanup.splice(0)) await dispose();
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+	document.body.innerHTML = '';
+});
+
+function inputText(value: string): HTMLInputElement {
+	const input = document.querySelector('input');
+	if (!input) throw new Error('input not rendered');
+	input.focus();
+	input.value = value;
+	input.dispatchEvent(new Event('input', { bubbles: true }));
+	flushSync();
+	return input;
+}
+
+function pressEscape(input: HTMLInputElement): KeyboardEvent {
+	const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+	input.dispatchEvent(event);
+	flushSync();
+	return event;
+}
+
+function mountTags(onAdd: (tag: string) => void) {
+	const component = mount(TagInput, {
+		target: document.body,
+		props: { tags: [], onAdd, onRemove: () => {} }
+	});
+	cleanup.push(() => unmount(component));
+	flushSync();
+}
+
+async function showTagSuggestions() {
+	vi.useFakeTimers();
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async () => Response.json([{ name: 'ambient', track_count: 4 }]))
+	);
+	const input = inputText('amb');
+	await vi.advanceTimersByTimeAsync(200);
+	flushSync();
+	return input;
+}
+
+describe('autocomplete interactions inside a dialog', () => {
+	it('commits pending tag text before the next button click', () => {
+		vi.useFakeTimers();
+		const added: string[] = [];
+		mountTags((tag) => added.push(tag));
+		const input = inputText('ambient');
+		const save = document.createElement('button');
+		const saveTags = vi.fn(() => [...added]);
+		save.onclick = saveTags;
+		document.body.append(save);
+		save.focus();
+		save.click();
+		flushSync();
+		expect(input.value).toBe('');
+		expect(saveTags).toHaveReturnedWith(['ambient']);
+	});
+
+	it('preserves focus during suggestion selection without committing the partial tag', async () => {
+		const onAdd = vi.fn();
+		mountTags(onAdd);
+		const input = await showTagSuggestions();
+		const suggestion = document.querySelector<HTMLButtonElement>('.suggestion-item');
+		if (!suggestion) throw new Error('suggestion not rendered');
+		const pointerdown = new Event('pointerdown', { bubbles: true, cancelable: true });
+		suggestion.dispatchEvent(pointerdown);
+		expect(pointerdown.defaultPrevented).toBe(true);
+		expect(document.activeElement).toBe(input);
+		suggestion.click();
+		expect(onAdd).toHaveBeenCalledExactlyOnceWith('ambient');
+	});
+
+	it('consumes Escape only while tag suggestions are open', async () => {
+		mountTags(() => {});
+		const input = await showTagSuggestions();
+		expect(pressEscape(input).defaultPrevented).toBe(true);
+		expect(document.querySelector('.suggestion-item')).toBeNull();
+		expect(pressEscape(input).defaultPrevented).toBe(false);
+	});
+
+	it('consumes Escape only while handle suggestions are open', async () => {
+		vi.useFakeTimers();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () =>
+				Response.json({
+					actors: [{ did: 'did:plc:test', handle: 'artist.test', displayName: 'artist' }]
+				})
+			)
+		);
+		const component = mount(HandleAutocomplete, {
+			target: document.body,
+			props: { value: '', onSelect: () => {} }
+		});
+		cleanup.push(() => unmount(component));
+		flushSync();
+		const input = inputText('artist');
+		await vi.advanceTimersByTimeAsync(300);
+		flushSync();
+		expect(document.querySelector('.result-item')).not.toBeNull();
+		expect(pressEscape(input).defaultPrevented).toBe(true);
+		expect(document.querySelector('.result-item')).toBeNull();
+		expect(pressEscape(input).defaultPrevented).toBe(false);
+	});
+	it('consumes Escape only while featured-artist suggestions are open', async () => {
+		vi.useFakeTimers();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () =>
+				Response.json({
+					actors: [{ did: 'did:plc:test', handle: 'artist.test', displayName: 'artist' }]
+				})
+			)
+		);
+		const component = mount(HandleSearch, {
+			target: document.body,
+			props: { selected: [], onAdd: () => {}, onRemove: () => {} }
+		});
+		cleanup.push(() => unmount(component));
+		flushSync();
+		const input = inputText('artist');
+		await vi.advanceTimersByTimeAsync(300);
+		flushSync();
+		expect(document.querySelector('.search-result-item')).not.toBeNull();
+		expect(pressEscape(input).defaultPrevented).toBe(true);
+		expect(document.querySelector('.search-result-item')).toBeNull();
+		expect(pressEscape(input).defaultPrevented).toBe(false);
+	});
+
+	it('consumes Escape only while album suggestions are open', () => {
+		const component = mount(AlbumSelect, {
+			target: document.body,
+			props: {
+				value: '',
+				albums: [{ id: 'album-1', title: 'album', slug: 'album', track_count: 2, total_plays: 0 }]
+			}
+		});
+		cleanup.push(() => unmount(component));
+		flushSync();
+		const input = inputText('alb');
+		expect(document.querySelector('.album-result-item')).not.toBeNull();
+		expect(pressEscape(input).defaultPrevented).toBe(true);
+		expect(document.querySelector('.album-result-item')).toBeNull();
+		expect(pressEscape(input).defaultPrevented).toBe(false);
+	});
+
+	it('associates visible labels with each editor autocomplete input', () => {
+		const tags = mount(TagInput, {
+			target: document.body,
+			props: { id: 'edit-tags', tags: [], onAdd: () => {}, onRemove: () => {} }
+		});
+		const album = mount(AlbumSelect, {
+			target: document.body,
+			props: { id: 'edit-album', albums: [], value: '' }
+		});
+		const features = mount(HandleSearch, {
+			target: document.body,
+			props: { id: 'edit-features', selected: [], onAdd: () => {}, onRemove: () => {} }
+		});
+		cleanup.push(
+			() => unmount(tags),
+			() => unmount(album),
+			() => unmount(features)
+		);
+		flushSync();
+		for (const id of ['edit-tags', 'edit-album', 'edit-features']) {
+			const label = document.createElement('label');
+			label.htmlFor = id;
+			label.textContent = id;
+			document.body.append(label);
+			const input = document.getElementById(id);
+			expect(input).toBeInstanceOf(HTMLInputElement);
+			expect(label.control).toBe(input);
+			expect(input?.hasAttribute('aria-label')).toBe(false);
+		}
+	});
+});

--- a/frontend/src/lib/components/EditTrackModal.svelte
+++ b/frontend/src/lib/components/EditTrackModal.svelte
@@ -1,0 +1,285 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { AlbumSummary, Track } from '$lib/types';
+	import { API_URL } from '$lib/config';
+	import { checkAtprotofansEligibility } from '$lib/utils/atprotofans';
+	import { queue } from '$lib/queue.svelte';
+	import { player } from '$lib/player.svelte';
+	import { tracksCache } from '$lib/tracks.svelte';
+	import ConfirmDialog from './ConfirmDialog.svelte';
+	import TrackEditForm from './TrackEditForm.svelte';
+
+	interface Props {
+		track: Track;
+		albums?: AlbumSummary[];
+		atprotofansEligible?: boolean;
+		onClose: () => void;
+		onSaved: (track: Track) => void | Promise<void>;
+	}
+	let { track, albums, atprotofansEligible, onClose, onSaved }: Props = $props();
+	let dialog = $state<HTMLDialogElement>();
+	let loadedAlbums = $state<AlbumSummary[]>([]);
+	let eligible = $state(false);
+	let busy = $state(false);
+	let dirty = $state(false);
+	let discardOpen = $state(false);
+	let closing = $state(false);
+	let closeTimer: ReturnType<typeof setTimeout>;
+	const titleId = $props.id();
+
+	onMount(() => {
+		const previousOverflow = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
+		dialog?.showModal();
+		dialog?.querySelector('input')?.focus();
+		const abort = new AbortController();
+		if (albums === undefined) {
+			void fetch(`${API_URL}/albums/${encodeURIComponent(track.artist_handle)}`, {
+				credentials: 'include',
+				signal: abort.signal
+			})
+				.then(async (response) => {
+					if (response.ok) {
+						const result: { albums: AlbumSummary[] } = await response.json();
+						loadedAlbums = result.albums;
+					}
+				})
+				.catch(() => {});
+		}
+		if (atprotofansEligible === undefined) {
+			void checkAtprotofansEligibility(track.artist_did).then((value) => {
+				eligible = value;
+			});
+		}
+		return () => {
+			abort.abort();
+			clearTimeout(closeTimer);
+			dialog?.close();
+			document.body.style.overflow = previousOverflow;
+		};
+	});
+
+	function close() {
+		if (closing) return;
+		closing = true;
+		const duration = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+			? 0
+			: parseFloat(
+					window.getComputedStyle(document.documentElement).getPropertyValue('--motion-exit')
+				);
+		closeTimer = setTimeout(() => {
+			dialog?.close();
+			onClose();
+		}, duration);
+	}
+
+	function requestClose() {
+		if (busy) return;
+		if (dirty) discardOpen = true;
+		else close();
+	}
+
+	async function updateTrack(updated: Track) {
+		queue.updateTrackMetadata(updated);
+		if (player.currentTrack?.id === updated.id)
+			player.currentTrack = { ...player.currentTrack, ...updated };
+		tracksCache.invalidate();
+		await onSaved(updated);
+	}
+
+	async function saved(updated: Track) {
+		await updateTrack(updated);
+		dirty = false;
+		close();
+	}
+</script>
+
+<dialog
+	bind:this={dialog}
+	class:closing
+	aria-labelledby={titleId}
+	oncancel={(event) => {
+		event.preventDefault();
+		requestClose();
+	}}
+	onkeydown={(event) => event.stopPropagation()}
+	onclick={(event) => {
+		if (event.target === dialog) requestClose();
+	}}
+>
+	<div class="editor">
+		<header>
+			<h2 id={titleId}>edit track</h2>
+			<button
+				class="close-button"
+				type="button"
+				aria-label="close edit track"
+				disabled={busy}
+				onclick={requestClose}
+			>
+				<svg
+					width="20"
+					height="20"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					aria-hidden="true"><path d="m6 6 12 12M6 18 18 6" /></svg
+				>
+			</button>
+		</header>
+		<TrackEditForm
+			{track}
+			albums={albums ?? loadedAlbums}
+			atprotofansEligible={atprotofansEligible ?? eligible}
+			onClose={requestClose}
+			onSaved={saved}
+			onTrackChanged={updateTrack}
+			onBusyChange={(value) => {
+				busy = value;
+			}}
+			onDirtyChange={(value) => {
+				dirty = value;
+			}}
+		/>
+	</div>
+</dialog>
+
+<ConfirmDialog
+	bind:open={discardOpen}
+	title="discard changes?"
+	body="your unsaved track details will be lost."
+	confirmText="discard changes"
+	cancelText="keep editing"
+	variant="danger"
+	onConfirm={() => {
+		discardOpen = false;
+		close();
+	}}
+	onCancel={() => {
+		discardOpen = false;
+	}}
+/>
+
+<style>
+	dialog {
+		padding: 0;
+		width: min(640px, calc(100vw - 32px));
+		max-width: none;
+		max-height: calc(100dvh - 48px);
+		margin: auto;
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-xl);
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+		overflow: hidden;
+	}
+	dialog[open] {
+		animation: editor-enter var(--motion-enter) var(--ease-surface) both;
+	}
+	dialog::backdrop {
+		background: rgb(0 0 0 / 60%);
+		animation: backdrop-enter var(--motion-enter) var(--ease-surface) both;
+	}
+	dialog.closing {
+		animation: editor-leave var(--motion-exit) ease-in both;
+	}
+	dialog.closing::backdrop {
+		animation: backdrop-enter var(--motion-exit) ease-in reverse both;
+	}
+	.editor {
+		display: flex;
+		flex-direction: column;
+		max-height: calc(100dvh - 48px);
+	}
+	header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 12px 24px;
+		border-bottom: 1px solid var(--border-subtle);
+		flex-shrink: 0;
+	}
+	h2 {
+		margin: 0;
+		font-size: var(--text-2xl);
+	}
+	.close-button {
+		display: grid;
+		place-items: center;
+		width: 44px;
+		height: 44px;
+		border: 0;
+		border-radius: var(--radius-full);
+		background: transparent;
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition:
+			background 140ms,
+			transform 140ms;
+	}
+	.close-button:hover {
+		background: var(--bg-hover);
+	}
+	.close-button:active {
+		transform: scale(0.94);
+	}
+	.close-button:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+	.close-button:disabled {
+		opacity: 0.5;
+		cursor: wait;
+	}
+	@keyframes editor-enter {
+		from {
+			opacity: 0;
+			transform: translateY(8px);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+	@keyframes editor-leave {
+		to {
+			opacity: 0;
+			transform: translateY(4px);
+		}
+	}
+	@keyframes backdrop-enter {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+	@media (max-width: 600px) {
+		dialog {
+			width: 100%;
+			max-height: calc(100dvh - 12px);
+			margin: auto 0 0;
+			border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+		}
+		.editor {
+			max-height: calc(100dvh - 12px);
+			padding-bottom: env(safe-area-inset-bottom);
+		}
+		header {
+			padding-inline: 16px;
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		dialog[open],
+		dialog.closing,
+		dialog::backdrop,
+		dialog.closing::backdrop {
+			animation: none;
+		}
+		.close-button {
+			transition: none;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/HandleAutocomplete.svelte
+++ b/frontend/src/lib/components/HandleAutocomplete.svelte
@@ -16,7 +16,12 @@
 		disabled?: boolean;
 	}
 
-	let { value = $bindable(''), onSelect, placeholder = 'search by handle...', disabled = false }: Props = $props();
+	let {
+		value = $bindable(''),
+		onSelect,
+		placeholder = 'search by handle...',
+		disabled = false
+	}: Props = $props();
 
 	let results = $state<HandleResult[]>([]);
 	let searching = $state(false);
@@ -31,17 +36,22 @@
 
 		searching = true;
 		try {
-			const response = await fetch(`${TYPEAHEAD_URL}/xrpc/app.bsky.actor.searchActorsTypeahead?q=${encodeURIComponent(value)}&limit=10`, {
-				headers: { 'X-Client': 'plyr.fm' }
-			});
+			const response = await fetch(
+				`${TYPEAHEAD_URL}/xrpc/app.bsky.actor.searchActorsTypeahead?q=${encodeURIComponent(value)}&limit=10`,
+				{
+					headers: { 'X-Client': 'plyr.fm' }
+				}
+			);
 			if (response.ok) {
 				const data = await response.json();
-				results = (data.actors ?? []).map((actor: { did: string; handle: string; displayName?: string; avatar?: string }) => ({
-					did: actor.did,
-					handle: actor.handle,
-					display_name: actor.displayName ?? actor.handle,
-					avatar_url: actor.avatar ?? null,
-				}));
+				results = (data.actors ?? []).map(
+					(actor: { did: string; handle: string; displayName?: string; avatar?: string }) => ({
+						did: actor.did,
+						handle: actor.handle,
+						display_name: actor.displayName ?? actor.handle,
+						avatar_url: actor.avatar ?? null
+					})
+				);
 				showResults = results.length > 0;
 			}
 		} catch (e) {
@@ -73,7 +83,8 @@
 	}
 
 	function handleKeydown(e: KeyboardEvent) {
-		if (e.key === 'Escape') {
+		if (e.key === 'Escape' && showResults) {
+			e.preventDefault();
 			showResults = false;
 		}
 	}
@@ -88,7 +99,9 @@
 			bind:value
 			oninput={handleInput}
 			onkeydown={handleKeydown}
-			onfocus={() => { if (results.length > 0) showResults = true; }}
+			onfocus={() => {
+				if (results.length > 0) showResults = true;
+			}}
 			{placeholder}
 			{disabled}
 			autocomplete="off"
@@ -103,11 +116,7 @@
 	{#if showResults && results.length > 0}
 		<div class="results">
 			{#each results as result}
-				<button
-					type="button"
-					class="result-item"
-					onclick={(e) => selectHandle(e, result)}
-				>
+				<button type="button" class="result-item" onclick={(e) => selectHandle(e, result)}>
 					{#if result.avatar_url}
 						<SensitiveImage src={result.avatar_url} compact>
 							<img src={result.avatar_url} alt="" class="avatar" />

--- a/frontend/src/lib/components/HandleSearch.svelte
+++ b/frontend/src/lib/components/HandleSearch.svelte
@@ -4,6 +4,7 @@
 	import type { FeaturedArtist } from '$lib/types';
 
 	interface Props {
+		id?: string;
 		selected: FeaturedArtist[];
 		onAdd: (_artist: FeaturedArtist) => void;
 		onRemove: (_did: string) => void;
@@ -12,7 +13,15 @@
 		hasUnresolvedInput?: boolean;
 	}
 
-	let { selected = $bindable([]), onAdd, onRemove, maxFeatures = 10, disabled = false, hasUnresolvedInput = $bindable(false) }: Props = $props();
+	let {
+		id,
+		selected = $bindable([]),
+		onAdd,
+		onRemove,
+		maxFeatures = 10,
+		disabled = false,
+		hasUnresolvedInput = $bindable(false)
+	}: Props = $props();
 
 	let query = $state('');
 	let results = $state<FeaturedArtist[]>([]);
@@ -36,17 +45,22 @@
 		searching = true;
 		noResultsFound = false;
 		try {
-			const response = await fetch(`${TYPEAHEAD_URL}/xrpc/app.bsky.actor.searchActorsTypeahead?q=${encodeURIComponent(query)}&limit=10`, {
-				headers: { 'X-Client': 'plyr.fm' }
-			});
+			const response = await fetch(
+				`${TYPEAHEAD_URL}/xrpc/app.bsky.actor.searchActorsTypeahead?q=${encodeURIComponent(query)}&limit=10`,
+				{
+					headers: { 'X-Client': 'plyr.fm' }
+				}
+			);
 			if (response.ok) {
 				const data = await response.json();
-				results = (data.actors ?? []).map((actor: { did: string; handle: string; displayName?: string; avatar?: string }) => ({
-					did: actor.did,
-					handle: actor.handle,
-					display_name: actor.displayName ?? actor.handle,
-					avatar_url: actor.avatar ?? null,
-				}));
+				results = (data.actors ?? []).map(
+					(actor: { did: string; handle: string; displayName?: string; avatar?: string }) => ({
+						did: actor.did,
+						handle: actor.handle,
+						display_name: actor.displayName ?? actor.handle,
+						avatar_url: actor.avatar ?? null
+					})
+				);
 				if (results.length === 0) {
 					noResultsFound = true;
 				}
@@ -66,7 +80,7 @@
 
 	function selectArtist(artist: FeaturedArtist) {
 		// check if already selected
-		if (selected.some(a => a.did === artist.did)) {
+		if (selected.some((a) => a.did === artist.did)) {
 			return;
 		}
 		// check max limit
@@ -85,6 +99,13 @@
 	}
 
 	// close dropdown when clicking outside
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape' && showResults) {
+			event.preventDefault();
+			showResults = false;
+		}
+	}
+
 	function handleClickOutside(e: MouseEvent) {
 		if (!(e.target instanceof Element && e.target.closest('.handle-search-container'))) {
 			showResults = false;
@@ -97,13 +118,18 @@
 <div class="handle-search-container">
 	<div class="search-input-wrapper">
 		<input
+			{id}
+			onkeydown={handleKeydown}
+			aria-label={id ? undefined : 'featured artists'}
 			type="text"
 			bind:value={query}
 			oninput={handleInput}
 			placeholder="search for artists by handle..."
 			{disabled}
 			class="search-input"
-			onfocus={() => { if (results.length > 0) showResults = true; }}
+			onfocus={() => {
+				if (results.length > 0) showResults = true;
+			}}
 		/>
 		{#if searching}
 			<span class="search-spinner">searching...</span>
@@ -115,9 +141,9 @@
 					<button
 						type="button"
 						class="search-result-item"
-						class:selected={selected.some(a => a.did === result.did)}
+						class:selected={selected.some((a) => a.did === result.did)}
 						onclick={() => selectArtist(result)}
-						disabled={selected.some(a => a.did === result.did) || selected.length >= maxFeatures}
+						disabled={selected.some((a) => a.did === result.did) || selected.length >= maxFeatures}
 					>
 						{#if result.avatar_url}
 							<SensitiveImage src={result.avatar_url} compact>

--- a/frontend/src/lib/components/TagInput.svelte
+++ b/frontend/src/lib/components/TagInput.svelte
@@ -10,6 +10,7 @@
 	const MAX_TAG_LENGTH = 50;
 
 	interface Props {
+		id?: string;
 		tags: string[];
 		onAdd: (_tag: string) => void;
 		onRemove: (_tag: string) => void;
@@ -17,7 +18,14 @@
 		disabled?: boolean;
 	}
 
-	let { tags = $bindable([]), onAdd, onRemove, placeholder = 'add tag...', disabled = false }: Props = $props();
+	let {
+		id,
+		tags = $bindable([]),
+		onAdd,
+		onRemove,
+		placeholder = 'add tag...',
+		disabled = false
+	}: Props = $props();
 
 	let inputValue = $state('');
 	let suggestions = $state<TagSuggestion[]>([]);
@@ -34,13 +42,16 @@
 
 		searching = true;
 		try {
-			const response = await fetch(`${API_URL}/tracks/tags?q=${encodeURIComponent(inputValue)}&limit=10`, {
-				credentials: 'include'
-			});
+			const response = await fetch(
+				`${API_URL}/tracks/tags?q=${encodeURIComponent(inputValue)}&limit=10`,
+				{
+					credentials: 'include'
+				}
+			);
 			if (response.ok) {
 				const data: TagSuggestion[] = await response.json();
 				// filter out tags already added
-				suggestions = data.filter(s => !tags.includes(s.name));
+				suggestions = data.filter((s) => !tags.includes(s.name));
 				showSuggestions = suggestions.length > 0;
 			}
 		} catch (e) {
@@ -81,7 +92,8 @@
 			}
 		} else if (e.key === 'Backspace' && !inputValue && tags.length > 0) {
 			onRemove(tags[tags.length - 1]);
-		} else if (e.key === 'Escape') {
+		} else if (e.key === 'Escape' && showSuggestions) {
+			e.preventDefault();
 			showSuggestions = false;
 			selectedIndex = -1;
 		} else if (e.key === 'ArrowDown') {
@@ -98,14 +110,11 @@
 	}
 
 	function handleBlur() {
-		// delay to allow click on suggestion
-		setTimeout(() => {
-			if (inputValue.trim()) {
-				addTag(inputValue);
-			}
-			showSuggestions = false;
-			selectedIndex = -1;
-		}, 150);
+		if (inputValue.trim()) {
+			addTag(inputValue);
+		}
+		showSuggestions = false;
+		selectedIndex = -1;
 	}
 
 	function handleClickOutside(e: MouseEvent) {
@@ -127,18 +136,21 @@
 					class="tag-remove"
 					aria-label="remove {tag}"
 					onclick={() => onRemove(tag)}
-					{disabled}
-				>×</button>
+					{disabled}>×</button
+				>
 			</span>
 		{/each}
 		<input
+			{id}
 			type="text"
-			aria-label="add tag"
+			aria-label={id ? undefined : 'add tag'}
 			bind:value={inputValue}
 			oninput={handleInput}
 			onkeydown={handleKeydown}
 			onblur={handleBlur}
-			onfocus={() => { if (suggestions.length > 0) showSuggestions = true; }}
+			onfocus={() => {
+				if (suggestions.length > 0) showSuggestions = true;
+			}}
 			placeholder={tags.length === 0 ? placeholder : ''}
 			class="tag-input"
 			disabled={disabled || tags.length >= MAX_TAGS}
@@ -163,10 +175,13 @@
 					type="button"
 					class="suggestion-item"
 					class:selected={i === selectedIndex}
+					onpointerdown={(event) => event.preventDefault()}
 					onclick={() => selectSuggestion(suggestion)}
 				>
 					<span class="tag-name">{suggestion.name}</span>
-					<span class="tag-count">{suggestion.track_count} {suggestion.track_count === 1 ? 'track' : 'tracks'}</span>
+					<span class="tag-count"
+						>{suggestion.track_count} {suggestion.track_count === 1 ? 'track' : 'tracks'}</span
+					>
 				</button>
 			{/each}
 		</div>
@@ -203,7 +218,7 @@
 		padding: 0.35rem 0.6rem;
 		background: color-mix(in srgb, var(--accent) 10%, transparent);
 		border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
-		color: var(--accent-hover);
+		color: var(--text-primary);
 		border-radius: var(--radius-xl);
 		font-size: var(--text-base);
 		font-weight: 500;

--- a/frontend/src/lib/components/TrackEditForm.svelte
+++ b/frontend/src/lib/components/TrackEditForm.svelte
@@ -1,0 +1,528 @@
+<script lang="ts">
+	import TrackAccessFields from './track-edit/TrackAccessFields.svelte';
+	import TrackArtworkField from './track-edit/TrackArtworkField.svelte';
+	import TrackAudioEditor from './track-edit/TrackAudioEditor.svelte';
+	import { onMount } from 'svelte';
+	import HandleSearch from '$lib/components/HandleSearch.svelte';
+	import AlbumSelect from '$lib/components/AlbumSelect.svelte';
+	import WaveLoading from '$lib/components/WaveLoading.svelte';
+	import TagInput from '$lib/components/TagInput.svelte';
+	import type { TrackRights } from '$lib/components/CopyrightRightsPanel.svelte';
+	import type { Track, FeaturedArtist, AlbumSummary } from '$lib/types';
+	import { API_URL } from '$lib/config';
+	import { toast } from '$lib/toast.svelte';
+
+	interface Props {
+		track: Track;
+		albums: AlbumSummary[];
+		atprotofansEligible: boolean;
+		onClose: () => void;
+		onSaved: (track: Track) => void | Promise<void>;
+		onTrackChanged?: (track: Track) => void | Promise<void>;
+		onBusyChange?: (busy: boolean) => void;
+		onDirtyChange?: (dirty: boolean) => void;
+	}
+	let {
+		track,
+		albums,
+		atprotofansEligible,
+		onClose,
+		onSaved,
+		onTrackChanged,
+		onBusyChange,
+		onDirtyChange
+	}: Props = $props();
+	let saveError = $state<string | null>(null);
+	let replaceCopyrightRights = $state(false);
+	let initialDraft = $state('');
+	function draftSnapshot(): string {
+		return JSON.stringify([
+			editTitle,
+			editDescription,
+			editAlbum,
+			editFeaturedArtists,
+			editTags,
+			editSupportGate,
+			editUnlisted,
+			editSelfLabels,
+			editCopyrightEnabled,
+			editCopyrightRights,
+			replaceCopyrightRights
+		]);
+	}
+	onMount(() => {
+		startEditTrack(track);
+		initialDraft = draftSnapshot();
+	});
+	$effect(() => {
+		onBusyChange?.(savingTrackEdit || audioPending);
+	});
+	$effect(() => {
+		onDirtyChange?.(
+			Boolean(
+				initialDraft &&
+				(draftSnapshot() !== initialDraft ||
+					editImageFile ||
+					editRemoveImage ||
+					audioDirty ||
+					hasUnresolvedEditFeaturesInput)
+			)
+		);
+	});
+
+	let savingTrackEdit = $state(false);
+	let editTitle = $state('');
+	let editDescription = $state('');
+	let editAlbum = $state('');
+	let editFeaturedArtists = $state<FeaturedArtist[]>([]);
+	let editTags = $state<string[]>([]);
+	let editImageFile = $state<File | null>(null);
+	let editRemoveImage = $state(false);
+
+	let audioPending = $state(false);
+	let audioDirty = $state(false);
+	let editSupportGate = $state(false);
+	let editUnlisted = $state(false);
+	let editSelfLabels = $state<string[]>([]);
+
+	let editCopyrightEnabled = $state(false);
+	let editCopyrightRights = $state<TrackRights>({});
+
+	let editCopyrightWasEnabled = $state(false);
+	let hasUnresolvedEditFeaturesInput = $state(false);
+	let recommendedTags = $state<{ name: string; score: number }[]>([]);
+	let loadingRecommendedTags = $state(false);
+	let recommendedTagsTrackId = $state<number | null>(null);
+	let visibleRecommendedTags = $derived(
+		recommendedTags.filter((r) => !editTags.includes(r.name.toLowerCase()))
+	);
+
+	function startEditTrack(track: Track) {
+		editTitle = track.title;
+		editDescription = track.description || '';
+		editAlbum = track.album?.title || '';
+		editFeaturedArtists = track.features || [];
+		editTags = track.tags || [];
+		editSupportGate =
+			track.support_gate !== null &&
+			track.support_gate !== undefined &&
+			track.support_gate.type !== 'copyright';
+		editUnlisted = track.unlisted ?? false;
+		editSelfLabels = [...(track.self_labels ?? [])];
+
+		editCopyrightEnabled = Boolean(track.copyright_song_uri);
+		editCopyrightWasEnabled = editCopyrightEnabled;
+		editCopyrightRights = {};
+		fetchRecommendedTags(track.id);
+	}
+
+	async function fetchRecommendedTags(trackId: number) {
+		loadingRecommendedTags = true;
+		recommendedTags = [];
+		recommendedTagsTrackId = trackId;
+		try {
+			const response = await fetch(`${API_URL}/tracks/${trackId}/recommended-tags?limit=8`, {
+				credentials: 'include'
+			});
+			if (!response.ok) return;
+			const data = await response.json();
+			if (recommendedTagsTrackId !== trackId) return;
+			if (!data.available || data.tags.length === 0) return;
+			recommendedTags = data.tags;
+		} catch {
+			recommendedTags = [];
+		} finally {
+			loadingRecommendedTags = false;
+		}
+	}
+
+	function cancelEdit() {
+		onClose();
+	}
+
+	async function refreshTrack(): Promise<Track> {
+		const response = await fetch(`${API_URL}/tracks/${track.id}`, { credentials: 'include' });
+		if (!response.ok) throw new Error('could not refresh track — try again');
+		const fresh: Track = await response.json();
+		return fresh;
+	}
+
+	async function saveTrackEdit(trackId: number) {
+		if (savingTrackEdit || audioPending || !editTitle.trim() || hasUnresolvedEditFeaturesInput)
+			return;
+		savingTrackEdit = true;
+		saveError = null;
+		const formData = new FormData();
+		formData.append('title', editTitle);
+		formData.append('description', editDescription);
+		formData.append('album', editAlbum);
+		if (editFeaturedArtists.length > 0) {
+			const handles = editFeaturedArtists.map((a) => a.handle);
+			formData.append('features', JSON.stringify(handles));
+		} else {
+			formData.append('features', JSON.stringify([]));
+		}
+
+		formData.append('tags', JSON.stringify(editTags));
+
+		if (!editCopyrightEnabled && !editCopyrightWasEnabled) {
+			if (editSupportGate) {
+				formData.append('support_gate', JSON.stringify({ type: 'any' }));
+			} else {
+				formData.append('support_gate', 'null');
+			}
+		}
+		formData.append('unlisted', editUnlisted ? 'true' : 'false');
+		formData.append('self_labels', JSON.stringify(editSelfLabels));
+
+		if (editRemoveImage) {
+			formData.append('remove_image', 'true');
+		} else if (editImageFile) {
+			formData.append('image', editImageFile);
+		}
+
+		try {
+			const response = await fetch(`${API_URL}/tracks/${trackId}`, {
+				method: 'PATCH',
+				body: formData,
+				credentials: 'include'
+			});
+
+			if (!response.ok) {
+				const error = await response.json();
+				saveError = error.detail || 'could not save changes — try again';
+				return;
+			}
+
+			if (editCopyrightEnabled && (!editCopyrightWasEnabled || replaceCopyrightRights)) {
+				const rightsResp = await fetch(`${API_URL}/tracks/${trackId}/copyright`, {
+					method: 'POST',
+					credentials: 'include',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify(editCopyrightRights)
+				});
+				if (!rightsResp.ok) {
+					const err = await rightsResp.json().catch(() => ({}));
+					saveError = `details saved, but copyright failed: ${err.detail ?? rightsResp.statusText}`;
+					return;
+				}
+			} else if (!editCopyrightEnabled && editCopyrightWasEnabled) {
+				const dropResp = await fetch(`${API_URL}/tracks/${trackId}/copyright`, {
+					method: 'DELETE',
+					credentials: 'include'
+				});
+				if (!dropResp.ok) {
+					saveError = 'details saved, but copyright could not be cleared — try again';
+					return;
+				}
+			}
+
+			const fresh = await refreshTrack();
+			await onSaved(fresh);
+			toast.success('track updated');
+		} catch (e) {
+			saveError = e instanceof Error ? e.message : 'could not save changes — try again';
+		} finally {
+			savingTrackEdit = false;
+		}
+	}
+</script>
+
+<form
+	class="edit-container"
+	onsubmit={(event) => {
+		event.preventDefault();
+		void saveTrackEdit(track.id);
+	}}
+>
+	<fieldset class="edit-fields" disabled={savingTrackEdit || audioPending}>
+		<div class="edit-field-group">
+			<label for="edit-title" class="edit-label">track title</label>
+			<input
+				id="edit-title"
+				type="text"
+				bind:value={editTitle}
+				placeholder="track title"
+				class="edit-input"
+				maxlength="256"
+			/>
+		</div>
+		<div class="edit-field-group">
+			<label for="edit-description" class="edit-label">description (optional)</label>
+			<textarea
+				id="edit-description"
+				bind:value={editDescription}
+				placeholder="liner notes, show notes, credits..."
+				rows="3"
+				maxlength="5000"
+				class="edit-input"
+			></textarea>
+			{#if editDescription.length > 0}
+				<div class="char-count">{editDescription.length} / 5000</div>
+			{/if}
+		</div>
+		<div class="edit-field-group">
+			<label for="edit-tags" class="edit-label">tags (optional)</label>
+			<TagInput
+				id="edit-tags"
+				tags={editTags}
+				onAdd={(tag) => {
+					editTags = [...editTags, tag];
+				}}
+				onRemove={(tag) => {
+					editTags = editTags.filter((t) => t !== tag);
+				}}
+				placeholder="type to search tags..."
+			/>
+			{#if loadingRecommendedTags}
+				<div class="suggested-tags-row">
+					<span class="suggested-label">suggested</span>
+					<WaveLoading size="sm" />
+				</div>
+			{:else if visibleRecommendedTags.length > 0}
+				<div class="suggested-tags-row">
+					<span class="suggested-label">suggested</span>
+					<div class="suggested-tags">
+						{#each visibleRecommendedTags as rec}
+							<button
+								type="button"
+								class="suggested-tag-chip"
+								onclick={() => {
+									editTags = [...editTags, rec.name.toLowerCase()];
+									recommendedTags = recommendedTags.filter((r) => r !== rec);
+								}}
+							>
+								+ {rec.name}
+							</button>
+						{/each}
+					</div>
+				</div>
+			{/if}
+		</div>
+		<TrackArtworkField imageUrl={track.image_url} bind:editImageFile bind:editRemoveImage />
+		<div class="edit-field-group">
+			<label for="edit-album" class="edit-label">album (optional)</label>
+			<AlbumSelect id="edit-album" {albums} bind:value={editAlbum} placeholder="album (optional)" />
+		</div>
+		<div class="edit-field-group">
+			<label for="edit-features" class="edit-label">featured artists (optional)</label>
+			<HandleSearch
+				id="edit-features"
+				bind:selected={editFeaturedArtists}
+				bind:hasUnresolvedInput={hasUnresolvedEditFeaturesInput}
+				onAdd={(artist) => {
+					editFeaturedArtists = [...editFeaturedArtists, artist];
+				}}
+				onRemove={(did) => {
+					editFeaturedArtists = editFeaturedArtists.filter((a) => a.did !== did);
+				}}
+			/>
+		</div>
+
+		<TrackAccessFields
+			{track}
+			{atprotofansEligible}
+			bind:editSupportGate
+			bind:editUnlisted
+			bind:editSelfLabels
+			bind:editCopyrightEnabled
+			bind:editCopyrightRights
+			bind:replaceCopyrightRights
+			{editCopyrightWasEnabled}
+		/>
+		<TrackAudioEditor
+			{track}
+			{onTrackChanged}
+			onBusyChange={(busy) => {
+				audioPending = busy;
+			}}
+			onDirtyChange={(dirty) => {
+				audioDirty = dirty;
+			}}
+		/>
+	</fieldset>
+	{#if saveError}<p class="save-error" role="alert">{saveError}</p>{/if}
+	<div class="edit-actions">
+		<button
+			type="button"
+			class="edit-cancel-btn"
+			onclick={cancelEdit}
+			disabled={savingTrackEdit || audioPending}
+		>
+			cancel
+		</button>
+		<button
+			type="submit"
+			class="edit-save-btn"
+			disabled={savingTrackEdit ||
+				audioPending ||
+				hasUnresolvedEditFeaturesInput ||
+				!editTitle.trim()}
+			title={hasUnresolvedEditFeaturesInput
+				? 'please select or clear featured artist'
+				: 'save changes'}
+		>
+			{savingTrackEdit ? 'saving…' : 'save changes'}
+		</button>
+	</div>
+</form>
+
+<style>
+	.edit-container {
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+	}
+	.edit-fields {
+		border: 0;
+		min-width: 0;
+		margin: 0;
+		padding: 1.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+	}
+	.edit-field-group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+	.edit-label {
+		font-size: var(--text-sm);
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+	.edit-input {
+		box-sizing: border-box;
+		width: 100%;
+		padding: 0.625rem 0.75rem;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-base);
+		color: var(--text-primary);
+		font-size: var(--text-lg);
+		font-family: inherit;
+		transition: border-color var(--motion-feedback) var(--ease-surface);
+	}
+	.edit-input:focus {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+		border-color: var(--accent);
+	}
+	textarea.edit-input {
+		resize: vertical;
+		min-height: 5rem;
+	}
+	.char-count {
+		font-size: var(--text-xs);
+		color: var(--text-tertiary);
+		text-align: right;
+	}
+	.suggested-tags-row {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5rem;
+	}
+	.suggested-label {
+		font-size: var(--text-xs);
+		color: var(--text-tertiary);
+	}
+	.suggested-tags {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+	}
+	.suggested-tag-chip {
+		padding: 0.3rem 0.6rem;
+		background: transparent;
+		border: 1px dashed var(--border-default);
+		color: var(--text-secondary);
+		border-radius: var(--radius-full);
+		font-size: var(--text-sm);
+		font-family: inherit;
+		cursor: pointer;
+		transition:
+			color var(--motion-feedback) var(--ease-surface),
+			border-color var(--motion-feedback) var(--ease-surface);
+	}
+	.suggested-tag-chip:hover {
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+	.edit-actions {
+		display: flex;
+		gap: 0.75rem;
+		justify-content: flex-end;
+		position: sticky;
+		bottom: 0;
+		padding: 1rem 1.5rem;
+		border-top: 1px solid var(--border-subtle);
+		background: var(--bg-primary);
+		z-index: 1;
+	}
+	.edit-cancel-btn,
+	.edit-save-btn {
+		min-height: 44px;
+		padding: 0.625rem 1.25rem;
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-base);
+		font-size: var(--text-base);
+		font-weight: 600;
+		font-family: inherit;
+		cursor: pointer;
+		transition:
+			background var(--motion-feedback) var(--ease-surface),
+			transform var(--motion-feedback) var(--ease-surface);
+	}
+	.edit-cancel-btn {
+		background: transparent;
+		color: var(--text-secondary);
+	}
+	.edit-cancel-btn:hover:not(:disabled) {
+		background: var(--bg-hover);
+	}
+	.edit-save-btn {
+		background: var(--accent);
+		border-color: var(--accent);
+		color: var(--accent-contrast);
+	}
+	.edit-save-btn:hover:not(:disabled) {
+		background: var(--accent-hover);
+	}
+	.edit-cancel-btn:active:not(:disabled),
+	.edit-save-btn:active:not(:disabled) {
+		transform: scale(0.98);
+	}
+	.edit-cancel-btn:disabled,
+	.edit-save-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+	.save-error {
+		color: var(--error);
+		font-size: var(--text-sm);
+		margin: 0;
+		padding: 0 1.5rem 1rem;
+	}
+	@media (max-width: 600px) {
+		.edit-fields {
+			padding: 1rem;
+		}
+		.edit-actions {
+			padding: 0.875rem 1rem;
+		}
+		.edit-save-btn {
+			flex: 1;
+		}
+		.save-error {
+			padding: 0 1rem 1rem;
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		button,
+		.edit-input {
+			transition: none;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/TrackEditForm.test.ts
+++ b/frontend/src/lib/components/TrackEditForm.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import TrackEditForm from './TrackEditForm.svelte';
+import { auth } from '$lib/auth.svelte';
+import { COPYRIGHT_PARADIGM_FLAG } from '$lib/config';
+import type { Track } from '$lib/types';
+
+const track = {
+	id: 7,
+	title: 'original title',
+	artist: 'nate',
+	artist_handle: 'nate.test',
+	artist_did: 'did:plc:owner',
+	file_id: 'audio',
+	file_type: 'mp3',
+	play_count: 0,
+	copyright_song_uri: 'at://did:plc:owner/song/7',
+	support_gate: { type: 'copyright' }
+} satisfies Track;
+let cleanup: (() => void) | undefined;
+
+afterEach(() => {
+	cleanup?.();
+	cleanup = undefined;
+	document.body.innerHTML = '';
+	vi.restoreAllMocks();
+	auth.user = null;
+});
+
+function mountEditor() {
+	const onSaved = vi.fn();
+	const onClose = vi.fn();
+	const onDirtyChange = vi.fn();
+	const component = mount(TrackEditForm, {
+		target: document.body,
+		props: { track, albums: [], atprotofansEligible: false, onSaved, onClose, onDirtyChange }
+	});
+	cleanup = () => {
+		void unmount(component);
+	};
+	flushSync();
+	return { onSaved, onClose, onDirtyChange };
+}
+
+function editTitle(value: string): void {
+	const input = document.querySelector<HTMLInputElement>('#edit-title');
+	if (!input) throw new Error('title input missing');
+	input.value = value;
+	input.dispatchEvent(new Event('input', { bubbles: true }));
+	flushSync();
+}
+
+function submit(): void {
+	document
+		.querySelector('form')
+		?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+	flushSync();
+}
+
+describe('shared track editor', () => {
+	it('saves ordinary details without overwriting existing copyright records', async () => {
+		const requests: Request[] = [];
+		vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+			const request = new Request(input, init);
+			requests.push(request);
+			if (request.url.includes('/recommended-tags'))
+				return Response.json({ available: false, tags: [] });
+			return Response.json({ ...track, title: 'new title' });
+		});
+		const { onSaved, onClose, onDirtyChange } = mountEditor();
+		editTitle('new title');
+		expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+		submit();
+		await vi.waitFor(() => expect(onSaved).toHaveBeenCalledWith({ ...track, title: 'new title' }));
+		const writes = requests.filter((request) => request.method !== 'GET');
+		expect(writes.map((request) => request.method)).toEqual(['PATCH']);
+		expect(writes[0]?.url).toMatch(/\/tracks\/7$/);
+		const saved = await writes[0]?.formData();
+		expect(saved?.get('title')).toBe('new title');
+		expect(saved?.has('support_gate')).toBe(false);
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('keeps the draft and shows the server error when saving fails', async () => {
+		vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+			const request = new Request(input, init);
+			if (request.method === 'PATCH')
+				return Response.json({ detail: 'could not save track' }, { status: 503 });
+			return Response.json({ available: false, tags: [] });
+		});
+		const { onSaved, onClose } = mountEditor();
+		editTitle('unsaved title');
+		submit();
+		await vi.waitFor(() =>
+			expect(document.querySelector('[role="alert"]')?.textContent).toBe('could not save track')
+		);
+		expect(document.querySelector<HTMLInputElement>('#edit-title')?.value).toBe('unsaved title');
+		expect(onSaved).not.toHaveBeenCalled();
+		expect(onClose).not.toHaveBeenCalled();
+		expect(document.querySelector<HTMLButtonElement>('button[type="submit"]')?.disabled).toBe(
+			false
+		);
+	});
+	it('keeps the editor open when copyright removal fails after metadata saved', async () => {
+		auth.user = {
+			did: track.artist_did,
+			handle: track.artist_handle,
+			linked_accounts: [],
+			enabled_flags: [COPYRIGHT_PARADIGM_FLAG]
+		};
+		vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+			const request = new Request(input, init);
+			if (request.method === 'DELETE')
+				return Response.json({ detail: 'PDS unavailable' }, { status: 503 });
+			if (request.method === 'PATCH') return Response.json(track);
+			return Response.json({ available: false, tags: [] });
+		});
+		const { onSaved, onClose } = mountEditor();
+		const licensing = [...document.querySelectorAll('label')]
+			.find((label) => label.textContent?.includes('copyright licensing'))
+			?.querySelector('input');
+		if (!licensing) throw new Error('copyright toggle missing');
+		licensing.click();
+		flushSync();
+		submit();
+		await vi.waitFor(() =>
+			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+				'copyright could not be cleared'
+			)
+		);
+		expect(onSaved).not.toHaveBeenCalled();
+		expect(onClose).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/lib/components/portal/TracksSection.stories.svelte
+++ b/frontend/src/lib/components/portal/TracksSection.stories.svelte
@@ -28,7 +28,7 @@
 		component: TracksSection,
 		parameters: { layout: 'padded' },
 		play: async ({ canvas }) => {
-			await userEvent.click(canvas.getByRole('button', { name: 'edit' }));
+			await userEvent.click(canvas.getByRole('button', { name: 'edit track' }));
 		},
 		args: {
 			tracks: [track],

--- a/frontend/src/lib/components/portal/TracksSection.svelte
+++ b/frontend/src/lib/components/portal/TracksSection.svelte
@@ -1,24 +1,11 @@
 <script lang="ts">
-	import HandleSearch from '$lib/components/HandleSearch.svelte';
-	import AlbumSelect from '$lib/components/AlbumSelect.svelte';
+	import EditTrackModal from '$lib/components/EditTrackModal.svelte';
 	import WaveLoading from '$lib/components/WaveLoading.svelte';
-	import TagInput from '$lib/components/TagInput.svelte';
-	import CopyrightRightsPanel from '$lib/components/CopyrightRightsPanel.svelte';
-	import type { TrackRights } from '$lib/components/CopyrightRightsPanel.svelte';
-	import type { Track, FeaturedArtist, AlbumSummary } from '$lib/types';
-	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import CopyrightFlag from '$lib/components/portal/CopyrightFlag.svelte';
-	import AudioRevisionsSheet from '$lib/components/AudioRevisionsSheet.svelte';
-	import { API_URL, getServerConfig } from '$lib/config';
+	import type { Track, AlbumSummary } from '$lib/types';
+	import { API_URL } from '$lib/config';
 	import { toast } from '$lib/toast.svelte';
-	import { uploader } from '$lib/uploader.svelte';
-	import { player } from '$lib/player.svelte';
-	import { isOptimizing } from '$lib/utils/track-audio';
-
-	// supported audio formats — matches backend AudioFormat enum + AlbumUploadForm
-	const AUDIO_FILE_INPUT_ACCEPT = '.mp3,.wav,.m4a,.aiff,.aif,.flac,audio/mpeg,audio/wav,audio/mp4,audio/aiff,audio/x-aiff,audio/flac';
-	const ADULT_SELF_LABELS = new Set(['sexual', 'porn']);
-
+	let editingTrack = $state<Track | null>(null);
 	type SortMode = 'recent' | 'title' | 'plays';
 
 	interface Props {
@@ -67,61 +54,6 @@
 		searchDebounce = setTimeout(emitFilter, 250);
 	}
 
-	// track editing state
-	let editingTrackId = $state<number | null>(null);
-	let savingTrackEdit = $state(false);
-	let editTitle = $state('');
-	let editDescription = $state('');
-	let editAlbum = $state('');
-	let editFeaturedArtists = $state<FeaturedArtist[]>([]);
-	let editTags = $state<string[]>([]);
-	let editImageFile = $state<File | null>(null);
-	let editImagePreviewUrl = $state<string | null>(null);
-	let editRemoveImage = $state(false);
-	// audio replace state — separate flow from metadata edit because the
-	// upload + transcode + PDS write can take 30s+ and has its own SSE progress
-	// (surfaced via toast, not inline). a confirm dialog gates the irreversible
-	// replace; previous audio is preserved in track_revisions for rollback.
-	let editAudioFile = $state<File | null>(null);
-	let replaceConfirm = $state<{ track: Track; file: File } | null>(null);
-
-	// version history sheet state
-	interface AudioRevision {
-		id: number;
-		track_id: number;
-		created_at: string;
-		file_type: string;
-		original_file_type: string | null;
-		audio_storage: string;
-		duration: number | null;
-		was_gated: boolean;
-	}
-	let revisionsSheetTrack = $state<Track | null>(null);
-	let revisionsList = $state<AudioRevision[]>([]);
-	let revisionsLoading = $state(false);
-	let revisionsError = $state<string | null>(null);
-	let restoreConfirm = $state<{ track: Track; revision: AudioRevision } | null>(null);
-	let restorePending = $state(false);
-	let editSupportGate = $state(false);
-	let editUnlisted = $state(false);
-	let editSelfLabels = $state<string[]>([]);
-	let editHasSensitiveAudio = $derived(
-		editSelfLabels.some((label) => ADULT_SELF_LABELS.has(label))
-	);
-	// copyright rights state for the inline edit form — kept in sync with the
-	// CopyrightRightsPanel via bindable props.
-	let editCopyrightEnabled = $state(false);
-	let editCopyrightRights = $state<TrackRights>({});
-	// snapshot of the on-load state so we know whether to POST/DELETE on save
-	let editCopyrightWasEnabled = $state(false);
-	let hasUnresolvedEditFeaturesInput = $state(false);
-	let recommendedTags = $state<{name: string; score: number}[]>([]);
-	let loadingRecommendedTags = $state(false);
-	let recommendedTagsTrackId = $state<number | null>(null);
-	let visibleRecommendedTags = $derived(
-		recommendedTags.filter(r => !editTags.includes(r.name.toLowerCase()))
-	);
-
 	async function deleteTrack(trackId: number, trackTitle: string) {
 		if (!confirm(`delete "${trackTitle}"?`)) return;
 
@@ -142,282 +74,6 @@
 			toast.error(`network error: ${e instanceof Error ? e.message : 'unknown error'}`);
 		}
 	}
-
-	function startEditTrack(track: Track) {
-		editingTrackId = track.id;
-		editTitle = track.title;
-		editDescription = track.description || '';
-		editAlbum = track.album?.title || '';
-		editFeaturedArtists = track.features || [];
-		editTags = track.tags || [];
-		editSupportGate =
-			track.support_gate !== null &&
-			track.support_gate !== undefined &&
-			track.support_gate.type !== 'copyright';
-		editUnlisted = track.unlisted ?? false;
-		editSelfLabels = [...(track.self_labels ?? [])];
-		// initialize copyright state from the track's persisted URIs.
-		// we don't have the original ISWC/ISRC/masterOwner stored locally — those
-		// live on the PDS records. for now we leave the form blank on open; a
-		// save will overwrite them with whatever's in the form.
-		editCopyrightEnabled = Boolean(track.copyright_song_uri);
-		editCopyrightWasEnabled = editCopyrightEnabled;
-		editCopyrightRights = {};
-		fetchRecommendedTags(track.id);
-	}
-
-	function setSensitiveAudio(enabled: boolean) {
-		const nonAdult = editSelfLabels.filter((label) => !ADULT_SELF_LABELS.has(label));
-		const existingAdult = editSelfLabels.filter((label) => ADULT_SELF_LABELS.has(label));
-		editSelfLabels = enabled
-			? [...nonAdult, ...(existingAdult.length > 0 ? existingAdult : ['sexual'])]
-			: nonAdult;
-	}
-
-	function hasOperatorSensitiveLabel(track: Track): boolean {
-		return (track.operator_labels ?? []).some((label) => ADULT_SELF_LABELS.has(label));
-	}
-
-	async function fetchRecommendedTags(trackId: number) {
-		loadingRecommendedTags = true;
-		recommendedTags = [];
-		recommendedTagsTrackId = trackId;
-		try {
-			const response = await fetch(
-				`${API_URL}/tracks/${trackId}/recommended-tags?limit=8`,
-				{ credentials: 'include' }
-			);
-			if (!response.ok) return;
-			const data = await response.json();
-			if (recommendedTagsTrackId !== trackId) return;
-			if (!data.available || data.tags.length === 0) return;
-			recommendedTags = data.tags;
-		} catch {
-			// silent — enhancement, not critical
-		} finally {
-			loadingRecommendedTags = false;
-		}
-	}
-
-	function cancelEdit() {
-		editingTrackId = null;
-		editTitle = '';
-		editDescription = '';
-		editAlbum = '';
-		editFeaturedArtists = [];
-		editTags = [];
-		editImageFile = null;
-		if (editImagePreviewUrl) {
-			URL.revokeObjectURL(editImagePreviewUrl);
-		}
-		editImagePreviewUrl = null;
-		editRemoveImage = false;
-		editSupportGate = false;
-		editUnlisted = false;
-		editSelfLabels = [];
-		editCopyrightEnabled = false;
-		editCopyrightWasEnabled = false;
-		editCopyrightRights = {};
-		editAudioFile = null;
-		recommendedTags = [];
-		loadingRecommendedTags = false;
-		recommendedTagsTrackId = null;
-	}
-
-	async function selectAudioReplacement(file: File) {
-		// validate against the same upload-size limit as the upload form. fetch
-		// dynamically because the limit comes from server config.
-		try {
-			const config = await getServerConfig();
-			const sizeMB = file.size / (1024 * 1024);
-			if (sizeMB > config.max_upload_size_mb) {
-				toast.error(`audio file exceeds ${config.max_upload_size_mb}MB limit`);
-				return;
-			}
-		} catch {
-			// config fetch failed — fall back to letting the server enforce
-		}
-		editAudioFile = file;
-	}
-
-	function requestReplaceAudio(track: Track) {
-		// stage the (track, file) pair; the confirm dialog will fire the
-		// actual replace. we don't run anything irreversible until confirmed.
-		if (!editAudioFile) return;
-		replaceConfirm = { track, file: editAudioFile };
-	}
-
-	async function reloadCurrentPlayingTrack(trackId: number) {
-		if (player.currentTrack?.id !== trackId) return;
-		try {
-			const resp = await fetch(`${API_URL}/tracks/${trackId}`, {
-				credentials: 'include'
-			});
-			if (resp.ok) {
-				const fresh = await resp.json();
-				player.currentTrack = { ...player.currentTrack, ...fresh };
-			}
-		} catch {
-			// best effort — next track navigation will pick up the new src
-		}
-	}
-
-	function executeReplaceAudio() {
-		if (!replaceConfirm) return;
-		const { track, file } = replaceConfirm;
-		const trackId = track.id;
-
-		// kick off the background upload+SSE flow. progress and outcome are
-		// surfaced via toast — same pattern as the initial upload form.
-		uploader.replaceAudio(trackId, file, track.title, async () => {
-			// refresh local tracks so the row reflects the new file_id and r2_url
-			await onTracksChanged();
-			await reloadCurrentPlayingTrack(trackId);
-		});
-
-		// clear the staged file + dialog. SSE flow continues in the toast;
-		// the rest of the edit form stays open for other unsaved metadata.
-		editAudioFile = null;
-		replaceConfirm = null;
-	}
-
-	async function openVersionHistory(track: Track) {
-		revisionsSheetTrack = track;
-		revisionsList = [];
-		revisionsError = null;
-		revisionsLoading = true;
-		try {
-			const resp = await fetch(`${API_URL}/tracks/${track.id}/revisions`, {
-				credentials: 'include'
-			});
-			if (!resp.ok) {
-				revisionsError = 'failed to load version history';
-				return;
-			}
-			const body = await resp.json();
-			revisionsList = body.revisions ?? [];
-		} catch {
-			revisionsError = 'failed to load version history';
-		} finally {
-			revisionsLoading = false;
-		}
-	}
-
-	function requestRestoreRevision(revision: AudioRevision) {
-		if (!revisionsSheetTrack) return;
-		restoreConfirm = { track: revisionsSheetTrack, revision };
-	}
-
-	async function executeRestoreRevision() {
-		if (!restoreConfirm) return;
-		const { track, revision } = restoreConfirm;
-		restorePending = true;
-		try {
-			const resp = await fetch(
-				`${API_URL}/tracks/${track.id}/revisions/${revision.id}/restore`,
-				{ method: 'POST', credentials: 'include' }
-			);
-			if (!resp.ok) {
-				const detail = await resp.json().catch(() => ({}));
-				toast.error(detail.detail ?? 'failed to restore audio');
-				return;
-			}
-			toast.success('audio restored');
-			await onTracksChanged();
-			await reloadCurrentPlayingTrack(track.id);
-			// refresh the sheet's revision list — the chosen one is now gone,
-			// the displaced current is now in the list
-			if (revisionsSheetTrack?.id === track.id) {
-				await openVersionHistory(track);
-			}
-			restoreConfirm = null;
-		} catch {
-			toast.error('failed to restore audio');
-		} finally {
-			restorePending = false;
-		}
-	}
-
-	async function saveTrackEdit(trackId: number) {
-		if (savingTrackEdit) return;
-		savingTrackEdit = true;
-		const formData = new FormData();
-		formData.append('title', editTitle);
-		formData.append('description', editDescription);
-		formData.append('album', editAlbum);
-		if (editFeaturedArtists.length > 0) {
-			const handles = editFeaturedArtists.map(a => a.handle);
-			formData.append('features', JSON.stringify(handles));
-		} else {
-			// send empty array to clear features
-			formData.append('features', JSON.stringify([]));
-		}
-		// always send tags (empty array clears them)
-		formData.append('tags', JSON.stringify(editTags));
-		// send support_gate - null to remove, or {type: "any"} to enable.
-		// copyright-gated tracks have their own toggle below; leave support_gate
-		// alone in that case so we don't clobber the copyright gate.
-		if (!editCopyrightEnabled && !editCopyrightWasEnabled) {
-			if (editSupportGate) {
-				formData.append('support_gate', JSON.stringify({ type: 'any' }));
-			} else {
-				formData.append('support_gate', 'null');
-			}
-		}
-		formData.append('unlisted', editUnlisted ? 'true' : 'false');
-		formData.append('self_labels', JSON.stringify(editSelfLabels));
-		// handle artwork: remove, replace, or leave unchanged
-		if (editRemoveImage) {
-			formData.append('remove_image', 'true');
-		} else if (editImageFile) {
-			formData.append('image', editImageFile);
-		}
-
-		try {
-			const response = await fetch(`${API_URL}/tracks/${trackId}`, {
-				method: 'PATCH',
-				body: formData,
-				credentials: 'include'
-			});
-
-			if (!response.ok) {
-				const error = await response.json();
-				toast.error(error.detail || 'failed to update track');
-				return;
-			}
-
-			// copyright rights are saved through a dedicated endpoint, not the
-			// PATCH formData. apply enable/disable transitions and field updates.
-			if (editCopyrightEnabled) {
-				const rightsResp = await fetch(`${API_URL}/tracks/${trackId}/copyright`, {
-					method: 'POST',
-					credentials: 'include',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify(editCopyrightRights)
-				});
-				if (!rightsResp.ok) {
-					const err = await rightsResp.json().catch(() => ({}));
-					toast.error(`copyright save failed: ${err.detail ?? rightsResp.statusText}`);
-				}
-			} else if (editCopyrightWasEnabled) {
-				const dropResp = await fetch(`${API_URL}/tracks/${trackId}/copyright`, {
-					method: 'DELETE',
-					credentials: 'include'
-				});
-				if (!dropResp.ok) {
-					toast.error('failed to clear copyright metadata');
-				}
-			}
-
-			await onTracksChanged();
-			cancelEdit();
-			toast.success('track updated successfully');
-		} catch (e) {
-			toast.error(`network error: ${e instanceof Error ? e.message : 'unknown error'}`);
-		} finally {
-			savingTrackEdit = false;
-		}
-	}
 </script>
 
 <section class="tracks-section">
@@ -433,7 +89,12 @@
 				oninput={onSearchInput}
 				aria-label="filter your tracks"
 			/>
-			<select class="track-sort" bind:value={sortMode} onchange={emitFilter} aria-label="sort tracks">
+			<select
+				class="track-sort"
+				bind:value={sortMode}
+				onchange={emitFilter}
+				aria-label="sort tracks"
+			>
 				<option value="recent">recent</option>
 				<option value="title">title</option>
 				<option value="plays">most played</option>
@@ -446,507 +107,175 @@
 			<WaveLoading size="lg" message="loading tracks..." />
 		</div>
 	{:else if tracks.length === 0}
-		<p class="empty">{hasQuery ? `no tracks match “${searchInput.trim()}”` : 'no tracks uploaded yet'}</p>
+		<p class="empty">
+			{hasQuery ? `no tracks match “${searchInput.trim()}”` : 'no tracks uploaded yet'}
+		</p>
 	{:else}
 		<div class="tracks-list" class:refreshing={loadingTracks}>
 			{#each tracks as track}
-				<div class="track-item" class:editing={editingTrackId === track.id} class:copyright-flagged={track.copyright_flagged}>
-					{#if editingTrackId === track.id}
-						<div class="edit-container">
-							<div class="edit-fields">
-								<div class="edit-field-group">
-									<label for="edit-title" class="edit-label">track title</label>
-									<input id="edit-title"
-										type="text"
-										bind:value={editTitle}
-										placeholder="track title"
-										class="edit-input"
-										maxlength="256"
-									/>
-								</div>
-								<div class="edit-field-group">
-									<label for="edit-description" class="edit-label">description (optional)</label>
-									<textarea
-										id="edit-description"
-										bind:value={editDescription}
-										placeholder="liner notes, show notes, credits..."
-										rows="3"
-										maxlength="5000"
-										class="edit-input"
-									></textarea>
-									{#if editDescription.length > 0}
-										<div class="char-count">{editDescription.length} / 5000</div>
-									{/if}
-								</div>
-								<div class="edit-field-group">
-									<label for="edit-album" class="edit-label">album (optional)</label>
-									<AlbumSelect
-										{albums}
-										bind:value={editAlbum}
-										placeholder="album (optional)"
-									/>
-								</div>
-								<div class="edit-field-group">
-									<div class="edit-label">featured artists (optional)</div>
-									<HandleSearch
-										bind:selected={editFeaturedArtists}
-										bind:hasUnresolvedInput={hasUnresolvedEditFeaturesInput}
-										onAdd={(artist) => { editFeaturedArtists = [...editFeaturedArtists, artist]; }}
-										onRemove={(did) => { editFeaturedArtists = editFeaturedArtists.filter(a => a.did !== did); }}
-									/>
-								</div>
-								<div class="edit-field-group">
-									<label for="edit-tags" class="edit-label">tags (optional)</label>
-									<TagInput
-										tags={editTags}
-										onAdd={(tag) => { editTags = [...editTags, tag]; }}
-										onRemove={(tag) => { editTags = editTags.filter(t => t !== tag); }}
-										placeholder="type to search tags..."
-									/>
-									{#if loadingRecommendedTags}
-										<div class="suggested-tags-row">
-											<span class="suggested-label">suggested</span>
-											<WaveLoading size="sm" />
-										</div>
-									{:else if visibleRecommendedTags.length > 0}
-										<div class="suggested-tags-row">
-											<span class="suggested-label">suggested</span>
-											<div class="suggested-tags">
-												{#each visibleRecommendedTags as rec}
-													<button
-														type="button"
-														class="suggested-tag-chip"
-														onclick={() => {
-															editTags = [...editTags, rec.name.toLowerCase()];
-															recommendedTags = recommendedTags.filter(r => r !== rec);
-														}}
-													>
-														+ {rec.name}
-													</button>
-												{/each}
-											</div>
-										</div>
-									{/if}
-								</div>
-								<div class="edit-field-group">
-									<span class="edit-label">artwork (optional)</span>
-									<div class="artwork-editor">
-										{#if editImagePreviewUrl}
-											<!-- New image selected - show preview -->
-											<div class="artwork-preview">
-												<img src={editImagePreviewUrl} alt="new artwork preview" />
-												<div class="artwork-preview-overlay">
-													<button
-														type="button"
-														class="artwork-action-btn"
-														onclick={() => {
-															editImageFile = null;
-															if (editImagePreviewUrl) {
-																URL.revokeObjectURL(editImagePreviewUrl);
-															}
-															editImagePreviewUrl = null;
-														}}
-														title="remove selection"
-													>
-														<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-															<line x1="18" y1="6" x2="6" y2="18"></line>
-															<line x1="6" y1="6" x2="18" y2="18"></line>
-														</svg>
-													</button>
-												</div>
-											</div>
-											<span class="artwork-status">new artwork selected</span>
-										{:else if editRemoveImage}
-											<!-- User chose to remove artwork -->
-											<div class="artwork-removed">
-												<svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-													<rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-													<line x1="9" y1="9" x2="15" y2="15"></line>
-													<line x1="15" y1="9" x2="9" y2="15"></line>
-												</svg>
-												<span>artwork will be removed</span>
-												<button
-													type="button"
-													class="undo-remove-btn"
-													onclick={() => { editRemoveImage = false; }}
-												>
-													undo
-												</button>
-											</div>
-										{:else if track.image_url}
-											<!-- Current artwork exists -->
-											<div class="artwork-preview">
-												<img src={track.image_url} alt="current artwork" />
-												<div class="artwork-preview-overlay">
-													<button
-														type="button"
-														class="artwork-action-btn"
-														onclick={() => { editRemoveImage = true; }}
-														title="remove artwork"
-													>
-														<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-															<polyline points="3 6 5 6 21 6"></polyline>
-															<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-														</svg>
-													</button>
-												</div>
-											</div>
-											<span class="artwork-status current">current artwork</span>
-										{:else}
-											<!-- No artwork -->
-											<div class="artwork-empty">
-												<svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-													<rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-													<circle cx="8.5" cy="8.5" r="1.5"></circle>
-													<polyline points="21 15 16 10 5 21"></polyline>
-												</svg>
-												<span>no artwork</span>
-											</div>
-										{/if}
-										{#if !editRemoveImage}
-											<label class="artwork-upload-btn">
-												<input
-													type="file"
-													accept=".jpg,.jpeg,.png,.webp,.gif,image/jpeg,image/png,image/webp,image/gif"
-													onchange={(e) => {
-														const target = e.target as HTMLInputElement;
-														const file = target.files?.[0];
-														if (file) {
-															if (file.size > 20 * 1024 * 1024) {
-																toast.error('image must be under 20 MB');
-																target.value = '';
-																return;
-															}
-															editImageFile = file;
-															if (editImagePreviewUrl) {
-																URL.revokeObjectURL(editImagePreviewUrl);
-															}
-															editImagePreviewUrl = URL.createObjectURL(file);
-														}
-													}}
-												/>
-												<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-													<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-													<polyline points="17 8 12 3 7 8"></polyline>
-													<line x1="12" y1="3" x2="12" y2="15"></line>
-												</svg>
-												{track.image_url || editImagePreviewUrl ? 'replace' : 'upload'}
-											</label>
-										{/if}
-									</div>
-								</div>
-								<div class="edit-field-group">
-									<span class="edit-label">audio file</span>
-									<div class="audio-replace-editor">
-										{#if editAudioFile}
-											<div class="audio-selected">
-												<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-													<path d="M9 18V5l12-2v13"></path>
-													<circle cx="6" cy="18" r="3"></circle>
-													<circle cx="18" cy="16" r="3"></circle>
-												</svg>
-												<span class="audio-filename">{editAudioFile.name}</span>
-												<button
-													type="button"
-													class="audio-clear-btn"
-													onclick={() => { editAudioFile = null; }}
-													title="discard selection"
-												>
-													<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-														<line x1="18" y1="6" x2="6" y2="18"></line>
-														<line x1="6" y1="6" x2="18" y2="18"></line>
-													</svg>
-												</button>
-											</div>
-											<button
-												type="button"
-												class="audio-replace-btn"
-												onclick={() => requestReplaceAudio(track)}
-											>
-												replace audio
-											</button>
-										{:else}
-											<div class="audio-current">
-												<span class="audio-current-label">
-													current: {track.file_type}{track.original_file_type && track.original_file_type !== track.file_type ? ` (transcoded from ${track.original_file_type})` : ''}{isOptimizing(track) ? ' · optimizing — mp3 will land on your PDS shortly' : track.audio_storage === 'both' || track.audio_storage === 'pds' ? ' · stored on your PDS' : ' · stored on plyr.fm'}
-												</span>
-											</div>
-											<label class="audio-upload-btn">
-												<input
-													type="file"
-													accept={AUDIO_FILE_INPUT_ACCEPT}
-													onchange={(e) => {
-														const target = e.target as HTMLInputElement;
-														const file = target.files?.[0];
-														if (file) {
-															void selectAudioReplacement(file);
-														}
-														target.value = '';
-													}}
-												/>
-												<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-													<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-													<polyline points="17 8 12 3 7 8"></polyline>
-													<line x1="12" y1="3" x2="12" y2="15"></line>
-												</svg>
-												choose new file
-											</label>
-											<button
-												type="button"
-												class="audio-history-btn"
-												onclick={() => openVersionHistory(track)}
-												title="view previous audio versions"
-											>
-												<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-													<path d="M3 12a9 9 0 1 0 3-6.7L3 8"></path>
-													<polyline points="3 3 3 8 8 8"></polyline>
-													<polyline points="12 7 12 12 15 14"></polyline>
-												</svg>
-												version history
-											</button>
-										{/if}
-										<p class="audio-replace-hint">
-											choose a new file, then confirm. uploading runs in the background and the previous audio is kept in version history so you can roll back. likes, comments, plays, and the track URL stay the same.
-										</p>
-									</div>
-								</div>
-								{#if atprotofansEligible || (track.support_gate && track.support_gate.type !== 'copyright')}
-									<div class="edit-field-group access-field">
-										<span class="edit-label">supporter access</span>
-										<label class="toggle-row">
-											<input
-												type="checkbox"
-												bind:checked={editSupportGate}
-												disabled={editCopyrightEnabled}
-											/>
-											<span>only supporters can play this track</span>
-										</label>
-										{#if editSupportGate}
-											<p class="field-hint">
-												only users who support you via <a href="https://atprotofans.com" target="_blank" rel="noopener">atprotofans</a> can play this track. <a href="https://docs.plyr.fm/artists/#supporter-gated-tracks" target="_blank" rel="noopener">learn more</a>
-											</p>
-										{/if}
-									</div>
-								{/if}
-								<div class="edit-field-group content-notice-field">
-									<span class="edit-label">content notice</span>
-									<label class="toggle-row">
-										<input
-											type="checkbox"
-											checked={editHasSensitiveAudio}
-											onchange={(event) => setSensitiveAudio((event.target as HTMLInputElement).checked)}
-										/>
-										<span>contains sexually explicit audio</span>
-									</label>
-									<p class="field-hint">
-										this notice travels with the track on ATProto. the track is hidden by default and listeners must opt in to sensitive audio.
-									</p>
-									{#if hasOperatorSensitiveLabel(track)}
-										<div class="moderation-status" role="status">
-											<strong>plyr.fm moderation notice active</strong>
-											<span>removing your notice will not make this track visible by default because an independent moderation label remains in effect.</span>
-										</div>
-									{:else}
-										<p class="field-hint">
-											this changes only your notice. moderators can apply a separate notice when needed.
-										</p>
-									{/if}
-								</div>
-								<CopyrightRightsPanel
-									bind:enabled={editCopyrightEnabled}
-									bind:rights={editCopyrightRights}
-									disabled={editSupportGate}
-								/>
-								<div class="edit-field-group access-field">
-									<span class="edit-label">visibility</span>
-									<label class="toggle-row">
-										<input
-											type="checkbox"
-											bind:checked={editUnlisted}
-										/>
-										<span>unlisted — won't appear in feeds</span>
-									</label>
-									{#if editUnlisted}
-										<p class="field-hint">
-											this track won't show up in the latest, top, or for-you feeds. it's still accessible via direct link, your profile, albums, playlists, and search.
-										</p>
-									{/if}
-								</div>
-							</div>
-							<div class="edit-actions">
-								<button
-									type="button"
-									class="edit-cancel-btn"
-									onclick={cancelEdit}
-									disabled={savingTrackEdit}
-								>
-									cancel
-								</button>
-								<button
-									type="button"
-									class="edit-save-btn"
-									onclick={() => saveTrackEdit(track.id)}
-									disabled={savingTrackEdit || hasUnresolvedEditFeaturesInput}
-									title={hasUnresolvedEditFeaturesInput ? "please select or clear featured artist" : "save changes"}
-								>
-									{savingTrackEdit ? 'saving...' : 'save changes'}
-								</button>
-							</div>
-						</div>
-					{:else}
-						<div class="track-artwork-col">
-							<div class="track-artwork">
-								{#if track.image_url}
-									<img src={track.image_url} alt="{track.title} artwork" />
-								{:else}
-									<div class="track-artwork-placeholder">
-										<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-											<path d="M9 18V5l12-2v13"></path>
-											<circle cx="6" cy="18" r="3"></circle>
-											<circle cx="18" cy="16" r="3"></circle>
-										</svg>
-									</div>
-								{/if}
-							</div>
-							<a href="/track/{track.id}" class="track-view-link" title="view track page">view</a>
-						</div>
-						<div class="track-info">
-							<div class="track-title">
-								{track.title}
-								{#if track.support_gate}
-									<span class="support-gate-badge" title="supporters only">
-										<svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-											<path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"/>
-										</svg>
-									</span>
-								{/if}
-								{#if track.copyright_flagged}
-									<CopyrightFlag
-										match={track.copyright_match}
-										recordUrl={track.atproto_record_url}
-									/>
-								{/if}
-							</div>
-							<div class="track-meta">
-								{#if track.features && track.features.length > 0}
-									<div class="meta-features" title={`feat. ${track.features.map(f => f.display_name).join(', ')}`}>
-										<span class="features-label">feat.</span>
-										<span class="features-list">{track.features.map(f => f.display_name).join(', ')}</span>
-									</div>
-								{/if}
-								{#if track.album}
-									<div class="meta-album" title={track.album.title}>
-										<svg class="album-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-											<rect x="2" y="2" width="12" height="12" stroke="currentColor" stroke-width="1.5" fill="none" />
-											<circle cx="8" cy="8" r="2.5" fill="currentColor" />
-										</svg>
-										<a href="/u/{track.artist_handle}/album/{track.album.slug}" class="album-link">
-											{track.album.title}
-										</a>
-									</div>
-								{/if}
-								{#if track.tags && track.tags.length > 0}
-									<div class="meta-tags">
-										{#each track.tags as tag}
-											<a href="/tag/{encodeURIComponent(tag)}" class="meta-tag">{tag}</a>
-										{/each}
-									</div>
-								{/if}
-							</div>
-							{#if track.created_at}
-								<div class="track-date">
-									{new Date(track.created_at).toLocaleDateString()}
+				<div class="track-item" class:copyright-flagged={track.copyright_flagged}>
+					<div class="track-artwork-col">
+						<div class="track-artwork">
+							{#if track.image_url}
+								<img src={track.image_url} alt="{track.title} artwork" />
+							{:else}
+								<div class="track-artwork-placeholder">
+									<svg
+										width="20"
+										height="20"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="1.5"
+									>
+										<path d="M9 18V5l12-2v13"></path>
+										<circle cx="6" cy="18" r="3"></circle>
+										<circle cx="18" cy="16" r="3"></circle>
+									</svg>
 								</div>
 							{/if}
 						</div>
-						<div class="track-actions">
-							<button
-								type="button"
-								class="track-action-btn edit"
-								onclick={() => startEditTrack(track)}
-							>
-								<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-									<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-									<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
-								</svg>
-								edit
-							</button>
-							<button
-								type="button"
-								class="track-action-btn delete"
-								onclick={() => deleteTrack(track.id, track.title)}
-							>
-								<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-									<polyline points="3 6 5 6 21 6"></polyline>
-									<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-								</svg>
-								delete
-							</button>
+						<a href="/track/{track.id}" class="track-view-link" title="view track page">view</a>
+					</div>
+					<div class="track-info">
+						<div class="track-title">
+							{track.title}
+							{#if track.support_gate}
+								<span class="support-gate-badge" title="supporters only">
+									<svg
+										width="12"
+										height="12"
+										viewBox="0 0 24 24"
+										fill="currentColor"
+										aria-hidden="true"
+									>
+										<path
+											d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"
+										/>
+									</svg>
+								</span>
+							{/if}
+							{#if track.copyright_flagged}
+								<CopyrightFlag match={track.copyright_match} recordUrl={track.atproto_record_url} />
+							{/if}
 						</div>
-					{/if}
+						<div class="track-meta">
+							{#if track.features && track.features.length > 0}
+								<div
+									class="meta-features"
+									title={`feat. ${track.features.map((f) => f.display_name).join(', ')}`}
+								>
+									<span class="features-label">feat.</span>
+									<span class="features-list"
+										>{track.features.map((f) => f.display_name).join(', ')}</span
+									>
+								</div>
+							{/if}
+							{#if track.album}
+								<div class="meta-album" title={track.album.title}>
+									<svg
+										class="album-icon"
+										viewBox="0 0 16 16"
+										fill="none"
+										xmlns="http://www.w3.org/2000/svg"
+										aria-hidden="true"
+										focusable="false"
+									>
+										<rect
+											x="2"
+											y="2"
+											width="12"
+											height="12"
+											stroke="currentColor"
+											stroke-width="1.5"
+											fill="none"
+										/>
+										<circle cx="8" cy="8" r="2.5" fill="currentColor" />
+									</svg>
+									<a href="/u/{track.artist_handle}/album/{track.album.slug}" class="album-link">
+										{track.album.title}
+									</a>
+								</div>
+							{/if}
+							{#if track.tags && track.tags.length > 0}
+								<div class="meta-tags">
+									{#each track.tags as tag}
+										<a href="/tag/{encodeURIComponent(tag)}" class="meta-tag">{tag}</a>
+									{/each}
+								</div>
+							{/if}
+						</div>
+						{#if track.created_at}
+							<div class="track-date">
+								{new Date(track.created_at).toLocaleDateString()}
+							</div>
+						{/if}
+					</div>
+					<div class="track-actions">
+						<button
+							type="button"
+							class="track-action-btn edit"
+							onclick={() => (editingTrack = track)}
+						>
+							<svg
+								width="14"
+								height="14"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+							>
+								<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+								<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+							</svg>
+							edit track
+						</button>
+						<button
+							type="button"
+							class="track-action-btn delete"
+							onclick={() => deleteTrack(track.id, track.title)}
+						>
+							<svg
+								width="14"
+								height="14"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+							>
+								<polyline points="3 6 5 6 21 6"></polyline>
+								<path
+									d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
+								></path>
+							</svg>
+							delete
+						</button>
+					</div>
 				</div>
 			{/each}
 		</div>
 
 		{#if tracksHasMore}
-			<button
-				class="load-more-btn"
-				onclick={onLoadMore}
-				disabled={loadingMoreTracks}
-			>
+			<button class="load-more-btn" onclick={onLoadMore} disabled={loadingMoreTracks}>
 				{loadingMoreTracks ? 'loading...' : `load more (${tracks.length} of ${tracksTotal})`}
 			</button>
 		{/if}
 	{/if}
 </section>
 
-<!-- audio replace confirmation: gates the irreversible upload -->
-<ConfirmDialog
-	open={replaceConfirm !== null}
-	title="replace audio?"
-	body={replaceConfirm
-		? `this will swap the audio file for "${replaceConfirm.track.title}". the previous audio will be saved in version history so you can roll back. likes, comments, plays, and the track URL won't change.`
-		: ''}
-	confirmText="replace"
-	cancelText="cancel"
-	onConfirm={executeReplaceAudio}
-	onCancel={() => { replaceConfirm = null; }}
-/>
-
-<!-- version history sheet: lists previous audio versions with restore -->
-<AudioRevisionsSheet
-	open={revisionsSheetTrack !== null}
-	trackTitle={revisionsSheetTrack?.title ?? ''}
-	revisions={revisionsList}
-	loading={revisionsLoading}
-	error={revisionsError}
-	onClose={() => {
-		revisionsSheetTrack = null;
-		revisionsList = [];
-		revisionsError = null;
-	}}
-	onRestore={requestRestoreRevision}
-/>
-
-<!-- restore confirmation: gates the swap-back-to-old-audio -->
-<ConfirmDialog
-	open={restoreConfirm !== null}
-	title="restore this version?"
-	body={restoreConfirm
-		? `this will make the selected version the live audio for "${restoreConfirm.track.title}". the current audio will move into version history.`
-		: ''}
-	confirmText="restore"
-	cancelText="cancel"
-	pending={restorePending}
-	pendingText="restoring..."
-	onConfirm={executeRestoreRevision}
-	onCancel={() => { restoreConfirm = null; }}
-/>
+{#if editingTrack}
+	<EditTrackModal
+		track={editingTrack}
+		{albums}
+		{atprotofansEligible}
+		onClose={() => {
+			editingTrack = null;
+		}}
+		onSaved={onTracksChanged}
+	/>
+{/if}
 
 <style>
-	/* shared page-level primitives — duplicated here because Svelte scoped CSS
-	   does not cross the component boundary; the parent keeps its own copies for
-	   the remaining sections. */
 	.empty {
 		color: var(--text-muted);
 		padding: 2rem;
@@ -955,19 +284,11 @@
 		border-radius: var(--radius-md);
 		border: 1px solid var(--border-subtle);
 	}
-
 	.loading-container {
 		display: flex;
 		justify-content: center;
 		padding: 3rem 1rem;
 	}
-
-	.char-count {
-		font-size: var(--text-xs);
-		color: var(--text-tertiary);
-		text-align: right;
-	}
-
 	.load-more-btn {
 		display: block;
 		width: 100%;
@@ -982,34 +303,26 @@
 		cursor: pointer;
 		transition: all 0.15s;
 	}
-
 	.load-more-btn:hover:not(:disabled) {
 		border-color: var(--accent);
 		color: var(--accent);
 	}
-
 	.load-more-btn:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
 	}
-
 	.tracks-section {
 		margin-top: 3rem;
 	}
-
 	.tracks-section h2 {
 		font-size: var(--text-page-heading);
 		margin-bottom: 1.5rem;
 	}
-
-	/* search + sort row — inline above the list, no surrounding surface; the
-	   input/select are the only chrome (they match the track cards below) */
 	.tracks-toolbar {
 		display: flex;
 		gap: 0.5rem;
 		margin-bottom: 1rem;
 	}
-
 	.track-search {
 		flex: 1;
 		min-width: 0;
@@ -1022,12 +335,10 @@
 		font-size: var(--text-base);
 		transition: border-color 0.15s;
 	}
-
 	.track-search:focus {
 		outline: none;
 		border-color: var(--accent);
 	}
-
 	.track-sort {
 		flex-shrink: 0;
 		padding: 0.55rem 0.6rem;
@@ -1039,25 +350,19 @@
 		font-size: var(--text-sm);
 		cursor: pointer;
 	}
-
 	.track-sort:focus {
 		outline: none;
 		border-color: var(--accent);
 	}
-
 	.tracks-list {
 		display: flex;
 		flex-direction: column;
 		gap: 0.75rem;
 	}
-
-	/* while a filter/sort reload is in flight, dim the prior results instead of
-	   blanking to a spinner — keeps the search box and list in place */
 	.tracks-list.refreshing {
 		opacity: 0.5;
 		transition: opacity 0.15s;
 	}
-
 	.track-item {
 		display: flex;
 		align-items: flex-start;
@@ -1069,26 +374,17 @@
 		padding: 1rem;
 		transition: all 0.2s;
 	}
-
-	.track-item.editing {
-		flex-direction: column;
-		align-items: stretch;
-	}
-
 	.track-item.copyright-flagged {
 		background: color-mix(in srgb, var(--warning) 8%, transparent);
 		border-color: color-mix(in srgb, var(--warning) 30%, transparent);
 	}
-
 	.track-item.copyright-flagged .track-title {
 		color: var(--warning);
 	}
-
 	.track-item.copyright-flagged .track-artwork img,
 	.track-item.copyright-flagged .track-artwork-placeholder {
 		opacity: 0.6;
 	}
-
 	.track-artwork-col {
 		display: flex;
 		flex-direction: column;
@@ -1096,7 +392,6 @@
 		gap: 0.35rem;
 		flex-shrink: 0;
 	}
-
 	.track-artwork {
 		width: 48px;
 		height: 48px;
@@ -1105,13 +400,11 @@
 		background: var(--bg-primary);
 		border: 1px solid var(--border-subtle);
 	}
-
 	.track-artwork img {
 		width: 100%;
 		height: 100%;
 		object-fit: cover;
 	}
-
 	.track-artwork-placeholder {
 		width: 100%;
 		height: 100%;
@@ -1120,164 +413,23 @@
 		justify-content: center;
 		color: var(--text-muted);
 	}
-
 	.track-view-link {
 		font-size: var(--text-xs);
 		color: var(--text-muted);
 		text-decoration: none;
 		transition: color 0.15s;
 	}
-
 	.track-view-link:hover {
 		color: var(--accent);
 	}
-
 	.track-item:hover {
 		background: var(--bg-hover);
 		border-color: var(--border-default);
 	}
-
 	.track-info {
 		flex: 1;
 		min-width: 0;
 	}
-
-	.edit-container {
-		width: 100%;
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-	}
-
-	.edit-fields {
-		display: flex;
-		flex-direction: column;
-		gap: 0.875rem;
-		flex: 1;
-	}
-
-	.edit-field-group {
-		display: flex;
-		flex-direction: column;
-		gap: 0.625rem;
-		padding: 1rem;
-		background: color-mix(in srgb, var(--bg-primary) 78%, var(--bg-tertiary));
-		border: 1px solid var(--border-subtle);
-		border-radius: var(--radius-base);
-		transition: border-color 0.15s, background 0.15s;
-	}
-
-	.edit-field-group:focus-within {
-		background: var(--bg-primary);
-		border-color: color-mix(in srgb, var(--accent) 55%, var(--border-default));
-	}
-
-	.content-notice-field {
-		border-left: 3px solid var(--accent);
-		background: color-mix(in srgb, var(--accent) 6%, var(--bg-primary));
-	}
-
-	.access-field {
-		background: color-mix(in srgb, var(--bg-primary) 88%, var(--bg-tertiary));
-	}
-
-	.suggested-tags-row {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		min-height: 24px;
-	}
-
-	.suggested-label {
-		font-size: var(--text-xs, 0.75rem);
-		color: var(--text-tertiary);
-		letter-spacing: 0.02em;
-		white-space: nowrap;
-		flex-shrink: 0;
-	}
-
-	.suggested-tags {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.35rem;
-	}
-
-	.suggested-tag-chip {
-		display: inline-flex;
-		align-items: center;
-		padding: 0.2rem 0.5rem;
-		background: transparent;
-		border: 1px dashed color-mix(in srgb, var(--accent) 30%, transparent);
-		color: var(--text-secondary);
-		border-radius: var(--radius-xl);
-		font-size: var(--text-sm);
-		font-family: inherit;
-		cursor: pointer;
-		transition: all 0.15s;
-	}
-
-	.suggested-tag-chip:hover {
-		background: color-mix(in srgb, var(--accent) 10%, transparent);
-		border-color: var(--accent);
-		color: var(--accent);
-	}
-
-	.edit-label {
-		font-size: var(--text-sm);
-		font-weight: 600;
-		letter-spacing: 0.015em;
-		color: var(--text-primary);
-	}
-
-	.toggle-row {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		cursor: pointer;
-		font-size: var(--text-base);
-		color: var(--text-primary);
-	}
-
-	.toggle-row input[type="checkbox"] {
-		width: 16px;
-		height: 16px;
-		accent-color: var(--accent);
-	}
-
-	.field-hint {
-		font-size: var(--text-sm);
-		color: var(--text-tertiary);
-		line-height: 1.45;
-		margin: 0;
-	}
-
-	.moderation-status {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-		padding: 0.75rem 0.875rem;
-		background: color-mix(in srgb, var(--accent) 10%, var(--bg-primary));
-		border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border-subtle));
-		border-radius: var(--radius-base);
-		font-size: var(--text-sm);
-		line-height: 1.45;
-		color: var(--text-secondary);
-	}
-
-	.moderation-status strong {
-		color: var(--text-primary);
-		font-weight: 600;
-	}
-
-	.field-hint a {
-		color: var(--accent);
-		text-decoration: none;
-	}
-
-	.field-hint a:hover {
-		text-decoration: underline;
-	}
-
 	.track-title {
 		font-weight: 600;
 		font-size: var(--text-lg);
@@ -1287,15 +439,12 @@
 		align-items: center;
 		gap: 0.5rem;
 	}
-
 	.support-gate-badge {
 		display: inline-flex;
 		align-items: center;
 		color: var(--accent);
 		flex-shrink: 0;
 	}
-
-
 	.track-meta {
 		font-size: var(--text-base);
 		color: var(--text-secondary);
@@ -1305,7 +454,6 @@
 		gap: 0.25rem;
 		min-width: 0;
 	}
-
 	.meta-features,
 	.meta-album {
 		display: inline-flex;
@@ -1317,23 +465,19 @@
 		width: 100%;
 		min-width: 0;
 	}
-
 	.features-label {
 		color: var(--accent-hover);
 		font-weight: 600;
 	}
-
 	.features-list {
 		color: var(--accent-hover);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}
-
 	.meta-album {
 		color: var(--text-tertiary);
 	}
-
 	.album-link {
 		color: var(--text-tertiary);
 		text-decoration: none;
@@ -1342,24 +486,20 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}
-
 	.album-link:hover {
 		color: var(--accent);
 	}
-
 	.album-icon {
 		width: 14px;
 		height: 14px;
 		opacity: 0.7;
 		flex-shrink: 0;
 	}
-
 	.meta-tags {
 		display: flex;
 		flex-wrap: wrap;
 		gap: 0.25rem;
 	}
-
 	.meta-tag {
 		display: inline-block;
 		padding: 0.1rem 0.4rem;
@@ -1371,17 +511,14 @@
 		text-decoration: none;
 		transition: all 0.15s;
 	}
-
 	.meta-tag:hover {
 		background: color-mix(in srgb, var(--accent) 25%, transparent);
 		color: var(--accent-hover);
 	}
-
 	.track-date {
 		font-size: var(--text-sm);
 		color: var(--text-muted);
 	}
-
 	.track-actions {
 		display: flex;
 		gap: 0.5rem;
@@ -1389,8 +526,6 @@
 		margin-left: 0.75rem;
 		align-self: flex-start;
 	}
-
-	/* track action buttons (edit/delete in non-editing state) */
 	.track-action-btn {
 		display: inline-flex;
 		align-items: center;
@@ -1408,472 +543,60 @@
 		white-space: nowrap;
 		width: auto;
 	}
-
 	.track-action-btn:hover {
 		transform: none;
 		box-shadow: none;
 		border-color: var(--border-emphasis);
 		color: var(--text-secondary);
 	}
-
 	.track-action-btn.delete:hover {
 		color: var(--text-secondary);
 	}
-
-	/* edit mode action buttons */
-	.edit-actions {
-		display: flex;
-		gap: 0.75rem;
-		justify-content: flex-end;
-		padding-top: 0.75rem;
-		border-top: 1px solid var(--border-subtle);
-		margin-top: 0.5rem;
-	}
-
-	.edit-cancel-btn {
-		padding: 0.6rem 1.25rem;
-		background: transparent;
-		border: 1px solid var(--border-default);
-		border-radius: var(--radius-base);
-		color: var(--text-secondary);
-		font-size: var(--text-base);
-		font-weight: 500;
-		font-family: inherit;
-		cursor: pointer;
-		transition: all 0.15s;
-		width: auto;
-	}
-
-	.edit-cancel-btn:hover {
-		border-color: var(--text-tertiary);
-		background: var(--bg-hover);
-		transform: none;
-		box-shadow: none;
-	}
-
-	.edit-save-btn {
-		padding: 0.6rem 1.25rem;
-		background: transparent;
-		border: 1px solid var(--accent);
-		border-radius: var(--radius-base);
-		color: var(--accent);
-		font-size: var(--text-base);
-		font-weight: 500;
-		font-family: inherit;
-		cursor: pointer;
-		transition: all 0.15s;
-		width: auto;
-	}
-
-	.edit-save-btn:hover:not(:disabled) {
-		background: color-mix(in srgb, var(--accent) 8%, transparent);
-	}
-
-	.edit-save-btn:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-
-	.edit-input {
-		width: 100%;
-		padding: 0.5rem;
-		background: var(--bg-primary);
-		border: 1px solid var(--border-default);
-		border-radius: var(--radius-sm);
-		color: var(--text-primary);
-		font-size: var(--text-base);
-		font-family: inherit;
-	}
-
-	textarea.edit-input {
-		resize: vertical;
-		min-height: 4rem;
-	}
-
-	/* artwork editor */
-	.artwork-editor {
-		display: flex;
-		align-items: center;
-		gap: 1rem;
-		padding: 0.75rem;
-		background: var(--bg-primary);
-		border: 1px solid var(--border-default);
-		border-radius: var(--radius-base);
-	}
-
-	.artwork-preview {
-		position: relative;
-		width: 80px;
-		height: 80px;
-		border-radius: var(--radius-base);
-		overflow: hidden;
-		flex-shrink: 0;
-	}
-
-	.artwork-preview img {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-	}
-
-	.artwork-preview-overlay {
-		position: absolute;
-		inset: 0;
-		background: rgba(0, 0, 0, 0.5);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		opacity: 0;
-		transition: opacity 0.15s;
-	}
-
-	.artwork-preview:hover .artwork-preview-overlay {
-		opacity: 1;
-	}
-
-	.artwork-action-btn {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 32px;
-		height: 32px;
-		padding: 0;
-		background: rgba(255, 255, 255, 0.15);
-		border: none;
-		border-radius: var(--radius-full);
-		color: white;
-		cursor: pointer;
-		transition: all 0.15s;
-	}
-
-	.artwork-action-btn:hover {
-		background: var(--error);
-		transform: scale(1.1);
-		box-shadow: none;
-	}
-
-	.artwork-status {
-		font-size: var(--text-sm);
-		color: var(--accent);
-		font-weight: 500;
-	}
-
-	.artwork-status.current {
-		color: var(--text-tertiary);
-		font-weight: 400;
-	}
-
-	.artwork-removed {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0.5rem;
-		padding: 0.75rem 1rem;
-		color: var(--text-tertiary);
-	}
-
-	.artwork-removed span {
-		font-size: var(--text-sm);
-	}
-
-	.undo-remove-btn {
-		padding: 0.25rem 0.75rem;
-		background: transparent;
-		border: 1px solid var(--border-default);
-		border-radius: var(--radius-full);
-		color: var(--accent);
-		font-size: var(--text-sm);
-		font-family: inherit;
-		cursor: pointer;
-		transition: all 0.15s;
-		width: auto;
-	}
-
-	.undo-remove-btn:hover {
-		border-color: var(--accent);
-		background: color-mix(in srgb, var(--accent) 10%, transparent);
-		transform: none;
-		box-shadow: none;
-	}
-
-	.artwork-empty {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0.5rem;
-		padding: 0.75rem 1rem;
-		color: var(--text-tertiary);
-	}
-
-	.artwork-empty span {
-		font-size: var(--text-sm);
-	}
-
-	.artwork-upload-btn {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.4rem;
-		padding: 0.5rem 0.85rem;
-		background: transparent;
-		border: 1px solid var(--accent);
-		border-radius: var(--radius-full);
-		color: var(--accent);
-		font-size: var(--text-sm);
-		font-weight: 500;
-		cursor: pointer;
-		transition: all 0.15s;
-		margin-left: auto;
-	}
-
-	.artwork-upload-btn:hover {
-		background: color-mix(in srgb, var(--accent) 12%, transparent);
-	}
-
-	.artwork-upload-btn input {
-		display: none;
-	}
-
-	.audio-replace-editor {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		gap: 0.6rem;
-	}
-
-	.audio-current {
-		flex: 1 1 auto;
-		min-width: 0;
-	}
-
-	.audio-current-label {
-		font-size: var(--text-sm);
-		color: var(--text-tertiary);
-	}
-
-	.audio-selected {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.5rem;
-		padding: 0.4rem 0.65rem;
-		background: color-mix(in srgb, var(--accent) 8%, transparent);
-		border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
-		border-radius: var(--radius-md);
-		color: var(--accent);
-		font-size: var(--text-sm);
-		max-width: 100%;
-		min-width: 0;
-		flex: 1 1 auto;
-	}
-
-	.audio-filename {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		min-width: 0;
-	}
-
-	.audio-clear-btn {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		padding: 0.15rem;
-		background: transparent;
-		border: none;
-		color: var(--accent);
-		font-family: inherit;
-		opacity: 0.7;
-		cursor: pointer;
-		transition: opacity 0.15s;
-		margin-left: auto;
-	}
-
-	.audio-clear-btn:hover {
-		opacity: 1;
-	}
-
-	.audio-upload-btn {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.4rem;
-		padding: 0.5rem 0.85rem;
-		background: transparent;
-		border: 1px solid var(--accent);
-		border-radius: var(--radius-full);
-		color: var(--accent);
-		font-family: inherit;
-		font-size: var(--text-sm);
-		font-weight: 500;
-		cursor: pointer;
-		transition: all 0.15s;
-		margin-left: auto;
-	}
-
-	.audio-upload-btn:hover {
-		background: color-mix(in srgb, var(--accent) 12%, transparent);
-	}
-
-	.audio-upload-btn input {
-		display: none;
-	}
-
-	.audio-replace-btn {
-		padding: 0.5rem 0.95rem;
-		background: var(--accent);
-		border: 1px solid var(--accent);
-		border-radius: var(--radius-full);
-		color: var(--bg);
-		font-family: inherit;
-		font-size: var(--text-sm);
-		font-weight: 600;
-		cursor: pointer;
-		transition: filter 0.15s;
-	}
-
-	.audio-replace-btn:hover {
-		filter: brightness(1.1);
-	}
-
-	.audio-history-btn {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.35rem;
-		padding: 0.4rem 0.7rem;
-		background: transparent;
-		border: 1px solid var(--border-default);
-		border-radius: var(--radius-full);
-		color: var(--text-secondary);
-		font-family: inherit;
-		font-size: var(--text-xs);
-		font-weight: 500;
-		cursor: pointer;
-		transition: all 0.15s;
-	}
-
-	.audio-history-btn:hover {
-		background: var(--bg-hover);
-		color: var(--text-primary);
-		border-color: var(--text-secondary);
-	}
-
-	.audio-replace-hint {
-		flex-basis: 100%;
-		margin: 0.35rem 0 0;
-		font-size: var(--text-xs);
-		color: var(--text-tertiary);
-	}
-
-	.edit-input:focus {
-		outline: none;
-		border-color: var(--accent);
-	}
-
 	@media (max-width: 600px) {
 		.tracks-section h2 {
 			font-size: var(--text-xl);
 		}
-
 		.tracks-section {
 			margin-top: 2rem;
 		}
-
 		.tracks-list {
 			gap: 0.5rem;
 		}
-
 		.track-item {
 			padding: 0.75rem;
 			gap: 0.75rem;
 		}
-
 		.track-artwork-col {
 			gap: 0.25rem;
 		}
-
 		.track-artwork {
 			width: 40px;
 			height: 40px;
 		}
-
 		.track-view-link {
 			font-size: 0.65rem;
 		}
-
 		.track-title {
 			font-size: var(--text-base);
 		}
-
 		.track-meta {
 			font-size: var(--text-sm);
 		}
-
 		.track-date {
 			font-size: var(--text-xs);
 		}
-
 		.track-actions {
 			margin-left: 0.5rem;
 			gap: 0.35rem;
 			flex-direction: column;
 		}
-
 		.track-action-btn {
 			padding: 0.35rem 0.55rem;
 			font-size: var(--text-xs);
 		}
-
 		.track-action-btn svg {
 			width: 12px;
 			height: 12px;
-		}
-
-		/* edit mode mobile */
-		.edit-container {
-			gap: 0.75rem;
-		}
-
-		.edit-fields {
-			gap: 0.75rem;
-		}
-
-		.edit-field-group {
-			padding: 0.875rem;
-		}
-
-		.edit-label {
-			font-size: var(--text-sm);
-		}
-
-		.edit-input {
-			padding: 0.45rem 0.5rem;
-			font-size: var(--text-sm);
-		}
-
-		.edit-actions {
-			gap: 0.5rem;
-			flex-direction: column;
-		}
-
-		.edit-cancel-btn,
-		.edit-save-btn {
-			width: 100%;
-			padding: 0.6rem;
-			font-size: var(--text-sm);
-		}
-
-		/* artwork editor mobile */
-		.artwork-editor {
-			flex-direction: column;
-			gap: 0.75rem;
-			padding: 0.65rem;
-		}
-
-		.artwork-preview {
-			width: 64px;
-			height: 64px;
-		}
-
-		.artwork-upload-btn {
-			margin-left: 0;
 		}
 	}
 </style>

--- a/frontend/src/lib/components/track-edit/TrackAccessFields.svelte
+++ b/frontend/src/lib/components/track-edit/TrackAccessFields.svelte
@@ -1,0 +1,237 @@
+<script lang="ts">
+	import { auth } from '$lib/auth.svelte';
+	import { COPYRIGHT_PARADIGM_FLAG } from '$lib/config';
+	import CopyrightRightsPanel from '$lib/components/CopyrightRightsPanel.svelte';
+	import type { TrackRights } from '$lib/components/CopyrightRightsPanel.svelte';
+	import type { Track } from '$lib/types';
+	interface Props {
+		track: Track;
+		atprotofansEligible: boolean;
+		editSupportGate: boolean;
+		editUnlisted: boolean;
+		editSelfLabels: string[];
+		editCopyrightEnabled: boolean;
+		editCopyrightRights: TrackRights;
+		replaceCopyrightRights: boolean;
+		editCopyrightWasEnabled: boolean;
+	}
+	let {
+		track,
+		atprotofansEligible,
+		editSupportGate = $bindable(),
+		editUnlisted = $bindable(),
+		editSelfLabels = $bindable(),
+		editCopyrightEnabled = $bindable(),
+		editCopyrightRights = $bindable(),
+		replaceCopyrightRights = $bindable(),
+		editCopyrightWasEnabled
+	}: Props = $props();
+	const ADULT_SELF_LABELS = new Set(['sexual', 'porn']);
+	let editHasSensitiveAudio = $derived(
+		editSelfLabels.some((label) => ADULT_SELF_LABELS.has(label))
+	);
+	function setSensitiveAudio(enabled: boolean) {
+		const nonAdult = editSelfLabels.filter((label) => !ADULT_SELF_LABELS.has(label));
+		const existingAdult = editSelfLabels.filter((label) => ADULT_SELF_LABELS.has(label));
+		editSelfLabels = enabled
+			? [...nonAdult, ...(existingAdult.length > 0 ? existingAdult : ['sexual'])]
+			: nonAdult;
+	}
+
+	function hasOperatorSensitiveLabel(track: Track): boolean {
+		return (track.operator_labels ?? []).some((label) => ADULT_SELF_LABELS.has(label));
+	}
+</script>
+
+<details class="advanced-section">
+	<summary>visibility &amp; access</summary>
+	<div class="advanced-content">
+		{#if atprotofansEligible || (track.support_gate && track.support_gate.type !== 'copyright')}
+			<div class="edit-field-group access-field">
+				<span class="edit-label">supporter access</span>
+				<label class="toggle-row">
+					<input type="checkbox" bind:checked={editSupportGate} disabled={editCopyrightEnabled} />
+					<span>only supporters can play this track</span>
+				</label>
+				{#if editSupportGate}
+					<p class="field-hint">
+						only users who support you via <a
+							href="https://atprotofans.com"
+							target="_blank"
+							rel="noopener">atprotofans</a
+						>
+						can play this track.
+						<a
+							href="https://docs.plyr.fm/artists/#supporter-gated-tracks"
+							target="_blank"
+							rel="noopener">learn more</a
+						>
+					</p>
+				{/if}
+			</div>
+		{/if}
+		<div class="edit-field-group content-notice-field">
+			<span class="edit-label">content notice</span>
+			<label class="toggle-row">
+				<input
+					type="checkbox"
+					checked={editHasSensitiveAudio}
+					onchange={(event) => setSensitiveAudio(event.currentTarget.checked)}
+				/>
+				<span>contains sexually explicit audio</span>
+			</label>
+			<p class="field-hint">
+				this notice travels with the track on ATProto. the track is hidden by default and listeners
+				must opt in to sensitive audio.
+			</p>
+			{#if hasOperatorSensitiveLabel(track)}
+				<div class="moderation-status" role="status">
+					<strong>plyr.fm moderation notice active</strong>
+					<span
+						>removing your notice will not make this track visible by default because an independent
+						moderation label remains in effect.</span
+					>
+				</div>
+			{:else}
+				<p class="field-hint">
+					this changes only your notice. moderators can apply a separate notice when needed.
+				</p>
+			{/if}
+		</div>
+
+		<div class="edit-field-group access-field">
+			<span class="edit-label">visibility</span>
+			<label class="toggle-row">
+				<input type="checkbox" bind:checked={editUnlisted} />
+				<span>unlisted — won't appear in feeds</span>
+			</label>
+			{#if editUnlisted}
+				<p class="field-hint">
+					this track won't show up in the latest, top, or for-you feeds. it's still accessible via
+					direct link, your profile, albums, playlists, and search.
+				</p>
+			{/if}
+		</div>
+	</div>
+</details>
+{#if auth.user?.enabled_flags?.includes(COPYRIGHT_PARADIGM_FLAG)}
+	<details class="advanced-section">
+		<summary>rights &amp; licensing</summary>
+		<div class="advanced-content">
+			{#if editCopyrightWasEnabled}
+				<p class="field-hint">
+					existing copyright details are preserved unless you choose to replace them.
+				</p>
+				<label class="toggle-row"
+					><input type="checkbox" bind:checked={replaceCopyrightRights} />replace existing rights
+					details</label
+				>
+				{#if !replaceCopyrightRights}<label class="toggle-row"
+						><input type="checkbox" bind:checked={editCopyrightEnabled} />copyright licensing
+						enabled</label
+					>{/if}
+			{/if}
+			{#if !editCopyrightWasEnabled || replaceCopyrightRights}
+				{#if editCopyrightWasEnabled}<p class="field-hint">
+						enter the full rights details below. blank fields clear previously saved values.
+					</p>{/if}
+				<CopyrightRightsPanel
+					bind:enabled={editCopyrightEnabled}
+					bind:rights={editCopyrightRights}
+					disabled={editSupportGate}
+				/>
+			{/if}
+		</div>
+	</details>
+{/if}
+
+<style>
+	.edit-field-group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.edit-label {
+		font-size: var(--text-sm);
+		font-weight: 600;
+		letter-spacing: 0.015em;
+		color: var(--text-primary);
+	}
+	.toggle-row {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		cursor: pointer;
+		font-size: var(--text-base);
+		color: var(--text-primary);
+	}
+	.toggle-row input[type='checkbox'] {
+		width: 16px;
+		height: 16px;
+		accent-color: var(--text-primary);
+	}
+	.field-hint {
+		font-size: var(--text-sm);
+		color: var(--text-tertiary);
+		line-height: 1.45;
+		margin: 0;
+	}
+	.moderation-status {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		padding: 0.75rem 0.875rem;
+		background: color-mix(in srgb, var(--accent) 10%, var(--bg-primary));
+		border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border-subtle));
+		border-radius: var(--radius-base);
+		font-size: var(--text-sm);
+		line-height: 1.45;
+		color: var(--text-secondary);
+	}
+	.moderation-status strong {
+		color: var(--text-primary);
+		font-weight: 600;
+	}
+	.field-hint a {
+		color: var(--text-primary);
+		text-decoration: none;
+	}
+	.field-hint a:hover {
+		text-decoration: underline;
+	}
+	@media (max-width: 600px) {
+		.edit-field-group {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+		}
+		.edit-label {
+			font-size: var(--text-sm);
+		}
+	}
+	.advanced-section {
+		border-top: 1px solid var(--border-subtle);
+		padding-top: 0.875rem;
+	}
+	.advanced-section summary {
+		cursor: pointer;
+		color: var(--text-primary);
+		font-size: var(--text-base);
+		font-weight: 600;
+		padding: 0.5rem 0;
+	}
+	.advanced-content {
+		display: flex;
+		flex-direction: column;
+		gap: 0.875rem;
+		padding-top: 0.75rem;
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.edit-field-group {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/track-edit/TrackArtworkField.svelte
+++ b/frontend/src/lib/components/track-edit/TrackArtworkField.svelte
@@ -1,0 +1,353 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	interface Props {
+		imageUrl: string | null | undefined;
+		editImageFile: File | null;
+		editRemoveImage: boolean;
+	}
+	let { imageUrl, editImageFile = $bindable(), editRemoveImage = $bindable() }: Props = $props();
+	let editImagePreviewUrl = $state<string | null>(null);
+	let fileError = $state<string | null>(null);
+	onDestroy(() => {
+		if (editImagePreviewUrl) URL.revokeObjectURL(editImagePreviewUrl);
+	});
+</script>
+
+<div class="edit-field-group">
+	<span class="edit-label">artwork (optional)</span>
+	{#if fileError}<p class="save-error" role="alert">{fileError}</p>{/if}
+	<div class="artwork-editor">
+		{#if editImagePreviewUrl}
+			<div class="artwork-preview">
+				<img src={editImagePreviewUrl} alt="new artwork preview" />
+				<div class="artwork-preview-overlay">
+					<button
+						type="button"
+						class="artwork-action-btn"
+						onclick={() => {
+							editImageFile = null;
+							if (editImagePreviewUrl) {
+								URL.revokeObjectURL(editImagePreviewUrl);
+							}
+							editImagePreviewUrl = null;
+						}}
+						title="remove selection"
+					>
+						<svg
+							width="16"
+							height="16"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+						>
+							<line x1="18" y1="6" x2="6" y2="18"></line>
+							<line x1="6" y1="6" x2="18" y2="18"></line>
+						</svg>
+					</button>
+				</div>
+			</div>
+			<span class="artwork-status">new artwork selected</span>
+		{:else if editRemoveImage}
+			<div class="artwork-removed">
+				<svg
+					width="32"
+					height="32"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="1.5"
+				>
+					<rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+					<line x1="9" y1="9" x2="15" y2="15"></line>
+					<line x1="15" y1="9" x2="9" y2="15"></line>
+				</svg>
+				<span>artwork will be removed</span>
+				<button
+					type="button"
+					class="undo-remove-btn"
+					onclick={() => {
+						editRemoveImage = false;
+					}}
+				>
+					undo
+				</button>
+			</div>
+		{:else if imageUrl}
+			<div class="artwork-preview">
+				<img src={imageUrl} alt="current artwork" />
+				<div class="artwork-preview-overlay">
+					<button
+						type="button"
+						class="artwork-action-btn"
+						onclick={() => {
+							editRemoveImage = true;
+						}}
+						title="remove artwork"
+					>
+						<svg
+							width="16"
+							height="16"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+						>
+							<polyline points="3 6 5 6 21 6"></polyline>
+							<path
+								d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
+							></path>
+						</svg>
+					</button>
+				</div>
+			</div>
+			<span class="artwork-status current">current artwork</span>
+		{:else}
+			<div class="artwork-empty">
+				<svg
+					width="32"
+					height="32"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="1.5"
+				>
+					<rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+					<circle cx="8.5" cy="8.5" r="1.5"></circle>
+					<polyline points="21 15 16 10 5 21"></polyline>
+				</svg>
+				<span>no artwork</span>
+			</div>
+		{/if}
+		{#if !editRemoveImage}
+			<label class="artwork-upload-btn">
+				<input
+					type="file"
+					accept=".jpg,.jpeg,.png,.webp,.gif,image/jpeg,image/png,image/webp,image/gif"
+					onchange={(e) => {
+						const target = e.currentTarget;
+						const file = target.files?.[0];
+						if (file) {
+							if (file.size > 20 * 1024 * 1024) {
+								fileError = 'image must be under 20 MB';
+								target.value = '';
+								return;
+							}
+							fileError = null;
+							editImageFile = file;
+							if (editImagePreviewUrl) {
+								URL.revokeObjectURL(editImagePreviewUrl);
+							}
+							editImagePreviewUrl = URL.createObjectURL(file);
+						}
+					}}
+				/>
+				<svg
+					width="16"
+					height="16"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+				>
+					<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+					<polyline points="17 8 12 3 7 8"></polyline>
+					<line x1="12" y1="3" x2="12" y2="15"></line>
+				</svg>
+				{imageUrl || editImagePreviewUrl ? 'replace' : 'upload'}
+			</label>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.edit-field-group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.edit-label {
+		font-size: var(--text-sm);
+		font-weight: 600;
+		letter-spacing: 0.015em;
+		color: var(--text-primary);
+	}
+	.artwork-editor {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		padding: 0.75rem;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-base);
+	}
+	.artwork-preview {
+		position: relative;
+		width: 80px;
+		height: 80px;
+		border-radius: var(--radius-base);
+		overflow: hidden;
+		flex-shrink: 0;
+	}
+	.artwork-preview img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+	.artwork-preview-overlay {
+		position: absolute;
+		inset: 0;
+		background: transparent;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		opacity: 0;
+		transition: opacity 0.15s;
+	}
+	.artwork-preview:hover .artwork-preview-overlay {
+		opacity: 1;
+	}
+	.artwork-action-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		padding: 0;
+		background: var(--bg-primary);
+		border: none;
+		border-radius: var(--radius-full);
+		color: var(--text-primary);
+		cursor: pointer;
+		transition:
+			background var(--motion-feedback) var(--ease-surface),
+			border-color var(--motion-feedback) var(--ease-surface);
+	}
+	.artwork-action-btn:hover {
+		background: var(--error);
+		transform: scale(1.1);
+		box-shadow: none;
+	}
+	.artwork-status {
+		font-size: var(--text-sm);
+		color: var(--text-primary);
+		font-weight: 500;
+	}
+	.artwork-status.current {
+		color: var(--text-tertiary);
+		font-weight: 400;
+	}
+	.artwork-removed {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.75rem 1rem;
+		color: var(--text-tertiary);
+	}
+	.artwork-removed span {
+		font-size: var(--text-sm);
+	}
+	.undo-remove-btn {
+		padding: 0.25rem 0.75rem;
+		background: transparent;
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-full);
+		color: var(--text-primary);
+		font-size: var(--text-sm);
+		font-family: inherit;
+		cursor: pointer;
+		transition:
+			background var(--motion-feedback) var(--ease-surface),
+			border-color var(--motion-feedback) var(--ease-surface);
+		width: auto;
+	}
+	.undo-remove-btn:hover {
+		border-color: var(--text-primary);
+		background: color-mix(in srgb, var(--accent) 10%, transparent);
+		transform: none;
+		box-shadow: none;
+	}
+	.artwork-empty {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.75rem 1rem;
+		color: var(--text-tertiary);
+	}
+	.artwork-empty span {
+		font-size: var(--text-sm);
+	}
+	.artwork-upload-btn {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		padding: 0.5rem 0.85rem;
+		background: transparent;
+		border: 1px solid var(--accent);
+		border-radius: var(--radius-full);
+		color: var(--text-primary);
+		font-size: var(--text-sm);
+		font-weight: 500;
+		cursor: pointer;
+		transition:
+			background var(--motion-feedback) var(--ease-surface),
+			border-color var(--motion-feedback) var(--ease-surface);
+		margin-left: auto;
+	}
+	.artwork-upload-btn:hover {
+		background: color-mix(in srgb, var(--accent) 12%, transparent);
+	}
+	.artwork-upload-btn input {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		opacity: 0;
+		cursor: pointer;
+	}
+	@media (max-width: 600px) {
+		.edit-field-group {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+		}
+		.edit-label {
+			font-size: var(--text-sm);
+		}
+		.artwork-editor {
+			flex-direction: column;
+			gap: 0.75rem;
+			padding: 0.65rem;
+		}
+		.artwork-preview {
+			width: 64px;
+			height: 64px;
+		}
+		.artwork-upload-btn {
+			position: relative;
+			margin-left: 0;
+		}
+	}
+	.save-error {
+		color: var(--error);
+		font-size: var(--text-sm);
+		margin: 0;
+	}
+	.artwork-preview-overlay {
+		opacity: 1;
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.edit-field-group,
+		.artwork-preview-overlay {
+			transition: none;
+		}
+	}
+	.artwork-upload-btn:focus-within {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+</style>

--- a/frontend/src/lib/components/track-edit/TrackAudioEditor.svelte
+++ b/frontend/src/lib/components/track-edit/TrackAudioEditor.svelte
@@ -1,0 +1,555 @@
+<script lang="ts">
+	import type { ComponentProps } from 'svelte';
+	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
+	import type AudioRevisionsSheet from '$lib/components/AudioRevisionsSheet.svelte';
+	import { API_URL, getServerConfig } from '$lib/config';
+	import { toast } from '$lib/toast.svelte';
+	import { uploader, type AudioReplacementStatus } from '$lib/uploader.svelte';
+	import { isOptimizing } from '$lib/utils/track-audio';
+	import type { Track } from '$lib/types';
+	interface Props {
+		track: Track;
+		onTrackChanged?: (track: Track) => void | Promise<void>;
+		onBusyChange: (busy: boolean) => void;
+		onDirtyChange: (dirty: boolean) => void;
+	}
+	let { track, onTrackChanged, onBusyChange, onDirtyChange }: Props = $props();
+	const AUDIO_FILE_INPUT_ACCEPT =
+		'.mp3,.wav,.m4a,.aiff,.aif,.flac,audio/mpeg,audio/wav,audio/mp4,audio/aiff,audio/x-aiff,audio/flac';
+	let replacementStatus = $state<AudioReplacementStatus | null>(null);
+	let audioError = $state<string | null>(null);
+	let restoreError = $state<string | null>(null);
+	$effect(() => {
+		onBusyChange(restorePending);
+	});
+	$effect(() => {
+		onDirtyChange(Boolean(editAudioFile));
+	});
+	let editAudioFile = $state<File | null>(null);
+	let replaceConfirm = $state<{ track: Track; file: File } | null>(null);
+
+	type AudioRevision = ComponentProps<typeof AudioRevisionsSheet>['revisions'][number];
+	let revisionsSheetTrack = $state<Track | null>(null);
+	let revisionsList = $state<AudioRevision[]>([]);
+	let revisionsLoading = $state(false);
+	let revisionsError = $state<string | null>(null);
+	let restoreConfirm = $state<{ track: Track; revision: AudioRevision } | null>(null);
+	let restorePending = $state(false);
+	async function selectAudioReplacement(file: File) {
+		try {
+			const config = await getServerConfig();
+			const sizeMB = file.size / (1024 * 1024);
+			if (sizeMB > config.max_upload_size_mb) {
+				audioError = `audio file exceeds ${config.max_upload_size_mb}MB limit`;
+				return;
+			}
+		} catch {
+			// The upload endpoint still enforces the size limit.
+		}
+		audioError = null;
+		editAudioFile = file;
+	}
+
+	function requestReplaceAudio(track: Track) {
+		if (!editAudioFile) return;
+		replaceConfirm = { track, file: editAudioFile };
+	}
+
+	async function refreshTrack(): Promise<Track> {
+		const response = await fetch(`${API_URL}/tracks/${track.id}`, { credentials: 'include' });
+		if (!response.ok) throw new Error('could not refresh track — try again');
+		const fresh: Track = await response.json();
+		await onTrackChanged?.(fresh);
+		return fresh;
+	}
+
+	function executeReplaceAudio() {
+		if (!replaceConfirm) return;
+		const { track, file } = replaceConfirm;
+		const trackId = track.id;
+
+		uploader.replaceAudio(
+			trackId,
+			file,
+			track.title,
+			async () => {
+				await refreshTrack();
+			},
+			(status) => {
+				replacementStatus = status;
+			}
+		);
+
+		editAudioFile = null;
+		replaceConfirm = null;
+	}
+
+	async function openVersionHistory(track: Track) {
+		revisionsSheetTrack = track;
+		revisionsList = [];
+		revisionsError = null;
+		revisionsLoading = true;
+		try {
+			const resp = await fetch(`${API_URL}/tracks/${track.id}/revisions`, {
+				credentials: 'include'
+			});
+			if (!resp.ok) {
+				revisionsError = 'failed to load version history';
+				return;
+			}
+			const body = await resp.json();
+			revisionsList = body.revisions ?? [];
+		} catch {
+			revisionsError = 'failed to load version history';
+		} finally {
+			revisionsLoading = false;
+		}
+	}
+
+	function requestRestoreRevision(revision: AudioRevision) {
+		if (!revisionsSheetTrack) return;
+		restoreConfirm = { track: revisionsSheetTrack, revision };
+	}
+
+	async function executeRestoreRevision() {
+		if (!restoreConfirm) return;
+		const { track, revision } = restoreConfirm;
+		restorePending = true;
+		restoreError = null;
+		try {
+			const resp = await fetch(`${API_URL}/tracks/${track.id}/revisions/${revision.id}/restore`, {
+				method: 'POST',
+				credentials: 'include'
+			});
+			if (!resp.ok) {
+				const detail = await resp.json().catch(() => ({}));
+				restoreError = detail.detail ?? 'could not restore audio — try again';
+				return;
+			}
+			await refreshTrack();
+			toast.success('audio restored');
+			replacementStatus = { type: 'success', message: 'audio restored' };
+
+			if (revisionsSheetTrack?.id === track.id) {
+				await openVersionHistory(track);
+			}
+			restoreConfirm = null;
+		} catch {
+			restoreError = 'could not restore audio — try again';
+		} finally {
+			restorePending = false;
+		}
+	}
+</script>
+
+<details class="advanced-section">
+	<summary>audio &amp; version history</summary>
+	<div class="advanced-content">
+		{#if replacementStatus}<p
+				class="replacement-status"
+				class:failed={replacementStatus.type === 'error'}
+				role={replacementStatus.type === 'error' ? 'alert' : 'status'}
+			>
+				{replacementStatus.message}
+			</p>{/if}
+		{#if audioError}<p class="save-error" role="alert">{audioError}</p>{/if}
+		<div class="edit-field-group">
+			<span class="edit-label">audio file</span>
+			<div class="audio-replace-editor">
+				{#if editAudioFile}
+					<div class="audio-selected">
+						<svg
+							width="20"
+							height="20"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+						>
+							<path d="M9 18V5l12-2v13"></path>
+							<circle cx="6" cy="18" r="3"></circle>
+							<circle cx="18" cy="16" r="3"></circle>
+						</svg>
+						<span class="audio-filename">{editAudioFile.name}</span>
+						<button
+							type="button"
+							class="audio-clear-btn"
+							onclick={() => {
+								editAudioFile = null;
+							}}
+							title="discard selection"
+						>
+							<svg
+								width="14"
+								height="14"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+							>
+								<line x1="18" y1="6" x2="6" y2="18"></line>
+								<line x1="6" y1="6" x2="18" y2="18"></line>
+							</svg>
+						</button>
+					</div>
+					<button
+						type="button"
+						class="audio-replace-btn"
+						onclick={() => requestReplaceAudio(track)}
+					>
+						replace audio
+					</button>
+				{:else}
+					<div class="audio-current">
+						<span class="audio-current-label">
+							current: {track.file_type}{track.original_file_type &&
+							track.original_file_type !== track.file_type
+								? ` (transcoded from ${track.original_file_type})`
+								: ''}{isOptimizing(track)
+								? ' · optimizing — mp3 will land on your PDS shortly'
+								: track.audio_storage === 'both' || track.audio_storage === 'pds'
+									? ' · stored on your PDS'
+									: ' · stored on plyr.fm'}
+						</span>
+					</div>
+					<label class="audio-upload-btn">
+						<input
+							type="file"
+							accept={AUDIO_FILE_INPUT_ACCEPT}
+							onchange={(e) => {
+								const target = e.currentTarget;
+								const file = target.files?.[0];
+								if (file) {
+									void selectAudioReplacement(file);
+								}
+								target.value = '';
+							}}
+						/>
+						<svg
+							width="16"
+							height="16"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+						>
+							<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+							<polyline points="17 8 12 3 7 8"></polyline>
+							<line x1="12" y1="3" x2="12" y2="15"></line>
+						</svg>
+						choose new file
+					</label>
+					<button
+						type="button"
+						class="audio-history-btn"
+						onclick={() => openVersionHistory(track)}
+						title="view previous audio versions"
+					>
+						<svg
+							width="14"
+							height="14"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+						>
+							<path d="M3 12a9 9 0 1 0 3-6.7L3 8"></path>
+							<polyline points="3 3 3 8 8 8"></polyline>
+							<polyline points="12 7 12 12 15 14"></polyline>
+						</svg>
+						version history
+					</button>
+				{/if}
+				<p class="audio-replace-hint">
+					choose a new file, then confirm. uploading runs in the background and the previous audio
+					is kept in version history so you can roll back. likes, comments, plays, and the track URL
+					stay the same.
+				</p>
+			</div>
+		</div>
+	</div>
+	{#if revisionsSheetTrack}
+		<section class="version-history" aria-label="audio version history">
+			<div class="history-heading">
+				<span>previous audio</span><button
+					type="button"
+					class="audio-history-btn"
+					onclick={() => {
+						revisionsSheetTrack = null;
+					}}>close history</button
+				>
+			</div>
+			{#if revisionsLoading}<p class="audio-replace-hint" role="status">loading versions…</p>
+			{:else if revisionsError}<p class="save-error" role="alert">{revisionsError}</p>
+				<button type="button" class="audio-history-btn" onclick={() => openVersionHistory(track)}
+					>retry</button
+				>
+			{:else if revisionsList.length === 0}<p class="audio-replace-hint">
+					no previous audio versions
+				</p>
+			{:else}<ul>
+					{#each revisionsList as revision (revision.id)}<li>
+							<span
+								>{new Date(revision.created_at).toLocaleString()} · {revision.original_file_type ??
+									revision.file_type}{revision.duration
+									? ` · ${Math.round(revision.duration)}s`
+									: ''}</span
+							><button
+								type="button"
+								class="audio-history-btn"
+								onclick={() => requestRestoreRevision(revision)}>restore</button
+							>
+						</li>{/each}
+				</ul>{/if}
+		</section>
+	{/if}
+</details>
+<ConfirmDialog
+	open={replaceConfirm !== null}
+	title="replace audio?"
+	body={replaceConfirm
+		? `this will swap the audio file for "${replaceConfirm.track.title}". the previous audio will be saved in version history so you can roll back. likes, comments, plays, and the track URL won't change.`
+		: ''}
+	confirmText="replace"
+	cancelText="cancel"
+	onConfirm={executeReplaceAudio}
+	onCancel={() => {
+		replaceConfirm = null;
+	}}
+/>
+
+<ConfirmDialog
+	open={restoreConfirm !== null}
+	title="restore this version?"
+	body={restoreConfirm
+		? `${restoreError ? `${restoreError}\n\n` : ''}this will make the selected version the live audio for "${restoreConfirm.track.title}". the current audio will move into version history.`
+		: ''}
+	confirmText="restore"
+	cancelText="cancel"
+	pending={restorePending}
+	pendingText="restoring..."
+	onConfirm={executeRestoreRevision}
+	onCancel={() => {
+		restoreConfirm = null;
+	}}
+/>
+
+<style>
+	.edit-field-group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.625rem;
+		padding: 1rem;
+		background: color-mix(in srgb, var(--bg-primary) 78%, var(--bg-tertiary));
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-base);
+		transition:
+			border-color 0.15s,
+			background 0.15s;
+	}
+	.edit-field-group:focus-within {
+		background: var(--bg-primary);
+		border-color: color-mix(in srgb, var(--accent) 55%, var(--border-default));
+	}
+	.edit-label {
+		font-size: var(--text-sm);
+		font-weight: 600;
+		letter-spacing: 0.015em;
+		color: var(--text-primary);
+	}
+	.audio-replace-editor {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.6rem;
+	}
+	.audio-current {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+	.audio-current-label {
+		font-size: var(--text-sm);
+		color: var(--text-tertiary);
+	}
+	.audio-selected {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.4rem 0.65rem;
+		background: color-mix(in srgb, var(--accent) 8%, transparent);
+		border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+		border-radius: var(--radius-md);
+		color: var(--text-primary);
+		font-size: var(--text-sm);
+		max-width: 100%;
+		min-width: 0;
+		flex: 1 1 auto;
+	}
+	.audio-filename {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		min-width: 0;
+	}
+	.audio-clear-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.15rem;
+		background: transparent;
+		border: none;
+		color: var(--text-primary);
+		font-family: inherit;
+		opacity: 0.7;
+		cursor: pointer;
+		transition: opacity 0.15s;
+		margin-left: auto;
+	}
+	.audio-clear-btn:hover {
+		opacity: 1;
+	}
+	.audio-upload-btn {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		padding: 0.5rem 0.85rem;
+		background: transparent;
+		border: 1px solid var(--accent);
+		border-radius: var(--radius-full);
+		color: var(--text-primary);
+		font-family: inherit;
+		font-size: var(--text-sm);
+		font-weight: 500;
+		cursor: pointer;
+		transition:
+			background var(--motion-feedback) var(--ease-surface),
+			border-color var(--motion-feedback) var(--ease-surface);
+		margin-left: auto;
+	}
+	.audio-upload-btn:hover {
+		background: color-mix(in srgb, var(--accent) 12%, transparent);
+	}
+	.audio-upload-btn input {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		opacity: 0;
+		cursor: pointer;
+	}
+	.audio-replace-btn {
+		padding: 0.5rem 0.95rem;
+		background: var(--accent);
+		border: 1px solid var(--accent);
+		border-radius: var(--radius-full);
+		color: var(--accent-contrast);
+		font-family: inherit;
+		font-size: var(--text-sm);
+		font-weight: 600;
+		cursor: pointer;
+		transition: filter 0.15s;
+	}
+	.audio-replace-btn:hover {
+		filter: brightness(1.1);
+	}
+	.audio-history-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		padding: 0.4rem 0.7rem;
+		background: transparent;
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-full);
+		color: var(--text-secondary);
+		font-family: inherit;
+		font-size: var(--text-xs);
+		font-weight: 500;
+		cursor: pointer;
+		transition:
+			background var(--motion-feedback) var(--ease-surface),
+			border-color var(--motion-feedback) var(--ease-surface);
+	}
+	.audio-history-btn:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+		border-color: var(--text-secondary);
+	}
+	.audio-replace-hint {
+		flex-basis: 100%;
+		margin: 0.35rem 0 0;
+		font-size: var(--text-xs);
+		color: var(--text-tertiary);
+	}
+	@media (max-width: 600px) {
+		.edit-field-group {
+			padding: 0.875rem;
+		}
+		.edit-label {
+			font-size: var(--text-sm);
+		}
+	}
+	.advanced-section {
+		border-top: 1px solid var(--border-subtle);
+		padding-top: 0.875rem;
+	}
+	.advanced-section summary {
+		cursor: pointer;
+		color: var(--text-primary);
+		font-size: var(--text-base);
+		font-weight: 600;
+		padding: 0.5rem 0;
+	}
+	.advanced-content {
+		display: flex;
+		flex-direction: column;
+		gap: 0.875rem;
+		padding-top: 0.75rem;
+	}
+	.save-error {
+		color: var(--error);
+		font-size: var(--text-sm);
+		margin: 0;
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.edit-field-group {
+			transition: none;
+		}
+	}
+	.version-history {
+		border-top: 1px solid var(--border-subtle);
+		margin-top: 1rem;
+		padding-top: 1rem;
+		font-size: var(--text-sm);
+	}
+	.history-heading,
+	.version-history li {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+	.version-history ul {
+		list-style: none;
+		padding: 0;
+		margin: 0.75rem 0 0;
+	}
+	.version-history li {
+		padding: 0.5rem 0;
+		color: var(--text-secondary);
+	}
+	.audio-upload-btn:focus-within {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+	.replacement-status {
+		margin: 0;
+		color: var(--text-secondary);
+		font-size: var(--text-sm);
+		line-height: 1.4;
+	}
+	.replacement-status.failed {
+		color: var(--error);
+	}
+</style>

--- a/frontend/src/lib/queue-identity.test.ts
+++ b/frontend/src/lib/queue-identity.test.ts
@@ -22,6 +22,41 @@ afterEach(() => {
 });
 
 describe('queue track identity', () => {
+	it('keeps an edit when an older queue write returns during the save', async () => {
+		auth.isAuthenticated = true;
+		queue.setQueue([original, reupload, original], 2);
+		queue.progressMs = 42000;
+		let finish: ((response: Response) => void) | undefined;
+		const response = new Promise<Response>((resolve) => {
+			finish = resolve;
+		});
+		vi.spyOn(globalThis, 'fetch').mockReturnValue(response);
+		const push = queue.pushQueue();
+		queue.updateTrackMetadata({ ...original, title: 'new title' });
+		finish?.(
+			new Response(
+				JSON.stringify({
+					revision: 1,
+					state: {
+						track_record_ids: [1249, 1261, 1249],
+						current_index: 2,
+						progress_ms: 42000
+					},
+					tracks: [original, reupload]
+				})
+			)
+		);
+		await push;
+		expect(queue.tracks.map((track) => track.title)).toEqual(['new title', 'test', 'new title']);
+		expect(queue.originalOrder.map((track) => track.title)).toEqual([
+			'new title',
+			'test',
+			'new title'
+		]);
+		expect(queue.currentIndex).toBe(2);
+		expect(queue.progressMs).toBe(42000);
+	});
+
 	it('saves track identities alongside legacy audio IDs and accepts the echo', async () => {
 		auth.isAuthenticated = true;
 		queue.setQueue([original, reupload, original], 2);

--- a/frontend/src/lib/queue.svelte.ts
+++ b/frontend/src/lib/queue.svelte.ts
@@ -399,6 +399,19 @@ class Queue {
 		}, SYNC_DEBOUNCE_MS);
 	}
 
+	updateTrackMetadata(updated: Track) {
+		if (!this.tracks.some((track) => track.id === updated.id)) return;
+		this.lastUpdateWasLocal = true;
+		this.mutationEpoch += 1;
+		this.tracks = this.tracks.map((track) =>
+			track.id === updated.id ? { ...track, ...updated } : track
+		);
+		this.originalOrder = this.originalOrder.map((track) =>
+			track.id === updated.id ? { ...track, ...updated } : track
+		);
+		this.syncState();
+	}
+
 	private syncState() {
 		if (!browser) return;
 		if (this.jamBridge) {

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -2,13 +2,18 @@ import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
 import { auth } from './auth.svelte';
 import { API_URL } from './config';
-import { toast } from './toast.svelte';
+import { toast, type ToastType } from './toast.svelte';
 import { tracksCache } from './tracks.svelte';
 import type { FeaturedArtist } from './types';
 import type { TrackRights } from './components/CopyrightRightsPanel.svelte';
 import { setReturnUrl } from './utils/return-url';
 import { finishUploadSession, UploadPartError, UploadSessionHttpError } from './upload-session';
 import { sessionTransport, StagedTransfer, type StagedTransport } from './staged-transfer.svelte';
+
+export interface AudioReplacementStatus {
+	type: ToastType;
+	message: string;
+}
 
 interface UploadTask {
 	id: string;
@@ -77,7 +82,7 @@ export async function startPermissionedScopeUpgrade(): Promise<void> {
 			// the backend has recorded that, so refreshing auth stops offering it.
 			const detail = await res.json().catch(() => null);
 			if (detail?.detail === 'spaces_refused') {
-				toast.error("your PDS refused private media", 8000);
+				toast.error('your PDS refused private media', 8000);
 				await auth.refresh();
 				return;
 			}
@@ -94,7 +99,11 @@ export async function startPermissionedScopeUpgrade(): Promise<void> {
 	}
 }
 
-function buildNetworkErrorMessage(progressPercent: number, fileSizeMB: number, isMobile: boolean): string {
+function buildNetworkErrorMessage(
+	progressPercent: number,
+	fileSizeMB: number,
+	isMobile: boolean
+): string {
 	const progressInfo = progressPercent > 0 ? ` (failed at ${progressPercent}%)` : '';
 
 	if (isMobile && fileSizeMB > MOBILE_LARGE_FILE_THRESHOLD_MB) {
@@ -114,7 +123,11 @@ function buildNetworkErrorMessage(progressPercent: number, fileSizeMB: number, i
 	return `upload failed before sending — try re-selecting the file`;
 }
 
-function buildTimeoutErrorMessage(progressPercent: number, fileSizeMB: number, isMobile: boolean): string {
+function buildTimeoutErrorMessage(
+	progressPercent: number,
+	fileSizeMB: number,
+	isMobile: boolean
+): string {
 	const progressInfo = progressPercent > 0 ? ` (stopped at ${progressPercent}%)` : '';
 
 	if (isMobile) {
@@ -133,7 +146,11 @@ type UploadFailure = UploadSessionHttpError | UploadPartError | Error;
 /** a transfer the server refused for want of a session; submit's preflight owns the sign-in bounce. */
 function sessionExpired(error: UploadFailure): boolean {
 	if (error instanceof UploadSessionHttpError) return error.status === 401;
-	return error instanceof UploadPartError && error.failure.kind === 'http' && error.failure.status === 401;
+	return (
+		error instanceof UploadPartError &&
+		error.failure.kind === 'http' &&
+		error.failure.status === 401
+	);
 }
 
 /**
@@ -165,8 +182,10 @@ function describeUploadFailure(
 	}
 	if (error instanceof UploadPartError) {
 		const failure = error.failure;
-		if (failure.kind === 'timeout') return buildTimeoutErrorMessage(progressPercent, fileSizeMB, isMobile);
-		if (failure.kind === 'network') return buildNetworkErrorMessage(progressPercent, fileSizeMB, isMobile);
+		if (failure.kind === 'timeout')
+			return buildTimeoutErrorMessage(progressPercent, fileSizeMB, isMobile);
+		if (failure.kind === 'network')
+			return buildNetworkErrorMessage(progressPercent, fileSizeMB, isMobile);
 		if (failure.status === 401) {
 			toast.error('your session expired — sign in to finish your upload');
 			setReturnUrl('/upload');
@@ -192,7 +211,10 @@ class UploaderState {
 		const fileSizeMB = file.size / 1024 / 1024;
 		const isMobile = isMobileDevice();
 		if (isMobile && fileSizeMB > MOBILE_LARGE_FILE_THRESHOLD_MB) {
-			toast.info(`uploading ${Math.round(fileSizeMB)}MB file on mobile - ensure stable connection`, 5000);
+			toast.info(
+				`uploading ${Math.round(fileSizeMB)}MB file on mobile - ensure stable connection`,
+				5000
+			);
 		}
 		return new StagedTransfer(file, transport, (failure, percent) =>
 			sessionExpired(failure)
@@ -227,9 +249,10 @@ class UploaderState {
 		const isMobile = isMobileDevice();
 		const displayName = label ?? title;
 
-		const uploadMessage = fileSizeMB > 10
-			? `uploading "${displayName}"... (large file)`
-			: `uploading "${displayName}"...`;
+		const uploadMessage =
+			fileSizeMB > 10
+				? `uploading "${displayName}"... (large file)`
+				: `uploading "${displayName}"...`;
 		// 0 means infinite/persist until dismissed
 		const toastId = toast.info(uploadMessage, 0);
 
@@ -241,7 +264,7 @@ class UploaderState {
 			formData.append('album', album);
 		}
 		if (features.length > 0) {
-			const handles = features.map(a => a.handle);
+			const handles = features.map((a) => a.handle);
 			formData.append('features', JSON.stringify(handles));
 		}
 		if (tags.length > 0) {
@@ -304,7 +327,12 @@ class UploaderState {
 				this.followProcessing(task, displayName, onSuccess);
 			} catch (error) {
 				const failure: UploadFailure = error instanceof Error ? error : new Error(String(error));
-				const message = describeUploadFailure(failure, staged.progressPercent, fileSizeMB, isMobile);
+				const message = describeUploadFailure(
+					failure,
+					staged.progressPercent,
+					fileSizeMB,
+					isMobile
+				);
 				if (message === null) {
 					toast.dismiss(toastId);
 					this.activeUploads.delete(taskId);
@@ -342,10 +370,16 @@ class UploaderState {
 				this.activeUploads.delete(task.id);
 
 				const trackId = update.track_id ?? null;
-				toast.success(`"${displayName}" uploaded`, 5000, trackId ? {
-					label: 'view track',
-					href: `/track/${trackId}`
-				} : undefined);
+				toast.success(
+					`"${displayName}" uploaded`,
+					5000,
+					trackId
+						? {
+								label: 'view track',
+								href: `/track/${trackId}`
+							}
+						: undefined
+				);
 
 				const warnings: string[] = update.warnings ?? [];
 				const warningAction = update.pds_blob_failed
@@ -399,22 +433,31 @@ class UploaderState {
 		trackId: number,
 		file: File,
 		title: string,
-		onComplete?: (_result: { trackId: number; atprotoCid: string | null }) => void
+		onComplete?: (_result: { trackId: number; atprotoCid: string | null }) => void | Promise<void>,
+		onStatus?: (status: AudioReplacementStatus) => void
 	): void {
 		if (!browser) return;
+		const report = (message: string, type: ToastType = 'info'): void => {
+			onStatus?.({ message, type });
+		};
 
 		const taskId = crypto.randomUUID();
 		const fileSizeMB = file.size / 1024 / 1024;
 		const isMobile = isMobileDevice();
 
 		if (isMobile && fileSizeMB > MOBILE_LARGE_FILE_THRESHOLD_MB) {
-			toast.info(`replacing audio: ${Math.round(fileSizeMB)}MB on mobile - ensure stable connection`, 5000);
+			toast.info(
+				`replacing audio: ${Math.round(fileSizeMB)}MB on mobile - ensure stable connection`,
+				5000
+			);
 		}
 
-		const startMessage = fileSizeMB > 10
-			? `replacing audio for "${title}"... (large file)`
-			: `replacing audio for "${title}"...`;
+		const startMessage =
+			fileSizeMB > 10
+				? `replacing audio for "${title}"... (large file)`
+				: `replacing audio for "${title}"...`;
 		const toastId = toast.info(startMessage, 0);
+		report('uploading replacement audio…');
 
 		let lastProgressPercent = 0;
 		const formData = new FormData();
@@ -431,6 +474,7 @@ class UploaderState {
 				const percent = Math.round((e.loaded / e.total) * 100);
 				lastProgressPercent = percent;
 				toast.update(toastId, `uploading new audio... ${percent}%`);
+				report(`uploading new audio… ${percent}%`);
 			}
 		});
 
@@ -438,6 +482,7 @@ class UploaderState {
 			if (xhr.status >= 200 && xhr.status < 300) {
 				try {
 					uploadComplete = true;
+					report('processing replacement audio…');
 					const result = JSON.parse(xhr.responseText);
 					const upload_id = result.upload_id;
 
@@ -455,14 +500,26 @@ class UploaderState {
 					task.eventSource = eventSource;
 
 					eventSource.onmessage = (event) => {
-						const update: UploadProgressUpdate = JSON.parse(event.data);
+						let update: UploadProgressUpdate;
+						try {
+							update = JSON.parse(event.data);
+						} catch {
+							eventSource.close();
+							toast.dismiss(task.toastId);
+							this.activeUploads.delete(taskId);
+							toast.error('could not read replacement status — reload to check');
+							report('could not read replacement status — reload to check', 'error');
+							return;
+						}
 
 						if (update.message && update.status === 'processing') {
 							const serverProgress = update.server_progress_pct;
 							if (serverProgress !== undefined && serverProgress !== null && serverProgress > 0) {
 								toast.update(task.toastId, `${update.message} (${Math.round(serverProgress)}%)`);
+								report(`${update.message} (${Math.round(serverProgress)}%)`);
 							} else {
 								toast.update(task.toastId, update.message);
+								report(update.message);
 							}
 						}
 
@@ -472,13 +529,20 @@ class UploaderState {
 							this.activeUploads.delete(taskId);
 
 							toast.success(`audio for "${title}" replaced`, 5000);
+							report('audio replaced', 'success');
 							tracksCache.invalidate();
 							tracksCache.fetch(true);
 
-							onComplete?.({
-								trackId,
-								atprotoCid: update.atproto_cid ?? null
-							});
+							void Promise.resolve()
+								.then(() =>
+									onComplete?.({
+										trackId,
+										atprotoCid: update.atproto_cid ?? null
+									})
+								)
+								.catch(() => {
+									report('audio replaced — reload to see the update', 'warning');
+								});
 						}
 
 						if (update.status === 'failed') {
@@ -486,6 +550,7 @@ class UploaderState {
 							toast.dismiss(task.toastId);
 							this.activeUploads.delete(taskId);
 							toast.error(update.error || 'audio replace failed');
+							report(update.error || 'audio replacement failed — try again', 'error');
 						}
 					};
 
@@ -494,10 +559,14 @@ class UploaderState {
 						toast.dismiss(task.toastId);
 						this.activeUploads.delete(taskId);
 						toast.error('lost connection during audio replace');
+						report('connection lost — reload to check replacement status', 'error');
 					};
 				} catch {
+					this.activeUploads.get(taskId)?.eventSource?.close();
+					this.activeUploads.delete(taskId);
 					toast.dismiss(toastId);
 					toast.error('failed to parse server response');
+					report('could not read replacement status — reload to check', 'error');
 				}
 			} else {
 				toast.dismiss(toastId);
@@ -511,7 +580,7 @@ class UploaderState {
 					} else if (xhr.status === 413) {
 						errorMsg = 'file too large: please use a smaller file';
 					} else if (xhr.status === 403) {
-						errorMsg = "you can only replace audio on your own tracks";
+						errorMsg = 'you can only replace audio on your own tracks';
 					} else if (xhr.status === 404) {
 						errorMsg = 'track not found';
 					} else if (xhr.status >= 500) {
@@ -519,21 +588,35 @@ class UploaderState {
 					}
 				}
 				toast.error(errorMsg);
+				report(errorMsg, 'error');
 			}
 		});
 
 		xhr.addEventListener('error', () => {
 			toast.dismiss(toastId);
 			toast.error(buildNetworkErrorMessage(lastProgressPercent, fileSizeMB, isMobile));
+			report(buildNetworkErrorMessage(lastProgressPercent, fileSizeMB, isMobile), 'error');
 		});
 
 		xhr.addEventListener('timeout', () => {
 			toast.dismiss(toastId);
 			toast.error(buildTimeoutErrorMessage(lastProgressPercent, fileSizeMB, isMobile));
+			report(buildTimeoutErrorMessage(lastProgressPercent, fileSizeMB, isMobile), 'error');
+		});
+
+		xhr.addEventListener('abort', () => {
+			toast.dismiss(toastId);
+			report('audio replacement canceled', 'warning');
 		});
 
 		xhr.timeout = 300000;
-		xhr.send(formData);
+		try {
+			xhr.send(formData);
+		} catch {
+			toast.dismiss(toastId);
+			toast.error('audio upload could not start — try again');
+			report('audio upload could not start — try again', 'error');
+		}
 	}
 }
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
 	import favicon from '$lib/assets/favicon.png';
-	import {
-		APP_NAME,
-		APP_TAGLINE,
-		APP_CANONICAL_URL
-	} from '$lib/branding';
+	import { APP_NAME, APP_TAGLINE, APP_CANONICAL_URL } from '$lib/branding';
 	import Player from '$lib/components/Player.svelte';
 	import Toast from '$lib/components/Toast.svelte';
 	import Queue from '$lib/components/Queue.svelte';
@@ -36,16 +32,16 @@
 	// pages that define their own <title> in svelte:head
 	let hasPageMetadata = $derived(
 		$page.url.pathname === '/' || // homepage
-		$page.url.pathname === '/activity' || // activity feed
-		$page.url.pathname === '/record' || // in-browser recording
-		$page.url.pathname.startsWith('/radio') || // radio + per-station previews
-		$page.url.pathname.startsWith('/track/') || // track detail
-		$page.url.pathname.startsWith('/playlist/') || // playlist detail
-		$page.url.pathname.startsWith('/tag/') || // tag detail
-		$page.url.pathname === '/liked' || // liked tracks
-		$page.url.pathname.startsWith('/jam/') || // jam invite
-		$page.url.pathname.match(/^\/u\/[^/]+$/) || // artist detail
-		$page.url.pathname.match(/^\/u\/[^/]+\/album\/[^/]+/) // album detail
+			$page.url.pathname === '/activity' || // activity feed
+			$page.url.pathname === '/record' || // in-browser recording
+			$page.url.pathname.startsWith('/radio') || // radio + per-station previews
+			$page.url.pathname.startsWith('/track/') || // track detail
+			$page.url.pathname.startsWith('/playlist/') || // playlist detail
+			$page.url.pathname.startsWith('/tag/') || // tag detail
+			$page.url.pathname === '/liked' || // liked tracks
+			$page.url.pathname.startsWith('/jam/') || // jam invite
+			$page.url.pathname.match(/^\/u\/[^/]+$/) || // artist detail
+			$page.url.pathname.match(/^\/u\/[^/]+\/album\/[^/]+/) // album detail
 	);
 
 	let isEmbed = $derived($page.url.pathname.startsWith('/embed/'));
@@ -55,10 +51,10 @@
 	// uses preferences.needsTermsAcceptance which compares accepted_at vs terms_last_updated
 	let showTermsOverlay = $derived(
 		auth.isAuthenticated &&
-		preferences.needsTermsAcceptance &&
-		!$page.url.pathname.startsWith('/terms') &&
-		!$page.url.pathname.startsWith('/privacy') &&
-		!$page.url.pathname.startsWith('/cookies')
+			preferences.needsTermsAcceptance &&
+			!$page.url.pathname.startsWith('/terms') &&
+			!$page.url.pathname.startsWith('/privacy') &&
+			!$page.url.pathname.startsWith('/cookies')
 	);
 
 	// initialize auth and preferences once on mount (not on every navigation)
@@ -190,16 +186,31 @@
 			const shouldTile = isUsingPlayingArtwork || uiSettings.background_tile;
 			root.style.setProperty('--bg-image-mode', shouldTile ? 'repeat' : 'no-repeat');
 			// playing artwork: 25% size (4x4 grid), custom: auto if tiled, cover if not
-			root.style.setProperty('--bg-image-size', isUsingPlayingArtwork ? '25%' : (uiSettings.background_tile ? 'auto' : 'cover'));
+			root.style.setProperty(
+				'--bg-image-size',
+				isUsingPlayingArtwork ? '25%' : uiSettings.background_tile ? 'auto' : 'cover'
+			);
 			// blur playing artwork for smoother look
 			root.style.setProperty('--bg-blur', isUsingPlayingArtwork ? '40px' : '0px');
 			// glass button styling for visibility against background images
 			const isLight = root.classList.contains('theme-light');
-			root.style.setProperty('--glass-btn-bg', isLight ? 'rgba(255, 255, 255, 0.8)' : 'rgba(18, 18, 18, 0.8)');
-			root.style.setProperty('--glass-btn-bg-hover', isLight ? 'rgba(255, 255, 255, 0.9)' : 'rgba(30, 30, 30, 0.9)');
-			root.style.setProperty('--glass-btn-border', isLight ? 'rgba(0, 0, 0, 0.12)' : 'rgba(255, 255, 255, 0.12)');
+			root.style.setProperty(
+				'--glass-btn-bg',
+				isLight ? 'rgba(255, 255, 255, 0.8)' : 'rgba(18, 18, 18, 0.8)'
+			);
+			root.style.setProperty(
+				'--glass-btn-bg-hover',
+				isLight ? 'rgba(255, 255, 255, 0.9)' : 'rgba(30, 30, 30, 0.9)'
+			);
+			root.style.setProperty(
+				'--glass-btn-border',
+				isLight ? 'rgba(0, 0, 0, 0.12)' : 'rgba(255, 255, 255, 0.12)'
+			);
 			// very subtle text outline for readability against background images
-			root.style.setProperty('--text-shadow', isLight ? '0 0 8px rgba(255, 255, 255, 0.6)' : '0 0 8px rgba(0, 0, 0, 0.6)');
+			root.style.setProperty(
+				'--text-shadow',
+				isLight ? '0 0 8px rgba(255, 255, 255, 0.6)' : '0 0 8px rgba(0, 0, 0, 0.6)'
+			);
 			// scrim layer painted over the cover art so foreground text/buttons keep
 			// the contrast floor they were designed for. only applied when the bg is
 			// auto-derived from the playing track — user-chosen custom images are an
@@ -209,8 +220,10 @@
 			root.style.setProperty(
 				'--bg-scrim',
 				isUsingPlayingArtwork
-					? (isLight ? 'rgba(250, 250, 250, 0.65)' : 'rgba(10, 10, 10, 0.65)')
-					: 'transparent',
+					? isLight
+						? 'rgba(250, 250, 250, 0.65)'
+						: 'rgba(10, 10, 10, 0.65)'
+					: 'transparent'
 			);
 		} else {
 			root.style.removeProperty('--bg-image');
@@ -253,6 +266,7 @@
 	let previousVolume = 0.7; // for mute toggle
 
 	function handleKeyboardShortcuts(event: KeyboardEvent) {
+		if (document.querySelector('dialog[open]')) return;
 		// Cmd/Ctrl+K: toggle search
 		if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
 			event.preventDefault();
@@ -374,7 +388,10 @@
 		if (savedAccent) {
 			document.documentElement.style.setProperty('--accent', savedAccent);
 			document.documentElement.style.setProperty('--accent-hover', getHoverColor(savedAccent));
-			document.documentElement.style.setProperty('--accent-contrast', getContrastColor(savedAccent));
+			document.documentElement.style.setProperty(
+				'--accent-contrast',
+				getContrastColor(savedAccent)
+			);
 		}
 
 		// apply saved theme from localStorage
@@ -437,7 +454,10 @@
 	<meta name="theme-color" content="#0a0a0a" />
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-	<link href="https://fonts.googleapis.com/css2?family=Comic+Neue:wght@400;700&family=Geist:wght@300..900&family=Inter:wght@300..900&display=swap" rel="stylesheet" />
+	<link
+		href="https://fonts.googleapis.com/css2?family=Comic+Neue:wght@400;700&family=Geist:wght@300..900&family=Inter:wght@300..900&display=swap"
+		rel="stylesheet"
+	/>
 
 	{#if !hasPageMetadata}
 		<!-- default meta tags for pages without specific metadata -->
@@ -476,52 +496,53 @@
 		// prevent flash by applying saved settings immediately.
 		// inline script — can't import the safe-storage helper, so read via a
 		// local shim (localStorage access throws in sandboxed embeds).
-		(function() {
-				const root = document.documentElement;
-				const getItem = (key) => {
-					try {
-						return localStorage.getItem(key);
-					} catch {
-						return null;
-					}
+		(function () {
+			const root = document.documentElement;
+			const getItem = (key) => {
+				try {
+					return localStorage.getItem(key);
+				} catch {
+					return null;
+				}
+			};
+
+			// apply accent color
+			const savedAccent = getItem('accentColor');
+			if (savedAccent) {
+				root.style.setProperty('--accent', savedAccent);
+				// simple lightening for hover state
+				const r = parseInt(savedAccent.slice(1, 3), 16);
+				const g = parseInt(savedAccent.slice(3, 5), 16);
+				const b = parseInt(savedAccent.slice(5, 7), 16);
+				const hover = `rgb(${Math.min(255, r + 30)}, ${Math.min(255, g + 30)}, ${Math.min(255, b + 30)})`;
+				root.style.setProperty('--accent-hover', hover);
+			}
+
+			// apply font
+			const savedFont = getItem('fontFamily');
+			if (savedFont) {
+				const fonts = {
+					mono: "'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', 'Consolas', monospace",
+					geist: "'Geist', 'Inter', system-ui, sans-serif",
+					inter: "'Inter', system-ui, sans-serif",
+					'system-ui': "system-ui, -apple-system, 'Segoe UI', sans-serif",
+					georgia: "'Georgia', 'Times New Roman', serif",
+					'comic-sans': "'Comic Sans MS', 'Comic Sans', 'Comic Neue', cursive"
 				};
+				if (fonts[savedFont]) root.style.setProperty('--font-family', fonts[savedFont]);
+			}
 
-				// apply accent color
-				const savedAccent = getItem('accentColor');
-				if (savedAccent) {
-					root.style.setProperty('--accent', savedAccent);
-					// simple lightening for hover state
-					const r = parseInt(savedAccent.slice(1, 3), 16);
-					const g = parseInt(savedAccent.slice(3, 5), 16);
-					const b = parseInt(savedAccent.slice(5, 7), 16);
-					const hover = `rgb(${Math.min(255, r + 30)}, ${Math.min(255, g + 30)}, ${Math.min(255, b + 30)})`;
-					root.style.setProperty('--accent-hover', hover);
-				}
-
-				// apply font
-				const savedFont = getItem('fontFamily');
-				if (savedFont) {
-					const fonts = {
-						'mono': "'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', 'Consolas', monospace",
-						'geist': "'Geist', 'Inter', system-ui, sans-serif",
-						'inter': "'Inter', system-ui, sans-serif",
-						'system-ui': "system-ui, -apple-system, 'Segoe UI', sans-serif",
-						'georgia': "'Georgia', 'Times New Roman', serif",
-						'comic-sans': "'Comic Sans MS', 'Comic Sans', 'Comic Neue', cursive",
-					};
-					if (fonts[savedFont]) root.style.setProperty('--font-family', fonts[savedFont]);
-				}
-
-				// apply theme
-				const savedTheme = getItem('theme') || 'dark';
-				let effectiveTheme = savedTheme;
-				if (savedTheme === 'live') {
-					effectiveTheme = 'dark';
-				} else if (savedTheme === 'system') {
-					effectiveTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-				}
-				root.classList.add('theme-' + effectiveTheme);
-
+			// apply theme
+			const savedTheme = getItem('theme') || 'dark';
+			let effectiveTheme = savedTheme;
+			if (savedTheme === 'live') {
+				effectiveTheme = 'dark';
+			} else if (savedTheme === 'system') {
+				effectiveTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
+					? 'dark'
+					: 'light';
+			}
+			root.classList.add('theme-' + effectiveTheme);
 		})();
 	</script>
 </svelte:head>
@@ -603,6 +624,11 @@
 		--text-small: var(--text-base);
 
 		/* border radius scale */
+		--motion-feedback: 140ms;
+		--motion-enter: 200ms;
+		--motion-exit: 140ms;
+		--ease-surface: cubic-bezier(0.2, 0, 0, 1);
+
 		--radius-sm: 4px;
 		--radius-base: 6px;
 		--radius-md: 8px;
@@ -689,7 +715,8 @@
 
 	/* shared animation for active play buttons */
 	@keyframes -global-ethereal-glow {
-		0%, 100% {
+		0%,
+		100% {
 			box-shadow: 0 0 8px 1px color-mix(in srgb, var(--accent) 25%, transparent);
 		}
 		50% {
@@ -719,7 +746,9 @@
 		opacity: 0;
 		z-index: -2;
 		pointer-events: none;
-		transition: opacity 1.5s ease-in-out, background 3s ease-in-out;
+		transition:
+			opacity 1.5s ease-in-out,
+			background 3s ease-in-out;
 	}
 
 	:global(body.ambient-active::after) {
@@ -728,8 +757,15 @@
 	}
 
 	@keyframes -global-ambient-drift {
-		0%, 100% { opacity: 0.35; filter: brightness(1); }
-		50% { opacity: 0.5; filter: brightness(1.08); }
+		0%,
+		100% {
+			opacity: 0.35;
+			filter: brightness(1);
+		}
+		50% {
+			opacity: 0.5;
+			filter: brightness(1.08);
+		}
 	}
 
 	/* background image with blur effect.
@@ -796,8 +832,6 @@
 		}
 	}
 
-
-
 	@media (max-width: 768px) {
 		.main-content.with-queue {
 			margin-right: 0;
@@ -806,8 +840,5 @@
 		.queue-sidebar {
 			width: 100%;
 		}
-
-
 	}
-
 </style>

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -494,7 +494,8 @@
 										stroke-linecap="round"
 										stroke-linejoin="round"
 										aria-hidden="true"
-										><path d="m16 3 5 5M4 20l5-1L21 7a2.12 2.12 0 0 0-3-3L6 16l-2 4Z" /></svg
+										><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+										<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" /></svg
 									>
 								</button>
 							{/if}
@@ -744,7 +745,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		gap: 0.5rem;
+		gap: 1rem;
 		max-width: 100%;
 	}
 	.track-title-row .edit-track-button {
@@ -757,17 +758,15 @@
 		min-height: 44px;
 		padding: 0.5rem;
 		border: none;
-		border-radius: var(--radius-full);
+		border-radius: var(--radius-md);
 		background: transparent;
 		color: var(--text-secondary);
 		cursor: pointer;
 		transition:
-			background var(--motion-feedback) ease-out,
 			color var(--motion-feedback) ease-out,
 			transform var(--motion-feedback) ease-out;
 	}
 	.edit-track-button:hover {
-		background: color-mix(in srgb, var(--accent) 10%, transparent);
 		color: var(--accent);
 	}
 	.edit-track-button:active {

--- a/frontend/src/routes/track/[id]/+page.svelte
+++ b/frontend/src/routes/track/[id]/+page.svelte
@@ -18,6 +18,7 @@
 	import RichText from '$lib/components/RichText.svelte';
 	import ShareButton from '$lib/components/ShareButton.svelte';
 	import DownloadButton from '$lib/components/DownloadButton.svelte';
+	import EditTrackModal from '$lib/components/EditTrackModal.svelte';
 	import { requestTrackDownload } from '$lib/downloads';
 	import { moderation } from '$lib/moderation.svelte';
 	import { player } from '$lib/player.svelte';
@@ -31,7 +32,6 @@
 	import { loginHref, redirectToLogin } from '$lib/utils/auth-redirect';
 	import type { Track } from '$lib/types';
 
-
 	// receive server-loaded data
 	let { data }: { data: PageData } = $props();
 
@@ -39,14 +39,18 @@
 	// refetch below fills it in for the owner, or flips `notFound`.
 	let track = $state<Track | null>(data.track);
 	let notFound = $state(false);
+	let editingTrack = $state<Track | null>(null);
+	let isOwner = $derived(
+		auth.isAuthenticated && auth.user?.did != null && auth.user.did === track?.artist_did
+	);
 	let isAdultLabeled = $derived(
 		track?.labels?.some((label) => label === 'sexual' || label === 'porn') ?? false
 	);
 	let isProcessing = $derived(track ? isAwaitingPlayableRendition(track) : false);
 	let mayPlayAdultAudio = $derived(
 		!isAdultLabeled ||
-		preferences.showSensitiveAudio ||
-		(auth.user?.did != null && auth.user.did === track?.artist_did)
+			preferences.showSensitiveAudio ||
+			(auth.user?.did != null && auth.user.did === track?.artist_did)
 	);
 
 	// the visible cover and the og:image cascade share the same root rule
@@ -88,8 +92,7 @@
 
 	// metadata disclosure panel
 	let metadataOpen = $state(false);
-	const reduceMotion =
-		browser && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+	const reduceMotion = browser && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 	let heartShake = $state(false);
 
 	function nudgeSignIn() {
@@ -140,7 +143,6 @@
 			showLikersTooltip = false;
 		}
 	}
-
 
 	async function loadLikedState() {
 		if (!track) return;
@@ -197,200 +199,199 @@
 		toast.success(`queued ${track.title}`, 1800);
 	}
 
+	// track which track we've loaded data for to detect navigation
+	let loadedForTrackId = $state<number | null>(null);
+	// track if we've loaded liked state for this track (separate from general load)
+	let likedStateLoadedForTrackId = $state<number | null>(null);
 
+	// pending seek time from ?t= URL param (milliseconds)
+	let pendingSeekMs = $state<number | null>(null);
 
-// track which track we've loaded data for to detect navigation
-let loadedForTrackId = $state<number | null>(null);
-// track if we've loaded liked state for this track (separate from general load)
-let likedStateLoadedForTrackId = $state<number | null>(null);
+	// reload data when navigating between track pages
+	// watch data.track.id (from server) not track.id (local state)
+	$effect(() => {
+		const currentId = data.track?.id;
+		if (!currentId || !browser) return;
 
-// pending seek time from ?t= URL param (milliseconds)
-let pendingSeekMs = $state<number | null>(null);
+		// check if we navigated to a different track
+		if (loadedForTrackId !== currentId) {
+			editingTrack = null;
+			// reset state for new track (comments reset themselves — the
+			// TrackComments component reloads on track.id change)
+			likedStateLoadedForTrackId = null; // reset liked state tracking
+			pendingSeekMs = null; // reset pending seek
 
-// reload data when navigating between track pages
-// watch data.track.id (from server) not track.id (local state)
-$effect(() => {
-	const currentId = data.track?.id;
-	if (!currentId || !browser) return;
+			// sync track from server data
+			track = data.track;
 
-	// check if we navigated to a different track
-	if (loadedForTrackId !== currentId) {
-		// reset state for new track (comments reset themselves — the
-		// TrackComments component reloads on track.id change)
-		likedStateLoadedForTrackId = null; // reset liked state tracking
-		pendingSeekMs = null; // reset pending seek
+			// mark as loaded for this track
+			loadedForTrackId = currentId;
+		}
+	});
 
-		// sync track from server data
-		track = data.track;
+	// separate effect to load liked state when auth becomes available
+	$effect(() => {
+		const currentId = data.track?.id;
+		if (!currentId || !browser) return;
 
-		// mark as loaded for this track
-		loadedForTrackId = currentId;
+		// load liked state when authenticated and haven't loaded for this track yet
+		if (auth.isAuthenticated && likedStateLoadedForTrackId !== currentId) {
+			likedStateLoadedForTrackId = currentId;
+			void loadLikedState();
+		}
+	});
 
-	}
-});
-
-// separate effect to load liked state when auth becomes available
-$effect(() => {
-	const currentId = data.track?.id;
-	if (!currentId || !browser) return;
-
-	// load liked state when authenticated and haven't loaded for this track yet
-	if (auth.isAuthenticated && likedStateLoadedForTrackId !== currentId) {
-		likedStateLoadedForTrackId = currentId;
-		void loadLikedState();
-	}
-});
-
-// SSR loads anonymously, so a private (owner-only) track arrives as null. retry
-// once on the client WITH the session cookie — an owner can read their own
-// private track; anyone else (or logged-out) gets a real 404 → notFound.
-let triedClientFetch = $state(false);
-$effect(() => {
-	if (track || triedClientFetch || !browser) return;
-	triedClientFetch = true;
-	void (async () => {
-		try {
-			const r = await fetch(`${API_URL}/tracks/${$page.params.id}`, {
-				credentials: 'include'
-			});
-			if (r.ok) {
-				track = await r.json();
-			} else {
+	// SSR loads anonymously, so a private (owner-only) track arrives as null. retry
+	// once on the client WITH the session cookie — an owner can read their own
+	// private track; anyone else (or logged-out) gets a real 404 → notFound.
+	let triedClientFetch = $state(false);
+	$effect(() => {
+		if (track || triedClientFetch || !browser) return;
+		triedClientFetch = true;
+		void (async () => {
+			try {
+				const r = await fetch(`${API_URL}/tracks/${$page.params.id}`, {
+					credentials: 'include'
+				});
+				if (r.ok) {
+					track = await r.json();
+				} else {
+					notFound = true;
+				}
+			} catch {
 				notFound = true;
 			}
-		} catch {
-			notFound = true;
-		}
-	})();
-});
+		})();
+	});
 
-let shareUrl = $derived(`${browser ? window.location.origin : ''}/track/${track?.id ?? $page.params.id}`);
+	let shareUrl = $derived(
+		`${browser ? window.location.origin : ''}/track/${track?.id ?? $page.params.id}`
+	);
 
-// handle ?t= timestamp param for deep linking (youtube-style)
-// handle ?ref= param for share link tracking
-onMount(() => {
-	// deep-link seek + share-ref attribution only apply to a track we already
-	// have (public tracks render server-side); private tracks are owner-only and
-	// don't carry these affordances.
-	if (!track) return;
-	const t = $page.url.searchParams.get('t');
-	if (t) {
-		const seconds = parseInt(t, 10);
-		if (!isNaN(seconds) && seconds >= 0) {
-			pendingSeekMs = seconds * 1000;
-			// load the track without auto-playing (browser blocks autoplay without interaction)
-			if (track.gated) {
-				void playTrack(track);
-			} else {
-				queue.playNow(track, false);
+	// handle ?t= timestamp param for deep linking (youtube-style)
+	// handle ?ref= param for share link tracking
+	onMount(() => {
+		// deep-link seek + share-ref attribution only apply to a track we already
+		// have (public tracks render server-side); private tracks are owner-only and
+		// don't carry these affordances.
+		if (!track) return;
+		const t = $page.url.searchParams.get('t');
+		if (t) {
+			const seconds = parseInt(t, 10);
+			if (!isNaN(seconds) && seconds >= 0) {
+				pendingSeekMs = seconds * 1000;
+				// load the track without auto-playing (browser blocks autoplay without interaction)
+				if (track.gated) {
+					void playTrack(track);
+				} else {
+					queue.playNow(track, false);
+				}
 			}
 		}
-	}
 
-	// capture ref for share link tracking
-	const ref = $page.url.searchParams.get('ref');
-	if (ref) {
-		// store ref in player state for attribution on play
-		player.setRef(ref, track.id);
+		// capture ref for share link tracking
+		const ref = $page.url.searchParams.get('ref');
+		if (ref) {
+			// store ref in player state for attribution on play
+			player.setRef(ref, track.id);
 
-		// record click event (fire-and-forget)
-		fetch(`${API_URL}/tracks/${track.id}/ref/${ref}/click`, {
-			method: 'POST',
-			credentials: 'include'
-		}).catch(() => {
-			// silently ignore errors - tracking is best-effort
-		});
-	}
-});
+			// record click event (fire-and-forget)
+			fetch(`${API_URL}/tracks/${track.id}/ref/${ref}/click`, {
+				method: 'POST',
+				credentials: 'include'
+			}).catch(() => {
+				// silently ignore errors - tracking is best-effort
+			});
+		}
+	});
 
-// perform pending seek once track is loaded and ready
-$effect(() => {
-	if (
-		pendingSeekMs !== null &&
-		track != null &&
-		player.currentTrack?.id === track.id &&
-		player.audioElement &&
-		player.audioElement.readyState >= 1
-	) {
-		const seekMs = pendingSeekMs;
-		pendingSeekMs = null;
-		queue.seek(seekMs);
-		// don't auto-play - browser policy blocks it without user interaction
-		// user will click play themselves
-	}
-});
+	// perform pending seek once track is loaded and ready
+	$effect(() => {
+		if (
+			pendingSeekMs !== null &&
+			track != null &&
+			player.currentTrack?.id === track.id &&
+			player.audioElement &&
+			player.audioElement.readyState >= 1
+		) {
+			const seekMs = pendingSeekMs;
+			pendingSeekMs = null;
+			queue.seek(seekMs);
+			// don't auto-play - browser policy blocks it without user interaction
+			// user will click play themselves
+		}
+	});
 </script>
 
 <svelte:head>
 	{#if !track}
 		<title>{APP_NAME}</title>
 	{:else}
-	{#if !player.currentTrack || player.currentTrack.id === track.id}
-		<title>{track.title} - {track.artist}{track.album ? ` • ${track.album.title}` : ''}</title>
-	{/if}
-	<meta
-		name="description"
-		content="{track.title} by {track.artist}{track.album ? ` from ${track.album.title}` : ''} - listen on {APP_NAME}"
-	/>
+		{#if !player.currentTrack || player.currentTrack.id === track.id}
+			<title>{track.title} - {track.artist}{track.album ? ` • ${track.album.title}` : ''}</title>
+		{/if}
+		<meta
+			name="description"
+			content="{track.title} by {track.artist}{track.album
+				? ` from ${track.album.title}`
+				: ''} - listen on {APP_NAME}"
+		/>
 
-	<!-- Open Graph / Facebook -->
-	<meta property="og:type" content="music.song" />
-	<meta property="og:title" content="{track.title} - {track.artist}" />
-	<meta
-		property="og:description"
-		content="{track.artist}{track.album ? ` • ${track.album.title}` : ''}"
-	/>
-	<meta
-		property="og:url"
-		content={`${APP_CANONICAL_URL}/track/${track.id}`}
-	/>
-	<meta property="og:site_name" content={APP_NAME} />
-	<meta property="music:musician" content="{track.artist_handle}" />
-	{#if track.album}
-		<meta property="music:album" content="{track.album.title}" />
-	{/if}
-	<!--
+		<!-- Open Graph / Facebook -->
+		<meta property="og:type" content="music.song" />
+		<meta property="og:title" content="{track.title} - {track.artist}" />
+		<meta
+			property="og:description"
+			content="{track.artist}{track.album ? ` • ${track.album.title}` : ''}"
+		/>
+		<meta property="og:url" content={`${APP_CANONICAL_URL}/track/${track.id}`} />
+		<meta property="og:site_name" content={APP_NAME} />
+		<meta property="music:musician" content={track.artist_handle} />
+		{#if track.album}
+			<meta property="music:album" content={track.album.title} />
+		{/if}
+		<!--
 		og:image cascade — track art → album art → artist avatar → brand logo.
 		always emit SOMETHING so scrapers don't fall back to their own heuristics
 		(favicon, first visible image, or whatever the posting client had cached).
 		see: https://github.com/zzstoatzz/plyr.fm/pull/1257
 	-->
-	<meta property="og:image" content={previewImage} />
-	<meta property="og:image:secure_url" content={previewImage} />
-	{#if previewIsTrackArt}
-		<meta property="og:image:width" content="1200" />
-		<meta property="og:image:height" content="1200" />
-	{/if}
-	<meta property="og:image:alt" content="{track.title} by {track.artist}" />
-	{#if track.r2_url && !isAdultLabeled}
-		<meta property="og:audio" content="{track.r2_url}" />
-		<meta property="og:audio:type" content="audio/{track.file_type}" />
-	{/if}
+		<meta property="og:image" content={previewImage} />
+		<meta property="og:image:secure_url" content={previewImage} />
+		{#if previewIsTrackArt}
+			<meta property="og:image:width" content="1200" />
+			<meta property="og:image:height" content="1200" />
+		{/if}
+		<meta property="og:image:alt" content="{track.title} by {track.artist}" />
+		{#if track.r2_url && !isAdultLabeled}
+			<meta property="og:audio" content={track.r2_url} />
+			<meta property="og:audio:type" content="audio/{track.file_type}" />
+		{/if}
 
-	<!-- Twitter -->
-	<meta name="twitter:card" content="summary_large_image" />
-	<meta name="twitter:title" content="{track.title}" />
-	<meta
-		name="twitter:description"
-		content="{track.artist}{track.album ? ` • ${track.album.title}` : ''}"
-	/>
-	<meta name="twitter:image" content={previewImage} />
+		<!-- Twitter -->
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:title" content={track.title} />
+		<meta
+			name="twitter:description"
+			content="{track.artist}{track.album ? ` • ${track.album.title}` : ''}"
+		/>
+		<meta name="twitter:image" content={previewImage} />
 
-	<!-- oEmbed discovery for embed services like iframely -->
-	<link
-		rel="alternate"
-		type="application/json+oembed"
-		href="{API_URL}/oembed?url={encodeURIComponent(`${APP_CANONICAL_URL}/track/${track.id}`)}"
-		title="{track.title} - {track.artist}"
-	/>
+		<!-- oEmbed discovery for embed services like iframely -->
+		<link
+			rel="alternate"
+			type="application/json+oembed"
+			href="{API_URL}/oembed?url={encodeURIComponent(`${APP_CANONICAL_URL}/track/${track.id}`)}"
+			title="{track.title} - {track.artist}"
+		/>
 
-	<!-- at-tags: map this page to its atproto records (https://tangled.org/chrisshank.com/at-tags/) -->
-	{#if track.atproto_record_uri}
-		<meta name="at:canonical" content={track.atproto_record_uri} />
-	{/if}
-	{#if track.artist_did}
-		<meta name="at:author" content="at://{track.artist_did}" />
-	{/if}
+		<!-- at-tags: map this page to its atproto records (https://tangled.org/chrisshank.com/at-tags/) -->
+		{#if track.atproto_record_uri}
+			<meta name="at:canonical" content={track.atproto_record_uri} />
+		{/if}
+		{#if track.artist_did}
+			<meta name="at:author" content="at://{track.artist_did}" />
+		{/if}
 	{/if}
 </svelte:head>
 
@@ -399,17 +400,19 @@ $effect(() => {
 		<Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={handleLogout} />
 		<main>
 			<div class="track-detail">
-			{#if isAdultLabeled && !mayPlayAdultAudio}
-				<div class="adult-content-warning" role="note">
-					<strong>adult content</strong>
-					<span>this audio has been labeled as sexually explicit and is hidden by default.</span>
-					{#if auth.isAuthenticated}
-						<a href="/settings">enable sensitive audio in settings</a>
-					{:else}
-						<button type="button" onclick={() => redirectToLogin()}>sign in to change this setting</button>
-					{/if}
-				</div>
-			{/if}
+				{#if isAdultLabeled && !mayPlayAdultAudio}
+					<div class="adult-content-warning" role="note">
+						<strong>adult content</strong>
+						<span>this audio has been labeled as sexually explicit and is hidden by default.</span>
+						{#if auth.isAuthenticated}
+							<a href="/settings">enable sensitive audio in settings</a>
+						{:else}
+							<button type="button" onclick={() => redirectToLogin()}
+								>sign in to change this setting</button
+							>
+						{/if}
+					</div>
+				{/if}
 				{#if notFound}
 					<p class="track-missing">track not found</p>
 				{:else}
@@ -418,206 +421,367 @@ $effect(() => {
 			</div>
 		</main>
 	{:else}
-	{#if track.tags && track.tags.length > 0}
-		<TagEffects tags={track.tags} trackTitle={track.title} />
-	{/if}
-	<Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={handleLogout} />
+		{#if track.tags && track.tags.length > 0}
+			<TagEffects tags={track.tags} trackTitle={track.title} />
+		{/if}
+		<Header user={auth.user} isAuthenticated={auth.isAuthenticated} onLogout={handleLogout} />
 
-	<main>
-		<div class="track-detail">
-			<!-- cover art (inherits from album when no per-track image is set) -->
-			<SensitiveImage src={coverUrl} tooltipPosition="center">
-				<div class="cover-art-container">
-					{#if coverUrl}
-						<img src={coverUrl} alt="{track.title} artwork" class="cover-art" />
-					{:else}
-						<div class="cover-art-placeholder">
-							<svg width="120" height="120" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1">
-								<path d="M9 18V5l12-2v13"></path>
-								<circle cx="6" cy="18" r="3"></circle>
-								<circle cx="18" cy="16" r="3"></circle>
-							</svg>
-						</div>
-					{/if}
-				</div>
-			</SensitiveImage>
-
-			<!-- track info wrapper -->
-			<div class="track-info-wrapper">
-				<div class="track-info">
-					<h1 class="track-title">
-						{track.title}
-						{#if isProcessing}
-							<span class="processing-badge" title="still processing — playable shortly">processing</span>
-						{/if}
-						{#if track.gated}
-							<span class="gated-badge" title="supporters only">
-								<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
-									<path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"/>
+		<main>
+			<div class="track-detail">
+				<!-- cover art (inherits from album when no per-track image is set) -->
+				<SensitiveImage src={coverUrl} tooltipPosition="center">
+					<div class="cover-art-container">
+						{#if coverUrl}
+							<img src={coverUrl} alt="{track.title} artwork" class="cover-art" />
+						{:else}
+							<div class="cover-art-placeholder">
+								<svg
+									width="120"
+									height="120"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="1"
+								>
+									<path d="M9 18V5l12-2v13"></path>
+									<circle cx="6" cy="18" r="3"></circle>
+									<circle cx="18" cy="16" r="3"></circle>
 								</svg>
-							</span>
-						{/if}
-					</h1>
-					<div class="track-metadata">
-						<a href="/u/{track.artist_handle}" class="artist-link">
-							{track.artist}
-						</a>
-						{#if track.features && track.features.length > 0}
-							<span class="separator">•</span>
-							<span class="features">
-								<span class="features-label">feat.</span>
-								{#each track.features as feature, i}
-									{#if i > 0}<span class="feature-separator">, </span>{/if}
-									<a href="/u/{feature.handle}" class="feature-link">
-										{feature.display_name}
-									</a>
-								{/each}
-							</span>
-						{/if}
-						{#if track.album}
-							<span class="separator">•</span>
-							<a href="/u/{track.artist_handle}/album/{track.album.slug}" class="album album-link">
-								<svg class="album-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-									<rect x="2" y="2" width="12" height="12" stroke="currentColor" stroke-width="1.5" fill="none"/>
-									<circle cx="8" cy="8" r="2.5" fill="currentColor"/>
-								</svg>
-								<span class="album-title-text">{track.album.title}</span>
-							</a>
+							</div>
 						{/if}
 					</div>
+				</SensitiveImage>
 
-					{#if track.tags && track.tags.length > 0}
-						<div class="track-tags">
-							{#each track.tags as tag}
-								<a href="/tag/{encodeURIComponent(tag)}" class="tag-badge">{tag}</a>
-							{/each}
-						</div>
-					{/if}
+				<!-- track info wrapper -->
+				<div class="track-info-wrapper">
+					<div class="track-info">
+						<div class="track-title-row">
+							<h1 class="track-title">
+								{track.title}
+								{#if isProcessing}
+									<span class="processing-badge" title="still processing — playable shortly"
+										>processing</span
+									>
+								{/if}
+								{#if track.gated}
+									<span class="gated-badge" title="supporters only">
+										<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+											<path
+												d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"
+											/>
+										</svg>
+									</span>
+								{/if}
+							</h1>
 
-					<!-- controls: like · play · queue (nate's sketch, 2026-08) -->
-					<div class="track-actions">
-						<div class="like-chip">
-							{#if auth.isAuthenticated}
-								<AddToMenu
-									trackId={track.id}
-									trackTitle={track.title}
-									trackUri={track.atproto_record_uri}
-									trackCid={track.atproto_record_cid}
-									fileId={track.file_id}
-									gated={track.gated}
-									initialLiked={track.is_liked || false}
-									onLikeChange={(liked) => {
-										if (track) {
-											track.like_count = (track.like_count || 0) + (liked ? 1 : -1);
-											track.is_liked = liked;
-										}
+							{#if isOwner}
+								<button
+									class="edit-track-button"
+									type="button"
+									aria-label="edit track"
+									title="edit track"
+									onclick={() => {
+										editingTrack = track;
 									}}
-								/>
-							{:else}
-								<button class="heart-static" class:shake={heartShake} onclick={nudgeSignIn} aria-label="sign in to like tracks" title="sign in to like tracks">
-									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-										<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
-									</svg>
+								>
+									<svg
+										width="20"
+										height="20"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="1.75"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										aria-hidden="true"
+										><path d="m16 3 5 5M4 20l5-1L21 7a2.12 2.12 0 0 0-3-3L6 16l-2 4Z" /></svg
+									>
 								</button>
 							{/if}
-							{#if track.like_count && track.like_count > 0}
-							<span
-								in:scale={{ start: 0.5, duration: reduceMotion ? 0 : 260, easing: backOut }}
-								class="likes"
-								role="button"
-								tabindex="0"
-								aria-label={`${track.like_count} ${track.like_count === 1 ? 'like' : 'likes'} (focus to view users)`}
-								aria-expanded={showLikersTooltip}
-								onclick={handleLikesClick}
-								onmouseenter={handleLikesMouseEnter}
-								onmouseleave={handleLikesMouseLeave}
-								onfocus={handleLikesMouseEnter}
-								onblur={handleLikesMouseLeave}
-								onkeydown={handleLikesKeydown}
-							>
-								{#key track.like_count}
-									<span class="likes-num" in:fly={{ y: 9, duration: reduceMotion ? 0 : 220 }}>{track.like_count}</span>
-								{/key}
-								{#if showLikersTooltip && !isMobile}
-									<LikersTooltip
-										trackId={track.id}
-										likeCount={track.like_count}
-										onMouseEnter={handleLikesMouseEnter}
-										onMouseLeave={handleLikesMouseLeave}
-									/>
-								{/if}
-							</span>
-						{/if}
 						</div>
-						<button class="btn-play" class:playing={isCurrentlyPlaying} disabled={isProcessing && !isCurrentlyPlaying} onclick={handlePlay} aria-label={isProcessing && !isCurrentlyPlaying ? 'still processing — playable shortly' : isCurrentlyPlaying ? 'pause' : 'play'} title={isProcessing && !isCurrentlyPlaying ? 'still processing — playable shortly' : isCurrentlyPlaying ? 'pause' : 'play'}>
-							{#if isCurrentlyPlaying}
-								<svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor">
-									<path d="M6 4h4v16H6zM14 4h4v16h-4z"/>
-								</svg>
-							{:else}
-								<svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor">
-									<path d="M8 5v14l11-7z"/>
-								</svg>
+						<div class="track-metadata">
+							<a href="/u/{track.artist_handle}" class="artist-link">
+								{track.artist}
+							</a>
+							{#if track.features && track.features.length > 0}
+								<span class="separator">•</span>
+								<span class="features">
+									<span class="features-label">feat.</span>
+									{#each track.features as feature, i}
+										{#if i > 0}<span class="feature-separator">, </span>{/if}
+										<a href="/u/{feature.handle}" class="feature-link">
+											{feature.display_name}
+										</a>
+									{/each}
+								</span>
 							{/if}
-						</button>
-						<button class="btn-queue" onclick={addToQueue} aria-label="add to queue" title="add to queue">
-							<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<line x1="5" y1="15" x2="5" y2="21"></line>
-								<line x1="2" y1="18" x2="8" y2="18"></line>
-								<line x1="9" y1="6" x2="21" y2="6"></line>
-								<line x1="9" y1="12" x2="21" y2="12"></line>
-								<line x1="9" y1="18" x2="21" y2="18"></line>
-							</svg>
-						</button>
-					</div>
-
-					<div class="track-stats">
-						<span class="plays">{track.play_count} {track.play_count === 1 ? 'listen' : 'listens'}</span>
-						<LosslessBadge originalFileType={track.original_file_type} fileType={track.file_type} withSeparator separatorClass="separator" />
-						{#if track.description}
-							<span class="separator">•</span>
-							<button
-								class="metadata-toggle"
-								class:open={metadataOpen}
-								onclick={() => metadataOpen = !metadataOpen}
-								aria-label={metadataOpen ? 'hide details' : 'show details'}
-								aria-expanded={metadataOpen}
-							>i</button>
-						{/if}
-					</div>
-
-					{#if track.description && metadataOpen}
-						<div class="metadata-panel" transition:slide={{ duration: 200 }}>
-							<p class="metadata-description"><RichText text={track.description} /></p>
+							{#if track.album}
+								<span class="separator">•</span>
+								<a
+									href="/u/{track.artist_handle}/album/{track.album.slug}"
+									class="album album-link"
+								>
+									<svg
+										class="album-icon"
+										viewBox="0 0 16 16"
+										fill="none"
+										xmlns="http://www.w3.org/2000/svg"
+									>
+										<rect
+											x="2"
+											y="2"
+											width="12"
+											height="12"
+											stroke="currentColor"
+											stroke-width="1.5"
+											fill="none"
+										/>
+										<circle cx="8" cy="8" r="2.5" fill="currentColor" />
+									</svg>
+									<span class="album-title-text">{track.album.title}</span>
+								</a>
+							{/if}
 						</div>
-					{/if}
 
-					<div class="side-buttons">
-						<ShareButton url={shareUrl} title="share track" trackId={track.id} />
-						{#if track.downloadable}
-							<DownloadButton
-								onDownload={() =>
-									track &&
-									requestTrackDownload(track.file_id, {
-										artistName: track.artist,
-										artistDid: track.artist_did,
-										policy: track.download_policy,
-										supportUrl: track.artist_support_url
-									})}
-							/>
+						{#if track.tags && track.tags.length > 0}
+							<div class="track-tags">
+								{#each track.tags as tag}
+									<a href="/tag/{encodeURIComponent(tag)}" class="tag-badge">{tag}</a>
+								{/each}
+							</div>
 						{/if}
-						<TrackComments {track} />
+
+						<!-- controls: like · play · queue (nate's sketch, 2026-08) -->
+						<div class="track-actions">
+							<div class="like-chip">
+								{#if auth.isAuthenticated}
+									<AddToMenu
+										trackId={track.id}
+										trackTitle={track.title}
+										trackUri={track.atproto_record_uri}
+										trackCid={track.atproto_record_cid}
+										fileId={track.file_id}
+										gated={track.gated}
+										initialLiked={track.is_liked || false}
+										onLikeChange={(liked) => {
+											if (track) {
+												track.like_count = (track.like_count || 0) + (liked ? 1 : -1);
+												track.is_liked = liked;
+											}
+										}}
+									/>
+								{:else}
+									<button
+										class="heart-static"
+										class:shake={heartShake}
+										onclick={nudgeSignIn}
+										aria-label="sign in to like tracks"
+										title="sign in to like tracks"
+									>
+										<svg
+											width="16"
+											height="16"
+											viewBox="0 0 24 24"
+											fill="none"
+											stroke="currentColor"
+											stroke-width="2"
+											stroke-linecap="round"
+											stroke-linejoin="round"
+										>
+											<path
+												d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"
+											></path>
+										</svg>
+									</button>
+								{/if}
+								{#if track.like_count && track.like_count > 0}
+									<span
+										in:scale={{ start: 0.5, duration: reduceMotion ? 0 : 260, easing: backOut }}
+										class="likes"
+										role="button"
+										tabindex="0"
+										aria-label={`${track.like_count} ${track.like_count === 1 ? 'like' : 'likes'} (focus to view users)`}
+										aria-expanded={showLikersTooltip}
+										onclick={handleLikesClick}
+										onmouseenter={handleLikesMouseEnter}
+										onmouseleave={handleLikesMouseLeave}
+										onfocus={handleLikesMouseEnter}
+										onblur={handleLikesMouseLeave}
+										onkeydown={handleLikesKeydown}
+									>
+										{#key track.like_count}
+											<span class="likes-num" in:fly={{ y: 9, duration: reduceMotion ? 0 : 220 }}
+												>{track.like_count}</span
+											>
+										{/key}
+										{#if showLikersTooltip && !isMobile}
+											<LikersTooltip
+												trackId={track.id}
+												likeCount={track.like_count}
+												onMouseEnter={handleLikesMouseEnter}
+												onMouseLeave={handleLikesMouseLeave}
+											/>
+										{/if}
+									</span>
+								{/if}
+							</div>
+							<button
+								class="btn-play"
+								class:playing={isCurrentlyPlaying}
+								disabled={isProcessing && !isCurrentlyPlaying}
+								onclick={handlePlay}
+								aria-label={isProcessing && !isCurrentlyPlaying
+									? 'still processing — playable shortly'
+									: isCurrentlyPlaying
+										? 'pause'
+										: 'play'}
+								title={isProcessing && !isCurrentlyPlaying
+									? 'still processing — playable shortly'
+									: isCurrentlyPlaying
+										? 'pause'
+										: 'play'}
+							>
+								{#if isCurrentlyPlaying}
+									<svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor">
+										<path d="M6 4h4v16H6zM14 4h4v16h-4z" />
+									</svg>
+								{:else}
+									<svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor">
+										<path d="M8 5v14l11-7z" />
+									</svg>
+								{/if}
+							</button>
+							<button
+								class="btn-queue"
+								onclick={addToQueue}
+								aria-label="add to queue"
+								title="add to queue"
+							>
+								<svg
+									width="20"
+									height="20"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+								>
+									<line x1="5" y1="15" x2="5" y2="21"></line>
+									<line x1="2" y1="18" x2="8" y2="18"></line>
+									<line x1="9" y1="6" x2="21" y2="6"></line>
+									<line x1="9" y1="12" x2="21" y2="12"></line>
+									<line x1="9" y1="18" x2="21" y2="18"></line>
+								</svg>
+							</button>
+						</div>
+
+						<div class="track-stats">
+							<span class="plays"
+								>{track.play_count} {track.play_count === 1 ? 'listen' : 'listens'}</span
+							>
+							<LosslessBadge
+								originalFileType={track.original_file_type}
+								fileType={track.file_type}
+								withSeparator
+								separatorClass="separator"
+							/>
+							{#if track.description}
+								<span class="separator">•</span>
+								<button
+									class="metadata-toggle"
+									class:open={metadataOpen}
+									onclick={() => (metadataOpen = !metadataOpen)}
+									aria-label={metadataOpen ? 'hide details' : 'show details'}
+									aria-expanded={metadataOpen}>i</button
+								>
+							{/if}
+						</div>
+
+						{#if track.description && metadataOpen}
+							<div class="metadata-panel" transition:slide={{ duration: 200 }}>
+								<p class="metadata-description"><RichText text={track.description} /></p>
+							</div>
+						{/if}
+
+						<div class="side-buttons">
+							<ShareButton url={shareUrl} title="share track" trackId={track.id} />
+							{#if track.downloadable}
+								<DownloadButton
+									onDownload={() =>
+										track &&
+										requestTrackDownload(track.file_id, {
+											artistName: track.artist,
+											artistDid: track.artist_did,
+											policy: track.download_policy,
+											supportUrl: track.artist_support_url
+										})}
+								/>
+							{/if}
+							<TrackComments {track} />
+						</div>
 					</div>
 				</div>
 			</div>
-		</div>
-
-
-	</main>
+		</main>
 	{/if}
 </div>
 
+{#if editingTrack && isOwner}
+	{#key editingTrack.id}
+		<EditTrackModal
+			track={editingTrack}
+			onClose={() => {
+				editingTrack = null;
+			}}
+			onSaved={(updated) => {
+				if (track?.id === updated.id) track = updated;
+			}}
+		/>
+	{/key}
+{/if}
+
 <style>
+	.track-title-row {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		max-width: 100%;
+	}
+	.track-title-row .edit-track-button {
+		flex-shrink: 0;
+	}
+	.edit-track-button {
+		display: grid;
+		place-items: center;
+		min-width: 44px;
+		min-height: 44px;
+		padding: 0.5rem;
+		border: none;
+		border-radius: var(--radius-full);
+		background: transparent;
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition:
+			background var(--motion-feedback) ease-out,
+			color var(--motion-feedback) ease-out,
+			transform var(--motion-feedback) ease-out;
+	}
+	.edit-track-button:hover {
+		background: color-mix(in srgb, var(--accent) 10%, transparent);
+		color: var(--accent);
+	}
+	.edit-track-button:active {
+		transform: scale(0.94);
+	}
+	.edit-track-button:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.edit-track-button {
+			transition: none;
+		}
+	}
 	.track-missing {
 		text-align: center;
 		color: var(--text-muted);
@@ -700,6 +864,8 @@ $effect(() => {
 	}
 
 	.track-title {
+		min-width: 0;
+		overflow-wrap: anywhere;
 		font-size: 2rem;
 		font-weight: 700;
 		color: var(--text-primary);
@@ -852,11 +1018,22 @@ $effect(() => {
 	}
 
 	@keyframes head-shake {
-		0%, 100% { transform: translateX(0); }
-		20% { transform: translateX(-4px); }
-		40% { transform: translateX(4px); }
-		60% { transform: translateX(-3px); }
-		80% { transform: translateX(3px); }
+		0%,
+		100% {
+			transform: translateX(0);
+		}
+		20% {
+			transform: translateX(-4px);
+		}
+		40% {
+			transform: translateX(4px);
+		}
+		60% {
+			transform: translateX(-3px);
+		}
+		80% {
+			transform: translateX(3px);
+		}
 	}
 
 	@media (prefers-reduced-motion: reduce) {
@@ -882,10 +1059,18 @@ $effect(() => {
 	}
 
 	@keyframes heart-beat {
-		0% { transform: scale(1); }
-		35% { transform: scale(1.35); }
-		65% { transform: scale(0.92); }
-		100% { transform: scale(1); }
+		0% {
+			transform: scale(1);
+		}
+		35% {
+			transform: scale(1.35);
+		}
+		65% {
+			transform: scale(0.92);
+		}
+		100% {
+			transform: scale(1);
+		}
 	}
 
 	.likes-num {
@@ -911,7 +1096,9 @@ $effect(() => {
 		padding: 0.125rem 0.25rem;
 		margin: -0.125rem -0.25rem;
 		border-radius: var(--radius-sm);
-		transition: background 0.15s, color 0.15s;
+		transition:
+			background 0.15s,
+			color 0.15s;
 	}
 
 	.like-chip .likes:hover,
@@ -936,7 +1123,9 @@ $effect(() => {
 		background: none;
 		font-family: inherit;
 		line-height: 1;
-		transition: color 0.15s, border-color 0.15s;
+		transition:
+			color 0.15s,
+			border-color 0.15s;
 		padding: 0;
 	}
 

--- a/loq.toml
+++ b/loq.toml
@@ -127,7 +127,7 @@ max_lines = 1137
 
 [[rules]]
 path = "frontend/src/lib/queue.svelte.ts"
-max_lines = 1010
+max_lines = 1023
 
 [[rules]]
 path = "frontend/src/routes/+layout.svelte"
@@ -335,7 +335,7 @@ max_lines = 1424
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"
-max_lines = 541
+max_lines = 623
 
 [[rules]]
 path = "frontend/src/routes/track/[[]id[]]/+page.svelte"
@@ -400,3 +400,11 @@ max_lines = 527
 [[rules]]
 path = "docs/internal/contracts/client-api.json"
 max_lines = 8280
+
+[[rules]]
+path = "frontend/src/lib/components/TrackEditForm.svelte"
+max_lines = 528
+
+[[rules]]
+path = "frontend/src/lib/components/track-edit/TrackAudioEditor.svelte"
+max_lines = 555


### PR DESCRIPTION
Owners can edit a track from an edit icon beside its title or from the portal without navigating away. Both entry points use one editor, with common details first, advanced settings below, and immediate updates to the page and player after saving.

<details>
<summary>Implementation and validation</summary>

- Extracts the portal editor into a shared form and focused artwork, access/rights, and audio components; preserves existing capabilities.
- Keeps the owner icon unframed, with space from the title and an invisible 44px hit target.
- Uses a native dialog with focus restoration, unsaved-change dismissal, pending controls, visible errors, phone layout, and reduced motion.
- Establishes shared feedback/entrance/exit timing tokens and documents a prioritized interaction-quality audit.
- Preserves existing copyright records during ordinary detail edits and identifies partial saves.
- Refreshes queue metadata through its optimistic write path; a mutation epoch protects edits against in-flight stale responses.
- Fixes pending-tag save timing, suggestion Escape handling, and input label associations.
- Adds inline audio replacement progress/outcomes through an explicit uploader callback.

Validation: 230 frontend unit tests and all 39 Storybook accessibility tests pass; Svelte check reports zero errors/warnings; lint passes. Browser verification covered owner/non-owner/signed-out access, portal and track entry points, save/error/discard, focus, playback shortcut isolation, 320/390/1280px widths, both themes, reduced motion, and inline audio failure. Axe reported no violations in the editor in dark/light themes with advanced sections expanded. Network writes were intercepted during browser checks; no real listener queue or track was modified. The stale-response regression failed without the mutation guard and passes with it.

This begins adoption of the interaction conventions; it does not migrate every existing modal or add native iOS haptics. No backend change or database migration.
</details>
