### PR TITLE
Add blind factual calibration for the audio listener

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -601,3 +601,13 @@ The peer context still included entire old synthesizers after own-history code
 was removed. Peer selection now supplies metadata, plans and feedback without
 source code; the selected recording is still heard later. The regression test
 checks that boundary. No published audio or musician state was replaced.
+
+### September 8 — factual listener calibration
+
+The timing audit motivates a separate calibration mode: six anonymous audio
+controls with host-known silence, pulse, sequential-note and stacked-note
+answers. It uses the same audio client and existing evaluation reservation;
+wrong answers and audio receipts are retained. Normal music runs and publication
+rules are unchanged. Offline tests verify actual event timing and that repeated
+calibration reads saved receipts without spending again. Live calibration is
+pending the next evaluation window; no accuracy claim is made yet.

--- a/services/musician-studio/README.md
+++ b/services/musician-studio/README.md
@@ -129,3 +129,18 @@ listeners no longer receive it. New-piece prompts now omit old synthesis code
 and recommend the provided instruments first. Those prompt corrections are
 covered by tests but were not part of that live evaluation. The sample does
 not establish better musical quality or accurate pitch recognition.
+
+## listener calibration
+
+An explicit run with `evaluation=true` and `calibration=true` classifies six
+unnamed, shuffled ten-second controls through the same native audio client:
+silence, regular noise pulses, sequential notes, and stacked notes. The source
+and expected answers stay on the host. Results retain wrong answers, confidence,
+audio hashes and positive provider audio-token receipts in
+`plyr-fm-listener-calibration` and the worker state directory.
+
+Calibration shares the one evaluation reservation per six-hour window, uses six model
+calls on a complete first attempt, and cannot publish. Explicit recovery remains
+subject to the same twelve-call session cap. It measures basic factual perception,
+not taste, pitch transcription, or quality of musical criticism. It does not run
+automatically before each composition or change the normal publication gate.

--- a/services/musician-studio/calibration.py
+++ b/services/musician-studio/calibration.py
@@ -1,0 +1,113 @@
+"""Blind, factual audio controls; these measure perception, not musical taste."""
+
+import hashlib
+import json
+import random
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+from prefect import task
+from prefect.artifacts import create_markdown_artifact
+from prefect.cache_policies import NO_CACHE
+from pydantic import BaseModel, Field
+
+from studio.audio_model import request_audio
+from studio.state import Store
+from studio_instruments import SAMPLE_RATE, Audio, mix_voice, pitched_note, write_track
+
+ControlKind = Literal[
+    "silence", "regular_noise_pulses", "separated_notes", "stacked_notes"
+]
+
+
+class HeardControl(BaseModel):
+    kind: ControlKind
+    confidence: float = Field(ge=0, le=1)
+    description: str = Field(min_length=1, max_length=800)
+
+
+def control_audio(kind: ControlKind, variation: int) -> Audio:
+    audio = np.zeros((10 * SAMPLE_RATE, 2))
+    if kind == "regular_noise_pulses":
+        rng = np.random.default_rng(variation)
+        t = np.arange(round(0.06 * SAMPLE_RATE)) / SAMPLE_RATE
+        noise = rng.normal(0, 1, len(t)) * np.sin(np.pi * t / 0.06) ** 2
+        for beat in range(1, 9):
+            mix_voice(audio, noise, float(beat), 0.15)
+    elif kind != "silence":
+        for index, note in enumerate([60, 64, 67, 72]):
+            start = 1 + index * 2 if kind == "separated_notes" else 1
+            mix_voice(audio, pitched_note(note + variation, 0.45), start, 0.2)
+    peak = float(np.max(np.abs(audio)))
+    if peak:
+        audio *= 0.5 / peak
+    return audio
+
+
+@task(name="calibrate-audio-listener", cache_policy=NO_CACHE, persist_result=False)
+def calibrate_listener(directory: Path, session: str) -> dict:
+    store = Store(directory)
+    saved = store.study(session, "listener-calibration") or {}
+    results = saved.get("results", [])
+    cases: list[tuple[ControlKind, int]] = [
+        ("silence", 0),
+        ("silence", 1),
+        ("regular_noise_pulses", 0),
+        ("regular_noise_pulses", 1),
+        ("separated_notes", 0),
+        ("stacked_notes", 0),
+    ]
+    random.Random(session).shuffle(cases)
+    folder = directory / session / "listener-calibration"
+    folder.mkdir(parents=True, exist_ok=True)
+    prompt = (
+        "Listen to this ten-second recording. Classify the actual audio as silence "
+        "(no audible events), regular_noise_pulses (repeated unpitched noise bursts), "
+        "separated_notes (pitched notes occurring one after another across the recording), "
+        "or stacked_notes (pitched notes sounding together as one event). "
+        "Report kind, confidence from 0 to 1, and a short description of the audible timing. "
+        "Silence is a valid answer. Do not invent a musical narrative. Return only JSON."
+    )
+    for index, (expected, variation) in enumerate(cases):
+        path = folder / f"{index}.wav"
+        write_track(control_audio(expected, variation), str(path))
+        if index < len(results):
+            if (
+                results[index]["audio_sha256"]
+                != hashlib.sha256(path.read_bytes()).hexdigest()
+            ):
+                raise ValueError("Calibration audio changed during recovery")
+            continue
+        answer, receipt = request_audio(store, session, path, prompt, HeardControl)
+        results.append(
+            {
+                "index": index,
+                "expected": expected,
+                **answer.model_dump(),
+                **receipt.model_dump(),
+                "correct": answer.kind == expected,
+            }
+        )
+        store.save_study(session, "listener-calibration", {"results": results})
+    summary = {
+        "results": results,
+        "correct": sum(result["correct"] for result in results),
+        "total": len(cases),
+        "scope": "Basic audio perception; not evidence of musical taste or reliable critique",
+    }
+    (folder / "results.json").write_text(json.dumps(summary, indent=2))
+    create_markdown_artifact(
+        key="plyr-fm-listener-calibration",
+        markdown=(
+            f"# Listener calibration: {summary['correct']}/{summary['total']} correct\n\n"
+            + summary["scope"]
+            + "\n\n"
+            + "\n\n".join(
+                f"{r['index']}: expected {r['expected']}; heard {r['kind']} "
+                f"(confidence {r['confidence']}, {r['audio_tokens']} audio tokens). {r['description']}"
+                for r in results
+            )
+        ),
+    )
+    return summary

