### PR TITLE
Require audio self-review and peer listening before musician uploads

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -553,3 +553,14 @@ is September 7 at 06:17 UTC. Deployed source and runs are recorded in Prefect; t
 must stay disabled. Model understanding of audio and title quality remain
 unproven; generated names are still formulaic. Current public display names have
 not been overwritten by the local account-name defaults.
+
+### September 7 — require listening before publication
+
+Nate clarified that every musical review must interpret actual audio, including
+self-review, a rendered revision and second listen, and peer feedback with the
+author's known inspirations. The old schedule and heartbeat were paused and all
+three queued runs cancelled. Native Gemini audio review and host-recorded release
+evidence now enforce this requirement locally; Luna is only the Python helper.
+The full live revision cycle is pending. Controls found real perception errors;
+model support for audio is not proof of accurate musical judgment. Diagnostic
+costs are retained in the same worker ledger, and caps are unchanged.

--- a/services/musician-studio/README.md
+++ b/services/musician-studio/README.md
@@ -1,110 +1,95 @@
-> The schedule is paused pending a complete native-audio revision run. The
-> September 7 change adds mandatory audio review; the earlier code-only run
-> below is historical evidence of publishing, not listening.
-
 # musician studio
 
-Moss, Kite, and Reed make ten-second pieces with Luna through Pi. Each has a
-persisted identity with named musical inspirations, specific works, reasons for
-those choices, and an experiment to try. Their generated Python runs in a
-container with NumPy and the standard library. They receive up to three earlier
-compositions and one published peer's work, including source and intentions.
-This is code-based study; it is not reliable audio perception.
+The schedule is paused until a complete native-audio revision cycle is verified.
+The former code-only review loop is disabled and its queued runs were cancelled.
 
-The bot project's voice work informed the identity setup: influences and
-self-authored personality are separate from operational rules. See bot commits
-3a5f576 and 60f3b55. A valid response or a rendered file does not establish good
-music. Titles remain formulaic and human listening is still needed.
+Moss, Kite, and Reed have persistent identities with named musical inspirations,
+specific works, reasons for those choices, and experiments to try. Gemini 3.5
+Flash receives the actual WAV and makes musical judgments. Luna implements
+Python drafts and requested revisions; it cannot approve a release or decide
+what belongs in a playlist. Reading code is not listening.
 
-The original score-entry experiment was deleted at Nate's request: seven tracks,
-three study playlists, and local/worker compositions. Accounts, avatars, bot
-labels, encrypted credentials, and historical cost reservations were preserved.
-The retired deployment remains disabled. Local identities use account names;
-they have not overwritten the earlier public display names.
+## before publication
 
-## recurring work
+For each ten-second piece, the author listens to the rendered draft and requests
+a revision. The revised audio is rendered and heard again by the author and by
+another musician. Both reviewers receive the author's stated inspirations; each
+also has its own identity and taste. Reviews focus on audible pitch relationships,
+timbre, bass, balance, articulation, and development, with uncertainty stated.
 
-`flow.py:community` runs as `plyr.fm-musician-community/continuous` on the existing
-Prefect `home-pool` worker, heavypad. The schedule is every six hours at :17 UTC.
-A file lock and deployment concurrency limit prevent overlap. SQLite state lives
-at `/home/stoat/prefect-analytics/musician-studio`; a fresh checkout does not reset
-identities, memory, upload reservations, or spending.
+The host records the listener, author, model version, positive audio-token count,
+audio SHA256, and a digest of the supplied inspirations. Those records live in a
+separate table from model-generated composition metadata. Publishing requires a
+different rendered revision, self-approval of that exact revision, and peer audio
+feedback. Missing, stale, text-only, or incomplete evidence blocks uploading. A
+musician declining release keeps the draft unpublished and completes its study.
+The peer can disagree without vetoing the author's work.
 
-Each musician composes, renders, considers publishing, and decides whether to
-keep its selected peer in its listening playlist. Peer selection is weighted by
-persisted taste and curiosity. Optional validated taste/inspiration revisions
-persist for later sessions. A daily upload reservation permits at most one
-upload attempt per musician per UTC day; the other sessions still compose and
-consider peers. Uploads are unlisted, tagged `ai`, and self-labeled `ai-generated`.
-Unlisted tracks retain plyr.fm's existing search and artist-page behavior.
+The artist also hears any selected published peer before deciding whether to
+add it to its playlist. Reviews and compositions persist for later iterations.
+A token receipt proves audio input processing, not accurate musical judgment.
 
-Each session reserves $0.05, with $0.20/day and $5/month available. Failed sessions
-retain reservations, and retries reuse the same session. At most 12 model calls
-are permitted per session; observed spending is checked before another call.
-These are conservative activity limits using estimated model costs, not a hard
-provider billing cap. Hosting, subscriptions, and monitoring are excluded.
-Budget exhaustion skips work until a later UTC budget window. There is no expiry
-date on the schedule. The one-time bootstrap also consumes the same budget.
+## operation and cost
 
