### PR TITLE
fix: use Prefect tasks for musician audio recovery

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -611,3 +611,19 @@ wrong answers and audio receipts are retained. Normal music runs and publication
 rules are unchanged. Offline tests verify actual event timing and that repeated
 calibration reads saved receipts without spending again. Live calibration is
 pending the next evaluation window; no accuracy claim is made yet.
+
+### September 8 — native Prefect audio recovery
+
+Each paid audio interpretation and composition request now has its own Prefect
+task and durable result under the worker's studio directory. Audio requests
+retry transient provider/transport failures up to three times; invalid responses,
+auth errors and budget exhaustion fail immediately. Inputs include audio bytes,
+review context, schema, model and session. Cached results do not charge the ledger.
+A flow ID owns its original budget reservation across same-day reruns, keeping
+musician rotation stable; cross-day recovery cannot spend an old reservation.
+Musician history, release evidence and upload idempotency remain application data.
+
+An isolated SDK test and a mocked-provider run against the actual Prefect server
+both verified task retry, flow retry reusing a completed audio result, and cache
+invalidation after audio/context changes. This proves orchestration behavior;
+it does not establish that the upstream audio provider has recovered.

--- a/services/musician-studio/audio_round.py
+++ b/services/musician-studio/audio_round.py
@@ -2,13 +2,16 @@
 
 from pathlib import Path
 
+from prefect import task
+from prefect.cache_policies import NO_CACHE
+from prefect.context import FlowRunContext
+
 from compose import compose, render
 from studio.audio_model import listen
 from studio.identity import Musician
 from studio.listening import (
     ListeningReview,
     digest,
-    inspiration_digest,
     require_listening,
 )
 from studio.state import Store
@@ -22,15 +25,12 @@ def reviewed(
     path: Path,
     inspirations: list[dict],
 ) -> ListeningReview:
-    for value in store.listening_reviews(session, author):
-        review = ListeningReview.model_validate(value)
-        if (
-            review.listener == listener
-            and review.audio_sha256 == digest(path)
-            and review.inspirations_sha256 == inspiration_digest(inspirations)
-        ):
-            return review
     return listen(store, session, author, listener, path, inspirations)
+
+
+@task(name="render-revision", cache_policy=NO_CACHE, persist_result=False)
+def render_revision(source: str, output: Path) -> dict:
+    return render(source, output)
 
 
 def prepare_release(directory: Path, session: str, name: str, draft_path: Path) -> Path:
@@ -52,7 +52,8 @@ def prepare_release(directory: Path, session: str, name: str, draft_path: Path) 
             revision=feedback.observations + "\n" + feedback.changes,
         )
         revised_path = directory / f"{session}-{name}" / "revision"
