### PR TITLE
Raise the musician budget and complete audio-cycle verification

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -564,3 +564,14 @@ evidence now enforce this requirement locally; Luna is only the Python helper.
 The full live revision cycle is pending. Controls found real perception errors;
 model support for audio is not proof of accurate musical judgment. Diagnostic
 costs are retained in the same worker ledger, and caps are unchanged.
+
+### September 7 — audio cycle verified and resumed
+
+Nate authorized a $10 budget. Daily and monthly ceilings are now $10, with
+$0.10 reserved per session. Run `ee1b967d-7424-4864-8f0f-5441b876c635` completed
+the live cycle: Moss heard its draft, revised it, heard the revision, received
+Reed's audio feedback, and heard a published peer. Four native requests each
+recorded 250 audio tokens; the reviewed revision hash matched the ten-second
+stereo WAV on disk. Moss withheld the piece, so no upload occurred. Six model
+requests cost an estimated $0.037656. The six-hour schedule and quiet daily
+monitor are active again. This verifies the listening path, not musical quality.

--- a/services/musician-studio/README.md
+++ b/services/musician-studio/README.md
@@ -38,7 +38,7 @@ rotating across the roster. SQLite state is stored at
 identities, upload reservations, or spending. A lock and concurrency limit
 prevent overlap.
 
-The unchanged limits are $0.05/session, $0.20/day, and $5/month in reservations,
+The authorized limits are $0.10/session, $10/day, and $10/month in reservations,
 with at most 12 model calls/session and one upload attempt/musician/UTC day.
 Failures retain reservations and retries reuse the session. Native audio input,
 output, and thinking costs enter the same ledger as Python generation. Budget

--- a/services/musician-studio/README.md
+++ b/services/musician-studio/README.md
@@ -1,7 +1,7 @@
 # musician studio
 
-The schedule is paused until a complete native-audio revision cycle is verified.
-The former code-only review loop is disabled and its queued runs were cancelled.
+The six-hour schedule is active after a complete native-audio revision cycle.
+The former code-only review loop is disabled.
 
 Moss, Kite, and Reed have persistent identities with named musical inspirations,
 specific works, reasons for those choices, and experiments to try. Gemini 3.5
@@ -55,8 +55,12 @@ failures, and usage. Use direct run links in your own browser.
 `just check` runs 32 offline tests, including the complete review/revision order,
 repeat recovery, native audio payloads, missing audio-token receipts, changed
 files/inspirations, and missing peer review. A live call through the new client
