### PR TITLE
Keep public listening separate from download permission

### DIFF
--- a/backend/src/backend/_internal/atproto/records/fm_plyr/track.py
+++ b/backend/src/backend/_internal/atproto/records/fm_plyr/track.py
@@ -338,7 +338,7 @@ async def rebuild_track_pds_record(
     if not record_uri:
         return
 
-    if track.support_gate is not None:
+    if track.uses_private_audio:
         backend_url = settings.atproto.redirect_uri.rsplit("/", 2)[0]
         audio_url = urljoin(backend_url + "/", f"audio/{track.file_id}")
     else:

--- a/backend/src/backend/_internal/copyright.py
+++ b/backend/src/backend/_internal/copyright.py
@@ -611,7 +611,7 @@ async def clear_track_rights(
         except Exception as e:
             logger.warning("failed to delete %s: %s", uri, e)
 
-    if was_copyright_gated:
+    if was_copyright_gated and track.audio_storage != "r2_private":
         # move the file back to the public bucket synchronously so the
         # rebuild below has a valid r2_url to write into the PDS record.
         # `move_track_audio` updates the row's r2_url after a successful

--- a/backend/src/backend/_internal/export_tasks.py
+++ b/backend/src/backend/_internal/export_tasks.py
@@ -13,9 +13,13 @@ from pathlib import Path
 import aioboto3
 import aiofiles
 import logfire
+from atproto_oauth.security import get_hardened_async_client
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
+from backend._internal import get_session
+from backend._internal.atproto.client import pds_blob_url
+from backend._internal.atproto.spaces.client import open_space_blob
 from backend._internal.background import get_docket
 from backend._internal.jobs import job_service
 from backend.config import settings
@@ -32,7 +36,9 @@ from backend.utilities.progress import R2ProgressTracker
 logger = logging.getLogger(__name__)
 
 
-async def process_export(export_id: str, artist_did: str) -> None:
+async def process_export(
+    export_id: str, artist_did: str, session_id: str | None = None
+) -> None:
     """process a media export in the background.
 
     downloads all tracks for the given artist concurrently, zips them,
@@ -51,6 +57,7 @@ async def process_export(export_id: str, artist_did: str) -> None:
         async with db_session() as db:
             stmt = (
                 select(Track)
+                .options(selectinload(Track.artist))
                 .where(Track.artist_did == artist_did)
                 .order_by(Track.created_at)
             )
@@ -163,15 +170,60 @@ async def process_export(export_id: str, artist_did: str) -> None:
                 async with semaphore:
                     track = info["track"]
                     try:
-                        response = await s3_client.get_object(
-                            Bucket=storage.audio_bucket_name,
-                            Key=info["key"],
-                        )
-
-                        # stream to disk in chunks
-                        async with aiofiles.open(info["temp_path"], "wb") as f:
-                            async for chunk in response["Body"].iter_chunks():
-                                await f.write(chunk)
+                        if track.audio_storage == "pds" and not track.original_file_id:
+                            if not track.pds_blob_cid:
+                                raise RuntimeError("PDS audio has no blob")
+                            if track.is_private:
+                                owner_session = (
+                                    await get_session(session_id)
+                                    if session_id
+                                    else None
+                                )
+                                if (
+                                    owner_session is None
+                                    or owner_session.did != artist_did
+                                    or not track.space_uri
+                                ):
+                                    raise RuntimeError(
+                                        "sign in again to export Space audio"
+                                    )
+                                async with (
+                                    open_space_blob(
+                                        owner_session,
+                                        space=track.space_uri,
+                                        repo=artist_did,
+                                        cid=track.pds_blob_cid,
+                                    ) as response,
+                                    aiofiles.open(info["temp_path"], "wb") as f,
+                                ):
+                                    async for chunk in response.aiter_bytes():
+                                        await f.write(chunk)
+                            else:
+                                if not track.artist.pds_url:
+                                    raise RuntimeError("PDS host unavailable")
+                                url = pds_blob_url(
+                                    track.artist.pds_url, artist_did, track.pds_blob_cid
+                                )
+                                async with (
+                                    get_hardened_async_client() as client,
+                                    client.stream("GET", url) as response,
+                                ):
+                                    response.raise_for_status()
+                                    async with aiofiles.open(
+                                        info["temp_path"], "wb"
+                                    ) as f:
+                                        async for chunk in response.aiter_bytes():
+                                            await f.write(chunk)
+                        else:
+                            response = await s3_client.get_object(
+                                Bucket=storage.private_audio_bucket_name
+                                if track.uses_private_audio
+                                else storage.audio_bucket_name,
+                                Key=info["key"],
+                            )
+                            async with aiofiles.open(info["temp_path"], "wb") as f:
+                                async for chunk in response["Body"].iter_chunks():
+                                    await f.write(chunk)
 
                         # update progress
                         async with download_lock:
@@ -227,6 +279,10 @@ async def process_export(export_id: str, artist_did: str) -> None:
 
             # filter out failed downloads
             successful_downloads = [r for r in results if r is not None]
+            if len(successful_downloads) != len(tracks):
+                raise RuntimeError(
+                    "some originals could not be retrieved; retry the export"
+                )
 
             # create zip file from downloaded tracks (sequential - zipfile not thread-safe)
             await job_service.update_progress(
@@ -281,7 +337,7 @@ async def process_export(export_id: str, artist_did: str) -> None:
                     with open(zip_path, "rb") as zip_file_obj:
                         await upload_client.upload_fileobj(
                             zip_file_obj,
-                            storage.audio_bucket_name,
+                            storage.private_audio_bucket_name,
                             r2_key,
                             ExtraArgs={
                                 "ContentType": "application/zip",
@@ -304,7 +360,10 @@ async def process_export(export_id: str, artist_did: str) -> None:
                 raise
 
             # get download URL
-            download_url = f"{storage.public_audio_bucket_url}/{r2_key}"
+            download_url = (
+                settings.atproto.redirect_uri.rsplit("/", 2)[0]
+                + f"/exports/{export_id}/download"
+            )
 
             # mark as completed
             await job_service.update_progress(
@@ -315,6 +374,8 @@ async def process_export(export_id: str, artist_did: str) -> None:
                     "processed_count": processed,
                     "total_count": len(tracks),
                     "download_url": download_url,
+                    "r2_key": r2_key,
+                    "filename": download_filename,
                 },
             )
 
@@ -332,16 +393,20 @@ async def process_export(export_id: str, artist_did: str) -> None:
 
 
 async def process_album_download(
-    job_id: str, track_ids: list[int], r2_key: str, zip_filename: str
+    job_id: str,
+    track_ids: list[int],
+    r2_key: str,
+    zip_filename: str,
+    download_path: str | None = None,
 ) -> None:
-    """build a public album zip and cache it in R2 under a content-digest key.
+    """build a private album zip and cache it under a content-digest key.
 
     sibling of `process_export` with two deliberate differences: entries are
     ZIP_STORED (audio is already compressed — deflate burns worker CPU for
     nothing), and the destination key encodes a digest of the member tracks,
     so an edited album naturally builds a fresh object while the old one is
     swept below. eligibility (no gated/labeled/opted-out tracks) is enforced
-    by the API endpoint before this job is ever enqueued.
+    by the API endpoint both before enqueueing and when releasing the ZIP.
     """
     try:
         await job_service.update_progress(
@@ -407,7 +472,10 @@ async def process_album_download(
                 async with semaphore:
                     try:
                         response = await s3_client.get_object(
-                            Bucket=storage.audio_bucket_name, Key=info["key"]
+                            Bucket=storage.private_audio_bucket_name
+                            if info["track"].uses_private_audio
+                            else storage.audio_bucket_name,
+                            Key=info["key"],
                         )
                         async with aiofiles.open(info["temp_path"], "wb") as f:
                             async for chunk in response["Body"].iter_chunks():
@@ -468,7 +536,7 @@ async def process_album_download(
                 with open(zip_path, "rb") as zip_file_obj:
                     await upload_client.upload_fileobj(
                         zip_file_obj,
-                        storage.audio_bucket_name,
+                        storage.private_audio_bucket_name,
                         r2_key,
                         ExtraArgs={
                             "ContentType": "application/zip",
@@ -481,16 +549,16 @@ async def process_album_download(
                 # sweep stale digests for this album so edits don't accrete zips
                 prefix = r2_key.rsplit("-", 1)[0] + "-"
                 listing = await upload_client.list_objects_v2(
-                    Bucket=storage.audio_bucket_name, Prefix=prefix
+                    Bucket=storage.private_audio_bucket_name, Prefix=prefix
                 )
                 for obj in listing.get("Contents", []):
                     if obj["Key"] != r2_key:
                         await upload_client.delete_object(
-                            Bucket=storage.audio_bucket_name, Key=obj["Key"]
+                            Bucket=storage.private_audio_bucket_name, Key=obj["Key"]
                         )
                         logfire.info("swept stale album zip", key=obj["Key"])
 
-        download_url = f"{storage.public_audio_bucket_url}/{r2_key}"
+        download_url = download_path
         await job_service.update_progress(
             job_id,
             JobStatus.COMPLETED,
@@ -509,16 +577,24 @@ async def process_album_download(
 
 
 async def schedule_album_download(
-    job_id: str, track_ids: list[int], r2_key: str, zip_filename: str
+    job_id: str,
+    track_ids: list[int],
+    r2_key: str,
+    zip_filename: str,
+    download_path: str | None = None,
 ) -> None:
     """schedule an album zip build via docket."""
     docket = get_docket()
-    await docket.add(process_album_download)(job_id, track_ids, r2_key, zip_filename)
+    await docket.add(process_album_download)(
+        job_id, track_ids, r2_key, zip_filename, download_path=download_path
+    )
     logfire.info("scheduled album download", job_id=job_id, r2_key=r2_key)
 
 
-async def schedule_export(export_id: str, artist_did: str) -> None:
+async def schedule_export(
+    export_id: str, artist_did: str, session_id: str | None = None
+) -> None:
     """schedule an export via docket."""
     docket = get_docket()
-    await docket.add(process_export)(export_id, artist_did)
+    await docket.add(process_export)(export_id, artist_did, session_id=session_id)
     logfire.info("scheduled export", export_id=export_id)

--- a/backend/src/backend/_internal/pds_save_tasks.py
+++ b/backend/src/backend/_internal/pds_save_tasks.py
@@ -158,7 +158,7 @@ async def save_tracks_to_pds(
                         skipped_count += 1
                         return
 
-                    if track.support_gate is not None:
+                    if track.is_private or track.uses_private_audio:
                         skipped_count += 1
                         return
 

--- a/backend/src/backend/_internal/tasks/hooks.py
+++ b/backend/src/backend/_internal/tasks/hooks.py
@@ -21,6 +21,7 @@ from backend._internal.tasks.ml import (
 from backend._internal.tasks.pds_mirror import schedule_pds_blob_mirror
 from backend.config import settings
 from backend.models import Artist, CopyrightScan, Track
+from backend.storage import storage
 from backend.utilities.database import db_session
 from backend.utilities.redis import get_async_redis_client
 
@@ -47,6 +48,8 @@ async def resolve_audio_url(track_id: int) -> str | None:
                 Track.audio_storage,
                 Track.pds_blob_cid,
                 Track.artist_did,
+                Track.file_id,
+                Track.file_type,
             )
             .where(Track.id == track_id)
             .limit(1)
@@ -55,8 +58,12 @@ async def resolve_audio_url(track_id: int) -> str | None:
         if not row:
             return None
 
-        r2_url, audio_storage, pds_blob_cid, artist_did = row
+        r2_url, audio_storage, pds_blob_cid, artist_did, file_id, file_type = row
 
+        if audio_storage == "r2_private":
+            return await storage.generate_presigned_url(
+                file_id=file_id, extension=file_type
+            )
         if r2_url:
             return r2_url
 
@@ -77,7 +84,13 @@ async def resolve_audio_url(track_id: int) -> str | None:
 async def _has_own_audio_object(track_id: int) -> bool:
     """whether the track's audio is stored by us rather than only on a PDS."""
     async with db_session() as db:
-        return bool(await db.scalar(select(Track.r2_url).where(Track.id == track_id)))
+        return bool(
+            await db.scalar(
+                select(
+                    Track.r2_url.isnot(None) | (Track.audio_storage == "r2_private")
+                ).where(Track.id == track_id)
+            )
+        )
 
 
 async def run_post_track_create_hooks(

--- a/backend/src/backend/_internal/track_revisions.py
+++ b/backend/src/backend/_internal/track_revisions.py
@@ -105,9 +105,7 @@ async def _maybe_delete_blob(
     """delete blobs owned by us if no live row still references them.
 
     PDS-only audio (audio_storage="pds") lives on the user's PDS — we never
-    delete those. for "r2" or "both" audio, the playable file is in our
-    storage and we own it. transcode originals always live in the public
-    bucket regardless of gating (gated tracks can't be lossless yet).
+    delete those. R2 renditions and originals use the snapshot's bucket.
     """
     if revision.audio_storage == "pds":
         return  # not ours to delete
@@ -132,13 +130,15 @@ async def _maybe_delete_blob(
                 revision.was_gated,
             )
 
-    # transcode original: always public bucket
+    # Originals use the same bucket as their rendition.
     if (
         revision.original_file_id
         and revision.original_file_id not in in_use_original_file_ids
     ):
         try:
-            await storage.delete(revision.original_file_id, revision.original_file_type)
+            await (storage.delete_gated if revision.was_gated else storage.delete)(
+                revision.original_file_id, revision.original_file_type
+            )
         except Exception:
             logger.exception(
                 "failed to delete pruned revision original (file_id=%s)",

--- a/backend/src/backend/api/albums/downloads.py
+++ b/backend/src/backend/api/albums/downloads.py
@@ -24,6 +24,7 @@ from backend._internal import get_optional_session, validate_supporter
 from backend._internal.export_tasks import schedule_album_download
 from backend._internal.jobs import job_service
 from backend._internal.track_visibility import visible_filter
+from backend.config import settings
 from backend.models import Album, Artist, Track, get_db
 from backend.models.job import JobType
 from backend.storage import storage
@@ -97,7 +98,13 @@ async def download_album(
         artist_prefs.download_policy if artist_prefs else None,
         artist_prefs.support_url if artist_prefs else None,
     )
-    if album_policy == "supporters" and session is not None and not viewer_is_artist:
+    if (
+        any(
+            (track.download_policy or album_policy) == "supporters" for track in ordered
+        )
+        and session is not None
+        and not viewer_is_artist
+    ):
         validation = await validate_supporter(
             supporter_did=session.did, artist_did=album.artist_did
         )
@@ -110,7 +117,7 @@ async def download_album(
             support_gate=track.support_gate,
             labels=set(track.self_labels or []) | set(track.operator_labels or []),
             moderation_override=track.moderation_override,
-            download_policy=album_policy,
+            download_policy=track.download_policy or album_policy,
             viewer_is_artist=viewer_is_artist,
             viewer_is_supporter=viewer_is_supporter,
         )
@@ -149,14 +156,22 @@ async def download_album(
     ).hexdigest()[:16]
     r2_key = f"exports/albums/{album.id}-{digest}.zip"
 
-    if await storage.object_exists(r2_key):
-        return RedirectResponse(url=f"{storage.public_audio_bucket_url}/{r2_key}")
-
     zip_filename = download_filename(artist.display_name, album.title, "zip")
+    if await storage.object_exists(r2_key, private=True):
+        return RedirectResponse(
+            url=await storage.generate_download_url(
+                key=r2_key, filename=zip_filename, private=True
+            )
+        )
     job_id = await job_service.create_job(
         JobType.EXPORT, album.artist_did, "album download queued"
     )
     await schedule_album_download(
-        job_id, [track_id for track_id, _, _ in entries], r2_key, zip_filename
+        job_id,
+        [track_id for track_id, _, _ in entries],
+        r2_key,
+        zip_filename,
+        download_path=settings.atproto.redirect_uri.rsplit("/", 2)[0]
+        + f"/albums/{handle}/{slug}/download",
     )
     return AlbumDownloadPending(job_id=job_id)

--- a/backend/src/backend/api/audio.py
+++ b/backend/src/backend/api/audio.py
@@ -267,11 +267,9 @@ async def download_audio(
 ) -> RedirectResponse:
     """download a track's audio as an attachment named `artist - title.ext`.
 
-    downloads are offered only where the bytes are already publicly
-    reachable (the artist's PDS serves them to anyone): public and unlisted
-    tracks that are not supporter-gated, not copyright-flagged, and whose
-    artist has not switched downloads off. prefers the preserved lossless
-    original over the streaming rendition.
+    resolves the track override before the artist policy and signs the source
+    bucket only after authorization. prefers the preserved original; artists
+    can recover protected R2 audio. Space audio uses the owner export path.
     """
     async with db_session() as db:
         result = await db.execute(

--- a/backend/src/backend/api/audio.py
+++ b/backend/src/backend/api/audio.py
@@ -127,9 +127,16 @@ async def stream_audio(
     serving_original = file_id == original_file_id and original_file_type is not None
     serve_file_id = file_id if serving_original else track_file_id
     serve_file_type = original_file_type if serving_original else file_type
+    if (
+        serving_original
+        and file_id != track_file_id
+        and (audio_storage == "r2_private" or support_gate is not None)
+    ):
+        authorized_download = await download_audio(file_id=file_id, session=session)
+        return Response(status_code=200) if is_head_request else authorized_download
 
     # check if track is gated
-    if support_gate is not None:
+    if support_gate is not None or audio_storage == "r2_private":
         return await _handle_gated_audio(
             file_id=serve_file_id,
             file_type=serve_file_type,
@@ -175,14 +182,10 @@ async def _check_gate_access(
 ) -> None:
     """raise HTTPException if `session` may not stream a track with this gate.
 
-    gate shape: `{"type": "any" | "copyright" | "stream"}`.
+    gate shape: `{"type": "any" | "copyright"}`.
     - "any" (atprotofans supporter-gated): artist or validated supporter
     - "copyright" (indiemusi paradigm): any authenticated listener
-    - "stream": any listener; files stay in private storage
     """
-    if gate.get("type") == "stream":
-        return
-
     if not session:
         raise HTTPException(
             status_code=401,
@@ -215,7 +218,7 @@ async def _handle_gated_audio(
     file_type: str,
     artist_did: str,
     session: Session | None,
-    support_gate: dict,
+    support_gate: dict | None,
     is_head_request: bool = False,
     audio_storage: str = "r2",
     pds_blob_cid: str | None = None,
@@ -228,13 +231,14 @@ async def _handle_gated_audio(
     for HEAD requests (used for pre-flight auth checks), returns 200 status
     without redirecting to avoid CORS issues with cross-origin redirects.
     """
-    await _check_gate_access(support_gate, session, artist_did)
+    if support_gate is not None:
+        await _check_gate_access(support_gate, session, artist_did)
 
     if is_head_request:
         return Response(status_code=200)
 
     # artist always sees their own track; otherwise we already validated above
-    if session is not None and session.did != artist_did:
+    if support_gate is not None and session is not None and session.did != artist_did:
         logfire.info(
             "serving gated content",
             file_id=file_id,
@@ -288,6 +292,7 @@ async def download_audio(
                 Track.artist_did,
                 Artist.display_name,
                 UserPreferences.download_policy,
+                Track.extra,
                 UserPreferences.support_url,
             )
             .join(Artist, Artist.did == Track.artist_did)
@@ -301,7 +306,9 @@ async def download_audio(
         if not row:
             raise HTTPException(status_code=404, detail="audio file not found")
 
-    policy = effective_download_policy(row.download_policy, row.support_url)
+    policy = effective_download_policy(
+        (row.extra or {}).get("download_policy") or row.download_policy, row.support_url
+    )
     viewer_is_artist = session is not None and session.did == row.artist_did
     viewer_is_supporter = False
     if policy == "supporters" and session is not None and not viewer_is_artist:
@@ -360,7 +367,11 @@ async def download_audio(
         raise HTTPException(status_code=404, detail="no downloadable file")
 
     filename = download_filename(row.display_name, row.title, key.extension)
-    url = await storage.generate_download_url(key=key.key, filename=filename)
+    url = await storage.generate_download_url(
+        key=key.key,
+        filename=filename,
+        private=row.audio_storage == "r2_private" or row.support_gate is not None,
+    )
     return RedirectResponse(url=url)
 
 
@@ -432,10 +443,22 @@ async def get_audio_url(
     serving_original = file_id == original_file_id and original_file_type is not None
     serve_file_id = file_id if serving_original else track_file_id
     serve_file_type = original_file_type if serving_original else file_type
+    if (
+        serving_original
+        and file_id != track_file_id
+        and (audio_storage == "r2_private" or support_gate is not None)
+    ):
+        authorized_download = await download_audio(file_id=file_id, session=session)
+        return AudioUrlResponse(
+            url=authorized_download.headers["location"],
+            file_id=file_id,
+            file_type=serve_file_type,
+        )
 
     # check if track is gated
-    if support_gate is not None:
-        await _check_gate_access(support_gate, session, artist_did)
+    if support_gate is not None or audio_storage == "r2_private":
+        if support_gate is not None:
+            await _check_gate_access(support_gate, session, artist_did)
 
         # PDS-backed gated tracks: return PDS blob URL
         if audio_storage == "pds" and pds_blob_cid:

--- a/backend/src/backend/api/audio.py
+++ b/backend/src/backend/api/audio.py
@@ -175,10 +175,14 @@ async def _check_gate_access(
 ) -> None:
     """raise HTTPException if `session` may not stream a track with this gate.
 
-    gate shape: `{"type": "any" | "copyright"}`.
+    gate shape: `{"type": "any" | "copyright" | "stream"}`.
     - "any" (atprotofans supporter-gated): artist or validated supporter
     - "copyright" (indiemusi paradigm): any authenticated listener
+    - "stream": any listener; files stay in private storage
     """
+    if gate.get("type") == "stream":
+        return
+
     if not session:
         raise HTTPException(
             status_code=401,

--- a/backend/src/backend/api/exports.py
+++ b/backend/src/backend/api/exports.py
@@ -16,6 +16,7 @@ from backend._internal.export_tasks import schedule_export
 from backend._internal.jobs import job_service
 from backend.models import Track, get_db
 from backend.models.job import JobStatus, JobType
+from backend.storage import storage
 
 router = APIRouter(prefix="/exports", tags=["exports"])
 logger = logging.getLogger(__name__)
@@ -53,7 +54,7 @@ async def export_media(
     )
 
     # schedule background processing via docket (or asyncio fallback)
-    await schedule_export(export_id, session.did)
+    await schedule_export(export_id, session.did, session_id=session.session_id)
 
     return ExportStartResponse(
         export_id=export_id,
@@ -133,4 +134,10 @@ async def download_export(
     if not job.result or "download_url" not in job.result:
         raise HTTPException(status_code=500, detail="export url not found")
 
+    if "r2_key" in job.result:
+        return RedirectResponse(
+            url=await storage.generate_download_url(
+                key=job.result["r2_key"], filename=job.result["filename"], private=True
+            )
+        )
     return RedirectResponse(url=job.result["download_url"])

--- a/backend/src/backend/api/for_you.py
+++ b/backend/src/backend/api/for_you.py
@@ -412,12 +412,7 @@ async def get_for_you_feed(
     gated_artist_dids = {
         t.artist_did
         for t in tracks
-        if t.support_gate
-        and t.artist_did != actor_did
-        and (
-            not isinstance(t.support_gate, dict)
-            or t.support_gate.get("type") not in ("copyright", "stream")
-        )
+        if t.needs_supporter_check and t.artist_did != actor_did
     }
     supported_artist_dids: set[str] = set()
     if gated_artist_dids:

--- a/backend/src/backend/api/for_you.py
+++ b/backend/src/backend/api/for_you.py
@@ -416,7 +416,7 @@ async def get_for_you_feed(
         and t.artist_did != actor_did
         and (
             not isinstance(t.support_gate, dict)
-            or t.support_gate.get("type") != "copyright"
+            or t.support_gate.get("type") not in ("copyright", "stream")
         )
     }
     supported_artist_dids: set[str] = set()

--- a/backend/src/backend/api/pds_save.py
+++ b/backend/src/backend/api/pds_save.py
@@ -51,7 +51,8 @@ async def save_audio_to_pds(
         select(Track.id)
         .where(
             Track.artist_did == session.did,
-            Track.support_gate.is_(None),
+            ~Track.uses_private_audio,
+            ~Track.is_private,
             Track.pds_blob_cid.is_(None),
             Track.file_id.isnot(None),
         )

--- a/backend/src/backend/api/subsonic/endpoints.py
+++ b/backend/src/backend/api/subsonic/endpoints.py
@@ -10,7 +10,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
 from atproto_oauth.scopes import ScopesSet
-from fastapi import Request, Response
+from fastapi import HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -23,6 +23,7 @@ from backend._internal.content_labels import (
 )
 from backend._internal.tasks import schedule_teal_scrobble
 from backend._internal.track_visibility import visible_filter
+from backend.api.audio import download_audio
 from backend.api.lists.playlists import _can_view, _read_playlist_items
 from backend.api.subsonic.auth import authenticate
 from backend.api.subsonic.responses import (
@@ -286,6 +287,19 @@ async def get_song(request: Request) -> Response:
 
 
 @_rest("download")
+async def download(request: Request) -> Response:
+    async def impl(session: Session, params: Params) -> Response:
+        track = await _track_by_id(params, session)
+        try:
+            response = await download_audio(file_id=track.file_id, session=session)
+        except HTTPException as exc:
+            raise SubsonicError(ERROR_NOT_AUTHORIZED, str(exc.detail)) from exc
+        response.status_code = 302
+        return response
+
+    return await _run(request, impl)
+
+
 @_rest("stream")
 async def stream(request: Request) -> Response:
     async def impl(session: Session, params: Params) -> Response:

--- a/backend/src/backend/api/tracks/audio_optimize.py
+++ b/backend/src/backend/api/tracks/audio_optimize.py
@@ -90,6 +90,7 @@ class _AudioState:
     interim_file_type: str
     created_at: datetime
     is_gated: bool
+    audio_storage: str = "r2"
 
 
 @dataclass
@@ -155,7 +156,8 @@ async def _load_audio_state(track_id: int) -> _AudioState | None:
             interim_file_id=track.file_id,
             interim_file_type=track.file_type,
             created_at=track.created_at,
-            is_gated=track.support_gate is not None,
+            is_gated=track.uses_private_audio,
+            audio_storage=track.audio_storage,
         )
 
 
@@ -252,7 +254,9 @@ async def _commit_optimize_swap(
                 file_id=sr.file_id,
                 file_type=OPTIMIZE_TARGET_FORMAT,
                 r2_url=sr.r2_url,
-                audio_storage="both" if has_pds_blob else "r2",
+                audio_storage="r2_private"
+                if state.audio_storage == "r2_private"
+                else ("both" if has_pds_blob else "r2"),
                 pds_blob_cid=pds_result.cid if pds_result else None,
                 pds_blob_size=pds_result.size if pds_result else None,
                 atproto_record_cid=new_record_cid,

--- a/backend/src/backend/api/tracks/audio_replace.py
+++ b/backend/src/backend/api/tracks/audio_replace.py
@@ -115,6 +115,8 @@ class TrackAudioState:
     self_labels: list[str]
     support_gate: dict | None
     created_at: datetime  # original record creation time — must survive replace
+    private_audio: bool = False
+    audio_storage: str = "r2"
 
 
 @dataclass
@@ -182,6 +184,8 @@ async def _load_and_authorize(
             self_labels=list(track.self_labels or []),
             support_gate=dict(track.support_gate) if track.support_gate else None,
             created_at=track.created_at,
+            private_audio=track.uses_private_audio,
+            audio_storage=track.audio_storage,
         )
 
 
@@ -207,6 +211,7 @@ def _build_upload_context_for_phases(
         features_json=None,
         tags=[],
         support_gate=state.support_gate,
+        private_audio=state.private_audio,
     )
 
 
@@ -216,7 +221,7 @@ def _audio_url_for_record(state: TrackAudioState, sr: StorageResult) -> str:
     gated tracks point at the auth-protected backend endpoint; public tracks
     point at the public storage URL.
     """
-    if state.support_gate is not None:
+    if state.private_audio or state.support_gate is not None:
         backend_url = settings.atproto.redirect_uri.rsplit("/", 2)[0]
         return urljoin(backend_url + "/", f"audio/{sr.file_id}")
     assert sr.r2_url is not None  # public tracks always have an r2_url
@@ -322,7 +327,7 @@ async def _commit_db_swap(
             pds_blob_cid=track.pds_blob_cid,
             pds_blob_size=track.pds_blob_size,
             duration=track.duration,
-            was_gated=track.support_gate is not None,
+            was_gated=track.uses_private_audio,
         )
         db.add(snapshot)
 
@@ -331,7 +336,11 @@ async def _commit_db_swap(
         track.original_file_id = sr.original_file_id
         track.original_file_type = sr.original_file_type
         track.r2_url = sr.r2_url
-        track.audio_storage = "both" if has_pds_blob else "r2"
+        track.audio_storage = (
+            "r2_private"
+            if state.audio_storage == "r2_private"
+            else ("both" if has_pds_blob else "r2")
+        )
         track.pds_blob_cid = pds_result.cid if pds_result else None
         track.pds_blob_size = pds_result.size if pds_result else None
         track.atproto_record_cid = new_record_cid
@@ -561,6 +570,8 @@ async def _refresh_metadata_state(state: TrackAudioState) -> TrackAudioState:
             self_labels=list(track.self_labels or []),
             support_gate=dict(track.support_gate) if track.support_gate else None,
             created_at=state.created_at,
+            private_audio=state.private_audio,
+            audio_storage=state.audio_storage,
         )
 
 
@@ -574,9 +585,7 @@ async def _rollback_new_files(
 ) -> None:
     """delete any new storage object we wrote before discovering the operation must abort.
 
-    `gated=True` routes the playable-file delete to the private bucket. transcode
-    originals always live in the public bucket (gated tracks can't be lossless),
-    so the original delete uses the public path unconditionally.
+    `gated=True` routes both rendition and original cleanup to the private bucket.
 
     `new_file_type` is the playable extension used to derive the storage
     key. it MUST be threaded through so the early-abort case (where the
@@ -589,7 +598,9 @@ async def _rollback_new_files(
             await delete_fn(new_file_id, new_file_type)
     if new_original_file_id:
         with contextlib.suppress(Exception):
-            await storage.delete(new_original_file_id, new_original_file_type)
+            await (storage.delete_gated if gated else storage.delete)(
+                new_original_file_id, new_original_file_type
+            )
 
 
 # -- background task registration -----------------------------------------------
@@ -718,13 +729,14 @@ async def replace_track_audio(
                 Track.artist_did,
                 Track.atproto_record_uri,
                 Track.support_gate,
+                Track.uses_private_audio,
                 Track.is_private,
             ).where(Track.id == track_id)
         )
         row = result.first()
         if not row:
             raise HTTPException(status_code=404, detail="track not found")
-        artist_did, atproto_uri, support_gate, is_private = row
+        artist_did, atproto_uri, _support_gate, private_audio, is_private = row
         if artist_did != auth_session.did:
             raise HTTPException(
                 status_code=403,
@@ -746,7 +758,7 @@ async def replace_track_audio(
                     "replacing audio"
                 ),
             )
-        is_gated = support_gate is not None
+        is_gated = private_audio
 
     # stage the new audio bytes to shared object storage BEFORE enqueueing
     # the docket task. workers may pick up the task on a different fly

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -229,7 +229,7 @@ async def list_tracks(
             and t.artist_did != viewer_did
             and (
                 not isinstance(t.support_gate, dict)
-                or t.support_gate.get("type") != "copyright"
+                or t.support_gate.get("type") not in ("copyright", "stream")
             )
         }
         if gated_artist_dids:
@@ -442,7 +442,7 @@ async def list_top_tracks(
             and t.artist_did != viewer_did
             and (
                 not isinstance(t.support_gate, dict)
-                or t.support_gate.get("type") != "copyright"
+                or t.support_gate.get("type") not in ("copyright", "stream")
             )
         }
         if gated_artist_dids:

--- a/backend/src/backend/api/tracks/listing.py
+++ b/backend/src/backend/api/tracks/listing.py
@@ -225,12 +225,7 @@ async def list_tracks(
         gated_artist_dids = {
             t.artist_did
             for t in tracks
-            if t.support_gate
-            and t.artist_did != viewer_did
-            and (
-                not isinstance(t.support_gate, dict)
-                or t.support_gate.get("type") not in ("copyright", "stream")
-            )
+            if t.needs_supporter_check and t.artist_did != viewer_did
         }
         if gated_artist_dids:
             supporter_task = asyncio.create_task(
@@ -438,12 +433,7 @@ async def list_top_tracks(
         gated_artist_dids = {
             t.artist_did
             for t in tracks
-            if t.support_gate
-            and t.artist_did != viewer_did
-            and (
-                not isinstance(t.support_gate, dict)
-                or t.support_gate.get("type") not in ("copyright", "stream")
-            )
+            if t.needs_supporter_check and t.artist_did != viewer_did
         }
         if gated_artist_dids:
             supported_artist_dids = await get_supported_artists(

--- a/backend/src/backend/api/tracks/mutations.py
+++ b/backend/src/backend/api/tracks/mutations.py
@@ -117,7 +117,9 @@ async def delete_track(
                 file_type=track.file_type,
                 r2_url=track.r2_url,
             )
-            await storage.delete(delete_key.file_id, delete_key.extension)
+            await (
+                storage.delete_gated if track.uses_private_audio else storage.delete
+            )(delete_key.file_id, delete_key.extension)
         except Exception as e:
             # log but don't fail - maybe file was already deleted
             logger.warning(f"failed to delete file {track.file_id}: {e}", exc_info=True)
@@ -677,11 +679,11 @@ async def migrate_track_to_pds(
             message="track already has PDS blob",
         )
 
-    # gated tracks can't be migrated (they need auth-protected access)
-    if track.support_gate:
+    # Public PDS blobs cannot preserve protected source access.
+    if track.is_private or track.uses_private_audio:
         raise HTTPException(
             status_code=400,
-            detail="supporter-gated tracks cannot be migrated to PDS",
+            detail="protected audio cannot be saved to a public PDS blob",
         )
 
     # `file_id` addresses storage only for uploads that came through us — an

--- a/backend/src/backend/api/tracks/mutations.py
+++ b/backend/src/backend/api/tracks/mutations.py
@@ -243,7 +243,11 @@ async def update_track_metadata(
         was_gated = track.support_gate is not None
         if support_gate.lower() == "null" or support_gate == "":
             # removing gating - need to move file back to public if it was gated
-            if was_gated and track.r2_url is None:
+            if (
+                was_gated
+                and track.r2_url is None
+                and track.audio_storage != "r2_private"
+            ):
                 move_to_private = False
             track.support_gate = None
             # keep visibility consistent: dropping the supporter gate returns the
@@ -373,7 +377,7 @@ async def update_track_metadata(
             updated_tags.add(tag_name)
 
     # always update ATProto record if any metadata changed
-    support_gate_changed = move_to_private is not None
+    support_gate_changed = support_gate is not None
     metadata_changed = (
         title_changed
         or description_changed

--- a/backend/src/backend/api/tracks/revisions.py
+++ b/backend/src/backend/api/tracks/revisions.py
@@ -188,7 +188,7 @@ async def restore_track_revision(
         raise HTTPException(status_code=404, detail="revision not found")
 
     # gating compat check — see module docstring
-    track_is_gated = track.support_gate is not None
+    track_is_gated = track.uses_private_audio
     if revision.was_gated != track_is_gated:
         raise HTTPException(
             status_code=409,
@@ -357,7 +357,7 @@ async def restore_track_revision(
             pds_blob_cid=live_track.pds_blob_cid,
             pds_blob_size=live_track.pds_blob_size,
             duration=live_track.duration,
-            was_gated=live_track.support_gate is not None,
+            was_gated=live_track.uses_private_audio,
         )
         db.add(snapshot)
 
@@ -365,7 +365,7 @@ async def restore_track_revision(
         live_track.file_type = revision.file_type
         live_track.original_file_id = revision.original_file_id
         live_track.original_file_type = revision.original_file_type
-        live_track.r2_url = revision.audio_url
+        live_track.r2_url = None if revision.was_gated else revision.audio_url
         live_track.atproto_record_cid = new_cid
 
         # if the PDS lost the blob AND we couldn't re-upload it, downgrade the
@@ -384,7 +384,11 @@ async def restore_track_revision(
             if effective_blob_cid is not None:
                 live_track.audio_storage = "both"
             else:
-                live_track.audio_storage = revision.audio_storage
+                live_track.audio_storage = (
+                    "r2_private"
+                    if revision.was_gated and live_track.support_gate is None
+                    else revision.audio_storage
+                )
             live_track.pds_blob_cid = effective_blob_cid
             live_track.pds_blob_size = effective_blob_size
 

--- a/backend/src/backend/api/tracks/upload_sessions.py
+++ b/backend/src/backend/api/tracks/upload_sessions.py
@@ -239,7 +239,7 @@ async def finish_upload_session(
     features: Annotated[str | None, Form()] = None,
     tags: Annotated[str | None, Form()] = None,
     visibility: Annotated[str, Form()] = "public",
-    allow_downloads: Annotated[bool, Form()] = True,
+    download_policy: Annotated[str | None, Form()] = None,
     copyright: Annotated[str | None, Form()] = None,
     description: Annotated[str | None, Form()] = None,
     self_labels: Annotated[str | None, Form()] = None,
@@ -253,7 +253,7 @@ async def finish_upload_session(
     once nothing else can refuse the upload.
     """
     _, transfer = await _open_transfer(upload_id, auth_session.did)
-    meta = parse_upload_metadata(
+    meta = await parse_upload_metadata(
         auth_session,
         filename=transfer.filename,
         title=title,
@@ -266,7 +266,7 @@ async def finish_upload_session(
         description=description,
         self_labels=self_labels,
         auto_tag=auto_tag,
-        allow_downloads=allow_downloads,
+        download_policy=download_policy,
     )
     staged = _staged(upload_id, transfer)
 
@@ -317,6 +317,8 @@ async def finish_upload_session(
             image_url=image_url,
             thumbnail_url=thumbnail_url,
             support_gate=meta.support_gate,
+            private_audio=meta.private_audio,
+            download_policy=meta.download_policy,
             copyright_rights=meta.copyright_rights,
             auto_tag=meta.auto_tag,
             visibility=meta.visibility,

--- a/backend/src/backend/api/tracks/upload_sessions.py
+++ b/backend/src/backend/api/tracks/upload_sessions.py
@@ -239,6 +239,7 @@ async def finish_upload_session(
     features: Annotated[str | None, Form()] = None,
     tags: Annotated[str | None, Form()] = None,
     visibility: Annotated[str, Form()] = "public",
+    allow_downloads: Annotated[bool, Form()] = True,
     copyright: Annotated[str | None, Form()] = None,
     description: Annotated[str | None, Form()] = None,
     self_labels: Annotated[str | None, Form()] = None,
@@ -265,6 +266,7 @@ async def finish_upload_session(
         description=description,
         self_labels=self_labels,
         auto_tag=auto_tag,
+        allow_downloads=allow_downloads,
     )
     staged = _staged(upload_id, transfer)
 

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -1594,7 +1594,7 @@ async def schedule_track_upload(ctx: UploadContext) -> None:
     )
 
 
-_VISIBILITIES = frozenset({"public", "unlisted", "supporters", "private"})
+_VISIBILITIES = frozenset({"public", "unlisted", "supporters", "private", "stream"})
 
 
 @dataclass(frozen=True)
@@ -1671,7 +1671,7 @@ def parse_upload_metadata(
 
     copyright_rights: dict | None = None
     if copyright:
-        if visibility in ("supporters", "private"):
+        if visibility in ("supporters", "private", "stream"):
             raise HTTPException(
                 status_code=400,
                 detail=f"copyright cannot combine with {visibility} visibility",
@@ -1709,6 +1709,10 @@ def parse_upload_metadata(
                     f"({ext} needs transcoding); convert to mp3/wav/m4a/flac first"
                 ),
             )
+
+    if visibility == "stream":
+        visibility = "public"
+        support_gate = {"type": "stream"}
 
     return UploadMetadata(
         title=title,
@@ -1768,9 +1772,9 @@ async def upload_track(
     visibility: Annotated[
         str,
         Form(
-            description="one of: public | unlisted | supporters | private. "
+            description="one of: public | unlisted | supporters | private | stream. "
             "supporters = atprotofans-gated; private = PDS permissioned space "
-            "(requires a PDS supporting com.atproto.space.*)."
+            "(requires a PDS supporting com.atproto.space.*); stream = public listening, private files."
         ),
     ] = "public",
     copyright: Annotated[
@@ -1830,6 +1834,7 @@ async def upload_track(
         self_labels=self_labels,
         auto_tag=auto_tag,
     )
+    visibility = meta.visibility
     audio_format = meta.audio_format
     is_private = meta.is_private
     parsed_support_gate = meta.support_gate

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -1737,10 +1737,6 @@ async def parse_upload_metadata(
     async with db_session() as db:
         prefs = await db.get(UserPreferences, auth_session.did)
         policy = download_policy or (prefs.download_policy if prefs else None)
-        if policy == "supporters" and (not prefs or prefs.support_url != "atprotofans"):
-            raise HTTPException(
-                status_code=400, detail="supporter downloads require atprotofans"
-            )
     private_audio = policy in ("off", "supporters") and not is_private
 
     return UploadMetadata(

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -75,6 +75,7 @@ from backend.storage.keys import AudioKey, StagedUploadKey
 from backend.utilities.audio import extract_duration, is_alac
 from backend.utilities.audio_formats import AudioFormat
 from backend.utilities.database import db_session
+from backend.utilities.downloads import DOWNLOAD_POLICIES
 from backend.utilities.hashing import CHUNK_SIZE, hash_file_chunked
 from backend.utilities.progress import R2ProgressTracker
 from backend.utilities.rate_limit import limiter
@@ -136,6 +137,8 @@ class UploadContext:
 
     # supporter-gated content (e.g., {"type": "any"} or {"type": "copyright"})
     support_gate: dict | None = None
+    download_policy: str | None = None
+    private_audio: bool = False
 
     # indiemusi rights metadata, written as song + recording records after PDS
     # publish. when set, the upload is treated as copyright-gated (audio lives
@@ -686,7 +689,7 @@ async def _settle_staged_audio(ctx: UploadContext) -> None:
                 ctx.audio_file_id = file_id
                 await storage.delete_staged(staged)
             else:
-                is_gated = ctx.support_gate is not None
+                is_gated = ctx.private_audio or ctx.support_gate is not None
                 await storage.promote_staged(
                     staged,
                     AudioKey.for_file(file_id, ctx.audio_extension),
@@ -718,7 +721,7 @@ async def _validate_audio(ctx: UploadContext) -> AudioInfo:
     if not audio_format:
         raise UploadPhaseError(f"unsupported file type: .{ctx.audio_extension}")
 
-    is_gated = ctx.support_gate is not None
+    is_gated = ctx.private_audio or ctx.support_gate is not None
     # the atprotofans requirement applies ONLY to supporter-gated tracks
     # (support_gate.type == "any"). copyright-typed gates use the same
     # private-storage pipeline but have a different access policy (any
@@ -1013,7 +1016,11 @@ async def _create_records(
             extra["album"] = ctx.album
 
         has_pds_blob = pds_result and pds_result.cid is not None
-        audio_storage = "both" if has_pds_blob else "r2"
+        audio_storage = (
+            "r2_private" if ctx.private_audio else ("both" if has_pds_blob else "r2")
+        )
+        if ctx.download_policy is not None:
+            extra["download_policy"] = ctx.download_policy
 
         artist_display_name = artist.display_name
 
@@ -1285,7 +1292,7 @@ async def _cleanup_staged_media_pre_db(
     if ctx.private:
         return
 
-    is_gated = ctx.support_gate is not None
+    is_gated = ctx.private_audio or ctx.support_gate is not None
 
     if sr is not None and sr.transcode_info is not None:
         # transcode produced a new sibling. both sibling and staged source
@@ -1465,6 +1472,8 @@ async def run_track_upload(
     visibility: str = "public",
     needs_transcode: bool = False,
     staged: bool = False,
+    download_policy: str | None = None,
+    private_audio: bool = False,
     concurrency: ConcurrencyLimit = ConcurrencyLimit("artist_did", max_concurrent=3),
 ) -> None:
     """docket task entry point for track uploads.
@@ -1511,7 +1520,7 @@ async def run_track_upload(
             await _delete_staged_audio(
                 audio_file_id,
                 Path(filename).suffix.lower().lstrip(".") or None,
-                gated=support_gate is not None,
+                gated=private_audio or support_gate is not None,
             )
         if image_id:
             with contextlib.suppress(Exception):
@@ -1542,6 +1551,8 @@ async def run_track_upload(
         image_url=image_url,
         thumbnail_url=thumbnail_url,
         support_gate=support_gate,
+        private_audio=private_audio,
+        download_policy=download_policy,
         copyright_rights=copyright_rights,
         auto_tag=auto_tag,
         visibility=visibility,
@@ -1585,6 +1596,8 @@ async def schedule_track_upload(ctx: UploadContext) -> None:
         image_url=ctx.image_url,
         thumbnail_url=ctx.thumbnail_url,
         support_gate=ctx.support_gate,
+        private_audio=ctx.private_audio,
+        download_policy=ctx.download_policy,
         copyright_rights=ctx.copyright_rights,
         auto_tag=ctx.auto_tag,
         visibility=ctx.visibility,
@@ -1619,6 +1632,8 @@ class UploadMetadata:
     support_gate: dict | None
     copyright_rights: dict | None
     auto_tag: bool
+    download_policy: str | None = None
+    private_audio: bool = False
 
     @property
     def is_private(self) -> bool:
@@ -1626,10 +1641,10 @@ class UploadMetadata:
 
     @property
     def is_gated(self) -> bool:
-        return self.support_gate is not None
+        return self.private_audio or self.support_gate is not None
 
 
-def parse_upload_metadata(
+async def parse_upload_metadata(
     auth_session: AuthSession,
     *,
     filename: str | None,
@@ -1643,7 +1658,7 @@ def parse_upload_metadata(
     description: str | None,
     self_labels: str | None,
     auto_tag: str | None,
-    allow_downloads: bool = True,
+    download_policy: str | None = None,
 ) -> UploadMetadata:
     """validate upload form fields; raises HTTPException with the user-facing detail."""
     if album and album_id:
@@ -1711,13 +1726,22 @@ def parse_upload_metadata(
                 ),
             )
 
-    if not allow_downloads:
+    if download_policy is not None:
+        if download_policy not in DOWNLOAD_POLICIES:
+            raise HTTPException(status_code=400, detail="invalid download policy")
         if visibility not in ("public", "unlisted") or copyright:
             raise HTTPException(
                 status_code=400,
-                detail="allow_downloads applies to public or unlisted tracks without copyright metadata",
+                detail="download policy applies to public or unlisted tracks without copyright metadata",
             )
-        support_gate = {"type": "stream"}
+    async with db_session() as db:
+        prefs = await db.get(UserPreferences, auth_session.did)
+        policy = download_policy or (prefs.download_policy if prefs else None)
+        if policy == "supporters" and (not prefs or prefs.support_url != "atprotofans"):
+            raise HTTPException(
+                status_code=400, detail="supporter downloads require atprotofans"
+            )
+    private_audio = policy in ("off", "supporters") and not is_private
 
     return UploadMetadata(
         title=title,
@@ -1733,6 +1757,8 @@ def parse_upload_metadata(
         support_gate=support_gate,
         copyright_rights=copyright_rights,
         auto_tag=auto_tag == "true",
+        download_policy=download_policy,
+        private_audio=private_audio,
     )
 
 
@@ -1782,7 +1808,7 @@ async def upload_track(
             "(requires a PDS supporting com.atproto.space.*)."
         ),
     ] = "public",
-    allow_downloads: Annotated[bool, Form()] = True,
+    download_policy: Annotated[str | None, Form()] = None,
     copyright: Annotated[
         str | None,
         Form(
@@ -1826,7 +1852,7 @@ async def upload_track(
     if not file.filename:
         raise HTTPException(status_code=400, detail="no filename provided")
     filename = file.filename
-    meta = parse_upload_metadata(
+    meta = await parse_upload_metadata(
         auth_session,
         filename=filename,
         title=title,
@@ -1839,7 +1865,7 @@ async def upload_track(
         description=description,
         self_labels=self_labels,
         auto_tag=auto_tag,
-        allow_downloads=allow_downloads,
+        download_policy=download_policy,
     )
     visibility = meta.visibility
     audio_format = meta.audio_format
@@ -1863,7 +1889,7 @@ async def upload_track(
     upload_id = await job_service.create_job(
         JobType.UPLOAD, auth_session.did, "upload queued for processing"
     )
-    is_gated = parsed_support_gate is not None
+    is_gated = meta.is_gated
     audio_extension = ext.lstrip(".") or None
 
     file_path: str | None = None
@@ -1980,6 +2006,8 @@ async def upload_track(
             image_url=image_url,
             thumbnail_url=thumbnail_url,
             support_gate=parsed_support_gate,
+            private_audio=meta.private_audio,
+            download_policy=meta.download_policy,
             copyright_rights=parsed_copyright,
             auto_tag=auto_tag == "true",
             visibility=visibility,

--- a/backend/src/backend/api/tracks/uploads.py
+++ b/backend/src/backend/api/tracks/uploads.py
@@ -1594,7 +1594,7 @@ async def schedule_track_upload(ctx: UploadContext) -> None:
     )
 
 
-_VISIBILITIES = frozenset({"public", "unlisted", "supporters", "private", "stream"})
+_VISIBILITIES = frozenset({"public", "unlisted", "supporters", "private"})
 
 
 @dataclass(frozen=True)
@@ -1643,6 +1643,7 @@ def parse_upload_metadata(
     description: str | None,
     self_labels: str | None,
     auto_tag: str | None,
+    allow_downloads: bool = True,
 ) -> UploadMetadata:
     """validate upload form fields; raises HTTPException with the user-facing detail."""
     if album and album_id:
@@ -1671,7 +1672,7 @@ def parse_upload_metadata(
 
     copyright_rights: dict | None = None
     if copyright:
-        if visibility in ("supporters", "private", "stream"):
+        if visibility in ("supporters", "private"):
             raise HTTPException(
                 status_code=400,
                 detail=f"copyright cannot combine with {visibility} visibility",
@@ -1710,8 +1711,12 @@ def parse_upload_metadata(
                 ),
             )
 
-    if visibility == "stream":
-        visibility = "public"
+    if not allow_downloads:
+        if visibility not in ("public", "unlisted") or copyright:
+            raise HTTPException(
+                status_code=400,
+                detail="allow_downloads applies to public or unlisted tracks without copyright metadata",
+            )
         support_gate = {"type": "stream"}
 
     return UploadMetadata(
@@ -1772,11 +1777,12 @@ async def upload_track(
     visibility: Annotated[
         str,
         Form(
-            description="one of: public | unlisted | supporters | private | stream. "
+            description="one of: public | unlisted | supporters | private. "
             "supporters = atprotofans-gated; private = PDS permissioned space "
-            "(requires a PDS supporting com.atproto.space.*); stream = public listening, private files."
+            "(requires a PDS supporting com.atproto.space.*)."
         ),
     ] = "public",
+    allow_downloads: Annotated[bool, Form()] = True,
     copyright: Annotated[
         str | None,
         Form(
@@ -1833,6 +1839,7 @@ async def upload_track(
         description=description,
         self_labels=self_labels,
         auto_tag=auto_tag,
+        allow_downloads=allow_downloads,
     )
     visibility = meta.visibility
     audio_format = meta.audio_format

--- a/backend/src/backend/models/track.py
+++ b/backend/src/backend/models/track.py
@@ -107,7 +107,7 @@ class Track(Base):
     # PDS blob storage (for audio stored on user's PDS)
     audio_storage: Mapped[str] = mapped_column(
         String, nullable=False, default="r2", server_default="r2"
-    )  # "r2" | "pds" | "both"
+    )  # "r2" | "r2_private" | "pds" | "both"
     pds_blob_cid: Mapped[str | None] = mapped_column(String, nullable=True)
     pds_blob_size: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
@@ -170,7 +170,7 @@ class Track(Base):
 
     @hybrid_property
     def is_private(self) -> bool:
-        """private (permissioned-space) media — owner-only, PDS-native."""
+        """private media — the Space authority admits readers."""
         return self.visibility == "private"
 
     @is_private.inplace.expression
@@ -208,6 +208,29 @@ class Track(Base):
             (cls.file_type != AudioFormat.MP3.value)
             & cls.original_file_id.isnot(None)
             & cls.original_file_type.isnot(None)
+        )
+
+    @hybrid_property
+    def uses_private_audio(self) -> bool:
+        """R2 location, including legacy gated rows."""
+        return self.audio_storage == "r2_private" or self.support_gate is not None
+
+    @uses_private_audio.inplace.expression
+    @classmethod
+    def _uses_private_audio_expr(cls) -> ColumnElement[bool]:
+        return (cls.audio_storage == "r2_private") | cls.support_gate.isnot(None)
+
+    @property
+    def download_policy(self) -> str | None:
+        return (self.extra or {}).get("download_policy")
+
+    @property
+    def needs_supporter_check(self) -> bool:
+        policy = self.download_policy or (
+            self.artist.preferences.download_policy if self.artist.preferences else None
+        )
+        return policy == "supporters" or bool(
+            self.support_gate and self.support_gate.get("type") != "copyright"
         )
 
     @property

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -257,7 +257,7 @@ class TrackResponse(BaseModel):
             if gate_type == "copyright":
                 # copyright tracks just need any authenticated listener
                 gated = not viewer_did
-            else:
+            elif gate_type != "stream":
                 is_owner = viewer_did and viewer_did == track.artist_did
                 is_supporter = (
                     supported_artist_dids and track.artist_did in supported_artist_dids

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -257,7 +257,7 @@ class TrackResponse(BaseModel):
             if gate_type == "copyright":
                 # copyright tracks just need any authenticated listener
                 gated = not viewer_did
-            elif gate_type != "stream":
+            else:
                 is_owner = viewer_did and viewer_did == track.artist_did
                 is_supporter = (
                     supported_artist_dids and track.artist_did in supported_artist_dids
@@ -292,7 +292,8 @@ class TrackResponse(BaseModel):
         # selectin-loads prefs)
         artist_prefs = track.artist.preferences
         download_policy = effective_download_policy(
-            artist_prefs.download_policy if artist_prefs else None,
+            track.download_policy
+            or (artist_prefs.download_policy if artist_prefs else None),
             artist_prefs.support_url if artist_prefs else None,
         )
         downloadable = (

--- a/backend/src/backend/storage/protocol.py
+++ b/backend/src/backend/storage/protocol.py
@@ -139,7 +139,7 @@ class StorageProtocol(Protocol):
         private: bool = False,
         expires_in: int | None = None,
     ) -> str:
-        """presigned public-bucket URL that downloads as ``filename``.
+        """presigned URL from the selected bucket that downloads as ``filename``.
 
         the attachment disposition is carried by the signed
         ``response-content-disposition`` param, so the object itself and its

--- a/backend/src/backend/storage/protocol.py
+++ b/backend/src/backend/storage/protocol.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 class StorageProtocol(Protocol):
     """interface for media storage backends."""
 
+    private_audio_bucket_name: str
     audio_bucket_name: str
     image_bucket_name: str
     public_audio_bucket_url: str
@@ -126,7 +127,7 @@ class StorageProtocol(Protocol):
         expires_in: int | None = None,
     ) -> str: ...
 
-    async def object_exists(self, key: str) -> bool:
+    async def object_exists(self, key: str, *, private: bool = False) -> bool:
         """whether an audio-bucket object exists at this raw key."""
         ...
 
@@ -135,6 +136,7 @@ class StorageProtocol(Protocol):
         *,
         key: str,
         filename: str,
+        private: bool = False,
         expires_in: int | None = None,
     ) -> str:
         """presigned public-bucket URL that downloads as ``filename``.

--- a/backend/src/backend/storage/r2.py
+++ b/backend/src/backend/storage/r2.py
@@ -1052,11 +1052,16 @@ class R2Storage:
                 )
                 return url
 
-    async def object_exists(self, key: str) -> bool:
+    async def object_exists(self, key: str, *, private: bool = False) -> bool:
         """HEAD an audio-bucket object by raw key (cache checks, not media reads)."""
         async with self._s3_client() as client:
             try:
-                await client.head_object(Bucket=self.audio_bucket_name, Key=key)
+                await client.head_object(
+                    Bucket=self.private_audio_bucket_name
+                    if private
+                    else self.audio_bucket_name,
+                    Key=key,
+                )
                 return True
             except ClientError:
                 return False
@@ -1066,14 +1071,10 @@ class R2Storage:
         *,
         key: str,
         filename: str,
+        private: bool = False,
         expires_in: int | None = None,
     ) -> str:
-        """presigned public-bucket URL that downloads as ``filename``.
-
-        the object is publicly readable anyway; presigning exists only to carry
-        a signed ``response-content-disposition`` so the browser saves the file
-        under a human filename instead of the content-hash key.
-        """
+        """sign a download from the selected bucket with a human filename."""
         expiry = expires_in or self.presigned_url_expiry
         with logfire.span("R2 generate_download_url", key=key, expires_in=expiry):
             async with self._s3_client(
@@ -1082,7 +1083,9 @@ class R2Storage:
                 return await client.generate_presigned_url(
                     "get_object",
                     Params={
-                        "Bucket": self.audio_bucket_name,
+                        "Bucket": self.private_audio_bucket_name
+                        if private
+                        else self.audio_bucket_name,
                         "Key": key,
                         "ResponseContentDisposition": content_disposition(filename),
                     },

--- a/backend/src/backend/utilities/downloads.py
+++ b/backend/src/backend/utilities/downloads.py
@@ -40,7 +40,7 @@ def download_key(
     r2_url: str | None,
     audio_storage: str,
 ) -> AudioKey | None:
-    """the public-bucket key a download would serve, or None if we hold none.
+    """the R2 key a download would serve, or None if we hold none.
 
     None for PDS-only rows (the R2 copy is gone or never existed — a PDS
     getBlob URL can't carry a filename disposition) and for firehose-ingested
@@ -80,7 +80,7 @@ def download_refusal(
     and streaming already filter on — never raw scan flags, which mark a
     pending review, not a finding.
 
-    `download_policy` is the artist's *effective* tier (callers resolve NULL
+    `download_policy` is the resolved track or artist tier (callers resolve NULL
     via effective_download_policy first). "ask" never refuses
     — it is a request the UI makes, not a lock. how a viewer came to count
     as a supporter is the caller's verifier concern (#1841), never this

--- a/backend/src/backend/utilities/downloads.py
+++ b/backend/src/backend/utilities/downloads.py
@@ -88,12 +88,12 @@ def download_refusal(
     """
     if is_private:
         return "private"
-    if support_gate is not None:
+    if support_gate is not None and not viewer_is_artist:
         return "gated"
     if has_copyright_label(labels) and moderation_override != "allow":
         return "copyright"
     policy = download_policy or "open"  # tolerate unresolved None as open
-    if policy == "off":
+    if policy == "off" and not viewer_is_artist:
         return "artist_opt_out"
     if policy == "supporters" and not (viewer_is_artist or viewer_is_supporter):
         return "supporters_only"

--- a/backend/tests/api/test_album_download.py
+++ b/backend/tests/api/test_album_download.py
@@ -100,14 +100,16 @@ async def test_album_download_redirects_when_cached(
 
     mock_storage = MagicMock()
     mock_storage.object_exists = AsyncMock(return_value=True)
-    mock_storage.public_audio_bucket_url = "https://audio.example.com"
+    mock_storage.generate_download_url = AsyncMock(
+        return_value="https://private.example.com/signed-album"
+    )
     with patch("backend.api.albums.downloads.storage", mock_storage):
         response = await _download(test_app)
 
     assert response.status_code == 307
-    assert response.headers["location"].startswith(
-        "https://audio.example.com/exports/albums/"
-    )
+    assert response.headers["location"] == "https://private.example.com/signed-album"
+    assert mock_storage.generate_download_url.call_args.kwargs["private"] is True
+    assert mock_storage.object_exists.call_args.kwargs["private"] is True
 
 
 async def test_album_download_refuses_if_any_track_gated(
@@ -145,3 +147,18 @@ async def test_album_download_404_unknown_album(
 ):
     response = await _download(test_app, handle="nobody.bsky.social")
     assert response.status_code == 404
+
+
+async def test_cached_album_rechecks_track_policy(
+    test_app: FastAPI, db_session: AsyncSession
+) -> None:
+    _, tracks = await _make_album(db_session)
+    tracks[0].extra = {"download_policy": "off"}
+    await db_session.commit()
+    with patch(
+        "backend.api.albums.downloads.storage.object_exists",
+        AsyncMock(return_value=True),
+    ) as cached:
+        response = await _download(test_app)
+    assert response.status_code == 403
+    cached.assert_not_awaited()

--- a/backend/tests/api/test_audio.py
+++ b/backend/tests/api/test_audio.py
@@ -886,10 +886,12 @@ class TestAudioPdsRedirect:
         assert f"cid={gated_pds_track.pds_blob_cid}" in location
 
 
-async def test_stream_gate_allows_anonymous_playback(
+async def test_private_r2_allows_anonymous_playback(
     test_app: FastAPI, gated_track: Track, db_session: AsyncSession
 ) -> None:
-    gated_track.support_gate = {"type": "stream"}
+    gated_track.support_gate = None
+    gated_track.audio_storage = "r2_private"
+    gated_track.extra = {"download_policy": "off"}
     await db_session.commit()
     signed_url = "https://private.example/audio.mp3?signature=test"
     with patch(

--- a/backend/tests/api/test_audio.py
+++ b/backend/tests/api/test_audio.py
@@ -884,3 +884,29 @@ class TestAudioPdsRedirect:
         assert "com.atproto.sync.getBlob" in location
         assert f"did={artist.did}" in location
         assert f"cid={gated_pds_track.pds_blob_cid}" in location
+
+
+async def test_stream_gate_allows_anonymous_playback(
+    test_app: FastAPI, gated_track: Track, db_session: AsyncSession
+) -> None:
+    gated_track.support_gate = {"type": "stream"}
+    await db_session.commit()
+    signed_url = "https://private.example/audio.mp3?signature=test"
+    with patch(
+        "backend.api.audio.storage.generate_presigned_url",
+        new=AsyncMock(return_value=signed_url),
+    ) as presign:
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            head = await client.head(f"/audio/{gated_track.file_id}")
+            assert head.status_code == 200
+            presign.assert_not_awaited()
+            stream = await client.get(
+                f"/audio/{gated_track.file_id}", follow_redirects=False
+            )
+            assert stream.status_code == 307
+            assert stream.headers["location"] == signed_url
+            resolved = await client.get(f"/audio/{gated_track.file_id}/url")
+            assert resolved.status_code == 200
+            assert resolved.json()["url"] == signed_url

--- a/backend/tests/api/test_audio_download.py
+++ b/backend/tests/api/test_audio_download.py
@@ -11,11 +11,13 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from backend._internal import get_optional_session
 from backend.main import app
 from backend.models import Artist, CopyrightScan, Track, UserPreferences
 from backend.schemas import TrackResponse
 from backend.storage.r2 import content_disposition
 from backend.utilities.downloads import download_filename
+from tests.api.track_audio_replace._helpers import MockSession
 
 
 @pytest.fixture
@@ -68,7 +70,9 @@ async def test_download_public_track_redirects_with_filename(
     assert response.status_code == 307
     assert response.headers["location"] == "https://r2.example.com/signed"
     mock_storage.generate_download_url.assert_awaited_once_with(
-        key="audio/aabbccddeeff0011.mp3", filename="Download Artist - My Song.mp3"
+        key="audio/aabbccddeeff0011.mp3",
+        filename="Download Artist - My Song.mp3",
+        private=False,
     )
 
 
@@ -89,11 +93,13 @@ async def test_download_prefers_lossless_original(
 
     assert response.status_code == 307
     mock_storage.generate_download_url.assert_awaited_once_with(
-        key="audio/ccddeeff00112233.flac", filename="Download Artist - My Song.flac"
+        key="audio/ccddeeff00112233.flac",
+        filename="Download Artist - My Song.flac",
+        private=False,
     )
 
 
-@pytest.mark.parametrize("gate_type", ["any", "copyright", "stream"])
+@pytest.mark.parametrize("gate_type", ["any", "copyright"])
 async def test_download_refuses_gated_track(
     test_app: FastAPI, db_session: AsyncSession, gate_type: str
 ) -> None:
@@ -327,8 +333,124 @@ async def test_no_support_link_defaults_policy_to_open(
 async def test_stream_track_is_playable_but_not_downloadable(
     test_app: FastAPI, db_session: AsyncSession
 ) -> None:
-    track = await _make_track(db_session, support_gate={"type": "stream"})
+    track = await _make_track(
+        db_session, audio_storage="r2_private", extra={"download_policy": "off"}
+    )
     response = await _response_for(db_session, track.id)
     assert response.visibility == "public"
     assert response.gated is False
     assert response.downloadable is False
+
+
+@pytest.mark.parametrize("path", ["", "/url", "/download"])
+async def test_protected_master_is_not_public_playback(
+    test_app: FastAPI, db_session: AsyncSession, path: str
+) -> None:
+    track = await _make_track(
+        db_session,
+        audio_storage="r2_private",
+        extra={"download_policy": "off"},
+        original_file_id="ccddeeff00112233",
+        original_file_type="flac",
+    )
+    with (
+        patch(
+            "backend.api.audio.storage.get_url",
+            AsyncMock(return_value="https://public.test/master"),
+        ),
+        patch(
+            "backend.api.audio.storage.generate_download_url",
+            AsyncMock(return_value="https://private.test/master"),
+        ),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.get(f"/audio/{track.original_file_id}{path}")
+    assert response.status_code == 403
+
+
+async def test_artist_recovers_protected_original(
+    test_app: FastAPI, db_session: AsyncSession
+) -> None:
+    track = await _make_track(
+        db_session,
+        audio_storage="r2_private",
+        extra={"download_policy": "off"},
+        original_file_id="ccddeeff00112233",
+        original_file_type="flac",
+    )
+    test_app.dependency_overrides[get_optional_session] = lambda: MockSession(
+        track.artist_did
+    )
+    try:
+        with patch(
+            "backend.api.audio.storage.generate_download_url",
+            AsyncMock(return_value="https://private.test/original"),
+        ) as sign:
+            response = await _download(test_app, track.file_id)
+        assert response.status_code == 307
+        sign.assert_awaited_once_with(
+            key="audio/ccddeeff00112233.flac",
+            filename="Download Artist - My Song.flac",
+            private=True,
+        )
+    finally:
+        test_app.dependency_overrides.pop(get_optional_session, None)
+
+
+@pytest.mark.parametrize(
+    "override,artist_policy,allowed",
+    [(None, "off", False), ("open", "off", True), ("off", "open", False)],
+)
+async def test_track_download_policy_overrides_artist_default(
+    test_app: FastAPI,
+    db_session: AsyncSession,
+    override: str | None,
+    artist_policy: str,
+    allowed: bool,
+) -> None:
+    track = await _make_track(
+        db_session, audio_storage="r2_private", extra={"download_policy": override}
+    )
+    db_session.add(UserPreferences(did=track.artist_did, download_policy=artist_policy))
+    await db_session.commit()
+    with patch(
+        "backend.api.audio.storage.generate_download_url",
+        AsyncMock(return_value="https://private.test/audio"),
+    ):
+        response = await _download(test_app, track.file_id)
+    metadata = await _response_for(db_session, track.id)
+    assert (response.status_code == 307) is allowed
+    assert metadata.downloadable is allowed
+    assert metadata.gated is False
+
+
+@pytest.mark.parametrize("is_supporter", [False, True])
+async def test_protected_supporter_download_uses_existing_verifier(
+    test_app: FastAPI, db_session: AsyncSession, is_supporter: bool
+) -> None:
+    track = await _make_track(
+        db_session, audio_storage="r2_private", extra={"download_policy": "supporters"}
+    )
+    test_app.dependency_overrides[get_optional_session] = lambda: MockSession(
+        "did:plc:listener"
+    )
+    try:
+        with (
+            patch(
+                "backend.api.audio.validate_supporter",
+                AsyncMock(return_value=MagicMock(valid=is_supporter)),
+            ),
+            patch(
+                "backend.api.audio.storage.generate_download_url",
+                AsyncMock(return_value="https://private.test/audio"),
+            ) as sign,
+        ):
+            response = await _download(test_app, track.file_id)
+        assert response.status_code == (307 if is_supporter else 403)
+        assert sign.await_count == int(is_supporter)
+        if is_supporter:
+            assert sign.call_args.kwargs["private"] is True
+    finally:
+        test_app.dependency_overrides.pop(get_optional_session, None)

--- a/backend/tests/api/test_audio_download.py
+++ b/backend/tests/api/test_audio_download.py
@@ -93,10 +93,11 @@ async def test_download_prefers_lossless_original(
     )
 
 
+@pytest.mark.parametrize("gate_type", ["any", "copyright", "stream"])
 async def test_download_refuses_gated_track(
-    test_app: FastAPI, db_session: AsyncSession
-):
-    track = await _make_track(db_session, support_gate={"type": "any"})
+    test_app: FastAPI, db_session: AsyncSession, gate_type: str
+) -> None:
+    track = await _make_track(db_session, support_gate={"type": gate_type})
     response = await _download(test_app, track.file_id)
     assert response.status_code == 403
 
@@ -321,3 +322,13 @@ async def test_no_support_link_defaults_policy_to_open(
     resp = await _response_for(db_session, track.id)
     assert resp.downloadable is True
     assert resp.download_policy == "open"
+
+
+async def test_stream_track_is_playable_but_not_downloadable(
+    test_app: FastAPI, db_session: AsyncSession
+) -> None:
+    track = await _make_track(db_session, support_gate={"type": "stream"})
+    response = await _response_for(db_session, track.id)
+    assert response.visibility == "public"
+    assert response.gated is False
+    assert response.downloadable is False

--- a/backend/tests/api/test_audio_optimize.py
+++ b/backend/tests/api/test_audio_optimize.py
@@ -874,8 +874,9 @@ async def test_optimize_raw_interim_does_not_delete_the_lossless_original(
     assert "AIFFID" not in deleted
 
 
+@pytest.mark.parametrize("private_source", [False, True])
 async def test_optimize_gated_lossless_uses_private_storage_and_backend_audio_url(
-    db_session: AsyncSession, owner: Artist
+    db_session: AsyncSession, owner: Artist, private_source: bool
 ) -> None:
     """for gated lossless tracks, the deferred MP3 stays private and the PDS
     record points at the auth-protected backend audio endpoint."""
@@ -885,7 +886,8 @@ async def test_optimize_gated_lossless_uses_private_storage_and_backend_audio_ur
         original_file_id="GATEDAIFF",
         original_file_type="aiff",
         r2_url=None,
-        support_gate={"type": "any"},
+        support_gate=None if private_source else {"type": "any"},
+        audio_storage="r2_private" if private_source else "r2",
     )
     db_session.add(track)
     await db_session.commit()
@@ -913,11 +915,13 @@ async def test_optimize_gated_lossless_uses_private_storage_and_backend_audio_ur
 
     record_kwargs = mocks["build_record"].await_args.kwargs
     assert record_kwargs["audio_url"].endswith("/audio/GATEDMP3")
-    assert record_kwargs["support_gate"] == {"type": "any"}
+    assert record_kwargs["support_gate"] == (
+        None if private_source else {"type": "any"}
+    )
 
     await db_session.refresh(track)
     assert track.file_id == "GATEDMP3"
     assert track.file_type == "mp3"
     assert track.r2_url is None
-    assert track.audio_storage == "r2"
+    assert track.audio_storage == ("r2_private" if private_source else "r2")
     assert track.pds_blob_cid is None

--- a/backend/tests/api/test_pds_save_access.py
+++ b/backend/tests/api/test_pds_save_access.py
@@ -1,0 +1,46 @@
+"""Single-track PDS saves cannot publish protected sources."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal import require_auth
+from backend.models import Artist, Track
+from tests.api.track_audio_replace._helpers import MockSession
+
+
+@pytest.mark.parametrize("source", ["r2_private", "supporters", "private"])
+async def test_single_track_save_refuses_protected_audio(
+    fastapi_app: FastAPI, db_session: AsyncSession, source: str
+) -> None:
+    artist = Artist(did="did:plc:pds-save", handle="save.test", display_name="Artist")
+    db_session.add(artist)
+    await db_session.flush()
+    track = Track(
+        artist_did=artist.did,
+        title="Protected",
+        file_id="aabbccddeeff0011",
+        file_type="mp3",
+        audio_storage="r2_private" if source == "r2_private" else "r2",
+        visibility="private" if source == "private" else "public",
+        support_gate={"type": "any"} if source == "supporters" else None,
+    )
+    db_session.add(track)
+    await db_session.commit()
+    fastapi_app.dependency_overrides[require_auth] = lambda: MockSession(artist.did)
+    try:
+        with patch(
+            "backend.api.tracks.mutations.storage.head_file",
+            AsyncMock(side_effect=AssertionError("protected audio must not be read")),
+        ) as read:
+            async with AsyncClient(
+                transport=ASGITransport(app=fastapi_app), base_url="http://test"
+            ) as client:
+                response = await client.post(f"/tracks/{track.id}/migrate-to-pds")
+        assert response.status_code == 400, response.text
+        read.assert_not_awaited()
+    finally:
+        fastapi_app.dependency_overrides.pop(require_auth, None)

--- a/backend/tests/api/test_track_deletion.py
+++ b/backend/tests/api/test_track_deletion.py
@@ -190,9 +190,13 @@ async def test_refcount_prevents_r2_deletion(db_session: AsyncSession):
     s3.delete_object.assert_not_awaited()
 
 
+@pytest.mark.parametrize("private_source", [False, True])
 async def test_atproto_cleanup_on_track_delete(
-    test_app: FastAPI, db_session: AsyncSession, test_artist: Artist
-):
+    test_app: FastAPI,
+    db_session: AsyncSession,
+    test_artist: Artist,
+    private_source: bool,
+) -> None:
     """test that ATProto records are cleaned up when track is deleted.
 
     regression test for banana mix incident where deleting track 57 left
@@ -205,6 +209,7 @@ async def test_atproto_cleanup_on_track_delete(
         file_id="test_file_789",
         file_type="mp3",
         extra={},
+        audio_storage="r2_private" if private_source else "r2",
         atproto_record_uri="at://did:plc:artist123/fm.plyr.track/abc123",
         atproto_record_cid="bafytest123",
     )
@@ -215,7 +220,12 @@ async def test_atproto_cleanup_on_track_delete(
     # mock storage delete to avoid R2 errors
     # mock ATProto delete at the records module level before import
     with (
-        patch("backend.api.tracks.mutations.storage.delete", new_callable=AsyncMock),
+        patch(
+            "backend.api.tracks.mutations.storage.delete", new_callable=AsyncMock
+        ) as public_delete,
+        patch(
+            "backend.api.tracks.mutations.storage.delete_gated", new_callable=AsyncMock
+        ) as private_delete,
         patch(
             "backend.api.tracks.mutations.delete_record_by_uri",
             new_callable=AsyncMock,
@@ -227,6 +237,10 @@ async def test_atproto_cleanup_on_track_delete(
             response = await client.delete(f"/tracks/{track.id}")
 
     assert response.status_code == 200
+    (private_delete if private_source else public_delete).assert_awaited_once_with(
+        "test_file_789", "mp3"
+    )
+    (public_delete if private_source else private_delete).assert_not_awaited()
 
     # verify ATProto record deletion was called
     mock_delete_atproto.assert_called_once()

--- a/backend/tests/api/test_upload_copyright_gate.py
+++ b/backend/tests/api/test_upload_copyright_gate.py
@@ -41,8 +41,10 @@ def _ctx(
     )
 
 
+@pytest.mark.parametrize("gate_type", ["copyright", "stream"])
 async def test_copyright_gate_does_not_require_atprotofans(
     db_session: AsyncSession,
+    gate_type: str,
 ) -> None:
     """the original bug: copyright-typed gate must pass validation without
     the user having atprotofans configured.
@@ -52,7 +54,7 @@ async def test_copyright_gate_does_not_require_atprotofans(
     await db_session.commit()
     # no UserPreferences row at all — definitely no atprotofans setup
 
-    ctx = _ctx(did, support_gate={"type": "copyright"})
+    ctx = _ctx(did, support_gate={"type": gate_type})
     info = await _validate_audio(ctx)
     # validation must pass; the upload would continue into _store_audio
     assert info.is_gated is True

--- a/backend/tests/api/test_upload_copyright_gate.py
+++ b/backend/tests/api/test_upload_copyright_gate.py
@@ -41,10 +41,10 @@ def _ctx(
     )
 
 
-@pytest.mark.parametrize("gate_type", ["copyright", "stream"])
+@pytest.mark.parametrize("gate_type", ["copyright", None])
 async def test_copyright_gate_does_not_require_atprotofans(
     db_session: AsyncSession,
-    gate_type: str,
+    gate_type: str | None,
 ) -> None:
     """the original bug: copyright-typed gate must pass validation without
     the user having atprotofans configured.
@@ -54,7 +54,8 @@ async def test_copyright_gate_does_not_require_atprotofans(
     await db_session.commit()
     # no UserPreferences row at all — definitely no atprotofans setup
 
-    ctx = _ctx(did, support_gate={"type": gate_type})
+    ctx = _ctx(did, support_gate={"type": gate_type} if gate_type else None)
+    ctx.private_audio = gate_type is None
     info = await _validate_audio(ctx)
     # validation must pass; the upload would continue into _store_audio
     assert info.is_gated is True

--- a/backend/tests/api/test_upload_sessions.py
+++ b/backend/tests/api/test_upload_sessions.py
@@ -16,7 +16,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import backend.storage
 from backend._internal import Session, require_artist_profile
 from backend._internal.jobs import job_service
-from backend.api.tracks.uploads import UploadContext, _settle_staged_audio
+from backend.api.tracks.uploads import (
+    UploadContext,
+    _settle_staged_audio,
+    parse_upload_metadata,
+)
+from backend.models import Artist, UserPreferences
 from backend.models.job import JobStatus, JobType
 from backend.storage.keys import StagedUploadKey
 
@@ -83,9 +88,9 @@ def _send_parts(
 
 
 @pytest.mark.parametrize("visibility", ["public", "unlisted"])
-@pytest.mark.parametrize("allow_downloads", [True, False])
+@pytest.mark.parametrize("download_policy", ["open", "off"])
 def test_session_round_trip_enqueues_a_staged_upload(
-    artist_app: FastAPI, visibility: str, allow_downloads: bool
+    artist_app: FastAPI, visibility: str, download_policy: str
 ) -> None:
     with (
         TestClient(artist_app) as client,
@@ -109,7 +114,7 @@ def test_session_round_trip_enqueues_a_staged_upload(
             data={
                 "title": "song",
                 "visibility": visibility,
-                "allow_downloads": str(allow_downloads).lower(),
+                "download_policy": download_policy,
                 "tags": '["a"]',
             },
         )
@@ -120,7 +125,9 @@ def test_session_round_trip_enqueues_a_staged_upload(
     assert schedule.await_args is not None
     ctx: UploadContext = schedule.await_args.args[0]
     assert ctx.visibility == visibility
-    assert ctx.support_gate == (None if allow_downloads else {"type": "stream"})
+    assert ctx.support_gate is None
+    assert ctx.private_audio is (download_policy == "off")
+    assert ctx.download_policy == download_policy
     assert ctx.copyright_rights is None
     assert ctx.staged is True
     assert ctx.audio_file_id == ""
@@ -259,15 +266,18 @@ async def test_settle_promotes_staged_bytes_to_their_content_hash(
     assert staged.key not in storage.staged_objects
 
 
-@pytest.mark.parametrize("gate_type", ["any", "copyright", "stream"])
+@pytest.mark.parametrize("gate_type", ["any", "copyright", None])
 async def test_settle_gated_upload_lands_in_the_private_bucket(
     db_session: AsyncSession,
-    gate_type: str,
+    gate_type: str | None,
 ) -> None:
     storage = _mock_storage()
     staged = StagedUploadKey(upload_id="u-gated", extension="wav")
     storage.staged_objects[staged.key] = _AUDIO
-    ctx = _staged_ctx("u-gated", support_gate={"type": gate_type})
+    ctx = _staged_ctx(
+        "u-gated", support_gate={"type": gate_type} if gate_type else None
+    )
+    ctx.private_audio = gate_type is None
 
     await _settle_staged_audio(ctx)
 
@@ -341,3 +351,37 @@ def _staged_ctx(
         visibility=visibility,
         staged=True,
     )
+
+
+@pytest.mark.parametrize(
+    "override,expected_private", [(None, True), ("open", False), ("off", True)]
+)
+async def test_upload_storage_resolves_artist_download_default(
+    db_session: AsyncSession, override: str | None, expected_private: bool
+) -> None:
+    session = _ArtistSession("did:test:inherit-downloads")
+    db_session.add(
+        Artist(did=session.did, handle=session.handle, display_name="Artist")
+    )
+    await db_session.flush()
+    db_session.add(UserPreferences(did=session.did, download_policy="off"))
+    await db_session.commit()
+    meta = await parse_upload_metadata(
+        session,
+        filename="song.mp3",
+        title="Song",
+        album=None,
+        album_id=None,
+        features=None,
+        tags=None,
+        visibility="public",
+        copyright=None,
+        description=None,
+        self_labels=None,
+        auto_tag=None,
+        download_policy=override,
+    )
+    assert meta.private_audio is expected_private
+    assert meta.support_gate is None
+    assert meta.download_policy == override
+    assert meta.visibility == "public"

--- a/backend/tests/api/test_upload_sessions.py
+++ b/backend/tests/api/test_upload_sessions.py
@@ -82,9 +82,10 @@ def _send_parts(
         assert resp.json()["part_number"] == n
 
 
-@pytest.mark.parametrize("visibility", ["public", "stream"])
+@pytest.mark.parametrize("visibility", ["public", "unlisted"])
+@pytest.mark.parametrize("allow_downloads", [True, False])
 def test_session_round_trip_enqueues_a_staged_upload(
-    artist_app: FastAPI, visibility: str
+    artist_app: FastAPI, visibility: str, allow_downloads: bool
 ) -> None:
     with (
         TestClient(artist_app) as client,
@@ -105,7 +106,12 @@ def test_session_round_trip_enqueues_a_staged_upload(
         _send_parts(client, upload_id)
         resp = client.post(
             f"/tracks/uploads/{upload_id}/finish",
-            data={"title": "song", "visibility": visibility, "tags": '["a"]'},
+            data={
+                "title": "song",
+                "visibility": visibility,
+                "allow_downloads": str(allow_downloads).lower(),
+                "tags": '["a"]',
+            },
         )
         assert resp.status_code == 200, resp.text
         assert resp.json()["upload_id"] == upload_id
@@ -113,8 +119,8 @@ def test_session_round_trip_enqueues_a_staged_upload(
     schedule.assert_awaited_once()
     assert schedule.await_args is not None
     ctx: UploadContext = schedule.await_args.args[0]
-    assert ctx.visibility == "public"
-    assert ctx.support_gate == ({"type": "stream"} if visibility == "stream" else None)
+    assert ctx.visibility == visibility
+    assert ctx.support_gate == (None if allow_downloads else {"type": "stream"})
     assert ctx.copyright_rights is None
     assert ctx.staged is True
     assert ctx.audio_file_id == ""

--- a/backend/tests/api/test_upload_sessions.py
+++ b/backend/tests/api/test_upload_sessions.py
@@ -82,7 +82,10 @@ def _send_parts(
         assert resp.json()["part_number"] == n
 
 
-def test_session_round_trip_enqueues_a_staged_upload(artist_app: FastAPI) -> None:
+@pytest.mark.parametrize("visibility", ["public", "stream"])
+def test_session_round_trip_enqueues_a_staged_upload(
+    artist_app: FastAPI, visibility: str
+) -> None:
     with (
         TestClient(artist_app) as client,
         patch(
@@ -102,7 +105,7 @@ def test_session_round_trip_enqueues_a_staged_upload(artist_app: FastAPI) -> Non
         _send_parts(client, upload_id)
         resp = client.post(
             f"/tracks/uploads/{upload_id}/finish",
-            data={"title": "song", "visibility": "public", "tags": '["a"]'},
+            data={"title": "song", "visibility": visibility, "tags": '["a"]'},
         )
         assert resp.status_code == 200, resp.text
         assert resp.json()["upload_id"] == upload_id
@@ -110,6 +113,9 @@ def test_session_round_trip_enqueues_a_staged_upload(artist_app: FastAPI) -> Non
     schedule.assert_awaited_once()
     assert schedule.await_args is not None
     ctx: UploadContext = schedule.await_args.args[0]
+    assert ctx.visibility == "public"
+    assert ctx.support_gate == ({"type": "stream"} if visibility == "stream" else None)
+    assert ctx.copyright_rights is None
     assert ctx.staged is True
     assert ctx.audio_file_id == ""
     assert ctx.filename == "song.wav"
@@ -247,13 +253,15 @@ async def test_settle_promotes_staged_bytes_to_their_content_hash(
     assert staged.key not in storage.staged_objects
 
 
+@pytest.mark.parametrize("gate_type", ["any", "copyright", "stream"])
 async def test_settle_gated_upload_lands_in_the_private_bucket(
     db_session: AsyncSession,
+    gate_type: str,
 ) -> None:
     storage = _mock_storage()
     staged = StagedUploadKey(upload_id="u-gated", extension="wav")
     storage.staged_objects[staged.key] = _AUDIO
-    ctx = _staged_ctx("u-gated", support_gate={"type": "any"})
+    ctx = _staged_ctx("u-gated", support_gate={"type": gate_type})
 
     await _settle_staged_audio(ctx)
 

--- a/backend/tests/api/test_upload_sessions.py
+++ b/backend/tests/api/test_upload_sessions.py
@@ -88,7 +88,7 @@ def _send_parts(
 
 
 @pytest.mark.parametrize("visibility", ["public", "unlisted"])
-@pytest.mark.parametrize("download_policy", ["open", "off"])
+@pytest.mark.parametrize("download_policy", ["open", "off", "supporters"])
 def test_session_round_trip_enqueues_a_staged_upload(
     artist_app: FastAPI, visibility: str, download_policy: str
 ) -> None:
@@ -126,7 +126,7 @@ def test_session_round_trip_enqueues_a_staged_upload(
     ctx: UploadContext = schedule.await_args.args[0]
     assert ctx.visibility == visibility
     assert ctx.support_gate is None
-    assert ctx.private_audio is (download_policy == "off")
+    assert ctx.private_audio is (download_policy in ("off", "supporters"))
     assert ctx.download_policy == download_policy
     assert ctx.copyright_rights is None
     assert ctx.staged is True

--- a/backend/tests/api/track_audio_replace/test_pipeline.py
+++ b/backend/tests/api/track_audio_replace/test_pipeline.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -189,12 +190,15 @@ class TestReplaceOrchestration:
         # second positional arg is album_id (after session_id)
         assert mocks["schedule_album_sync"].call_args.args[1] == album_id
 
+    @pytest.mark.parametrize("private_source", [False, True])
     async def test_gated_track_record_uses_backend_audio_url(
-        self, db_session: AsyncSession, owner: Artist
+        self, db_session: AsyncSession, owner: Artist, private_source: bool
     ) -> None:
         """gated tracks must not write a public R2 URL into the ATProto record;
         they need the auth-protected `/audio/{file_id}` redirect endpoint."""
-        track = make_track(support_gate={"type": "any"})
+        track = make_track(support_gate=None if private_source else {"type": "any"})
+        track.audio_storage = "r2_private" if private_source else "r2"
+        track.extra = {"download_policy": "off"} if private_source else {}
         db_session.add(track)
         await db_session.commit()
         await db_session.refresh(track)
@@ -211,15 +215,19 @@ class TestReplaceOrchestration:
         with patched_replace_pipeline(
             validate=audio_info(is_gated=True),
             store=storage_result(file_id="NEW", r2_url=None),  # gated → r2_url=None
-            pds=None,  # gated tracks skip PDS upload
+            pds=pds_result(cid=None, size=None),
             update_record_side_effect=fake_update_record,
         ):
             await _process_replace_background(replace_ctx(track_id=track_id))
 
         # the recorded audioUrl points at /audio/{file_id}, not at R2
         assert captured_record["audioUrl"].endswith("/audio/NEW")
-        assert "supportGate" in captured_record
-        assert captured_record["supportGate"] == {"type": "any"}
+        assert captured_record.get("supportGate") == (
+            None if private_source else {"type": "any"}
+        )
+        await db_session.refresh(track)
+        assert track.audio_storage == ("r2_private" if private_source else "r2")
+        assert track.download_policy == ("off" if private_source else None)
 
     async def test_pds_record_preserves_original_created_at(
         self, db_session: AsyncSession, owner: Artist

--- a/backend/tests/api/track_audio_replace/test_revisions.py
+++ b/backend/tests/api/track_audio_replace/test_revisions.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
@@ -298,18 +299,30 @@ class TestListRevisionsEndpoint:
 class TestRestoreEndpoint:
     """POST /tracks/{id}/revisions/{revision_id}/restore"""
 
+    @pytest.mark.parametrize("private_source", [False, True])
     async def test_restore_swaps_audio_and_publishes_record(
         self,
         test_app_owner: FastAPI,
         db_session: AsyncSession,
         owner: Artist,
+        private_source: bool,
     ) -> None:
         track = make_track(file_id="CURRENT", duration=200)
+        track.audio_storage = "r2_private" if private_source else "r2"
+        if private_source:
+            track.r2_url = None
+            track.extra = {"duration": 200, "download_policy": "off"}
         db_session.add(track)
         await db_session.commit()
         await db_session.refresh(track)
 
-        revision = _add_revision(track.id, file_id="OLD", duration=120)
+        revision = _add_revision(
+            track.id,
+            file_id="OLD",
+            duration=120,
+            was_gated=private_source,
+            audio_storage="r2_private" if private_source else "r2",
+        )
         db_session.add(revision)
         await db_session.commit()
         await db_session.refresh(revision)
@@ -335,6 +348,11 @@ class TestRestoreEndpoint:
         assert track.file_id == "OLD"
         assert track.atproto_record_cid == "bafyRESTORED"
         assert track.extra["duration"] == 120
+        assert track.audio_storage == ("r2_private" if private_source else "r2")
+        if private_source:
+            assert track.download_policy == "off"
+            assert track.r2_url is None
+            assert track.support_gate is None
 
         # the chosen revision row was deleted (its content is now current).
         # expire the session so the SELECT goes to the DB rather than the

--- a/backend/tests/api/track_audio_replace/test_revisions.py
+++ b/backend/tests/api/track_audio_replace/test_revisions.py
@@ -116,8 +116,9 @@ class TestPruneRevisions:
         assert len(revisions) == 3
         mock_delete.assert_not_called()
 
+    @pytest.mark.parametrize("private_source", [False, True])
     async def test_over_cap_drops_oldest_and_deletes_blob(
-        self, db_session: AsyncSession, owner: Artist
+        self, db_session: AsyncSession, owner: Artist, private_source: bool
     ) -> None:
         from datetime import UTC, datetime, timedelta
 
@@ -130,14 +131,23 @@ class TestPruneRevisions:
         base = datetime(2026, 1, 1, tzinfo=UTC)
         for i in range(MAX_REVISIONS_PER_TRACK + 2):
             r = _add_revision(track.id, file_id=f"REV-{i:02d}")
+            r.was_gated = private_source
+            r.original_file_id = f"ORIG-{i:02d}"
+            r.original_file_type = "flac"
             r.created_at = base + timedelta(hours=i)
             db_session.add(r)
         await db_session.commit()
 
-        with patch(
-            "backend._internal.track_revisions.storage.delete",
-            AsyncMock(return_value=True),
-        ) as mock_delete:
+        with (
+            patch(
+                "backend._internal.track_revisions.storage.delete",
+                AsyncMock(return_value=True),
+            ) as public_delete,
+            patch(
+                "backend._internal.track_revisions.storage.delete_gated",
+                AsyncMock(return_value=True),
+            ) as private_delete,
+        ):
             await prune_revisions(track.id)
 
         # exactly MAX remain; the two oldest are gone
@@ -158,9 +168,12 @@ class TestPruneRevisions:
         assert "REV-02" in remaining
 
         # blobs for the two pruned revisions were deleted
+        mock_delete = private_delete if private_source else public_delete
+        (public_delete if private_source else private_delete).assert_not_awaited()
         deleted_keys = {call.args[0] for call in mock_delete.call_args_list}
         assert "REV-00" in deleted_keys
         assert "REV-01" in deleted_keys
+        assert {"ORIG-00", "ORIG-01"} <= deleted_keys
 
     async def test_does_not_delete_blob_still_referenced_by_track(
         self, db_session: AsyncSession, owner: Artist

--- a/backend/tests/test_background_tasks.py
+++ b/backend/tests/test_background_tasks.py
@@ -13,7 +13,9 @@ async def test_schedule_export_uses_docket() -> None:
     """schedule_export should add task to docket."""
     calls: list[tuple[str, str]] = []
 
-    async def mock_schedule(export_id: str, artist_did: str) -> None:
+    async def mock_schedule(
+        export_id: str, artist_did: str, session_id: str | None = None
+    ) -> None:
         calls.append((export_id, artist_did))
 
     mock_docket = MagicMock()

--- a/backend/tests/test_export_storage.py
+++ b/backend/tests/test_export_storage.py
@@ -1,0 +1,151 @@
+"""Exports preserve source authority and never publish protected archives."""
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend._internal.atproto.spaces.client import SpaceAccessError
+from backend._internal.export_tasks import process_album_download, process_export
+from backend.models import Artist, Track
+from tests.api.track_audio_replace._helpers import MockSession
+
+
+class Body:
+    async def iter_chunks(self) -> AsyncIterator[bytes]:
+        yield b"audio bytes"
+
+
+@pytest.mark.parametrize("source", ["r2", "r2_private", "space", "space_refused"])
+async def test_artist_export_preserves_source_and_archive_privacy(
+    db_session: AsyncSession, source: str
+) -> None:
+    artist = Artist(
+        did="did:plc:exporter", handle="exporter.test", display_name="Exporter"
+    )
+    db_session.add(artist)
+    await db_session.flush()
+    track = Track(
+        title="Song",
+        artist_did=artist.did,
+        file_id="aabbccddeeff0011",
+        file_type="mp3",
+        audio_storage="pds" if source.startswith("space") else source,
+        visibility="private" if source.startswith("space") else "public",
+        space_uri="at://did:plc:authority/space/example"
+        if source.startswith("space")
+        else None,
+        pds_blob_cid="bafkblob" if source.startswith("space") else None,
+        extra={"download_policy": "off"},
+    )
+    db_session.add(track)
+    await db_session.commit()
+    client = MagicMock()
+    client.get_object = AsyncMock(return_value={"Body": Body()})
+    client.upload_fileobj = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    session_factory = MagicMock()
+    session_factory.client.return_value = client
+    jobs = MagicMock(update_progress=AsyncMock())
+    owner_session = MockSession(artist.did)
+    space_read = MagicMock()
+
+    @asynccontextmanager
+    async def blob(*args, **kwargs) -> AsyncIterator[httpx.Response]:
+        space_read(*args, **kwargs)
+        if source == "space_refused":
+            raise SpaceAccessError("authority refused")
+        yield httpx.Response(200, content=b"space bytes")
+
+    with (
+        patch(
+            "backend._internal.export_tasks.aioboto3.Session",
+            return_value=session_factory,
+        ),
+        patch("backend._internal.export_tasks.job_service", jobs),
+        patch("backend._internal.export_tasks.R2ProgressTracker") as tracker,
+        patch(
+            "backend._internal.export_tasks.get_session",
+            AsyncMock(return_value=owner_session),
+        ),
+        patch("backend._internal.export_tasks.open_space_blob", blob),
+        patch("backend._internal.export_tasks.storage") as storage,
+    ):
+        storage.audio_bucket_name = "public"
+        storage.private_audio_bucket_name = "private"
+        tracker.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+        tracker.return_value.__aexit__ = AsyncMock(return_value=None)
+        await process_export("export-test", artist.did, session_id="session-id")
+
+    if source == "space_refused":
+        client.upload_fileobj.assert_not_awaited()
+        assert jobs.update_progress.call_args.args[1] == "failed"
+        return
+    client.upload_fileobj.assert_awaited_once()
+    assert client.upload_fileobj.call_args.args[1] == "private"
+    result = jobs.update_progress.call_args.kwargs["result"]
+    assert result["r2_key"] == "exports/export-test.zip"
+    assert result["download_url"].endswith("/exports/export-test/download")
+    if source.startswith("space"):
+        client.get_object.assert_not_awaited()
+        assert space_read.call_args.args[0] is owner_session
+        assert space_read.call_args.kwargs["space"] == track.space_uri
+    else:
+        assert client.get_object.call_args.kwargs["Bucket"] == (
+            "private" if source == "r2_private" else "public"
+        )
+
+
+async def test_album_job_keeps_zip_private_and_returns_permission_check(
+    db_session: AsyncSession,
+) -> None:
+    artist = Artist(
+        did="did:plc:album-export", handle="album-export.test", display_name="Artist"
+    )
+    db_session.add(artist)
+    await db_session.flush()
+    track = Track(
+        title="Song",
+        artist_did=artist.did,
+        file_id="aabbccddeeff0011",
+        file_type="mp3",
+        audio_storage="r2_private",
+    )
+    db_session.add(track)
+    await db_session.commit()
+    client = MagicMock()
+    client.get_object = AsyncMock(return_value={"Body": Body()})
+    client.upload_fileobj = AsyncMock()
+    client.list_objects_v2 = AsyncMock(return_value={})
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    session_factory = MagicMock()
+    session_factory.client.return_value = client
+    jobs = MagicMock(update_progress=AsyncMock())
+    with (
+        patch(
+            "backend._internal.export_tasks.aioboto3.Session",
+            return_value=session_factory,
+        ),
+        patch("backend._internal.export_tasks.job_service", jobs),
+        patch("backend._internal.export_tasks.storage") as storage,
+    ):
+        storage.private_audio_bucket_name = "private"
+        storage.audio_bucket_name = "public"
+        await process_album_download(
+            "job",
+            [track.id],
+            "exports/albums/album-digest.zip",
+            "album.zip",
+            download_path="https://api.test/albums/artist/album/download",
+        )
+    assert client.get_object.call_args.kwargs["Bucket"] == "private"
+    assert client.upload_fileobj.call_args.args[1] == "private"
+    assert (
+        jobs.update_progress.call_args.kwargs["result"]["download_url"]
+        == "https://api.test/albums/artist/album/download"
+    )

--- a/backend/tests/test_post_create_hooks.py
+++ b/backend/tests/test_post_create_hooks.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend._internal.atproto.client import pds_blob_url
@@ -125,11 +126,26 @@ class TestResolveAudioUrl:
 
 
 class TestRunPostTrackCreateHooks:
-    async def test_schedules_copyright_scan(self, db_session: AsyncSession) -> None:
+    @pytest.mark.parametrize("private_source", [False, True])
+    async def test_schedules_copyright_scan(
+        self, db_session: AsyncSession, private_source: bool
+    ) -> None:
         artist = await _create_artist(db_session)
-        track = await _create_track(db_session, artist)
+        track = await _create_track(
+            db_session,
+            artist,
+            r2_url=None if private_source else "https://r2.example.com/test.mp3",
+            audio_storage="r2_private" if private_source else "r2",
+        )
 
         with (
+            patch(
+                "backend._internal.tasks.hooks.storage.generate_presigned_url",
+                AsyncMock(return_value="https://private.test/signed"),
+            ),
+            patch(
+                "backend._internal.tasks.hooks.schedule_pds_blob_mirror", AsyncMock()
+            ) as mirror,
             patch(MOCK_COPYRIGHT_PATH, new_callable=AsyncMock) as mock_copyright,
             patch(MOCK_EMBEDDING_PATH, new_callable=AsyncMock),
             patch(MOCK_GENRE_PATH, new_callable=AsyncMock),
@@ -140,13 +156,16 @@ class TestRunPostTrackCreateHooks:
             mock_settings.modal.enabled = False
             mock_settings.turbopuffer.enabled = False
             mock_settings.replicate.enabled = False
-            await run_post_track_create_hooks(
-                track.id, audio_url="https://r2.example.com/test.mp3"
-            )
+            await run_post_track_create_hooks(track.id)
 
         mock_copyright.assert_called_once_with(
-            track.id, "https://r2.example.com/test.mp3"
+            track.id,
+            "https://private.test/signed"
+            if private_source
+            else "https://r2.example.com/test.mp3",
         )
+
+        mirror.assert_not_awaited()
 
     async def test_schedules_embedding(self, db_session: AsyncSession) -> None:
         artist = await _create_artist(db_session)

--- a/docs/internal/architecture/audio-access-reconciliation.md
+++ b/docs/internal/architecture/audio-access-reconciliation.md
@@ -5,6 +5,32 @@ Public listening with downloads off is not a private audience. A Space remains
 private to the readers its authority admits, regardless of download settings or
 supporter standing.
 
+## decision history reviewed for #2047
+
+These are decisions recorded in merged PRs, not inferred from today's field names.
+
+| Date | Decision | Consequence here |
+| --- | --- | --- |
+| 2025-12-23, [#637](https://github.com/zzstoatzz/plyr.fm/pull/637) | Supporter playback introduced private R2 and signed serving. Toggling the listener gate moved the rendition between buckets. | Legacy `support_gate` still implies a private R2 source. |
+| 2026-01-29, [#823](https://github.com/zzstoatzz/plyr.fm/pull/823) | Public uploads gained PDS blobs for ownership, with R2 for CDN performance. Gated audio was excluded from public PDS saves. | Both bulk and single-track saves must also exclude protected sources without listener gates. |
+| 2026-05-14, [#1402](https://github.com/zzstoatzz/plyr.fm/pull/1402) | Copyright reused private R2 and `support_gate`, admitting authenticated listeners. That reuse was deliberate because the storage paths matched. | Preserve copyright's authenticated audience. Public listening needs a source marker rather than another gate type. |
+| 2026-06-08, [#1557](https://github.com/zzstoatzz/plyr.fm/pull/1557) | One visibility axis replaced overlapping booleans. Private media became PDS-native with no R2 upload fallback. | Do not overload `private` or make its meaning depend on PDS capability. |
+| 2026-08-14, [#1842](https://github.com/zzstoatzz/plyr.fm/pull/1842) | Download policy became open/ask/supporters/off, with an automatic default and verifier-neutral enforcement. Bytes and album ZIPs remained public; per-track overrides were a stated follow-up. | Reuse those policies and precedence. Private storage for new restricted uploads and private ZIPs are deliberate changes to the old courtesy-only behavior. |
+| 2026-08-23, [#1930](https://github.com/zzstoatzz/plyr.fm/pull/1930) | Removed the app's membership mirror. The Space authority answers for each reader, subject to credential lifetime. | Never infer membership from downloads, payments, or artist activity in plyr. |
+| 2026-08-26, [#1939](https://github.com/zzstoatzz/plyr.fm/pull/1939) | Supporter verification gained attested.network before its atprotofans fallback. | Download selection cannot require an atprotofans profile; verification remains in `validate_supporter`. |
+
+Within this PR, the initial `visibility=stream` proposal and subsequent synthetic
+stream gate were discarded. They confused public listening with audience control
+and duplicated download policy. The final model adds a source location and a
+per-track override to existing contracts, without adding another visibility.
+
+Self-review found and fixed the missed single-track PDS-save guard, public-bucket
+assumptions in rendition deletion and revision-original pruning, and the new
+atprotofans-only download-selection restriction. Endpoint and pruning regressions
+fail on the previous implementation. The older access-list design's comparison
+table describes its pre-membership baseline; its later authority section and the
+contract below describe current behavior.
+
 ## policies
 
 | Choice | Listening | Downloads through plyr.fm | New audio location |
@@ -44,7 +70,7 @@ fetched anonymously through either audio route.
 | private R2 audio | protected/gated uploads, transcodes, replacements | signed playback URLs; original downloads enforce policy |
 | public PDS blobs | ordinary uploads and PDS saves | public getBlob; protected sources excluded from public mirroring |
 | permissioned PDS audio | Spaces uploads | reader credentials, without an owner-credential fallback for public playback |
-| original masters | upload / optimization | same private bucket as protected rendition; artist recovery permitted |
+| original masters | upload / optimization | same private bucket as protected rendition; artist recovery permitted; revision pruning uses that bucket |
 | retained revisions | replacement / restore | was_gated retains its historical bucket meaning; restore checks the boundary and preserves private storage |
 | artist ZIPs | export worker | source bucket or PDS, including owner-authorized Space reads; incomplete exports fail; owner endpoint signs private ZIP |
 | album ZIPs | album worker | private source reads and ZIP; completion returns the album endpoint to recheck current policy and content before signing |
@@ -71,6 +97,10 @@ owns those wire details, and authority refusal remains final.
 
 Detecting Spaces support does not migrate sources, publish private tracks or
 change audiences. Private R2 is application-managed storage, not a fake Space.
+An explicitly requested owner export can create a private R2 ZIP containing Space
+audio. That is an additional export artifact, not a playback source or an upload
+fallback; it remains behind the owner download endpoint.
+
 A future artist-authorized service publishing playback from a Space needs that
 distinct authorization; it must not borrow the private-track owner's credential
 to bypass a listener's refusal.

--- a/docs/internal/architecture/audio-access-reconciliation.md
+++ b/docs/internal/architecture/audio-access-reconciliation.md
@@ -1,0 +1,150 @@
+# audio access reconciliation
+
+Reviewed 2026-09-11 against `00266df4` (PR #2047) and the current upstream
+[Spaces proposal](https://github.com/bluesky-social/proposals/blob/main/0016-permissioned-data/README.md).
+This is a code-path audit and proposed contract, not a production bucket inventory
+or evidence that the proposed changes have shipped.
+
+## product promises
+
+Three questions must remain independent:
+
+1. Who can discover the track and listen?
+2. Who can obtain a download through the artist's chosen distribution service?
+3. Which host holds each audio object, and what authority permits its retrieval?
+
+Public listening with downloads off, public listening with purchaser downloads,
+and access-list-only listening are different promises. A private storage bucket
+is not a private audience. A supporter is not necessarily a purchaser of a
+particular track. Copyright metadata is not itself a playback entitlement.
+
+The first two PR iterations conflated these concerns: first by substituting a
+public-listening mode for private visibility, then by adding a download boolean
+that competed with the existing artist policy and reused a listener-access gate
+as a storage selector. Neither should become the long-term contract.
+
+## storage inventory
+
+| Objects / location | Writers and lifetime | Readers / important constraint |
+| --- | --- | --- |
+| R2 private multipart staging (`StagedUploadKey`) | `upload_sessions.py`, `uploads.py`, `storage/r2.py`; finish promotes bytes and removes staging | upload worker only; staging privacy is not the published track policy |
+| R2 public audio bucket | ordinary uploads, public transcodes, PDS mirrors; content-hash keys and immutable CDN caching | public audio redirects, public downloads, offline `/url`, exports; changing an app policy cannot revoke already-public bytes |
+| R2 private audio bucket | gated uploads/transcodes/replacements and public-to-private moves | presigned audio URLs; these are shareable until expiry, unlike Space credentials |
+| Public PDS blobs | upload publish, optimization, explicit PDS saves; public track records reference `audioBlob` | public `com.atproto.sync.getBlob`; R2 may coexist (`audio_storage=both`) or have been removed (`pds`) |
+| Permissioned PDS blobs and records | Spaces upload path; authority and writer/repo host resolved separately | `_handle_private_audio` uses the requesting reader's Space credential; do not serve using the artist's authority on behalf of an unauthorized listener |
+| Original masters and playback renditions | upload/optimization records `original_file_id/type` separately from `file_id/type` | `/audio/{id}` and `/url` accept original IDs too; “no downloads” does not currently separate a purchasable master from playable bytes |
+| Retained audio revisions | `audio_replace.py`, `revisions.py`; snapshots include `was_gated` and PDS location | revision URLs and restores depend on the snapshot's storage boundary; cross-boundary restores are refused |
+| Album ZIPs and artist exports | `_internal/export_tasks.py` writes `exports/...` into public audio bucket; temporary local files during assembly | API authorization does not protect the resulting public object URL |
+| PDS-ingested / mirrored audio | `_internal/tasks/ingest.py`, `tasks/pds_mirror.py`; blob/URL validation and mirror policy | cannot infer R2 ownership from a file ID or arbitrary URL; `download_key` already distinguishes these cases |
+
+Images use a separate public bucket; changing audio storage does not make artwork
+or public track metadata private. Worker/transcoder temporary files are processing
+copies, not an additional artist-facing access mode. Existing public caches,
+third-party copies, and blobs on other hosts cannot be recalled by a local toggle.
+
+## current gate inventory
+
+| Mechanism | Playback / discovery | Downloads |
+| --- | --- | --- |
+| `visibility=public/unlisted` | public listening; unlisted is excluded from feeds but remains reachable through profile/search/lists | artist policy and moderation decide |
+| `visibility=supporters`, `support_gate.type=any` | owner or `validate_supporter`; existence is public, denied listening returns 401/402 | refused even for supporters |
+| `support_gate.type=copyright` | authenticated listening; usually public/unlisted metadata; private R2 | refused; rights writes/removal also change storage and public records |
+| `visibility=private`, `space_uri` | Space authority decides access; hidden with 404 outside the list; reader credential used for bytes | currently refused even for owner/members |
+| artist `download_policy` | no effect on playback or storage | `open`, `ask`, `supporters`, `off`; unset chooses ask with a support link and open otherwise; ask is a nudge, not authorization |
+| PR `allow_downloads=false`, gate type `stream` | anonymous playback but some callers still interpret any gate as restricted listening | refuses everyone before artist policy or supporter standing is considered |
+| moderation and sensitive-content preferences | discovery, shared radio, and personal playback have distinct restrictions | copyright labels can refuse downloads; operator allow override is separate from creator rights metadata |
+
+Primary policy owners: `_internal/track_visibility.py`, `_internal/private_access.py`,
+`api/audio.py:_check_gate_access`, `utilities/downloads.py:download_refusal`,
+`_internal/supporters.py`, and `schemas.py:TrackResponse.from_track`.
+
+## concrete inconsistencies
+
+1. **Storage and listening are coupled.** `support_gate is not None` chooses
+   the private bucket, disables public PDS saves, excludes radio and Subsonic,
+   and unconditionally refuses downloads. A public stream gate therefore
+   creates exceptions throughout the app instead of reconciling its policies.
+2. **The checkbox has competing authority.** False overrides every artist
+   download tier; true still permits the artist tier to refuse. The UI does not
+   explain that precedence. A track-level policy should reuse the existing
+   policy vocabulary with explicit inheritance, not add another independent veto.
+3. **Master retrieval is not purchaser-only.** Both public audio routes resolve
+   original IDs and apply the playback gate. The proposed stream gate admits
+   everyone there. Download-endpoint refusal is not a master-file boundary.
+4. **Artist recovery is incomplete.** `process_export` queries all artist tracks
+   but fetches from the public bucket only, then packages successful fetches.
+   Private R2 and PDS-only originals are not covered. Earlier claims that the
+   portal already retrieves every protected original were too broad.
+5. **Protected album downloads produce public artifacts.** The album endpoint
+   checks supporter policy, but the ZIP worker and cached redirect use public R2.
+   Neither later policy changes nor the endpoint gate revoke a copied ZIP URL.
+6. **Transitions are not a complete object migration.** `move_track_audio`
+   moves the current file only, not all originals/revisions/PDS copies. Its
+   private-direction success and failure both return None, yet the caller clears
+   `r2_url`. Artist preference writes perform no migration at all. Replacement
+   rollback still has a public-bucket-only original cleanup branch. These paths
+   need explicit tests before expanding protected-storage behavior to them.
+7. **Audio identity is shared.** Audio endpoints choose among tracks by file ID,
+   preferring a public R2 row. Reuploading the same bytes under a restrictive
+   policy cannot make an existing public copy private. Object ownership and
+   track policy must not be inferred from one another.
+8. **Documentation has drifted.** Some model/docs comments still say Spaces is
+   owner-only or describe older capability probing. Executable access uses the
+   reader's credential and the authority's member-list decision. The new design
+   must follow those owners rather than copy stale prose.
+
+These are code-review findings, not claims of observed production disclosure.
+The broader audit has not modified any artist's media, policy, or Space.
+
+## a contract compatible with native Spaces
+
+The upstream proposal evaluates the requesting user and client application
+separately. A Space credential admits reads across a Space; it is not a
+“stream but never save” credential. The authority owns that decision. The
+proposal remains a draft, so wire details stay isolated in the existing Spaces
+client rather than becoming a new application-wide permission framework.
+
+- Keep Space identity, authority, repo host, and credential checks intact. A local
+  supporter/payment result cannot bypass a Space refusal.
+- Preserve the artist's explicit publication choice across host migrations.
+  Detecting Spaces support must not publish private tracks, add public members,
+  or silently convert public listening into access-list-only listening.
+- A service explicitly authorized by an artist to publish playback from a
+  protected source is a separate product contract from accessing the artist's
+  private-track Space. Do not reuse the owner's credential to bypass the latter.
+- Treat private R2 as an application-managed source, not a simulated Space.
+  A future Space-backed source can replace it only with compatible authority
+  and consent; no fake membership list or invented Space URI is needed today.
+- Reuse the existing download policy and entitlement verifier. Any track override
+  should inherit by default and use the same policy values. Purchaser access
+  needs a verified track/product entitlement, not a renamed supporter boolean.
+- Represent object location independently of listening authorization, covering
+  original, rendition, revision and ZIP. This does not require a new service.
+
+## bounded revision of PR #2047
+
+The current implementation is not ready to merge. Its green tests prove the
+implemented shortcut, not the desired product contract.
+
+1. Replace the extra download boolean/stream support gate with an explicit
+   policy resolution that reuses the artist defaults. Keep current visibility
+   semantics and Spaces behavior. Preserve legacy copyright behavior until an
+   explicit migration is designed; attaching/removing rights must not silently
+   widen the audience in the new path.
+2. Separate source location from playback gating in the existing model/storage
+   owners. Retain compatibility for existing rows; do not migrate already-public
+   catalogs as a side effect of an artist preference edit.
+3. Route new protected uploads, transcodes, replacements, original recovery and
+   downloads through that distinction. Keep authorized ZIPs private. Public
+   playback eligibility must not be inferred from a private bucket.
+4. Use the same resolved policy in track responses, download endpoints, album
+   jobs and upload/edit UI. Public playback should work in radio/embeds and
+   Subsonic stream; Subsonic download must honor download policy independently.
+5. Verify public/unlisted/Space/supporter/copyright cases, artist/member/outsider
+   viewers, inherited/explicit download policy, master vs rendition vs revision,
+   policy changes during asynchronous jobs, failed moves and PDS-only sources.
+
+This is a correction within existing policy and storage owners, not a generic
+permissions service or a replacement for Spaces. Per-track purchase integration
+remains a separately verified entitlement capability; do not advertise it as
+complete while implementing only the no-download case.

--- a/docs/internal/architecture/audio-access-reconciliation.md
+++ b/docs/internal/architecture/audio-access-reconciliation.md
@@ -1,150 +1,81 @@
-# audio access reconciliation
+# audio storage and access
 
-Reviewed 2026-09-11 against `00266df4` (PR #2047) and the current upstream
-[Spaces proposal](https://github.com/bluesky-social/proposals/blob/main/0016-permissioned-data/README.md).
-This is a code-path audit and proposed contract, not a production bucket inventory
-or evidence that the proposed changes have shipped.
+Visibility, download permission, and object location answer different questions.
+Public listening with downloads off is not a private audience. A Space remains
+private to the readers its authority admits, regardless of download settings or
+supporter standing.
 
-## product promises
+## policies
 
-Three questions must remain independent:
+| Choice | Listening | Downloads through plyr.fm | New audio location |
+| --- | --- | --- | --- |
+| public / unlisted, open or ask | anyone; unlisted stays out of discovery | open, or a support-link prompt | existing public R2 / PDS pipeline |
+| public / unlisted, off | anyone | artist recovery only | private R2 |
+| public / unlisted, supporters | anyone | artist or verified supporter | private R2 |
+| supporters visibility | owner or verified supporter | artist recovery; existing refusal for listeners | existing private R2 pipeline |
+| copyright metadata | authenticated listeners, preserving the rights workflow | artist recovery, subject to moderation | existing private R2 pipeline |
+| private visibility | requesting reader's Space credential | owner export through the owner's credential; no public download route | permissioned PDS |
 
-1. Who can discover the track and listen?
-2. Who can obtain a download through the artist's chosen distribution service?
-3. Which host holds each audio object, and what authority permits its retrieval?
+The optional upload `download_policy` reuses `open`, `ask`, `supporters`, and
+`off`. Omission inherits the artist preference and its automatic open/ask default.
+Explicit overrides live in `Track.extra`; responses, individual downloads and
+album downloads use the same precedence. Metadata edits preserve the override.
+This PR does not add an existing-track conversion control.
 
-Public listening with downloads off, public listening with purchaser downloads,
-and access-list-only listening are different promises. A private storage bucket
-is not a private audience. A supporter is not necessarily a purchaser of a
-particular track. Copyright metadata is not itself a playback entitlement.
+`audio_storage=r2_private` records location independently of permission. Legacy
+gated R2 rows remain readable without migration. Artist preference changes affect
+eligibility for inheriting tracks, not location. Copyright removal and supporter
+gate removal keep explicitly protected R2 sources private. Public playback does
+not require a synthetic support gate.
 
-The first two PR iterations conflated these concerns: first by substituting a
-public-listening mode for private visibility, then by adding a download boolean
-that competed with the existing artist policy and reused a listener-access gate
-as a storage selector. Neither should become the long-term contract.
+Supporter standing does not prove purchase of a particular track. A purchaser
+integration needs a verified product entitlement; this change does not claim to
+provide that integration. Playback delivers audio bytes, so this is distribution
+control, not DRM. Before optimization the original may also be the playable
+rendition. Once a distinct rendition exists, the protected master cannot be
+fetched anonymously through either audio route.
 
-## storage inventory
+## storage and lifecycle
 
-| Objects / location | Writers and lifetime | Readers / important constraint |
+| Objects | Writers | Retrieval / lifetime |
 | --- | --- | --- |
-| R2 private multipart staging (`StagedUploadKey`) | `upload_sessions.py`, `uploads.py`, `storage/r2.py`; finish promotes bytes and removes staging | upload worker only; staging privacy is not the published track policy |
-| R2 public audio bucket | ordinary uploads, public transcodes, PDS mirrors; content-hash keys and immutable CDN caching | public audio redirects, public downloads, offline `/url`, exports; changing an app policy cannot revoke already-public bytes |
-| R2 private audio bucket | gated uploads/transcodes/replacements and public-to-private moves | presigned audio URLs; these are shareable until expiry, unlike Space credentials |
-| Public PDS blobs | upload publish, optimization, explicit PDS saves; public track records reference `audioBlob` | public `com.atproto.sync.getBlob`; R2 may coexist (`audio_storage=both`) or have been removed (`pds`) |
-| Permissioned PDS blobs and records | Spaces upload path; authority and writer/repo host resolved separately | `_handle_private_audio` uses the requesting reader's Space credential; do not serve using the artist's authority on behalf of an unauthorized listener |
-| Original masters and playback renditions | upload/optimization records `original_file_id/type` separately from `file_id/type` | `/audio/{id}` and `/url` accept original IDs too; “no downloads” does not currently separate a purchasable master from playable bytes |
-| Retained audio revisions | `audio_replace.py`, `revisions.py`; snapshots include `was_gated` and PDS location | revision URLs and restores depend on the snapshot's storage boundary; cross-boundary restores are refused |
-| Album ZIPs and artist exports | `_internal/export_tasks.py` writes `exports/...` into public audio bucket; temporary local files during assembly | API authorization does not protect the resulting public object URL |
-| PDS-ingested / mirrored audio | `_internal/tasks/ingest.py`, `tasks/pds_mirror.py`; blob/URL validation and mirror policy | cannot infer R2 ownership from a file ID or arbitrary URL; `download_key` already distinguishes these cases |
+| multipart staging | resumable uploads | private staging; promotion selects the destination bucket |
+| public R2 audio | ordinary uploads, transcodes, PDS mirrors | existing CDN and download paths |
+| private R2 audio | protected/gated uploads, transcodes, replacements | signed playback URLs; original downloads enforce policy |
+| public PDS blobs | ordinary uploads and PDS saves | public getBlob; protected sources excluded from public mirroring |
+| permissioned PDS audio | Spaces uploads | reader credentials, without an owner-credential fallback for public playback |
+| original masters | upload / optimization | same private bucket as protected rendition; artist recovery permitted |
+| retained revisions | replacement / restore | was_gated retains its historical bucket meaning; restore checks the boundary and preserves private storage |
+| artist ZIPs | export worker | source bucket or PDS, including owner-authorized Space reads; incomplete exports fail; owner endpoint signs private ZIP |
+| album ZIPs | album worker | private source reads and ZIP; completion returns the album endpoint to recheck current policy and content before signing |
+| ingested records | firehose | public metadata echoes do not turn an existing protected source public |
 
-Images use a separate public bucket; changing audio storage does not make artwork
-or public track metadata private. Worker/transcoder temporary files are processing
-copies, not an additional artist-facing access mode. Existing public caches,
-third-party copies, and blobs on other hosts cannot be recalled by a local toggle.
+Public protected tracks remain eligible for radio and Subsonic streaming.
+Subsonic downloads enforce the normal download policy independently. Moderation
+and classification receive signed private-R2 URLs; these sources are already
+application-owned objects and do not need public-PDS mirroring. Native private
+tracks retain their exclusion from public hooks.
 
-## current gate inventory
+Artwork and public metadata are separate from audio storage. Worker/transcoder
+temporary files are processing copies, not another audience setting. Already
+public copies, CDN caches, PDS blobs and old public ZIPs cannot be recalled by a
+new setting. A content-hash ID may be shared by public and protected uploads;
+the latter cannot make the former private.
 
-| Mechanism | Playback / discovery | Downloads |
-| --- | --- | --- |
-| `visibility=public/unlisted` | public listening; unlisted is excluded from feeds but remains reachable through profile/search/lists | artist policy and moderation decide |
-| `visibility=supporters`, `support_gate.type=any` | owner or `validate_supporter`; existence is public, denied listening returns 401/402 | refused even for supporters |
-| `support_gate.type=copyright` | authenticated listening; usually public/unlisted metadata; private R2 | refused; rights writes/removal also change storage and public records |
-| `visibility=private`, `space_uri` | Space authority decides access; hidden with 404 outside the list; reader credential used for bytes | currently refused even for owner/members |
-| artist `download_policy` | no effect on playback or storage | `open`, `ask`, `supporters`, `off`; unset chooses ask with a support link and open otherwise; ask is a nudge, not authorization |
-| PR `allow_downloads=false`, gate type `stream` | anonymous playback but some callers still interpret any gate as restricted listening | refuses everyone before artist policy or supporter standing is considered |
-| moderation and sensitive-content preferences | discovery, shared radio, and personal playback have distinct restrictions | copyright labels can refuse downloads; operator allow override is separate from creator rights metadata |
+## Spaces compatibility and bounds
 
-Primary policy owners: `_internal/track_visibility.py`, `_internal/private_access.py`,
-`api/audio.py:_check_gate_access`, `utilities/downloads.py:download_refusal`,
-`_internal/supporters.py`, and `schemas.py:TrackResponse.from_track`.
+The [upstream proposal](https://github.com/bluesky-social/proposals/blob/main/0016-permissioned-data/README.md)
+evaluates the requesting user and client separately. Space read credentials do
+not distinguish playback from saving received bytes. The existing Spaces client
+owns those wire details, and authority refusal remains final.
 
-## concrete inconsistencies
+Detecting Spaces support does not migrate sources, publish private tracks or
+change audiences. Private R2 is application-managed storage, not a fake Space.
+A future artist-authorized service publishing playback from a Space needs that
+distinct authorization; it must not borrow the private-track owner's credential
+to bypass a listener's refusal.
 
-1. **Storage and listening are coupled.** `support_gate is not None` chooses
-   the private bucket, disables public PDS saves, excludes radio and Subsonic,
-   and unconditionally refuses downloads. A public stream gate therefore
-   creates exceptions throughout the app instead of reconciling its policies.
-2. **The checkbox has competing authority.** False overrides every artist
-   download tier; true still permits the artist tier to refuse. The UI does not
-   explain that precedence. A track-level policy should reuse the existing
-   policy vocabulary with explicit inheritance, not add another independent veto.
-3. **Master retrieval is not purchaser-only.** Both public audio routes resolve
-   original IDs and apply the playback gate. The proposed stream gate admits
-   everyone there. Download-endpoint refusal is not a master-file boundary.
-4. **Artist recovery is incomplete.** `process_export` queries all artist tracks
-   but fetches from the public bucket only, then packages successful fetches.
-   Private R2 and PDS-only originals are not covered. Earlier claims that the
-   portal already retrieves every protected original were too broad.
-5. **Protected album downloads produce public artifacts.** The album endpoint
-   checks supporter policy, but the ZIP worker and cached redirect use public R2.
-   Neither later policy changes nor the endpoint gate revoke a copied ZIP URL.
-6. **Transitions are not a complete object migration.** `move_track_audio`
-   moves the current file only, not all originals/revisions/PDS copies. Its
-   private-direction success and failure both return None, yet the caller clears
-   `r2_url`. Artist preference writes perform no migration at all. Replacement
-   rollback still has a public-bucket-only original cleanup branch. These paths
-   need explicit tests before expanding protected-storage behavior to them.
-7. **Audio identity is shared.** Audio endpoints choose among tracks by file ID,
-   preferring a public R2 row. Reuploading the same bytes under a restrictive
-   policy cannot make an existing public copy private. Object ownership and
-   track policy must not be inferred from one another.
-8. **Documentation has drifted.** Some model/docs comments still say Spaces is
-   owner-only or describe older capability probing. Executable access uses the
-   reader's credential and the authority's member-list decision. The new design
-   must follow those owners rather than copy stale prose.
-
-These are code-review findings, not claims of observed production disclosure.
-The broader audit has not modified any artist's media, policy, or Space.
-
-## a contract compatible with native Spaces
-
-The upstream proposal evaluates the requesting user and client application
-separately. A Space credential admits reads across a Space; it is not a
-“stream but never save” credential. The authority owns that decision. The
-proposal remains a draft, so wire details stay isolated in the existing Spaces
-client rather than becoming a new application-wide permission framework.
-
-- Keep Space identity, authority, repo host, and credential checks intact. A local
-  supporter/payment result cannot bypass a Space refusal.
-- Preserve the artist's explicit publication choice across host migrations.
-  Detecting Spaces support must not publish private tracks, add public members,
-  or silently convert public listening into access-list-only listening.
-- A service explicitly authorized by an artist to publish playback from a
-  protected source is a separate product contract from accessing the artist's
-  private-track Space. Do not reuse the owner's credential to bypass the latter.
-- Treat private R2 as an application-managed source, not a simulated Space.
-  A future Space-backed source can replace it only with compatible authority
-  and consent; no fake membership list or invented Space URI is needed today.
-- Reuse the existing download policy and entitlement verifier. Any track override
-  should inherit by default and use the same policy values. Purchaser access
-  needs a verified track/product entitlement, not a renamed supporter boolean.
-- Represent object location independently of listening authorization, covering
-  original, rendition, revision and ZIP. This does not require a new service.
-
-## bounded revision of PR #2047
-
-The current implementation is not ready to merge. Its green tests prove the
-implemented shortcut, not the desired product contract.
-
-1. Replace the extra download boolean/stream support gate with an explicit
-   policy resolution that reuses the artist defaults. Keep current visibility
-   semantics and Spaces behavior. Preserve legacy copyright behavior until an
-   explicit migration is designed; attaching/removing rights must not silently
-   widen the audience in the new path.
-2. Separate source location from playback gating in the existing model/storage
-   owners. Retain compatibility for existing rows; do not migrate already-public
-   catalogs as a side effect of an artist preference edit.
-3. Route new protected uploads, transcodes, replacements, original recovery and
-   downloads through that distinction. Keep authorized ZIPs private. Public
-   playback eligibility must not be inferred from a private bucket.
-4. Use the same resolved policy in track responses, download endpoints, album
-   jobs and upload/edit UI. Public playback should work in radio/embeds and
-   Subsonic stream; Subsonic download must honor download policy independently.
-5. Verify public/unlisted/Space/supporter/copyright cases, artist/member/outsider
-   viewers, inherited/explicit download policy, master vs rendition vs revision,
-   policy changes during asynchronous jobs, failed moves and PDS-only sources.
-
-This is a correction within existing policy and storage owners, not a generic
-permissions service or a replacement for Spaces. Per-track purchase integration
-remains a separately verified entitlement capability; do not advertise it as
-complete while implementing only the no-download case.
+Legacy public-to-gated moves are not complete catalog migrations: they cannot
+revoke public originals, historical PDS blobs or third-party caches. This upload
+feature performs no such migration and makes no such promise. New protected
+audio stays private through optimization, replacement, revisions and ZIP creation.

--- a/docs/internal/contracts/client-api.json
+++ b/docs/internal/contracts/client-api.json
@@ -5510,10 +5510,16 @@
             "title": "Visibility",
             "default": "public"
           },
-          "allow_downloads": {
-            "type": "boolean",
-            "title": "Allow Downloads",
-            "default": true
+          "download_policy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Download Policy"
           },
           "copyright": {
             "anyOf": [
@@ -5826,10 +5832,16 @@
             "description": "one of: public | unlisted | supporters | private. supporters = atprotofans-gated; private = PDS permissioned space (requires a PDS supporting com.atproto.space.*).",
             "default": "public"
           },
-          "allow_downloads": {
-            "type": "boolean",
-            "title": "Allow Downloads",
-            "default": true
+          "download_policy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Download Policy"
           },
           "copyright": {
             "anyOf": [

--- a/docs/internal/contracts/client-api.json
+++ b/docs/internal/contracts/client-api.json
@@ -5510,6 +5510,11 @@
             "title": "Visibility",
             "default": "public"
           },
+          "allow_downloads": {
+            "type": "boolean",
+            "title": "Allow Downloads",
+            "default": true
+          },
           "copyright": {
             "anyOf": [
               {
@@ -5820,6 +5825,11 @@
             "title": "Visibility",
             "description": "one of: public | unlisted | supporters | private. supporters = atprotofans-gated; private = PDS permissioned space (requires a PDS supporting com.atproto.space.*).",
             "default": "public"
+          },
+          "allow_downloads": {
+            "type": "boolean",
+            "title": "Allow Downloads",
+            "default": true
           },
           "copyright": {
             "anyOf": [

--- a/frontend/src/lib/components/PdsSaveControl.svelte
+++ b/frontend/src/lib/components/PdsSaveControl.svelte
@@ -29,7 +29,7 @@
 	let savableTrackCount = $derived(
 		tracks.filter(
 			(track) =>
-				!track.support_gate &&
+				!track.support_gate && track.audio_storage !== 'r2_private' &&
 				(track.audio_storage ?? 'r2') !== 'both' &&
 				!isOptimizing(track)
 		).length
@@ -37,7 +37,7 @@
 	let savedTrackCount = $derived(
 		tracks.filter((track) => ['both', 'pds'].includes(track.audio_storage ?? 'r2')).length
 	);
-	let gatedTrackCount = $derived(tracks.filter((track) => track.support_gate).length);
+	let gatedTrackCount = $derived(tracks.filter((track) => track.support_gate || track.audio_storage === 'r2_private').length);
 
 	onMount(() => {
 		if ($page.url.searchParams.get(DEEP_LINK_PARAM) !== DEEP_LINK_VALUE) return;
@@ -176,7 +176,7 @@
 					? 'your track'
 					: `all ${savedTrackCount} tracks`} live on your personal data server, with the CDN as fallback{gatedTrackCount >
 				0
-					? ` (${gatedTrackCount} gated ${gatedTrackCount === 1 ? 'track streams' : 'tracks stream'} through plyr.fm and ${gatedTrackCount === 1 ? "isn't" : "aren't"} mirrored)`
+					? ` (${gatedTrackCount} protected ${gatedTrackCount === 1 ? 'track streams' : 'tracks stream'} through plyr.fm and ${gatedTrackCount === 1 ? "isn't" : "aren't"} mirrored)`
 					: ''}
 			</p>
 		</div>

--- a/frontend/src/lib/components/TrackEditForm.svelte
+++ b/frontend/src/lib/components/TrackEditForm.svelte
@@ -106,7 +106,7 @@
 		editSupportGate =
 			track.support_gate !== null &&
 			track.support_gate !== undefined &&
-			track.support_gate.type !== 'copyright';
+			track.support_gate.type === 'any';
 		editUnlisted = track.unlisted ?? false;
 		editSelfLabels = [...(track.self_labels ?? [])];
 
@@ -163,7 +163,7 @@
 
 		formData.append('tags', JSON.stringify(editTags));
 
-		if (!editCopyrightEnabled && !editCopyrightWasEnabled) {
+		if (!editCopyrightEnabled && !editCopyrightWasEnabled && track.support_gate?.type !== 'stream') {
 			if (editSupportGate) {
 				formData.append('support_gate', JSON.stringify({ type: 'any' }));
 			} else {

--- a/frontend/src/lib/components/TrackEditForm.svelte
+++ b/frontend/src/lib/components/TrackEditForm.svelte
@@ -163,7 +163,7 @@
 
 		formData.append('tags', JSON.stringify(editTags));
 
-		if (!editCopyrightEnabled && !editCopyrightWasEnabled && track.support_gate?.type !== 'stream') {
+		if (!editCopyrightEnabled && !editCopyrightWasEnabled) {
 			if (editSupportGate) {
 				formData.append('support_gate', JSON.stringify({ type: 'any' }));
 			} else {

--- a/frontend/src/lib/components/TrackEditForm.test.ts
+++ b/frontend/src/lib/components/TrackEditForm.test.ts
@@ -27,13 +27,13 @@ afterEach(() => {
 	auth.user = null;
 });
 
-function mountEditor(editorTrack: Track = track) {
+function mountEditor(editorTrack: Track = track, atprotofansEligible = false) {
 	const onSaved = vi.fn();
 	const onClose = vi.fn();
 	const onDirtyChange = vi.fn();
 	const component = mount(TrackEditForm, {
 		target: document.body,
-		props: { track: editorTrack, albums: [], atprotofansEligible: false, onSaved, onClose, onDirtyChange }
+		props: { track: editorTrack, albums: [], atprotofansEligible, onSaved, onClose, onDirtyChange }
 	});
 	cleanup = () => {
 		void unmount(component);
@@ -59,7 +59,7 @@ function submit(): void {
 
 describe('shared track editor', () => {
 	it('preserves private files when editing public listening metadata', async () => {
-		const streamTrack = { ...track, copyright_song_uri: null, support_gate: { type: 'stream' } };
+		const streamTrack = { ...track, copyright_song_uri: null, support_gate: null, audio_storage: 'r2_private' as const, download_policy: 'off' };
 		const requests: Request[] = [];
 		vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
 			const request = new Request(input, init);
@@ -67,14 +67,15 @@ describe('shared track editor', () => {
 			if (request.url.includes('/recommended-tags')) return Response.json({ available: false, tags: [] });
 			return Response.json({ ...streamTrack, title: 'new title' });
 		});
-		const { onSaved } = mountEditor(streamTrack);
-		expect(document.body.textContent).toContain('downloads are off');
-		expect(document.body.textContent).not.toContain('only supporters can play');
+		const { onSaved } = mountEditor(streamTrack, true);
+		expect(document.body.textContent).toContain('download policy: off');
+		expect(document.body.textContent).toContain('only supporters can play');
 		editTitle('new title');
 		submit();
 		await vi.waitFor(() => expect(onSaved).toHaveBeenCalled());
 		const saved = await requests.find((request) => request.method === 'PATCH')?.formData();
-		expect(saved?.has('support_gate')).toBe(false);
+		expect(saved?.get('support_gate')).toBe('null');
+		expect(saved?.has('download_policy')).toBe(false);
 	});
 
 	it('saves ordinary details without overwriting existing copyright records', async () => {

--- a/frontend/src/lib/components/TrackEditForm.test.ts
+++ b/frontend/src/lib/components/TrackEditForm.test.ts
@@ -68,7 +68,7 @@ describe('shared track editor', () => {
 			return Response.json({ ...streamTrack, title: 'new title' });
 		});
 		const { onSaved } = mountEditor(streamTrack);
-		expect(document.body.textContent).toContain('public listening, private files');
+		expect(document.body.textContent).toContain('downloads are off');
 		expect(document.body.textContent).not.toContain('only supporters can play');
 		editTitle('new title');
 		submit();

--- a/frontend/src/lib/components/TrackEditForm.test.ts
+++ b/frontend/src/lib/components/TrackEditForm.test.ts
@@ -27,13 +27,13 @@ afterEach(() => {
 	auth.user = null;
 });
 
-function mountEditor() {
+function mountEditor(editorTrack: Track = track) {
 	const onSaved = vi.fn();
 	const onClose = vi.fn();
 	const onDirtyChange = vi.fn();
 	const component = mount(TrackEditForm, {
 		target: document.body,
-		props: { track, albums: [], atprotofansEligible: false, onSaved, onClose, onDirtyChange }
+		props: { track: editorTrack, albums: [], atprotofansEligible: false, onSaved, onClose, onDirtyChange }
 	});
 	cleanup = () => {
 		void unmount(component);
@@ -58,6 +58,25 @@ function submit(): void {
 }
 
 describe('shared track editor', () => {
+	it('preserves private files when editing public listening metadata', async () => {
+		const streamTrack = { ...track, copyright_song_uri: null, support_gate: { type: 'stream' } };
+		const requests: Request[] = [];
+		vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+			const request = new Request(input, init);
+			requests.push(request);
+			if (request.url.includes('/recommended-tags')) return Response.json({ available: false, tags: [] });
+			return Response.json({ ...streamTrack, title: 'new title' });
+		});
+		const { onSaved } = mountEditor(streamTrack);
+		expect(document.body.textContent).toContain('public listening, private files');
+		expect(document.body.textContent).not.toContain('only supporters can play');
+		editTitle('new title');
+		submit();
+		await vi.waitFor(() => expect(onSaved).toHaveBeenCalled());
+		const saved = await requests.find((request) => request.method === 'PATCH')?.formData();
+		expect(saved?.has('support_gate')).toBe(false);
+	});
+
 	it('saves ordinary details without overwriting existing copyright records', async () => {
 		const requests: Request[] = [];
 		vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {

--- a/frontend/src/lib/components/VisibilityPicker.stories.svelte
+++ b/frontend/src/lib/components/VisibilityPicker.stories.svelte
@@ -1,0 +1,27 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { expect, userEvent, within } from 'storybook/test';
+	import VisibilityPicker from './VisibilityPicker.svelte';
+
+	const { Story } = defineMeta({
+		title: 'upload/VisibilityPicker',
+		component: VisibilityPicker,
+		parameters: { layout: 'padded' }
+	});
+</script>
+
+<Story
+	name="Private files"
+	args={{ visibility: 'public' }}
+	play={async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const option = canvas.getByRole('radio', { name: /public listening, private files/ });
+		await userEvent.click(option);
+		await expect(option).toBeChecked();
+	}}
+/>
+<Story
+	name="Spaces available"
+	args={{ visibility: 'private', showPrivate: true, privateGranted: true }}
+/>
+<Story name="Copyright configured" args={{ visibility: 'public', restrictedToPublic: true }} />

--- a/frontend/src/lib/components/VisibilityPicker.stories.svelte
+++ b/frontend/src/lib/components/VisibilityPicker.stories.svelte
@@ -17,6 +17,8 @@
 		const canvas = within(canvasElement);
 		const downloads = canvas.getByRole('combobox', { name: 'downloads' });
 		await expect(downloads).toHaveValue('');
+			await userEvent.selectOptions(downloads, 'supporters');
+			await expect(downloads).toHaveValue('supporters');
 		await userEvent.selectOptions(downloads, 'off');
 		await expect(downloads).toHaveValue('off');
 		await expect(canvas.getByRole('radio', { name: /^public / })).toBeChecked();

--- a/frontend/src/lib/components/VisibilityPicker.stories.svelte
+++ b/frontend/src/lib/components/VisibilityPicker.stories.svelte
@@ -15,10 +15,10 @@
 	args={{ visibility: 'public' }}
 	play={async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const downloads = canvas.getByRole('checkbox', { name: /allow downloads/ });
-		await expect(downloads).toBeChecked();
-		await userEvent.click(downloads);
-		await expect(downloads).not.toBeChecked();
+		const downloads = canvas.getByRole('combobox', { name: 'downloads' });
+		await expect(downloads).toHaveValue('');
+		await userEvent.selectOptions(downloads, 'off');
+		await expect(downloads).toHaveValue('off');
 		await expect(canvas.getByRole('radio', { name: /^public / })).toBeChecked();
 	}}
 />
@@ -27,12 +27,15 @@
 	args={{ visibility: 'public', showPrivate: true, privateGranted: true }}
 	play={async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByRole('checkbox', { name: /allow downloads/ })).toBeVisible();
+		await expect(canvas.getByRole('combobox', { name: 'downloads' })).toBeVisible();
 		await userEvent.click(canvas.getByRole('radio', { name: /^private / }));
 		await expect(
-			canvas.queryByRole('checkbox', { name: /allow downloads/ })
+			canvas.queryByRole('combobox', { name: 'downloads' })
 		).not.toBeInTheDocument();
 	}}
 />
-<Story name="Unlisted downloads off" args={{ visibility: 'unlisted', allowDownloads: false }} />
+<Story name="Unlisted downloads off" args={{ visibility: 'unlisted', downloadPolicy: 'off' }} />
 <Story name="Copyright configured" args={{ visibility: 'public', restrictedToPublic: true }} />
+
+<Story name="Artist settings" args={{ visibility: 'public' }} />
+<Story name="Supporter downloads" args={{ visibility: 'public', supportUrl: 'atprotofans', downloadPolicy: 'supporters' }} />

--- a/frontend/src/lib/components/VisibilityPicker.stories.svelte
+++ b/frontend/src/lib/components/VisibilityPicker.stories.svelte
@@ -11,17 +11,28 @@
 </script>
 
 <Story
-	name="Private files"
+	name="Public downloads"
 	args={{ visibility: 'public' }}
 	play={async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const option = canvas.getByRole('radio', { name: /public listening, private files/ });
-		await userEvent.click(option);
-		await expect(option).toBeChecked();
+		const downloads = canvas.getByRole('checkbox', { name: /allow downloads/ });
+		await expect(downloads).toBeChecked();
+		await userEvent.click(downloads);
+		await expect(downloads).not.toBeChecked();
+		await expect(canvas.getByRole('radio', { name: /^public / })).toBeChecked();
 	}}
 />
 <Story
 	name="Spaces available"
-	args={{ visibility: 'private', showPrivate: true, privateGranted: true }}
+	args={{ visibility: 'public', showPrivate: true, privateGranted: true }}
+	play={async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole('checkbox', { name: /allow downloads/ })).toBeVisible();
+		await userEvent.click(canvas.getByRole('radio', { name: /^private / }));
+		await expect(
+			canvas.queryByRole('checkbox', { name: /allow downloads/ })
+		).not.toBeInTheDocument();
+	}}
 />
+<Story name="Unlisted downloads off" args={{ visibility: 'unlisted', allowDownloads: false }} />
 <Story name="Copyright configured" args={{ visibility: 'public', restrictedToPublic: true }} />

--- a/frontend/src/lib/components/VisibilityPicker.svelte
+++ b/frontend/src/lib/components/VisibilityPicker.svelte
@@ -115,9 +115,7 @@
 			<option value="">use artist settings</option>
 			<option value="open">allow downloads</option>
 			<option value="ask">ask for support</option>
-			{#if supportUrl === 'atprotofans'}
-				<option value="supporters">supporters can download</option>
-			{/if}
+			<option value="supporters">supporters can download</option>
 			<option value="off">downloads off</option>
 		</select>
 		<span class="access-note">downloads off keeps audio with plyr.fm while anyone can listen. use artist settings follows your download preference.</span>

--- a/frontend/src/lib/components/VisibilityPicker.svelte
+++ b/frontend/src/lib/components/VisibilityPicker.svelte
@@ -8,7 +8,7 @@
 	interface Props {
 		/** the selected visibility. */
 		visibility: Visibility;
-		allowDownloads?: boolean;
+		downloadPolicy?: string;
 		/** when set, offer "supporters only" and link to this atprotofans page. */
 		supportUrl?: string | null;
 		/** offer "private" — only meaningful on a spaces-capable PDS. */
@@ -25,7 +25,7 @@
 
 	let {
 		visibility = $bindable(),
-		allowDownloads = $bindable(true),
+		downloadPolicy = $bindable(''),
 		supportUrl = null,
 		showPrivate = false,
 		privateDisabled = false,
@@ -109,16 +109,39 @@
 </fieldset>
 
 {#if (visibility === 'public' || visibility === 'unlisted') && !restrictedToPublic}
-	<label class="access-row">
-		<input type="checkbox" bind:checked={allowDownloads} />
-		<span class="access-body">
-			<span class="access-title">allow downloads</span>
-			<span class="access-note">when off, anyone can still listen. audio stays with plyr.fm and downloads are unavailable.</span>
-		</span>
+	<label class="download-field">
+		<span class="access-title">downloads</span>
+		<select aria-label="downloads" bind:value={downloadPolicy}>
+			<option value="">use artist settings</option>
+			<option value="open">allow downloads</option>
+			<option value="ask">ask for support</option>
+			{#if supportUrl === 'atprotofans'}
+				<option value="supporters">supporters can download</option>
+			{/if}
+			<option value="off">downloads off</option>
+		</select>
+		<span class="access-note">downloads off keeps audio with plyr.fm while anyone can listen. use artist settings follows your download preference.</span>
 	</label>
 {/if}
 
 <style>
+	.download-field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		margin-top: 1rem;
+	}
+
+	.download-field select {
+		width: 100%;
+		padding: 0.65rem;
+		border: 1px solid var(--border-default);
+		border-radius: var(--radius-sm);
+		background: var(--bg-primary);
+		color: var(--text-primary);
+		font: inherit;
+	}
+
 	.access-card {
 		display: flex;
 		flex-direction: column;
@@ -161,8 +184,7 @@
 		color: var(--text-muted);
 	}
 
-	.access-row input[type='radio'],
-	.access-row input[type='checkbox'] {
+	.access-row input[type='radio'] {
 		margin-top: 0.2rem;
 		flex-shrink: 0;
 		accent-color: var(--accent);

--- a/frontend/src/lib/components/VisibilityPicker.svelte
+++ b/frontend/src/lib/components/VisibilityPicker.svelte
@@ -3,7 +3,7 @@
 	 * The one "visibility & access" choice, shared by /upload and /record so
 	 * both surfaces describe the same options in the same words.
 	 */
-	export type Visibility = 'public' | 'unlisted' | 'supporters' | 'private';
+	export type Visibility = 'public' | 'unlisted' | 'supporters' | 'private' | 'stream';
 
 	interface Props {
 		/** the selected visibility. */
@@ -101,6 +101,14 @@
 					private
 				</span>
 				<span class="access-note">{privateNote ?? defaultPrivateNote}</span>
+			</span>
+		</label>
+	{:else}
+		<label class="access-row" class:unavailable={restrictedToPublic}>
+			<input type="radio" bind:group={visibility} value="stream" disabled={restrictedToPublic} />
+			<span class="access-body">
+				<span class="access-title">public listening, private files</span>
+				<span class="access-note">appears in feeds; anyone can listen. downloads are off and your audio stays with plyr.fm.</span>
 			</span>
 		</label>
 	{/if}

--- a/frontend/src/lib/components/VisibilityPicker.svelte
+++ b/frontend/src/lib/components/VisibilityPicker.svelte
@@ -3,11 +3,12 @@
 	 * The one "visibility & access" choice, shared by /upload and /record so
 	 * both surfaces describe the same options in the same words.
 	 */
-	export type Visibility = 'public' | 'unlisted' | 'supporters' | 'private' | 'stream';
+	export type Visibility = 'public' | 'unlisted' | 'supporters' | 'private';
 
 	interface Props {
 		/** the selected visibility. */
 		visibility: Visibility;
+		allowDownloads?: boolean;
 		/** when set, offer "supporters only" and link to this atprotofans page. */
 		supportUrl?: string | null;
 		/** offer "private" — only meaningful on a spaces-capable PDS. */
@@ -24,6 +25,7 @@
 
 	let {
 		visibility = $bindable(),
+		allowDownloads = $bindable(true),
 		supportUrl = null,
 		showPrivate = false,
 		privateDisabled = false,
@@ -103,16 +105,18 @@
 				<span class="access-note">{privateNote ?? defaultPrivateNote}</span>
 			</span>
 		</label>
-	{:else}
-		<label class="access-row" class:unavailable={restrictedToPublic}>
-			<input type="radio" bind:group={visibility} value="stream" disabled={restrictedToPublic} />
-			<span class="access-body">
-				<span class="access-title">public listening, private files</span>
-				<span class="access-note">appears in feeds; anyone can listen. downloads are off and your audio stays with plyr.fm.</span>
-			</span>
-		</label>
 	{/if}
 </fieldset>
+
+{#if (visibility === 'public' || visibility === 'unlisted') && !restrictedToPublic}
+	<label class="access-row">
+		<input type="checkbox" bind:checked={allowDownloads} />
+		<span class="access-body">
+			<span class="access-title">allow downloads</span>
+			<span class="access-note">when off, anyone can still listen. audio stays with plyr.fm and downloads are unavailable.</span>
+		</span>
+	</label>
+{/if}
 
 <style>
 	.access-card {
@@ -157,7 +161,8 @@
 		color: var(--text-muted);
 	}
 
-	.access-row input[type='radio'] {
+	.access-row input[type='radio'],
+	.access-row input[type='checkbox'] {
 		margin-top: 0.2rem;
 		flex-shrink: 0;
 		accent-color: var(--accent);

--- a/frontend/src/lib/components/portal/TracksSection.svelte
+++ b/frontend/src/lib/components/portal/TracksSection.svelte
@@ -140,7 +140,7 @@
 					<div class="track-info">
 						<div class="track-title">
 							{track.title}
-							{#if track.support_gate}
+							{#if track.support_gate?.type === 'any'}
 								<span class="support-gate-badge" title="supporters only">
 									<svg
 										width="12"

--- a/frontend/src/lib/components/track-edit/TrackAccessFields.svelte
+++ b/frontend/src/lib/components/track-edit/TrackAccessFields.svelte
@@ -47,7 +47,7 @@
 	<summary>visibility &amp; access</summary>
 	<div class="advanced-content">
 		{#if track.support_gate?.type === 'stream'}
-			<p class="field-hint">public listening, private files — downloads are off.</p>
+			<p class="field-hint">downloads are off. listening follows the track’s visibility.</p>
 		{:else if atprotofansEligible || track.support_gate?.type === 'any'}
 			<div class="edit-field-group access-field">
 				<span class="edit-label">supporter access</span>

--- a/frontend/src/lib/components/track-edit/TrackAccessFields.svelte
+++ b/frontend/src/lib/components/track-edit/TrackAccessFields.svelte
@@ -46,9 +46,10 @@
 <details class="advanced-section">
 	<summary>visibility &amp; access</summary>
 	<div class="advanced-content">
-		{#if track.support_gate?.type === 'stream'}
-			<p class="field-hint">downloads are off. listening follows the track’s visibility.</p>
-		{:else if atprotofansEligible || track.support_gate?.type === 'any'}
+		{#if track.audio_storage === 'r2_private'}
+			<p class="field-hint">download policy: {track.download_policy}. listening follows the track’s visibility.</p>
+		{/if}
+		{#if atprotofansEligible || track.support_gate?.type === 'any'}
 			<div class="edit-field-group access-field">
 				<span class="edit-label">supporter access</span>
 				<label class="toggle-row">
@@ -116,7 +117,7 @@
 		</div>
 	</div>
 </details>
-{#if track.support_gate?.type !== 'stream' && auth.user?.enabled_flags?.includes(COPYRIGHT_PARADIGM_FLAG)}
+{#if auth.user?.enabled_flags?.includes(COPYRIGHT_PARADIGM_FLAG)}
 	<details class="advanced-section">
 		<summary>rights &amp; licensing</summary>
 		<div class="advanced-content">

--- a/frontend/src/lib/components/track-edit/TrackAccessFields.svelte
+++ b/frontend/src/lib/components/track-edit/TrackAccessFields.svelte
@@ -46,7 +46,9 @@
 <details class="advanced-section">
 	<summary>visibility &amp; access</summary>
 	<div class="advanced-content">
-		{#if atprotofansEligible || (track.support_gate && track.support_gate.type !== 'copyright')}
+		{#if track.support_gate?.type === 'stream'}
+			<p class="field-hint">public listening, private files — downloads are off.</p>
+		{:else if atprotofansEligible || track.support_gate?.type === 'any'}
 			<div class="edit-field-group access-field">
 				<span class="edit-label">supporter access</span>
 				<label class="toggle-row">
@@ -114,7 +116,7 @@
 		</div>
 	</div>
 </details>
-{#if auth.user?.enabled_flags?.includes(COPYRIGHT_PARADIGM_FLAG)}
+{#if track.support_gate?.type !== 'stream' && auth.user?.enabled_flags?.includes(COPYRIGHT_PARADIGM_FLAG)}
 	<details class="advanced-section">
 		<summary>rights &amp; licensing</summary>
 		<div class="advanced-content">

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -68,7 +68,7 @@ export interface Track {
 	original_file_id?: string | null; // original file hash if transcoded
 	original_file_type?: string | null; // original format if transcoded (e.g., aiff, flac)
 	description?: string | null; // track description (liner notes, show notes)
-	audio_storage?: 'r2' | 'pds' | 'both'; // where audio is stored
+	audio_storage?: 'r2' | 'r2_private' | 'pds' | 'both'; // where audio is stored
 	pds_blob_cid?: string | null; // CID if stored on user's PDS
 	is_optimizing?: boolean; // deferred mp3 optimize still pending (server-computed)
 	unlisted?: boolean; // excluded from discovery feeds

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -238,7 +238,8 @@ class UploaderState {
 		label?: string,
 		albumId?: string,
 		copyright?: TrackRights | null,
-		selfLabels: string[] = []
+		selfLabels: string[] = [],
+		allowDownloads = true
 	): void {
 		if (!browser) return;
 		const staged = source instanceof StagedTransfer ? source : this.stage(source);
@@ -276,6 +277,7 @@ class UploaderState {
 		// visibility is the single source of truth (public | unlisted | supporters
 		// | private); copyright is orthogonal (rides on public/unlisted).
 		formData.append('visibility', visibility);
+		formData.append('allow_downloads', String(allowDownloads));
 		if (copyright) {
 			formData.append('copyright', JSON.stringify(copyright));
 		}

--- a/frontend/src/lib/uploader.svelte.ts
+++ b/frontend/src/lib/uploader.svelte.ts
@@ -239,7 +239,7 @@ class UploaderState {
 		albumId?: string,
 		copyright?: TrackRights | null,
 		selfLabels: string[] = [],
-		allowDownloads = true
+		downloadPolicy = ''
 	): void {
 		if (!browser) return;
 		const staged = source instanceof StagedTransfer ? source : this.stage(source);
@@ -277,7 +277,7 @@ class UploaderState {
 		// visibility is the single source of truth (public | unlisted | supporters
 		// | private); copyright is orthogonal (rides on public/unlisted).
 		formData.append('visibility', visibility);
-		formData.append('allow_downloads', String(allowDownloads));
+		if (downloadPolicy) formData.append('download_policy', downloadPolicy);
 		if (copyright) {
 			formData.append('copyright', JSON.stringify(copyright));
 		}

--- a/frontend/src/routes/record/+page.svelte
+++ b/frontend/src/routes/record/+page.svelte
@@ -32,6 +32,7 @@
 	let title = $state('');
 	let tags = $state<string[]>([]);
 	let visibility = $state<Visibility>('public');
+	let allowDownloads = $state(true);
 	let previewBlob = $state<Blob | null>(null);
 	// the live tick count at stop time: a length the preview can show before the
 	// browser has scanned the recording for its real one
@@ -192,7 +193,11 @@
 			'',
 			() => {},
 			undefined,
-			title
+			title,
+			undefined,
+			undefined,
+			[],
+			visibility === 'public' || visibility === 'unlisted' ? allowDownloads : true
 		);
 		uiState = 'uploading';
 		void clearStashedRecording();
@@ -335,6 +340,7 @@
 
 			<VisibilityPicker
 				bind:visibility
+				bind:allowDownloads
 				showPrivate={permissionedSupported}
 				privateGranted={permissionedGranted}
 			/>

--- a/frontend/src/routes/record/+page.svelte
+++ b/frontend/src/routes/record/+page.svelte
@@ -32,7 +32,7 @@
 	let title = $state('');
 	let tags = $state<string[]>([]);
 	let visibility = $state<Visibility>('public');
-	let allowDownloads = $state(true);
+	let downloadPolicy = $state('');
 	let previewBlob = $state<Blob | null>(null);
 	// the live tick count at stop time: a length the preview can show before the
 	// browser has scanned the recording for its real one
@@ -197,7 +197,7 @@
 			undefined,
 			undefined,
 			[],
-			visibility === 'public' || visibility === 'unlisted' ? allowDownloads : true
+			visibility === 'public' || visibility === 'unlisted' ? downloadPolicy : ''
 		);
 		uiState = 'uploading';
 		void clearStashedRecording();
@@ -340,7 +340,7 @@
 
 			<VisibilityPicker
 				bind:visibility
-				bind:allowDownloads
+				bind:downloadPolicy
 				showPrivate={permissionedSupported}
 				privateGranted={permissionedGranted}
 			/>

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -85,7 +85,7 @@
 	const VISIBILITIES = ['public', 'unlisted', 'supporters', 'private'] as const;
 	type Visibility = (typeof VISIBILITIES)[number];
 	let visibility = $state<Visibility>('public');
-	let allowDownloads = $state(true);
+	let downloadPolicy = $state('');
 
 	function parseVisibility(raw: string | undefined): Visibility {
 		return VISIBILITIES.find((option) => option === raw) ?? 'public';
@@ -274,7 +274,7 @@
 			autoTag = false;
 			sensitiveAudio = false;
 			visibility = 'public';
-			allowDownloads = true;
+			downloadPolicy = '';
 			copyrightEnabled = false;
 			copyrightRights = {};
 
@@ -332,7 +332,7 @@
 			undefined, // albumId
 			copyrightToSend,
 			uploadSelfLabels,
-			(uploadVisibility === 'public' || uploadVisibility === 'unlisted') && !copyrightEnabled ? allowDownloads : true,
+			(uploadVisibility === 'public' || uploadVisibility === 'unlisted') && !copyrightEnabled ? downloadPolicy : '',
 		);
 	}
 
@@ -564,7 +564,7 @@
 
 			<VisibilityPicker
 				bind:visibility
-				bind:allowDownloads
+				bind:downloadPolicy
 				supportUrl={artistProfile?.support_url}
 				showPrivate={permissionedSupported}
 				restrictedToPublic={copyrightEnabled}

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -82,7 +82,7 @@
 	// visibility/access — one mutually-exclusive choice:
 	//   public | unlisted | supporters | private
 	// "private" is only offered when the PDS supports com.atproto.space.* (/auth/me).
-	const VISIBILITIES = ['public', 'unlisted', 'supporters', 'private'] as const;
+	const VISIBILITIES = ['public', 'unlisted', 'supporters', 'private', 'stream'] as const;
 	type Visibility = (typeof VISIBILITIES)[number];
 	let visibility = $state<Visibility>('public');
 

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -82,9 +82,10 @@
 	// visibility/access — one mutually-exclusive choice:
 	//   public | unlisted | supporters | private
 	// "private" is only offered when the PDS supports com.atproto.space.* (/auth/me).
-	const VISIBILITIES = ['public', 'unlisted', 'supporters', 'private', 'stream'] as const;
+	const VISIBILITIES = ['public', 'unlisted', 'supporters', 'private'] as const;
 	type Visibility = (typeof VISIBILITIES)[number];
 	let visibility = $state<Visibility>('public');
+	let allowDownloads = $state(true);
 
 	function parseVisibility(raw: string | undefined): Visibility {
 		return VISIBILITIES.find((option) => option === raw) ?? 'public';
@@ -273,6 +274,7 @@
 			autoTag = false;
 			sensitiveAudio = false;
 			visibility = 'public';
+			allowDownloads = true;
 			copyrightEnabled = false;
 			copyrightRights = {};
 
@@ -330,6 +332,7 @@
 			undefined, // albumId
 			copyrightToSend,
 			uploadSelfLabels,
+			(uploadVisibility === 'public' || uploadVisibility === 'unlisted') && !copyrightEnabled ? allowDownloads : true,
 		);
 	}
 
@@ -561,6 +564,7 @@
 
 			<VisibilityPicker
 				bind:visibility
+				bind:allowDownloads
 				supportUrl={artistProfile?.support_url}
 				showPrivate={permissionedSupported}
 				restrictedToPublic={copyrightEnabled}

--- a/loq.toml
+++ b/loq.toml
@@ -39,7 +39,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 2090
+max_lines = 2118
 
 [[rules]]
 path = "backend/src/backend/config.py"
@@ -47,11 +47,11 @@ max_lines = 1266
 
 [[rules]]
 path = "backend/src/backend/storage/r2.py"
-max_lines = 1184
+max_lines = 1187
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"
-max_lines = 912
+max_lines = 914
 
 [[rules]]
 path = "backend/tests/api/test_albums.py"
@@ -255,7 +255,7 @@ max_lines = 1086
 
 [[rules]]
 path = "backend/src/backend/api/tracks/audio_replace.py"
-max_lines = 840
+max_lines = 852
 
 [[rules]]
 path = "backend/tests/conftest.py"
@@ -263,11 +263,11 @@ max_lines = 666
 
 [[rules]]
 path = "backend/tests/api/track_audio_replace/test_pipeline.py"
-max_lines = 612
+max_lines = 620
 
 [[rules]]
 path = "backend/tests/api/track_audio_replace/test_revisions.py"
-max_lines = 705
+max_lines = 723
 
 [[rules]]
 path = "frontend/src/routes/embed/track/[[]id[]]/+page.svelte"
@@ -303,11 +303,11 @@ max_lines = 649
 
 [[rules]]
 path = "backend/tests/test_post_create_hooks.py"
-max_lines = 523
+max_lines = 542
 
 [[rules]]
 path = "backend/tests/api/test_audio_optimize.py"
-max_lines = 923
+max_lines = 927
 
 [[rules]]
 path = "frontend/src/lib/components/portal/TracksSection.svelte"
@@ -371,11 +371,11 @@ max_lines = 1182
 
 [[rules]]
 path = "backend/src/backend/api/audio.py"
-max_lines = 552
+max_lines = 568
 
 [[rules]]
 path = "backend/src/backend/_internal/export_tasks.py"
-max_lines = 524
+max_lines = 600
 
 [[rules]]
 path = "frontend/src/lib/components/TrackComments.svelte"
@@ -399,7 +399,7 @@ max_lines = 527
 
 [[rules]]
 path = "docs/internal/contracts/client-api.json"
-max_lines = 8290
+max_lines = 8302
 
 [[rules]]
 path = "frontend/src/lib/components/TrackEditForm.svelte"

--- a/loq.toml
+++ b/loq.toml
@@ -223,7 +223,7 @@ max_lines = 715
 
 [[rules]]
 path = "backend/tests/api/test_track_deletion.py"
-max_lines = 585
+max_lines = 599
 
 [[rules]]
 path = "backend/tests/api/test_top_tracks.py"
@@ -267,7 +267,7 @@ max_lines = 620
 
 [[rules]]
 path = "backend/tests/api/track_audio_replace/test_revisions.py"
-max_lines = 723
+max_lines = 736
 
 [[rules]]
 path = "frontend/src/routes/embed/track/[[]id[]]/+page.svelte"

--- a/loq.toml
+++ b/loq.toml
@@ -39,7 +39,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 2083
+max_lines = 2090
 
 [[rules]]
 path = "backend/src/backend/config.py"
@@ -335,7 +335,7 @@ max_lines = 1424
 
 [[rules]]
 path = "frontend/src/lib/uploader.svelte.ts"
-max_lines = 623
+max_lines = 625
 
 [[rules]]
 path = "frontend/src/routes/track/[[]id[]]/+page.svelte"
@@ -399,7 +399,7 @@ max_lines = 527
 
 [[rules]]
 path = "docs/internal/contracts/client-api.json"
-max_lines = 8280
+max_lines = 8290
 
 [[rules]]
 path = "frontend/src/lib/components/TrackEditForm.svelte"

--- a/loq.toml
+++ b/loq.toml
@@ -39,7 +39,7 @@ max_lines = 850
 
 [[rules]]
 path = "backend/src/backend/api/tracks/uploads.py"
-max_lines = 2078
+max_lines = 2083
 
 [[rules]]
 path = "backend/src/backend/config.py"
@@ -51,7 +51,7 @@ max_lines = 1184
 
 [[rules]]
 path = "backend/tests/api/test_audio.py"
-max_lines = 886
+max_lines = 912
 
 [[rules]]
 path = "backend/tests/api/test_albums.py"


### PR DESCRIPTION
adds a download setting to public and unlisted uploads without changing who can listen. it inherits the artist's existing policy by default; choosing downloads off keeps new audio in private R2, while private visibility continues to use native Spaces membership.

| intent | listening | download behavior |
| --- | --- | --- |
| public/unlisted + off | anyone | artist recovery only |
| public/unlisted + supporters | anyone | artist or verified supporter |
| private visibility | readers admitted by the Space authority | owner export uses the owner's Space credential |

<details>
<summary>how the existing paths fit together</summary>

- both upload endpoints accept optional `download_policy`, using the existing open/ask/supporters/off values. explicit track overrides use `Track.extra`; omitted values inherit the artist preference. responses, individual downloads and album downloads resolve the same precedence. supporter downloads use the existing attested.network/atprotofans verifier without requiring an atprotofans profile.
- `audio_storage=r2_private` records location independently of listener gates. existing gated rows remain compatible. no synthetic stream gate, fake Space, new service, bucket or database migration.
- staging, optimization, replacement, cleanup and revision restore preserve the selected bucket. bulk and single-track public PDS saves exclude protected audio; rendition deletion and revision-original pruning use the correct bucket. copyright removal and supporter-gate removal preserve explicitly private R2 storage.
- anonymous playback remains available through audio redirects, radio and Subsonic streaming. Subsonic downloads enforce download policy separately. moderation/classification still receive access to public protected audio through signed R2 URLs.
- protected originals use download authorization when requested through either audio route. artists can retrieve their originals. artist exports read the source bucket or PDS, use owner credentials for Space reads, and fail instead of silently producing incomplete archives.
- both ZIP producers write private objects. artist exports require owner authentication; album jobs return to the album endpoint for a fresh content and policy check before signing a short-lived download link.
- the shared editor preserves download policy on metadata edits. the upload setting is available regardless of Spaces support and does not overload private visibility.

[storage and access contract, including the dated decision history](https://github.com/zzstoatzz/plyr.fm/blob/codex/private-files-public-listening/docs/internal/architecture/audio-access-reconciliation.md)

</details>

<details>
<summary>bounds and merge dependency</summary>

this changes new uploads, not the storage of an existing catalog. artist preference edits change inherited download eligibility without moving bytes. previously public originals, PDS blobs, ZIPs and cached copies cannot be recalled. shared content hashes do not give a protected upload authority over another public copy.

streaming still delivers audio bytes. before optimization, the source may also be the playable rendition. supporter standing is not a per-track purchase entitlement. Spaces capability detection does not migrate sources or change audiences, and no listener is served private Space audio through the artist's credentials.

the reciprocal interface check requires the matching 22-line upload-schema snapshot update in `zzstoatzz/plyr-python-client/contracts/http.json`. that exact companion snapshot is prepared and passes the API checker and the client's 51 interface tests locally; it must reach the client repository before this PR's reciprocal contract check can pass.

</details>

<details>
<summary>validation</summary>

- full backend suite: 1,678 passed; 25 existing skips. backend lint passes with the existing type-check warnings.
- frontend: 240 tests passed; Svelte check reports no errors or warnings; lint passes. six upload-control stories pass their interaction/accessibility checks.
- self-review regression proof: six cases fail on the previous implementation for protected PDS-save eligibility, supporter-download selection, rendition deletion and revision-original pruning; they pass here.
- regression proof: the three protected-master cases return unauthorized 307/200/307 responses on the previous implementation, and correctly refuse with 403 here.
- coverage includes inherited versus explicit download policy, anonymous/artist/supporter access, protected optimization and replacement, revision restore, private ZIP storage, album reauthorization, owner Space export and authority refusal, and continued moderation hooks.
- inspected all six upload-control states at 390px and 1280px in light and dark themes: the download section is separated from visibility and no horizontal overflow occurs. self-review also checked supporter selection without an atprotofans profile in all four width/theme cells: the section gap is 16px, with the existing native fieldset inset of 2px. these are local Storybook checks, not deployed-page verification.
- local API/SDK contracts and the companion client's 51 interface checks pass.

</details>

![bufo-headphones](https://all-the.bufo.zone/bufo-headphones.png)

generated with Codex (GPT-6)