--- a/services/musician-studio/flow.py
+++ b/services/musician-studio/flow.py
@@ -12,6 +12,7 @@ from prefect.cache_policies import NO_CACHE
 from prefect.states import Completed, State
 
 from audio_round import prepare_release
+from calibration import calibrate_listener
 from compose import Composition, compose, plan_music, render
 from studio.context import choose_peer
 from studio.identity import Musician
@@ -220,8 +221,13 @@ def report(store: Store, session: str | None, errors: list[str]) -> None:
     persist_result=False,
 )
 def community(
-    retry_failed: bool = False, bootstrap: bool = False, evaluation: bool = False
+    retry_failed: bool = False,
+    bootstrap: bool = False,
+    evaluation: bool = False,
+    calibration: bool = False,
 ) -> State:
+    if calibration and not evaluation:
+        raise ValueError("Calibration requires evaluation mode")
     directory = Path(os.environ["STUDIO_STATE_DIR"])
     directory.mkdir(parents=True, exist_ok=True)
     with (directory / "session.lock").open("w") as lock:
@@ -246,6 +252,12 @@ def community(
                 name="Skipped", message="Session slot or estimated budget unavailable"
             )
         try:
+            if calibration:
+                result = calibrate_listener(directory, session)
+                store.finish(session, "completed")
+                return Completed(
+                    message=f"Listener calibration: {result['correct']}/{result['total']} correct"
+                )
             names = seed(directory)
             now = datetime.now(UTC)
             selected = names[(now.toordinal() * 4 + now.hour // 6) % len(names)]

--- a/services/musician-studio/studio/audio_model.py
+++ b/services/musician-studio/studio/audio_model.py
@@ -61,6 +61,27 @@ def listen(
         "Suggest a specific revision to how it sounds. Ready means you would release it as the author, or keep it as a peer. "
         "A difference from your own taste is not a technical defect. Return JSON with observations, changes, and ready."
     )
+    feedback, receipt = request_audio(store, session, path, prompt, Feedback)
+    review = ListeningReview(
+        listener=listener,
+        author=author,
+        **receipt.model_dump(),
+        inspirations_sha256=inspiration_digest(inspirations),
+        **feedback.model_dump(),
+    )
+    record_review(store, session, author, review)
+    return review
+
+
+class AudioReceipt(BaseModel):
+    audio_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    model: str = Field(min_length=1)
+    audio_tokens: int = Field(gt=0)
+
+
+def request_audio[Response: BaseModel](
+    store: Store, session: str, path: Path, prompt: str, schema: type[Response]
+) -> tuple[Response, AudioReceipt]:
     data = path.read_bytes()
     if not data or len(data) > 4_000_000:
         raise ValueError("Missing or oversized review audio")
@@ -87,7 +108,7 @@ def listen(
                     "maxOutputTokens": 1600,
                     "thinkingConfig": {"thinkingLevel": "LOW"},
                     "responseMimeType": "application/json",
-                    "responseJsonSchema": Feedback.model_json_schema(),
+                    "responseJsonSchema": schema.model_json_schema(),
                 },
             },
         )