-Prefect artifacts `plyr-fm-musician-progress` and `plyr-fm-musician-costs` show
-intentions, memory, track/playlist links, failures, and monthly usage. The first
-replacement scheduled run completed with three uploads and one peer playlist
-addition: https://prefect-server.waow.tech/runs/flow-run/77c97743-2d28-45e0-8bfe-85198e7b8a83
-It used about $0.01225 in estimated model usage. Known local draft and profile
-usage were imported into the worker ledger; early unrecorded probes are not an
-invoice-quality total.
+`flow.py:community` runs as `plyr.fm-musician-community/continuous` on heavypad's
+existing Prefect `home-pool`. One artist takes a turn every six hours at :17 UTC,
+rotating across the roster. SQLite state is stored at
+`/home/stoat/prefect-analytics/musician-studio`; checkouts do not reset memory,
+identities, upload reservations, or spending. A lock and concurrency limit
+prevent overlap.
+
+The unchanged limits are $0.05/session, $0.20/day, and $5/month in reservations,
+with at most 12 model calls/session and one upload attempt/musician/UTC day.
+Failures retain reservations and retries reuse the session. Native audio input,
+output, and thinking costs enter the same ledger as Python generation. Budget
+exhaustion skips work until a later UTC window. These are estimates, not a hard
+provider billing cap; subscriptions, hosting, and monitoring are excluded.
+
+Uploads remain unlisted, tagged `ai`, and self-labeled `ai-generated`. Existing
+unlisted search and artist-page behavior is preserved. Prefect artifacts
+`plyr-fm-musician-progress` and `plyr-fm-musician-costs` show reviews, links,
+failures, and usage. Use direct run links in your own browser.
+
+## validation and limitations
+
+`just check` runs 32 offline tests, including the complete review/revision order,
+repeat recovery, native audio payloads, missing audio-token receipts, changed
+files/inspirations, and missing peer review. A live call through the new client
+returned 250 audio tokens and rejected Moss's draft. The full live revision
+cycle is still pending the next UTC budget window.
+
+`audio-validation.json` retains blind controls: Flash-Lite confused pitched tones
+with noise; 3.8 Flash hallucinated music in silence and then returned 503s. Short
+3.5 temporal answers recognized steady tones and pulses but were truncated by
+the response limit. These probes do not establish reliable perception or good
+music. Titles also remain formulaic. Known diagnostic usage was added to the
+worker ledger: $0.033589, bringing September 7's reserved/charged total to
+$0.187489/$0.20. No limits were raised to run another full session.
+
+The original score-entry experiment's seven tracks, three playlists, and local
+and worker compositions were deleted. Accounts, avatars, bot labels, credentials,
+and historical costs remain. The earlier replacement run
+[77c97743](https://prefect-server.waow.tech/runs/flow-run/77c97743-2d28-45e0-8bfe-85198e7b8a83)
+proved publishing and curation, not listening. Local identity defaults have not
+overwritten the earlier public display names. Bot's influence-choice and
+self-authored personality work informed the identity design (commits 3a5f576
+and 60f3b55).
 
 ## runtime and credentials
 
-Build the image with `just image`. Source executes as non-root with no network,
-a read-only root filesystem, one CPU, 512 MB RAM, a 30-second timeout, and a fresh
-output mount. Host checks require ten seconds of stereo PCM without silence or
-clipping. The worker uses `DOCKER_CONTEXT=default`.
+`just image` builds the execution container. Python runs without network access,
+as non-root with a read-only root filesystem, one CPU, 512 MB RAM, a 30-second
+timeout, and a fresh output mount. The host requires ten-second stereo PCM
+without silence or clipping. Heavypad uses `DOCKER_CONTEXT=default`.
+`uv run python compose.py moss` produces a local, unpublished draft.
 
-`uv run python compose.py moss` runs a local draft without publishing. `just check`
-runs the offline service tests. Deployment uses the my-prefect-server justfile
-and the source commit pinned in `prefect.yaml`.
+The canonical sops store owns all credentials. `provision_tokens.py` derives
+only developer tokens and the existing Gemini key into the encrypted worker
+consumer, verifies equality in memory, and is idempotent. PDS passwords stay in
+the canonical store. `renew_tokens.py --renew-if-needed` renews developer tokens
+within seven days of expiry through normal OAuth and syncs the consumer.
 
-The canonical sops store owns credentials. `provision_tokens.py` derives only
-developer tokens into the worker's encrypted consumer, compares decrypted values
-in memory, and prints no credentials. `renew_tokens.py` checks effective expiry;
-`--renew-if-needed` renews within seven days through normal OAuth and syncs the
-consumer, including after a partial renewal. The local daily monitor runs this
-maintenance command. PDS passwords stay in the canonical local store. Renewal
-network behavior is covered with mocks; current tokens expire October 6 and
-have not been rotated just to test renewal.
-
-## mandatory audio review
-
-Gemini 3.5 Flash receives the actual WAV and the listener's identity, plus the
-author's explicit inspirations. Reviews focus on audible pitch relationships,
-timbre, bass, balance, articulation, and development. Luna implements Python
-changes; it is not the listener and cannot approve publication.
-
-Every release requires an initial self-review, a different rendered revision,
-a self-review approving that exact revision, and another musician's audio
-feedback. The host records audio SHA256, provider model/version, positive audio
-token count, listener/author identities, and the inspirations supplied. Evidence
-is stored separately from generated composition metadata. Missing, truncated,
-text-only, stale, or rejected self-review blocks publication before an upload
-reservation or network request. Curation decisions also come from audio review.
-The feedback persists alongside compositions for future iterations.
-
-One artist takes a turn per six-hour run, rotating across the roster. This leaves
-room for listening and revision under the existing $0.05/session, $0.20/day, and
-$5/month reservation limits. Audio requests, including thinking tokens, enter
-the same ledger. No fallback to code-only approval is allowed. The encrypted
-worker consumer now also derives the existing Gemini key from canonical sops.
-
-`audio-validation.json` records the blind controls. Native audio-token receipts
-confirm input processing, not accuracy: Flash-Lite confused a chord with noise,
-and 3.8 Flash hallucinated music in silence. 3.5 Flash recognized steady tone and
-pulses, but the short response limit truncated temporal descriptions. A real
-Moss review through the new client returned 250 audio tokens and rejected the
-draft. None of this establishes improved musical quality. The full revision
-cycle must be verified before resuming recurring publication.
-
-Audio API: https://ai.google.dev/gemini-api/docs/audio
-Rates checked September 7: https://ai.google.dev/gemini-api/docs/pricing
-Gemini 3.5 Flash standard rates used here are $1.50/million input tokens and
-$9/million output tokens, including thinking. These are estimates, not invoices.
+[Audio API](https://ai.google.dev/gemini-api/docs/audio) and
+[pricing](https://ai.google.dev/gemini-api/docs/pricing), checked September 7:
+Gemini 3.5 Flash standard estimates use $1.50/million input tokens and $9/million
+output tokens including thinking. Pricing is not an invoice.

--- a/services/musician-studio/README.md
+++ b/services/musician-studio/README.md
@@ -1,3 +1,7 @@
+> The schedule is paused pending a complete native-audio revision run. The
+> September 7 change adds mandatory audio review; the earlier code-only run
+> below is historical evidence of publishing, not listening.
+
 # musician studio
 
 Moss, Kite, and Reed make ten-second pieces with Luna through Pi. Each has a
@@ -69,3 +73,38 @@ consumer, including after a partial renewal. The local daily monitor runs this
 maintenance command. PDS passwords stay in the canonical local store. Renewal
 network behavior is covered with mocks; current tokens expire October 6 and
 have not been rotated just to test renewal.
+
+## mandatory audio review
+
+Gemini 3.5 Flash receives the actual WAV and the listener's identity, plus the
+author's explicit inspirations. Reviews focus on audible pitch relationships,
+timbre, bass, balance, articulation, and development. Luna implements Python
+changes; it is not the listener and cannot approve publication.
+
+Every release requires an initial self-review, a different rendered revision,
+a self-review approving that exact revision, and another musician's audio
+feedback. The host records audio SHA256, provider model/version, positive audio
+token count, listener/author identities, and the inspirations supplied. Evidence
+is stored separately from generated composition metadata. Missing, truncated,
+text-only, stale, or rejected self-review blocks publication before an upload
+reservation or network request. Curation decisions also come from audio review.
+The feedback persists alongside compositions for future iterations.
+
+One artist takes a turn per six-hour run, rotating across the roster. This leaves
+room for listening and revision under the existing $0.05/session, $0.20/day, and
+$5/month reservation limits. Audio requests, including thinking tokens, enter
+the same ledger. No fallback to code-only approval is allowed. The encrypted
+worker consumer now also derives the existing Gemini key from canonical sops.
+
+`audio-validation.json` records the blind controls. Native audio-token receipts
+confirm input processing, not accuracy: Flash-Lite confused a chord with noise,
+and 3.8 Flash hallucinated music in silence. 3.5 Flash recognized steady tone and
+pulses, but the short response limit truncated temporal descriptions. A real
+Moss review through the new client returned 250 audio tokens and rejected the
+draft. None of this establishes improved musical quality. The full revision
+cycle must be verified before resuming recurring publication.
+
+Audio API: https://ai.google.dev/gemini-api/docs/audio
+Rates checked September 7: https://ai.google.dev/gemini-api/docs/pricing
+Gemini 3.5 Flash standard rates used here are $1.50/million input tokens and
+$9/million output tokens, including thinking. These are estimates, not invoices.

--- a/services/musician-studio/audio-validation.json
+++ b/services/musician-studio/audio-validation.json
@@ -1,0 +1,215 @@
+{
+  "date": "2026-09-07",
+  "controls": [
+    {
+      "control": "silent",
+      "model": "gemini-3.5-flash-lite",
+      "text": "I hear unpitched broadband noise.",
+      "usage": {
+        "promptTokenCount": 295,
+        "candidatesTokenCount": 7,
+        "totalTokenCount": 302,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 45
+          },
+          {
+            "modality": "AUDIO",
+            "tokenCount": 250
+          }
+        ],
+        "serviceTier": "standard"
+      },
+      "estimated_cost": 0.000106
+    },
+    {
+      "control": "chord",
+      "model": "gemini-3.5-flash-lite",
+      "text": "Unpitched broadband noise. There is uncertainty as to whether it is entirely unpitched.",
+      "usage": {
+        "promptTokenCount": 295,
+        "candidatesTokenCount": 17,
+        "totalTokenCount": 312,
+        "promptTokensDetails": [
+          {
+            "modality": "AUDIO",
+            "tokenCount": 250
+          },
+          {
+            "modality": "TEXT",
+            "tokenCount": 45
+          }
+        ],
+        "serviceTier": "standard"
+      },
+      "estimated_cost": 0.000131
+    },
+    {
+      "control": "noise",
+      "model": "gemini-3.5-flash-lite",
+      "text": "Unpitched broadband noise. I am certain.",
+      "usage": {
+        "promptTokenCount": 295,
+        "candidatesTokenCount": 9,
+        "totalTokenCount": 304,
+        "promptTokensDetails": [
+          {
+            "modality": "AUDIO",
+            "tokenCount": 250
+          },
+          {
+            "modality": "TEXT",
+            "tokenCount": 45
+          }
+        ],
+        "serviceTier": "standard"
+      },
+      "estimated_cost": 0.000111
+    },
+    {
+      "control": "silent",
+      "model": "gemini-3.8-flash",
+      "text": "This recording contains pitched musical tones. A sequence of distinct, melodic, resonant tones plays with clear pitch center and rhythmic repetition. The pitches vary in frequency, creating a short, repeating musical phrase that decays between notes. There is no significant unpitched broadband noise or complete silence. While the tonal quality is unmistakably pitched, there is some uncertainty regarding the exact frequency intervals or whether subtle background acoustic artifacts are present.",
+      "usage": {
+        "promptTokenCount": 295,
+        "candidatesTokenCount": 82,
+        "totalTokenCount": 569,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 45
+          },
+          {
+            "modality": "AUDIO",
+            "tokenCount": 250
+          }
+        ],
+        "thoughtsTokenCount": 192,
+        "serviceTier": "standard"
+      },
+      "estimated_cost": 0.00124875
+    },
+    {
+      "control": "chord",
+      "model": "gemini-3.8-flash",
+      "text": "The recording consists of pitched musical tones, specifically a continuous, low-frequency sustained drone. A steady pitch is audible along with subtle harmonic overtones and a gentle, pulsing amplitude modulation or  beating sensation. It is not silence. It is uncertain whether a faint layer of broadband noise is present beneath the sound, but the dominant, clearly discernible characteristic is a pitched, resonant tone.",
+      "usage": {
+        "promptTokenCount": 295,
+        "candidatesTokenCount": 75,
+        "totalTokenCount": 732,
+        "promptTokensDetails": [
+          {
+            "modality": "AUDIO",
+            "tokenCount": 250
+          },
+          {
+            "modality": "TEXT",
+            "tokenCount": 45
+          }
+        ],
+        "thoughtsTokenCount": 362,
+        "serviceTier": "standard"
+      },
+      "estimated_cost": 0.00186
+    },
+    {
+      "control": "noise",
+      "model": "gemini-3.8-flash",
+      "text": "The recording consists of continuous, unpitched broadband noise. It is a steady, rushing and hissing sound with acoustic energy distributed across a wide frequency spectrum, featuring slight fluctuations in volume throughout. There are no discernible pitched musical tones or periods of silence. It is uncertain what physical source generated this sound, as it could be environmental noise, fluid flow, or electronic static.",
+      "usage": {
+        "promptTokenCount": 295,
+        "candidatesTokenCount": 74,
+        "totalTokenCount": 558,
+        "promptTokensDetails": [
+          {
+            "modality": "AUDIO",
+            "tokenCount": 250
+          },
+          {
+            "modality": "TEXT",
+            "tokenCount": 45
+          }
+        ],
+        "thoughtsTokenCount": 189,
+        "serviceTier": "standard"
+      },
+      "estimated_cost": 0.0012075
+    },
+    {
+      "control": "steady",
+      "model": "gemini-3.5-flash",
+      "text": "The recording features a continuous tone where both the pitch and loudness remain steady and unchanging from 0:00 to 0:09. There are no interruptions, repetitions, or major pitch changes. The sound is completely uniform. There is slight uncertainty regarding any extremely subtle, imperceptible fluctuations, but the signal appears entirely constant.",
+      "usage": {
+        "promptTokenCount": 302,
+        "candidatesTokenCount": 67,
+        "totalTokenCount": 774,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 52
+          },
+          {
+            "modality": "AUDIO",
+            "tokenCount": 250
+          }
+        ],
+        "thoughtsTokenCount": 405,
+        "serviceTier": "standard"
+      },
+      "estimated_cost": 0.004701
+    },
+    {
+      "control": "step",
+      "model": "gemini-3.5-flash",
+      "text": "The recording features a steady tone with constant pitch and loudness from 0:00 to approximately 0:04. A brief period of silence interrupts the sound from about 0:04 to ",
+      "usage": {
+        "promptTokenCount": 302,
+        "candidatesTokenCount": 42,
+        "totalTokenCount": 798,
+        "promptTokensDetails": [
+          {
+            "modality": "AUDIO",
+            "tokenCount": 250
+          },
+          {
+            "modality": "TEXT",
+            "tokenCount": 52
+          }
+        ],
+        "thoughtsTokenCount": 454,
+        "serviceTier": "standard"
+      },
+      "estimated_cost": 0.004917
+    },
+    {
+      "control": "pulse",
+      "model": "gemini-3.5-flash",
+      "text": "The audio consists of a highly regular repetition of short, identical pulses occurring approximately once per second from ",
+      "usage": {
+        "promptTokenCount": 302,
+        "candidatesTokenCount": 20,
+        "totalTokenCount": 798,
+        "promptTokensDetails": [
+          {
+            "modality": "AUDIO",
+            "tokenCount": 250
+          },
+          {
+            "modality": "TEXT",
+            "tokenCount": 52
+          }
+        ],
+        "thoughtsTokenCount": 476,
+        "serviceTier": "standard"
+      },
+      "estimated_cost": 0.004917
+    }
+  ],
+  "limitations": [
+    "Two Gemini 3.8 temporal-control requests returned HTTP 503.",
+    "The 3.5 temporal responses for step and pulse exhausted the 500-token output limit.",
+    "Silence hallucinations and pitch-change errors mean these controls do not establish reliable musical judgment."
+  ],
+  "estimated_probe_cost": 0.01919925
+}

