### PR TITLE
Explain unavailable tag suggestions and retry failures

### DIFF
--- a/frontend/src/lib/components/TrackEditForm.svelte
+++ b/frontend/src/lib/components/TrackEditForm.svelte
@@ -91,7 +91,7 @@
 	let editCopyrightWasEnabled = $state(false);
 	let hasUnresolvedEditFeaturesInput = $state(false);
 	let recommendedTags = $state<{ name: string; score: number }[]>([]);
-	let loadingRecommendedTags = $state(false);
+	let recommendedTagsStatus = $state<'loading' | 'ready' | 'unavailable' | 'error'>('loading');
 	let recommendedTagsTrackId = $state<number | null>(null);
 	let visibleRecommendedTags = $derived(
 		recommendedTags.filter((r) => !editTags.includes(r.name.toLowerCase()))
@@ -117,22 +117,20 @@
 	}
 
 	async function fetchRecommendedTags(trackId: number) {
-		loadingRecommendedTags = true;
+		recommendedTagsStatus = 'loading';
 		recommendedTags = [];
 		recommendedTagsTrackId = trackId;
 		try {
 			const response = await fetch(`${API_URL}/tracks/${trackId}/recommended-tags?limit=8`, {
 				credentials: 'include'
 			});
-			if (!response.ok) return;
+			if (!response.ok) throw new Error('could not load suggested tags');
 			const data = await response.json();
 			if (recommendedTagsTrackId !== trackId) return;
-			if (!data.available || data.tags.length === 0) return;
+			recommendedTagsStatus = data.available ? 'ready' : 'unavailable';
 			recommendedTags = data.tags;
 		} catch {
-			recommendedTags = [];
-		} finally {
-			loadingRecommendedTags = false;
+			recommendedTagsStatus = 'error';
 		}
 	}
 
@@ -274,10 +272,21 @@
 				}}
 				placeholder="type to search tags..."
 			/>
-			{#if loadingRecommendedTags}
+			{#if recommendedTagsStatus === 'loading'}
 				<div class="suggested-tags-row">
 					<span class="suggested-label">suggested</span>
 					<WaveLoading size="sm" />
+				</div>
+			{:else if recommendedTagsStatus === 'unavailable'}
+				<p class="suggested-status" role="status">suggested tags unavailable</p>
+			{:else if recommendedTagsStatus === 'error'}
+				<div class="suggested-tags-row">
+					<span class="suggested-status" role="status">could not load suggested tags</span>
+					<button
+						type="button"
+						class="suggested-tag-chip"
+						onclick={() => fetchRecommendedTags(track.id)}>retry</button
+					>
 				</div>
 			{:else if visibleRecommendedTags.length > 0}
 				<div class="suggested-tags-row">
@@ -297,6 +306,8 @@
 						{/each}
 					</div>
 				</div>
+			{:else}
+				<p class="suggested-status" role="status">no new suggested tags</p>
 			{/if}
 		</div>
 		<TrackArtworkField imageUrl={track.image_url} bind:editImageFile bind:editRemoveImage />
@@ -423,6 +434,11 @@
 		flex-wrap: wrap;
 		align-items: center;
 		gap: 0.5rem;
+	}
+	.suggested-status {
+		margin: 0;
+		font-size: var(--text-sm);
+		color: var(--text-secondary);
 	}
 	.suggested-label {
 		font-size: var(--text-xs);

--- a/frontend/src/lib/components/TrackEditForm.test.ts
+++ b/frontend/src/lib/components/TrackEditForm.test.ts
@@ -132,3 +132,43 @@ describe('shared track editor', () => {
 		expect(onClose).not.toHaveBeenCalled();
 	});
 });
+
+describe('suggested tag feedback', () => {
+	it.each([
+		[{ available: false, tags: [] }, 'suggested tags unavailable'],
+		[{ available: true, tags: [] }, 'no new suggested tags']
+	])('explains an empty response %j', async (response, message) => {
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(Response.json(response));
+		mountEditor();
+		await vi.waitFor(() => expect(document.body.textContent).toContain(message));
+	});
+
+	it('retries a failed request and lets the owner select the resulting tag', async () => {
+		const fetch = vi
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValueOnce(new Response(null, { status: 503 }))
+			.mockResolvedValueOnce(
+				Response.json({ available: true, tags: [{ name: 'Drone', score: 0.8 }] })
+			);
+		mountEditor();
+		await vi.waitFor(() =>
+			expect(document.body.textContent).toContain('could not load suggested tags')
+		);
+		const retry = [...document.querySelectorAll('button')].find(
+			(button) => button.textContent?.trim() === 'retry'
+		);
+		if (!retry) throw new Error('retry button missing');
+		retry.click();
+		await vi.waitFor(() => expect(document.body.textContent).toContain('+ Drone'));
+		expect(fetch).toHaveBeenCalledTimes(2);
+		const suggestion = [...document.querySelectorAll('button')].find((button) =>
+			button.textContent?.includes('+ Drone')
+		);
+		if (!suggestion) throw new Error('suggestion missing');
+		suggestion.click();
+		flushSync();
+		expect(document.body.textContent).toContain('no new suggested tags');
+		expect(document.body.textContent).not.toContain('could not load suggested tags');
+		expect(document.querySelector('#edit-tags')?.parentElement?.textContent).toContain('drone');
+	});
+});

--- a/loq.toml
+++ b/loq.toml
@@ -403,7 +403,7 @@ max_lines = 8280
 
 [[rules]]
 path = "frontend/src/lib/components/TrackEditForm.svelte"
-max_lines = 528
+max_lines = 544
 
 [[rules]]
 path = "frontend/src/lib/components/track-edit/TrackAudioEditor.svelte"


### PR DESCRIPTION
The shared track editor now explains when suggested tags are unavailable or empty instead of silently hiding the row. Failed requests show a retry button; successful retries restore selectable suggestions.

<details>
<summary>Implementation and validation</summary>

- Distinguishes loading, ready, unavailable, and failed requests in the shared editor used by the track page and portal.
- Shows “suggested tags unavailable” when the API reports generation unavailable, and “no new suggested tags” when no suggestions remain.
- Keeps the existing suggestion selection and metadata save behavior.
- Adds mounted-component regression coverage for unavailable/empty responses and failure → retry → selection. All three new cases fail against the previous implementation.

Validation: 236 frontend tests pass, Svelte check has zero errors/warnings, and full lint passes. Real-browser verification covers 1280px and 390px in dark/light themes, plus failed-request retry and selection. Browser writes were intercepted.

This changes feedback only; it does not enable the staging tag-generation service.
</details>
