### PR TITLE
default top tracks to the past month

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -68,9 +68,9 @@
 	} satisfies Record<Period, string>;
 
 	function readSavedPeriod(): Period {
-		if (!browser) return 'all_time';
+		if (!browser) return 'month';
 		const saved = safeLocalStorage.getItem('topTracksPeriod');
-		return PERIODS.find((period) => period === saved) ?? 'all_time';
+		return PERIODS.find((period) => period === saved) ?? 'month';
 	}
 
 	let topTracksPeriod = $state<Period>(readSavedPeriod());


### PR DESCRIPTION
defaults top tracks to the existing “past month” window when no valid filter preference is saved. an explicitly saved choice still wins, and the existing fallback for empty periods is unchanged.

checked the initial heading and populated rankings in the local frontend against staging data. Svelte check and lint pass; all 240 frontend tests pass. staging verification is pending the audio-access smoke test.

![bufo-headphones](https://all-the.bufo.zone/bufo-headphones.png)

generated with Codex (GPT-6)