-        metrics = render(revision.python, revised_path)
+        renderer = render_revision if FlowRunContext.get() else render_revision.fn
+        metrics = renderer(revision.python, revised_path)
         store.save_study(
             session,
             name,

--- a/services/musician-studio/compose.py
+++ b/services/musician-studio/compose.py
@@ -13,6 +13,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import numpy as np
+from prefect import task
+from prefect.cache_policies import INPUTS, TASK_SOURCE
+from prefect.context import FlowRunContext
 from pydantic import BaseModel, Field
 
 from studio.context import history_context, musical_identity
@@ -150,6 +153,16 @@ def compose(
 
 
 def request_music(prompt: str, store: Store, session: str) -> str:
+    operation = composition_request.with_options(
+        result_storage=store.path.parent / "prefect-results"
+    )
+    call = operation if FlowRunContext.get() else operation.fn
+    return call(prompt, store.path.parent, session, "openai-codex/gpt-5.6-luna")
+
+
+@task(name="write-music-python", cache_policy=INPUTS + TASK_SOURCE, persist_result=True)
+def composition_request(prompt: str, directory: Path, session: str, model: str) -> str:
+    store = Store(directory)
     if len(prompt.encode()) > 48000:
         raise ValueError("Music context exceeds 48 KB")
     store.call(session)
@@ -171,7 +184,7 @@ def request_music(prompt: str, store: Store, session: str) -> str:
             [
                 "pi",
                 "--model",
-                "openai-codex/gpt-5.6-luna",
+                model,
                 "--thinking",
                 "low",
                 "--no-session",

--- a/services/musician-studio/docs/recovery.md
+++ b/services/musician-studio/docs/recovery.md
@@ -1,0 +1,36 @@
+# recovering a studio run
+
+Prefect retries an individual audio request for HTTP 408, 429, 500, 502, 503
+and 504 or transport failures. There are three retries with delays of 15, 45
+and 120 seconds plus jitter. Every actual attempt consumes the existing request
+allowance. Malformed audio responses, missing audio tokens, authorization errors
+and exhausted budgets are not retryable. There is no text-only listening fallback.
+
+Successful composition and audio responses are persisted in
+`$STUDIO_STATE_DIR/prefect-results`. Keep that directory on the persistent worker
+volume with `studio.sqlite3` and the audio files. Cache identity includes the
+session, model and actual request content; audio cache keys include the bytes,
+not a mutable pathname. A changed prompt, audio or schema requires a new request.
+Result persistence cannot guarantee exactly-once billing if a worker dies after
+a provider answers but before the result is committed.
+
+After an exhausted transient failure, retry the original run:
+
+```sh
+# in my-prefect-server
+just prefect flow-run retry RUN_UUID
+```
+
+The flow retains its original reservation and selected musician when retried
+within the same UTC day. It skips if that reservation has exhausted its request
+or cost allowance, or belongs to a previous day. New scheduled runs continue on
+the six-hour cadence. The legacy `retry_failed` parameter is retained only for
+old runs without a flow reservation binding; routine recovery should not create
+replacement runs with it.
+
+SQLite retains musician history, draft/revision identity, listening evidence,
+cost reservations and publication idempotency. Successful paid responses are
+reused by Prefect. Rendering is a separate task and validates the output files;
+publication still verifies audio receipts and enforces the existing unlisted,
+AI-label and daily upload rules. Never add automatic retries to an ambiguous
+upload without its existing idempotency checks.

--- a/services/musician-studio/flow.py
+++ b/services/musician-studio/flow.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from prefect import flow, get_run_logger, task
 from prefect.artifacts import create_markdown_artifact
 from prefect.cache_policies import NO_CACHE
+from prefect.context import FlowRunContext
 from prefect.states import Completed, State
 
 from audio_round import prepare_release
@@ -106,12 +107,6 @@ def render_piece(directory: Path, session: str, name: str) -> Path:
     return output / "track.wav"
 
 
-@task(
-    name="listen-revise-and-peer-review",
-    task_run_name="{name}-audio-review",
-    cache_policy=NO_CACHE,
-    persist_result=False,
-)
 def review_audio(directory: Path, session: str, name: str, path: Path) -> Path:
     return prepare_release(directory, session, name, path)
 
@@ -246,6 +241,9 @@ def community(
             retry_failed=retry_failed,
             bootstrap=bootstrap,
             evaluation=evaluation,
+            flow_run_id=str(context.flow_run.id)
+            if (context := FlowRunContext.get())
+            else None,
         )
         errors = []
         logger = get_run_logger()
@@ -262,8 +260,9 @@ def community(
                     message=f"Listener calibration: {result['correct']}/{result['total']} correct"
                 )
             names = seed(directory)
-            now = datetime.now(UTC)
-            selected = names[(now.toordinal() * 4 + now.hour // 6) % len(names)]
+            day = datetime.strptime(session[:10], "%Y-%m-%d").replace(tzinfo=UTC)
+            slot = int(session[11])
+            selected = names[(day.toordinal() * 4 + slot) % len(names)]
             for name in [selected]:
                 try:
                     compose_piece(directory, session, name)

--- a/services/musician-studio/studio/audio_model.py
+++ b/services/musician-studio/studio/audio_model.py
@@ -8,6 +8,10 @@ import subprocess
 from pathlib import Path
 
 import httpx
+from prefect import task
+from prefect.cache_policies import INPUTS, TASK_SOURCE
+from prefect.context import FlowRunContext
+from prefect.states import State
 from pydantic import BaseModel, Field
 
 from studio.context import musical_identity
@@ -79,16 +83,57 @@ class AudioReceipt(BaseModel):
     audio_tokens: int = Field(gt=0)
 
 
+class AudioProviderError(RuntimeError):
+    def __init__(self, status: int) -> None:
+        self.status = status
+        super().__init__(status)
+
+    def __str__(self) -> str:
+        return f"Audio review HTTP {self.status}; no text fallback"
+
+
+def retry_audio(task: object, task_run: object, state: State) -> bool:
+    error = state.result(raise_on_failure=False)
+    if isinstance(error, AudioProviderError):
+        return error.status in {408, 429, 500, 502, 503, 504}
+    return isinstance(error, httpx.TransportError)
+
+
 def request_audio[Response: BaseModel](
     store: Store, session: str, path: Path, prompt: str, schema: type[Response]
 ) -> tuple[Response, AudioReceipt]:
     data = path.read_bytes()
+    operation = audio_request.with_options(
+        result_storage=store.path.parent / "prefect-results"
+    )
+    call = operation if FlowRunContext.get() else operation.fn
+    return call(store.path.parent, session, data, prompt, schema, MODEL)
+
+
+@task(
+    name="interpret-audio",
+    retries=3,
+    retry_delay_seconds=[15, 45, 120],
+    retry_jitter_factor=0.2,
+    retry_condition_fn=retry_audio,
+    cache_policy=INPUTS + TASK_SOURCE,
+    persist_result=True,
+)
+def audio_request[Response: BaseModel](
+    directory: Path,
+    session: str,
+    data: bytes,
+    prompt: str,
+    schema: type[Response],
+    model: str,
+) -> tuple[Response, AudioReceipt]:
+    store = Store(directory)
     if not data or len(data) > 4_000_000:
         raise ValueError("Missing or oversized review audio")
     store.call(session)
     with httpx.Client(timeout=90) as client:
         response = client.post(
-            f"https://generativelanguage.googleapis.com/v1beta/models/{MODEL}:generateContent",
+            f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent",
             headers={"x-goog-api-key": key()},
             json={
                 "contents": [
@@ -113,9 +158,7 @@ def request_audio[Response: BaseModel](
             },
         )
     if response.status_code != 200:
-        raise RuntimeError(
-            f"Audio review HTTP {response.status_code}; no text fallback"
-        )
+        raise AudioProviderError(response.status_code)
     result = response.json()
     usage = result["usageMetadata"]
     store.charge(

--- a/services/musician-studio/studio/listening.py
+++ b/services/musician-studio/studio/listening.py
@@ -85,6 +85,14 @@ def record_review(
 ) -> None:
     with store.connect() as db:
         db.execute(
-            "INSERT INTO listening_reviews VALUES (?,?,?)",
-            (session, name, review.model_dump_json()),
+            "INSERT INTO listening_reviews SELECT ?,?,? WHERE NOT EXISTS "
+            "(SELECT 1 FROM listening_reviews WHERE session=? AND musician=? AND body=?)",
+            (
+                session,
+                name,
+                review.model_dump_json(),
+                session,
+                name,
+                review.model_dump_json(),
+            ),
         )

--- a/services/musician-studio/studio/state.py
+++ b/services/musician-studio/studio/state.py
@@ -40,6 +40,7 @@ class Store:
         *,
         bootstrap: bool = False,
         evaluation: bool = False,
+        flow_run_id: str | None = None,
     ) -> str | None:
         if bootstrap and evaluation:
             raise ValueError("Bootstrap and evaluation are separate sessions")
@@ -48,6 +49,28 @@ class Store:
         key += "-evaluation" if evaluation else ""
         with self.connect() as db:
             db.execute("BEGIN IMMEDIATE")
+            owner_key = f"flow-reservation:{flow_run_id}"
+            if flow_run_id:
+                owned = db.execute(
+                    "SELECT value FROM settings WHERE key=?", (owner_key,)
+                ).fetchone()
+                if owned:
+                    reservation = db.execute(
+                        "SELECT day,month,spent,calls FROM sessions WHERE id=?",
+                        (owned[0],),
+                    ).fetchone()
+                    if (
+                        reservation is None
+                        or reservation[0] != day
+                        or reservation[1] != month
+                    ):
+                        return None
+                    if reservation[2] >= SESSION_BUDGET or reservation[3] >= 12:
+                        return None
+                    db.execute(
+                        "UPDATE sessions SET status='running' WHERE id=?", (owned[0],)
+                    )
+                    return owned[0]
             if bootstrap:
                 prior = db.execute(
                     "SELECT id FROM sessions WHERE id LIKE '%-bootstrap'"
@@ -67,6 +90,11 @@ class Store:
                     db.execute(
                         "UPDATE sessions SET status='running' WHERE id=?", (key,)
                     )
+                    if flow_run_id:
+                        db.execute(
+                            "INSERT INTO settings(key,value) VALUES (?,?)",
+                            (owner_key, key),
+                        )
                     return key
                 return None
             for field, value, limit in [
@@ -83,6 +111,10 @@ class Store:
                 "INSERT INTO sessions(id,day,month,status,reserved) VALUES (?,?,?,?,?)",
                 (key, day, month, "running", SESSION_BUDGET),
             )
+            if flow_run_id:
+                db.execute(
+                    "INSERT INTO settings(key,value) VALUES (?,?)", (owner_key, key)
+                )
         return key
 
     def call(self, session: str) -> None:

--- a/services/musician-studio/tests/test_audio_round.py
+++ b/services/musician-studio/tests/test_audio_round.py
@@ -97,3 +97,4 @@ def test_round_reviews_draft_and_revision_and_obtains_peer_feedback(
     assert len(store.study(session, "moss")["audio_feedback"]) == 2
     assert audio_round.prepare_release(tmp_path, session, "moss", draft) == final
     assert len(heard) == 5
+    assert len(store.listening_reviews(session, "moss")) == 3

--- a/services/musician-studio/tests/test_audio_round.py
+++ b/services/musician-studio/tests/test_audio_round.py
@@ -96,4 +96,4 @@ def test_round_reviews_draft_and_revision_and_obtains_peer_feedback(
     assert len(store.listening_reviews(session, "moss")) == 3
     assert len(store.study(session, "moss")["audio_feedback"]) == 2
     assert audio_round.prepare_release(tmp_path, session, "moss", draft) == final
-    assert len(heard) == 3
+    assert len(heard) == 5

--- a/services/musician-studio/tests/test_prefect_recovery.py
+++ b/services/musician-studio/tests/test_prefect_recovery.py
@@ -97,6 +97,7 @@ def test_native_retry_and_audio_cache(
     operation = audio_model.audio_request.with_options(
         retry_delay_seconds=0, result_storage=tmp_path / "results"
     )
+    monkeypatch.setattr(audio_model, "audio_request", operation)
     stages = []
 
     @flow(
@@ -106,7 +107,9 @@ def test_native_retry_and_audio_cache(
         retry_delay_seconds=0,
     )
     def pipeline(data: bytes, prompt: str) -> None:
-        operation(tmp_path, session, data, prompt, Feedback, "test-model")
+        audio = tmp_path / "recording.wav"
+        audio.write_bytes(data)
+        audio_model.request_audio(store, session, audio, prompt, Feedback)
         stages.append(True)
         if len(stages) == 1:
             raise ValueError("later step failed")

--- a/services/musician-studio/tests/test_prefect_recovery.py
+++ b/services/musician-studio/tests/test_prefect_recovery.py
@@ -1,0 +1,129 @@
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from prefect import flow
+from prefect.settings import temporary_settings
+from prefect.testing.utilities import prefect_test_harness
+
+from studio import audio_model
+from studio.audio_model import AudioProviderError, Feedback, retry_audio
+from studio.state import Store
+
+
+def test_original_run_keeps_reservation_across_slots(tmp_path: Path) -> None:
+    store = Store(tmp_path)
+    now = datetime(2026, 9, 8, 5, tzinfo=UTC)
+    session = store.reserve(now, flow_run_id="original")
+    store.call(session)
+    store.finish(session, "failed")
+    assert store.reserve(now + timedelta(hours=2), flow_run_id="original") == session
+    assert store.usage(now)["day"]["sessions"] == 1
+    assert store.usage(now)["day"]["calls"] == 1
+    assert store.reserve(now + timedelta(days=1), flow_run_id="original") is None
+
+
+@pytest.mark.parametrize(
+    "error,expected",
+    [
+        (AudioProviderError(503), True),
+        (AudioProviderError(429), True),
+        (AudioProviderError(401), False),
+        (ValueError("bad audio"), False),
+        (RuntimeError("budget exceeded"), False),
+    ],
+)
+def test_only_transient_failures_retry(error: Exception, expected: bool) -> None:
+    state = SimpleNamespace(result=lambda **kwargs: error)
+    assert retry_audio(None, None, state) == expected
+
+
+def test_native_retry_and_audio_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = Store(tmp_path)
+    session = store.reserve(datetime.now(UTC))
+    attempts = []
+    client = httpx.Client
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        attempts.append(request)
+        if len(attempts) == 1:
+            return httpx.Response(503)
+        return httpx.Response(
+            200,
+            json={
+                "modelVersion": "test-audio",
+                "usageMetadata": {
+                    "promptTokenCount": 500,
+                    "candidatesTokenCount": 100,
+                    "promptTokensDetails": [{"modality": "AUDIO", "tokenCount": 250}],
+                },
+                "candidates": [
+                    {
+                        "finishReason": "STOP",
+                        "content": {
+                            "parts": [
+                                {
+                                    "text": json.dumps(
+                                        {
+                                            "observations": "The bass obscures the upper notes.",
+                                            "changes": "Lower the bass by three decibels.",
+                                            "ready": True,
+                                        }
+                                    )
+                                }
+                            ]
+                        },
+                    }
+                ],
+            },
+        )
+
+    monkeypatch.setattr(audio_model, "key", lambda: "fake")
+    monkeypatch.setattr(
+        audio_model,
+        "httpx",
+        SimpleNamespace(
+            Client=lambda **kwargs: client(
+                transport=httpx.MockTransport(handle), **kwargs
+            ),
+            TransportError=httpx.TransportError,
+        ),
+    )
+    operation = audio_model.audio_request.with_options(
+        retry_delay_seconds=0, result_storage=tmp_path / "results"
+    )
+    stages = []
+
+    @flow(
+        name="plyr.fm-studio-recovery-check",
+        flow_run_name="plyr.fm-studio-recovery-check",
+        retries=1,
+        retry_delay_seconds=0,
+    )
+    def pipeline(data: bytes, prompt: str) -> None:
+        operation(tmp_path, session, data, prompt, Feedback, "test-model")
+        stages.append(True)
+        if len(stages) == 1:
+            raise ValueError("later step failed")
+
+    with (
+        temporary_settings({"PREFECT_SERVER_ANALYTICS_ENABLED": False}),
+        prefect_test_harness(),
+    ):
+        pipeline(b"audio one", "review")
+        assert len(attempts) == 2
+        pipeline(b"audio one", "review")
+        assert len(attempts) == 2
+        pipeline(b"audio two", "review")
+        assert len(attempts) == 3
+        pipeline(b"audio two", "new context")
+        assert len(attempts) == 4
+    assert store.usage(datetime.now(UTC))["day"]["calls"] == 4
+    assert store.usage(datetime.now(UTC))["day"]["estimated_cost"] == pytest.approx(
+        3 * 0.00165
+    )


### PR DESCRIPTION
Transient audio-provider failures now retry the individual Prefect task, and successful audio/composition responses persist on the studio worker for reuse. The original flow keeps its budget reservation and musician across same-day retries instead of requiring a replacement run.

<details>
<summary>behavior and verification</summary>

Audio tasks retry transient HTTP and transport errors up to three times with bounded delays and jitter. Each actual request counts toward the existing allowance; cached results do not. Cache inputs include the actual audio bytes, prompt, schema, model and session. Authorization, response-validation and budget failures do not retry.

The monolithic listening task is removed; individual listening calls and revision rendering appear in Prefect. SQLite retains musician memory, release evidence and publication idempotency. Unlisted publication, actual-audio requirements and cost limits are unchanged. Old runs retain the legacy recovery parameter; new runs can use `prefect flow-run retry` with their original reservation. Cross-day retries cannot spend yesterday's reservation.

`just check`: 59 tests passed. The integration test exercises a simulated 503, successful task retry, a later flow failure, cache reuse on flow retry, and invalidation after audio/context changes. The same assertions passed against the deployed Prefect API with a mocked provider and no uploads. This does not establish upstream provider recovery.

</details>

![bufo trying](https://all-the.bufo.zone/bufo-just-wanted-you-to-know-this-is-him-trying.jpg)

generated with Codex (GPT-6)