--- a/services/musician-studio/audio_round.py
+++ b/services/musician-studio/audio_round.py
@@ -1,0 +1,94 @@
+"""Listen, revise, listen again, and exchange feedback before publication."""
+
+from pathlib import Path
+
+from compose import compose, render
+from studio.audio_model import listen
+from studio.identity import Musician
+from studio.listening import (
+    ListeningReview,
+    digest,
+    inspiration_digest,
+    require_listening,
+)
+from studio.state import Store
+
+
+def reviewed(
+    store: Store,
+    session: str,
+    author: str,
+    listener: str,
+    path: Path,
+    inspirations: list[dict],
+) -> ListeningReview:
+    for value in store.listening_reviews(session, author):
+        review = ListeningReview.model_validate(value)
+        if (
+            review.listener == listener
+            and review.audio_sha256 == digest(path)
+            and review.inspirations_sha256 == inspiration_digest(inspirations)
+        ):
+            return review
+    return listen(store, session, author, listener, path, inspirations)
+
+
+def prepare_release(directory: Path, session: str, name: str, draft_path: Path) -> Path:
+    store = Store(directory)
+    study = store.study(session, name)
+    profile = Musician.model_validate(store.musicians()[name]["profile"])
+    inspirations = study.get("review_inspirations") or [
+        i.model_dump() for i in profile.inspirations
+    ]
+    store.save_study(session, name, {"review_inspirations": inspirations})
+    if not study.get("draft_audio_sha256"):
+        feedback = reviewed(store, session, name, name, draft_path, inspirations)
+        revision = compose(
+            profile,
+            [study],
+            store,
+            session,
+            musician_id=name,
+            revision=feedback.observations + "\n" + feedback.changes,
+        )
+        revised_path = directory / f"{session}-{name}" / "revision"
+        metrics = render(revision.python, revised_path)
+        store.save_study(
+            session,
+            name,
+            {
+                **revision.model_dump(),
+                "rendered": True,
+                "metrics": metrics,
+                "draft_audio_sha256": digest(draft_path),
+                "audio_path": str((revised_path / "track.wav").relative_to(directory)),
+            },
+        )
+    study = store.study(session, name)
+    path = directory / study["audio_path"]
+    own = reviewed(store, session, name, name, path, inspirations)
+    names = sorted(store.musicians())
+    peer_name = names[(names.index(name) + 1) % len(names)]
+    peer = reviewed(store, session, name, peer_name, path, inspirations)
+    store.save_study(
+        session, name, {"audio_feedback": [own.model_dump(), peer.model_dump()]}
+    )
+    selected = study.get("peer")
+    if selected:
+        peer_study = store.study(selected["work"]["session"], selected["id"])
+        peer_path = directory / peer_study.get(
+            "audio_path",
+            f"{selected['work']['session']}-{selected['id']}/audio/track.wav",
+        )
+        selection = reviewed(
+            store, session, selected["id"], name, peer_path, selected["inspirations"]
+        )
+        store.save_study(
+            session,
+            name,
+            {"keep_peer": selection.ready, "peer_note": selection.observations},
+        )
+    require_listening(
+        store.study(session, name), name, path, store.listening_reviews(session, name)
+    )
+    return path

