### PR TITLE
Fix scrolling in the mobile track editor

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -650,3 +650,13 @@ Track and collection seeking now uses a keyboard-accessible native range input.
 Collection lists scroll within the space above the transport; the iframe layout
 owns its viewport height so long lists cannot push controls out of view.
 Existing station/autoplay URLs, media-session behavior and moderation remain.
+
+### September 9 — restore scrolling in the mobile track editor
+
+The in-place editor locked body scrolling and clipped its dialog, but its form
+had no scroll owner. On a 390×640 viewport the form grew to 1,093px and lower
+fields could not be reached. The modal now constrains the form with min-height
+zero and overflow-y auto; its header stays visible and the existing sticky
+save/cancel row remains reachable. A real-browser Storybook regression fails
+without the scroll rules and passes with them. The header also links the
+published track record to pds.ls when an AT URI is available.

--- a/frontend/src/lib/components/EditTrackModal.stories.svelte
+++ b/frontend/src/lib/components/EditTrackModal.stories.svelte
@@ -1,0 +1,43 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { expect, fn, waitFor } from 'storybook/test';
+	import EditTrackModal from './EditTrackModal.svelte';
+	import type { Track } from '$lib/types';
+
+	const track = {
+		id: 0,
+		title: 'a track with a long editing form',
+		artist: 'artist',
+		artist_handle: 'artist.test',
+		artist_did: 'did:plc:artist',
+		file_id: 'test',
+		file_type: 'mp3',
+		play_count: 0,
+		atproto_record_uri: 'at://did:plc:artist/fm.plyr.track/test'
+	} satisfies Track;
+	const { Story } = defineMeta({
+		title: 'editing/EditTrackModal',
+		component: EditTrackModal,
+		args: { track, albums: [], atprotofansEligible: false, onClose: fn(), onSaved: fn() }
+	});
+</script>
+
+<Story
+	name="Scrollable form"
+	play={async () => {
+		await waitFor(() => expect(document.querySelector('dialog[open]')).not.toBeNull());
+		const editor = document.querySelector<HTMLElement>('.editor');
+		const form = document.querySelector<HTMLFormElement>('.edit-container');
+		const actions = document.querySelector<HTMLElement>('.edit-actions');
+		if (!editor || !form || !actions) throw new Error('editor did not render');
+		editor.style.maxHeight = '400px';
+		form.scrollTop = form.scrollHeight;
+		await waitFor(() => expect(form.scrollTop).toBeGreaterThan(0));
+		expect(form.clientHeight).toBeLessThan(form.scrollHeight);
+		expect(actions.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+			editor.getBoundingClientRect().bottom + 1
+		);
+		const record = editor.querySelector<HTMLAnchorElement>('.record-link');
+		expect(record?.href).toBe('https://pds.ls/at/did:plc:artist/fm.plyr.track/test');
+	}}
+/>

--- a/frontend/src/lib/components/EditTrackModal.svelte
+++ b/frontend/src/lib/components/EditTrackModal.svelte
@@ -109,7 +109,17 @@
 >
 	<div class="editor">
 		<header>
-			<h2 id={titleId}>edit track</h2>
+			<div class="heading">
+				<h2 id={titleId}>edit track</h2>
+				{#if track.atproto_record_uri?.startsWith('at://')}
+					<a
+						class="record-link"
+						href={`https://pds.ls/at/${track.atproto_record_uri.slice(5)}`}
+						target="_blank"
+						rel="noopener noreferrer">view record on pds.ls</a
+					>
+				{/if}
+			</div>
 			<button
 				class="close-button"
 				type="button"
@@ -192,6 +202,11 @@
 		flex-direction: column;
 		max-height: calc(100dvh - 48px);
 	}
+	.editor > :global(.edit-container) {
+		min-height: 0;
+		overflow-y: auto;
+		overscroll-behavior: contain;
+	}
 	header {
 		display: flex;
 		align-items: center;
@@ -199,6 +214,23 @@
 		padding: 12px 24px;
 		border-bottom: 1px solid var(--border-subtle);
 		flex-shrink: 0;
+	}
+	.heading {
+		min-width: 0;
+	}
+	.record-link {
+		display: inline-block;
+		padding-block: 4px;
+		font-size: var(--text-sm);
+		color: var(--text-secondary);
+		text-underline-offset: 3px;
+	}
+	.record-link:hover {
+		color: var(--text-primary);
+	}
+	.record-link:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
 	}
 	h2 {
 		margin: 0;


### PR DESCRIPTION
fix the track editor’s unreachable lower fields on mobile. the dialog clipped overflow while its form grew beyond the viewport; the form now owns vertical scrolling, with the existing header and sticky save/cancel controls remaining visible.

also add a header link to the track’s record on pds.ls when its AT URI is available.

<details>
<summary>validation</summary>

- reproduced at 390×640: form height 1,093px with no scroll container
- real-browser regression fails without the scroll rules and passes with them
- 239 frontend unit tests and 40 Storybook interaction/accessibility tests pass; typecheck and lint pass
- Chromium and WebKit at 390×640, 390×360 and 1280×800 in dark/light themes, with both lower sections expanded
- verified the record link against an actual published track

The CSS is scoped to the modal; the shared form’s other callers retain their layout. No track data was changed during verification.
</details>

![bufo-headphones](https://all-the.bufo.zone/bufo-headphones.png)

generated with Codex (GPT-6)
