### PR TITLE
Give musicians a composition plan and reusable instruments

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -575,3 +575,14 @@ recorded 250 audio tokens; the reviewed revision hash matched the ten-second
 stereo WAV on disk. Moss withheld the piece, so no upload occurred. Six model
 requests cost an estimated $0.037656. The six-hour schedule and quiet daily
 monitor are active again. This verifies the listening path, not musical quality.
+
+### September 8 — musical plans and instruments
+
+The studio now plans a ten-second phrase before generating Python, with tempo,
+meter, pitch relationships, motif, instrument roles and development persisted
+for later work. Optional pitched voices, percussion, timing and mixing helpers
+run inside the existing isolated container. Evaluation-only sessions share the
+normal budget ledger and cannot publish or curate. Live run `856e3252-7b2f-4710-9d61-21256c647005`
+completed for $0.040811, with no upload. It exposed plan-primed reviews and reuse
+of old synthesis: the final prompts hide plans from listeners and old code from
+new-piece generation. Musical quality remains for human assessment.

--- a/services/musician-studio/README.md
+++ b/services/musician-studio/README.md
@@ -9,6 +9,19 @@ Flash receives the actual WAV and makes musical judgments. Luna implements
 Python drafts and requested revisions; it cannot approve a release or decide
 what belongs in a playlist. Reading code is not listening.
 
+## composition
+
+Before writing audio code, Luna saves a plan for the tempo and meter, pitch
+relationships, motif, instrument roles, and development of the ten-second phrase.
+That plan and prior audio feedback accompany implementation and later studies.
+Planning and implementation use low reasoning effort. The audio reviewer checks
+whether the musical relationships are audible; prose alone earns no approval.
+
+The optional `studio_instruments` module supplies pitched plucks, bass and pads,
+percussion, beat-to-second conversion, mixing and WAV output. It is mounted
+read-only in the existing isolated Python container. Artists can alter the
+sounds or synthesize their own; the helpers prescribe no score or genre.
+
 ## before publication
 
 For each ten-second piece, the author listens to the rendered draft and requests
@@ -45,6 +58,11 @@ output, and thinking costs enter the same ledger as Python generation. Budget
 exhaustion skips work until a later UTC window. These are estimates, not a hard
 provider billing cap; subscriptions, hosting, and monitoring are excluded.
 
+An explicit `evaluation=true` run performs planning, composition and audio
+reviews without publishing or editing playlists. It has one separate reservation
+per six-hour window, charged against the same daily/monthly limits. Normal runs
+do not enable it.
+
 Uploads remain unlisted, tagged `ai`, and self-labeled `ai-generated`. Existing
 unlisted search and artist-page behavior is preserved. Prefect artifacts
 `plyr-fm-musician-progress` and `plyr-fm-musician-costs` show reviews, links,
@@ -52,7 +70,7 @@ failures, and usage. Use direct run links in your own browser.
 
 ## validation and limitations
 
-`just check` runs 32 offline tests, including the complete review/revision order,
+`just check` runs offline tests, including the complete review/revision order,
 repeat recovery, native audio payloads, missing audio-token receipts, changed
 files/inspirations, and missing peer review. A live call through the new client
 returned 250 audio tokens and rejected Moss's draft. The full live cycle then completed in run

--- a/services/musician-studio/README.md
+++ b/services/musician-studio/README.md
@@ -14,6 +14,10 @@ what belongs in a playlist. Reading code is not listening.
 Before writing audio code, Luna saves a plan for the tempo and meter, pitch
 relationships, motif, instrument roles, and development of the ten-second phrase.
 That plan and prior audio feedback accompany implementation and later studies.
+New-piece prompts omit old synthesis code to avoid carrying the same implementation
+forward; revision prompts retain the current draft.
+Listeners do not receive the plan or code, so they cannot merely repeat the
+composer's intended notes. They still receive the author's inspirations.
 Planning and implementation use low reasoning effort. The audio reviewer checks
 whether the musical relationships are audible; prose alone earns no approval.
 
