### PR TITLE
fix studio daily quota diagnosis and retries

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -660,3 +660,18 @@ zero and overflow-y auto; its header stays visible and the existing sticky
 save/cancel row remains reachable. A real-browser Storybook regression fails
 without the scroll rules and passes with them. The header also links the
 published track record to pds.ls when an AT URI is available.
+
+### September 9 — diagnose the studio's Gemini daily quota
+
+A budgeted native-audio request reproduced HTTP 429 with quota
+`GenerateRequestsPerDayPerProjectPerModel-FreeTier=20` for Gemini 3.5 Flash.
+The provider also suggested a five-second retry, despite identifying a daily
+limit. Audio errors now retain structured quota IDs and limits in Prefect while
+omitting raw provider messages. Daily quota exhaustion stops task retries;
+minute limits, unknown 429s and transient service failures remain retryable.
+The diagnostic cost was zero. Billing/quota configuration remains an external
+blocker; this change does not claim restored listening or musical progress.
+
+The full studio check passes 65 tests. The two HTTP-boundary quota regression
+cases fail against the previous audio client. Existing retry/cache integration
+coverage still passes. Schedule, publication policy and spending caps are unchanged.

--- a/services/musician-studio/studio/audio_errors.py
+++ b/services/musician-studio/studio/audio_errors.py
@@ -1,0 +1,51 @@
+"""Provider quota evidence safe to retain in orchestration errors."""
+
+import re
+
+import httpx
+
+
+class AudioProviderError(RuntimeError):
+    def __init__(self, status: int, quotas: tuple[str, ...] = ()) -> None:
+        self.status = status
+        self.quotas = quotas
+        super().__init__(status, quotas)
+
+    @property
+    def daily_quota_exhausted(self) -> bool:
+        return self.status == 429 and any("PerDay" in quota for quota in self.quotas)
+
+    def __str__(self) -> str:
+        detail = f"; quotas: {', '.join(self.quotas)}" if self.quotas else ""
+        return f"Audio review HTTP {self.status}{detail}; no text fallback"
+
+    @classmethod
+    def from_response(cls, response: httpx.Response) -> "AudioProviderError":
+        try:
+            body = response.json()
+        except ValueError:
+            return cls(response.status_code)
+        error = body.get("error") if isinstance(body, dict) else None
+        details = error.get("details") if isinstance(error, dict) else None
+        quotas = []
+        for detail in details if isinstance(details, list) else []:
+            if not isinstance(detail, dict) or detail.get("@type") != (
+                "type.googleapis.com/google.rpc.QuotaFailure"
+            ):
+                continue
+            violations = detail.get("violations")
+            for violation in violations if isinstance(violations, list) else []:
+                if not isinstance(violation, dict):
+                    continue
+                quota = violation.get("quotaId")
+                value = violation.get("quotaValue")
+                if isinstance(quota, str) and re.fullmatch(
+                    r"[A-Za-z0-9_-]{1,160}", quota
+                ):
+                    limit = (
+                        f"={value}"
+                        if isinstance(value, str) and value.isdecimal()
+                        else ""
+                    )
+                    quotas.append(quota + limit)
+        return cls(response.status_code, tuple(quotas))

--- a/services/musician-studio/studio/audio_model.py
+++ b/services/musician-studio/studio/audio_model.py
@@ -14,6 +14,7 @@ from prefect.context import FlowRunContext
 from prefect.states import State
 from pydantic import BaseModel, Field
 
+from studio.audio_errors import AudioProviderError
 from studio.context import musical_identity
 from studio.identity import Musician
 from studio.listening import ListeningReview, inspiration_digest, record_review
@@ -83,19 +84,17 @@ class AudioReceipt(BaseModel):
     audio_tokens: int = Field(gt=0)
 
 
-class AudioProviderError(RuntimeError):
-    def __init__(self, status: int) -> None:
-        self.status = status
-        super().__init__(status)
-
-    def __str__(self) -> str:
-        return f"Audio review HTTP {self.status}; no text fallback"
-
-
 def retry_audio(task: object, task_run: object, state: State) -> bool:
     error = state.result(raise_on_failure=False)
     if isinstance(error, AudioProviderError):
