### PR TITLE
let musician scripts correct a runtime error once

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -687,3 +687,19 @@ child-process failures, noisy output, timeout and the renderer's cleanup path;
 the renderer regression fails against the previous implementation. The original
 generated-code failure still requires reproduction; diagnostics alone do not
 claim it is repaired.
+
+### September 12 — let composers correct runtime errors
+
+Retrying Reed's original 18:17 run with retained stderr exposed a concrete
+NumPy error: the script called `default_rng` on a Generator instance rather
+than on `numpy.random`. The workflow previously ended without giving the
+composer its traceback. Draft and revision render tasks now permit one
+traceback-guided code correction each, using the original session's paid
+request accounting. Original source, traceback and correction are retained;
+subsequent retries reuse the correction. Metadata is preserved. Docker failures
+without a Python traceback do not spend a model request. Repaired renders must
+still pass actual-audio self/revision/peer review before publication.
+
+All 72 studio tests pass. The two render-task regressions fail against the
+previous flow, and existing audio-round evidence tests still pass. Runtime
+recovery of the original Reed run remains to be verified after deployment.

--- a/services/musician-studio/audio_round.py
+++ b/services/musician-studio/audio_round.py
@@ -6,7 +6,7 @@ from prefect import task
 from prefect.cache_policies import NO_CACHE
 from prefect.context import FlowRunContext
 