@@ -117,21 +138,15 @@ def listen(
     candidate = result["candidates"][0]
     if candidate.get("finishReason") != "STOP":
         raise ValueError("Audio review was incomplete")
-    feedback = Feedback.model_validate_json(
+    parsed = schema.model_validate_json(
         "".join(
             p.get("text", "")
             for p in candidate["content"]["parts"]
             if not p.get("thought")
         )
     )
-    review = ListeningReview(
-        listener=listener,
-        author=author,
+    return parsed, AudioReceipt(
         audio_sha256=hashlib.sha256(data).hexdigest(),
         model=result["modelVersion"],
         audio_tokens=audio_tokens,
-        inspirations_sha256=inspiration_digest(inspirations),
-        **feedback.model_dump(),
     )
-    record_review(store, session, author, review)
-    return review

--- a/services/musician-studio/tests/test_calibration.py
+++ b/services/musician-studio/tests/test_calibration.py
@@ -1,0 +1,65 @@
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import calibration
+from studio.audio_model import AudioReceipt
+from studio.state import Store
+
+
+@pytest.mark.parametrize(
+    ("kind", "active_seconds"),
+    [
+        ("silence", []),
+        ("regular_noise_pulses", list(range(1, 9))),
+        ("separated_notes", [1, 3, 5, 7]),
+        ("stacked_notes", [1]),
+    ],
+)
+def test_controls_have_known_event_timing(
+    kind: calibration.ControlKind, active_seconds: list[int]
+) -> None:
+    audio = calibration.control_audio(kind, 0)
+    assert audio.shape == (441000, 2)
+    blocks = audio.reshape(10, 44100, 2)
+    observed = np.flatnonzero(np.max(np.abs(blocks), axis=(1, 2)) > 0.001)
+    assert observed.tolist() == active_seconds
+
+
+def test_calibration_saves_wrong_answers_and_reuses_receipts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = Store(tmp_path)
+    session = store.reserve(datetime.now(UTC), evaluation=True)
+    calls = []
+
+    def answer(
+        store: Store, session: str, path: Path, prompt: str, schema: type
+    ) -> tuple[calibration.HeardControl, AudioReceipt]:
+        store.call(session)
+        store.charge(session, 0.001)
+        calls.append(path)
+        assert path.stem.isdigit()
+        assert "expected" not in prompt
+        return calibration.HeardControl(
+            kind="silence", confidence=1, description="No sound heard"
+        ), AudioReceipt(
+            model="test",
+            audio_tokens=250,
+            audio_sha256=hashlib.sha256(path.read_bytes()).hexdigest(),
+        )
+
+    monkeypatch.setattr(calibration, "request_audio", answer)
+    monkeypatch.setattr(calibration, "create_markdown_artifact", lambda **_kwargs: None)
+    first = calibration.calibrate_listener.fn(tmp_path, session)
+    second = calibration.calibrate_listener.fn(tmp_path, session)
+    assert first == second
+    assert first["correct"] == 2
+    assert first["total"] == 6
+    assert len(calls) == 6
+    assert store.usage(datetime.now(UTC))["month"]["estimated_cost"] == pytest.approx(
+        0.006
+    )


### PR DESCRIPTION
add an explicit listener calibration mode after audio reviews missed a seconds/sample timing error. six anonymous recordings test silence, regular noise pulses, sequential notes and stacked notes through the same native audio client used by the musicians.

<details>
<summary>scope and validation</summary>

expected answers remain on the host. receipts preserve model identity, audio hash, positive audio-token counts, predictions and confidence. calibration shares the existing evaluation reservation and cannot publish; normal music runs and release rules are unchanged.

46 tests pass, including waveform timing, incorrect answers, recovery without repeat charges, and the existing native audio payload/receipt tests. live accuracy remains unproven; passing these controls would establish basic perception only, not musical taste.

</details>

![bufo-loves-this-song](https://all-the.bufo.zone/bufo-loves-this-song.png)

generated with Codex (GPT-6)