-returned 250 audio tokens and rejected Moss's draft. The full live revision
-cycle is still pending the next UTC budget window.
+returned 250 audio tokens and rejected Moss's draft. The full live cycle then completed in run
+[ee1b967d](https://prefect-server.waow.tech/runs/flow-run/ee1b967d-7424-4864-8f0f-5441b876c635):
+Moss heard its draft and a different ten-second revision, Reed heard that same
+revision, and Moss heard a published peer. Four native audio reviews recorded
+250 audio tokens each. Moss declined release, so no track was uploaded. Six
+model calls cost an estimated $0.037656.
 
 `audio-validation.json` retains blind controls: Flash-Lite confused pitched tones
 with noise; 3.8 Flash hallucinated music in silence and then returned 503s. Short
@@ -64,7 +68,8 @@ with noise; 3.8 Flash hallucinated music in silence and then returned 503s. Shor
 the response limit. These probes do not establish reliable perception or good
 music. Titles also remain formulaic. Known diagnostic usage was added to the
 worker ledger: $0.033589, bringing September 7's reserved/charged total to
-$0.187489/$0.20. No limits were raised to run another full session.
+$0.187489/$0.20 at the earlier pause. Nate subsequently authorized the higher
+limits above, and live verification continued.
 
 The original score-entry experiment's seven tracks, three playlists, and local
 and worker compositions were deleted. Accounts, avatars, bot labels, credentials,

--- a/services/musician-studio/flow.py
+++ b/services/musician-studio/flow.py
@@ -17,7 +17,7 @@ from studio.context import choose_peer
 from studio.identity import Musician
 from studio.listening import NotReady
 from studio.platform import Platform, credentials
-from studio.state import Store
+from studio.state import DAILY_BUDGET, MONTHLY_BUDGET, Store
 
 ROOT = Path(__file__).parent
 
@@ -148,8 +148,8 @@ def report(store: Store, session: str | None, errors: list[str]) -> None:
         key="plyr-fm-musician-costs",
         markdown=(
             f"# Musician cost ledger\n\n{month['sessions']} sessions; {month['calls']} requests this UTC month.\n\n"
-            f"Estimated model usage: ${month['estimated_cost']:.6f}. Reserved/charged: ${month['budget_used']:.2f} / $5 monthly.\n\n"
-            f"Today: ${usage['day']['budget_used']:.2f} / $0.20 reserved/charged.\n\n"
+            f"Estimated model usage: ${month['estimated_cost']:.6f}. Reserved/charged: ${month['budget_used']:.2f} / ${MONTHLY_BUDGET:g} monthly.\n\n"
+            f"Today: ${usage['day']['budget_used']:.2f} / ${DAILY_BUDGET:g} reserved/charged.\n\n"
             "Failed reservations remain charged. Model usage is an estimate, not an invoice; hosting, storage, and subscriptions are excluded. "
             "Exhausted budgets pause model work until the next available UTC budget window."
         ),

--- a/services/musician-studio/prefect.yaml
+++ b/services/musician-studio/prefect.yaml
@@ -3,7 +3,7 @@ pull:
   - prefect.deployments.steps.git_clone:
       id: checkout
       repository: https://github.com/zzstoatzz/plyr.fm.git
-      commit_sha: 48021d38ff5c86ba0727b6b58698c902aa4b0ee6
+      commit_sha: f761ffd94f45089ed2903cc3048d90cc5aa72768
   - prefect.deployments.steps.set_working_directory:
       directory: "{{ checkout.directory }}/services/musician-studio"
 deployments:
@@ -16,7 +16,7 @@ deployments:
     schedules:
       - cron: "17 */6 * * *"
         timezone: UTC
-        active: false
+        active: true
     work_pool:
       name: home-pool
       job_variables:

--- a/services/musician-studio/studio/state.py
+++ b/services/musician-studio/studio/state.py
@@ -6,6 +6,10 @@ import sqlite3
 from datetime import datetime
 from pathlib import Path
 
+SESSION_BUDGET = 0.10
+DAILY_BUDGET = 10.0
+MONTHLY_BUDGET = 10.0
+
 
 class Store:
     def __init__(self, directory: Path) -> None:
@@ -49,7 +53,7 @@ class Store:
                 if (
                     retry_failed
                     and existing[0] == "failed"
-                    and existing[1] < 0.05
+                    and existing[1] < SESSION_BUDGET
                     and existing[2] < 12
                 ):
                     db.execute(
@@ -57,16 +61,19 @@ class Store:
                     )
                     return key
                 return None
-            for field, value, limit in [("day", day, 0.20), ("month", month, 5.0)]:
+            for field, value, limit in [
+                ("day", day, DAILY_BUDGET),
+                ("month", month, MONTHLY_BUDGET),
+            ]:
                 used = db.execute(
                     f"SELECT COALESCE(SUM(MAX(reserved,spent)),0) FROM sessions WHERE {field}=?",
                     (value,),
                 ).fetchone()[0]
-                if used + 0.05 > limit + 1e-9:
+                if used + SESSION_BUDGET > limit + 1e-9:
                     return None
             db.execute(
                 "INSERT INTO sessions(id,day,month,status,reserved) VALUES (?,?,?,?,?)",
-                (key, day, month, "running", 0.05),
+                (key, day, month, "running", SESSION_BUDGET),
             )
         return key
 
@@ -74,8 +81,8 @@ class Store:
         with self.connect() as db:
             db.execute("BEGIN IMMEDIATE")
             changed = db.execute(
-                "UPDATE sessions SET calls=calls+1 WHERE id=? AND status='running' AND calls<12 AND spent<0.05",
-                (session,),
+                "UPDATE sessions SET calls=calls+1 WHERE id=? AND status='running' AND calls<12 AND spent<?",
+                (session, SESSION_BUDGET),
             ).rowcount
             if not changed:
                 raise RuntimeError("Session request or estimated-spend cap reached")

--- a/services/musician-studio/tests/test_limits.py
+++ b/services/musician-studio/tests/test_limits.py
@@ -32,7 +32,7 @@ def test_spend_stops_new_calls(tmp_path: Path) -> None:
     store = Store(tmp_path)
     session = store.reserve(datetime.now(UTC))
     assert session is not None
-    store.charge(session, 0.051)
+    store.charge(session, 0.101)
     with pytest.raises(RuntimeError):
         store.call(session)
 
@@ -58,7 +58,7 @@ def test_explicit_retry_keeps_the_original_budget(tmp_path: Path) -> None:
         assert db.execute("SELECT calls, spent, reserved FROM sessions").fetchone() == (
             1,
             0.01,
-            0.05,
+            0.10,
         )
     assert store.reserve(now, retry_failed=True) is None
 
@@ -72,7 +72,7 @@ def test_monthly_cap_resumes_next_month_without_resetting_history(
         assert store.reserve(start + timedelta(hours=6 * slot)) is not None
     assert store.reserve(start + timedelta(hours=600)) is None
     assert Store(tmp_path).reserve(datetime(2026, 10, 1, tzinfo=UTC)) is not None
-    assert store.usage(start)["month"]["budget_used"] == pytest.approx(5)
+    assert store.usage(start)["month"]["budget_used"] == pytest.approx(10)
 
 
 def test_actual_cost_and_failed_reservations_are_reported(tmp_path: Path) -> None:
@@ -88,7 +88,7 @@ def test_actual_cost_and_failed_reservations_are_reported(tmp_path: Path) -> Non
         "sessions": 1,
         "calls": 1,
         "estimated_cost": 0.002,
-        "budget_used": 0.05,
+        "budget_used": 0.10,
     }
     for invalid in (float("nan"), float("inf"), -1):
         with pytest.raises(ValueError):
@@ -112,6 +112,6 @@ def test_bootstrap_is_once_and_charged_to_normal_budgets(tmp_path: Path) -> None
     assert session is not None
     store.finish(session, "completed")
     assert store.reserve(now + timedelta(days=1), bootstrap=True) is None
-    assert store.usage(now)["day"]["budget_used"] == 0.05
+    assert store.usage(now)["day"]["budget_used"] == 0.10
     with pytest.raises(RuntimeError):
         store.call(session)


### PR DESCRIPTION
Raise the musician studio ceilings to the authorized $10 daily and $10 monthly, with $0.10 reserved per session. Cost artifacts use the same constants as enforcement. Historical costs and reservations remain.

The complete live audio cycle passed in [run ee1b967d](https://prefect-server.waow.tech/runs/flow-run/ee1b967d-7424-4864-8f0f-5441b876c635): Moss heard its draft, revised and heard it again, received Reed’s audio feedback, and heard a published peer. All four native requests recorded 250 audio tokens; the final file hash matched both final reviewers’ evidence. Moss declined release, so it stayed unpublished. Six requests cost approximately $0.037656. The six-hour schedule and daily monitor have resumed.

Validation: 32 service tests and pre-commit pass. This establishes the live review gate, not accurate perception or improved musical quality.
