### PR TITLE
Keep old peer synthesizers out of new composition context

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -586,3 +586,18 @@ normal budget ledger and cannot publish or curate. Live run `856e3252-7b2f-4710-
 completed for $0.040811, with no upload. It exposed plan-primed reviews and reuse
 of old synthesis: the final prompts hide plans from listeners and old code from
 new-piece generation. Musical quality remains for human assessment.
+
+### September 8 — peer code still carried a broken timing implementation
+
+Auditing Moss's published bootstrap track 1284 found a seconds/sample mismatch:
+`tone` forwards its start argument directly to a sample-index mixer, but chords,
+bass and melody supply seconds. Events intended for 0–9 seconds collapse into
+the first 0–9 samples; the pulse and percussion paths use sample units correctly.
+An isolated original render reproduced the saved peak/RMS; a two-line units
+correction restored the intended scheduling. This is a forensic correction, not
+evidence that a musician learned to fix it. Existing reviews missed the defect.
+
+The peer context still included entire old synthesizers after own-history code
+was removed. Peer selection now supplies metadata, plans and feedback without
+source code; the selected recording is still heard later. The regression test
+checks that boundary. No published audio or musician state was replaced.

--- a/services/musician-studio/studio/context.py
+++ b/services/musician-studio/studio/context.py
@@ -72,7 +72,7 @@ def choose_peer(store: Store, name: str, session: str) -> dict | None:
             "id": key,
             "name": peer.name,
             "inspirations": [i.model_dump() for i in peer.inspirations],
-            "work": history_context(history[:1], 12000)[0],
+            "work": history_context(history[:1], 12000, include_code=False)[0],
         }
     if not weights:
         return None

--- a/services/musician-studio/tests/test_context.py
+++ b/services/musician-studio/tests/test_context.py
@@ -59,7 +59,7 @@ def test_peer_choice_uses_only_another_artists_published_previous_work(
     peer = choose_peer(store, "moss", "2026-09-02-0")
     assert peer["id"] == "kite"
     assert peer["work"]["track_id"] == 123
-    assert peer["work"]["python"] == "pass"
+    assert "python" not in peer["work"]
     assert peer["probabilities"] == {"kite": 1.0}
 
 


### PR DESCRIPTION
new compositions no longer receive a peer's old synthesizer source. peer context retains the selected track, musical plan, memory and feedback, and the actual recording is still heard during the listening round.

<details>
<summary>evidence and validation</summary>

Moss's bootstrap track contains a seconds/sample timing mismatch affecting its chords, bass and melody. an isolated render reproduced the exact hash recorded by the audio reviewers, who missed that defect. passing this source to new composers could preserve the broken implementation even after their own historical source was removed.

41 studio tests pass; the peer-selection regression test now requires source to be absent. no published recordings or musician state were changed.

</details>

![bufo-loves-this-song](https://all-the.bufo.zone/bufo-loves-this-song.png)

generated with Codex (GPT-6)