-        return error.status in {408, 429, 500, 502, 503, 504}
+        return not error.daily_quota_exhausted and error.status in {
+            408,
+            429,
+            500,
+            502,
+            503,
+            504,
+        }
     return isinstance(error, httpx.TransportError)
 
 
@@ -158,7 +157,7 @@ def audio_request[Response: BaseModel](
             },
         )
     if response.status_code != 200:
-        raise AudioProviderError(response.status_code)
+        raise AudioProviderError.from_response(response)
     result = response.json()
     usage = result["usageMetadata"]
     store.charge(

--- a/services/musician-studio/tests/test_audio_model.py
+++ b/services/musician-studio/tests/test_audio_model.py
@@ -5,9 +5,11 @@ from pathlib import Path
 
 import httpx
 import pytest
+from prefect.states import Failed
 from pydantic import ValidationError
 
 from studio import audio_model
+from studio.audio_model import AudioProviderError, Feedback, retry_audio
 from studio.listening import digest
 from studio.state import Store
 
@@ -87,3 +89,60 @@ def test_review_sends_audio_and_records_provider_evidence(
     assert store.usage(datetime.now(UTC))["month"]["estimated_cost"] == pytest.approx(
         0.0021
     )
+
+
+@pytest.mark.parametrize("period,expected_retry", [("Day", False), ("Minute", True)])
+def test_quota_failure_retains_daily_limit_and_controls_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, period: str, expected_retry: bool
+) -> None:
+    store = Store(tmp_path)
+    session = store.reserve(datetime.now(UTC))
+    client = httpx.Client
+    quota = f"GenerateRequestsPer{period}PerProjectPerModel-FreeTier"
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            429,
+            json={
+                "error": {
+                    "message": "sensitive provider message must not be logged",
+                    "details": [
+                        {
+                            "@type": "type.googleapis.com/google.rpc.QuotaFailure",
+                            "violations": [{"quotaId": quota, "quotaValue": "20"}],
+                        },
+                        {
+                            "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                            "retryDelay": "5s",
+                        },
+                    ],
+                }
+            },
+        )
+
+    monkeypatch.setattr(audio_model, "key", lambda: "fake")
+    monkeypatch.setattr(
+        audio_model.httpx,
+        "Client",
+        lambda **kwargs: client(transport=httpx.MockTransport(handle), **kwargs),
+    )
+    with pytest.raises(AudioProviderError) as raised:
+        audio_model.audio_request.fn(
+            tmp_path, session, b"audio", "review", Feedback, "test"
+        )
+    error = raised.value
+    assert f"{quota}=20" in str(error)
+    assert "sensitive" not in str(error)
+    assert error.daily_quota_exhausted is (not expected_retry)
+    assert store.usage(datetime.now(UTC))["day"]["calls"] == 1
+    assert store.usage(datetime.now(UTC))["day"]["estimated_cost"] == 0
+    assert retry_audio(None, None, Failed(data=error)) is expected_retry
+
+
+@pytest.mark.parametrize(
+    "body", [None, [], {"error": []}, {"error": {"details": [None]}}]
+)
+def test_unstructured_provider_error_keeps_http_status(body: object) -> None:
+    error = AudioProviderError.from_response(httpx.Response(503, json=body))
+    assert error.status == 503
+    assert not error.quotas


### PR DESCRIPTION
the studio now reports Gemini's structured quota IDs and limits in Prefect and stops retrying a confirmed daily quota failure. transient 429s and service errors keep their existing retries.

<details>
<summary>evidence and validation</summary>

a native-audio diagnostic returned `GenerateRequestsPerDayPerProjectPerModel-FreeTier=20` for Gemini 3.5 Flash. the response also suggested a five-second retry; the daily quota takes precedence. raw provider messages are omitted from exceptions.

`just check` passes all 65 studio tests, including Prefect retry/cache integration. both quota regression cases fail with the previous audio client. pre-commit checks pass.

this does not raise Google's quota or establish recovered audio reviews. billing configuration is still required. scheduling, unlisted publication and cost caps are unchanged.
</details>

![bufo-placeholder](https://all-the.bufo.zone/bufo-placeholder.png)

generated with Codex (GPT-6)
