### PR TITLE
fix: close interrupted PDS upload streams

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -627,3 +627,14 @@ An isolated SDK test and a mocked-provider run against the actual Prefect server
 both verified task retry, flow retry reusing a completed audio result, and cache
 invalidation after audio/context changes. This proves orchestration behavior;
 it does not establish that the upstream audio provider has recovered.
+
+### September 9 — close interrupted PDS upload streams
+
+Track 1288's Blacksky mirroring failures exposed unclosed source sessions.
+A transport-level regression reproduced an audio iterator remaining open after
+an interrupted POST, including through the progress-heartbeat wrapper. Upload
+attempts now explicitly own and close both the wrapper and source iterator for
+OAuth and app-password sessions, including cancellation and early rejection.
+The twelve regression cases fail on the previous implementation and pass with
+the fix. This repairs cleanup; it does not identify or resolve the original
+Blacksky transport failure, and no user track was retried or rewritten.

--- a/backend/src/backend/_internal/atproto/client.py
+++ b/backend/src/backend/_internal/atproto/client.py
@@ -75,6 +75,23 @@ async def _heartbeating_body(
             bytes_since_beat = 0
 
 
+@contextlib.asynccontextmanager
+async def _upload_body(
+    factory: StreamBodyFactory, heartbeat: ProgressHeartbeat | None
+) -> AsyncIterator[AsyncIterable[bytes]]:
+    source = aiter(factory())
+    content = _heartbeating_body(lambda: source, heartbeat) if heartbeat else source
+    try:
+        yield content
+    finally:
+        try:
+            if content is not source and (close := getattr(content, "aclose", None)):
+                await close()
+        finally:
+            if close := getattr(source, "aclose", None):
+                await close()
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -486,12 +503,10 @@ async def _app_password_upload_blob(
                 if body_factory is not None:
                     assert content_length is not None
                     headers["Content-Length"] = str(content_length)
-                    content = (
-                        _heartbeating_body(body_factory, heartbeat)
-                        if heartbeat is not None
-                        else body_factory()
-                    )
-                    response = await http.post(url, headers=headers, content=content)
+                    async with _upload_body(body_factory, heartbeat) as content:
+                        response = await http.post(
+                            url, headers=headers, content=content
+                        )
                 else:
                     response = await http.post(url, headers=headers, content=blob_data)
         except _TRANSIENT_HTTP_ERRORS as e:
@@ -740,18 +755,11 @@ async def _signed_streaming_post(
         request_headers = dict(headers)
         request_headers["Authorization"] = f"DPoP {oauth_session.access_token}"
         request_headers["DPoP"] = proof
-        # wrap the per-attempt factory so each retry gets a fresh iterator
-        # AND a fresh heartbeat throttle state.
-        if heartbeat is not None:
-
-            def attempt_body() -> AsyncIterable[bytes]:
-                return _heartbeating_body(body_factory, heartbeat)
-        else:
-            attempt_body = body_factory
-        async with httpx.AsyncClient(timeout=httpx.Timeout(None)) as http:
-            response = await http.post(
-                url, headers=request_headers, content=attempt_body()
-            )
+        async with (
+            httpx.AsyncClient(timeout=httpx.Timeout(None)) as http,
+            _upload_body(body_factory, heartbeat) as content,
+        ):
+            response = await http.post(url, headers=request_headers, content=content)
         if dpop.is_dpop_nonce_error(response):
             new_nonce = dpop.extract_nonce_from_response(response)
             if new_nonce and attempt == 0:

--- a/backend/tests/_internal/test_upload_stream_cleanup.py
+++ b/backend/tests/_internal/test_upload_stream_cleanup.py
@@ -1,0 +1,100 @@
+"""An interrupted upload closes its source before the next attempt."""
+
+import asyncio
+from collections.abc import AsyncGenerator
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from atproto_oauth.models import OAuthSession
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from backend._internal import Session
+from backend._internal.atproto import client as c
+
+
+@pytest.mark.parametrize("bearer", [False, True])
+@pytest.mark.parametrize("heartbeat", [False, True])
+@pytest.mark.parametrize("outcome", ["network", "early_response", "cancel"])
+async def test_upload_closes_partial_source(
+    monkeypatch: pytest.MonkeyPatch, bearer: bool, heartbeat: bool, outcome: str
+) -> None:
+    closed: list[bool] = []
+    sources: list[AsyncGenerator[bytes, None]] = []
+
+    async def source() -> AsyncGenerator[bytes, None]:
+        try:
+            yield b"first"
+            yield b"second"
+        finally:
+            closed.append(True)
+
+    def factory() -> AsyncGenerator[bytes, None]:
+        stream = source()
+        sources.append(stream)
+        return stream
+
+    async def beat() -> None:
+        pass
+
+    class Transport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            assert isinstance(request.stream, httpx.AsyncByteStream)
+            async for _chunk in request.stream:
+                if outcome == "network":
+                    raise httpx.ReadError("connection interrupted")
+                if outcome == "cancel":
+                    raise asyncio.CancelledError
+                return httpx.Response(413, json={"error": "too large"})
+            raise AssertionError("Expected request data")
+
+    http_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        c.httpx, "AsyncClient", lambda **kw: http_client(transport=Transport(), **kw)
+    )
+    monkeypatch.setattr(c, "_PDS_MAX_ATTEMPTS", 1)
+    monkeypatch.setattr(c, "is_safe_url", lambda _url: True)
+    oauth = OAuthSession(
+        did="did:plc:test",
+        handle="test.test",
+        pds_url="https://pds.test",
+        authserver_iss="https://auth.test",
+        access_token="token",
+        refresh_token="refresh",
+        dpop_private_key=ec.generate_private_key(ec.SECP256R1()),
+        scope="atproto",
+        dpop_authserver_nonce="nonce",
+    )
+    monkeypatch.setattr(c, "reconstruct_oauth_session", lambda _data: oauth)
+    monkeypatch.setattr(
+        c,
+        "get_oauth_client",
+        lambda: SimpleNamespace(
+            _dpop=SimpleNamespace(
+                create_proof=lambda **kw: "proof",
+                is_dpop_nonce_error=lambda _response: False,
+            )
+        ),
+    )
+    session = Session.__new__(Session)
+    session.did = "did:plc:test"
+    session.oauth_session = {
+        "access_token": "token",
+        "pds_url": "https://pds.test",
+        "auth_type": "app_password" if bearer else "oauth",
+    }
+    try:
+        with pytest.raises(
+            asyncio.CancelledError if outcome == "cancel" else Exception
+        ):
+            await c.upload_blob(
+                session,
+                body_factory=factory,
+                content_length=11,
+                content_type="audio/wav",
+                heartbeat=beat if heartbeat else None,
+            )
+        assert closed == [True]
+    finally:
+        for stream in sources:
+            await stream.aclose()

--- a/loq.toml
+++ b/loq.toml
@@ -283,7 +283,7 @@ max_lines = 2589
 
 [[rules]]
 path = "backend/src/backend/_internal/atproto/client.py"
-max_lines = 930
+max_lines = 936
 
 [[rules]]
 path = "backend/src/backend/_internal/auth/oauth.py"


### PR DESCRIPTION
Interrupted PDS uploads now close the source audio iterator before leaving the attempt. Previously, a connection failure or early response could leave the R2 source open through the heartbeat wrapper, matching the unclosed-session warnings seen during failed mirroring.

<details>
<summary>scope and validation</summary>

A shared context manager owns the source and optional heartbeat wrapper in both OAuth and app-password uploads. Both layers close on failure, cancellation and normal exit. Retry timing and authentication behavior are unchanged.

Twelve transport-level regressions exercise partial consumption followed by ReadError, HTTP 413 or cancellation, with both authentication modes and heartbeat settings. All twelve fail against the prior implementation and pass with this change. Full backend validation: 1,640 passed, 25 existing skips; lint and pre-commit checks pass. The file limit was updated through `just loq-relax`.

This fixes resource cleanup, not the unexplained Blacksky transport failure. It does not retry or rewrite any user's track.

</details>

![bufo has been cleaning](https://all-the.bufo.zone/bufo-has-been-cleaning.png)

generated with Codex (GPT-6)
