### PR TITLE
Generate suggested tags for PDS-hosted tracks

### DIFF
--- a/backend/src/backend/api/tracks/tags.py
+++ b/backend/src/backend/api/tracks/tags.py
@@ -12,6 +12,8 @@ from sqlalchemy.orm import selectinload
 
 from backend._internal import Session as AuthSession
 from backend._internal import get_optional_session
+from backend._internal.clients.replicate import get_replicate_client
+from backend._internal.tasks.hooks import resolve_audio_url
 from backend._internal.track_visibility import (
     ensure_track_visible,
     visible_filter,
@@ -215,12 +217,17 @@ async def get_recommended_tags(
     ):
         predictions = None
 
-    if predictions is None and settings.replicate.enabled and track.r2_url:
-        # classify on-demand
-        from backend._internal.clients.replicate import get_replicate_client
+    if predictions is None and settings.replicate.enabled:
+        audio_url = None if track.is_private else await resolve_audio_url(track.id)
+        if not audio_url:
+            return RecommendedTagsResponse(track_id=track_id, tags=[], available=False)
 
         client = get_replicate_client()
-        classify_result = await client.classify(track.r2_url)
+        classify_result = await client.classify(audio_url)
+        if not classify_result.success:
+            raise HTTPException(
+                status_code=502, detail="could not generate suggested tags"
+            )
 
         if classify_result.success and classify_result.genres:
             predictions = [

--- a/backend/tests/api/test_recommended_tags.py
+++ b/backend/tests/api/test_recommended_tags.py
@@ -116,11 +116,21 @@ async def test_recommended_tags_returns_stored_predictions(
     assert data["tags"][1]["name"] == "Electronic"
 
 
+@pytest.mark.parametrize("audio_storage", ["r2", "pds"])
 async def test_recommended_tags_on_demand_classification(
     test_app: FastAPI,
     target_track: Track,
-):
+    db_session: AsyncSession,
+    artist: Artist,
+    audio_storage: str,
+) -> None:
     """test that on-demand classification happens when no predictions stored."""
+    if audio_storage == "pds":
+        target_track.r2_url = None
+        target_track.audio_storage = "pds"
+        target_track.pds_blob_cid = "bafyaudio001"
+        await db_session.commit()
+
     mock_result = ClassificationResult(
         success=True,
         genres=[
@@ -131,9 +141,7 @@ async def test_recommended_tags_on_demand_classification(
 
     with (
         patch("backend.config.settings.replicate") as mock_replicate,
-        patch(
-            "backend._internal.clients.replicate.get_replicate_client"
-        ) as mock_get_client,
+        patch("backend.api.tracks.tags.get_replicate_client") as mock_get_client,
     ):
         mock_replicate.enabled = True
         mock_client = AsyncMock()
@@ -154,7 +162,13 @@ async def test_recommended_tags_on_demand_classification(
     assert data["tags"][0]["score"] == 0.91
 
     # verify classify was called with the track's R2 URL
-    mock_client.classify.assert_called_once_with(target_track.r2_url)
+    expected_url = target_track.r2_url or (
+        f"{artist.pds_url}/xrpc/com.atproto.sync.getBlob"
+        f"?did={artist.did}&cid={target_track.pds_blob_cid}"
+    )
+    mock_client.classify.assert_called_once_with(expected_url)
+    await db_session.refresh(target_track)
+    assert target_track.extra["genre_predictions"][0]["name"] == "Drum and Bass"
 
 
 async def test_recommended_tags_excludes_existing_tags(
@@ -240,9 +254,7 @@ async def test_recommended_tags_reclassifies_when_file_id_changes(
 
     with (
         patch("backend.config.settings.replicate") as mock_replicate,
-        patch(
-            "backend._internal.clients.replicate.get_replicate_client"
-        ) as mock_get_client,
+        patch("backend.api.tracks.tags.get_replicate_client") as mock_get_client,
     ):
         mock_replicate.enabled = True
         mock_client = AsyncMock()
@@ -279,3 +291,25 @@ async def test_recommended_tags_replicate_disabled(
     data = response.json()
     assert data["available"] is False
     assert data["tags"] == []
+
+
+async def test_recommended_tags_classification_failure_is_retryable(
+    test_app: FastAPI,
+    target_track: Track,
+) -> None:
+    with (
+        patch("backend.config.settings.replicate") as config,
+        patch("backend.api.tracks.tags.get_replicate_client") as get_client,
+    ):
+        config.enabled = True
+        get_client.return_value.classify = AsyncMock(
+            return_value=ClassificationResult(
+                success=False, error="upstream unavailable"
+            )
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.get(f"/tracks/{target_track.id}/recommended-tags")
+    assert response.status_code == 502
+    assert response.json()["detail"] == "could not generate suggested tags"

--- a/backend/tests/api/test_track_description.py
+++ b/backend/tests/api/test_track_description.py
@@ -83,7 +83,9 @@ async def test_description_in_track_listing(
     track_without_description: Track,
 ) -> None:
     """track listing includes description field."""
-    response = client.get("/tracks/")
+    response = client.get(
+        "/tracks/", params={"artist_did": track_with_description.artist_did}
+    )
     assert response.status_code == 200
     data = response.json()
     tracks = data["tracks"]


### PR DESCRIPTION
Suggested tags now classify PDS-hosted audio as well as R2 audio. Previously the endpoint required an R2 URL, so tracks such as “Test Drone - Cross User Like” silently returned no suggestions even with classification enabled.

<details>
<summary>Implementation and validation</summary>

- Uses the existing audio URL resolver, including its PDS URL safety check, after track visibility validation.
- Preserves prediction caching keyed to the audio file ID and existing-tag exclusion.
- Does not send private media to the classifier. Missing resolvable audio reports suggestions unavailable.
- Returns an upstream error on failed classification so the editor offers retry instead of claiming there are no new tags.
- Moves the classifier import to module scope.
- Scopes the existing description-listing test to its fixture artist; it previously depended on the anonymous discovery cache containing newly inserted fixture rows.

The new PDS regression failed against the prior code (zero suggestions) and passes with the fix. Focused endpoint tests cover R2/PDS classification, caching, stale file IDs, existing tags, disabled generation, and classification failure. Full backend suite: 1,628 passed, 25 existing skips. Backend lint passes (existing type-check warnings remain).

Operational prerequisite: staging was missing REPLICATE_ENABLED and REPLICATE_API_TOKEN. Both are now configured through Fly's secret surface; no credential values are in this PR. Production configuration is unchanged.
</details>
