### PR TITLE
retain Python tracebacks from musician renders

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -675,3 +675,15 @@ blocker; this change does not claim restored listening or musical progress.
 The full studio check passes 65 tests. The two HTTP-boundary quota regression
 cases fail against the previous audio client. Existing retry/cache integration
 coverage still passes. Schedule, publication policy and spending caps are unchanged.
+
+### September 12 — retain isolated renderer failures
+
+Repeated musician runs ended in Docker exit code 1 with no Python traceback,
+because the renderer discarded stderr. Rendering now drains stderr while
+retaining its last 8 KB, reports that tail in the Prefect exception, and writes
+`render-error.txt` beside the intended audio output. The 30-second deadline,
+container isolation and forced container cleanup remain. Tests cover actual
+child-process failures, noisy output, timeout and the renderer's cleanup path;
+the renderer regression fails against the previous implementation. The original
+generated-code failure still requires reproduction; diagnostics alone do not
+claim it is repaired.

--- a/services/musician-studio/compose.py
+++ b/services/musician-studio/compose.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field
 
 from studio.context import history_context, musical_identity
 from studio.identity import Inspiration, Musician, Taste
+from studio.render_process import RenderError, run_renderer
 from studio.state import Store
 
 ROOT = Path(__file__).parent
@@ -293,13 +294,10 @@ def render(code: str, output: Path) -> dict:
             "plyr-musician-python:local",
         ]
         try:
-            subprocess.run(
-                command,
-                timeout=30,
-                check=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
+            run_renderer(command)
+        except RenderError as error:
+            (output / "render-error.txt").write_text(str(error))
+            raise
         finally:
             subprocess.run(
                 ["docker", "rm", "-f", container],

--- a/services/musician-studio/studio/render_process.py
+++ b/services/musician-studio/studio/render_process.py
@@ -1,0 +1,50 @@
+"""Keep bounded diagnostics from the isolated audio renderer."""
+
+import os
+import selectors
+import subprocess
+import time
+
+
+class RenderError(RuntimeError):
+    def __init__(self, reason: str, stderr: str) -> None:
+        self.reason = reason
+        self.stderr = stderr
+        super().__init__(reason, stderr)
+
+    def __str__(self) -> str:
+        return f"Audio render {self.reason}: {self.stderr or 'no stderr emitted'}"
+
+
+def run_renderer(command: list[str], timeout: float = 30) -> None:
+    tail = bytearray()
+    with subprocess.Popen(
+        command, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
+    ) as process:
+        assert process.stderr is not None
+        os.set_blocking(process.stderr.fileno(), False)
+        deadline = time.monotonic() + timeout
+        try:
+            with selectors.DefaultSelector() as selector:
+                selector.register(process.stderr, selectors.EVENT_READ)
+                while selector.get_map():
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise RenderError("timed out", tail.decode(errors="replace"))
+                    for key, _ in selector.select(min(remaining, 0.1)):
+                        chunk = os.read(key.fd, 4096)
+                        if not chunk:
+                            selector.unregister(key.fileobj)
+                        else:
+                            tail.extend(chunk)
+                            del tail[:-8192]
+            try:
+                code = process.wait(timeout=max(0, deadline - time.monotonic()))
+            except subprocess.TimeoutExpired:
+                raise RenderError("timed out", tail.decode(errors="replace")) from None
+            if code:
+                raise RenderError(f"exited {code}", tail.decode(errors="replace"))
+        finally:
+            if process.poll() is None:
+                process.kill()
+                process.wait()

--- a/services/musician-studio/tests/test_render_process.py
+++ b/services/musician-studio/tests/test_render_process.py
@@ -1,0 +1,63 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import compose
+from studio.render_process import RenderError, run_renderer
+
+
+def test_python_traceback_is_retained() -> None:
+    with pytest.raises(
+        RenderError, match="NameError: name 'missing_voice' is not defined"
+    ):
+        run_renderer([sys.executable, "-c", "missing_voice()"])
+
+
+def test_large_stderr_is_drained_with_bounded_retention() -> None:
+    with pytest.raises(RenderError) as raised:
+        run_renderer(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.stderr.write('x'*1000000+'THE END'); sys.exit(1)",
+            ]
+        )
+    assert len(raised.value.stderr) == 8192
+    assert raised.value.stderr.endswith("THE END")
+
+
+def test_timeout_retains_diagnostics() -> None:
+    with pytest.raises(RenderError, match="timed out: started"):
+        run_renderer(
+            [
+                sys.executable,
+                "-c",
+                "import sys,time; print('started',file=sys.stderr,flush=True); time.sleep(10)",
+            ],
+            timeout=0.5,
+        )
+
+
+def test_successful_renderer_stderr_does_not_fail() -> None:
+    run_renderer([sys.executable, "-c", "import sys; print('warning',file=sys.stderr)"])
+
+
+def test_render_retains_error_artifact_and_removes_container(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    original = subprocess.Popen
+    commands: list[list[str]] = []
+
+    def launch(command: list[str], **kwargs: object) -> subprocess.Popen:
+        commands.append(command)
+        source = "missing_voice()" if command[1] == "run" else "pass"
+        return original([sys.executable, "-c", source], **kwargs)
+
+    monkeypatch.setattr(subprocess, "Popen", launch)
+    with pytest.raises(RenderError, match="NameError"):
+        compose.render("fixture", tmp_path)
+    assert "NameError" in (tmp_path / "render-error.txt").read_text()
+    assert commands[-1][:3] == ["docker", "rm", "-f"]
+    assert commands[0][commands[0].index("--network") + 1] == "none"


### PR DESCRIPTION
musician renders now report the Python error instead of a long Docker command with no stderr. the last 8 KB is retained in the Prefect exception and a `render-error.txt` artifact.

<details>
<summary>validation and limits</summary>

real child-process tests cover tracebacks, large stderr, timeouts and successful processes. the renderer regression verifies its error artifact and container cleanup and fails on the previous implementation. container isolation, runtime limits and spending controls are unchanged.

this makes the recurring failures diagnosable; the original Reed source still needs reproduction on the worker.
</details>

![bufo-placeholder](https://all-the.bufo.zone/bufo-placeholder.png)

generated with Codex (GPT-6)
