### PR TITLE
fix musician syntax errors with one budgeted correction

### DIFF
--- a/services/musician-studio/compose.py
+++ b/services/musician-studio/compose.py
@@ -124,10 +124,29 @@ def compose(
     if len(prompt.encode()) > 48000:
         raise ValueError("Composition context exceeds 48 KB")
     source = request_music(prompt, store, session)
-    if source.startswith("```python\n") and source.endswith("```"):
-        source = source[len("```python\n") : -3].strip()
-    store.save_study(session, musician_id or profile.name.lower(), {"source": source})
-    return parse_composition(source)
+    for attempt in range(2):
+        if source.startswith("```python\n") and source.endswith("```"):
+            source = source[len("```python\n") : -3].strip()
+        store.save_study(session, name, {"source": source})
+        try:
+            return parse_composition(source)
+        except SyntaxError as error:
+            if attempt:
+                raise
+            store.save_study(
+                session,
+                name,
+                {"syntax_failure": {"source": source, "error": str(error)}},
+            )
+            source = request_music(
+                "Correct the Python syntax error in this music script. Preserve the composition, "
+                "metadata and musical intent. Return the complete executable Python source only. "
+                "It must still write /output/track.wav; no extra tools are available.\n"
+                + f"Compiler error: {error}\nSource:\n{source}",
+                store,
+                session,
+            )
+    raise AssertionError("Unreachable composition attempt")
 
 
 def request_music(prompt: str, store: Store, session: str) -> str:

--- a/services/musician-studio/tests/test_composition.py
+++ b/services/musician-studio/tests/test_composition.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -65,3 +66,50 @@ def test_musical_plan_is_validated_and_reused(
     with pytest.raises(ValidationError):
         compose.plan_music(profile, [], store, "other-session", "reed")
     assert store.study("other-session", "reed") is None
+
+
+@pytest.mark.parametrize("repair_valid", [True, False])
+def test_syntax_repair_is_bounded_and_charged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, repair_valid: bool
+) -> None:
+    store = Store(tmp_path)
+    profile = Musician.model_validate(
+        json.loads((Path(__file__).parents[1] / "profiles/reed.json").read_text())[
+            "profile"
+        ]
+    )
+    plan = compose.MusicalPlan(
+        tempo_bpm=96,
+        meter="4/4",
+        tonal_organization="D minor with a fixed D bass pedal",
+        motif="D F E D in eighth notes, followed by a rest",
+        instrument_roles=["pluck melody"],
+        development="Repeat the phrase, then answer and resolve to D.",
+    )
+    monkeypatch.setattr(compose, "plan_music", lambda *_args: plan)
+    session = store.reserve(datetime.now(UTC))
+    assert session
+    broken = 'TITLE="one"\nIDEA="two"\nx = (0. fifty if False else 0.52)'
+    fixed = 'TITLE="one"\nIDEA="two"\nx = 0.52'
+    prompts: list[str] = []
+
+    def request(prompt: str, ledger: Store, key: str) -> str:
+        ledger.call(key)
+        ledger.charge(key, 0.001)
+        prompts.append(prompt)
+        return fixed if repair_valid and len(prompts) == 2 else broken
+
+    monkeypatch.setattr(compose, "request_music", request)
+    if repair_valid:
+        assert (
+            compose.compose(profile, [], store, session, musician_id="reed").python
+            == fixed
+        )
+    else:
+        with pytest.raises(SyntaxError):
+            compose.compose(profile, [], store, session, musician_id="reed")
+    assert len(prompts) == 2
+    assert "Compiler error:" in prompts[1] and broken in prompts[1]
+    assert store.study(session, "reed")["syntax_failure"]["source"] == broken
+    with store.connect() as db:
+        assert db.execute("SELECT calls,spent FROM sessions").fetchone() == (2, 0.002)


### PR DESCRIPTION
Kite’s latest audio revision failed because its generated Python contained `0. fifty`. The composer now sends syntax errors back to Luna for one correction attempt, preserving the musical intent and retaining the failed source for diagnosis.

The correction uses the existing session request and spending limits. A second syntax failure still stops the run; audio listening and publication requirements remain in force.

<details>
<summary>validation</summary>

- all 48 musician-studio tests pass; lint and formatting pass
- both regression cases fail against the previous implementation
- tests cover a successful correction, a second syntax failure, and accounting both requests in the same session

</details>

![fix-it-bufo](https://all-the.bufo.zone/fix-it-bufo.png)

generated with Codex (GPT-6)