@@ -116,3 +120,12 @@ within seven days of expiry through normal OAuth and syncs the consumer.
 [pricing](https://ai.google.dev/gemini-api/docs/pricing), checked September 7:
 Gemini 3.5 Flash standard estimates use $1.50/million input tokens and $9/million
 output tokens including thinking. Pricing is not an invoice.
+
+The September 8 planning evaluation completed in run
+[856e3252](https://prefect-server.waow.tech/runs/flow-run/856e3252-7b2f-4710-9d61-21256c647005)
+for an estimated $0.040811 across seven model calls, without publishing. Reed
+chose custom synthesis. Reviews repeated exact notes supplied in the plan, so
+listeners no longer receive it. New-piece prompts now omit old synthesis code
+and recommend the provided instruments first. Those prompt corrections are
+covered by tests but were not part of that live evaluation. The sample does
+not establish better musical quality or accurate pitch recognition.

--- a/services/musician-studio/compose.py
+++ b/services/musician-studio/compose.py
@@ -22,6 +22,45 @@ from studio.state import Store
 ROOT = Path(__file__).parent
 
 
+class MusicalPlan(BaseModel):
+    tempo_bpm: float = Field(gt=0, le=400)
+    meter: str = Field(min_length=1, max_length=300)
+    tonal_organization: str = Field(min_length=20, max_length=1000)
+    motif: str = Field(min_length=20, max_length=1000)
+    instrument_roles: list[str] = Field(min_length=1, max_length=6)
+    development: str = Field(min_length=20, max_length=1000)
+
+
+def plan_music(
+    profile: Musician, previous: list[dict], store: Store, session: str, name: str
+) -> MusicalPlan:
+    saved = store.study(session, name) or {}
+    if saved.get("musical_plan"):
+        return MusicalPlan.model_validate(saved["musical_plan"])
+    prompt = (
+        "Plan a ten-second piece before writing any synthesis code. "
+        "Use your inspirations and lessons from previous audio reviews. "
+        "Choose a coherent musical idea that can be recognized by listening. "
+        "Specify tempo and meter (or explain free timing), a tonal center/mode and chord or "
+        "pitch relationships, a short motif with concrete notes or intervals and rhythmic values, "
+        "the role/register of each instrument, and how the phrase develops and ends within ten seconds. "
+        "Relate bass notes and voicings to the motif; use repetition with purposeful variation, "
+        "space, phrasing and tension/release. Texture alone is not a composition plan. "
+        "Non-tonal and percussion-led music are welcome: explain the organizing relationships "
+        "instead of inventing a key or forcing melody or chords. A single voice can be sufficient. "
+        "Avoid unrelated effects and competing ideas. Pick the few musical relationships that matter. "
+        "Return only JSON matching this schema: "
+        + json.dumps(MusicalPlan.model_json_schema())
+        + "\nMusician: "
+        + json.dumps(musical_identity(profile))
+        + "\nPrevious work and heard feedback: "
+        + json.dumps(history_context(previous))
+    )
+    plan = MusicalPlan.model_validate_json(request_music(prompt, store, session))
+    store.save_study(session, name, {"musical_plan": plan.model_dump()})
+    return plan
+
+
 class Composition(BaseModel):
     title: str = Field(min_length=1, max_length=80)
     idea: str = Field(min_length=1, max_length=1500)
@@ -45,10 +84,23 @@ def compose(
     peer: dict | None = None,
     revision: str | None = None,
 ) -> Composition:
+    name = musician_id or profile.name.lower()
+    plan = plan_music(profile, previous, store, session, name)
     prompt = (
         "Make a ten-second piece of music as this musician. Use Python and numpy to create the audio. "
         "You control the instruments, synthesis, musical structure, rhythm, harmony, and mix. "
-        "Write a complete executable script using only numpy and the Python standard library. "
+        "Write a complete executable script using numpy, the Python standard library, and optionally studio_instruments. "
+        "Implement this musical plan, prioritizing audible phrasing and relationships over effects: "
+        + plan.model_dump_json()
+        + "\nOptional tested tools from studio_instruments: SAMPLE_RATE=44100; "
+        "note_hz(midi) supports fractional MIDI; beat_seconds(beat,bpm) converts beats to seconds; "
+        "pitched_note(midi,seconds,voice='pluck') returns mono numpy audio, voice is pluck/bass/pad, "
+        "duration includes release; drum_hit(voice,seed=0) returns a 0.3-second kick/snare/hat; "
+        "mix_voice(stereo,mono,start,gain=0.2,pan=0) adds a voice in-place at start SECONDS, "
+        "pan -1..1; write_track(stereo,path='/output/track.wav') fades endpoints and prevents clipping. "
+        "Create stereo with np.zeros((441000,2)). Layer chord notes with mix_voice, "
+        "schedule beats through beat_seconds, and leave room for note releases. "
+        "You may transform these sounds or synthesize your own. They impose no notes, chords or genre. "
         "It must write /output/track.wav as ten seconds of 16-bit PCM stereo at 44100 Hz. "
         "The environment has no network or external files; runtime is limited to 30 seconds and 512 MB. "
         "Avoid clipping. Choose a title for this particular composition. "
@@ -69,6 +121,16 @@ def compose(
     )
     if len(prompt.encode()) > 48000:
         raise ValueError("Composition context exceeds 48 KB")
+    source = request_music(prompt, store, session)
+    if source.startswith("```python\n") and source.endswith("```"):
+        source = source[len("```python\n") : -3].strip()
+    store.save_study(session, musician_id or profile.name.lower(), {"source": source})
+    return parse_composition(source)
+
+
+def request_music(prompt: str, store: Store, session: str) -> str:
+    if len(prompt.encode()) > 48000:
+        raise ValueError("Music context exceeds 48 KB")
     store.call(session)
     with tempfile.TemporaryDirectory() as scratch:
         pi = Path(scratch) / ".pi"
@@ -90,7 +152,7 @@ def compose(
                 "--model",
                 "openai-codex/gpt-5.6-luna",
                 "--thinking",
-                "off",
+                "low",
                 "--no-session",
                 "--no-extensions",
                 "--no-context-files",
@@ -127,10 +189,7 @@ def compose(
     source = "".join(
         p["text"] for p in messages[0]["content"] if p["type"] == "text"
     ).strip()
-    if source.startswith("```python\n") and source.endswith("```"):
-        source = source[len("```python\n") : -3].strip()
-    store.save_study(session, musician_id or profile.name.lower(), {"source": source})
-    return parse_composition(source)
+    return source
 
 
 def parse_composition(source: str) -> Composition:
@@ -195,6 +254,8 @@ def render(code: str, output: Path) -> dict:
             f"{source.resolve()}:/input/compose.py:ro",
             "-v",
             f"{fresh.resolve()}:/output",
+            "-v",
+            f"{ROOT / 'studio_instruments.py'}:/usr/local/lib/python3.13/site-packages/studio_instruments.py:ro",
             "plyr-musician-python:local",
         ]
         try:

--- a/services/musician-studio/compose.py
+++ b/services/musician-studio/compose.py
@@ -54,7 +54,7 @@ def plan_music(
         + "\nMusician: "
         + json.dumps(musical_identity(profile))
         + "\nPrevious work and heard feedback: "
-        + json.dumps(history_context(previous))
+        + json.dumps(history_context(previous, include_code=False))
     )
     plan = MusicalPlan.model_validate_json(request_music(prompt, store, session))
     store.save_study(session, name, {"musical_plan": plan.model_dump()})
@@ -100,6 +100,8 @@ def compose(
         "pan -1..1; write_track(stereo,path='/output/track.wav') fades endpoints and prevents clipping. "
         "Create stereo with np.zeros((441000,2)). Layer chord notes with mix_voice, "
         "schedule beats through beat_seconds, and leave room for note releases. "
+        "Start with these instruments for ordinary pitched and percussion parts; write custom synthesis "
+        "when a particular sound calls for it. Do not copy an old synthesizer merely because it appears in history. "
         "You may transform these sounds or synthesize your own. They impose no notes, chords or genre. "
         "It must write /output/track.wav as ten seconds of 16-bit PCM stereo at 44100 Hz. "
         "The environment has no network or external files; runtime is limited to 30 seconds and 512 MB. "
@@ -107,7 +109,7 @@ def compose(
         "Identity and inspirations: "
         + json.dumps(musical_identity(profile))
         + "\nYour earlier work (code and intentions, not an audio listening experience): "
-        + json.dumps(history_context(previous))
+        + json.dumps(history_context(previous, include_code=revision is not None))
         + "\nPeer work, if available: "
         + json.dumps(peer)
         + "\nYou have code, not auditory perception. Respond to the peer if their work interests you. "

--- a/services/musician-studio/flow.py
+++ b/services/musician-studio/flow.py
@@ -12,7 +12,7 @@ from prefect.cache_policies import NO_CACHE
 from prefect.states import Completed, State
 
 from audio_round import prepare_release
-from compose import Composition, compose, render
+from compose import Composition, compose, plan_music, render
 from studio.context import choose_peer
 from studio.identity import Musician
 from studio.listening import NotReady
@@ -58,6 +58,7 @@ def compose_piece(directory: Path, session: str, name: str) -> dict:
     profile = Musician.model_validate(store.musicians()[name]["profile"])
     peer = saved.get("peer") or choose_peer(store, name, session)
     store.save_study(session, name, {"peer": peer})
+    plan_piece(directory, session, name)
     piece = compose(
         profile,
         store.history(name, session),
@@ -76,6 +77,15 @@ def compose_piece(directory: Path, session: str, name: str) -> dict:
         ]
     store.save_musician(name, entry)
     return store.study(session, name)
+
+
+@task(name="plan-musical-phrase", cache_policy=NO_CACHE, persist_result=False)
+def plan_piece(directory: Path, session: str, name: str) -> dict:
+    store = Store(directory)
+    profile = Musician.model_validate(store.musicians()[name]["profile"])
+    return plan_music(
+        profile, store.history(name, session), store, session, name
+    ).model_dump()
 
 
 @task(
@@ -164,6 +174,11 @@ def report(store: Store, session: str | None, errors: list[str]) -> None:
             notes.append(
                 f"## {name}: {study.get('title', 'unfinished')}\n\n{study.get('idea', '')}\n\n"
                 f"Memory: {study.get('memory', '')}\n\n"
+                + (
+                    "Musical plan: " + json.dumps(study["musical_plan"]) + "\n\n"
+                    if study.get("musical_plan")
+                    else ""
+                )
                 + "\n\n".join(
                     f"Audio review by {r['listener']} ({r['model']}, {r['audio_tokens']} audio tokens): {r['observations']} Next: {r['changes']}"
                     for r in study.get("audio_feedback", [])
@@ -204,7 +219,9 @@ def report(store: Store, session: str | None, errors: list[str]) -> None:
     log_prints=True,
     persist_result=False,
 )
-def community(retry_failed: bool = False, bootstrap: bool = False) -> State:
+def community(
+    retry_failed: bool = False, bootstrap: bool = False, evaluation: bool = False
+) -> State:
     directory = Path(os.environ["STUDIO_STATE_DIR"])
     directory.mkdir(parents=True, exist_ok=True)
     with (directory / "session.lock").open("w") as lock:
@@ -216,7 +233,10 @@ def community(retry_failed: bool = False, bootstrap: bool = False) -> State:
             )
         store = Store(directory)
         session = store.reserve(
-            datetime.now(UTC), retry_failed=retry_failed, bootstrap=bootstrap
+            datetime.now(UTC),
+            retry_failed=retry_failed,
+            bootstrap=bootstrap,
+            evaluation=evaluation,
         )
         errors = []
         logger = get_run_logger()
@@ -234,8 +254,13 @@ def community(retry_failed: bool = False, bootstrap: bool = False) -> State:
                     compose_piece(directory, session, name)
                     audio = render_piece(directory, session, name)
                     audio = review_audio(directory, session, name, audio)
-                    publish_piece(directory, session, name, audio)
-                    curate_peer(directory, session, name)
+                    if evaluation:
+                        store.save_study(
+                            session, name, {"withheld": True, "evaluation": True}
+                        )
+                    else:
+                        publish_piece(directory, session, name, audio)
+                        curate_peer(directory, session, name)
                 except NotReady as exc:
                     store.save_study(session, name, {"withheld": True})
                     logger.info("%s: %s", name, exc)

--- a/services/musician-studio/prefect.yaml
+++ b/services/musician-studio/prefect.yaml
@@ -3,7 +3,7 @@ pull:
   - prefect.deployments.steps.git_clone:
       id: checkout
       repository: https://github.com/zzstoatzz/plyr.fm.git
-      commit_sha: f761ffd94f45089ed2903cc3048d90cc5aa72768
+      commit_sha: 7d510d0234f080e5d5881e5332575e1ef8058e67
   - prefect.deployments.steps.set_working_directory:
       directory: "{{ checkout.directory }}/services/musician-studio"
 deployments:

--- a/services/musician-studio/studio/audio_model.py
+++ b/services/musician-studio/studio/audio_model.py
@@ -45,7 +45,6 @@ def listen(
     inspirations: list[dict],
 ) -> ListeningReview:
     profile = Musician.model_validate(store.musicians()[listener]["profile"])
-    study = store.study(session, author) or {}
     prompt = (
         "Listen to the attached ten-second recording as this musician: "
         + json.dumps(musical_identity(profile))
@@ -53,17 +52,14 @@ def listen(
         + json.dumps(inspirations)
         + ". Review the audible tonality, pitch relationships, timbre, bass, balance, articulation, and development. "
         "Describe concrete audible moments and uncertainty; do not invent instrument names or infer sound from inspirations. "
-        "First describe what you hear independently of the plan: is there a discernible pulse or intentional "
+        "Describe only what you hear: is there a discernible pulse or intentional "
         "free rhythm, a motif with phrasing, coherent pitch relationships, and development? "
         "Name timestamps and uncertainty. Do not reward theory words or effects without audible organization. "
-        "Then compare what you heard with the author's plan below; intentions are not evidence. "
         "Explain which musical relationship works or fails, and give an actionable note/rhythm/voicing "
         "or arrangement change rather than just more hiss, reverb or saturation. "
-        "Judge percussion-led or non-tonal work by its stated organization, not compulsory chords. "
+        "Judge percussion-led or non-tonal work by audible organization, not compulsory chords. "
         "Suggest a specific revision to how it sounds. Ready means you would release it as the author, or keep it as a peer. "
         "A difference from your own taste is not a technical defect. Return JSON with observations, changes, and ready."
-        + "\nAuthor's plan (may be absent for older work): "
-        + json.dumps(study.get("musical_plan"))
     )
     data = path.read_bytes()
     if not data or len(data) > 4_000_000:

--- a/services/musician-studio/studio/audio_model.py
+++ b/services/musician-studio/studio/audio_model.py
@@ -45,6 +45,7 @@ def listen(
     inspirations: list[dict],
 ) -> ListeningReview:
     profile = Musician.model_validate(store.musicians()[listener]["profile"])
+    study = store.study(session, author) or {}
     prompt = (
         "Listen to the attached ten-second recording as this musician: "
         + json.dumps(musical_identity(profile))
@@ -52,8 +53,17 @@ def listen(
         + json.dumps(inspirations)
         + ". Review the audible tonality, pitch relationships, timbre, bass, balance, articulation, and development. "
         "Describe concrete audible moments and uncertainty; do not invent instrument names or infer sound from inspirations. "
+        "First describe what you hear independently of the plan: is there a discernible pulse or intentional "
+        "free rhythm, a motif with phrasing, coherent pitch relationships, and development? "
+        "Name timestamps and uncertainty. Do not reward theory words or effects without audible organization. "
+        "Then compare what you heard with the author's plan below; intentions are not evidence. "
+        "Explain which musical relationship works or fails, and give an actionable note/rhythm/voicing "
+        "or arrangement change rather than just more hiss, reverb or saturation. "
+        "Judge percussion-led or non-tonal work by its stated organization, not compulsory chords. "
         "Suggest a specific revision to how it sounds. Ready means you would release it as the author, or keep it as a peer. "
         "A difference from your own taste is not a technical defect. Return JSON with observations, changes, and ready."
+        + "\nAuthor's plan (may be absent for older work): "
+        + json.dumps(study.get("musical_plan"))
     )
     data = path.read_bytes()
     if not data or len(data) > 4_000_000:

--- a/services/musician-studio/studio/context.py
+++ b/services/musician-studio/studio/context.py
@@ -12,7 +12,9 @@ def musical_identity(profile: Musician) -> dict:
     return profile.model_dump(exclude={"avatar_prompt", "bio"})
 
 
-def history_context(history: list[dict], byte_limit: int = 18000) -> list[dict]:
+def history_context(
+    history: list[dict], byte_limit: int = 18000, *, include_code: bool = True
+) -> list[dict]:
     selected = []
     for entry in history:
         item = {
@@ -30,6 +32,8 @@ def history_context(history: list[dict], byte_limit: int = 18000) -> list[dict]:
             )
             if key in entry
         }
+        if not include_code:
+            item.pop("python", None)
         if len(json.dumps(selected + [item]).encode()) <= byte_limit:
             selected.append(item)
         elif not selected:

--- a/services/musician-studio/studio/context.py
+++ b/services/musician-studio/studio/context.py
@@ -23,6 +23,7 @@ def history_context(history: list[dict], byte_limit: int = 18000) -> list[dict]:
                 "idea",
                 "python",
                 "memory",
+                "musical_plan",
                 "audio_feedback",
                 "metrics",
                 "track_id",

--- a/services/musician-studio/studio/state.py
+++ b/services/musician-studio/studio/state.py
@@ -34,10 +34,18 @@ class Store:
         return sqlite3.connect(self.path, timeout=30)
 
     def reserve(
-        self, now: datetime, retry_failed: bool = False, *, bootstrap: bool = False
+        self,
+        now: datetime,
+        retry_failed: bool = False,
+        *,
+        bootstrap: bool = False,
+        evaluation: bool = False,
     ) -> str | None:
+        if bootstrap and evaluation:
+            raise ValueError("Bootstrap and evaluation are separate sessions")
         day, month = now.strftime("%Y-%m-%d"), now.strftime("%Y-%m")
         key = f"{day}-{now.hour // 6}" + ("-bootstrap" if bootstrap else "")
+        key += "-evaluation" if evaluation else ""
         with self.connect() as db:
             db.execute("BEGIN IMMEDIATE")
             if bootstrap:

--- a/services/musician-studio/studio_instruments.py
+++ b/services/musician-studio/studio_instruments.py
@@ -1,0 +1,99 @@
+"""Optional instruments and timing tools; musical choices belong to the composer."""
+
+import wave
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+from numpy.typing import NDArray
+
+SAMPLE_RATE = 44100
+Audio = NDArray[np.float64]
+
+
+def note_hz(midi: float) -> float:
+    return 440.0 * 2.0 ** ((midi - 69) / 12)
+
+
+def beat_seconds(beat: float, bpm: float) -> float:
+    if bpm <= 0:
+        raise ValueError("Tempo must be positive")
+    return beat * 60 / bpm
+
+
+def pitched_note(
+    midi: float,
+    seconds: float,
+    voice: Literal["pluck", "bass", "pad"] = "pluck",
+) -> Audio:
+    """Return a mono note; duration includes release. MIDI may be fractional."""
+    if seconds <= 0 or voice not in {"pluck", "bass", "pad"}:
+        raise ValueError("Expected positive duration and pluck, bass, or pad")
+    t = np.arange(round(seconds * SAMPLE_RATE)) / SAMPLE_RATE
+    frequency = note_hz(midi)
+    if not 0 < frequency < SAMPLE_RATE / 2:
+        raise ValueError("Pitch outside the audible synthesis range")
+    signal = np.zeros_like(t)
+    for harmonic in range(1, 13):
+        if frequency * harmonic >= SAMPLE_RATE / 2:
+            break
+        decay = np.exp(-t * harmonic / max(seconds * 0.5, 0.05))
+        if voice == "pad":
+            decay = np.ones_like(t)
+        weight = harmonic ** (-2 if voice == "bass" else -1.5)
+        signal += weight * decay * np.sin(2 * np.pi * frequency * harmonic * t)
+    attack = min(seconds / 4, 0.15 if voice == "pad" else 0.005)
+    release = min(seconds / 3, 0.25 if voice == "pad" else 0.04)
+    envelope = np.minimum(1, t / attack) * np.minimum(1, (seconds - t) / release)
+    signal *= envelope
+    return signal / max(float(np.max(np.abs(signal), initial=0)), 1)
+
+
+def drum_hit(voice: Literal["kick", "snare", "hat"], seed: int = 0) -> Audio:
+    if voice not in {"kick", "snare", "hat"}:
+        raise ValueError("Expected kick, snare, or hat")
+    t = np.arange(round(0.3 * SAMPLE_RATE)) / SAMPLE_RATE
+    noise = np.random.default_rng(seed).normal(0, 0.3, len(t))
+    if voice == "kick":
+        phase = 2 * np.pi * (48 * t + 85 * 0.025 * (1 - np.exp(-t / 0.025)))
+        signal = np.sin(phase) * np.exp(-t / 0.065)
+    elif voice == "snare":
+        signal = (noise + 0.35 * np.sin(2 * np.pi * 185 * t)) * np.exp(-t / 0.045)
+    else:
+        signal = np.diff(noise, prepend=0) * np.exp(-t / 0.025)
+    signal *= np.minimum(1, t / 0.001) * np.minimum(1, (0.3 - t) / 0.015)
+    return signal / max(float(np.max(np.abs(signal))), 1)
+
+
+def mix_voice(
+    stereo: Audio, mono: Audio, start: float, gain: float = 0.2, pan: float = 0
+) -> None:
+    """Add a mono signal at a time in seconds, with equal-power pan (-1 to 1)."""
+    if stereo.ndim != 2 or stereo.shape[1] != 2 or mono.ndim != 1:
+        raise ValueError("Expected stereo destination and mono voice")
+    if start < 0 or not -1 <= pan <= 1:
+        raise ValueError("Expected nonnegative start and pan between -1 and 1")
+    offset = round(start * SAMPLE_RATE)
+    length = min(len(mono), len(stereo) - offset)
+    if length <= 0:
+        return
+    angle = (pan + 1) * np.pi / 4
+    stereo[offset : offset + length] += (
+        mono[:length, None] * gain * np.array([np.cos(angle), np.sin(angle)])
+    )
+
+
+def write_track(stereo: Audio, path: str = "/output/track.wav") -> None:
+    if stereo.shape != (10 * SAMPLE_RATE, 2) or not np.isfinite(stereo).all():
+        raise ValueError("Expected ten seconds of finite stereo audio")
+    audio = stereo.copy()
+    fade = round(0.01 * SAMPLE_RATE)
+    audio[:fade] *= np.linspace(0, 1, fade)[:, None]
+    audio[-fade:] *= np.linspace(1, 0, fade)[:, None]
+    audio *= min(1, 0.9 / max(float(np.max(np.abs(audio))), 1e-12))
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(path, "wb") as output:
+        output.setnchannels(2)
+        output.setsampwidth(2)
+        output.setframerate(SAMPLE_RATE)
+        output.writeframes((audio * 32767).astype("<i2").tobytes())

--- a/services/musician-studio/tests/test_audio_model.py
+++ b/services/musician-studio/tests/test_audio_model.py
@@ -33,7 +33,7 @@ def test_review_sends_audio_and_records_provider_evidence(
         assert base64.b64decode(parts[1]["inline_data"]["data"]) == audio.read_bytes()
         assert parts[1]["inline_data"]["mime_type"] == "audio/wav"
         assert inspirations[0]["artist"] in parts[0]["text"]
-        assert "D F E D, answered in the bass" in parts[0]["text"]
+        assert "D F E D, answered in the bass" not in parts[0]["text"]
         return httpx.Response(
             200,
             json={

--- a/services/musician-studio/tests/test_audio_model.py
+++ b/services/musician-studio/tests/test_audio_model.py
@@ -20,6 +20,9 @@ def test_review_sends_audio_and_records_provider_evidence(
     profile = json.loads((Path(__file__).parents[1] / "profiles/moss.json").read_text())
     store.save_musician("moss", profile)
     session = store.reserve(datetime.now(UTC))
+    store.save_study(
+        session, "moss", {"musical_plan": {"motif": "D F E D, answered in the bass"}}
+    )
     audio = tmp_path / "recording.wav"
     audio.write_bytes(b"the exact rendered audio")
     inspirations = profile["profile"]["inspirations"]
@@ -30,6 +33,7 @@ def test_review_sends_audio_and_records_provider_evidence(
         assert base64.b64decode(parts[1]["inline_data"]["data"]) == audio.read_bytes()
         assert parts[1]["inline_data"]["mime_type"] == "audio/wav"
         assert inspirations[0]["artist"] in parts[0]["text"]
+        assert "D F E D, answered in the bass" in parts[0]["text"]
         return httpx.Response(
             200,
             json={

--- a/services/musician-studio/tests/test_composition.py
+++ b/services/musician-studio/tests/test_composition.py
@@ -1,7 +1,13 @@
+import json
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
+import compose
 from compose import parse_composition
+from studio.identity import Musician
+from studio.state import Store
 
 
 def test_metadata_is_read_without_executing_composer_code() -> None:
@@ -21,3 +27,41 @@ def test_executable_metadata_is_not_evaluated() -> None:
 def test_inspirations_can_change_but_cannot_be_cleared() -> None:
     with pytest.raises(ValidationError):
         parse_composition('TITLE="one"\nIDEA="two"\nINSPIRATIONS=[]')
+
+
+def test_musical_plan_is_validated_and_reused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = Store(tmp_path)
+    profile = Musician.model_validate(
+        json.loads((Path(__file__).parents[1] / "profiles/reed.json").read_text())[
+            "profile"
+        ]
+    )
+    response = {
+        "tempo_bpm": 96,
+        "meter": "4/4, four bars in ten seconds",
+        "tonal_organization": "D minor, Dm to Gm with stepwise inner voices",
+        "motif": "D F E D, eighth eighth quarter half; answer an octave below",
+        "instrument_roles": [
+            "mid-register pluck melody",
+            "bass roots on beats one and three",
+        ],
+        "development": "Repeat the first phrase, then answer it and land on D.",
+    }
+    requests = []
+
+    def request(prompt: str, *_args: object) -> str:
+        requests.append(prompt)
+        return json.dumps(response)
+
+    monkeypatch.setattr(compose, "request_music", request)
+    first = compose.plan_music(profile, [], store, "session", "reed")
+    second = compose.plan_music(profile, [], store, "session", "reed")
+    assert first == second
+    assert len(requests) == 1
+    assert store.study("session", "reed")["musical_plan"]["tempo_bpm"] == 96
+    response["tempo_bpm"] = -1
+    with pytest.raises(ValidationError):
+        compose.plan_music(profile, [], store, "other-session", "reed")
+    assert store.study("other-session", "reed") is None

--- a/services/musician-studio/tests/test_context.py
+++ b/services/musician-studio/tests/test_context.py
@@ -71,3 +71,17 @@ def test_composition_context_excludes_visual_profile_instructions() -> None:
     assert "avatar_prompt" not in context and "bio" not in context
     assert context["inspirations"] == [i.model_dump() for i in profile.inspirations]
     assert context["ethos"] == profile.ethos
+
+
+def test_planning_history_keeps_lessons_without_old_synthesis() -> None:
+    history = [
+        {
+            "python": "old oscillator code",
+            "memory": "bass masks melody",
+            "musical_plan": {"motif": "D F E D"},
+        }
+    ]
+    context = history_context(history, include_code=False)
+    assert context == [
+        {"memory": "bass masks melody", "musical_plan": {"motif": "D F E D"}}
+    ]

--- a/services/musician-studio/tests/test_evaluation.py
+++ b/services/musician-studio/tests/test_evaluation.py
@@ -1,0 +1,32 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+import flow
+from studio.state import Store
+
+
+def test_evaluation_never_calls_publication_or_curation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("STUDIO_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(flow, "get_run_logger", lambda: logging.getLogger("test"))
+    monkeypatch.setattr(flow, "seed", lambda _directory: ["reed"])
+    monkeypatch.setattr(flow, "compose_piece", lambda *_args: {})
+    monkeypatch.setattr(flow, "render_piece", lambda *_args: tmp_path / "draft.wav")
+    monkeypatch.setattr(flow, "review_audio", lambda *_args: tmp_path / "revision.wav")
+    monkeypatch.setattr(flow, "report", lambda *_args: None)
+
+    def forbid_write(*_args: object) -> None:
+        pytest.fail("An evaluation must not write to plyr.fm")
+
+    monkeypatch.setattr(flow, "publish_piece", forbid_write)
+    monkeypatch.setattr(flow, "curate_peer", forbid_write)
+    assert flow.community.fn(evaluation=True).is_completed()
+    store = Store(tmp_path)
+    with store.connect() as db:
+        session, status = db.execute("SELECT id,status FROM sessions").fetchone()
+    assert session.endswith("-evaluation")
+    assert status == "completed"
+    assert store.study(session, "reed")["withheld"]

--- a/services/musician-studio/tests/test_instruments.py
+++ b/services/musician-studio/tests/test_instruments.py
@@ -1,0 +1,53 @@
+import wave
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+import pytest
+
+from studio_instruments import (
+    SAMPLE_RATE,
+    beat_seconds,
+    drum_hit,
+    mix_voice,
+    pitched_note,
+    write_track,
+)
+
+
+@pytest.mark.parametrize("voice", ["pluck", "bass", "pad"])
+def test_pitched_voices_preserve_audible_fundamental(
+    voice: Literal["pluck", "bass", "pad"],
+) -> None:
+    audio = pitched_note(69, 1, voice)
+    spectrum = np.abs(np.fft.rfft(audio))
+    assert np.argmax(spectrum) == 440
+    assert np.isfinite(audio).all()
+    assert audio[0] == 0
+    assert abs(audio[-1]) < 0.001
+
+
+def test_arrangement_preserves_timing_pan_and_output(tmp_path: Path) -> None:
+    mix = np.zeros((10 * SAMPLE_RATE, 2))
+    start = beat_seconds(2, 120)
+    mix_voice(mix, drum_hit("kick"), start, gain=0.3, pan=-1)
+    assert np.max(np.abs(mix[:SAMPLE_RATE])) == 0
+    assert np.max(np.abs(mix[SAMPLE_RATE:, 0])) > 0.1
+    assert np.max(np.abs(mix[:, 1])) == 0
+    path = tmp_path / "track.wav"
+    write_track(mix * 20, str(path))
+    with wave.open(str(path)) as wav:
+        assert (wav.getnframes(), wav.getnchannels(), wav.getsampwidth()) == (
+            441000,
+            2,
+            2,
+        )
+        audio = np.frombuffer(wav.readframes(wav.getnframes()), dtype="<i2")
+        assert np.max(np.abs(audio)) < 30000
+
+
+def test_silent_tail_and_invalid_output_are_not_hidden(tmp_path: Path) -> None:
+    audio = np.zeros((10 * SAMPLE_RATE, 2))
+    audio[0, 0] = np.nan
+    with pytest.raises(ValueError):
+        write_track(audio, str(tmp_path / "bad.wav"))

--- a/services/musician-studio/tests/test_limits.py
+++ b/services/musician-studio/tests/test_limits.py
@@ -115,3 +115,17 @@ def test_bootstrap_is_once_and_charged_to_normal_budgets(tmp_path: Path) -> None
     assert store.usage(now)["day"]["budget_used"] == 0.10
     with pytest.raises(RuntimeError):
         store.call(session)
+
+
+def test_evaluation_reserves_separately_without_resetting_budget(
+    tmp_path: Path,
+) -> None:
+    store = Store(tmp_path)
+    now = datetime(2026, 9, 8, 8, tzinfo=UTC)
+    normal = store.reserve(now)
+    evaluation = store.reserve(now, evaluation=True)
+    assert normal != evaluation
+    assert store.reserve(now, evaluation=True) is None
+    assert store.usage(now)["day"]["budget_used"] == pytest.approx(0.2)
+    store.charge(evaluation, 10)
+    assert store.reserve(now.replace(hour=14), evaluation=True) is None


### PR DESCRIPTION
musicians now plan a ten-second phrase before writing Python: tempo and meter, pitch relationships, motif, instrument roles, and development. optional instruments handle pitched voices, percussion, timing, mixing and WAV output so composition does not require rebuilding every synthesizer.

<details>
<summary>listening and operation</summary>

plans persist with previous work and guide implementation. listeners receive actual audio and inspirations, without the plan or source code. new-piece prompts preserve lessons but omit old synthesis code; revisions retain the current draft. reviewers assess audible musical relationships and propose concrete musical changes. Luna uses low reasoning effort for planning and implementation; Gemini still receives the actual audio for every review.

an evaluation-only run reserves 10¢ against the existing daily/monthly limits and cannot upload or curate playlists. evaluations are limited to one per six-hour window. normal scheduling, unlisted uploads, and the release evidence gate remain in place.

41 tests pass, including pitch, timing, panning, output format, plan validation/reuse, and evaluation budgeting. a real Docker render successfully imported the read-only instrument module. live evaluation [856e3252](https://prefect-server.waow.tech/runs/flow-run/856e3252-7b2f-4710-9d61-21256c647005) completed for $0.040811 with seven model calls and no upload. it exposed reviews repeating supplied notes, so the final prompts hide the plan and default to provided instruments. those final prompt corrections have offline coverage but were not part of that live run; no claim of improved musical quality.

</details>

![bufo-loves-this-song](https://all-the.bufo.zone/bufo-loves-this-song.png)

generated with Codex (GPT-6)