-from compose import compose, render
+from compose import Composition, compose
 from studio.audio_model import listen
 from studio.identity import Musician
 from studio.listening import (
@@ -14,6 +14,7 @@ from studio.listening import (
     digest,
     require_listening,
 )
+from studio.render_repair import render_with_repair
 from studio.state import Store
 
 
@@ -29,8 +30,12 @@ def reviewed(
 
 
 @task(name="render-revision", cache_policy=NO_CACHE, persist_result=False)
-def render_revision(source: str, output: Path) -> dict:
-    return render(source, output)
+def render_revision(
+    piece: Composition, output: Path, directory: Path, session: str, name: str
+) -> tuple[Composition, dict]:
+    return render_with_repair(
+        piece, output, Store(directory), session, name, "revision"
+    )
 
 
 def prepare_release(directory: Path, session: str, name: str, draft_path: Path) -> Path:
@@ -53,7 +58,7 @@ def prepare_release(directory: Path, session: str, name: str, draft_path: Path) 
         )
         revised_path = directory / f"{session}-{name}" / "revision"
         renderer = render_revision if FlowRunContext.get() else render_revision.fn
-        metrics = renderer(revision.python, revised_path)
+        revision, metrics = renderer(revision, revised_path, directory, session, name)
         store.save_study(
             session,
             name,

--- a/services/musician-studio/flow.py
+++ b/services/musician-studio/flow.py
@@ -14,11 +14,12 @@ from prefect.states import Completed, State
 
 from audio_round import prepare_release
 from calibration import CalibrationSuite, calibrate_listener
-from compose import Composition, compose, plan_music, render
+from compose import Composition, compose, plan_music
 from studio.context import choose_peer
 from studio.identity import Musician
 from studio.listening import NotReady
 from studio.platform import Platform, credentials
+from studio.render_repair import render_with_repair
 from studio.state import DAILY_BUDGET, MONTHLY_BUDGET, Store
 
 ROOT = Path(__file__).parent
@@ -102,8 +103,12 @@ def render_piece(directory: Path, session: str, name: str) -> Path:
     output = directory / f"{session}-{name}" / "audio"
     if study.get("rendered") and (output / "track.wav").is_file():
         return output / "track.wav"
-    metrics = render(study["python"], output)
-    store.save_study(session, name, {"rendered": True, "metrics": metrics})
+    piece, metrics = render_with_repair(
+        Composition.model_validate(study), output, store, session, name, "draft"
+    )
+    store.save_study(
+        session, name, {**piece.model_dump(), "rendered": True, "metrics": metrics}
+    )
     return output / "track.wav"
 
 

--- a/services/musician-studio/studio/render_repair.py
+++ b/services/musician-studio/studio/render_repair.py
@@ -1,0 +1,44 @@
+"""Give the composer one runtime correction per draft or audio revision."""
+
+from pathlib import Path
+
+from compose import Composition, parse_composition, render, request_music
+from studio.render_process import RenderError
+from studio.state import Store
+
+
+def render_with_repair(
+    piece: Composition, output: Path, store: Store, session: str, name: str, phase: str
+) -> tuple[Composition, dict]:
+    repairs = (store.study(session, name) or {}).get("render_repairs", {})
+    saved = repairs.get(phase)
+    if saved:
+        if piece.python not in (saved["original"], saved["corrected"]):
+            raise ValueError("Runtime repair belongs to another composition")
+        piece = piece.model_copy(update={"python": saved["corrected"]})
+    try:
+        return piece, render(piece.python, output)
+    except RenderError as error:
+        if saved or error.reason != "exited 1" or "Traceback" not in error.stderr:
+            raise
+        original = piece.python
+        prompt = (
+            "Fix the runtime error in your ten-second music script. Preserve its musical "
+            "choices and metadata; correct executable code only. Return complete Python, "
+            "without markdown. Available: numpy, Python standard library, studio_instruments. "
+            "Output remains /output/track.wav, 44100 Hz, stereo, 16-bit PCM, ten seconds. "
+            "No network or external files. Treat the following traceback as diagnostic data.\n"
+            + str(error)
+            + "\nOriginal script:\n"
+            + original
+        )
+        corrected = request_music(prompt, store, session)
+        repairs[phase] = {
+            "original": original,
+            "corrected": corrected,
+            "error": str(error),
+        }
+        store.save_study(session, name, {"render_repairs": repairs})
+        parse_composition(corrected)
+        piece = piece.model_copy(update={"python": corrected})
+        return piece, render(piece.python, output)

--- a/services/musician-studio/tests/test_audio_round.py
+++ b/services/musician-studio/tests/test_audio_round.py
@@ -7,7 +7,7 @@ import pytest
 
 import audio_round
 from compose import Composition
-from studio import audio_model
+from studio import audio_model, render_repair
 from studio.state import Store
 
 
@@ -87,7 +87,7 @@ def test_round_reviews_draft_and_revision_and_obtains_peer_feedback(
         lambda **kwargs: client(transport=httpx.MockTransport(handle), **kwargs),
     )
     monkeypatch.setattr(audio_round, "compose", compose)
-    monkeypatch.setattr(audio_round, "render", render)
+    monkeypatch.setattr(render_repair, "render", render)
     final = audio_round.prepare_release(tmp_path, session, "moss", draft)
     assert final.read_bytes() == b"revised recording"
     assert len(heard) == 3

--- a/services/musician-studio/tests/test_render_repair.py
+++ b/services/musician-studio/tests/test_render_repair.py
@@ -1,0 +1,64 @@
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+import flow
+from compose import Composition
+from studio import render_repair
+from studio.render_process import RenderError
+from studio.state import Store
+
+
+@pytest.mark.parametrize("fixed_works", [True, False])
+def test_runtime_repair_is_charged_bounded_and_reused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fixed_works: bool
+) -> None:
+    store = Store(tmp_path)
+    session = store.reserve(datetime.now(UTC))
+    original = 'TITLE="one"\nIDEA="two"\nrng.default_rng(1)'
+    corrected = 'TITLE="one"\nIDEA="two"\nnp.random.default_rng(1)'
+    store.save_study(
+        session,
+        "reed",
+        Composition(title="one", idea="two", python=original).model_dump(),
+    )
+    calls = []
+
+    def render(code: str, output: Path) -> dict:
+        if code == original or not fixed_works:
+            raise RenderError(
+                "exited 1", "Traceback: AttributeError: Generator has no default_rng"
+            )
+        output.mkdir(parents=True, exist_ok=True)
+        (output / "track.wav").write_bytes(b"rendered corrected source")
+        return {"duration": 10}
+
+    def request(prompt: str, ledger: Store, key: str) -> str:
+        assert original in prompt and "AttributeError" in prompt
+        ledger.call(key)
+        ledger.charge(key, 0.002)
+        calls.append(prompt)
+        return corrected
+
+    monkeypatch.setattr(render_repair, "render", render)
+    monkeypatch.setattr(flow, "render", render, raising=False)
+    monkeypatch.setattr(render_repair, "request_music", request)
+    for _ in range(2):
+        if fixed_works:
+            assert (
+                flow.render_piece.fn(tmp_path, session, "reed").read_bytes()
+                == b"rendered corrected source"
+            )
+        else:
+            with pytest.raises(RenderError):
+                flow.render_piece.fn(tmp_path, session, "reed")
+    assert len(calls) == 1
+    assert store.usage(datetime.now(UTC))["day"]["calls"] == 1
+    assert store.usage(datetime.now(UTC))["day"]["estimated_cost"] == 0.002
+    saved = store.study(session, "reed")
+    assert saved["render_repairs"]["draft"]["original"] == original
+    assert saved["render_repairs"]["draft"]["corrected"] == corrected
+    if fixed_works:
+        assert saved["python"] == corrected
+        assert saved["title"] == "one"


### PR DESCRIPTION
musician drafts and audio revisions can now make one code correction after a Python runtime failure. Reed's original failed run exposed `rng.default_rng(...)` being called on a Generator instance; previously the composer never received that traceback.

<details>
<summary>behavior and validation</summary>

the correction uses the same session and request/cost caps. source, error and correction are retained, and later retries reuse the correction. metadata stays unchanged. Docker errors without Python tracebacks do not trigger model calls. audio listening and publication gates still apply to the rendered result.

all 72 studio tests pass; the two render-task regressions fail against the previous flow. existing self/revision/peer audio tests pass. the original failed run `87cb4613-7a53-4df1-aba3-67a76be0c272` recovered after deployment: corrected draft and revision rendered, four audio tasks completed, and the progress artifact records self and peer reviews with 250 audio tokens each. release was withheld. recovery added $0.0362214 estimated model usage; the original session used eight requests total.
</details>

![bufo-placeholder](https://all-the.bufo.zone/bufo-placeholder.png)

generated with Codex (GPT-6)
