### PR TITLE
test listener perception of bass entrances and melody changes

### DIFF
--- a/services/musician-studio/README.md
+++ b/services/musician-studio/README.md
@@ -144,3 +144,10 @@ calls on a complete first attempt, and cannot publish. Explicit recovery remains
 subject to the same twelve-call session cap. It measures basic factual perception,
 not taste, pitch transcription, or quality of musical criticism. It does not run
 automatically before each composition or change the normal publication gate.
+
+Set `calibration_suite="arrangement"` with evaluation and calibration enabled to
+check bass entrances and melody changes in six matched arrangements. The listener
+gets anonymous audio and the same questions for every clip; the host scores bass
+and melody answers separately. This shares the existing evaluation allowance.
+A failed run can resume its saved suite, but cannot switch suites within a session.
+These controls test perception of specific musical events, not aesthetic quality.

--- a/services/musician-studio/calibration.py
+++ b/services/musician-studio/calibration.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 import random
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 import numpy as np
 from prefect import task
@@ -14,7 +14,16 @@ from pydantic import BaseModel, Field
 
 from studio.audio_model import request_audio
 from studio.state import Store
-from studio_instruments import SAMPLE_RATE, Audio, mix_voice, pitched_note, write_track
+from studio_instruments import (
+    SAMPLE_RATE,
+    Audio,
+    drum_hit,
+    mix_voice,
+    pitched_note,
+    write_track,
+)
+
+CalibrationSuite = Literal["basic", "arrangement"]
 
 ControlKind = Literal[
     "silence", "regular_noise_pulses", "separated_notes", "stacked_notes"
@@ -25,6 +34,31 @@ class HeardControl(BaseModel):
     kind: ControlKind
     confidence: float = Field(ge=0, le=1)
     description: str = Field(min_length=1, max_length=800)
+
+
+class HeardArrangement(BaseModel):
+    bass_entry: Literal["opening", "delayed", "absent"]
+    motif_change: Literal["same", "higher_ending"]
+    confidence: float = Field(ge=0, le=1)
+    description: str = Field(min_length=1, max_length=800)
+
+
+def arrangement_audio(bass_entry: str, changed: bool) -> Audio:
+    audio = np.zeros((10 * SAMPLE_RATE, 2))
+    for beat in range(20):
+        mix_voice(audio, drum_hit("hat", seed=beat), beat / 2, 0.025, 0.3)
+    for start in (0, 4, 8):
+        for note in (60, 64, 67):
+            mix_voice(audio, pitched_note(note, 1.8, "pad"), start, 0.055, -0.2)
+    if bass_entry != "absent":
+        for beat in range(0 if bass_entry == "opening" else 6, 20):
+            mix_voice(audio, pitched_note(36, 0.28, "bass"), beat / 2, 0.4)
+    for repeat, start in enumerate((1.5, 5.5)):
+        for index, note in enumerate((72, 76, 79)):
+            if repeat and index == 2 and changed:
+                note = 84
+            mix_voice(audio, pitched_note(note, 0.4), start + index * 0.5, 0.3, 0.15)
+    return audio
 
 
 def control_audio(kind: ControlKind, variation: int) -> Audio:
@@ -46,11 +80,16 @@ def control_audio(kind: ControlKind, variation: int) -> Audio:
 
 
 @task(name="calibrate-audio-listener", cache_policy=NO_CACHE, persist_result=False)
-def calibrate_listener(directory: Path, session: str) -> dict:
+def calibrate_listener(
+    directory: Path, session: str, suite: CalibrationSuite = "basic"
+) -> dict:
     store = Store(directory)
     saved = store.study(session, "listener-calibration") or {}
+    if saved and saved.get("suite", "basic") != suite:
+        raise ValueError("Cannot change calibration suite during recovery")
+    store.save_study(session, "listener-calibration", {"suite": suite})
     results = saved.get("results", [])
-    cases: list[tuple[ControlKind, int]] = [
+    cases: list[tuple[str, int]] = [
         ("silence", 0),
         ("silence", 1),
         ("regular_noise_pulses", 0),
@@ -58,6 +97,12 @@ def calibrate_listener(directory: Path, session: str) -> dict:
         ("separated_notes", 0),
         ("stacked_notes", 0),
     ]
+    if suite == "arrangement":
+        cases = [
+            (entry, changed)
+            for entry in ("opening", "delayed", "absent")
+            for changed in (0, 1)
+        ]
     random.Random(session).shuffle(cases)
     folder = directory / session / "listener-calibration"
     folder.mkdir(parents=True, exist_ok=True)
@@ -69,9 +114,24 @@ def calibrate_listener(directory: Path, session: str) -> dict:
         "Report kind, confidence from 0 to 1, and a short description of the audible timing. "
         "Silence is a valid answer. Do not invent a musical narrative. Return only JSON."
     )
+    if suite == "arrangement":
+        prompt = (
+            "Listen to this ten-second arrangement with a chord background, light high percussion, "
+            "and two statements of a high three-note melody. Report whether a separate low pulsing "
+            "bass is present from the opening (opening), first enters partway through (delayed), "
+            "or never appears (absent). Do not mistake the chord background for the bass. "
+            "Compare the second melody statement with the first: are its pitches the same (same), "
+            "or does its final note end higher (higher_ending)? Report bass_entry, motif_change, "
+            "confidence from 0 to 1, and a short description of what you actually hear. Return only JSON."
+        )
     for index, (expected, variation) in enumerate(cases):
         path = folder / f"{index}.wav"
-        write_track(control_audio(expected, variation), str(path))
+        audio = (
+            arrangement_audio(expected, bool(variation))
+            if suite == "arrangement"
+            else control_audio(cast(ControlKind, expected), variation)
+        )
+        write_track(audio, str(path))
         if index < len(results):
             if (
                 results[index]["audio_sha256"]
@@ -79,22 +139,38 @@ def calibrate_listener(directory: Path, session: str) -> dict:
             ):
                 raise ValueError("Calibration audio changed during recovery")
             continue
-        answer, receipt = request_audio(store, session, path, prompt, HeardControl)
+        schema = HeardArrangement if suite == "arrangement" else HeardControl
+        answer, receipt = request_audio(store, session, path, prompt, schema)
+        observed = answer.model_dump()
+        fields = ("bass_entry", "motif_change") if suite == "arrangement" else ("kind",)
+        target = (
+            {
+                "bass_entry": expected,
+                "motif_change": "higher_ending" if variation else "same",
+            }
+            if suite == "arrangement"
+            else {"kind": expected}
+        )
+        matches = {field: observed[field] == target[field] for field in fields}
         results.append(
             {
                 "index": index,
-                "expected": expected,
+                "expected": target if suite == "arrangement" else expected,
                 **answer.model_dump(),
                 **receipt.model_dump(),
-                "correct": answer.kind == expected,
+                "correct": all(matches.values()),
+                "field_correct": matches,
             }
         )
-        store.save_study(session, "listener-calibration", {"results": results})
+        store.save_study(
+            session, "listener-calibration", {"suite": suite, "results": results}
+        )
     summary = {
         "results": results,
         "correct": sum(result["correct"] for result in results),
         "total": len(cases),
-        "scope": "Basic audio perception; not evidence of musical taste or reliable critique",
+        "suite": suite,
+        "scope": "Controlled audio perception; not evidence of musical taste or reliable critique",
     }
     (folder / "results.json").write_text(json.dumps(summary, indent=2))
     create_markdown_artifact(
@@ -104,7 +180,7 @@ def calibrate_listener(directory: Path, session: str) -> dict:
             + summary["scope"]
             + "\n\n"
             + "\n\n".join(
-                f"{r['index']}: expected {r['expected']}; heard {r['kind']} "
+                f"{r['index']}: expected {r['expected']}; heard {r.get('kind', {k: r[k] for k in ('bass_entry', 'motif_change') if k in r})} "
                 f"(confidence {r['confidence']}, {r['audio_tokens']} audio tokens). {r['description']}"
                 for r in results
             )

--- a/services/musician-studio/flow.py
+++ b/services/musician-studio/flow.py
@@ -12,7 +12,7 @@ from prefect.cache_policies import NO_CACHE
 from prefect.states import Completed, State
 
 from audio_round import prepare_release
-from calibration import calibrate_listener
+from calibration import CalibrationSuite, calibrate_listener
 from compose import Composition, compose, plan_music, render
 from studio.context import choose_peer
 from studio.identity import Musician
@@ -225,9 +225,12 @@ def community(
     bootstrap: bool = False,
     evaluation: bool = False,
     calibration: bool = False,
+    calibration_suite: CalibrationSuite = "basic",
 ) -> State:
     if calibration and not evaluation:
         raise ValueError("Calibration requires evaluation mode")
+    if calibration_suite != "basic" and not calibration:
+        raise ValueError("A calibration suite requires calibration mode")
     directory = Path(os.environ["STUDIO_STATE_DIR"])
     directory.mkdir(parents=True, exist_ok=True)
     with (directory / "session.lock").open("w") as lock:
@@ -253,7 +256,7 @@ def community(
             )
         try:
             if calibration:
-                result = calibrate_listener(directory, session)
+                result = calibrate_listener(directory, session, calibration_suite)
                 store.finish(session, "completed")
                 return Completed(
                     message=f"Listener calibration: {result['correct']}/{result['total']} correct"

--- a/services/musician-studio/tests/test_calibration.py
+++ b/services/musician-studio/tests/test_calibration.py
@@ -63,3 +63,73 @@ def test_calibration_saves_wrong_answers_and_reuses_receipts(
     assert store.usage(datetime.now(UTC))["month"]["estimated_cost"] == pytest.approx(
         0.006
     )
+
+
+def test_arrangements_change_only_the_intended_events() -> None:
+    sr = 44100
+    absent = calibration.arrangement_audio("absent", False)
+    opening = calibration.arrangement_audio("opening", False)
+    delayed = calibration.arrangement_audio("delayed", False)
+    changed = calibration.arrangement_audio("opening", True)
+    assert np.array_equal(delayed[: 3 * sr], absent[: 3 * sr])
+    assert np.array_equal(delayed[3 * sr :], opening[3 * sr :])
+    assert np.sqrt(np.mean((opening[:sr] - absent[:sr]) ** 2)) > 0.03
+    assert np.array_equal(changed[: int(6.5 * sr)], opening[: int(6.5 * sr)])
+    assert np.array_equal(changed[7 * sr :], opening[7 * sr :])
+    for audio, frequency in [(opening, 784), (changed, 1047)]:
+        section = audio[int(6.55 * sr) : int(6.8 * sr)].mean(axis=1)
+        spectrum = np.abs(np.fft.rfft(section * np.hanning(len(section))))
+        frequencies = np.fft.rfftfreq(len(section), 1 / sr)
+        spectrum[frequencies < 600] = 0
+        assert frequencies[np.argmax(spectrum)] == pytest.approx(frequency, abs=8)
+    assert max(np.max(np.abs(x)) for x in [absent, opening, delayed, changed]) < 0.99
+
+
+def test_arrangement_scores_bass_and_melody_separately(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = Store(tmp_path)
+    session = store.reserve(datetime.now(UTC), evaluation=True)
+    calls = []
+
+    def answer(
+        store: Store, session: str, path: Path, prompt: str, schema: type
+    ) -> tuple[calibration.HeardArrangement, AudioReceipt]:
+        store.call(session)
+        calls.append((prompt, path.name))
+        return calibration.HeardArrangement(
+            bass_entry="absent",
+            motif_change="same",
+            confidence=1,
+            description="A repeated melody with no low bass heard.",
+        ), AudioReceipt(
+            model="test",
+            audio_tokens=250,
+            audio_sha256=hashlib.sha256(path.read_bytes()).hexdigest(),
+        )
+
+    monkeypatch.setattr(calibration, "request_audio", answer)
+    monkeypatch.setattr(calibration, "create_markdown_artifact", lambda **_kwargs: None)
+    result = calibration.calibrate_listener.fn(tmp_path, session, "arrangement")
+    assert result["correct"] == 1
+    assert sum(r["field_correct"]["bass_entry"] for r in result["results"]) == 2
+    assert sum(r["field_correct"]["motif_change"] for r in result["results"]) == 3
+    assert len({prompt for prompt, _ in calls}) == 1
+    assert all(name[:-4].isdigit() for _, name in calls)
+    assert calibration.calibrate_listener.fn(tmp_path, session, "arrangement") == result
+    assert len(calls) == 6
+    with pytest.raises(ValueError, match="Cannot change"):
+        calibration.calibrate_listener.fn(tmp_path, session, "basic")
+
+
+def test_suite_is_preserved_when_first_request_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail(*_args: object) -> None:
+        raise RuntimeError("Provider unavailable")
+
+    monkeypatch.setattr(calibration, "request_audio", fail)
+    with pytest.raises(RuntimeError):
+        calibration.calibrate_listener.fn(tmp_path, "session", "arrangement")
+    with pytest.raises(ValueError, match="Cannot change"):
+        calibration.calibrate_listener.fn(tmp_path, "session", "basic")

--- a/services/musician-studio/tests/test_evaluation.py
+++ b/services/musician-studio/tests/test_evaluation.py
@@ -30,3 +30,30 @@ def test_evaluation_never_calls_publication_or_curation(
     assert session.endswith("-evaluation")
     assert status == "completed"
     assert store.study(session, "reed")["withheld"]
+
+
+def test_arrangement_calibration_uses_evaluation_without_loading_musicians(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("STUDIO_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(flow, "get_run_logger", lambda: logging.getLogger("test"))
+    monkeypatch.setattr(flow, "report", lambda *_args: None)
+    seen = []
+
+    def calibrate(directory: Path, session: str, suite: str) -> dict:
+        seen.append((directory, session, suite))
+        return {"correct": 2, "total": 6}
+
+    def forbid(*_args: object) -> None:
+        pytest.fail("Calibration must not load musicians or publish")
+
+    monkeypatch.setattr(flow, "calibrate_listener", calibrate)
+    monkeypatch.setattr(flow, "seed", forbid)
+    monkeypatch.setattr(flow, "publish_piece", forbid)
+    assert flow.community.fn(
+        evaluation=True, calibration=True, calibration_suite="arrangement"
+    ).is_completed()
+    assert seen[0][1].endswith("-evaluation")
+    assert seen[0][2] == "arrangement"
+    with pytest.raises(ValueError, match="requires calibration"):
+        flow.community.fn(calibration_suite="arrangement")


### PR DESCRIPTION
The musician listener passed isolated sound controls but gave questionable bass-entry descriptions for a mixed recording. Add a blind arrangement evaluation with six matched clips covering bass from the opening, delayed bass, and absent bass, each paired with an unchanged or higher-ending melody.

The host scores bass and melody answers separately. Every clip gets the same prompt and an anonymous filename; expected answers stay out of the model request. The existing evaluation allowance, audio receipts, and publication exclusion apply.

<details>
<summary>validation and recovery</summary>

All 52 studio tests pass, along with lint, formatting and commit checks. Waveform comparisons verify that the controls differ only at the intended events; spectral checks verify the changed melody pitch. Tests also cover wrong answers, receipt reuse, suite preservation after an initial provider failure, and calibration without loading or publishing musicians.

The default remains the basic control suite. Select the arrangement suite explicitly; recovery cannot change suites within a session. These results measure specific audio perception, not musical taste.

</details>

![fix-it-bufo](https://all-the.bufo.zone/fix-it-bufo.png)

generated with Codex (GPT-6)