--- a/services/musician-studio/compose.py
+++ b/services/musician-studio/compose.py
@@ -43,6 +43,7 @@ def compose(
     *,
     musician_id: str | None = None,
     peer: dict | None = None,
+    revision: str | None = None,
 ) -> Composition:
     prompt = (
         "Make a ten-second piece of music as this musician. Use Python and numpy to create the audio. "
@@ -62,6 +63,8 @@ def compose(
         "to a short reason. Set MEMORY to what you want your future self to remember about this piece. "
         "If your preferences or influences have changed, optionally include TASTE (a literal dictionary using your existing dimensions) "
         "or INSPIRATIONS (a literal list using the existing inspiration fields). Otherwise omit them. "
+        + "\nAudio review instructions for this revision: "
+        + (revision or "First draft; audio review follows rendering.")
         + "\nReturn only executable Python source, no JSON or markdown. Include TITLE and IDEA as string constants."
     )
     if len(prompt.encode()) > 48000:

--- a/services/musician-studio/flow.py
+++ b/services/musician-studio/flow.py
@@ -11,9 +11,11 @@ from prefect.artifacts import create_markdown_artifact
 from prefect.cache_policies import NO_CACHE
 from prefect.states import Completed, State
 
+from audio_round import prepare_release
 from compose import Composition, compose, render
 from studio.context import choose_peer
 from studio.identity import Musician
+from studio.listening import NotReady
 from studio.platform import Platform, credentials
 from studio.state import Store
 
@@ -94,6 +96,16 @@ def render_piece(directory: Path, session: str, name: str) -> Path:
 
 
 @task(
+    name="listen-revise-and-peer-review",
+    task_run_name="{name}-audio-review",
+    cache_policy=NO_CACHE,
+    persist_result=False,
+)
+def review_audio(directory: Path, session: str, name: str, path: Path) -> Path:
+    return prepare_release(directory, session, name, path)
+
+
+@task(
     name="publish-unlisted",
     task_run_name="{name}-publish",
     cache_policy=NO_CACHE,
@@ -152,6 +164,11 @@ def report(store: Store, session: str | None, errors: list[str]) -> None:
             notes.append(
                 f"## {name}: {study.get('title', 'unfinished')}\n\n{study.get('idea', '')}\n\n"
                 f"Memory: {study.get('memory', '')}\n\n"
+                + "\n\n".join(
+                    f"Audio review by {r['listener']} ({r['model']}, {r['audio_tokens']} audio tokens): {r['observations']} Next: {r['changes']}"
+                    for r in study.get("audio_feedback", [])
+                )
+                + "\n\n"
                 + (
                     f"Studied {peer['name']}: {study.get('peer_note', '')}\n\n"
                     if peer
@@ -209,12 +226,19 @@ def community(retry_failed: bool = False, bootstrap: bool = False) -> State:
                 name="Skipped", message="Session slot or estimated budget unavailable"
             )
         try:
-            for name in seed(directory):
+            names = seed(directory)
+            now = datetime.now(UTC)
+            selected = names[(now.toordinal() * 4 + now.hour // 6) % len(names)]
+            for name in [selected]:
                 try:
                     compose_piece(directory, session, name)
                     audio = render_piece(directory, session, name)
+                    audio = review_audio(directory, session, name, audio)
                     publish_piece(directory, session, name, audio)
                     curate_peer(directory, session, name)
+                except NotReady as exc:
+                    store.save_study(session, name, {"withheld": True})
+                    logger.info("%s: %s", name, exc)
                 except Exception as exc:
                     errors.append(f"{name}: {type(exc).__name__}: {exc}")
                     logger.exception("Musician %s failed", name)
@@ -226,6 +250,4 @@ def community(retry_failed: bool = False, bootstrap: bool = False) -> State:
             raise
         finally:
             report(store, session, errors)
-    return Completed(
-        message="Musicians composed, published, and considered peer curation"
-    )
+    return Completed(message="Music study finished; publication follows audio review")

--- a/services/musician-studio/prefect.yaml
+++ b/services/musician-studio/prefect.yaml
@@ -16,7 +16,7 @@ deployments:
     schedules:
       - cron: "17 */6 * * *"
         timezone: UTC
-        active: true
+        active: false
     work_pool:
       name: home-pool
       job_variables:

--- a/services/musician-studio/prefect.yaml
+++ b/services/musician-studio/prefect.yaml
@@ -3,7 +3,7 @@ pull:
   - prefect.deployments.steps.git_clone:
       id: checkout
       repository: https://github.com/zzstoatzz/plyr.fm.git
-      commit_sha: 8b76d4298585a60499b993f758aab62cfd30eaa1
+      commit_sha: 48021d38ff5c86ba0727b6b58698c902aa4b0ee6
   - prefect.deployments.steps.set_working_directory:
       directory: "{{ checkout.directory }}/services/musician-studio"
 deployments:

--- a/services/musician-studio/provision_tokens.py
+++ b/services/musician-studio/provision_tokens.py
@@ -12,6 +12,7 @@ raw = subprocess.run(
 )
 entries = json.loads(raw.stdout)["atproto"]["agent_musicians"]
 subset = {name: {"plyr_token": entry["plyr_token"]} for name, entry in entries.items()}
+subset["gemini_api_key"] = json.loads(raw.stdout)["local"]["gemini_api_key"]
 current = subprocess.run(
     [
         "ssh",
@@ -68,5 +69,5 @@ verify = subprocess.run(
 )
 assert json.loads(verify.stdout) == subset
 print(
-    f"{len(subset)} encrypted musician tokens provisioned and equality verified on heavypad."
+    f"{len(entries)} encrypted musician tokens and audio credential provisioned and equality verified on heavypad."
 )

--- a/services/musician-studio/studio/audio_model.py
+++ b/services/musician-studio/studio/audio_model.py
@@ -1,0 +1,131 @@
+"""Send rendered sound to a multimodal musician and retain host-side evidence."""
+
+import base64
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import httpx
+from pydantic import BaseModel, Field
+
+from studio.context import musical_identity
+from studio.identity import Musician
+from studio.listening import ListeningReview, inspiration_digest, record_review
+from studio.state import Store
+
+MODEL = "gemini-3.5-flash"
+
+
+class Feedback(BaseModel):
+    observations: str = Field(min_length=20)
+    changes: str = Field(min_length=10)
+    ready: bool
+
+
+def key() -> str:
+    path = os.environ["STUDIO_CREDENTIALS_FILE"]
+    raw = subprocess.run(
+        ["sops", "-d", "--output-type", "json", path],
+        capture_output=True,
+        check=True,
+        timeout=30,
+    )
+    values = json.loads(raw.stdout)
+    return values.get("gemini_api_key") or values["local"]["gemini_api_key"]
+
+
+def listen(
+    store: Store,
+    session: str,
+    author: str,
+    listener: str,
+    path: Path,
+    inspirations: list[dict],
+) -> ListeningReview:
+    profile = Musician.model_validate(store.musicians()[listener]["profile"])
+    prompt = (
+        "Listen to the attached ten-second recording as this musician: "
+        + json.dumps(musical_identity(profile))
+        + ". The author's stated inspirations are: "
+        + json.dumps(inspirations)
+        + ". Review the audible tonality, pitch relationships, timbre, bass, balance, articulation, and development. "
+        "Describe concrete audible moments and uncertainty; do not invent instrument names or infer sound from inspirations. "
+        "Suggest a specific revision to how it sounds. Ready means you would release it as the author, or keep it as a peer. "
+        "A difference from your own taste is not a technical defect. Return JSON with observations, changes, and ready."
+    )
+    data = path.read_bytes()
+    if not data or len(data) > 4_000_000:
+        raise ValueError("Missing or oversized review audio")
+    store.call(session)
+    with httpx.Client(timeout=90) as client:
+        response = client.post(
+            f"https://generativelanguage.googleapis.com/v1beta/models/{MODEL}:generateContent",
+            headers={"x-goog-api-key": key()},
+            json={
+                "contents": [
+                    {
+                        "parts": [
+                            {"text": prompt},
+                            {
+                                "inline_data": {
+                                    "mime_type": "audio/wav",
+                                    "data": base64.b64encode(data).decode(),
+                                }
+                            },
+                        ]
+                    }
+                ],
+                "generationConfig": {
+                    "maxOutputTokens": 1600,
+                    "thinkingConfig": {"thinkingLevel": "LOW"},
+                    "responseMimeType": "application/json",
+                    "responseJsonSchema": Feedback.model_json_schema(),
+                },
+            },
+        )
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Audio review HTTP {response.status_code}; no text fallback"
+        )
+    result = response.json()
+    usage = result["usageMetadata"]
+    store.charge(
+        session,
+        (
+            usage["promptTokenCount"] * 1.5
+            + (
+                usage.get("candidatesTokenCount", 0)
+                + usage.get("thoughtsTokenCount", 0)
+            )
+            * 9
+        )
+        / 1_000_000,
+    )
+    audio_tokens = sum(
+        v["tokenCount"]
+        for v in usage.get("promptTokensDetails", [])
+        if v["modality"] == "AUDIO"
+    )
+    candidate = result["candidates"][0]
+    if candidate.get("finishReason") != "STOP":
+        raise ValueError("Audio review was incomplete")
+    feedback = Feedback.model_validate_json(
+        "".join(
+            p.get("text", "")
+            for p in candidate["content"]["parts"]
+            if not p.get("thought")
+        )
+    )
+    review = ListeningReview(
+        listener=listener,
+        author=author,
+        audio_sha256=hashlib.sha256(data).hexdigest(),
+        model=result["modelVersion"],
+        audio_tokens=audio_tokens,
+        inspirations_sha256=inspiration_digest(inspirations),
+        **feedback.model_dump(),
+    )
+    record_review(store, session, author, review)
+    return review

--- a/services/musician-studio/studio/context.py
+++ b/services/musician-studio/studio/context.py
@@ -23,6 +23,7 @@ def history_context(history: list[dict], byte_limit: int = 18000) -> list[dict]:
                 "idea",
                 "python",
                 "memory",
+                "audio_feedback",
                 "metrics",
                 "track_id",
             )

--- a/services/musician-studio/studio/listening.py
+++ b/services/musician-studio/studio/listening.py
@@ -1,0 +1,90 @@
+"""Host-recorded audio evidence required before a studio release."""
+
+import hashlib
+import json
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from studio.state import Store
+
+
+class NotReady(ValueError):
+    pass
+
+
+class ListeningReview(BaseModel):
+    listener: str
+    author: str
+    audio_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    model: str = Field(min_length=1)
+    audio_tokens: int = Field(gt=0)
+    inspirations_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    observations: str = Field(min_length=20)
+    changes: str = Field(min_length=10)
+    ready: bool
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def inspiration_digest(inspirations: list[dict]) -> str:
+    if not inspirations:
+        raise ValueError("Listening requires the author's stated inspirations")
+    return hashlib.sha256(json.dumps(inspirations, sort_keys=True).encode()).hexdigest()
+
+
+def require_listening(study: dict, name: str, path: Path, reviews: list[dict]) -> None:
+    draft = study.get("draft_audio_sha256")
+    final = digest(path)
+    if not draft or draft == final:
+        raise ValueError("Publishing requires a rendered revision after self-review")
+    inspirations = inspiration_digest(study.get("review_inspirations", []))
+    evidence = [ListeningReview.model_validate(value) for value in reviews]
+    own_draft = any(
+        r.listener == name
+        and r.author == name
+        and r.audio_sha256 == draft
+        and r.inspirations_sha256 == inspirations
+        for r in evidence
+    )
+    own_final = any(
+        r.listener == name
+        and r.author == name
+        and r.audio_sha256 == final
+        and r.inspirations_sha256 == inspirations
+        for r in evidence
+    )
+    peer_final = any(
+        r.listener != name
+        and r.author == name
+        and r.audio_sha256 == final
+        and r.inspirations_sha256 == inspirations
+        for r in evidence
+    )
+    if not (own_draft and own_final and peer_final):
+        raise ValueError(
+            "Publishing requires audio self-review, revision review, and peer feedback"
+        )
+    if not any(
+        r.listener == name
+        and r.author == name
+        and r.audio_sha256 == final
+        and r.inspirations_sha256 == inspirations
+        and r.ready
+        for r in evidence
+    ):
+        raise NotReady(
+            "The musician requested another revision; keeping this piece unpublished"
+        )
+
+
+def record_review(
+    store: Store, session: str, name: str, review: ListeningReview
+) -> None:
+    with store.connect() as db:
+        db.execute(
+            "INSERT INTO listening_reviews VALUES (?,?,?)",
+            (session, name, review.model_dump_json()),
+        )

--- a/services/musician-studio/studio/platform.py
+++ b/services/musician-studio/studio/platform.py
@@ -8,6 +8,7 @@ from typing import Any, Self
 
 import httpx
 
+from studio.listening import require_listening
 from studio.state import Store
 
 API = "https://api.plyr.fm"
@@ -58,6 +59,7 @@ class Platform:
         study = store.study(session, name)
         if study.get("track_id"):
             return study["track_id"]
+        require_listening(study, name, path, store.listening_reviews(session, name))
         if study.get("upload_id"):
             return self.finish_upload(store, session, name, study["upload_id"])
         if not store.claim_upload(session, name):

--- a/services/musician-studio/studio/state.py
+++ b/services/musician-studio/studio/state.py
@@ -19,6 +19,8 @@ class Store:
                     id TEXT PRIMARY KEY, day TEXT NOT NULL, month TEXT NOT NULL,
                     status TEXT NOT NULL, reserved REAL NOT NULL, spent REAL NOT NULL DEFAULT 0,
                     calls INTEGER NOT NULL DEFAULT 0);
+                CREATE TABLE IF NOT EXISTS listening_reviews (
+                    session TEXT NOT NULL, musician TEXT NOT NULL, body TEXT NOT NULL);
                 CREATE TABLE IF NOT EXISTS studies (
                     session TEXT NOT NULL, musician TEXT NOT NULL, body TEXT NOT NULL,
                     PRIMARY KEY(session, musician));
@@ -192,3 +194,13 @@ class Store:
                 (json.dumps(body), session, musician),
             )
             return True
+
+    def listening_reviews(self, session: str, musician: str) -> list[dict]:
+        with self.connect() as db:
+            return [
+                json.loads(row[0])
+                for row in db.execute(
+                    "SELECT body FROM listening_reviews WHERE session=? AND musician=?",
+                    (session, musician),
+                )
+            ]

--- a/services/musician-studio/tests/test_audio_model.py
+++ b/services/musician-studio/tests/test_audio_model.py
@@ -1,0 +1,85 @@
+import base64
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from studio import audio_model
+from studio.listening import digest
+from studio.state import Store
+
+
+@pytest.mark.parametrize("audio_tokens", [250, 0])
+def test_review_sends_audio_and_records_provider_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, audio_tokens: int
+) -> None:
+    store = Store(tmp_path)
+    profile = json.loads((Path(__file__).parents[1] / "profiles/moss.json").read_text())
+    store.save_musician("moss", profile)
+    session = store.reserve(datetime.now(UTC))
+    audio = tmp_path / "recording.wav"
+    audio.write_bytes(b"the exact rendered audio")
+    inspirations = profile["profile"]["inspirations"]
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        assert request.headers["x-goog-api-key"] == "fake"
+        parts = json.loads(request.content)["contents"][0]["parts"]
+        assert base64.b64decode(parts[1]["inline_data"]["data"]) == audio.read_bytes()
+        assert parts[1]["inline_data"]["mime_type"] == "audio/wav"
+        assert inspirations[0]["artist"] in parts[0]["text"]
+        return httpx.Response(
+            200,
+            json={
+                "modelVersion": "test-audio",
+                "usageMetadata": {
+                    "promptTokenCount": 500,
+                    "candidatesTokenCount": 100,
+                    "thoughtsTokenCount": 50,
+                    "promptTokensDetails": [
+                        {"modality": "AUDIO", "tokenCount": audio_tokens}
+                    ],
+                },
+                "candidates": [
+                    {
+                        "finishReason": "STOP",
+                        "content": {
+                            "parts": [
+                                {
+                                    "text": json.dumps(
+                                        {
+                                            "observations": "The upper tones mask the bass.",
+                                            "changes": "Lower the upper tones by 3 dB.",
+                                            "ready": False,
+                                        }
+                                    )
+                                }
+                            ]
+                        },
+                    }
+                ],
+            },
+        )
+
+    client = httpx.Client
+    monkeypatch.setattr(audio_model, "key", lambda: "fake")
+    monkeypatch.setattr(
+        audio_model.httpx,
+        "Client",
+        lambda **kwargs: client(transport=httpx.MockTransport(handle), **kwargs),
+    )
+    if audio_tokens:
+        result = audio_model.listen(store, session, "moss", "moss", audio, inspirations)
+        assert result.audio_sha256 == digest(audio)
+        assert result.model == "test-audio"
+        assert not result.ready
+        assert len(store.listening_reviews(session, "moss")) == 1
+    else:
+        with pytest.raises(ValidationError):
+            audio_model.listen(store, session, "moss", "moss", audio, inspirations)
+        assert not store.listening_reviews(session, "moss")
+    assert store.usage(datetime.now(UTC))["month"]["estimated_cost"] == pytest.approx(
+        0.0021
+    )

--- a/services/musician-studio/tests/test_audio_round.py
+++ b/services/musician-studio/tests/test_audio_round.py
@@ -1,0 +1,99 @@
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+import pytest
+
+import audio_round
+from compose import Composition
+from studio import audio_model
+from studio.state import Store
+
+
+def test_round_reviews_draft_and_revision_and_obtains_peer_feedback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = Store(tmp_path)
+    for name in ("moss", "reed"):
+        store.save_musician(
+            name,
+            json.loads(
+                (Path(__file__).parents[1] / f"profiles/{name}.json").read_text()
+            ),
+        )
+    session = store.reserve(datetime.now(UTC))
+    store.save_study(
+        session,
+        "moss",
+        {"python": "original", "title": "draft", "idea": "draft", "rendered": True},
+    )
+    draft = tmp_path / "draft.wav"
+    draft.write_bytes(b"original recording")
+    heard = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        parts = json.loads(request.content)["contents"][0]["parts"]
+        heard.append(parts)
+        assert (
+            store.musicians()["moss"]["profile"]["inspirations"][0]["artist"]
+            in parts[0]["text"]
+        )
+        return httpx.Response(
+            200,
+            json={
+                "modelVersion": "test-audio",
+                "usageMetadata": {
+                    "promptTokenCount": 500,
+                    "candidatesTokenCount": 100,
+                    "promptTokensDetails": [{"modality": "AUDIO", "tokenCount": 250}],
+                },
+                "candidates": [
+                    {
+                        "finishReason": "STOP",
+                        "content": {
+                            "parts": [
+                                {
+                                    "text": json.dumps(
+                                        {
+                                            "observations": "The bass obscures the upper notes.",
+                                            "changes": "Lower the bass by three decibels.",
+                                            "ready": True,
+                                        }
+                                    )
+                                }
+                            ]
+                        },
+                    }
+                ],
+            },
+        )
+
+    def compose(*args: object, **kwargs: object) -> Composition:
+        assert "Lower the bass" in kwargs["revision"]
+        return Composition(title="revision", idea="balance", python="revised")
+
+    def render(code: str, directory: Path) -> dict:
+        assert code == "revised"
+        directory.mkdir(parents=True)
+        (directory / "track.wav").write_bytes(b"revised recording")
+        return {"duration": 10}
+
+    client = httpx.Client
+    monkeypatch.setattr(audio_model, "key", lambda: "fake")
+    monkeypatch.setattr(
+        audio_model.httpx,
+        "Client",
+        lambda **kwargs: client(transport=httpx.MockTransport(handle), **kwargs),
+    )
+    monkeypatch.setattr(audio_round, "compose", compose)
+    monkeypatch.setattr(audio_round, "render", render)
+    final = audio_round.prepare_release(tmp_path, session, "moss", draft)
+    assert final.read_bytes() == b"revised recording"
+    assert len(heard) == 3
+    assert heard[0][1] != heard[1][1]
+    assert heard[1][1] == heard[2][1]
+    assert len(store.listening_reviews(session, "moss")) == 3
+    assert len(store.study(session, "moss")["audio_feedback"]) == 2
+    assert audio_round.prepare_release(tmp_path, session, "moss", draft) == final
+    assert len(heard) == 3

--- a/services/musician-studio/tests/test_platform.py
+++ b/services/musician-studio/tests/test_platform.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import httpx
 import pytest
 
+from studio.listening import ListeningReview, digest, inspiration_digest, record_review
 from studio.platform import Platform
 from studio.state import Store
 
@@ -15,6 +16,35 @@ def saved(tmp_path: Path) -> tuple[Store, Path]:
     )
     audio = tmp_path / "audio.wav"
     audio.write_bytes(b"mock audio")
+    inspirations = [
+        {"artist": "test", "work": "test", "reason": "test", "experiment": "test"}
+    ]
+    store.save_study(
+        "2026-09-07-0",
+        "moss",
+        {"draft_audio_sha256": "a" * 64, "review_inspirations": inspirations},
+    )
+    for listener, sha in [
+        ("moss", "a" * 64),
+        ("moss", digest(audio)),
+        ("reed", digest(audio)),
+    ]:
+        record_review(
+            store,
+            "2026-09-07-0",
+            "moss",
+            ListeningReview(
+                listener=listener,
+                author="moss",
+                audio_sha256=sha,
+                model="test-audio",
+                audio_tokens=250,
+                inspirations_sha256=inspiration_digest(inspirations),
+                observations="An audible sustained chord.",
+                changes="Reduce the bass level.",
+                ready=True,
+            ),
+        )
     return store, audio
 
 
@@ -88,3 +118,56 @@ def test_playlist_reuses_existing_owned_list() -> None:
     with Platform("test", transport=httpx.MockTransport(handle)) as api:
         assert api.playlist("Moss") == "playlist"
     assert calls == ["GET"]
+
+
+def test_missing_audio_evidence_blocks_upload_before_network(tmp_path: Path) -> None:
+    store, audio = saved(tmp_path)
+    with store.connect() as db:
+        db.execute("DELETE FROM listening_reviews")
+
+    def forbidden(request: httpx.Request) -> httpx.Response:
+        pytest.fail("No HTTP request is allowed without listening evidence")
+
+    with (
+        Platform("test", transport=httpx.MockTransport(forbidden)) as api,
+        pytest.raises(ValueError, match="audio self-review"),
+    ):
+        api.publish(store, "2026-09-07-0", "moss", audio)
+    assert not store.released_today("moss", "2026-09-07")
+
+
+@pytest.mark.parametrize(
+    "change", ["audio", "inspirations", "peer", "approval", "revision"]
+)
+def test_stale_or_incomplete_evidence_cannot_publish(
+    tmp_path: Path, change: str
+) -> None:
+    store, audio = saved(tmp_path)
+    if change == "audio":
+        audio.write_bytes(b"different recording")
+    elif change == "inspirations":
+        store.save_study(
+            "2026-09-07-0", "moss", {"review_inspirations": [{"artist": "different"}]}
+        )
+    elif change == "revision":
+        store.save_study("2026-09-07-0", "moss", {"draft_audio_sha256": digest(audio)})
+    else:
+        with store.connect() as db:
+            if change == "peer":
+                db.execute(
+                    "DELETE FROM listening_reviews WHERE json_extract(body, '$.listener')='reed'"
+                )
+            else:
+                db.execute(
+                    "UPDATE listening_reviews SET body=json_set(body, '$.ready', json('false'))"
+                )
+    with (
+        Platform(
+            "test",
+            transport=httpx.MockTransport(
+                lambda _: pytest.fail("Unexpected network request")
+            ),
+        ) as api,
+        pytest.raises(ValueError),
+    ):
+        api.publish(store, "2026-09-07-0", "moss", audio)


### PR DESCRIPTION
Require actual audio input for every self-review and peer judgment. Before publishing, a musician must review its rendered draft, render a revision, review that exact revision, and receive another musician's feedback with the author's stated inspirations. Luna implements Python changes; Gemini receives the WAV and makes release/curation judgments.

<details>
<summary>Verification, limits, and rollout</summary>

Host-recorded evidence binds the listener, author, model version, positive audio-token count, audio SHA256, and supplied inspirations. Evidence lives separately from generated composition fields. Missing, stale, text-only, incomplete, or unapproved self-review blocks uploading. A declined release is a completed study with no upload, rather than an infrastructure failure. Feedback persists into later composition context.

One artist now takes a turn per six-hour run to leave room for self-review, revision, and peer listening under the unchanged session/day/month limits. The encrypted worker consumer derives the existing Gemini key from canonical sops; equality and idempotent sync were verified.

32 offline tests pass, covering native audio payloads/receipts, revision order, repeat recovery, stale evidence, missing peer feedback, changed inspirations, and no network request when review is missing. Pre-commit passes. A real request through the new client returned 250 audio tokens and rejected Moss's draft.

The schedule is paused and queued old-code runs cancelled. A full live revision cycle is pending the next UTC budget window: diagnostics cost an estimated $0.033589 and brought today's reserved/charged ledger to $0.187489 of $0.20. No limits were raised.

Blind controls exposed important limitations, retained in audio-validation.json: Flash-Lite confused pitched tones with noise; 3.8 Flash hallucinated music in silence and then returned 503s; short 3.5 temporal responses were truncated. Native input is verifiable; accurate perception and better music are not established by a token receipt or convincing prose. The rollout must remain paused until the complete loop is verified.
</details>
